### PR TITLE
fix(registry): make views.update hash an optional input

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/views/update_view.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/views/update_view.yml
@@ -15,6 +15,14 @@ definition:
       description: >
         Updated view payload for the modal.
         See: https://docs.slack.dev/reference/views/modal-views/
+    hash:
+      description: >
+        Optional view state hash for optimistic concurrency control.
+        Obtained from the response of views.open or a previous views.update.
+        If provided, the update fails with hash_conflict when the view has
+        been modified since. Omit to update unconditionally.
+      type: str | None
+      default: null
   steps:
     - ref: update_view
       action: tools.slack_sdk.call_method
@@ -23,5 +31,5 @@ definition:
         params:
           view_id: ${{ inputs.view_id }}
           view: ${{ inputs.view }}
-          hash: ${{ FN.to_isoformat(FN.utcnow()) }}
+          hash: ${{ inputs.hash }}
   returns: ${{ steps.update_view.result }}


### PR DESCRIPTION
The hash parameter was hardcoded to `FN.to_isoformat(FN.utcnow())` which is never a valid Slack view state hash, causing hash_conflict errors on every call. Replace with an optional input that defaults to null, allowing callers to pass the real hash for optimistic concurrency control or omit it to update unconditionally.

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes the `tools.slack.update_view` registry template. The `hash` parameter was hardcoded to `FN.to_isoformat(FN.utcnow())`, which always produces an invalid Slack view state hash and causes every `views.update` call to fail with a `hash_conflict` error.

The fix changes `hash` to an optional input (`str | None`, default `null`). Callers can now:
- Pass a real hash (from `views.open` or a prior `views.update` response) for optimistic concurrency control
- Omit it to update unconditionally

## Related Issues

## Screenshots / Recordings

N/A — template-only change, no UI.

## Steps to QA

1. Use a Slack bot workflow that calls `tools.slack.update_view` without a hash — confirm it succeeds
2. Call `tools.slack.update_view` with a valid hash from a prior `views.open` — confirm it succeeds
3. Call with a stale/invalid hash — confirm Slack returns `hash_conflict` as expected


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `hash` an optional input (default `null`) in `tools.slack.update_view` instead of using a hardcoded timestamp. This fixes `views.update` `hash_conflict` errors and enables proper optimistic concurrency.

Callers can pass a real hash from `views.open` or a prior `views.update`, or omit it to update unconditionally.

<sup>Written for commit 33e66f6f36a05c9d62db3ef4d2b14fc461ed96f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

