### PR TITLE
fix(ui): avoid logging secret payloads

### DIFF
--- a/frontend/src/components/organization/org-secret-create.tsx
+++ b/frontend/src/components/organization/org-secret-create.tsx
@@ -76,16 +76,18 @@ export function CreateOrgSecretDialog({
   const { control, register } = methods
 
   const onSubmit = async (values: SecretCreate) => {
-    console.log("Submitting new secret", values)
     try {
       await createSecret(values)
-    } catch (error) {
-      console.error(error)
+    } catch {
+      toast({
+        title: "Failed to create secret",
+        description: "An error occurred while creating the secret.",
+        variant: "destructive",
+      })
     }
     methods.reset()
   }
   const onValidationFailed = () => {
-    console.error("Form validation failed")
     toast({
       title: "Form validation failed",
       description: "A validation error occurred while adding the new secret.",

--- a/frontend/src/components/organization/org-secret-delete.tsx
+++ b/frontend/src/components/organization/org-secret-delete.tsx
@@ -47,8 +47,12 @@ export function DeleteOrgSecretAlertDialog({
             variant="destructive"
             onClick={async () => {
               if (selectedSecret) {
-                console.log("Deleting secret", selectedSecret)
-                await deleteSecretById(selectedSecret)
+                try {
+                  await deleteSecretById(selectedSecret)
+                } catch {
+                  // The organization secret mutation hook shows a sanitized toast.
+                  return
+                }
               }
               setSelectedSecret(null)
             }}

--- a/frontend/src/components/organization/org-secret-update.tsx
+++ b/frontend/src/components/organization/org-secret-update.tsx
@@ -92,7 +92,6 @@ export function UpdateOrgSecretDialog({
   const onSubmit = useCallback(
     async (values: SecretUpdate) => {
       if (!selectedSecret) {
-        console.error("No secret selected")
         return
       }
       // Remove unset values from the params object
@@ -103,14 +102,17 @@ export function UpdateOrgSecretDialog({
         environment: values.environment || undefined,
         keys: isSshKey ? undefined : values.keys,
       }
-      console.log("Submitting edit secret", params)
       try {
         await updateSecretById({
           secretId: selectedSecret.id,
           params,
         })
-      } catch (error) {
-        console.error(error)
+      } catch {
+        toast({
+          title: "Failed to update secret",
+          description: "An error occurred while updating the secret.",
+          variant: "destructive",
+        })
       }
       methods.reset()
       setSelectedSecret(null) // Only unset the selected secret after the form has been submitted
@@ -118,8 +120,7 @@ export function UpdateOrgSecretDialog({
     [selectedSecret, setSelectedSecret]
   )
 
-  const onValidationFailed = (errors: unknown) => {
-    console.error("Form validation failed", errors)
+  const onValidationFailed = () => {
     toast({
       title: "Form validation failed",
       description: "A validation error occurred while editing the secret.",

--- a/frontend/src/components/organization/org-secrets-table.tsx
+++ b/frontend/src/components/organization/org-secrets-table.tsx
@@ -35,7 +35,7 @@ export function OrgSecretsTable() {
     return (
       <AlertNotification
         level="error"
-        message={`Error loading secrets: ${orgSecretsError?.message || "Secrets undefined"}`}
+        message="Unable to load organization secrets."
       />
     )
   }
@@ -160,14 +160,9 @@ export function OrgSecretsTable() {
                         <DropdownMenuItem
                           onClick={() => {
                             if (!row.original) {
-                              console.error("No secret to edit")
                               return
                             }
                             setSelectedSecret(row.original)
-                            console.debug(
-                              "Selected secret to edit",
-                              row.original
-                            )
                           }}
                         >
                           Edit
@@ -179,10 +174,6 @@ export function OrgSecretsTable() {
                           className="text-rose-500 focus:text-rose-600"
                           onClick={() => {
                             setSelectedSecret(row.original)
-                            console.debug(
-                              "Selected secret to delete",
-                              row.original
-                            )
                           }}
                         >
                           Delete
@@ -217,7 +208,7 @@ export function OrgSSHKeysTable() {
     return (
       <AlertNotification
         level="error"
-        message={`Error loading secrets: ${orgSSHKeysError?.message || "Secrets undefined"}`}
+        message="Unable to load organization SSH keys."
       />
     )
   }
@@ -343,14 +334,9 @@ export function OrgSSHKeysTable() {
                           disabled
                           onClick={() => {
                             if (!row.original) {
-                              console.error("No secret to edit")
                               return
                             }
                             setSelectedSecret(row.original)
-                            console.debug(
-                              "Selected secret to edit",
-                              row.original
-                            )
                           }}
                         >
                           Edit
@@ -362,10 +348,6 @@ export function OrgSSHKeysTable() {
                           className="text-rose-500 focus:text-rose-600"
                           onClick={() => {
                             setSelectedSecret(row.original)
-                            console.debug(
-                              "Selected secret to delete",
-                              row.original
-                            )
                           }}
                         >
                           Delete

--- a/frontend/src/components/workspaces/create-credential-dialog.tsx
+++ b/frontend/src/components/workspaces/create-credential-dialog.tsx
@@ -865,18 +865,13 @@ export function CreateCredentialDialog({
     try {
       await createSecret(secret)
       onOpenChange(false)
-      toast({
-        title: "Secret created",
-        description: `Secret "${secretName}" has been created successfully.`,
-      })
       methods.reset()
-    } catch (error) {
-      console.log(error)
+    } catch {
+      // The workspace secret mutation hook already shows a sanitized toast.
     }
   }
 
   const onValidationFailed = () => {
-    console.error("Form validation failed")
     toast({
       title: "Form validation failed",
       description: "A validation error occurred while adding the new secret.",
@@ -1437,8 +1432,7 @@ export function CreateCredentialDialog({
                             </p>
                           ) : shouldHideAwsAssumeRoleNote ? null : (
                             <p className="text-xs text-destructive">
-                              {awsAssumeRoleAccessError?.message ||
-                                "Unable to load AWS role access details."}
+                              Unable to load AWS role access details.
                             </p>
                           )}
                         </div>

--- a/frontend/src/components/workspaces/delete-workspace-secret.tsx
+++ b/frontend/src/components/workspaces/delete-workspace-secret.tsx
@@ -50,8 +50,12 @@ export function DeleteSecretAlertDialog({
             variant="destructive"
             onClick={async () => {
               if (selectedSecret) {
-                console.log("Deleting secret", selectedSecret)
-                await deleteSecretById(selectedSecret)
+                try {
+                  await deleteSecretById(selectedSecret)
+                } catch {
+                  // The workspace secret mutation hook shows a sanitized toast.
+                  return
+                }
               }
               setSelectedSecret(null)
             }}

--- a/frontend/src/components/workspaces/edit-workspace-secret.tsx
+++ b/frontend/src/components/workspaces/edit-workspace-secret.tsx
@@ -570,7 +570,6 @@ export function EditCredentialsDialog({
   const onSubmit = useCallback(
     async (values: EditSecretForm) => {
       if (!selectedSecret) {
-        console.error("No secret selected")
         return
       }
       // Remove unset values from the params object
@@ -606,15 +605,14 @@ export function EditCredentialsDialog({
         keys:
           isSshKey || submittedKeys.length === 0 ? undefined : submittedKeys,
       }
-      console.log("Submitting edit secret", params)
       try {
         await updateSecretById({
           secretId: selectedSecret.id,
           params,
         })
         handleDialogOpenChange(false)
-      } catch (error) {
-        console.error(error)
+      } catch {
+        // The workspace secret mutation hook already shows a sanitized toast.
       }
     },
     [
@@ -629,8 +627,7 @@ export function EditCredentialsDialog({
     ]
   )
 
-  const onValidationFailed = (errors: unknown) => {
-    console.error("Form validation failed", errors)
+  const onValidationFailed = () => {
     toast({
       title: "Form validation failed",
       description: "A validation error occurred while editing the secret.",

--- a/frontend/src/components/workspaces/workspace-credentials-inventory.tsx
+++ b/frontend/src/components/workspaces/workspace-credentials-inventory.tsx
@@ -211,11 +211,7 @@ export function WorkspaceCredentialsInventory() {
     return (
       <AlertNotification
         level="error"
-        message={
-          secretDefinitionsError?.message ||
-          secretsError?.message ||
-          "Error loading credentials."
-        }
+        message="Unable to load workspace credentials."
       />
     )
   }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -1426,7 +1426,6 @@ export function useWorkspaceSecrets(
               "Secrets with the same name and environment are not supported.",
           })
         default:
-          console.error("Failed to create secret", error)
           return toast({
             title: "Failed to add new secret",
             description:
@@ -1467,7 +1466,6 @@ export function useWorkspaceSecrets(
             description: "You cannot update secrets in this workspace.",
           })
         default:
-          console.error("Failed to update secret", error)
           return toast({
             title: "Failed to update secret",
             description: "An error occurred while updating the secret.",
@@ -1497,7 +1495,6 @@ export function useWorkspaceSecrets(
             description: "You cannot delete secrets in this workspace.",
           })
         default:
-          console.error("Failed to delete secret", error)
           return toast({
             title: "Failed to delete secret",
             description: "An error occurred while deleting the secret.",
@@ -1807,6 +1804,13 @@ export function useOrgSecrets() {
           })
           break
       }
+    },
+    onError: () => {
+      toast({
+        title: "Failed to delete secret",
+        description: "An error occurred while deleting the secret.",
+        variant: "destructive",
+      })
     },
   })
 

--- a/frontend/tests/secret-console-logs.test.ts
+++ b/frontend/tests/secret-console-logs.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const SECRET_MANAGEMENT_COMPONENTS = [
+  "src/components/organization/org-secret-create.tsx",
+  "src/components/organization/org-secret-update.tsx",
+  "src/components/organization/org-secret-delete.tsx",
+  "src/components/organization/org-secrets-table.tsx",
+  "src/components/workspaces/create-credential-dialog.tsx",
+  "src/components/workspaces/edit-workspace-secret.tsx",
+  "src/components/workspaces/delete-workspace-secret.tsx",
+  "src/components/workspaces/workspace-credentials-inventory.tsx",
+]
+
+const SECRET_HOOKS = ["useWorkspaceSecrets", "useOrgSecrets"]
+
+const SECRET_ERROR_MESSAGE_COMPONENTS = [
+  "src/components/organization/org-secrets-table.tsx",
+  "src/components/workspaces/create-credential-dialog.tsx",
+  "src/components/workspaces/workspace-credentials-inventory.tsx",
+]
+
+const SECRET_DELETE_COMPONENTS = [
+  "src/components/organization/org-secret-delete.tsx",
+  "src/components/workspaces/delete-workspace-secret.tsx",
+]
+
+const disallowedConsolePattern =
+  /\b(?:console|window\.console|globalThis\.console)\s*\.\s*(?:log|debug|info|warn|error)\s*\(/
+
+const disallowedRawErrorMessagePattern = /\w+Error\?\.message/
+
+function readFrontendSource(relativePath: string) {
+  return readFileSync(join(process.cwd(), relativePath), "utf8")
+}
+
+function extractHookSource(source: string, hookName: string) {
+  const start = source.indexOf(`export function ${hookName}(`)
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const nextExport = source.indexOf("\nexport function ", start + 1)
+  return nextExport === -1
+    ? source.slice(start)
+    : source.slice(start, nextExport)
+}
+
+describe("secret management logging", () => {
+  it.each(SECRET_MANAGEMENT_COMPONENTS)(
+    "does not write secret data to the browser console from %s",
+    (relativePath) => {
+      const source = readFrontendSource(relativePath)
+
+      expect(source).not.toMatch(disallowedConsolePattern)
+    }
+  )
+
+  it.each(SECRET_HOOKS)(
+    "does not log secret mutation errors from %s",
+    (hookName) => {
+      const source = readFrontendSource("src/lib/hooks.tsx")
+      const hookSource = extractHookSource(source, hookName)
+
+      expect(hookSource).not.toMatch(disallowedConsolePattern)
+    }
+  )
+
+  it.each(SECRET_ERROR_MESSAGE_COMPONENTS)(
+    "does not render raw API error messages from %s",
+    (relativePath) => {
+      const source = readFrontendSource(relativePath)
+
+      expect(source).not.toMatch(disallowedRawErrorMessagePattern)
+    }
+  )
+
+  it.each(SECRET_DELETE_COMPONENTS)(
+    "catches rejected secret deletion promises in %s",
+    (relativePath) => {
+      const source = readFrontendSource(relativePath)
+
+      expect(source).toContain("await deleteSecretById(selectedSecret)")
+      expect(source).toContain("} catch {")
+    }
+  )
+})


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Relevant frontend regression test passing (`pnpm -C frontend test -- secret-console-logs.test.ts --runInBand`).
- [x] Affected frontend lint/type checks passing (`biome check` on affected files and `pnpm -C frontend run typecheck`).
- [ ] Full `uv run pytest tests` and `pre-commit run --all-files` were not run locally; see validation notes below.

## Description

This PR removes browser console output and raw secret-related error surfaces from organization and workspace secret-management create, edit, delete, inventory, and mutation-error flows.

Why this matters:

- Secret-management forms can include secret values, key material, or selected secret metadata.
- Generated API errors retain the original request options, including request bodies, so logging raw secret mutation errors can expose submitted secret payloads in DevTools.
- Raw API error messages can include serialized backend response details and should not be rendered in secret-management UI.
- Browser console output can persist locally or be copied into support/debug artifacts.
- Removing these surfaces reduces accidental exposure without changing the underlying secret-management mutations.

Changes:

- Removed submitted payload logging from organization and workspace secret create/edit/delete flows.
- Removed selected secret metadata logging from organization secret tables.
- Removed raw secret mutation error logging from workspace secret hooks.
- Replaced organization secret create/update raw error logs with sanitized destructive toasts.
- Added sanitized organization secret delete failure feedback.
- Caught secret delete mutation rejections locally so raw API errors do not escape the click handler after hook-level sanitized toasts run.
- Replaced raw secret-related API error message rendering with fixed safe messages in organization and workspace secret-management UI.
- Removed validation-error console logs from covered secret-management components.
- Removed the extra component-level workspace secret create success toast so the existing hook-owned success toast is the single feedback path.
- Added a focused regression test that guards covered secret-management components and secret hooks against browser console output, raw error message rendering, and uncaught delete mutation promises.

Validation run:

- `pnpm -C frontend test -- secret-console-logs.test.ts --runInBand` — passed
- `pnpm -C frontend exec biome check tests/secret-console-logs.test.ts src/components/organization/org-secret-create.tsx src/components/organization/org-secret-update.tsx src/components/organization/org-secret-delete.tsx src/components/organization/org-secrets-table.tsx src/components/workspaces/create-credential-dialog.tsx src/components/workspaces/edit-workspace-secret.tsx src/components/workspaces/delete-workspace-secret.tsx src/components/workspaces/workspace-credentials-inventory.tsx src/lib/hooks.tsx` — passed
- `pnpm -C frontend run typecheck` — passed
- `git diff --check` — passed

Not run:

- Full frontend Jest suite — not run locally; this PR is limited to frontend secret-management logging plus one focused static regression test.
- Browser E2E flows — not run locally; rendered UI behavior is unchanged aside from removing browser console output and consolidating feedback through existing/sanitized toast paths.
- Full backend pytest suite / full pre-commit — not run locally because this PR only touches frontend secret-management files.

Security / disclosure notes:

- Public hardening PR: yes.
- CVE/GHSA/advisory: none.
- Sensitive details omitted: yes.
- This does not disclose a private vulnerability; it removes unnecessary client-side secret logging, raw secret mutation error logging, and raw secret-related API error rendering.

Risk level: low. The change removes debug/error output, preserves existing mutation behavior, and keeps user-facing failure feedback through existing or sanitized toast messages, including organization secret delete failures.

## Related Issues

No existing issue. This was discovered during repository analysis.

## Screenshots / Recordings

Not applicable; this PR does not change visible UI.

## Steps to QA

Run the focused regression test:

```bash
pnpm -C frontend test -- secret-console-logs.test.ts --runInBand
```
