### PR TITLE
ci: validate manual image publish refs

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -23,7 +23,49 @@ permissions:
   packages: write
 
 jobs:
+  validate-manual-publish-ref:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Validate manual publish tag/ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            exit 0
+          fi
+
+          if [ -z "$INPUT_TAG" ]; then
+            echo "Manual image publish requires a tag input." >&2
+            exit 1
+          fi
+
+          if [[ "$INPUT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?(\+[0-9A-Za-z.]+)?$ ]]; then
+            :
+          elif [[ "$INPUT_TAG" =~ ^nightly-[0-9]{8}(-[0-9A-Fa-f]{7,40})?$ ]]; then
+            :
+          else
+            echo "Manual image publish tag '$INPUT_TAG' must be semver or nightly-YYYYMMDD." >&2
+            exit 1
+          fi
+
+          if [ "$REF_TYPE" != "tag" ]; then
+            echo "Manual image publish must run from a Git tag ref, got '$REF_TYPE'." >&2
+            exit 1
+          fi
+
+          if [ "$REF_NAME" != "$INPUT_TAG" ]; then
+            echo "Manual image publish tag '$INPUT_TAG' must match workflow ref '$REF_NAME'." >&2
+            exit 1
+          fi
+
   build-and-push-api:
+    needs: validate-manual-publish-ref
     if: >-
       github.event_name != 'workflow_dispatch' ||
       github.actor == 'github-actions[bot]' ||
@@ -165,6 +207,7 @@ jobs:
           docker buildx imagetools inspect ghcr.io/tracecathq/tracecat:${{ steps.meta.outputs.version }}
 
   build-and-push-ui:
+    needs: validate-manual-publish-ref
     if: >-
       github.event_name != 'workflow_dispatch' ||
       github.actor == 'github-actions[bot]' ||

--- a/tests/unit/test_github_workflow_image_publish_ref.py
+++ b/tests/unit/test_github_workflow_image_publish_ref.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "build-push-images.yml"
+VALIDATION_JOB = "validate-manual-publish-ref"
+VALIDATION_STEP = "Validate manual publish tag/ref"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def default_org() -> Iterator[None]:
+    """Workflow policy checks do not need seeded organization state."""
+    yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def workflow_bucket() -> Iterator[None]:
+    """Workflow policy checks do not need object storage buckets."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def clean_redis_db() -> Iterator[None]:
+    """Workflow policy checks do not need Redis isolation."""
+    yield
+
+
+def _workflow() -> Mapping[str, Any]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
+    assert isinstance(workflow, Mapping)
+    return workflow
+
+
+def _jobs() -> Mapping[str, Any]:
+    jobs = _workflow().get("jobs")
+    assert isinstance(jobs, Mapping)
+    return jobs
+
+
+def _validation_script() -> str:
+    job = _jobs().get(VALIDATION_JOB)
+    assert isinstance(job, Mapping)
+
+    for step in job.get("steps") or []:
+        if isinstance(step, Mapping) and step.get("name") == VALIDATION_STEP:
+            script = step.get("run")
+            assert isinstance(script, str)
+            return script
+
+    pytest.fail(f"Missing {VALIDATION_STEP!r} step in {VALIDATION_JOB!r}")
+
+
+def _run_validation(
+    *,
+    event_name: str,
+    input_tag: str,
+    ref_type: str,
+    ref_name: str,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "EVENT_NAME": event_name,
+        "INPUT_TAG": input_tag,
+        "REF_NAME": ref_name,
+        "REF_TYPE": ref_type,
+    }
+    return subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", _validation_script()],
+        check=False,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_image_build_jobs_wait_for_manual_publish_ref_validation() -> None:
+    jobs = _jobs()
+
+    for job_name in ("build-and-push-api", "build-and-push-ui"):
+        job = jobs.get(job_name)
+        assert isinstance(job, Mapping)
+        assert job.get("needs") == VALIDATION_JOB
+
+
+def test_manual_publish_validation_job_does_not_get_package_write_scope() -> None:
+    job = _jobs().get(VALIDATION_JOB)
+    assert isinstance(job, Mapping)
+
+    permissions = job.get("permissions")
+    assert isinstance(permissions, Mapping)
+    assert permissions.get("contents") == "read"
+    assert permissions.get("packages") is None
+
+
+@pytest.mark.parametrize(
+    ("input_tag", "ref_name"),
+    [
+        ("1.2.3", "1.2.3"),
+        ("1.2.3-beta.0", "1.2.3-beta.0"),
+        ("1.2.3+build.1", "1.2.3+build.1"),
+        ("nightly-20250101", "nightly-20250101"),
+        ("nightly-20250101-abcdef0", "nightly-20250101-abcdef0"),
+    ],
+)
+def test_manual_publish_validation_accepts_matching_tag_refs(
+    input_tag: str, ref_name: str
+) -> None:
+    result = _run_validation(
+        event_name="workflow_dispatch",
+        input_tag=input_tag,
+        ref_type="tag",
+        ref_name=ref_name,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_manual_publish_validation_ignores_non_manual_events() -> None:
+    result = _run_validation(
+        event_name="push",
+        input_tag="",
+        ref_type="branch",
+        ref_name="staging",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("input_tag", "ref_type", "ref_name", "expected_error"),
+    [
+        ("", "tag", "", "requires a tag input"),
+        ("latest", "tag", "latest", "must be semver or nightly-YYYYMMDD"),
+        ("refs/pull/1/merge", "tag", "refs/pull/1/merge", "must be semver"),
+        ("1.2.3", "branch", "main", "must run from a Git tag ref"),
+        ("1.2.3", "tag", "1.2.4", "must match workflow ref"),
+        ("nightly-main", "tag", "nightly-main", "must be semver"),
+    ],
+)
+def test_manual_publish_validation_rejects_unsafe_tag_ref_pairs(
+    input_tag: str,
+    ref_type: str,
+    ref_name: str,
+    expected_error: str,
+) -> None:
+    result = _run_validation(
+        event_name="workflow_dispatch",
+        input_tag=input_tag,
+        ref_type=ref_type,
+        ref_name=ref_name,
+    )
+
+    assert result.returncode != 0
+    assert expected_error in result.stderr


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)? Focused workflow-policy tests passed; full test suite was not run for this CI workflow hardening change.
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)? Focused Ruff/type checks passed; full pre-commit was not run.

## Description

This PR validates manual image publish tag/ref inputs before the workflow reaches checkout, registry login, or image build jobs.

Why this matters:

- `build-push-images.yml` uses `workflow_dispatch.inputs.tag` as a raw GHCR image tag for API and UI images.
- For non-nightly manual tags, the manifest jobs also publish `latest`.
- `.github/AGENTS.md` asks privileged workflows to validate branch names, versions, tags, and other trusted inputs before mutating releases, tags, registries, or downstream repositories.
- Requiring the manual input tag to match the workflow's Git tag ref reduces the chance that a trusted/operator dispatch typo publishes images from the wrong commit under a release-like tag.

Changes:

- Adds a lightweight `validate-manual-publish-ref` job before the API/UI image build jobs.
- For non-`workflow_dispatch` events, the validation job exits without changing push/schedule behavior.
- For manual runs, the job now requires:
  - a semver or `nightly-YYYYMMDD`-style tag input,
  - `github.ref_type == tag`, and
  - `github.ref_name == inputs.tag`.
- Scopes the validation job to `contents: read` so it does not inherit package write scope.
- Adds focused pytest coverage that extracts and executes the workflow validation script for accepted and rejected tag/ref combinations.

Security / disclosure notes:

- Classification: release/registry integrity hardening.
- Public disclosure safe: yes.
- CVE/GHSA/advisory: none.
- Sensitive details omitted: yes; this does not disclose a private vulnerability.

Risk:

- Risk level: low.
- Compatibility impact: push and scheduled image publishes continue through the validation job unchanged. The automated release flow already dispatches this workflow with `--ref <version>` and `--field tag=<version>`, which matches the new manual validation rule.
- Manual image publishes from branches now fail early and must be rerun from the matching Git tag.

## Related Issues

Fixes #2977

## Screenshots / Recordings

Not applicable; CI workflow policy change only.

## Steps to QA

Validation run locally:

- `uv run pytest tests/unit/test_github_workflow_image_publish_ref.py -q` — passed (`14 passed`; one unrelated existing Pydantic deprecation warning surfaced during collection)
- `uv run pytest --confcutdir=tests/unit tests/unit/test_github_workflow_image_publish_ref.py -q` — passed (`14 passed`)
- `uv run pytest tests/unit/test_github_workflow_image_publish_ref.py -m "not live_secret" -n auto -ra -o faulthandler_timeout=300` — passed (`14 passed`; unrelated existing Pydantic deprecation warnings across xdist workers)
- `uv run ruff check tests/unit/test_github_workflow_image_publish_ref.py` — passed
- `uv run ruff format --check tests/unit/test_github_workflow_image_publish_ref.py` — passed
- `uv run basedpyright --warnings tests/unit/test_github_workflow_image_publish_ref.py` — passed
- Static YAML parse of `.github/workflows/build-push-images.yml` — passed; API/UI image build jobs depend on `validate-manual-publish-ref`, and the validation job has `contents: read` with no package write scope
- `git diff --check` — passed

Commands not run:

- Full image publishing workflow execution — not run because it requires GitHub Actions runners and protected registry credentials.
- `actionlint` — not run because it is not installed in this local environment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pre-validation step to `build-push-images.yml` so manual image publishes only run when the input tag is semver or nightly and matches the Git tag ref. This prevents publishing from the wrong commit and keeps manual runs aligned with the automated release flow.

- **New Features**
  - Added `validate-manual-publish-ref` job that accepts only semver or `nightly-YYYYMMDD(-<sha>)`, requires `github.ref_type: tag`, and `github.ref_name == inputs.tag`.
  - Scoped to `contents: read`; `build-and-push-api` and `build-and-push-ui` depend on it; non-manual events are unchanged.
  - Added unit tests covering accepted and rejected tag/ref pairs.

- **Migration**
  - For manual publishes, run the workflow from the matching Git tag and pass the same value as `tag`. Branch-based manual runs will fail early.

<sup>Written for commit d9986b3d53555961ae99bbab0d0b6220d2de2599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

