### PR TITLE
ci: bound privileged workflow job runtimes

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -32,6 +32,7 @@ jobs:
         github.triggering_actor || github.actor
       )
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +115,7 @@ jobs:
       )
     needs: build-and-push-api
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -268,6 +270,7 @@ jobs:
       )
     needs: build-and-push-ui
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,6 +25,7 @@ jobs:
         github.triggering_actor || github.actor
       )
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,6 +23,7 @@ jobs:
         github.triggering_actor || github.actor
       )
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 180
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
@@ -169,6 +170,7 @@ jobs:
     if: ${{ needs.publish-release.result == 'success' }}
     continue-on-error: true
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     environment: release
     permissions:
       contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   main:
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    timeout-minutes: 10
     steps:
       - name: Draft release
         uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6

--- a/tests/unit/test_github_workflow_timeouts.py
+++ b/tests/unit/test_github_workflow_timeouts.py
@@ -1,0 +1,43 @@
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def default_org() -> Iterator[None]:
+    """Workflow policy checks do not need seeded organization state."""
+    yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def workflow_bucket() -> Iterator[None]:
+    """Workflow policy checks do not need object storage buckets."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def clean_redis_db() -> Iterator[None]:
+    """Workflow policy checks do not need Redis isolation."""
+    yield
+
+
+def test_github_actions_jobs_set_timeout_minutes() -> None:
+    missing_timeouts: list[str] = []
+
+    for workflow_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        workflow = yaml.safe_load(workflow_path.read_text()) or {}
+        jobs = workflow.get("jobs") or {}
+
+        for job_name, job in jobs.items():
+            if isinstance(job, dict) and "timeout-minutes" not in job:
+                relative_path = workflow_path.relative_to(REPO_ROOT)
+                missing_timeouts.append(f"{relative_path}:{job_name}")
+
+    assert not missing_timeouts, (
+        "GitHub Actions jobs must set timeout-minutes: " + ", ".join(missing_timeouts)
+    )

--- a/tests/unit/test_github_workflow_timeouts.py
+++ b/tests/unit/test_github_workflow_timeouts.py
@@ -29,7 +29,13 @@ def clean_redis_db() -> Iterator[None]:
 def test_github_actions_jobs_set_timeout_minutes() -> None:
     missing_timeouts: list[str] = []
 
-    for workflow_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+    workflow_paths = sorted(
+        path
+        for suffix in (".yaml", ".yml")
+        for path in WORKFLOWS_DIR.glob(f"*{suffix}")
+    )
+
+    for workflow_path in workflow_paths:
         workflow = yaml.safe_load(workflow_path.read_text()) or {}
         jobs = workflow.get("jobs") or {}
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)? Focused workflow-policy tests passed; full test suite was not run for this static CI policy change.
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)? Focused Ruff checks passed; full pre-commit was not run.

## Description

This PR bounds the runtime of release/image publishing jobs by adding explicit `timeout-minutes` values to the remaining GitHub Actions jobs that did not have them.

Why this matters:

- `.github/AGENTS.md` requires `timeout-minutes` so privileged workflows cannot run indefinitely.
- The touched workflows publish container images, create release branches/tags, publish draft releases, or dispatch downstream release automation.
- The change is intentionally small: it adds job-level timeouts and a static regression test that fails if a future GitHub Actions YAML job omits `timeout-minutes`.

Changes:

- Adds timeouts to the unbounded jobs in:
  - `.github/workflows/build-push-images.yml`
  - `.github/workflows/create-release.yml`
  - `.github/workflows/publish-release.yml`
  - `.github/workflows/release-drafter.yml`
- Adds `tests/unit/test_github_workflow_timeouts.py` to enforce the policy across `.github/workflows/*.yml` and `.github/workflows/*.yaml`.

Security / disclosure notes:

- Classification: security hardening / release reliability.
- Public disclosure safe: yes.
- CVE/GHSA/advisory: none.
- Sensitive details omitted: yes; this does not disclose a private vulnerability.

Risk:

- Risk level: low.
- Compatibility impact: none expected; this only bounds maximum job runtime.
- The `publish-release` timeout is intentionally generous because it dispatches and waits for image publishing and may rerun failed jobs.

## Related Issues

Fixes #2972

## Screenshots / Recordings

Not applicable; CI workflow policy change only.

## Steps to QA

Validation run locally:

- `uv run pytest tests/unit/test_github_workflow_timeouts.py -q` — passed (`1 passed`; one unrelated existing Pydantic deprecation warning surfaced during collection)
- `uv run pytest --confcutdir=tests/unit tests/unit/test_github_workflow_timeouts.py -q` — passed (`1 passed`)
- `uv run ruff check tests/unit/test_github_workflow_timeouts.py` — passed
- `uv run ruff format --check tests/unit/test_github_workflow_timeouts.py` — passed
- `uv run basedpyright --warnings tests/unit/test_github_workflow_timeouts.py` — passed
- Static YAML timeout scan over `.github/workflows/*.yml` and `.github/workflows/*.yaml` — passed; all jobs define `timeout-minutes`
- `git diff --check` — passed
