### PR TITLE
fix(attachments): serialize per-case quota checks

### DIFF
--- a/tests/unit/test_case_attachment_quota_concurrency.py
+++ b/tests/unit/test_case_attachment_quota_concurrency.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from collections.abc import Iterator
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from tracecat import config
+from tracecat.auth.types import Role
+from tracecat.cases.attachments.schemas import CaseAttachmentCreate
+from tracecat.cases.attachments.service import CaseAttachmentService
+from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.db.models import Base, Case, CaseAttachment, Organization, Workspace
+from tracecat.storage.exceptions import MaxAttachmentsExceededError
+
+TEST_ORG_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _service_role(*, workspace_id: uuid.UUID) -> Role:
+    return Role(
+        type="service",
+        workspace_id=workspace_id,
+        organization_id=TEST_ORG_ID,
+        service_id="tracecat-api",
+        scopes=frozenset({"case:update"}),
+    )
+
+
+def _postgres_base_url() -> str:
+    return (
+        f"postgresql+asyncpg://postgres:postgres@localhost:"
+        f"{os.environ.get('PG_PORT', '5432')}/"
+    )
+
+
+def _terminate_database_connections(conn: sa.Connection, database_name: str) -> None:
+    conn.execute(
+        text(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = :database_name
+            AND pid <> pg_backend_pid()
+            """
+        ),
+        {"database_name": database_name},
+    )
+
+
+@pytest.fixture
+def attachment_quota_db_url() -> Iterator[str]:
+    database_name = f"test_case_attachment_quota_{uuid.uuid4().hex}"
+    base_url = _postgres_base_url()
+    sys_url_sync = f"{base_url}postgres".replace("+asyncpg", "+psycopg")
+    test_url = f"{base_url}{database_name}"
+    test_url_sync = test_url.replace("+asyncpg", "+psycopg")
+
+    sys_engine = create_engine(sys_url_sync, isolation_level="AUTOCOMMIT")
+    test_engine = None
+    try:
+        with sys_engine.connect() as conn:
+            _terminate_database_connections(conn, database_name)
+            conn.execute(text(f'CREATE DATABASE "{database_name}"'))
+
+        test_engine = create_engine(test_url_sync)
+        with test_engine.begin() as conn:
+            Base.metadata.create_all(conn)
+
+        yield test_url
+    finally:
+        if test_engine is not None:
+            test_engine.dispose()
+        with sys_engine.connect() as conn:
+            _terminate_database_connections(conn, database_name)
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+        sys_engine.dispose()
+
+
+async def _load_case(session: AsyncSession, case_id: uuid.UUID) -> Case:
+    result = await session.execute(select(Case).where(Case.id == case_id))
+    case = result.scalars().one()
+    return case
+
+
+@pytest.mark.anyio
+async def test_concurrent_case_uploads_do_not_exceed_attachment_limit(
+    attachment_quota_db_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    case_id = uuid.uuid4()
+    first_content = b"first concurrent upload"
+    second_content = b"second concurrent upload"
+
+    engine = create_async_engine(
+        attachment_quota_db_url,
+        isolation_level="READ COMMITTED",
+        poolclass=NullPool,
+    )
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                sa.insert(Organization).values(
+                    id=TEST_ORG_ID,
+                    name="Test Organization",
+                    slug=f"test-org-{uuid.uuid4().hex[:8]}",
+                    is_active=True,
+                )
+            )
+            await conn.execute(
+                sa.insert(Workspace).values(
+                    id=workspace_id,
+                    organization_id=TEST_ORG_ID,
+                    name="Attachment Quota Race Workspace",
+                    settings={"validate_attachment_magic_number": False},
+                )
+            )
+            await conn.execute(
+                sa.insert(Case).values(
+                    id=case_id,
+                    workspace_id=workspace_id,
+                    case_number=1,
+                    summary="Attachment quota race",
+                    description="Concurrent upload quota regression",
+                    status=CaseStatus.NEW,
+                    priority=CasePriority.MEDIUM,
+                    severity=CaseSeverity.LOW,
+                )
+            )
+
+        monkeypatch.setattr(config, "TRACECAT__MAX_ATTACHMENTS_PER_CASE", 1)
+
+        first_upload_paused = asyncio.Event()
+        release_first_upload = asyncio.Event()
+        second_lock_attempted = asyncio.Event()
+        lock_calls = 0
+        original_lock = CaseAttachmentService._lock_case_for_attachment_write
+
+        async def lock_case_for_attachment_write(
+            self: CaseAttachmentService, case: Case
+        ) -> Case:
+            nonlocal lock_calls
+            lock_calls += 1
+            if lock_calls == 2:
+                second_lock_attempted.set()
+            return await original_lock(self, case)
+
+        async def upload_to_attachments_bucket(
+            self: CaseAttachmentService,
+            *,
+            content: bytes,
+            sha256: str,
+            content_type: str,
+        ) -> None:
+            _ = (self, sha256, content_type)
+            if content == first_content:
+                first_upload_paused.set()
+                await release_first_upload.wait()
+
+        monkeypatch.setattr(
+            CaseAttachmentService,
+            "_lock_case_for_attachment_write",
+            lock_case_for_attachment_write,
+        )
+        monkeypatch.setattr(
+            CaseAttachmentService,
+            "_upload_to_attachments_bucket",
+            upload_to_attachments_bucket,
+        )
+
+        async def emit_case_event(*args: object, **kwargs: object) -> None:
+            _ = (args, kwargs)
+
+        monkeypatch.setattr(
+            CaseAttachmentService,
+            "_emit_case_event",
+            emit_case_event,
+        )
+
+        async def create_attachment(content: bytes, filename: str) -> CaseAttachment:
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                service = CaseAttachmentService(
+                    session=session,
+                    role=_service_role(workspace_id=workspace_id),
+                )
+                case = await _load_case(session, case_id)
+                return await service.create_attachment(
+                    case,
+                    CaseAttachmentCreate(
+                        file_name=filename,
+                        content_type="text/plain",
+                        size=len(content),
+                        content=content,
+                    ),
+                )
+
+        first_task = asyncio.create_task(create_attachment(first_content, "first.txt"))
+        await asyncio.wait_for(first_upload_paused.wait(), timeout=5)
+
+        second_task = asyncio.create_task(
+            create_attachment(second_content, "second.txt")
+        )
+        await asyncio.wait_for(second_lock_attempted.wait(), timeout=5)
+
+        release_first_upload.set()
+        results = await asyncio.wait_for(
+            asyncio.gather(first_task, second_task, return_exceptions=True),
+            timeout=10,
+        )
+
+        successes = [result for result in results if isinstance(result, CaseAttachment)]
+        limit_errors = [
+            result
+            for result in results
+            if isinstance(result, MaxAttachmentsExceededError)
+        ]
+        assert len(successes) == 1
+        assert len(limit_errors) == 1
+
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            count_result = await session.execute(
+                select(func.count())
+                .select_from(CaseAttachment)
+                .where(CaseAttachment.case_id == case_id)
+            )
+            assert count_result.scalar_one() == 1
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_case_attachment_quota_concurrency.py
+++ b/tests/unit/test_case_attachment_quota_concurrency.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import uuid
 from collections.abc import Iterator
+from urllib.parse import quote_plus
 
 import pytest
 import sqlalchemy as sa
@@ -33,10 +34,13 @@ def _service_role(*, workspace_id: uuid.UUID) -> Role:
 
 
 def _postgres_base_url() -> str:
-    return (
-        f"postgresql+asyncpg://postgres:postgres@localhost:"
-        f"{os.environ.get('PG_PORT', '5432')}/"
-    )
+    host = os.environ.get("PG_HOST")
+    if host is None:
+        host = "postgres_db" if os.path.exists("/.dockerenv") else "localhost"
+    port = os.environ.get("PG_PORT", "5432")
+    username = quote_plus(os.environ.get("POSTGRES_USER", "postgres"))
+    password = quote_plus(os.environ.get("POSTGRES_PASSWORD", "postgres"))
+    return f"postgresql+asyncpg://{username}:{password}@{host}:{port}/"
 
 
 def _terminate_database_connections(conn: sa.Connection, database_name: str) -> None:
@@ -80,6 +84,12 @@ def attachment_quota_db_url() -> Iterator[str]:
             _terminate_database_connections(conn, database_name)
             conn.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
         sys_engine.dispose()
+
+
+async def _set_transaction_timeouts(session: AsyncSession) -> None:
+    # Fail fast if the regression accidentally leaves a row lock waiting forever.
+    await session.execute(text("SET lock_timeout = '5s'"))
+    await session.execute(text("SET statement_timeout = '15s'"))
 
 
 async def _load_case(session: AsyncSession, case_id: uuid.UUID) -> Case:
@@ -185,6 +195,7 @@ async def test_concurrent_case_uploads_do_not_exceed_attachment_limit(
 
         async def create_attachment(content: bytes, filename: str) -> CaseAttachment:
             async with AsyncSession(engine, expire_on_commit=False) as session:
+                await _set_transaction_timeouts(session)
                 service = CaseAttachmentService(
                     session=session,
                     role=_service_role(workspace_id=workspace_id),
@@ -200,19 +211,35 @@ async def test_concurrent_case_uploads_do_not_exceed_attachment_limit(
                     ),
                 )
 
-        first_task = asyncio.create_task(create_attachment(first_content, "first.txt"))
-        await asyncio.wait_for(first_upload_paused.wait(), timeout=5)
+        first_task: asyncio.Task[CaseAttachment] | None = None
+        second_task: asyncio.Task[CaseAttachment] | None = None
+        try:
+            first_task = asyncio.create_task(
+                create_attachment(first_content, "first.txt")
+            )
+            await asyncio.wait_for(first_upload_paused.wait(), timeout=5)
 
-        second_task = asyncio.create_task(
-            create_attachment(second_content, "second.txt")
-        )
-        await asyncio.wait_for(second_lock_attempted.wait(), timeout=5)
+            second_task = asyncio.create_task(
+                create_attachment(second_content, "second.txt")
+            )
+            await asyncio.wait_for(second_lock_attempted.wait(), timeout=5)
 
-        release_first_upload.set()
-        results = await asyncio.wait_for(
-            asyncio.gather(first_task, second_task, return_exceptions=True),
-            timeout=10,
-        )
+            release_first_upload.set()
+            results = await asyncio.wait_for(
+                asyncio.gather(first_task, second_task, return_exceptions=True),
+                timeout=10,
+            )
+        finally:
+            release_first_upload.set()
+            pending_tasks = [
+                task
+                for task in (first_task, second_task)
+                if task is not None and not task.done()
+            ]
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
 
         successes = [result for result in results if isinstance(result, CaseAttachment)]
         limit_errors = [

--- a/tests/unit/test_case_attachments_internal_router.py
+++ b/tests/unit/test_case_attachments_internal_router.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import base64
+import uuid
+from typing import Any, cast
+
+import pytest
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.cases.attachments import internal_router
+from tracecat.cases.attachments.internal_router import ExecutorAttachmentCreateRequest
+from tracecat.db.models import Case
+from tracecat.storage.exceptions import (
+    MaxAttachmentsExceededError,
+    StorageLimitExceededError,
+)
+
+
+def _role(*, workspace_id: uuid.UUID, organization_id: uuid.UUID) -> Role:
+    return Role(
+        type="service",
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+        service_id="tracecat-api",
+        scopes=frozenset({"case:update"}),
+    )
+
+
+async def _invoke_internal_create_with_attachment_error(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> HTTPException:
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    case_id = uuid.uuid4()
+    case = Case(id=case_id, workspace_id=workspace_id)
+
+    class _Attachments:
+        async def create_attachment(self, *args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            raise error
+
+    class _CasesService:
+        attachments = _Attachments()
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            _ = (args, kwargs)
+
+        async def get_case(self, requested_case_id: uuid.UUID) -> Case | None:
+            assert requested_case_id == case_id
+            return case
+
+    monkeypatch.setattr(internal_router, "CasesService", _CasesService)
+
+    content = b"hello tracecat"
+    params = ExecutorAttachmentCreateRequest(
+        filename="hello.txt",
+        content_base64=base64.b64encode(content).decode(),
+        content_type="text/plain",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_router.create_attachment(
+            role=_role(
+                workspace_id=workspace_id,
+                organization_id=organization_id,
+            ),
+            session=cast(AsyncSession, object()),
+            case_id=case_id,
+            params=params,
+        )
+    return exc_info.value
+
+
+@pytest.mark.anyio
+async def test_internal_create_attachment_maps_max_attachments_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exc = await _invoke_internal_create_with_attachment_error(
+        monkeypatch,
+        MaxAttachmentsExceededError(
+            "Maximum attachments per case exceeded", current_count=1, max_count=1
+        ),
+    )
+
+    assert exc.status_code == status.HTTP_409_CONFLICT
+    assert exc.detail == {
+        "error": "max_attachments_exceeded",
+        "message": "Maximum attachments per case exceeded",
+        "current_count": 1,
+        "max_count": 1,
+    }
+
+
+@pytest.mark.anyio
+async def test_internal_create_attachment_maps_storage_limit_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exc = await _invoke_internal_create_with_attachment_error(
+        monkeypatch,
+        StorageLimitExceededError(
+            "Case attachment storage limit exceeded",
+            current_size=1024 * 1024,
+            new_file_size=512 * 1024,
+            max_size=1024 * 1024,
+        ),
+    )
+
+    assert exc.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert exc.detail == {
+        "error": "storage_limit_exceeded",
+        "message": "Case attachment storage limit exceeded",
+        "current_size_mb": 1.0,
+        "new_file_size_mb": 0.5,
+        "max_size_mb": 1.0,
+    }

--- a/tests/unit/test_case_attachments_service_locking.py
+++ b/tests/unit/test_case_attachments_service_locking.py
@@ -77,7 +77,7 @@ async def test_create_attachment_locks_case_before_asserting_case_limits(
     events: list[str] = []
 
     case = Case(id=case_id, workspace_id=workspace_id)
-    session = _RecordingSession([case], events)
+    session = _RecordingSession([case, None], events)
     service = CaseAttachmentService(
         session=cast(AsyncSession, session),
         role=_service_role(
@@ -108,12 +108,13 @@ async def test_create_attachment_locks_case_before_asserting_case_limits(
     with pytest.raises(_StopAfterLimits):
         await service.create_attachment(case, params)
 
-    assert events == ["execute", "assert_case_limits", "rollback"]
+    assert events == ["execute", "execute", "assert_case_limits", "rollback"]
 
     compiled = [
         str(stmt.compile(dialect=postgresql.dialect())) for stmt in session.statements
     ]
-    assert any('FROM "case"' in sql and "FOR UPDATE" in sql for sql in compiled)
+    assert 'FROM "case"' in compiled[0]
+    assert "FOR UPDATE" in compiled[0]
     assert any('"case".workspace_id' in sql for sql in compiled)
     assert any('"case".id' in sql for sql in compiled)
 
@@ -180,9 +181,8 @@ async def test_existing_attachment_fast_path_commits_after_lock(
         return _workspace(workspace_id=workspace_id, organization_id=organization_id)
 
     async def assert_case_limits(locked_case: Case, new_size: int) -> None:
-        events.append("assert_case_limits")
-        assert locked_case.id == case_id
-        assert new_size == len(content)
+        _ = (locked_case, new_size)
+        raise AssertionError("idempotent uploads must not consume quota")
 
     monkeypatch.setattr(service, "_get_workspace", get_workspace)
     monkeypatch.setattr(service, "_assert_case_limits", assert_case_limits)
@@ -199,7 +199,6 @@ async def test_existing_attachment_fast_path_commits_after_lock(
     assert result is attachment
     assert events == [
         "execute",
-        "assert_case_limits",
         "execute",
         "execute",
         "commit",

--- a/tests/unit/test_case_attachments_service_locking.py
+++ b/tests/unit/test_case_attachments_service_locking.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.cases.attachments.schemas import CaseAttachmentCreate
+from tracecat.cases.attachments.service import CaseAttachmentService
+from tracecat.db.models import Case
+
+
+class _StopAfterLimits(Exception):
+    pass
+
+
+class _CaseLockResult:
+    def __init__(self, case: Case | None) -> None:
+        self.case = case
+
+    def scalars(self) -> _CaseLockResult:
+        return self
+
+    def first(self) -> Case | None:
+        return self.case
+
+
+class _RecordingSession:
+    def __init__(self, locked_case: Case | None, events: list[str]) -> None:
+        self.locked_case = locked_case
+        self.events = events
+        self.statements: list[Any] = []
+
+    async def execute(self, stmt: Any) -> _CaseLockResult:
+        self.events.append("execute")
+        self.statements.append(stmt)
+        return _CaseLockResult(self.locked_case)
+
+
+def _service_role(*, workspace_id: uuid.UUID, organization_id: uuid.UUID) -> Role:
+    return Role(
+        type="service",
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+        service_id="tracecat-api",
+        scopes=frozenset({"case:update"}),
+    )
+
+
+@pytest.mark.anyio
+async def test_create_attachment_locks_case_before_asserting_case_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    case_id = uuid.uuid4()
+    content = b"hello tracecat"
+    events: list[str] = []
+
+    case = Case(id=case_id, workspace_id=workspace_id)
+    session = _RecordingSession(case, events)
+    service = CaseAttachmentService(
+        session=cast(AsyncSession, session),
+        role=_service_role(
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+        ),
+    )
+
+    async def assert_case_limits(locked_case: Case, new_size: int) -> None:
+        events.append("assert_case_limits")
+        assert locked_case.id == case_id
+        assert new_size == len(content)
+        raise _StopAfterLimits
+
+    monkeypatch.setattr(service, "_assert_case_limits", assert_case_limits)
+
+    params = CaseAttachmentCreate(
+        file_name="hello.txt",
+        content_type="text/plain",
+        size=len(content),
+        content=content,
+    )
+
+    with pytest.raises(_StopAfterLimits):
+        await service.create_attachment(case, params)
+
+    assert events == ["execute", "assert_case_limits"]
+
+    compiled = [
+        str(stmt.compile(dialect=postgresql.dialect())) for stmt in session.statements
+    ]
+    assert any('FROM "case"' in sql and "FOR UPDATE" in sql for sql in compiled)
+    assert any('"case".workspace_id' in sql for sql in compiled)
+    assert any('"case".id' in sql for sql in compiled)

--- a/tests/unit/test_case_attachments_service_locking.py
+++ b/tests/unit/test_case_attachments_service_locking.py
@@ -10,34 +10,41 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat.auth.types import Role
 from tracecat.cases.attachments.schemas import CaseAttachmentCreate
 from tracecat.cases.attachments.service import CaseAttachmentService
-from tracecat.db.models import Case
+from tracecat.db.models import Case, CaseAttachment, File, Workspace
+from tracecat.exceptions import TracecatNotFoundError
 
 
 class _StopAfterLimits(Exception):
     pass
 
 
-class _CaseLockResult:
-    def __init__(self, case: Case | None) -> None:
-        self.case = case
+class _ExecuteResult:
+    def __init__(self, value: Any) -> None:
+        self.value = value
 
-    def scalars(self) -> _CaseLockResult:
+    def scalars(self) -> _ExecuteResult:
         return self
 
-    def first(self) -> Case | None:
-        return self.case
+    def first(self) -> Any:
+        return self.value
 
 
 class _RecordingSession:
-    def __init__(self, locked_case: Case | None, events: list[str]) -> None:
-        self.locked_case = locked_case
+    def __init__(self, results: list[Any], events: list[str]) -> None:
+        self.results = results
         self.events = events
         self.statements: list[Any] = []
 
-    async def execute(self, stmt: Any) -> _CaseLockResult:
+    async def execute(self, stmt: Any) -> _ExecuteResult:
         self.events.append("execute")
         self.statements.append(stmt)
-        return _CaseLockResult(self.locked_case)
+        return _ExecuteResult(self.results.pop(0))
+
+    async def commit(self) -> None:
+        self.events.append("commit")
+
+    async def rollback(self) -> None:
+        self.events.append("rollback")
 
 
 def _service_role(*, workspace_id: uuid.UUID, organization_id: uuid.UUID) -> Role:
@@ -47,6 +54,15 @@ def _service_role(*, workspace_id: uuid.UUID, organization_id: uuid.UUID) -> Rol
         organization_id=organization_id,
         service_id="tracecat-api",
         scopes=frozenset({"case:update"}),
+    )
+
+
+def _workspace(*, workspace_id: uuid.UUID, organization_id: uuid.UUID) -> Workspace:
+    return Workspace(
+        id=workspace_id,
+        organization_id=organization_id,
+        name="Test Workspace",
+        settings={"validate_attachment_magic_number": False},
     )
 
 
@@ -61,7 +77,7 @@ async def test_create_attachment_locks_case_before_asserting_case_limits(
     events: list[str] = []
 
     case = Case(id=case_id, workspace_id=workspace_id)
-    session = _RecordingSession(case, events)
+    session = _RecordingSession([case], events)
     service = CaseAttachmentService(
         session=cast(AsyncSession, session),
         role=_service_role(
@@ -70,12 +86,16 @@ async def test_create_attachment_locks_case_before_asserting_case_limits(
         ),
     )
 
+    async def get_workspace() -> Workspace:
+        return _workspace(workspace_id=workspace_id, organization_id=organization_id)
+
     async def assert_case_limits(locked_case: Case, new_size: int) -> None:
         events.append("assert_case_limits")
         assert locked_case.id == case_id
         assert new_size == len(content)
         raise _StopAfterLimits
 
+    monkeypatch.setattr(service, "_get_workspace", get_workspace)
     monkeypatch.setattr(service, "_assert_case_limits", assert_case_limits)
 
     params = CaseAttachmentCreate(
@@ -88,7 +108,7 @@ async def test_create_attachment_locks_case_before_asserting_case_limits(
     with pytest.raises(_StopAfterLimits):
         await service.create_attachment(case, params)
 
-    assert events == ["execute", "assert_case_limits"]
+    assert events == ["execute", "assert_case_limits", "rollback"]
 
     compiled = [
         str(stmt.compile(dialect=postgresql.dialect())) for stmt in session.statements
@@ -96,3 +116,91 @@ async def test_create_attachment_locks_case_before_asserting_case_limits(
     assert any('FROM "case"' in sql and "FOR UPDATE" in sql for sql in compiled)
     assert any('"case".workspace_id' in sql for sql in compiled)
     assert any('"case".id' in sql for sql in compiled)
+
+
+@pytest.mark.anyio
+async def test_lock_case_for_attachment_write_raises_when_case_disappears() -> None:
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    case = Case(id=uuid.uuid4(), workspace_id=workspace_id)
+    events: list[str] = []
+    session = _RecordingSession([None], events)
+    service = CaseAttachmentService(
+        session=cast(AsyncSession, session),
+        role=_service_role(
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+        ),
+    )
+
+    with pytest.raises(TracecatNotFoundError):
+        await service._lock_case_for_attachment_write(case)
+
+    assert events == ["execute"]
+
+
+@pytest.mark.anyio
+async def test_existing_attachment_fast_path_commits_after_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    case_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    attachment_id = uuid.uuid4()
+    content = b"hello tracecat"
+    events: list[str] = []
+
+    case = Case(id=case_id, workspace_id=workspace_id)
+    file = File(
+        id=file_id,
+        workspace_id=workspace_id,
+        sha256=CaseAttachmentService._compute_sha256(content),
+        name="hello.txt",
+        content_type="text/plain",
+        size=len(content),
+    )
+    attachment = CaseAttachment(
+        id=attachment_id,
+        case_id=case_id,
+        file_id=file_id,
+    )
+    attachment.file = file
+
+    session = _RecordingSession([case, file, attachment], events)
+    service = CaseAttachmentService(
+        session=cast(AsyncSession, session),
+        role=_service_role(
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+        ),
+    )
+
+    async def get_workspace() -> Workspace:
+        return _workspace(workspace_id=workspace_id, organization_id=organization_id)
+
+    async def assert_case_limits(locked_case: Case, new_size: int) -> None:
+        events.append("assert_case_limits")
+        assert locked_case.id == case_id
+        assert new_size == len(content)
+
+    monkeypatch.setattr(service, "_get_workspace", get_workspace)
+    monkeypatch.setattr(service, "_assert_case_limits", assert_case_limits)
+
+    params = CaseAttachmentCreate(
+        file_name="hello.txt",
+        content_type="text/plain",
+        size=len(content),
+        content=content,
+    )
+
+    result = await service.create_attachment(case, params)
+
+    assert result is attachment
+    assert events == [
+        "execute",
+        "assert_case_limits",
+        "execute",
+        "execute",
+        "commit",
+    ]

--- a/tracecat/cases/attachments/internal_router.py
+++ b/tracecat/cases/attachments/internal_router.py
@@ -19,6 +19,10 @@ from tracecat.cases.service import CasesService
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.logger import logger
+from tracecat.storage.exceptions import (
+    MaxAttachmentsExceededError,
+    StorageLimitExceededError,
+)
 
 router = APIRouter(
     tags=["internal-case-attachments"],
@@ -108,6 +112,30 @@ async def create_attachment(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
+        ) from e
+    except MaxAttachmentsExceededError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "max_attachments_exceeded",
+                "message": str(e),
+                "current_count": e.current_count,
+                "max_count": e.max_count,
+            },
+        ) from e
+    except StorageLimitExceededError as e:
+        current_mb = e.current_size / 1024 / 1024
+        new_mb = e.new_file_size / 1024 / 1024
+        max_mb = e.max_size / 1024 / 1024
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={
+                "error": "storage_limit_exceeded",
+                "message": str(e),
+                "current_size_mb": round(current_mb, 2),
+                "new_file_size_mb": round(new_mb, 2),
+                "max_size_mb": round(max_mb, 2),
+            },
         ) from e
     return CaseAttachmentRead(
         id=attachment.id,

--- a/tracecat/cases/attachments/internal_router.py
+++ b/tracecat/cases/attachments/internal_router.py
@@ -94,15 +94,21 @@ async def create_attachment(
             detail=f"Invalid base64 content: {str(e)}",
         ) from e
 
-    attachment = await service.attachments.create_attachment(
-        case,
-        CaseAttachmentCreate(
-            file_name=params.filename or "unnamed",
-            content_type=params.content_type or "application/octet-stream",
-            size=len(content),
-            content=content,
-        ),
-    )
+    try:
+        attachment = await service.attachments.create_attachment(
+            case,
+            CaseAttachmentCreate(
+                file_name=params.filename or "unnamed",
+                content_type=params.content_type or "application/octet-stream",
+                size=len(content),
+                content=content,
+            ),
+        )
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
     return CaseAttachmentRead(
         id=attachment.id,
         case_id=attachment.case_id,

--- a/tracecat/cases/attachments/router.py
+++ b/tracecat/cases/attachments/router.py
@@ -14,6 +14,7 @@ from tracecat.cases.attachments.schemas import (
     CaseAttachmentRead,
 )
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatNotFoundError
 from tracecat.logger import logger
 from tracecat.storage.exceptions import (
     FileContentMismatchError,
@@ -307,6 +308,17 @@ async def create_attachment(
                 "new_file_size_mb": round(new_mb, 2),
                 "max_size_mb": round(max_mb, 2),
             },
+        ) from e
+    except TracecatNotFoundError as e:
+        logger.warning(
+            "Case not found while creating attachment",
+            case_id=case_id,
+            filename=file.filename,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
         ) from e
     except Exception as e:
         logger.error(

--- a/tracecat/cases/attachments/service.py
+++ b/tracecat/cases/attachments/service.py
@@ -107,6 +107,28 @@ class CaseAttachmentService(BaseWorkspaceService):
             self._workspace_cache = workspace
         return self._workspace_cache
 
+    async def _lock_case_for_attachment_write(self, case: Case) -> Case:
+        """Lock the case row while enforcing attachment quotas and writing rows.
+
+        Attachment count and storage limits are derived from aggregate reads. Without a
+        per-case serialization point, concurrent uploads can both observe the same
+        pre-insert state and commit over the configured limits. The row lock is held
+        by the current transaction until ``create_attachment`` commits or rolls back.
+        """
+        statement = (
+            select(Case)
+            .where(
+                Case.workspace_id == self.workspace_id,
+                Case.id == case.id,
+            )
+            .with_for_update()
+        )
+        result = await self.session.execute(statement)
+        locked_case = result.scalars().first()
+        if locked_case is None:
+            raise TracecatNotFoundError(f"Case {case.id} not found")
+        return locked_case
+
     async def _assert_case_limits(self, case: Case, new_size: int) -> None:
         """Validate case-level constraints for attachments (count and total storage)."""
         # Use COUNT(*) with join on non-deleted files (matches list_attachments semantics)
@@ -239,7 +261,8 @@ class CaseAttachmentService(BaseWorkspaceService):
                 f"({config.TRACECAT__MAX_ATTACHMENT_SIZE_BYTES / 1024 / 1024}MB)"
             )
 
-        # Validate case-level limits (count + storage) efficiently using actual size
+        # Serialize the aggregate quota check with the attachment write for this case.
+        case = await self._lock_case_for_attachment_write(case)
         await self._assert_case_limits(case, actual_size)
 
         # Get workspace settings for attachment validation

--- a/tracecat/cases/attachments/service.py
+++ b/tracecat/cases/attachments/service.py
@@ -309,8 +309,6 @@ class CaseAttachmentService(BaseWorkspaceService):
             # case. The following transaction owns all post-lock exit paths so the
             # row lock is released by an explicit commit or rollback.
             case = await self._lock_case_for_attachment_write(case)
-            await self._assert_case_limits(case, actual_size)
-
             # Determine uploader ID (may be None for workflow/service uploads)
             creator_id: uuid.UUID | None = (
                 self.role.user_id if self.role.type == "user" else None
@@ -325,7 +323,46 @@ class CaseAttachmentService(BaseWorkspaceService):
             )
             file = existing_file.scalars().first()
 
-            restored = False
+            attachment: CaseAttachment | None = None
+            if file:
+                # Check if attachment already exists for this case and file before
+                # enforcing aggregate quotas. Re-uploading an already-active
+                # attachment is idempotent and does not consume additional case
+                # count/storage quota.
+                existing_attachment = await self.session.execute(
+                    select(CaseAttachment)
+                    .where(
+                        CaseAttachment.case_id == case.id,
+                        CaseAttachment.file_id == file.id,
+                    )
+                    .options(selectinload(CaseAttachment.file))
+                )
+                attachment = existing_attachment.scalars().first()
+
+                # Verify existing file's recorded size matches actual content
+                if file.size != actual_size:
+                    logger.error(
+                        "Security: Existing file size mismatch detected",
+                        case_id=case.id,
+                        file_id=file.id,
+                        sha256=sha256,
+                        recorded_size=file.size,
+                        actual_size=actual_size,
+                        filename=params.file_name,
+                    )
+                    # Update the file record with correct size
+                    file.size = actual_size
+
+                if (
+                    attachment
+                    and file.deleted_at is None
+                    and getattr(attachment.file, "deleted_at", None) is None
+                ):
+                    await self.session.commit()
+                    return attachment
+
+            await self._assert_case_limits(case, actual_size)
+
             if not file:
                 # Create new file record
                 file = File(
@@ -346,53 +383,20 @@ class CaseAttachmentService(BaseWorkspaceService):
                     content_type=validation_result.content_type,
                 )
             else:
-                # Verify existing file's recorded size matches actual content
-                if file.size != actual_size:
-                    logger.error(
-                        "Security: Existing file size mismatch detected",
-                        case_id=case.id,
-                        file_id=file.id,
-                        sha256=sha256,
-                        recorded_size=file.size,
-                        actual_size=actual_size,
-                        filename=params.file_name,
-                    )
-                    # Update the file record with correct size
-                    file.size = actual_size
-
                 # If the file entity exists but has been soft deleted, restore and re-upload
                 if file.deleted_at is not None:
                     file.deleted_at = None
-                    restored = True
                     await self._upload_to_attachments_bucket(
                         content=params.content,
                         sha256=sha256,
                         content_type=validation_result.content_type,
                     )
 
-            # Check if attachment already exists for this case and file
-            existing_attachment = await self.session.execute(
-                select(CaseAttachment)
-                .where(
-                    CaseAttachment.case_id == case.id,
-                    CaseAttachment.file_id == file.id,
-                )
-                .options(selectinload(CaseAttachment.file))
-            )
-            attachment = existing_attachment.scalars().first()
-
             should_create_event = False
             if attachment:
-                # Attachment already exists and is active - return it
-                # (If the underlying file was restored above, emit restoration event)
-                if (
-                    not restored
-                    and file.deleted_at is None
-                    and getattr(attachment.file, "deleted_at", None) is None
-                ):
-                    await self.session.commit()
-                    return attachment
-                # Ensure relationship is consistent
+                # The attachment existed but was not active because the underlying
+                # file was soft-deleted. Ensure the relationship is consistent and
+                # emit a restoration event after quota enforcement.
                 attachment.file = file
                 should_create_event = True
             else:

--- a/tracecat/cases/attachments/service.py
+++ b/tracecat/cases/attachments/service.py
@@ -261,10 +261,6 @@ class CaseAttachmentService(BaseWorkspaceService):
                 f"({config.TRACECAT__MAX_ATTACHMENT_SIZE_BYTES / 1024 / 1024}MB)"
             )
 
-        # Serialize the aggregate quota check with the attachment write for this case.
-        case = await self._lock_case_for_attachment_write(case)
-        await self._assert_case_limits(case, actual_size)
-
         # Get workspace settings for attachment validation
         workspace = await self._get_workspace()
         workspace_settings = workspace.settings or {}
@@ -304,119 +300,133 @@ class CaseAttachmentService(BaseWorkspaceService):
             declared_mime_type=declared_mime_type,
         )
 
-        # Compute content hash for deduplication and integrity
+        # Compute content hash for deduplication and integrity before taking the
+        # case lock; hashing does not depend on aggregate case attachment state.
         sha256 = self._compute_sha256(params.content)
 
-        # Determine uploader ID (may be None for workflow/service uploads)
-        creator_id: uuid.UUID | None = (
-            self.role.user_id if self.role.type == "user" else None
-        )
+        try:
+            # Serialize the aggregate quota check with the attachment write for this
+            # case. The following transaction owns all post-lock exit paths so the
+            # row lock is released by an explicit commit or rollback.
+            case = await self._lock_case_for_attachment_write(case)
+            await self._assert_case_limits(case, actual_size)
 
-        # Check if file already exists (deduplication)
-        existing_file = await self.session.execute(
-            select(File).where(
-                File.sha256 == sha256,
-                File.workspace_id == self.workspace_id,
+            # Determine uploader ID (may be None for workflow/service uploads)
+            creator_id: uuid.UUID | None = (
+                self.role.user_id if self.role.type == "user" else None
             )
-        )
-        file = existing_file.scalars().first()
 
-        restored = False
-        if not file:
-            # Create new file record
-            file = File(
-                workspace_id=self.workspace_id,
-                sha256=sha256,
-                name=validation_result.filename,
-                content_type=validation_result.content_type,
-                size=actual_size,
-                creator_id=creator_id,
-            )
-            self.session.add(file)
-            await self.session.flush()
-            # Upload to blob storage
-            await self._upload_to_attachments_bucket(
-                content=params.content,
-                sha256=sha256,
-                content_type=validation_result.content_type,
-            )
-        else:
-            # Verify existing file's recorded size matches actual content
-            if file.size != actual_size:
-                logger.error(
-                    "Security: Existing file size mismatch detected",
-                    case_id=case.id,
-                    file_id=file.id,
-                    sha256=sha256,
-                    recorded_size=file.size,
-                    actual_size=actual_size,
-                    filename=params.file_name,
+            # Check if file already exists (deduplication)
+            existing_file = await self.session.execute(
+                select(File).where(
+                    File.sha256 == sha256,
+                    File.workspace_id == self.workspace_id,
                 )
-                # Update the file record with correct size
-                file.size = actual_size
+            )
+            file = existing_file.scalars().first()
 
-            # If the file entity exists but has been soft deleted, restore and re-upload
-            if file.deleted_at is not None:
-                file.deleted_at = None
-                restored = True
+            restored = False
+            if not file:
+                # Create new file record
+                file = File(
+                    workspace_id=self.workspace_id,
+                    sha256=sha256,
+                    name=validation_result.filename,
+                    content_type=validation_result.content_type,
+                    size=actual_size,
+                    creator_id=creator_id,
+                )
+                self.session.add(file)
+                await self.session.flush()
+                # Upload to blob storage while the DB transaction is still open so a
+                # storage failure can roll back the File/CaseAttachment rows.
                 await self._upload_to_attachments_bucket(
                     content=params.content,
                     sha256=sha256,
                     content_type=validation_result.content_type,
                 )
+            else:
+                # Verify existing file's recorded size matches actual content
+                if file.size != actual_size:
+                    logger.error(
+                        "Security: Existing file size mismatch detected",
+                        case_id=case.id,
+                        file_id=file.id,
+                        sha256=sha256,
+                        recorded_size=file.size,
+                        actual_size=actual_size,
+                        filename=params.file_name,
+                    )
+                    # Update the file record with correct size
+                    file.size = actual_size
 
-        # Check if attachment already exists for this case and file
-        existing_attachment = await self.session.execute(
-            select(CaseAttachment)
-            .where(
-                CaseAttachment.case_id == case.id,
-                CaseAttachment.file_id == file.id,
+                # If the file entity exists but has been soft deleted, restore and re-upload
+                if file.deleted_at is not None:
+                    file.deleted_at = None
+                    restored = True
+                    await self._upload_to_attachments_bucket(
+                        content=params.content,
+                        sha256=sha256,
+                        content_type=validation_result.content_type,
+                    )
+
+            # Check if attachment already exists for this case and file
+            existing_attachment = await self.session.execute(
+                select(CaseAttachment)
+                .where(
+                    CaseAttachment.case_id == case.id,
+                    CaseAttachment.file_id == file.id,
+                )
+                .options(selectinload(CaseAttachment.file))
             )
-            .options(selectinload(CaseAttachment.file))
-        )
-        attachment = existing_attachment.scalars().first()
+            attachment = existing_attachment.scalars().first()
 
-        should_create_event = False
-        if attachment:
-            # Attachment already exists and is active - return it
-            # (If the underlying file was restored above, emit restoration event)
-            if (
-                not restored
-                and file.deleted_at is None
-                and getattr(attachment.file, "deleted_at", None) is None
-            ):
-                return attachment
-            # Ensure relationship is consistent
-            attachment.file = file
-            should_create_event = True
-        else:
-            # Create new attachment link
-            attachment = CaseAttachment(
-                case_id=case.id,
-                file_id=file.id,
-            )
-            # Eagerly link the file relationship to avoid lazy loading in async contexts
-            attachment.file = file
-            self.session.add(attachment)
-            should_create_event = True  # New attachment event
+            should_create_event = False
+            if attachment:
+                # Attachment already exists and is active - return it
+                # (If the underlying file was restored above, emit restoration event)
+                if (
+                    not restored
+                    and file.deleted_at is None
+                    and getattr(attachment.file, "deleted_at", None) is None
+                ):
+                    await self.session.commit()
+                    return attachment
+                # Ensure relationship is consistent
+                attachment.file = file
+                should_create_event = True
+            else:
+                # Create new attachment link
+                attachment = CaseAttachment(
+                    case_id=case.id,
+                    file_id=file.id,
+                )
+                # Eagerly link the file relationship to avoid lazy loading in async contexts
+                attachment.file = file
+                self.session.add(attachment)
+                should_create_event = True  # New attachment event
 
-        # Flush to ensure the attachment gets an ID
-        await self.session.flush()
+            # Flush to ensure the attachment gets an ID
+            await self.session.flush()
 
-        # Record attachment event (for new attachments or restorations)
-        if should_create_event:
-            await self._emit_case_event(
-                case,
-                AttachmentCreatedEvent(
-                    attachment_id=attachment.id,
-                    file_name=file.name,
-                    content_type=file.content_type,
-                    size=file.size,  # This now uses the actual size from the File record
-                    wf_exec_id=None,  # populated by _emit_case_event if run context available
-                ),
-            )
+            # Record attachment event (for new attachments or restorations)
+            if should_create_event:
+                await self._emit_case_event(
+                    case,
+                    AttachmentCreatedEvent(
+                        attachment_id=attachment.id,
+                        file_name=file.name,
+                        content_type=file.content_type,
+                        size=file.size,  # This now uses the actual size from the File record
+                        wf_exec_id=None,  # populated by _emit_case_event if run context available
+                    ),
+                )
 
-        await self.session.commit()
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+
         # Reload attachment with the file relationship eagerly loaded
         await self.session.refresh(attachment, attribute_names=["file"])
         return attachment


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
  - Full suite not run locally. Focused structural, disposable-Postgres concurrency, and internal-router regression tests passed.
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?
  - Full pre-commit not run; focused Ruff, format, basedpyright, and whitespace checks passed for touched files.

## Description

This PR serializes per-case attachment quota checks for uploads by locking the target case row before enforcing aggregate count/storage limits and before mutating file or attachment rows.

Why this matters:

- Attachment count and storage limits are derived from aggregate reads.
- Concurrent uploads can otherwise make quota decisions from the same stale pre-insert state.
- Keeping the lock in `CaseAttachmentService.create_attachment()` makes the invariant shared by public, internal, and future service-level callers.
- The deterministic request checks still run before the row lock, so invalid file policy/size/content inputs do not hold the case lock.
- Already-active duplicate uploads remain idempotent and do not consume additional quota.

Changes:

- Add `_lock_case_for_attachment_write()` to select the target `Case` in the current workspace with `FOR UPDATE`.
- Run size, workspace policy, file validation, and content hashing before acquiring the row lock.
- Enforce aggregate quota checks and file/attachment mutation inside the post-lock transaction for net-new/restored attachments.
- Preserve already-active duplicate uploads as idempotent returns before quota enforcement.
- Explicitly commit duplicate fast paths and rollback quota/failure paths so the row lock is released promptly.
- Map a missing locked case to `404` in both public and internal attachment upload routers.
- Map internal executor quota failures to structured `409` / `413` responses instead of surfacing expected quota outcomes as generic errors.
- Add structural unit coverage, a disposable-Postgres concurrency regression, and internal-router quota mapping tests.

## Related Issues

Fixes #2970

## Screenshots / Recordings

N/A — backend-only reliability fix.

## Steps to QA

Validation run locally:

- `uv run pytest --confcutdir=tests/unit tests/unit/test_case_attachments_service_locking.py tests/unit/test_case_attachment_quota_concurrency.py tests/unit/test_case_attachments_internal_router.py -q` — passed (`6 passed`)
- `uv run ruff check tracecat/cases/attachments/service.py tracecat/cases/attachments/router.py tracecat/cases/attachments/internal_router.py tests/unit/test_case_attachments_service_locking.py tests/unit/test_case_attachment_quota_concurrency.py tests/unit/test_case_attachments_internal_router.py` — passed
- `uv run ruff format --check tracecat/cases/attachments/service.py tracecat/cases/attachments/router.py tracecat/cases/attachments/internal_router.py tests/unit/test_case_attachments_service_locking.py tests/unit/test_case_attachment_quota_concurrency.py tests/unit/test_case_attachments_internal_router.py` — passed
- `uv run basedpyright --warnings --threads 4 tracecat/cases/attachments/service.py tracecat/cases/attachments/router.py tracecat/cases/attachments/internal_router.py tests/unit/test_case_attachments_service_locking.py tests/unit/test_case_attachment_quota_concurrency.py tests/unit/test_case_attachments_internal_router.py` — passed (`0 errors, 0 warnings, 0 notes`)
- `git diff --check` — passed

Attempted but not completed locally:

- `uv run pytest tests/unit/test_case_attachment_quota_concurrency.py -q` — interrupted during the root session fixture setup because the local host did not have the full service stack expected by root conftest. The same regression was run with `--confcutdir=tests/unit` against a disposable PostgreSQL database.
- Full `uv run pytest tests` / `pre-commit run --all-files` — not run locally due scope/time; focused checks above cover the changed files and regression path.

## Security / disclosure notes

- Classification: security-relevant reliability hardening / business-rule race; no CVE/GHSA claim.
- Public disclosure safe: yes. The PR describes quota serialization at a high level and does not include exploit payloads.
- Required boundary: callers already need the existing attachment upload authorization path (for example `case:update`). This is not an auth bypass or data exposure fix.
- Sensitive details omitted: yes.
- Remaining adjacent risk: this PR serializes the quota read/write path for a case. It does not attempt to change workspace-wide file deduplication constraints or pre-service request body buffering.

## Risk

Risk level: low to medium.

Compatibility impact: no public API/schema changes; internal executor quota failures now receive structured quota HTTP errors instead of unhandled exceptions.
Rollback simplicity: revert the service helper, call site, router error handling, and tests.
Operational tradeoff: concurrent uploads to the same case now serialize while the upload transaction is in progress; uploads to different cases are unaffected.
Docs: not changed because this is an internal consistency fix with no API, setup, or user-facing workflow change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize per-case attachment quota checks by locking the case row in the service to prevent concurrent uploads from exceeding limits. Also return 404 if the case disappears and surface structured quota errors to internal clients.

- **Bug Fixes**
  - Lock the case row with `FOR UPDATE` in `CaseAttachmentService.create_attachment()` before `_assert_case_limits()`; keep hashing and workspace/file validation outside the lock; run upload/mutations under the lock with explicit commit/rollback, and return already-active duplicates before quota checks.
  - Map `TracecatNotFoundError` to 404 in both public and internal routers; map internal executor quota failures to 409 (`max_attachments_exceeded`) and 413 (`storage_limit_exceeded`) with MB details.
  - Add tests: service locking behavior, a disposable-Postgres concurrency regression with timeouts and task cancellation, and internal router error mapping.

<sup>Written for commit 4734d96f9a0e459e03ef0ff70fe70041643a77c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

