### PR TITLE
fix(attachments)!: respect empty workspace allowlists

### DIFF
--- a/docs/automations/core-actions/case-actions/attachments.mdx
+++ b/docs/automations/core-actions/case-actions/attachments.mdx
@@ -6,7 +6,7 @@ title: "Attachments"
 
 ## `core.cases.upload_attachment`
 
-Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads.
+Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values.
 
 ### Inputs
 
@@ -83,7 +83,7 @@ The original filename.
 
 ## `core.cases.upload_attachment_from_url`
 
-Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads.
+Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values.
 
 ### Inputs
 

--- a/docs/automations/core-actions/case-actions/attachments.mdx
+++ b/docs/automations/core-actions/case-actions/attachments.mdx
@@ -6,7 +6,7 @@ title: "Attachments"
 
 ## `core.cases.upload_attachment`
 
-Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values.
+Upload a file attachment to a case. Uploads are governed by workspace attachment settings. In workspace settings, null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads.
 
 ### Inputs
 
@@ -83,7 +83,7 @@ The original filename.
 
 ## `core.cases.upload_attachment_from_url`
 
-Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values.
+Upload a file attachment to a case from a URL. Uploads are governed by workspace attachment settings. In workspace settings, null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads.
 
 ### Inputs
 

--- a/docs/automations/core-actions/case-actions/attachments.mdx
+++ b/docs/automations/core-actions/case-actions/attachments.mdx
@@ -6,7 +6,7 @@ title: "Attachments"
 
 ## `core.cases.upload_attachment`
 
-Upload a file attachment to a case.
+Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads.
 
 ### Inputs
 
@@ -83,7 +83,7 @@ The original filename.
 
 ## `core.cases.upload_attachment_from_url`
 
-Upload a file attachment to a case from a URL.
+Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads.
 
 ### Inputs
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -32153,6 +32153,8 @@ export const $WorkspaceSettingsRead = {
         },
       ],
       title: "Allowed Attachment Extensions",
