### PR TITLE
ci: avoid persisted checkout credentials in read-only jobs

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
         run: |
@@ -187,6 +189,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
         run: |

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -31,6 +31,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
@@ -49,6 +51,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -96,6 +96,8 @@ jobs:
     timeout-minutes: 5 # short fail-fast window
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # Load the private deploy key into an ssh-agent.
       # The secret value MUST be the *raw* PEM text, not base64.
@@ -138,6 +140,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/test-pnpm-build.yml
+++ b/.github/workflows/test-pnpm-build.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
         run: |

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -42,6 +42,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4
@@ -79,6 +81,8 @@ jobs:
           # - ee # TODO: re-enable this when we have tests
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4

--- a/tests/unit/test_github_workflow_checkout_credentials.py
+++ b/tests/unit/test_github_workflow_checkout_credentials.py
@@ -1,0 +1,94 @@
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+CHECKOUT_ACTION_PREFIX = "actions/checkout@"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def default_org() -> Iterator[None]:
+    """Workflow policy checks do not need seeded organization state."""
+    yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def workflow_bucket() -> Iterator[None]:
+    """Workflow policy checks do not need object storage buckets."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def clean_redis_db() -> Iterator[None]:
+    """Workflow policy checks do not need Redis isolation."""
+    yield
+
+
+def _workflow_paths() -> list[Path]:
+    return sorted(
+        path
+        for suffix in (".yaml", ".yml")
+        for path in WORKFLOWS_DIR.glob(f"*{suffix}")
+    )
+
+
+def _contents_permission(permissions: Any) -> str | None:
+    if isinstance(permissions, str):
+        if permissions == "write-all":
+            return "write"
+        if permissions == "read-all":
+            return "read"
+        return None
+
+    if isinstance(permissions, Mapping):
+        contents = permissions.get("contents")
+        return contents if isinstance(contents, str) else None
+
+    return None
+
+
+def _checkout_persists_credentials(step: Mapping[str, Any]) -> bool:
+    with_config = step.get("with") or {}
+    if not isinstance(with_config, Mapping):
+        return True
+
+    persist_credentials = with_config.get("persist-credentials")
+    return (
+        persist_credentials is not False and str(persist_credentials).lower() != "false"
+    )
+
+
+def test_read_only_checkout_steps_do_not_persist_credentials() -> None:
+    persisted_credentials: list[str] = []
+
+    for workflow_path in _workflow_paths():
+        workflow = yaml.safe_load(workflow_path.read_text()) or {}
+        workflow_permissions = workflow.get("permissions")
+
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            if not isinstance(job, Mapping):
+                continue
+
+            permissions = job.get("permissions", workflow_permissions)
+            if _contents_permission(permissions) == "write":
+                continue
+
+            for index, step in enumerate(job.get("steps") or []):
+                if not isinstance(step, Mapping):
+                    continue
+                if not str(step.get("uses", "")).startswith(CHECKOUT_ACTION_PREFIX):
+                    continue
+                if _checkout_persists_credentials(step):
+                    relative_path = workflow_path.relative_to(REPO_ROOT)
+                    persisted_credentials.append(
+                        f"{relative_path}:{job_name}:steps[{index}]"
+                    )
+
+    assert not persisted_credentials, (
+        "Read-only checkout steps must set persist-credentials: false: "
+        + ", ".join(persisted_credentials)
+    )

--- a/tests/unit/test_github_workflow_checkout_credentials.py
+++ b/tests/unit/test_github_workflow_checkout_credentials.py
@@ -8,6 +8,14 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 CHECKOUT_ACTION_PREFIX = "actions/checkout@"
+PUSH_REQUIRED_CHECKOUT_JOBS = {
+    (Path(".github/workflows/create-release.yml"), "create-release"): (
+        "pushes release branches with GITHUB_TOKEN"
+    ),
+    (Path(".github/workflows/publish-release.yml"), "publish-release"): (
+        "pushes release tags with GITHUB_TOKEN"
+    ),
+}
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -62,33 +70,99 @@ def _checkout_persists_credentials(step: Mapping[str, Any]) -> bool:
     )
 
 
-def test_read_only_checkout_steps_do_not_persist_credentials() -> None:
-    persisted_credentials: list[str] = []
+@pytest.mark.parametrize(
+    ("permissions", "expected"),
+    [
+        ("write-all", "write"),
+        ("read-all", "read"),
+        ({"contents": "write"}, "write"),
+        ({"contents": "read"}, "read"),
+        ({"contents": "none"}, "none"),
+        ({"packages": "write"}, None),
+        ({}, None),
+        (None, None),
+    ],
+)
+def test_contents_permission(permissions: Any, expected: str | None) -> None:
+    assert _contents_permission(permissions) == expected
 
-    for workflow_path in _workflow_paths():
+
+@pytest.mark.parametrize(
+    ("step", "expected"),
+    [
+        ({}, True),
+        ({"with": {}}, True),
+        ({"with": "invalid"}, True),
+        ({"with": {"persist-credentials": False}}, False),
+        ({"with": {"persist-credentials": "false"}}, False),
+        ({"with": {"persist-credentials": "FALSE"}}, False),
+        ({"with": {"persist-credentials": True}}, True),
+        ({"with": {"persist-credentials": "true"}}, True),
+    ],
+)
+def test_checkout_persists_credentials(step: Mapping[str, Any], expected: bool) -> None:
+    assert _checkout_persists_credentials(step) is expected
+
+
+def test_non_exempt_checkout_steps_do_not_persist_credentials() -> None:
+    workflow_paths = _workflow_paths()
+    assert workflow_paths, "No GitHub Actions workflow files found"
+
+    persisted_credentials: list[str] = []
+    checked_checkout_steps = 0
+    seen_push_required_checkout_jobs: set[tuple[Path, str]] = set()
+
+    for workflow_path in workflow_paths:
         workflow = yaml.safe_load(workflow_path.read_text()) or {}
         workflow_permissions = workflow.get("permissions")
+        relative_path = workflow_path.relative_to(REPO_ROOT)
 
         for job_name, job in (workflow.get("jobs") or {}).items():
             if not isinstance(job, Mapping):
                 continue
 
             permissions = job.get("permissions", workflow_permissions)
-            if _contents_permission(permissions) == "write":
+            checkout_steps = [
+                (index, step)
+                for index, step in enumerate(job.get("steps") or [])
+                if isinstance(step, Mapping)
+                and str(step.get("uses", "")).startswith(CHECKOUT_ACTION_PREFIX)
+            ]
+
+            push_required_job = (relative_path, job_name)
+            if push_required_job in PUSH_REQUIRED_CHECKOUT_JOBS:
+                assert _contents_permission(permissions) == "write", (
+                    f"{relative_path}:{job_name} is listed as a push-required "
+                    "checkout exemption but does not have contents: write"
+                )
+                assert checkout_steps, (
+                    f"{relative_path}:{job_name} is listed as a push-required "
+                    "checkout exemption but has no checkout step"
+                )
+                seen_push_required_checkout_jobs.add(push_required_job)
                 continue
 
-            for index, step in enumerate(job.get("steps") or []):
-                if not isinstance(step, Mapping):
-                    continue
-                if not str(step.get("uses", "")).startswith(CHECKOUT_ACTION_PREFIX):
-                    continue
+            for index, step in checkout_steps:
+                checked_checkout_steps += 1
                 if _checkout_persists_credentials(step):
-                    relative_path = workflow_path.relative_to(REPO_ROOT)
                     persisted_credentials.append(
                         f"{relative_path}:{job_name}:steps[{index}]"
                     )
 
+    assert seen_push_required_checkout_jobs == set(PUSH_REQUIRED_CHECKOUT_JOBS), (
+        "Push-required checkout exemptions must match existing checkout jobs: "
+        + ", ".join(
+            f"{path}:{job_name}"
+            for path, job_name in sorted(
+                set(PUSH_REQUIRED_CHECKOUT_JOBS) ^ seen_push_required_checkout_jobs,
+                key=lambda item: (str(item[0]), item[1]),
+            )
+        )
+    )
+    assert checked_checkout_steps > 0, (
+        "No non-exempt actions/checkout steps were evaluated"
+    )
     assert not persisted_credentials, (
-        "Read-only checkout steps must set persist-credentials: false: "
+        "Non-exempt checkout steps must set persist-credentials: false: "
         + ", ".join(persisted_credentials)
     )


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)? Focused workflow-policy tests passed; full test suite was not run for this static CI policy change.
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)? Focused Ruff/type checks passed; full pre-commit was not run.

## Description

This PR avoids persisting checkout credentials in GitHub Actions jobs that only need read access to the repository.

Why this matters:

- `.github/AGENTS.md` requires `persist-credentials: false` on `actions/checkout` unless a job must push with `GITHUB_TOKEN`.
- Read-only lint/test/build jobs do not need the checkout token persisted into local git config for later steps.
- Disabling persistence reduces unnecessary token exposure in CI without changing repository checkout behavior.

Changes:

- Adds `persist-credentials: false` to read-only checkout steps in CI, image, frontend, Python, integration, and build-test workflows.
- Leaves the two current release jobs that push branches/tags with `GITHUB_TOKEN` exempt.
- Adds `tests/unit/test_github_workflow_checkout_credentials.py` to enforce the policy across `.github/workflows/*.yml` and `.github/workflows/*.yaml`. The test uses explicit push-required checkout exemptions instead of treating every `contents: write` job as exempt, and includes helper/anti-vacuous coverage so future regressions fail loudly.

Security / disclosure notes:

- Classification: security hardening / CI supply-chain hardening.
- Public disclosure safe: yes.
- CVE/GHSA/advisory: none.
- Sensitive details omitted: yes; this does not disclose a private vulnerability.

Risk:

- Risk level: low.
- Compatibility impact: read-only jobs still check out the same repository content; they simply do not persist checkout credentials for later git commands.
- Jobs that intentionally push release branches/tags with `GITHUB_TOKEN` are not changed by this PR.

## Related Issues

Fixes #2975

## Screenshots / Recordings

Not applicable; CI workflow policy change only.

## Steps to QA

Validation run locally:

- `uv run pytest tests/unit/test_github_workflow_checkout_credentials.py -q` — passed (`17 passed`; one unrelated existing Pydantic deprecation warning surfaced during collection)
- `uv run pytest --confcutdir=tests/unit tests/unit/test_github_workflow_checkout_credentials.py -q` — passed (`17 passed`)
- `uv run pytest tests/unit/test_github_workflow_checkout_credentials.py -m "not live_secret" -n auto -ra -o faulthandler_timeout=300` — passed (`17 passed`; unrelated existing Pydantic deprecation warnings across xdist workers)
- `uv run ruff check tests/unit/test_github_workflow_checkout_credentials.py` — passed
- `uv run ruff format --check tests/unit/test_github_workflow_checkout_credentials.py` — passed
- `uv run basedpyright --warnings tests/unit/test_github_workflow_checkout_credentials.py` — passed
- Static checkout credential scan over `.github/workflows/*.yml` and `.github/workflows/*.yaml` — passed; 13 non-exempt checkout steps disable persisted credentials; only the explicit release branch/tag push jobs are exempt
- `git diff --check` — passed