+      description:
+        "Workspace attachment extension allowlist. null means system defaults; [] disables uploads; non-empty lists allow only those extensions.",
     },
     allowed_attachment_mime_types: {
       anyOf: [
@@ -32167,6 +32169,8 @@ export const $WorkspaceSettingsRead = {
         },
       ],
       title: "Allowed Attachment Mime Types",
+      description:
+        "Workspace attachment MIME type allowlist. null means system defaults; [] disables uploads; non-empty lists allow only those MIME types.",
     },
     validate_attachment_magic_number: {
       anyOf: [
@@ -32186,7 +32190,7 @@ export const $WorkspaceSettingsRead = {
       type: "array",
       title: "Effective Allowed Attachment Extensions",
       description:
-        "Returns workspace-specific extensions if set, otherwise system defaults.",
+        "Return the workspace extension allowlist, including [] as deny-all, or system defaults when null.",
       readOnly: true,
     },
     effective_allowed_attachment_mime_types: {
@@ -32196,7 +32200,7 @@ export const $WorkspaceSettingsRead = {
       type: "array",
       title: "Effective Allowed Attachment Mime Types",
       description:
-        "Returns workspace-specific MIME types if set, otherwise system defaults.",
+        "Return the workspace MIME type allowlist, including [] as deny-all, or system defaults when null.",
       readOnly: true,
     },
   },
@@ -32272,7 +32276,7 @@ export const $WorkspaceSettingsUpdate = {
       ],
       title: "Allowed Attachment Extensions",
       description:
-        "Allowed file extensions for attachments (e.g., ['.pdf', '.docx']). Overrides global defaults.",
+        "Allowed file extensions for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those extensions.",
     },
     allowed_attachment_mime_types: {
       anyOf: [
@@ -32288,7 +32292,7 @@ export const $WorkspaceSettingsUpdate = {
       ],
       title: "Allowed Attachment Mime Types",
       description:
-        "Allowed MIME types for attachments (e.g., ['application/pdf', 'image/jpeg']). Overrides global defaults.",
+        "Allowed MIME types for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those MIME types.",
     },
     validate_attachment_magic_number: {
       anyOf: [

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -32276,7 +32276,7 @@ export const $WorkspaceSettingsUpdate = {
       ],
       title: "Allowed Attachment Extensions",
       description:
-        "Allowed file extensions for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those extensions.",
+        "Allowed file extensions for attachments. null resets to system defaults; [] disables uploads; non-empty lists allow only those extensions; omitted leaves the existing setting unchanged.",
     },
     allowed_attachment_mime_types: {
       anyOf: [
@@ -32292,7 +32292,7 @@ export const $WorkspaceSettingsUpdate = {
       ],
       title: "Allowed Attachment Mime Types",
       description:
-        "Allowed MIME types for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those MIME types.",
+        "Allowed MIME types for attachments. null resets to system defaults; [] disables uploads; non-empty lists allow only those MIME types; omitted leaves the existing setting unchanged.",
     },
     validate_attachment_magic_number: {
       anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9576,11 +9576,11 @@ export type WorkspaceSettingsUpdate = {
    */
   workflow_default_timeout_seconds?: number | null
   /**
-   * Allowed file extensions for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those extensions.
+   * Allowed file extensions for attachments. null resets to system defaults; [] disables uploads; non-empty lists allow only those extensions; omitted leaves the existing setting unchanged.
    */
   allowed_attachment_extensions?: Array<string> | null
   /**
-   * Allowed MIME types for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those MIME types.
+   * Allowed MIME types for attachments. null resets to system defaults; [] disables uploads; non-empty lists allow only those MIME types; omitted leaves the existing setting unchanged.
    */
   allowed_attachment_mime_types?: Array<string> | null
   /**

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9545,15 +9545,21 @@ export type WorkspaceSettingsRead = {
   git_repo_url?: string | null
   workflow_unlimited_timeout_enabled?: boolean | null
   workflow_default_timeout_seconds?: number | null
+  /**
+   * Workspace attachment extension allowlist. null means system defaults; [] disables uploads; non-empty lists allow only those extensions.
+   */
   allowed_attachment_extensions?: Array<string> | null
+  /**
+   * Workspace attachment MIME type allowlist. null means system defaults; [] disables uploads; non-empty lists allow only those MIME types.
+   */
   allowed_attachment_mime_types?: Array<string> | null
   validate_attachment_magic_number?: boolean | null
   /**
-   * Returns workspace-specific extensions if set, otherwise system defaults.
+   * Return the workspace extension allowlist, including [] as deny-all, or system defaults when null.
    */
   readonly effective_allowed_attachment_extensions: Array<string>
   /**
-   * Returns workspace-specific MIME types if set, otherwise system defaults.
+   * Return the workspace MIME type allowlist, including [] as deny-all, or system defaults when null.
    */
   readonly effective_allowed_attachment_mime_types: Array<string>
 }
@@ -9570,11 +9576,11 @@ export type WorkspaceSettingsUpdate = {
    */
   workflow_default_timeout_seconds?: number | null
   /**
-   * Allowed file extensions for attachments (e.g., ['.pdf', '.docx']). Overrides global defaults.
+   * Allowed file extensions for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those extensions.
    */
   allowed_attachment_extensions?: Array<string> | null
   /**
-   * Allowed MIME types for attachments (e.g., ['application/pdf', 'image/jpeg']). Overrides global defaults.
+   * Allowed MIME types for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those MIME types.
    */
   allowed_attachment_mime_types?: Array<string> | null
   /**

--- a/frontend/src/components/cases/case-attachments-section.tsx
+++ b/frontend/src/components/cases/case-attachments-section.tsx
@@ -478,7 +478,7 @@ export function CaseAttachmentsSection({
         <div className="space-y-4 p-4">
           <div
             role="button"
-            tabIndex={uploadsDisabled ? -1 : 0}
+            tabIndex={0}
             aria-label={uploadControlLabel}
             onClick={handleAddAttachment}
             onKeyDown={handleUploadControlKeyDown}

--- a/frontend/src/components/cases/case-attachments-section.tsx
+++ b/frontend/src/components/cases/case-attachments-section.tsx
@@ -61,7 +61,7 @@ interface ApiErrorBody {
   detail?: ApiErrorDetail | string
 }
 
-/** Upload policy derived from effective workspace attachment extensions. */
+/** Upload policy derived from effective workspace attachment allowlists. */
 export interface AttachmentUploadPolicy {
   /** Whether uploads should be blocked by workspace policy. */
   uploadsDisabled: boolean
@@ -70,24 +70,31 @@ export interface AttachmentUploadPolicy {
 }
 
 /**
- * Build the browser upload policy from effective workspace attachment extensions.
+ * Build the browser upload policy from effective workspace attachment allowlists.
  *
- * An explicit empty array means the workspace disabled uploads, while `null` or
- * `undefined` means the UI should inherit server defaults instead of adding an
- * unrestricted or misleading accept hint.
+ * An explicit empty array on either allowlist means the workspace disabled
+ * uploads, while `null` or `undefined` means the UI should inherit server
+ * defaults. The browser accept hint is still extension-only because MIME
+ * allowlists are enforced by the API.
  *
  * @param acceptedExtensions - Effective workspace attachment extensions.
+ * @param acceptedMimeTypes - Effective workspace attachment MIME types.
  * @returns The upload disabled flag and optional file input accept attribute.
  */
 export function buildAttachmentUploadPolicy(
-  acceptedExtensions: string[] | null | undefined
+  acceptedExtensions: string[] | null | undefined,
+  acceptedMimeTypes: string[] | null | undefined
 ): AttachmentUploadPolicy {
-  if (!Array.isArray(acceptedExtensions)) {
-    return { uploadsDisabled: false }
+  if (Array.isArray(acceptedExtensions) && acceptedExtensions.length === 0) {
+    return { uploadsDisabled: true }
   }
 
-  if (acceptedExtensions.length === 0) {
+  if (Array.isArray(acceptedMimeTypes) && acceptedMimeTypes.length === 0) {
     return { uploadsDisabled: true }
+  }
+
+  if (!Array.isArray(acceptedExtensions) || acceptedExtensions.length === 0) {
+    return { uploadsDisabled: false }
   }
 
   return {
@@ -152,14 +159,18 @@ export function CaseAttachmentsSection({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const queryClient = useQueryClient()
 
-  // Get workspace settings for allowed file extensions
+  // Get workspace settings for attachment allowlists
   const { workspace } = useWorkspaceDetails()
 
   // Create upload policy from workspace settings
   const acceptedExtensions =
     workspace?.settings?.effective_allowed_attachment_extensions
-  const { acceptAttribute, uploadsDisabled } =
-    buildAttachmentUploadPolicy(acceptedExtensions)
+  const acceptedMimeTypes =
+    workspace?.settings?.effective_allowed_attachment_mime_types
+  const { acceptAttribute, uploadsDisabled } = buildAttachmentUploadPolicy(
+    acceptedExtensions,
+    acceptedMimeTypes
+  )
 
   // Fetch attachments from API
   const {
@@ -293,6 +304,17 @@ export function CaseAttachmentsSection({
     }
 
     fileInputRef.current?.click()
+  }
+
+  const handleUploadControlKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>
+  ) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return
+    }
+
+    event.preventDefault()
+    handleAddAttachment()
   }
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
@@ -455,14 +477,18 @@ export function CaseAttachmentsSection({
       <div className="mx-auto w-full">
         <div className="space-y-4 p-4">
           <div
+            role="button"
+            tabIndex={uploadsDisabled ? -1 : 0}
+            aria-label={uploadControlLabel}
             onClick={handleAddAttachment}
+            onKeyDown={handleUploadControlKeyDown}
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
             aria-disabled={uploadsDisabled}
             className={cn(
-              "flex items-center gap-2 p-1.5 rounded-md border border-dashed transition-all group",
+              "flex items-center gap-2 p-1.5 rounded-md border border-dashed transition-all group focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
               uploadsDisabled
                 ? "cursor-not-allowed border-muted-foreground/20 opacity-60"
                 : "cursor-pointer border-muted-foreground/25 hover:border-muted-foreground/50 hover:bg-muted/30",

--- a/frontend/src/components/cases/case-attachments-section.tsx
+++ b/frontend/src/components/cases/case-attachments-section.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import { useWorkspaceDetails } from "@/hooks/use-workspace"
+import { describeAttachmentUploadError } from "@/lib/cases/attachment-errors"
 import { invalidateCaseActivityQueries } from "@/lib/cases/invalidation"
 import { cn } from "@/lib/utils"
 
@@ -52,22 +53,47 @@ interface CaseAttachmentDownloadResponse {
   content_type: string
 }
 
-// Type definitions for API error responses
 interface ApiErrorDetail {
-  error?: string
   message?: string
-  allowed_extensions?: string[]
-  // Max attachments exceeded error fields
-  current_count?: number
-  max_count?: number
-  // Storage limit exceeded error fields
-  current_size_mb?: number
-  new_file_size_mb?: number
-  max_size_mb?: number
 }
 
 interface ApiErrorBody {
   detail?: ApiErrorDetail | string
+}
+
+/** Upload policy derived from effective workspace attachment extensions. */
+export interface AttachmentUploadPolicy {
+  /** Whether uploads should be blocked by workspace policy. */
+  uploadsDisabled: boolean
+  /** File input accept attribute, omitted when the policy inherits defaults. */
+  acceptAttribute?: string
+}
+
+/**
+ * Build the browser upload policy from effective workspace attachment extensions.
+ *
+ * An explicit empty array means the workspace disabled uploads, while `null` or
+ * `undefined` means the UI should inherit server defaults instead of adding an
+ * unrestricted or misleading accept hint.
+ *
+ * @param acceptedExtensions - Effective workspace attachment extensions.
+ * @returns The upload disabled flag and optional file input accept attribute.
+ */
+export function buildAttachmentUploadPolicy(
+  acceptedExtensions: string[] | null | undefined
+): AttachmentUploadPolicy {
+  if (!Array.isArray(acceptedExtensions)) {
+    return { uploadsDisabled: false }
+  }
+
+  if (acceptedExtensions.length === 0) {
+    return { uploadsDisabled: true }
+  }
+
+  return {
+    uploadsDisabled: false,
+    acceptAttribute: acceptedExtensions.join(","),
+  }
 }
 
 function getFileIcon(contentType: string) {
@@ -129,10 +155,11 @@ export function CaseAttachmentsSection({
   // Get workspace settings for allowed file extensions
   const { workspace } = useWorkspaceDetails()
 
-  // Create accept attribute from workspace settings
+  // Create upload policy from workspace settings
   const acceptedExtensions =
     workspace?.settings?.effective_allowed_attachment_extensions
-  const acceptAttribute = acceptedExtensions?.join(",") || undefined
+  const { acceptAttribute, uploadsDisabled } =
+    buildAttachmentUploadPolicy(acceptedExtensions)
 
   // Fetch attachments from API
   const {
@@ -169,140 +196,7 @@ export function CaseAttachmentsSection({
     },
     onError: (error: ApiError, file) => {
       setIsUploading(false)
-
-      // Handle structured error responses with specific HTTP status codes
-      if (
-        error.status === 415 &&
-        error.body &&
-        typeof error.body === "object"
-      ) {
-        const body = error.body as ApiErrorBody
-        const detail = body.detail
-
-        if (
-          typeof detail === "object" &&
-          detail?.error === "unsupported_file_extension"
-        ) {
-          toast({
-            title: "File type not supported",
-            description: `${file.name} cannot be uploaded. Allowed file types: ${detail.allowed_extensions?.join(", ") || "txt, pdf, png, jpeg, gif, csv"}`,
-          })
-          return
-        }
-
-        if (
-          typeof detail === "object" &&
-          detail?.error === "unsupported_content_type"
-        ) {
-          toast({
-            title: "Content type not supported",
-            description: `${file.name} has an unsupported content type. Please try a different file type.`,
-          })
-          return
-        }
-      }
-
-      if (
-        error.status === 413 &&
-        error.body &&
-        typeof error.body === "object"
-      ) {
-        const body = error.body as ApiErrorBody
-        const detail = body.detail
-
-        if (typeof detail === "object" && detail?.error === "file_too_large") {
-          toast({
-            title: "File too large",
-            description: `${file.name} is too large to upload. ${detail.message || "Please choose a smaller file."}`,
-          })
-          return
-        }
-
-        if (
-          typeof detail === "object" &&
-          detail?.error === "storage_limit_exceeded"
-        ) {
-          let description = `Adding ${file.name} would exceed the case storage limit.`
-
-          if (
-            detail.current_size_mb &&
-            detail.new_file_size_mb &&
-            detail.max_size_mb
-          ) {
-            description = `Adding ${file.name} (${detail.new_file_size_mb}MB) would exceed the case storage limit. Current usage: ${detail.current_size_mb}MB of ${detail.max_size_mb}MB allowed.`
-          }
-
-          toast({
-            title: "Case storage limit exceeded",
-            description: `${description} Please remove some attachments or choose a smaller file.`,
-          })
-          return
-        }
-      }
-
-      if (
-        error.status === 409 &&
-        error.body &&
-        typeof error.body === "object"
-      ) {
-        const body = error.body as ApiErrorBody
-        const detail = body.detail
-
-        if (
-          typeof detail === "object" &&
-          detail?.error === "max_attachments_exceeded"
-        ) {
-          let description =
-            "This case already has the maximum number of attachments allowed."
-
-          if (detail.current_count && detail.max_count) {
-            description = `This case already has ${detail.current_count} of ${detail.max_count} attachments allowed.`
-          }
-
-          toast({
-            title: "Too many attachments",
-            description: `${description} Please remove some attachments before adding new ones.`,
-          })
-          return
-        }
-      }
-
-      if (
-        error.status === 400 &&
-        error.body &&
-        typeof error.body === "object"
-      ) {
-        const body = error.body as ApiErrorBody
-        const detail = body.detail
-
-        if (
-          typeof detail === "object" &&
-          detail?.error === "file_validation_failed"
-        ) {
-          toast({
-            title: "File validation failed",
-            description: `${file.name} failed validation. Please check the file and try again.`,
-          })
-          return
-        }
-      }
-
-      // Fallback for other errors
-      let errorMessage = error.message || "Unknown error"
-      if (error.body && typeof error.body === "object") {
-        const body = error.body as ApiErrorBody
-        if (body.detail) {
-          errorMessage =
-            typeof body.detail === "string"
-              ? body.detail
-              : body.detail.message || JSON.stringify(body.detail)
-        }
-      }
-
-      toast({
-        title: "Upload failed",
-        description: `Failed to upload ${file.name}. ${errorMessage}`,
-      })
+      toast(describeAttachmentUploadError(error, file.name))
     },
   })
 
@@ -346,6 +240,13 @@ export function CaseAttachmentsSection({
     },
   })
 
+  const showUploadsDisabledToast = useCallback(() => {
+    toast({
+      title: "Attachment uploads disabled",
+      description: "Uploads are disabled for this workspace.",
+    })
+  }, [])
+
   // Add file validation function
   const validateFile = (file: File): boolean => {
     if (file.size > MAX_FILE_SIZE_BYTES) {
@@ -358,23 +259,39 @@ export function CaseAttachmentsSection({
     return true
   }
 
+  const resetFileInput = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""
+    }
+  }
+
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (uploadsDisabled) {
+      showUploadsDisabledToast()
+      resetFileInput()
+      return
+    }
+
     const file = event.target.files?.[0]
     if (file) {
       // Validate file size before uploading
       if (!validateFile(file)) {
+        resetFileInput()
         return
       }
       setIsUploading(true)
       uploadMutation.mutate(file)
     }
     // Reset input
-    if (fileInputRef.current) {
-      fileInputRef.current.value = ""
-    }
+    resetFileInput()
   }
 
   const handleAddAttachment = () => {
+    if (uploadsDisabled) {
+      showUploadsDisabledToast()
+      return
+    }
+
     fileInputRef.current?.click()
   }
 
@@ -401,6 +318,11 @@ export function CaseAttachmentsSection({
       e.stopPropagation()
       setIsDragOver(false)
 
+      if (uploadsDisabled) {
+        showUploadsDisabledToast()
+        return
+      }
+
       const files = Array.from(e.dataTransfer.files)
       const file = files[0] // Only handle the first file
 
@@ -413,7 +335,7 @@ export function CaseAttachmentsSection({
         uploadMutation.mutate(file)
       }
     },
-    [uploadMutation]
+    [showUploadsDisabledToast, uploadMutation, uploadsDisabled]
   )
 
   const handleDownload = async (attachment: CaseAttachmentRead) => {
@@ -521,6 +443,13 @@ export function CaseAttachmentsSection({
     )
   }
 
+  let uploadControlLabel = "Add new attachment (max 20MB)"
+  if (isUploading || uploadMutation.isPending) {
+    uploadControlLabel = "Uploading..."
+  } else if (uploadsDisabled) {
+    uploadControlLabel = "Attachment uploads disabled"
+  }
+
   return (
     <TooltipProvider>
       <div className="mx-auto w-full">
@@ -531,20 +460,32 @@ export function CaseAttachmentsSection({
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
+            aria-disabled={uploadsDisabled}
             className={cn(
-              "flex items-center gap-2 p-1.5 rounded-md border border-dashed transition-all cursor-pointer group",
-              isDragOver
-                ? "border-blue-500 bg-blue-50 dark:bg-blue-950/20"
-                : "border-muted-foreground/25 hover:border-muted-foreground/50 hover:bg-muted/30"
+              "flex items-center gap-2 p-1.5 rounded-md border border-dashed transition-all group",
+              uploadsDisabled
+                ? "cursor-not-allowed border-muted-foreground/20 opacity-60"
+                : "cursor-pointer border-muted-foreground/25 hover:border-muted-foreground/50 hover:bg-muted/30",
+              isDragOver &&
+                !uploadsDisabled &&
+                "border-blue-500 bg-blue-50 dark:bg-blue-950/20"
             )}
           >
-            <div className="p-1.5 rounded bg-muted group-hover:bg-muted-foreground/10 transition-colors">
+            <div
+              className={cn(
+                "p-1.5 rounded bg-muted transition-colors",
+                !uploadsDisabled && "group-hover:bg-muted-foreground/10"
+              )}
+            >
               <Plus className="h-3.5 w-3.5 text-muted-foreground" />
             </div>
-            <span className="text-xs text-muted-foreground group-hover:text-foreground transition-colors">
-              {isUploading || uploadMutation.isPending
-                ? "Uploading..."
-                : "Add new attachment (max 20MB)"}
+            <span
+              className={cn(
+                "text-xs text-muted-foreground transition-colors",
+                !uploadsDisabled && "group-hover:text-foreground"
+              )}
+            >
+              {uploadControlLabel}
             </span>
           </div>
 
@@ -558,8 +499,9 @@ export function CaseAttachmentsSection({
                 No attachments found
               </h3>
               <p className="text-xs text-muted-foreground/75 text-center max-w-[250px]">
-                Add files by clicking the add button above or drag and drop
-                files directly.
+                {uploadsDisabled
+                  ? "Uploads are disabled for this workspace."
+                  : "Add files by clicking the add button above or drag and drop files directly."}
               </p>
             </div>
           ) : (
@@ -663,6 +605,7 @@ export function CaseAttachmentsSection({
             onChange={handleFileSelect}
             className="hidden"
             accept={acceptAttribute}
+            disabled={uploadsDisabled}
           />
 
           {/* Image Preview Modal */}

--- a/frontend/src/components/cases/case-attachments-section.tsx
+++ b/frontend/src/components/cases/case-attachments-section.tsx
@@ -160,7 +160,7 @@ export function CaseAttachmentsSection({
   const queryClient = useQueryClient()
 
   // Get workspace settings for attachment allowlists
-  const { workspace } = useWorkspaceDetails()
+  const { workspace, workspaceLoading } = useWorkspaceDetails()
 
   // Create upload policy from workspace settings
   const acceptedExtensions =
@@ -171,6 +171,8 @@ export function CaseAttachmentsSection({
     acceptedExtensions,
     acceptedMimeTypes
   )
+  const workspaceSettingsLoaded = !workspaceLoading && !!workspace?.settings
+  const uploadControlDisabled = !workspaceSettingsLoaded || uploadsDisabled
 
   // Fetch attachments from API
   const {
@@ -277,6 +279,11 @@ export function CaseAttachmentsSection({
   }
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!workspaceSettingsLoaded) {
+      resetFileInput()
+      return
+    }
+
     if (uploadsDisabled) {
       showUploadsDisabledToast()
       resetFileInput()
@@ -298,6 +305,10 @@ export function CaseAttachmentsSection({
   }
 
   const handleAddAttachment = () => {
+    if (!workspaceSettingsLoaded) {
+      return
+    }
+
     if (uploadsDisabled) {
       showUploadsDisabledToast()
       return
@@ -340,6 +351,10 @@ export function CaseAttachmentsSection({
       e.stopPropagation()
       setIsDragOver(false)
 
+      if (!workspaceSettingsLoaded) {
+        return
+      }
+
       if (uploadsDisabled) {
         showUploadsDisabledToast()
         return
@@ -357,7 +372,12 @@ export function CaseAttachmentsSection({
         uploadMutation.mutate(file)
       }
     },
-    [showUploadsDisabledToast, uploadMutation, uploadsDisabled]
+    [
+      showUploadsDisabledToast,
+      uploadMutation,
+      uploadsDisabled,
+      workspaceSettingsLoaded,
+    ]
   )
 
   const handleDownload = async (attachment: CaseAttachmentRead) => {
@@ -468,8 +488,18 @@ export function CaseAttachmentsSection({
   let uploadControlLabel = "Add new attachment (max 20MB)"
   if (isUploading || uploadMutation.isPending) {
     uploadControlLabel = "Uploading..."
+  } else if (!workspaceSettingsLoaded) {
+    uploadControlLabel = "Loading attachment policy..."
   } else if (uploadsDisabled) {
     uploadControlLabel = "Attachment uploads disabled"
+  }
+
+  let emptyAttachmentMessage =
+    "Add files by clicking the add button above or drag and drop files directly."
+  if (!workspaceSettingsLoaded) {
+    emptyAttachmentMessage = "Attachment policy is loading."
+  } else if (uploadsDisabled) {
+    emptyAttachmentMessage = "Uploads are disabled for this workspace."
   }
 
   return (
@@ -486,21 +516,21 @@ export function CaseAttachmentsSection({
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
-            aria-disabled={uploadsDisabled}
+            aria-disabled={uploadControlDisabled}
             className={cn(
               "flex items-center gap-2 p-1.5 rounded-md border border-dashed transition-all group focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
-              uploadsDisabled
+              uploadControlDisabled
                 ? "cursor-not-allowed border-muted-foreground/20 opacity-60"
                 : "cursor-pointer border-muted-foreground/25 hover:border-muted-foreground/50 hover:bg-muted/30",
               isDragOver &&
-                !uploadsDisabled &&
+                !uploadControlDisabled &&
                 "border-blue-500 bg-blue-50 dark:bg-blue-950/20"
             )}
           >
             <div
               className={cn(
                 "p-1.5 rounded bg-muted transition-colors",
-                !uploadsDisabled && "group-hover:bg-muted-foreground/10"
+                !uploadControlDisabled && "group-hover:bg-muted-foreground/10"
               )}
             >
               <Plus className="h-3.5 w-3.5 text-muted-foreground" />
@@ -508,7 +538,7 @@ export function CaseAttachmentsSection({
             <span
               className={cn(
                 "text-xs text-muted-foreground transition-colors",
-                !uploadsDisabled && "group-hover:text-foreground"
+                !uploadControlDisabled && "group-hover:text-foreground"
               )}
             >
               {uploadControlLabel}
@@ -525,9 +555,7 @@ export function CaseAttachmentsSection({
                 No attachments found
               </h3>
               <p className="text-xs text-muted-foreground/75 text-center max-w-[250px]">
-                {uploadsDisabled
-                  ? "Uploads are disabled for this workspace."
-                  : "Add files by clicking the add button above or drag and drop files directly."}
+                {emptyAttachmentMessage}
               </p>
             </div>
           ) : (
@@ -631,7 +659,7 @@ export function CaseAttachmentsSection({
             onChange={handleFileSelect}
             className="hidden"
             accept={acceptAttribute}
-            disabled={uploadsDisabled}
+            disabled={uploadControlDisabled}
           />
 
           {/* Image Preview Modal */}

--- a/frontend/src/components/settings/workspace-files-settings.tsx
+++ b/frontend/src/components/settings/workspace-files-settings.tsx
@@ -158,6 +158,7 @@ export function WorkspaceFilesSettings({
                   type="button"
                   variant="ghost"
                   size="sm"
+                  aria-label="Restore inherited file extensions"
                   onClick={() => {
                     setInheritAttachmentExtensions(true)
                     field.onChange(
@@ -185,7 +186,8 @@ export function WorkspaceFilesSettings({
               </FormControl>
               <FormDescription>
                 Add file extensions that users can upload as attachments (e.g.,
-                .pdf, .docx, .png)
+                .pdf, .docx, .png). Clearing all values disables uploads; use
+                the reset button to restore inherited defaults.
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -203,6 +205,7 @@ export function WorkspaceFilesSettings({
                   type="button"
                   variant="ghost"
                   size="sm"
+                  aria-label="Restore inherited MIME types"
                   onClick={() => {
                     setInheritAttachmentMimeTypes(true)
                     field.onChange(
@@ -230,7 +233,8 @@ export function WorkspaceFilesSettings({
               </FormControl>
               <FormDescription>
                 Add MIME types that are allowed for attachments (e.g.,
-                application/pdf, image/jpeg)
+                application/pdf, image/jpeg). Clearing all values disables
+                uploads; use the reset button to restore inherited defaults.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/frontend/src/components/settings/workspace-files-settings.tsx
+++ b/frontend/src/components/settings/workspace-files-settings.tsx
@@ -144,10 +144,6 @@ interface WorkspaceFilesSettingsProps {
 export function WorkspaceFilesSettings({
   workspace,
 }: WorkspaceFilesSettingsProps) {
-  const systemDefaultExtensions =
-    workspace.settings?.effective_allowed_attachment_extensions || []
-  const systemDefaultMimeTypes =
-    workspace.settings?.effective_allowed_attachment_mime_types || []
   const [inheritAttachmentExtensions, setInheritAttachmentExtensions] =
     useState(false)
   const [inheritAttachmentMimeTypes, setInheritAttachmentMimeTypes] =
@@ -192,6 +188,9 @@ export function WorkspaceFilesSettings({
               field.value,
               inheritAttachmentExtensions
             )
+            const displayedTags = inheritAttachmentExtensions
+              ? []
+              : field.value || []
 
             return (
               <FormItem>
@@ -204,12 +203,7 @@ export function WorkspaceFilesSettings({
                     aria-label="Restore inherited file extensions"
                     onClick={() => {
                       setInheritAttachmentExtensions(true)
-                      field.onChange(
-                        systemDefaultExtensions.map((ext, index) => ({
-                          id: `ext-default-${index}`,
-                          text: ext,
-                        }))
-                      )
+                      field.onChange(undefined)
                     }}
                     className="h-auto p-1"
                   >
@@ -220,7 +214,7 @@ export function WorkspaceFilesSettings({
                   <CustomTagInput
                     {...field}
                     placeholder="Enter an extension..."
-                    tags={field.value || []}
+                    tags={displayedTags}
                     setTags={(tags) => {
                       setInheritAttachmentExtensions(false)
                       field.onChange(tags)
@@ -252,6 +246,9 @@ export function WorkspaceFilesSettings({
               field.value,
               inheritAttachmentMimeTypes
             )
+            const displayedTags = inheritAttachmentMimeTypes
+              ? []
+              : field.value || []
 
             return (
               <FormItem>
@@ -264,12 +261,7 @@ export function WorkspaceFilesSettings({
                     aria-label="Restore inherited MIME types"
                     onClick={() => {
                       setInheritAttachmentMimeTypes(true)
-                      field.onChange(
-                        systemDefaultMimeTypes.map((mime, index) => ({
-                          id: `mime-default-${index}`,
-                          text: mime,
-                        }))
-                      )
+                      field.onChange(undefined)
                     }}
                     className="h-auto p-1"
                   >
@@ -280,7 +272,7 @@ export function WorkspaceFilesSettings({
                   <CustomTagInput
                     {...field}
                     placeholder="Enter a MIME type..."
-                    tags={field.value || []}
+                    tags={displayedTags}
                     setTags={(tags) => {
                       setInheritAttachmentMimeTypes(false)
                       field.onChange(tags)

--- a/frontend/src/components/settings/workspace-files-settings.tsx
+++ b/frontend/src/components/settings/workspace-files-settings.tsx
@@ -45,6 +45,43 @@ type AttachmentTag = NonNullable<
   FilesSettingsForm["allowed_attachment_extensions"]
 >[number]
 
+/** UI copy describing how an attachment allowlist is currently applied. */
+export interface AttachmentAllowlistState {
+  /** Short policy label for the settings form. */
+  label: string
+  /** Helper text explaining the policy effect. */
+  description: string
+}
+
+/**
+ * Describe whether an attachment allowlist inherits defaults, disables uploads,
+ * or applies custom values.
+ */
+export function describeAttachmentAllowlistState(
+  tags: Array<{ id: string; text: string }> | undefined,
+  inherit: boolean
+): AttachmentAllowlistState {
+  if (inherit || tags === undefined) {
+    return {
+      label: "Inherited defaults",
+      description: "Uses system attachment defaults.",
+    }
+  }
+
+  if (tags.length === 0) {
+    return {
+      label: "Uploads disabled",
+      description:
+        "No values are allowed until you add entries or restore inherited defaults.",
+    }
+  }
+
+  return {
+    label: "Custom allowlist",
+    description: "Only the listed values are allowed.",
+  }
+}
+
 /**
  * Convert persisted attachment allowlist values into tag input values.
  */
@@ -150,95 +187,121 @@ export function WorkspaceFilesSettings({
         <FormField
           control={form.control}
           name="allowed_attachment_extensions"
-          render={({ field }) => (
-            <FormItem>
-              <div className="flex items-center justify-between">
-                <FormLabel>Allowed file extensions</FormLabel>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  aria-label="Restore inherited file extensions"
-                  onClick={() => {
-                    setInheritAttachmentExtensions(true)
-                    field.onChange(
-                      systemDefaultExtensions.map((ext, index) => ({
-                        id: `ext-default-${index}`,
-                        text: ext,
-                      }))
-                    )
-                  }}
-                  className="h-auto p-1"
-                >
-                  <RefreshCwIcon className="size-3" />
-                </Button>
-              </div>
-              <FormControl>
-                <CustomTagInput
-                  {...field}
-                  placeholder="Enter an extension..."
-                  tags={field.value || []}
-                  setTags={(tags) => {
-                    setInheritAttachmentExtensions(false)
-                    field.onChange(tags)
-                  }}
-                />
-              </FormControl>
-              <FormDescription>
-                Add file extensions that users can upload as attachments (e.g.,
-                .pdf, .docx, .png). Clearing all values disables uploads; use
-                the reset button to restore inherited defaults.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
+          render={({ field }) => {
+            const allowlistState = describeAttachmentAllowlistState(
+              field.value,
+              inheritAttachmentExtensions
+            )
+
+            return (
+              <FormItem>
+                <div className="flex items-center justify-between">
+                  <FormLabel>Allowed file extensions</FormLabel>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label="Restore inherited file extensions"
+                    onClick={() => {
+                      setInheritAttachmentExtensions(true)
+                      field.onChange(
+                        systemDefaultExtensions.map((ext, index) => ({
+                          id: `ext-default-${index}`,
+                          text: ext,
+                        }))
+                      )
+                    }}
+                    className="h-auto p-1"
+                  >
+                    <RefreshCwIcon className="size-3" />
+                  </Button>
+                </div>
+                <FormControl>
+                  <CustomTagInput
+                    {...field}
+                    placeholder="Enter an extension..."
+                    tags={field.value || []}
+                    setTags={(tags) => {
+                      setInheritAttachmentExtensions(false)
+                      field.onChange(tags)
+                    }}
+                  />
+                </FormControl>
+                <FormDescription>
+                  <span className="block">
+                    Add file extensions that users can upload as attachments
+                    (e.g., .pdf, .docx, .png). Clearing all values disables
+                    uploads; use the reset button to restore inherited defaults.
+                  </span>
+                  <span className="block">
+                    Current policy: {allowlistState.label}.{" "}
+                    {allowlistState.description}
+                  </span>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )
+          }}
         />
 
         <FormField
           control={form.control}
           name="allowed_attachment_mime_types"
-          render={({ field }) => (
-            <FormItem>
-              <div className="flex items-center justify-between">
-                <FormLabel>Allowed MIME types</FormLabel>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  aria-label="Restore inherited MIME types"
-                  onClick={() => {
-                    setInheritAttachmentMimeTypes(true)
-                    field.onChange(
-                      systemDefaultMimeTypes.map((mime, index) => ({
-                        id: `mime-default-${index}`,
-                        text: mime,
-                      }))
-                    )
-                  }}
-                  className="h-auto p-1"
-                >
-                  <RefreshCwIcon className="size-3" />
-                </Button>
-              </div>
-              <FormControl>
-                <CustomTagInput
-                  {...field}
-                  placeholder="Enter a MIME type..."
-                  tags={field.value || []}
-                  setTags={(tags) => {
-                    setInheritAttachmentMimeTypes(false)
-                    field.onChange(tags)
-                  }}
-                />
-              </FormControl>
-              <FormDescription>
-                Add MIME types that are allowed for attachments (e.g.,
-                application/pdf, image/jpeg). Clearing all values disables
-                uploads; use the reset button to restore inherited defaults.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
+          render={({ field }) => {
+            const allowlistState = describeAttachmentAllowlistState(
+              field.value,
+              inheritAttachmentMimeTypes
+            )
+
+            return (
+              <FormItem>
+                <div className="flex items-center justify-between">
+                  <FormLabel>Allowed MIME types</FormLabel>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label="Restore inherited MIME types"
+                    onClick={() => {
+                      setInheritAttachmentMimeTypes(true)
+                      field.onChange(
+                        systemDefaultMimeTypes.map((mime, index) => ({
+                          id: `mime-default-${index}`,
+                          text: mime,
+                        }))
+                      )
+                    }}
+                    className="h-auto p-1"
+                  >
+                    <RefreshCwIcon className="size-3" />
+                  </Button>
+                </div>
+                <FormControl>
+                  <CustomTagInput
+                    {...field}
+                    placeholder="Enter a MIME type..."
+                    tags={field.value || []}
+                    setTags={(tags) => {
+                      setInheritAttachmentMimeTypes(false)
+                      field.onChange(tags)
+                    }}
+                  />
+                </FormControl>
+                <FormDescription>
+                  <span className="block">
+                    Add MIME types that are allowed for attachments (e.g.,
+                    application/pdf, image/jpeg). Clearing all values disables
+                    uploads; use the reset button to restore inherited defaults.
+                  </span>
+                  <span className="block">
+                    Current policy: {allowlistState.label}.{" "}
+                    {allowlistState.description}
+                  </span>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )
+          }}
         />
 
         <FormField

--- a/frontend/src/components/settings/workspace-files-settings.tsx
+++ b/frontend/src/components/settings/workspace-files-settings.tsx
@@ -41,31 +41,61 @@ export const filesSettingsSchema = z.object({
 })
 
 type FilesSettingsForm = z.infer<typeof filesSettingsSchema>
+type AttachmentTag = NonNullable<
+  FilesSettingsForm["allowed_attachment_extensions"]
+>[number]
+
+/**
+ * Convert persisted attachment allowlist values into tag input values.
+ */
+export function buildAttachmentTags(
+  values: string[] | null | undefined,
+  idPrefix: string
+): AttachmentTag[] | undefined {
+  if (values === undefined || values === null) {
+    return undefined
+  }
+
+  return values.map((text, index) => ({
+    id: `${idPrefix}-${index}`,
+    text,
+  }))
+}
+
+function serializeAttachmentTags(
+  tags: AttachmentTag[] | undefined,
+  inherit: boolean
+): string[] | null | undefined {
+  if (inherit) {
+    return null
+  }
+  if (tags === undefined) {
+    return undefined
+  }
+  return tags.map((tag) => tag.text)
+}
 
 interface FilesSettingsUpdateOptions {
   inheritAttachmentExtensions?: boolean
   inheritAttachmentMimeTypes?: boolean
 }
 
+/**
+ * Serialize the files settings form into a workspace settings update payload.
+ */
 export function buildFilesSettingsUpdate(
   values: FilesSettingsForm,
   options: FilesSettingsUpdateOptions = {}
 ) {
   return {
-    allowed_attachment_extensions: options.inheritAttachmentExtensions
-      ? null
-      : values.allowed_attachment_extensions === undefined
-        ? undefined
-        : values.allowed_attachment_extensions.length > 0
-          ? values.allowed_attachment_extensions.map((ext) => ext.text)
-          : null,
-    allowed_attachment_mime_types: options.inheritAttachmentMimeTypes
-      ? null
-      : values.allowed_attachment_mime_types === undefined
-        ? undefined
-        : values.allowed_attachment_mime_types.length > 0
-          ? values.allowed_attachment_mime_types.map((mime) => mime.text)
-          : null,
+    allowed_attachment_extensions: serializeAttachmentTags(
+      values.allowed_attachment_extensions,
+      options.inheritAttachmentExtensions ?? false
+    ),
+    allowed_attachment_mime_types: serializeAttachmentTags(
+      values.allowed_attachment_mime_types,
+      options.inheritAttachmentMimeTypes ?? false
+    ),
     validate_attachment_magic_number: values.validate_attachment_magic_number,
   }
 }
@@ -92,24 +122,14 @@ export function WorkspaceFilesSettings({
     resolver: zodResolver(filesSettingsSchema),
     mode: "onChange",
     defaultValues: {
-      allowed_attachment_extensions: workspace.settings
-        ?.allowed_attachment_extensions?.length
-        ? workspace.settings.allowed_attachment_extensions.map(
-            (ext, index) => ({
-              id: `ext-${index}`,
-              text: ext,
-            })
-          )
-        : undefined,
-      allowed_attachment_mime_types: workspace.settings
-        ?.allowed_attachment_mime_types?.length
-        ? workspace.settings.allowed_attachment_mime_types.map(
-            (mime, index) => ({
-              id: `mime-${index}`,
-              text: mime,
-            })
-          )
-        : undefined,
+      allowed_attachment_extensions: buildAttachmentTags(
+        workspace.settings?.allowed_attachment_extensions,
+        "ext"
+      ),
+      allowed_attachment_mime_types: buildAttachmentTags(
+        workspace.settings?.allowed_attachment_mime_types,
+        "mime"
+      ),
       validate_attachment_magic_number:
         workspace.settings?.validate_attachment_magic_number ?? true,
     },

--- a/frontend/src/lib/cases/attachment-errors.ts
+++ b/frontend/src/lib/cases/attachment-errors.ts
@@ -4,6 +4,7 @@ interface ApiErrorDetail {
   error?: string
   message?: string
   allowed_extensions?: string[]
+  allowed_types?: string[]
   current_count?: number
   max_count?: number
   current_size_mb?: number
@@ -36,6 +37,15 @@ function getErrorDetail(error: ApiError): ApiErrorDetail | string | undefined {
   return undefined
 }
 
+function buildUploadsDisabledToast(
+  fileName: string
+): AttachmentUploadErrorToast {
+  return {
+    title: "Attachment uploads disabled",
+    description: `${fileName} cannot be uploaded because uploads are disabled for this workspace.`,
+  }
+}
+
 /**
  * Map a case attachment upload failure to a human-readable toast payload.
  *
@@ -64,10 +74,7 @@ export function describeAttachmentUploadError(
   switch (detailObject?.error) {
     case "unsupported_file_extension": {
       if (detailObject.allowed_extensions?.length === 0) {
-        return {
-          title: "Attachment uploads disabled",
-          description: `${fileName} cannot be uploaded because uploads are disabled for this workspace.`,
-        }
+        return buildUploadsDisabledToast(fileName)
       }
 
       return {
@@ -79,6 +86,10 @@ export function describeAttachmentUploadError(
       }
     }
     case "unsupported_content_type":
+      if (detailObject.allowed_types?.length === 0) {
+        return buildUploadsDisabledToast(fileName)
+      }
+
       return {
         title: "Content type not supported",
         description: `${fileName} has an unsupported content type. Please try a different file type.`,

--- a/frontend/src/lib/cases/attachment-errors.ts
+++ b/frontend/src/lib/cases/attachment-errors.ts
@@ -79,10 +79,9 @@ export function describeAttachmentUploadError(
 
       return {
         title: "File type not supported",
-        description: `${fileName} cannot be uploaded. Allowed file types: ${
-          detailObject.allowed_extensions?.join(", ") ||
-          "txt, pdf, png, jpeg, gif, csv"
-        }`,
+        description: detailObject.allowed_extensions?.length
+          ? `${fileName} cannot be uploaded. Allowed file types: ${detailObject.allowed_extensions.join(", ")}`
+          : `${fileName} cannot be uploaded. Allowed file types are controlled by workspace policy.`,
       }
     }
     case "unsupported_content_type":

--- a/frontend/src/lib/cases/attachment-errors.ts
+++ b/frontend/src/lib/cases/attachment-errors.ts
@@ -62,7 +62,14 @@ export function describeAttachmentUploadError(
   const detailObject = typeof detail === "object" ? detail : undefined
 
   switch (detailObject?.error) {
-    case "unsupported_file_extension":
+    case "unsupported_file_extension": {
+      if (detailObject.allowed_extensions?.length === 0) {
+        return {
+          title: "Attachment uploads disabled",
+          description: `${fileName} cannot be uploaded because uploads are disabled for this workspace.`,
+        }
+      }
+
       return {
         title: "File type not supported",
         description: `${fileName} cannot be uploaded. Allowed file types: ${
@@ -70,6 +77,7 @@ export function describeAttachmentUploadError(
           "txt, pdf, png, jpeg, gif, csv"
         }`,
       }
+    }
     case "unsupported_content_type":
       return {
         title: "Content type not supported",

--- a/frontend/tests/case-attachment-upload-policy.test.ts
+++ b/frontend/tests/case-attachment-upload-policy.test.ts
@@ -3,23 +3,31 @@ import { describeAttachmentUploadError } from "@/lib/cases/attachment-errors"
 
 describe("case attachment upload policy", () => {
   it("disables uploads when effective extensions are explicitly empty", () => {
-    expect(buildAttachmentUploadPolicy([])).toEqual({
+    expect(buildAttachmentUploadPolicy([], undefined)).toEqual({
+      uploadsDisabled: true,
+    })
+  })
+
+  it("disables uploads when effective MIME types are explicitly empty", () => {
+    expect(buildAttachmentUploadPolicy([".pdf"], [])).toEqual({
       uploadsDisabled: true,
     })
   })
 
   it("builds an accept attribute for non-empty effective extensions", () => {
-    expect(buildAttachmentUploadPolicy([".pdf", ".png"])).toEqual({
+    expect(
+      buildAttachmentUploadPolicy([".pdf", ".png"], ["application/pdf"])
+    ).toEqual({
       uploadsDisabled: false,
       acceptAttribute: ".pdf,.png",
     })
   })
 
   it("inherits server defaults for null or undefined effective extensions", () => {
-    expect(buildAttachmentUploadPolicy(null)).toEqual({
+    expect(buildAttachmentUploadPolicy(null, null)).toEqual({
       uploadsDisabled: false,
     })
-    expect(buildAttachmentUploadPolicy(undefined)).toEqual({
+    expect(buildAttachmentUploadPolicy(undefined, undefined)).toEqual({
       uploadsDisabled: false,
     })
   })
@@ -66,6 +74,28 @@ describe("describeAttachmentUploadError", () => {
       title: "File type not supported",
       description:
         "blocked.exe cannot be uploaded. Allowed file types: txt, pdf, png, jpeg, gif, csv",
+    })
+  })
+
+  it("treats empty allowed MIME types as disabled uploads", () => {
+    const toast = describeAttachmentUploadError(
+      {
+        status: 415,
+        message: "Unsupported content type",
+        body: {
+          detail: {
+            error: "unsupported_content_type",
+            allowed_types: [],
+          },
+        },
+      },
+      "blocked.txt"
+    )
+
+    expect(toast).toEqual({
+      title: "Attachment uploads disabled",
+      description:
+        "blocked.txt cannot be uploaded because uploads are disabled for this workspace.",
     })
   })
 })

--- a/frontend/tests/case-attachment-upload-policy.test.ts
+++ b/frontend/tests/case-attachment-upload-policy.test.ts
@@ -56,7 +56,7 @@ describe("describeAttachmentUploadError", () => {
     })
   })
 
-  it("preserves default file type fallback when allowed extensions are absent", () => {
+  it("uses policy-based fallback when allowed extensions are absent", () => {
     const toast = describeAttachmentUploadError(
       {
         status: 415,
@@ -73,7 +73,7 @@ describe("describeAttachmentUploadError", () => {
     expect(toast).toEqual({
       title: "File type not supported",
       description:
-        "blocked.exe cannot be uploaded. Allowed file types: txt, pdf, png, jpeg, gif, csv",
+        "blocked.exe cannot be uploaded. Allowed file types are controlled by workspace policy.",
     })
   })
 

--- a/frontend/tests/case-attachment-upload-policy.test.ts
+++ b/frontend/tests/case-attachment-upload-policy.test.ts
@@ -1,0 +1,71 @@
+import { buildAttachmentUploadPolicy } from "@/components/cases/case-attachments-section"
+import { describeAttachmentUploadError } from "@/lib/cases/attachment-errors"
+
+describe("case attachment upload policy", () => {
+  it("disables uploads when effective extensions are explicitly empty", () => {
+    expect(buildAttachmentUploadPolicy([])).toEqual({
+      uploadsDisabled: true,
+    })
+  })
+
+  it("builds an accept attribute for non-empty effective extensions", () => {
+    expect(buildAttachmentUploadPolicy([".pdf", ".png"])).toEqual({
+      uploadsDisabled: false,
+      acceptAttribute: ".pdf,.png",
+    })
+  })
+
+  it("inherits server defaults for null or undefined effective extensions", () => {
+    expect(buildAttachmentUploadPolicy(null)).toEqual({
+      uploadsDisabled: false,
+    })
+    expect(buildAttachmentUploadPolicy(undefined)).toEqual({
+      uploadsDisabled: false,
+    })
+  })
+})
+
+describe("describeAttachmentUploadError", () => {
+  it("does not fall back to default file types for empty allowed extensions", () => {
+    const toast = describeAttachmentUploadError(
+      {
+        status: 415,
+        message: "Unsupported file extension",
+        body: {
+          detail: {
+            error: "unsupported_file_extension",
+            allowed_extensions: [],
+          },
+        },
+      },
+      "blocked.exe"
+    )
+
+    expect(toast).toEqual({
+      title: "Attachment uploads disabled",
+      description:
+        "blocked.exe cannot be uploaded because uploads are disabled for this workspace.",
+    })
+  })
+
+  it("preserves default file type fallback when allowed extensions are absent", () => {
+    const toast = describeAttachmentUploadError(
+      {
+        status: 415,
+        message: "Unsupported file extension",
+        body: {
+          detail: {
+            error: "unsupported_file_extension",
+          },
+        },
+      },
+      "blocked.exe"
+    )
+
+    expect(toast).toEqual({
+      title: "File type not supported",
+      description:
+        "blocked.exe cannot be uploaded. Allowed file types: txt, pdf, png, jpeg, gif, csv",
+    })
+  })
+})

--- a/frontend/tests/case-attachments-section.test.tsx
+++ b/frontend/tests/case-attachments-section.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { caseAttachmentsListAttachments } from "@/client"
+import { CaseAttachmentsSection } from "@/components/cases/case-attachments-section"
+import { toast } from "@/components/ui/use-toast"
+import { useWorkspaceDetails } from "@/hooks/use-workspace"
+
+jest.mock("@/client", () => {
+  const actual = jest.requireActual("@/client")
+  return {
+    ...actual,
+    caseAttachmentsCreateAttachment: jest.fn(),
+    caseAttachmentsDeleteAttachment: jest.fn(),
+    caseAttachmentsDownloadAttachment: jest.fn(),
+    caseAttachmentsListAttachments: jest.fn(),
+  }
+})
+
+jest.mock("@/hooks/use-workspace", () => ({
+  useWorkspaceDetails: jest.fn(),
+}))
+
+jest.mock("@/components/ui/use-toast", () => ({
+  toast: jest.fn(),
+}))
+
+const mockCaseAttachmentsListAttachments =
+  caseAttachmentsListAttachments as jest.MockedFunction<
+    typeof caseAttachmentsListAttachments
+  >
+const mockToast = toast as jest.MockedFunction<typeof toast>
+const mockUseWorkspaceDetails = useWorkspaceDetails as jest.MockedFunction<
+  typeof useWorkspaceDetails
+>
+
+function renderCaseAttachmentsSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CaseAttachmentsSection caseId="case-1" workspaceId="workspace-1" />
+    </QueryClientProvider>
+  )
+}
+
+describe("CaseAttachmentsSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCaseAttachmentsListAttachments.mockResolvedValue([])
+    mockUseWorkspaceDetails.mockReturnValue({
+      workspace: {
+        settings: {
+          effective_allowed_attachment_extensions: [] as string[],
+          effective_allowed_attachment_mime_types: null,
+        },
+      },
+      workspaceLoading: false,
+      workspaceError: null,
+    } as unknown as ReturnType<typeof useWorkspaceDetails>)
+  })
+
+  it("keeps disabled attachment upload control tabbable and blocks file picker on Enter", async () => {
+    const inputClickSpy = jest.spyOn(HTMLInputElement.prototype, "click")
+
+    renderCaseAttachmentsSection()
+
+    const uploadControl = await screen.findByRole("button", {
+      name: "Attachment uploads disabled",
+    })
+
+    expect(uploadControl).toHaveAttribute("aria-disabled", "true")
+    expect(uploadControl).toHaveAttribute("tabindex", "0")
+
+    fireEvent.keyDown(uploadControl, { key: "Enter" })
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "Attachment uploads disabled",
+        description: "Uploads are disabled for this workspace.",
+      })
+    })
+    expect(inputClickSpy).not.toHaveBeenCalled()
+
+    inputClickSpy.mockRestore()
+  })
+})

--- a/frontend/tests/case-attachments-section.test.tsx
+++ b/frontend/tests/case-attachments-section.test.tsx
@@ -4,7 +4,10 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { caseAttachmentsListAttachments } from "@/client"
+import {
+  caseAttachmentsCreateAttachment,
+  caseAttachmentsListAttachments,
+} from "@/client"
 import { CaseAttachmentsSection } from "@/components/cases/case-attachments-section"
 import { toast } from "@/components/ui/use-toast"
 import { useWorkspaceDetails } from "@/hooks/use-workspace"
@@ -28,6 +31,10 @@ jest.mock("@/components/ui/use-toast", () => ({
   toast: jest.fn(),
 }))
 
+const mockCaseAttachmentsCreateAttachment =
+  caseAttachmentsCreateAttachment as jest.MockedFunction<
+    typeof caseAttachmentsCreateAttachment
+  >
 const mockCaseAttachmentsListAttachments =
   caseAttachmentsListAttachments as jest.MockedFunction<
     typeof caseAttachmentsListAttachments
@@ -92,4 +99,47 @@ describe("CaseAttachmentsSection", () => {
 
     inputClickSpy.mockRestore()
   })
+
+  it.each([
+    { label: "loading", workspace: undefined, workspaceLoading: true },
+    { label: "unknown", workspace: undefined, workspaceLoading: false },
+  ])(
+    "keeps attachment uploads non-interactive while workspace settings are $label",
+    async ({ workspace, workspaceLoading }) => {
+      mockUseWorkspaceDetails.mockReturnValue({
+        workspace,
+        workspaceLoading,
+        workspaceError: null,
+      } as unknown as ReturnType<typeof useWorkspaceDetails>)
+      const inputClickSpy = jest.spyOn(HTMLInputElement.prototype, "click")
+
+      const { container } = renderCaseAttachmentsSection()
+
+      const uploadControl = await screen.findByRole("button", {
+        name: "Loading attachment policy...",
+      })
+      const fileInput =
+        container.querySelector<HTMLInputElement>('input[type="file"]')
+
+      expect(uploadControl).toHaveAttribute("aria-disabled", "true")
+      expect(fileInput).not.toBeNull()
+      expect(fileInput).toBeDisabled()
+
+      fireEvent.click(uploadControl)
+      fireEvent.keyDown(uploadControl, { key: "Enter" })
+      fireEvent.drop(uploadControl, {
+        dataTransfer: {
+          files: [
+            new File(["content"], "evidence.txt", { type: "text/plain" }),
+          ],
+        },
+      })
+
+      expect(inputClickSpy).not.toHaveBeenCalled()
+      expect(mockCaseAttachmentsCreateAttachment).not.toHaveBeenCalled()
+      expect(mockToast).not.toHaveBeenCalled()
+
+      inputClickSpy.mockRestore()
+    }
+  )
 })

--- a/frontend/tests/workspace-files-settings.test.ts
+++ b/frontend/tests/workspace-files-settings.test.ts
@@ -116,6 +116,46 @@ describe("workspace files settings", () => {
     })
   })
 
+  it("clears stale custom MIME type tags when restoring inherited defaults", async () => {
+    const workspace = createWorkspace()
+    const updateWorkspace = jest.fn().mockResolvedValue(undefined)
+    mockUseWorkspaceSettings.mockReturnValue({
+      deleteWorkspace: jest.fn(),
+      isDeleting: false,
+      isUpdating: false,
+      updateWorkspace,
+    } as unknown as ReturnType<typeof useWorkspaceSettings>)
+
+    render(createElement(WorkspaceFilesSettings, { workspace }))
+
+    expect(screen.getByText("application/x-msdownload")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Restore inherited MIME types",
+      })
+    )
+
+    expect(
+      screen.queryByText("application/x-msdownload")
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/Current policy: Inherited defaults/)
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(updateWorkspace).toHaveBeenCalledWith({
+        settings: {
+          allowed_attachment_extensions: [".exe"],
+          allowed_attachment_mime_types: null,
+          validate_attachment_magic_number: true,
+        },
+      })
+    })
+  })
+
   it("sends empty arrays when attachment override lists are cleared", () => {
     const result = buildFilesSettingsUpdate({
       allowed_attachment_extensions: [],

--- a/frontend/tests/workspace-files-settings.test.ts
+++ b/frontend/tests/workspace-files-settings.test.ts
@@ -1,6 +1,7 @@
 import {
   buildAttachmentTags,
   buildFilesSettingsUpdate,
+  describeAttachmentAllowlistState,
   filesSettingsSchema,
 } from "@/components/settings/workspace-files-settings"
 
@@ -61,6 +62,28 @@ describe("workspace files settings", () => {
       allowed_attachment_extensions: null,
       allowed_attachment_mime_types: null,
       validate_attachment_magic_number: true,
+    })
+  })
+
+  it("describes inherited, disabled, and custom attachment allowlist states", () => {
+    expect(describeAttachmentAllowlistState(undefined, false)).toEqual({
+      label: "Inherited defaults",
+      description: "Uses system attachment defaults.",
+    })
+    expect(describeAttachmentAllowlistState([], false)).toEqual({
+      label: "Uploads disabled",
+      description:
+        "No values are allowed until you add entries or restore inherited defaults.",
+    })
+    expect(
+      describeAttachmentAllowlistState([{ id: "ext-1", text: ".pdf" }], false)
+    ).toEqual({
+      label: "Custom allowlist",
+      description: "Only the listed values are allowed.",
+    })
+    expect(describeAttachmentAllowlistState([], true)).toEqual({
+      label: "Inherited defaults",
+      description: "Uses system attachment defaults.",
     })
   })
 

--- a/frontend/tests/workspace-files-settings.test.ts
+++ b/frontend/tests/workspace-files-settings.test.ts
@@ -1,10 +1,11 @@
 import {
+  buildAttachmentTags,
   buildFilesSettingsUpdate,
   filesSettingsSchema,
 } from "@/components/settings/workspace-files-settings"
 
 describe("workspace files settings", () => {
-  it("sends null when attachment override lists are cleared", () => {
+  it("sends empty arrays when attachment override lists are cleared", () => {
     const result = buildFilesSettingsUpdate({
       allowed_attachment_extensions: [],
       allowed_attachment_mime_types: [],
@@ -12,10 +13,17 @@ describe("workspace files settings", () => {
     })
 
     expect(result).toEqual({
-      allowed_attachment_extensions: null,
-      allowed_attachment_mime_types: null,
+      allowed_attachment_extensions: [],
+      allowed_attachment_mime_types: [],
       validate_attachment_magic_number: true,
     })
+  })
+
+  it("round-trips stored empty attachment allowlists as empty tag lists", () => {
+    expect(buildAttachmentTags([], "ext")).toEqual([])
+    expect(buildAttachmentTags([], "mime")).toEqual([])
+    expect(buildAttachmentTags(null, "ext")).toBeUndefined()
+    expect(buildAttachmentTags(undefined, "mime")).toBeUndefined()
   })
 
   it("keeps configured attachment override lists when present", () => {

--- a/frontend/tests/workspace-files-settings.test.ts
+++ b/frontend/tests/workspace-files-settings.test.ts
@@ -1,11 +1,121 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { createElement } from "react"
+import type { WorkspaceRead } from "@/client"
 import {
   buildAttachmentTags,
   buildFilesSettingsUpdate,
   describeAttachmentAllowlistState,
   filesSettingsSchema,
+  WorkspaceFilesSettings,
 } from "@/components/settings/workspace-files-settings"
+import { useWorkspaceSettings } from "@/lib/hooks"
+
+jest.mock("@/components/tags-input", () => {
+  const React = require("react") as typeof import("react")
+
+  interface MockTag {
+    id: string
+    text: string
+  }
+
+  interface MockCustomTagInputProps {
+    placeholder?: string
+    tags?: MockTag[]
+    setTags: (tags: MockTag[]) => void
+  }
+
+  const CustomTagInput = React.forwardRef<
+    HTMLDivElement,
+    MockCustomTagInputProps
+  >(function CustomTagInput({ placeholder, tags = [], setTags }, ref) {
+    return React.createElement(
+      "div",
+      { "data-testid": placeholder, ref },
+      tags.map((tag) => React.createElement("span", { key: tag.id }, tag.text)),
+      React.createElement(
+        "button",
+        {
+          "aria-label": `Clear ${placeholder}`,
+          onClick: () => setTags([]),
+          type: "button",
+        },
+        "Clear"
+      )
+    )
+  })
+
+  return { CustomTagInput }
+})
+
+jest.mock("@/lib/hooks", () => ({
+  useWorkspaceSettings: jest.fn(),
+}))
+
+const mockUseWorkspaceSettings = jest.mocked(useWorkspaceSettings)
+
+function createWorkspace(): WorkspaceRead {
+  return {
+    id: "workspace-id",
+    name: "Workspace",
+    organization_id: "organization-id",
+    settings: {
+      allowed_attachment_extensions: [".exe"],
+      allowed_attachment_mime_types: ["application/x-msdownload"],
+      effective_allowed_attachment_extensions: [".exe"],
+      effective_allowed_attachment_mime_types: ["application/x-msdownload"],
+      validate_attachment_magic_number: true,
+    },
+  }
+}
 
 describe("workspace files settings", () => {
+  beforeEach(() => {
+    mockUseWorkspaceSettings.mockReturnValue({
+      deleteWorkspace: jest.fn(),
+      isDeleting: false,
+      isUpdating: false,
+      updateWorkspace: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof useWorkspaceSettings>)
+  })
+
+  it("clears stale custom extension tags when restoring inherited defaults", async () => {
+    const workspace = createWorkspace()
+    const updateWorkspace = jest.fn().mockResolvedValue(undefined)
+    mockUseWorkspaceSettings.mockReturnValue({
+      deleteWorkspace: jest.fn(),
+      isDeleting: false,
+      isUpdating: false,
+      updateWorkspace,
+    } as unknown as ReturnType<typeof useWorkspaceSettings>)
+
+    render(createElement(WorkspaceFilesSettings, { workspace }))
+
+    expect(screen.getByText(".exe")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Restore inherited file extensions",
+      })
+    )
+
+    expect(screen.queryByText(".exe")).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/Current policy: Inherited defaults/)
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(updateWorkspace).toHaveBeenCalledWith({
+        settings: {
+          allowed_attachment_extensions: null,
+          allowed_attachment_mime_types: ["application/x-msdownload"],
+          validate_attachment_magic_number: true,
+        },
+      })
+    })
+  })
+
   it("sends empty arrays when attachment override lists are cleared", () => {
     const result = buildFilesSettingsUpdate({
       allowed_attachment_extensions: [],

--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -698,7 +698,7 @@ async def _upload_attachment(
 @registry.register(
     default_title="Upload attachment",
     display_group="Cases",
-    description="Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values.",
+    description="Upload a file attachment to a case. Uploads are governed by workspace attachment settings. In workspace settings, null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads.",
     namespace="core.cases",
 )
 async def upload_attachment(
@@ -719,7 +719,7 @@ async def upload_attachment(
         Doc("The MIME type of the file (e.g., 'application/pdf')."),
     ],
 ) -> types.CaseAttachmentRead:
-    """Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values."""
+    """Upload a file attachment to a case. Uploads are governed by workspace attachment settings. In workspace settings, null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads."""
     # Decode base64 content
     try:
         content = base64.b64decode(content_base64, validate=True)
@@ -747,7 +747,7 @@ def _infer_filename_from_url(url: str) -> str:
 @registry.register(
     default_title="Upload attachment from URL",
     display_group="Cases",
-    description="Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values.",
+    description="Upload a file attachment to a case from a URL. Uploads are governed by workspace attachment settings. In workspace settings, null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads.",
     namespace="core.cases",
 )
 async def upload_attachment_from_url(
@@ -770,7 +770,7 @@ async def upload_attachment_from_url(
         ),
     ] = None,
 ) -> types.CaseAttachmentRead:
-    """Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values."""
+    """Upload a file attachment to a case from a URL. Uploads are governed by workspace attachment settings. In workspace settings, null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads."""
     async with httpx.AsyncClient() as client:
         response = await client.get(url, headers=headers)
         response.raise_for_status()

--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -698,7 +698,7 @@ async def _upload_attachment(
 @registry.register(
     default_title="Upload attachment",
     display_group="Cases",
-    description="Upload a file attachment to a case. File size and type restrictions apply for security.",
+    description="Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads.",
     namespace="core.cases",
 )
 async def upload_attachment(
@@ -719,7 +719,7 @@ async def upload_attachment(
         Doc("The MIME type of the file (e.g., 'application/pdf')."),
     ],
 ) -> types.CaseAttachmentRead:
-    """Upload a file attachment to a case."""
+    """Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads."""
     # Decode base64 content
     try:
         content = base64.b64decode(content_base64, validate=True)
@@ -747,7 +747,7 @@ def _infer_filename_from_url(url: str) -> str:
 @registry.register(
     default_title="Upload attachment from URL",
     display_group="Cases",
-    description="Upload a file attachment to a case from a URL.",
+    description="Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads.",
     namespace="core.cases",
 )
 async def upload_attachment_from_url(
@@ -770,7 +770,7 @@ async def upload_attachment_from_url(
         ),
     ] = None,
 ) -> types.CaseAttachmentRead:
-    """Upload a file attachment to a case from a URL."""
+    """Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads."""
     async with httpx.AsyncClient() as client:
         response = await client.get(url, headers=headers)
         response.raise_for_status()

--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -698,7 +698,7 @@ async def _upload_attachment(
 @registry.register(
     default_title="Upload attachment",
     display_group="Cases",
-    description="Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads.",
+    description="Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values.",
     namespace="core.cases",
 )
 async def upload_attachment(
@@ -719,7 +719,7 @@ async def upload_attachment(
         Doc("The MIME type of the file (e.g., 'application/pdf')."),
     ],
 ) -> types.CaseAttachmentRead:
-    """Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads."""
+    """Upload a file attachment to a case. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values."""
     # Decode base64 content
     try:
         content = base64.b64decode(content_base64, validate=True)
@@ -747,7 +747,7 @@ def _infer_filename_from_url(url: str) -> str:
 @registry.register(
     default_title="Upload attachment from URL",
     display_group="Cases",
-    description="Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads.",
+    description="Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values.",
     namespace="core.cases",
 )
 async def upload_attachment_from_url(
@@ -770,7 +770,7 @@ async def upload_attachment_from_url(
         ),
     ] = None,
 ) -> types.CaseAttachmentRead:
-    """Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults and [] disables uploads."""
+    """Upload a file attachment to a case from a URL. Workspace attachment settings control allowed extensions and MIME types; null inherits defaults, [] disables uploads, and non-empty allowlists restrict uploads to those values."""
     async with httpx.AsyncClient() as client:
         response = await client.get(url, headers=headers)
         response.raise_for_status()

--- a/tests/unit/test_case_attachment_allowlists.py
+++ b/tests/unit/test_case_attachment_allowlists.py
@@ -50,7 +50,7 @@ def test_explicit_empty_workspace_allowlists_reject_attachment_like_input() -> N
 
 
 @pytest.mark.anyio
-async def test_create_attachment_rejects_explicit_empty_workspace_allowlists_before_blob_or_db(
+async def test_create_attachment_rejects_explicit_empty_workspace_allowlists_before_blob_or_file_writes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workspace_id = uuid.UUID("00000000-0000-4000-8000-000000000001")
@@ -100,7 +100,6 @@ async def test_create_attachment_rejects_explicit_empty_workspace_allowlists_bef
         await service.create_attachment(case=case, params=params)  # type: ignore[arg-type]
 
     upload.assert_not_awaited()
-    session.execute.assert_not_awaited()
     session.add.assert_not_called()
     session.flush.assert_not_awaited()
     session.commit.assert_not_awaited()

--- a/tests/unit/test_case_attachment_allowlists.py
+++ b/tests/unit/test_case_attachment_allowlists.py
@@ -1,0 +1,17 @@
+from tracecat.cases.attachments.service import (
+    _attachment_allowlist_from_workspace_setting,
+)
+
+
+def test_attachment_allowlist_setting_none_inherits_defaults() -> None:
+    assert _attachment_allowlist_from_workspace_setting(None) is None
+
+
+def test_attachment_allowlist_setting_empty_list_is_preserved() -> None:
+    assert _attachment_allowlist_from_workspace_setting([]) == []
+
+
+def test_attachment_allowlist_setting_values_are_copied_to_list() -> None:
+    source = (".pdf", ".txt")
+
+    assert _attachment_allowlist_from_workspace_setting(source) == [".pdf", ".txt"]

--- a/tests/unit/test_case_attachment_allowlists.py
+++ b/tests/unit/test_case_attachment_allowlists.py
@@ -10,7 +10,7 @@ from tracecat.cases.attachments.service import (
     CaseAttachmentService,
     _resolve_workspace_attachment_allowlist,
 )
-from tracecat.storage.exceptions import FileExtensionError
+from tracecat.storage.exceptions import FileExtensionError, MaxAttachmentsExceededError
 from tracecat.storage.validation import FileSecurityValidator
 
 
@@ -50,7 +50,7 @@ def test_explicit_empty_workspace_allowlists_reject_attachment_like_input() -> N
 
 
 @pytest.mark.anyio
-async def test_create_attachment_rejects_explicit_empty_workspace_allowlists_before_blob_or_file_writes(
+async def test_create_attachment_rejects_explicit_empty_workspace_allowlists_before_case_limits_or_writes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workspace_id = uuid.UUID("00000000-0000-4000-8000-000000000001")
@@ -70,7 +70,14 @@ async def test_create_attachment_rejects_explicit_empty_workspace_allowlists_bef
         rollback=AsyncMock(),
     )
     service = CaseAttachmentService(session=session, role=role)  # type: ignore[arg-type]
-    monkeypatch.setattr(service, "_assert_case_limits", AsyncMock())
+    assert_case_limits = AsyncMock(
+        side_effect=MaxAttachmentsExceededError(
+            "Case already has 100 attachments. Maximum allowed is 100",
+            current_count=100,
+            max_count=100,
+        )
+    )
+    monkeypatch.setattr(service, "_assert_case_limits", assert_case_limits)
     monkeypatch.setattr(
         service,
         "_get_workspace",
@@ -99,6 +106,7 @@ async def test_create_attachment_rejects_explicit_empty_workspace_allowlists_bef
     with pytest.raises(FileExtensionError):
         await service.create_attachment(case=case, params=params)  # type: ignore[arg-type]
 
+    assert_case_limits.assert_not_awaited()
     upload.assert_not_awaited()
     session.add.assert_not_called()
     session.flush.assert_not_awaited()

--- a/tests/unit/test_case_attachment_allowlists.py
+++ b/tests/unit/test_case_attachment_allowlists.py
@@ -1,17 +1,106 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from tracecat.auth.types import Role
+from tracecat.cases.attachments.schemas import CaseAttachmentCreate
 from tracecat.cases.attachments.service import (
-    _attachment_allowlist_from_workspace_setting,
+    CaseAttachmentService,
+    _resolve_workspace_attachment_allowlist,
 )
+from tracecat.storage.exceptions import FileExtensionError
+from tracecat.storage.validation import FileSecurityValidator
 
 
-def test_attachment_allowlist_setting_none_inherits_defaults() -> None:
-    assert _attachment_allowlist_from_workspace_setting(None) is None
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        (None, None),
+        ([], []),
+        ([".txt", ".pdf"], [".txt", ".pdf"]),
+        ((".txt",), [".txt"]),
+    ],
+)
+def test_resolve_workspace_attachment_allowlist_preserves_none_and_empty(
+    configured: list[str] | tuple[str, ...] | None,
+    expected: list[str] | None,
+) -> None:
+    resolved = _resolve_workspace_attachment_allowlist(configured)
+
+    assert resolved == expected
+    if configured is not None:
+        assert resolved is not configured
 
 
-def test_attachment_allowlist_setting_empty_list_is_preserved() -> None:
-    assert _attachment_allowlist_from_workspace_setting([]) == []
+def test_explicit_empty_workspace_allowlists_reject_attachment_like_input() -> None:
+    validator = FileSecurityValidator(
+        allowed_extensions=_resolve_workspace_attachment_allowlist([]),
+        allowed_mime_types=_resolve_workspace_attachment_allowlist([]),
+        validate_magic_number=False,
+    )
+
+    with pytest.raises(FileExtensionError):
+        validator.validate_file(
+            content=b"hello tracecat",
+            filename="hello.txt",
+            declared_mime_type="text/plain",
+        )
 
 
-def test_attachment_allowlist_setting_values_are_copied_to_list() -> None:
-    source = (".pdf", ".txt")
+@pytest.mark.anyio
+async def test_create_attachment_rejects_explicit_empty_workspace_allowlists_before_blob_or_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.UUID("00000000-0000-4000-8000-000000000001")
+    organization_id = uuid.UUID("00000000-0000-4000-8000-000000000002")
+    role = Role(
+        type="service",
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        service_id="tracecat-runner",
+    )
+    session = SimpleNamespace(
+        execute=AsyncMock(),
+        add=Mock(),
+        flush=AsyncMock(),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+        rollback=AsyncMock(),
+    )
+    service = CaseAttachmentService(session=session, role=role)  # type: ignore[arg-type]
+    monkeypatch.setattr(service, "_assert_case_limits", AsyncMock())
+    monkeypatch.setattr(
+        service,
+        "_get_workspace",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                settings={
+                    "allowed_attachment_extensions": [],
+                    "allowed_attachment_mime_types": [],
+                    "validate_attachment_magic_number": False,
+                }
+            )
+        ),
+    )
+    upload = AsyncMock()
+    monkeypatch.setattr(service, "_upload_to_attachments_bucket", upload)
 
-    assert _attachment_allowlist_from_workspace_setting(source) == [".pdf", ".txt"]
+    content = b"hello tracecat"
+    params = CaseAttachmentCreate(
+        file_name="hello.txt",
+        content_type="text/plain",
+        size=len(content),
+        content=content,
+    )
+    case = SimpleNamespace(id=uuid.UUID("00000000-0000-4000-8000-000000000003"))
+
+    with pytest.raises(FileExtensionError):
+        await service.create_attachment(case=case, params=params)  # type: ignore[arg-type]
+
+    upload.assert_not_awaited()
+    session.execute.assert_not_awaited()
+    session.add.assert_not_called()
+    session.flush.assert_not_awaited()
+    session.commit.assert_not_awaited()

--- a/tests/unit/test_case_attachment_internal_router.py
+++ b/tests/unit/test_case_attachment_internal_router.py
@@ -1,0 +1,70 @@
+import base64
+import uuid
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from tracecat.auth.types import Role
+from tracecat.cases.attachments import internal_router
+from tracecat.storage.exceptions import FileExtensionError
+
+
+@pytest.mark.anyio
+async def test_internal_create_attachment_maps_file_extension_error_to_415(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case_id = uuid.UUID("00000000-0000-4000-8000-000000000001")
+    workspace_id = uuid.UUID("00000000-0000-4000-8000-000000000002")
+    organization_id = uuid.UUID("00000000-0000-4000-8000-000000000003")
+    case = SimpleNamespace(id=case_id)
+
+    class AttachmentsStub:
+        create_attachment = AsyncMock(
+            side_effect=FileExtensionError(
+                "File extension '.txt' is not allowed",
+                extension=".txt",
+                allowed_extensions=[],
+            )
+        )
+
+    class CasesServiceStub:
+        def __init__(self, session: object, role: Role) -> None:
+            self.session = session
+            self.role = role
+            self.attachments = AttachmentsStub()
+
+        async def get_case(self, case_id: uuid.UUID) -> object:
+            return case
+
+    monkeypatch.setattr(internal_router, "CasesService", CasesServiceStub)
+
+    role = Role(
+        type="service",
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        service_id="tracecat-runner",
+        scopes=frozenset({"case:update"}),
+    )
+    params = internal_router.ExecutorAttachmentCreateRequest(
+        filename="hello.txt",
+        content_type="text/plain",
+        content_base64=base64.b64encode(b"hello tracecat").decode("utf-8"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_router.create_attachment(
+            role=role,
+            session=cast(Any, object()),
+            case_id=case_id,
+            params=params,
+        )
+
+    exc = exc_info.value
+    detail = cast(dict[str, object], exc.detail)
+    assert exc.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+    assert detail["error"] == "unsupported_file_extension"
+    assert detail["extension"] == ".txt"
+    assert detail["allowed_extensions"] == []

--- a/tests/unit/test_case_attachment_internal_router.py
+++ b/tests/unit/test_case_attachment_internal_router.py
@@ -9,7 +9,14 @@ from fastapi import HTTPException, status
 
 from tracecat.auth.types import Role
 from tracecat.cases.attachments import internal_router
-from tracecat.storage.exceptions import FileExtensionError
+from tracecat.storage.exceptions import (
+    FileContentMismatchError,
+    FileExtensionError,
+    FileMimeTypeError,
+    FileSizeError,
+    MaxAttachmentsExceededError,
+    StorageLimitExceededError,
+)
 
 
 @pytest.mark.anyio
@@ -68,3 +75,119 @@ async def test_internal_create_attachment_maps_file_extension_error_to_415(
     assert detail["error"] == "unsupported_file_extension"
     assert detail["extension"] == ".txt"
     assert detail["allowed_extensions"] == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("service_error", "expected_status", "expected_detail"),
+    [
+        pytest.param(
+            FileMimeTypeError(
+                "Content type 'text/plain' is not allowed",
+                mime_type="text/plain",
+                allowed_types=["image/png"],
+            ),
+            status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            {
+                "error": "unsupported_content_type",
+                "content_type": "text/plain",
+                "allowed_types": ["image/png"],
+            },
+            id="mime-type",
+        ),
+        pytest.param(
+            FileSizeError("File size exceeds the configured limit"),
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            {"error": "file_too_large"},
+            id="file-size",
+        ),
+        pytest.param(
+            MaxAttachmentsExceededError(
+                "Maximum attachments per case exceeded",
+                current_count=5,
+                max_count=5,
+            ),
+            status.HTTP_409_CONFLICT,
+            {
+                "error": "max_attachments_exceeded",
+                "current_count": 5,
+                "max_count": 5,
+            },
+            id="max-attachments",
+        ),
+        pytest.param(
+            StorageLimitExceededError(
+                "Case storage limit exceeded",
+                current_size=2 * 1024 * 1024,
+                new_file_size=1024 * 1024,
+                max_size=2 * 1024 * 1024,
+            ),
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            {
+                "error": "storage_limit_exceeded",
+                "current_size_mb": 2.0,
+                "new_file_size_mb": 1.0,
+                "max_size_mb": 2.0,
+            },
+            id="storage-limit",
+        ),
+        pytest.param(
+            FileContentMismatchError("File content does not match metadata"),
+            status.HTTP_400_BAD_REQUEST,
+            {"error": "file_validation_failed"},
+            id="content-mismatch",
+        ),
+    ],
+)
+async def test_internal_create_attachment_maps_service_errors_to_structured_http_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    service_error: Exception,
+    expected_status: int,
+    expected_detail: dict[str, object],
+) -> None:
+    case_id = uuid.UUID("00000000-0000-4000-8000-000000000001")
+    workspace_id = uuid.UUID("00000000-0000-4000-8000-000000000002")
+    organization_id = uuid.UUID("00000000-0000-4000-8000-000000000003")
+    case = SimpleNamespace(id=case_id)
+
+    class AttachmentsStub:
+        create_attachment = AsyncMock(side_effect=service_error)
+
+    class CasesServiceStub:
+        def __init__(self, session: object, role: Role) -> None:
+            self.session = session
+            self.role = role
+            self.attachments = AttachmentsStub()
+
+        async def get_case(self, case_id: uuid.UUID) -> object:
+            return case
+
+    monkeypatch.setattr(internal_router, "CasesService", CasesServiceStub)
+
+    role = Role(
+        type="service",
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        service_id="tracecat-runner",
+        scopes=frozenset({"case:update"}),
+    )
+    params = internal_router.ExecutorAttachmentCreateRequest(
+        filename="hello.png",
+        content_type="image/png",
+        content_base64=base64.b64encode(b"hello tracecat").decode("utf-8"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_router.create_attachment(
+            role=role,
+            session=cast(Any, object()),
+            case_id=case_id,
+            params=params,
+        )
+
+    exc = exc_info.value
+    detail = cast(dict[str, object], exc.detail)
+    assert exc.status_code == expected_status
+    assert detail["message"] == str(service_error)
+    for key, value in expected_detail.items():
+        assert detail[key] == value

--- a/tests/unit/test_storage_validation.py
+++ b/tests/unit/test_storage_validation.py
@@ -3,6 +3,7 @@ import zipfile
 
 import pytest
 
+from tracecat import config
 from tracecat.storage.exceptions import (
     FileExtensionError,
     FileMimeTypeError,
@@ -232,3 +233,63 @@ def test_vbscript_rejected_by_extension(
             filename="script.vbs",
             declared_mime_type="application/vbscript",
         )
+
+
+def test_explicit_empty_extension_allowlist_is_preserved_and_rejects() -> None:
+    validator = FileSecurityValidator(
+        allowed_extensions=[],
+        allowed_mime_types=["text/plain"],
+        validate_magic_number=False,
+    )
+
+    assert validator.allowed_extensions == []
+
+    with pytest.raises(FileExtensionError):
+        validator.validate_file(
+            content=b"hello tracecat",
+            filename="hello.txt",
+            declared_mime_type="text/plain",
+        )
+
+
+def test_explicit_empty_mime_allowlist_is_preserved_and_rejects() -> None:
+    validator = FileSecurityValidator(
+        allowed_extensions=[".txt"],
+        allowed_mime_types=[],
+        validate_magic_number=False,
+    )
+
+    assert validator.allowed_mime_types == []
+
+    with pytest.raises(FileMimeTypeError):
+        validator.validate_file(
+            content=b"hello tracecat",
+            filename="hello.txt",
+            declared_mime_type="text/plain",
+        )
+
+
+def test_none_allowlists_fall_back_to_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__ALLOWED_ATTACHMENT_EXTENSIONS",
+        [".txt"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__ALLOWED_ATTACHMENT_MIME_TYPES",
+        ["text/plain"],
+        raising=False,
+    )
+
+    validator = FileSecurityValidator(
+        allowed_extensions=None,
+        allowed_mime_types=None,
+        validate_magic_number=False,
+    )
+
+    assert validator.allowed_extensions == [".txt"]
+    assert validator.allowed_mime_types == ["text/plain"]

--- a/tests/unit/test_storage_validation.py
+++ b/tests/unit/test_storage_validation.py
@@ -74,6 +74,40 @@ def test_extension_not_allowed_raises(validator_basic: FileSecurityValidator) ->
         )
 
 
+def test_empty_extension_allowlist_rejects_all_extensions() -> None:
+    validator = FileSecurityValidator(
+        max_file_size=1024 * 1024,
+        max_filename_length=128,
+        allowed_extensions=[],
+        allowed_mime_types=["application/pdf"],
+        validate_magic_number=False,
+    )
+
+    with pytest.raises(FileExtensionError):
+        validator.validate_file(
+            content=pdf_bytes(),
+            filename="sample.pdf",
+            declared_mime_type="application/pdf",
+        )
+
+
+def test_empty_mime_allowlist_rejects_all_mime_types() -> None:
+    validator = FileSecurityValidator(
+        max_file_size=1024 * 1024,
+        max_filename_length=128,
+        allowed_extensions=[".pdf"],
+        allowed_mime_types=[],
+        validate_magic_number=False,
+    )
+
+    with pytest.raises(FileMimeTypeError):
+        validator.validate_file(
+            content=pdf_bytes(),
+            filename="sample.pdf",
+            declared_mime_type="application/pdf",
+        )
+
+
 def test_declared_mime_normalization_allows_params(
     validator_basic: FileSecurityValidator,
 ) -> None:

--- a/tracecat/cases/attachments/internal_router.py
+++ b/tracecat/cases/attachments/internal_router.py
@@ -19,6 +19,15 @@ from tracecat.cases.service import CasesService
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.logger import logger
+from tracecat.storage.exceptions import (
+    FileContentMismatchError,
+    FileExtensionError,
+    FileMimeTypeError,
+    FileNameError,
+    FileSizeError,
+    MaxAttachmentsExceededError,
+    StorageLimitExceededError,
+)
 
 router = APIRouter(
     tags=["internal-case-attachments"],
@@ -94,15 +103,135 @@ async def create_attachment(
             detail=f"Invalid base64 content: {str(e)}",
         ) from e
 
-    attachment = await service.attachments.create_attachment(
-        case,
-        CaseAttachmentCreate(
-            file_name=params.filename or "unnamed",
-            content_type=params.content_type or "application/octet-stream",
-            size=len(content),
-            content=content,
-        ),
-    )
+    try:
+        attachment = await service.attachments.create_attachment(
+            case,
+            CaseAttachmentCreate(
+                file_name=params.filename or "unnamed",
+                content_type=params.content_type or "application/octet-stream",
+                size=len(content),
+                content=content,
+            ),
+        )
+    except FileExtensionError as e:
+        logger.error(
+            "File extension validation error",
+            case_id=case_id,
+            filename=params.filename,
+            extension=e.extension,
+            allowed_extensions=e.allowed_extensions,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail={
+                "error": "unsupported_file_extension",
+                "message": str(e),
+                "extension": e.extension,
+                "allowed_extensions": e.allowed_extensions,
+            },
+        ) from e
+    except FileMimeTypeError as e:
+        logger.error(
+            "Content type validation error",
+            case_id=case_id,
+            filename=params.filename,
+            content_type=e.mime_type,
+            allowed_types=e.allowed_types,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail={
+                "error": "unsupported_content_type",
+                "message": str(e),
+                "content_type": e.mime_type,
+                "allowed_types": e.allowed_types,
+            },
+        ) from e
+    except FileSizeError as e:
+        logger.error(
+            "File size validation error",
+            case_id=case_id,
+            filename=params.filename,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={
+                "error": "file_too_large",
+                "message": str(e),
+            },
+        ) from e
+    except (FileContentMismatchError, FileNameError) as e:
+        logger.error(
+            "File validation error",
+            case_id=case_id,
+            filename=params.filename,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "file_validation_failed",
+                "message": str(e),
+            },
+        ) from e
+    except MaxAttachmentsExceededError as e:
+        logger.error(
+            "Maximum attachments per case exceeded",
+            case_id=case_id,
+            filename=params.filename,
+            current_count=e.current_count,
+            max_count=e.max_count,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "max_attachments_exceeded",
+                "message": str(e),
+                "current_count": e.current_count,
+                "max_count": e.max_count,
+            },
+        ) from e
+    except StorageLimitExceededError as e:
+        current_mb = e.current_size / 1024 / 1024
+        new_mb = e.new_file_size / 1024 / 1024
+        max_mb = e.max_size / 1024 / 1024
+        logger.error(
+            "Case storage limit exceeded",
+            case_id=case_id,
+            filename=params.filename,
+            current_size_mb=round(current_mb, 2),
+            new_file_size_mb=round(new_mb, 2),
+            max_size_mb=round(max_mb, 2),
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={
+                "error": "storage_limit_exceeded",
+                "message": str(e),
+                "current_size_mb": round(current_mb, 2),
+                "new_file_size_mb": round(new_mb, 2),
+                "max_size_mb": round(max_mb, 2),
+            },
+        ) from e
+    except Exception as e:
+        logger.error(
+            "Failed to create attachment",
+            case_id=case_id,
+            filename=params.filename,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to upload attachment.",
+        ) from e
+
     return CaseAttachmentRead(
         id=attachment.id,
         case_id=attachment.case_id,

--- a/tracecat/cases/attachments/service.py
+++ b/tracecat/cases/attachments/service.py
@@ -39,11 +39,11 @@ IMAGE_PREVIEW_MIME_TYPES = frozenset(
 )
 
 
-def _attachment_allowlist_from_workspace_setting(
-    value: Sequence[str] | None,
+def _resolve_workspace_attachment_allowlist(
+    allowlist: Sequence[str] | None,
 ) -> list[str] | None:
-    """Preserve None as default inheritance and empty lists as deny-all."""
-    return None if value is None else list(value)
+    """Preserve explicit empty workspace allowlists while copying configured values."""
+    return list(allowlist) if allowlist is not None else None
 
 
 class CaseAttachmentService(BaseWorkspaceService):
@@ -253,12 +253,11 @@ class CaseAttachmentService(BaseWorkspaceService):
         workspace = await self._get_workspace()
         workspace_settings = workspace.settings or {}
 
-        # Use workspace-specific allowed extensions/MIME types when configured.
-        # None inherits defaults; an empty list is an explicit deny-all.
-        allowed_extensions = _attachment_allowlist_from_workspace_setting(
+        # Use workspace-specific allowed extensions/MIME types if configured, otherwise use defaults
+        allowed_extensions = _resolve_workspace_attachment_allowlist(
             workspace_settings.get("allowed_attachment_extensions")
         )
-        allowed_mime_types = _attachment_allowlist_from_workspace_setting(
+        allowed_mime_types = _resolve_workspace_attachment_allowlist(
             workspace_settings.get("allowed_attachment_mime_types")
         )
 

--- a/tracecat/cases/attachments/service.py
+++ b/tracecat/cases/attachments/service.py
@@ -246,9 +246,6 @@ class CaseAttachmentService(BaseWorkspaceService):
                 f"({config.TRACECAT__MAX_ATTACHMENT_SIZE_BYTES / 1024 / 1024}MB)"
             )
 
-        # Validate case-level limits (count + storage) efficiently using actual size
-        await self._assert_case_limits(case, actual_size)
-
         # Get workspace settings for attachment validation
         workspace = await self._get_workspace()
         workspace_settings = workspace.settings or {}
@@ -281,6 +278,9 @@ class CaseAttachmentService(BaseWorkspaceService):
             filename=params.file_name,
             declared_mime_type=declared_mime_type,
         )
+
+        # Validate case-level limits (count + storage) after workspace policy checks.
+        await self._assert_case_limits(case, actual_size)
 
         # Compute content hash for deduplication and integrity
         sha256 = self._compute_sha256(params.content)

--- a/tracecat/cases/attachments/service.py
+++ b/tracecat/cases/attachments/service.py
@@ -39,6 +39,13 @@ IMAGE_PREVIEW_MIME_TYPES = frozenset(
 )
 
 
+def _attachment_allowlist_from_workspace_setting(
+    value: Sequence[str] | None,
+) -> list[str] | None:
+    """Preserve None as default inheritance and empty lists as deny-all."""
+    return None if value is None else list(value)
+
+
 class CaseAttachmentService(BaseWorkspaceService):
     """Service for managing case attachments."""
 
@@ -246,14 +253,14 @@ class CaseAttachmentService(BaseWorkspaceService):
         workspace = await self._get_workspace()
         workspace_settings = workspace.settings or {}
 
-        # Use workspace-specific allowed extensions/MIME types if configured, otherwise use defaults
-        allowed_extensions = workspace_settings.get("allowed_attachment_extensions")
-        if allowed_extensions:
-            allowed_extensions = set(allowed_extensions)
-
-        allowed_mime_types = workspace_settings.get("allowed_attachment_mime_types")
-        if allowed_mime_types:
-            allowed_mime_types = set(allowed_mime_types)
+        # Use workspace-specific allowed extensions/MIME types when configured.
+        # None inherits defaults; an empty list is an explicit deny-all.
+        allowed_extensions = _attachment_allowlist_from_workspace_setting(
+            workspace_settings.get("allowed_attachment_extensions")
+        )
+        allowed_mime_types = _attachment_allowlist_from_workspace_setting(
+            workspace_settings.get("allowed_attachment_mime_types")
+        )
 
         # Get magic number validation setting (default to True for security)
         validate_magic_number = workspace_settings.get(
@@ -263,14 +270,9 @@ class CaseAttachmentService(BaseWorkspaceService):
             validate_magic_number = True
 
         # Comprehensive security validation using the new validator
-        # Ensure allowed lists are Sequences for type checking
         validator = FileSecurityValidator(
-            allowed_extensions=(
-                list(allowed_extensions) if allowed_extensions else None
-            ),
-            allowed_mime_types=(
-                list(allowed_mime_types) if allowed_mime_types else None
-            ),
+            allowed_extensions=allowed_extensions,
+            allowed_mime_types=allowed_mime_types,
             validate_magic_number=validate_magic_number,
         )
         # Strip "Content-Type" from the declared MIME type

--- a/tracecat/storage/validation.py
+++ b/tracecat/storage/validation.py
@@ -87,17 +87,17 @@ class FileSecurityValidator:
         )
         # Normalize extensions: trim whitespace and lowercase for robust comparison
         raw_exts = list(
-            config.TRACECAT__ALLOWED_ATTACHMENT_EXTENSIONS
-            if allowed_extensions is None
-            else allowed_extensions
+            allowed_extensions
+            if allowed_extensions is not None
+            else config.TRACECAT__ALLOWED_ATTACHMENT_EXTENSIONS
         )
         self.allowed_extensions = [
             e.strip().lower() for e in raw_exts if str(e).strip()
         ]
         self.allowed_mime_types = list(
-            config.TRACECAT__ALLOWED_ATTACHMENT_MIME_TYPES
-            if allowed_mime_types is None
-            else allowed_mime_types
+            allowed_mime_types
+            if allowed_mime_types is not None
+            else config.TRACECAT__ALLOWED_ATTACHMENT_MIME_TYPES
         )
         self.validate_magic_number = validate_magic_number
 

--- a/tracecat/storage/validation.py
+++ b/tracecat/storage/validation.py
@@ -87,13 +87,17 @@ class FileSecurityValidator:
         )
         # Normalize extensions: trim whitespace and lowercase for robust comparison
         raw_exts = list(
-            allowed_extensions or config.TRACECAT__ALLOWED_ATTACHMENT_EXTENSIONS
+            config.TRACECAT__ALLOWED_ATTACHMENT_EXTENSIONS
+            if allowed_extensions is None
+            else allowed_extensions
         )
         self.allowed_extensions = [
             e.strip().lower() for e in raw_exts if str(e).strip()
         ]
         self.allowed_mime_types = list(
-            allowed_mime_types or config.TRACECAT__ALLOWED_ATTACHMENT_MIME_TYPES
+            config.TRACECAT__ALLOWED_ATTACHMENT_MIME_TYPES
+            if allowed_mime_types is None
+            else allowed_mime_types
         )
         self.validate_magic_number = validate_magic_number
 

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -32,14 +32,20 @@ class WorkspaceSettingsRead(Schema):
     git_repo_url: str | None = None
     workflow_unlimited_timeout_enabled: bool | None = None
     workflow_default_timeout_seconds: int | None = None
-    allowed_attachment_extensions: list[str] | None = None
-    allowed_attachment_mime_types: list[str] | None = None
+    allowed_attachment_extensions: list[str] | None = Field(
+        default=None,
+        description="Workspace attachment extension allowlist. null means system defaults; [] disables uploads; non-empty lists allow only those extensions.",
+    )
+    allowed_attachment_mime_types: list[str] | None = Field(
+        default=None,
+        description="Workspace attachment MIME type allowlist. null means system defaults; [] disables uploads; non-empty lists allow only those MIME types.",
+    )
     validate_attachment_magic_number: bool | None = None
 
     @computed_field
     @property
     def effective_allowed_attachment_extensions(self) -> list[str]:
-        """Returns workspace-specific extensions if set, otherwise system defaults."""
+        """Return the workspace extension allowlist, including [] as deny-all, or system defaults when null."""
         if self.allowed_attachment_extensions is not None:
             return self.allowed_attachment_extensions
         return sorted(config.TRACECAT__ALLOWED_ATTACHMENT_EXTENSIONS)
@@ -47,7 +53,7 @@ class WorkspaceSettingsRead(Schema):
     @computed_field
     @property
     def effective_allowed_attachment_mime_types(self) -> list[str]:
-        """Returns workspace-specific MIME types if set, otherwise system defaults."""
+        """Return the workspace MIME type allowlist, including [] as deny-all, or system defaults when null."""
         if self.allowed_attachment_mime_types is not None:
             return self.allowed_attachment_mime_types
         return sorted(config.TRACECAT__ALLOWED_ATTACHMENT_MIME_TYPES)
@@ -67,11 +73,11 @@ class WorkspaceSettingsUpdate(Schema):
     )
     allowed_attachment_extensions: list[str] | None = Field(
         default=None,
-        description="Allowed file extensions for attachments (e.g., ['.pdf', '.docx']). Overrides global defaults.",
+        description="Allowed file extensions for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those extensions.",
     )
     allowed_attachment_mime_types: list[str] | None = Field(
         default=None,
-        description="Allowed MIME types for attachments (e.g., ['application/pdf', 'image/jpeg']). Overrides global defaults.",
+        description="Allowed MIME types for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those MIME types.",
     )
     validate_attachment_magic_number: bool | None = Field(
         default=None,

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -73,11 +73,11 @@ class WorkspaceSettingsUpdate(Schema):
     )
     allowed_attachment_extensions: list[str] | None = Field(
         default=None,
-        description="Allowed file extensions for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those extensions.",
+        description="Allowed file extensions for attachments. null resets to system defaults; [] disables uploads; non-empty lists allow only those extensions; omitted leaves the existing setting unchanged.",
     )
     allowed_attachment_mime_types: list[str] | None = Field(
         default=None,
-        description="Allowed MIME types for attachments. null or omitted inherits system defaults; [] disables uploads; non-empty lists allow only those MIME types.",
+        description="Allowed MIME types for attachments. null resets to system defaults; [] disables uploads; non-empty lists allow only those MIME types; omitted leaves the existing setting unchanged.",
     )
     validate_attachment_magic_number: bool | None = Field(
         default=None,


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic.
- [x] PR only implements a single bug fix.
- [x] Focused backend, frontend, generated-client, docs, and visual-evidence checks pass (see QA below).
- [ ] Full `uv run pytest tests` was not run locally because PostgreSQL/Docker were unavailable.
- [ ] Full `pre-commit run --all-files` was not run locally; focused lint, type, format, generation, and regression checks passed.

## Description

- Preserve `None` / `null` as inheritance from global attachment defaults.
- Preserve explicit empty workspace attachment allowlists as empty policy values instead of falling back to global defaults.
- Keep the workspace files settings UI aligned with that contract: clearing a list saves `[]`, while the reset/inherit button saves `null`.
- Clear stale custom extension and MIME tags from the settings UI immediately when an admin restores inherited defaults, so old overrides are not shown as inherited policy values.
- Show admins the current attachment policy state in settings (`Inherited defaults`, `Uploads disabled`, or `Custom allowlist`) so `null` and explicit `[]` are distinguishable.
- Disable the case attachment upload affordance when either effective extensions or MIME types are explicit empty lists, keep the disabled control keyboard-accessible, and avoid misleading default file-type fallback messages.
- Keep the upload affordance non-interactive while workspace attachment policy is still loading or unknown, so users cannot start an upload before the effective policy is known.
- Validate workspace attachment policy before case quota/storage checks so explicit deny-all policy errors are not masked by quota errors.
- Return structured validation, size, quota, and storage-limit errors from the internal executor upload route instead of surfacing attachment-policy denials as generic 500s.
- Document the read/update contract in workspace schemas, generated client comments, and the core case attachment action docs: `null` resets/inherits, `[]` disables uploads, non-empty lists restrict uploads, and omitted update fields leave the existing setting unchanged.
- Add focused backend and frontend regression coverage for empty, inherited, configured, reset, loading, internal-route, and disabled upload paths.

## Compatibility note

This intentionally makes an explicit stored `[]` policy enforce deny-all semantics. Workspaces that stored `[]` but intended to inherit global defaults should reset the setting to `null` with the reset/inherit control.

## Related Issues

No existing issue. Discovered during repository analysis.

## Screenshots / Recordings

Local visual evidence was generated for the changed UI states and inspected before this update:

- Workspace Files settings policy states: inherited defaults, uploads disabled, and custom allowlist, including reset/inherit clearing stale custom tags. Local artifact: `/tmp/tracecat-pr2968-visuals/workspace-files-policy-states.png`.
- Case attachments deny-all state: disabled, tabbable upload affordance plus disabled-upload toast. Local artifact: `/tmp/tracecat-pr2968-visuals/case-attachments-disabled-upload.png`.

I could not safely attach binary screenshots through the GitHub CLI/API from this environment without using third-party cookie/upload tooling. The same interaction states are covered by the focused React tests listed below.

## Steps to QA

- `uv run pytest --confcutdir=tests/unit tests/unit/test_storage_validation.py tests/unit/test_case_attachment_allowlists.py tests/unit/test_case_attachment_internal_router.py -q` — passed, 42 passed, 4 warnings (pre-existing Pydantic warning plus Starlette 413 deprecation warnings from existing status constants)
- `pnpm -C frontend test -- workspace-files-settings.test.ts case-attachment-upload-policy.test.ts case-attachments-section.test.tsx --runInBand` — passed, 3 suites / 19 tests passed
- `pnpm -C frontend generate-client-ci && pnpm -C frontend exec biome check --write src/client` — passed earlier in the PR; final generated client diff is limited to attachment-setting comments in `schemas.gen.ts` and `types.gen.ts`
- Targeted attachments docs generation check using `scripts.generate_core_action_docs._render_page` for `case-actions/attachments` — passed; generated source matches `docs/automations/core-actions/case-actions/attachments.mdx`
- `jq . docs/docs.json >/dev/null` — passed
- Local Playwright/Chrome visual preview generated the two screenshots listed above — passed locally; artifacts were inspected before updating this PR body
- `uv run ruff check tracecat/storage/validation.py tracecat/cases/attachments/service.py tracecat/cases/attachments/internal_router.py tracecat/workspaces/schemas.py packages/tracecat-registry/tracecat_registry/core/cases.py tests/unit/test_storage_validation.py tests/unit/test_case_attachment_allowlists.py tests/unit/test_case_attachment_internal_router.py` — passed
- `uv run ruff format --check tracecat/storage/validation.py tracecat/cases/attachments/service.py tracecat/cases/attachments/internal_router.py tracecat/workspaces/schemas.py packages/tracecat-registry/tracecat_registry/core/cases.py tests/unit/test_storage_validation.py tests/unit/test_case_attachment_allowlists.py tests/unit/test_case_attachment_internal_router.py` — passed, 8 files already formatted
- `uv run basedpyright --warnings --threads 4 tracecat/storage/validation.py tracecat/cases/attachments/service.py tracecat/cases/attachments/internal_router.py tracecat/workspaces/schemas.py packages/tracecat-registry/tracecat_registry/core/cases.py tests/unit/test_storage_validation.py tests/unit/test_case_attachment_allowlists.py tests/unit/test_case_attachment_internal_router.py` — passed, 0 errors/warnings/notes
- `pnpm -C frontend exec biome check src/components/settings/workspace-files-settings.tsx src/components/cases/case-attachments-section.tsx src/lib/cases/attachment-errors.ts tests/workspace-files-settings.test.ts tests/case-attachment-upload-policy.test.ts tests/case-attachments-section.test.tsx src/client/schemas.gen.ts src/client/types.gen.ts` — passed
- `pnpm -C frontend run typecheck` — passed
- `git diff --check` — passed

Checks attempted but not counted as passing:

- `uv run python scripts/generate_core_action_docs.py --check` — failed before page comparison because the repo currently has unrelated undocumented core actions outside this PR (`core.table.*`, `core.workflow.*`, and other case/table/workflow actions). The targeted attachments page generation check above passed.
- Running the Python files without `--confcutdir` was attempted separately and loaded `tests/conftest.py`, whose autouse session fixtures require PostgreSQL at `localhost:5432`; that service was unavailable locally. The local Docker daemon was also unavailable, so I could not start the DB-backed test stack.
- First-party GitHub Actions for this fork PR are currently fork-gated and require maintainer approval before they can execute.

## Security / disclosure

No CVE or advisory is claimed. This is being submitted publicly as a configuration-correctness fix for workspace attachment allowlist semantics. The PR includes no exploit payloads, secrets, customer data, or weaponized reproduction steps. Maintainers can decide whether any advisory follow-up is warranted.

## Risk

Risk level: low to medium.

- Unset / `null` workspace settings continue to inherit global defaults.
- Non-empty workspace allowlists continue to allow only their configured values.
- Omitted update fields leave existing workspace settings unchanged.
- Explicit empty arrays now remain explicit empty policies end to end for both extension and MIME allowlists. Existing workspaces that stored `[]` but intended inheritance should reset the setting to `null` via the reset/inherit control.
- The upload control remains keyboard-accessible while disabled policies block picker, drop, and input paths.
- Unknown/loading workspace policy now keeps upload entry points non-interactive until the effective policy is known.
- GitHub Actions for this fork PR require maintainer approval before first-party workflows execute; local focused verification is documented above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes attachment allowlist handling so explicit empty workspace lists block all uploads, while null inherits global defaults, across UI and backend. Also keeps the upload control non-interactive until workspace policy loads.

- **Bug Fixes**
  - Backend: Added `_resolve_workspace_attachment_allowlist` in `CaseAttachmentService` and updated `FileSecurityValidator` to fall back to config only when `allowed_extensions`/`allowed_mime_types` is `None` (empty lists now deny-all). Validates workspace policy before any blob/DB writes or quota checks. The internal executor route returns structured errors (415 extension/content type with `allowed_extensions`/`allowed_types`, 413 size/storage, 409 max attachments, 400 validation).
  - Frontend: `CaseAttachmentsSection` builds an upload policy from effective extensions and MIME types, disables the add/dropzone and file input when either list is empty or while settings load, keeps the control keyboard-accessible, and uses `describeAttachmentUploadError` to show “Attachment uploads disabled” without default-type fallbacks. `WorkspaceFilesSettings` uses `buildAttachmentTags`, serializes cleared lists as `[]` (deny-all) and inheritance as `null`, clears stale override tags on reset, and shows the current policy state.
  - Docs/Client: Updated action docs and generated `schemas.gen.ts`/`types.gen.ts` to document the contract: `null` inherits defaults, `[]` disables uploads, non-empty lists restrict uploads, omitted update fields leave settings unchanged.
  - Tests: Added coverage for internal router error mapping, upload policy (including loading-state non-interactivity and a11y) and error messages, storage validator behavior for empty/None allowlists, and workspace settings tag round-trips.

<sup>Written for commit 744a941a1b72addab16ac270196935c4c25f6c65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

