### PR TITLE
feat(ui): show provider and hover card on agent tool chips

### DIFF
--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -171,7 +171,7 @@ import {
   useRegistryActions,
   useWorkspaceAgentModels,
 } from "@/lib/hooks"
-import { humanizeActionName } from "@/lib/registry"
+import { registryActionToSuggestion } from "@/lib/registry"
 import { cn, slugify } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -526,14 +526,8 @@ export function AgentPresetsBuilder({
     }
     return registryActions
       .map((action) => ({
-        id: action.id,
+        ...registryActionToSuggestion(action),
         label: action.default_title ?? action.name,
-        value: action.action,
-        description: action.description,
-        group: action.namespace,
-        tooltip: action.action,
-        tagLabel: action.default_title || humanizeActionName(action.name),
-        tagGroup: action.display_group || action.namespace,
         icon: getIcon(action.action, {
           className: "size-6 p-[3px] border-[0.5px]",
         }),
@@ -703,14 +697,8 @@ export function AgentPresetArtifactView({
     }
     return registryActions
       .map((action) => ({
-        id: action.id,
+        ...registryActionToSuggestion(action),
         label: action.default_title ?? action.name,
-        value: action.action,
-        description: action.description,
-        group: action.namespace,
-        tooltip: action.action,
-        tagLabel: action.default_title || humanizeActionName(action.name),
-        tagGroup: action.display_group || action.namespace,
         icon: getIcon(action.action, {
           className: "size-6 p-[3px] border-[0.5px]",
         }),

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -171,6 +171,7 @@ import {
   useRegistryActions,
   useWorkspaceAgentModels,
 } from "@/lib/hooks"
+import { humanizeActionName } from "@/lib/registry"
 import { cn, slugify } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -530,6 +531,9 @@ export function AgentPresetsBuilder({
         value: action.action,
         description: action.description,
         group: action.namespace,
+        tooltip: action.action,
+        tagLabel: action.default_title || humanizeActionName(action.name),
+        tagGroup: action.display_group || action.namespace,
         icon: getIcon(action.action, {
           className: "size-6 p-[3px] border-[0.5px]",
         }),
@@ -704,6 +708,9 @@ export function AgentPresetArtifactView({
         value: action.action,
         description: action.description,
         group: action.namespace,
+        tooltip: action.action,
+        tagLabel: action.default_title || humanizeActionName(action.name),
+        tagGroup: action.display_group || action.namespace,
         icon: getIcon(action.action, {
           className: "size-6 p-[3px] border-[0.5px]",
         }),

--- a/frontend/src/components/builder/panel/action-panel-fields.tsx
+++ b/frontend/src/components/builder/panel/action-panel-fields.tsx
@@ -75,7 +75,7 @@ import {
   useWorkspaceAgentModels,
 } from "@/lib/hooks"
 import { getType } from "@/lib/jsonschema"
-import { humanizeActionName } from "@/lib/registry"
+import { registryActionToSuggestion } from "@/lib/registry"
 import {
   type ExpressionComponent,
   getTracecatComponents,
@@ -811,14 +811,8 @@ function MultipleActionTypeField({
     return (
       registryActions
         ?.map((action) => ({
-          id: action.action,
+          ...registryActionToSuggestion(action),
           label: action.default_title || action.action,
-          value: action.action,
-          description: action.description,
-          group: action.namespace,
-          tooltip: action.action,
-          tagLabel: action.default_title || humanizeActionName(action.name),
-          tagGroup: action.display_group || action.namespace,
           icon: getIcon(action.action, {
             className: "size-6 p-[3px] border-[0.5px]",
           }),

--- a/frontend/src/components/builder/panel/action-panel-fields.tsx
+++ b/frontend/src/components/builder/panel/action-panel-fields.tsx
@@ -75,6 +75,7 @@ import {
   useWorkspaceAgentModels,
 } from "@/lib/hooks"
 import { getType } from "@/lib/jsonschema"
+import { humanizeActionName } from "@/lib/registry"
 import {
   type ExpressionComponent,
   getTracecatComponents,
@@ -815,6 +816,9 @@ function MultipleActionTypeField({
           value: action.action,
           description: action.description,
           group: action.namespace,
+          tooltip: action.action,
+          tagLabel: action.default_title || humanizeActionName(action.name),
+          tagGroup: action.display_group || action.namespace,
           icon: getIcon(action.action, {
             className: "size-6 p-[3px] border-[0.5px]",
           }),

--- a/frontend/src/components/tags-input.tsx
+++ b/frontend/src/components/tags-input.tsx
@@ -63,11 +63,11 @@ export interface Suggestion {
   description?: string
   group?: string
   /**
-   * When set, the selected chip shows a hover card with the provider, display
-   * name, and description. Omit for values that don't warrant a hover card
-   * (raw UUIDs, slugs).
+   * When true, the selected chip shows a hover card with the provider,
+   * display name, and description. Omit for values that don't warrant a
+   * hover card (raw UUIDs, slugs).
    */
-  tooltip?: string
+  showHoverCard?: boolean
   /**
    * Optional display name for the selected chip when the dropdown `label`
    * isn't chip-friendly (e.g. a full dotted action id). Falls back to `label`.
@@ -143,7 +143,7 @@ export function MultiTagCommandInput({
           icon: suggestion?.icon,
           group: suggestion?.tagGroup || suggestion?.group,
           description: suggestion?.description,
-          tooltip: suggestion?.tooltip,
+          showHoverCard: suggestion?.showHoverCard ?? false,
         }
       }) || []
     )
@@ -330,7 +330,7 @@ export function MultiTagCommandInput({
               )
               // The remove button lives inside the hover card trigger; its
               // click handler still fires and removes the tag.
-              if (tag.tooltip) {
+              if (tag.showHoverCard) {
                 return (
                   <HoverCard key={tag.id} openDelay={200}>
                     <HoverCardTrigger asChild>{badge}</HoverCardTrigger>

--- a/frontend/src/components/tags-input.tsx
+++ b/frontend/src/components/tags-input.tsx
@@ -14,6 +14,11 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command"
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card"
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
@@ -57,6 +62,23 @@ export interface Suggestion {
   value: string
   description?: string
   group?: string
+  /**
+   * When set, the selected chip shows a hover card with the provider, display
+   * name, and description. Omit for values that don't warrant a hover card
+   * (raw UUIDs, slugs).
+   */
+  tooltip?: string
+  /**
+   * Optional display name for the selected chip when the dropdown `label`
+   * isn't chip-friendly (e.g. a full dotted action id). Falls back to `label`.
+   */
+  tagLabel?: string
+  /**
+   * Optional provider/vendor display name for the selected chip's prefix
+   * (e.g. "PagerDuty") when the dropdown `group` is a raw namespace. Falls
+   * back to `group`.
+   */
+  tagGroup?: string
   icon?: React.ReactNode
   locked?: boolean
   onSelect?: () => void
@@ -116,9 +138,12 @@ export function MultiTagCommandInput({
         const suggestion = suggestions.find((s) => s.value === val)
         return {
           id: `${index}`,
-          text: suggestion?.label || val,
+          text: suggestion?.tagLabel || suggestion?.label || val,
           value: val,
           icon: suggestion?.icon,
+          group: suggestion?.tagGroup || suggestion?.group,
+          description: suggestion?.description,
+          tooltip: suggestion?.tooltip,
         }
       }) || []
     )
@@ -264,36 +289,79 @@ export function MultiTagCommandInput({
             onClick={() => inputRef.current?.focus()}
           >
             {/* Render tags */}
-            {tags.map((tag) => (
-              <Badge
-                key={tag.id}
-                variant="secondary"
-                className="gap-1 pr-1 text-xs"
-              >
-                {tag.icon ? (
-                  <span className="flex items-center gap-1">
-                    <span className="flex items-center justify-center rounded-sm bg-transparent">
-                      {tag.icon}
+            {tags.map((tag) => {
+              const label = tag.group ? (
+                <span>
+                  <span className="text-muted-foreground">{tag.group}</span> ·{" "}
+                  {tag.text}
+                </span>
+              ) : (
+                <span>{tag.text}</span>
+              )
+              const badge = (
+                <Badge
+                  key={tag.id}
+                  variant="secondary"
+                  className="gap-1 pr-1 text-xs"
+                >
+                  {tag.icon ? (
+                    <span className="flex items-center gap-1">
+                      <span className="flex items-center justify-center rounded-sm bg-transparent">
+                        {tag.icon}
+                      </span>
+                      {label}
                     </span>
-                    <span>{tag.text}</span>
-                  </span>
-                ) : (
-                  tag.text
-                )}
-                {!disabled && (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      handleRemoveTag(tag.value)
-                    }}
-                    className="ml-1 rounded-full hover:bg-muted-foreground/20"
-                  >
-                    <X className="size-3" />
-                  </button>
-                )}
-              </Badge>
-            ))}
+                  ) : (
+                    label
+                  )}
+                  {!disabled && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        handleRemoveTag(tag.value)
+                      }}
+                      className="ml-1 rounded-full hover:bg-muted-foreground/20"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  )}
+                </Badge>
+              )
+              // The remove button lives inside the hover card trigger; its
+              // click handler still fires and removes the tag.
+              if (tag.tooltip) {
+                return (
+                  <HoverCard key={tag.id} openDelay={200}>
+                    <HoverCardTrigger asChild>{badge}</HoverCardTrigger>
+                    <HoverCardContent
+                      className="w-[300px] p-4 text-xs"
+                      align="start"
+                    >
+                      <div className="flex items-center gap-2">
+                        {tag.icon}
+                        <div className="flex flex-col">
+                          {tag.group && (
+                            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                              {tag.group}
+                            </span>
+                          )}
+                          <span className="text-sm font-medium">
+                            {tag.text}
+                          </span>
+                        </div>
+                      </div>
+                      {tag.description && (
+                        <p className="mt-2 text-muted-foreground">
+                          {tag.description}
+                        </p>
+                      )}
+                    </HoverCardContent>
+                  </HoverCard>
+                )
+              }
+              return badge
+            })}
 
             {/* Input */}
             <input

--- a/frontend/src/lib/registry.ts
+++ b/frontend/src/lib/registry.ts
@@ -8,3 +8,16 @@ export function isTemplateAction(
 ): implementation is RegistryActionTemplateImpl {
   return implementation?.type === "template"
 }
+
+/**
+ * Humanize a registry action leaf name or dotted id into a readable title.
+ *
+ * Accepts either a leaf name (`list_tools`) or a full dotted action id
+ * (`tools.okta.list_tools`); the last segment is used, with underscores
+ * replaced by spaces and the first letter capitalized, e.g. `List tools`.
+ */
+export function humanizeActionName(nameOrAction: string): string {
+  const leaf = nameOrAction.split(".").pop() ?? nameOrAction
+  const spaced = leaf.replace(/_/g, " ")
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}

--- a/frontend/src/lib/registry.ts
+++ b/frontend/src/lib/registry.ts
@@ -1,4 +1,5 @@
 import type {
+  RegistryActionReadMinimal,
   RegistryActionTemplateImpl,
   RegistryActionUDFImpl,
 } from "@/client"
@@ -20,4 +21,21 @@ export function humanizeActionName(nameOrAction: string): string {
   const leaf = nameOrAction.split(".").pop() ?? nameOrAction
   const spaced = leaf.replace(/_/g, " ")
   return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+/**
+ * Map a registry action to the shared tool-selector suggestion fields used by
+ * `MultiTagCommandInput`. Callers add surface-specific fields (`label`,
+ * `icon`, `locked`, `onSelect`) at the call site.
+ */
+export function registryActionToSuggestion(action: RegistryActionReadMinimal) {
+  return {
+    id: action.action,
+    value: action.action,
+    description: action.description,
+    group: action.namespace,
+    showHoverCard: true,
+    tagLabel: action.default_title || humanizeActionName(action.name),
+    tagGroup: action.display_group || action.namespace,
+  }
 }


### PR DESCRIPTION
## What

Improves the selected-tool chips in the two agent tool pickers — the `ai.agent` action panel in the workflow builder and the agent presets builder — which previously showed only a generic leaf title (e.g. "List tools") with no provider context and no hover detail.

- **Provider prefix on chips**: chips now render `PagerDuty · Acknowledge event` — a muted vendor prefix from `display_group`, falling back to the namespace.
- **Best-effort display name**: chips prefer `default_title`, falling back to a humanized leaf name (`list_tools` → "List tools") instead of the raw dotted id or snake_case name.
- **Hover card**: hovering a chip opens a `HoverCard` with the provider icon, an uppercase vendor eyebrow, the tool display name, and the tool description.

## How

- `MultiTagCommandInput` (`tags-input.tsx`) gains three optional, chip-only fields on `Suggestion`: `tagLabel`, `tagGroup`, and `tooltip` (the hover-card opt-in flag). The dropdown rendering, labels, and sort order are untouched.
- Both consumers set the new fields from `RegistryActionReadMinimal` (`default_title`, `display_group`, `namespace`, `action`). Namespace tags and MCP-integration chips don't set them, so they render exactly as before.
- New `humanizeActionName` helper in `frontend/src/lib/registry.ts`.

## Screens
<img width="958" height="436" alt="image" src="https://github.com/user-attachments/assets/f2b76a41-553d-4f7f-88c2-30a900d413be" />


## Testing

- `pnpm -C frontend check` and `pnpm -C frontend run typecheck` pass.
- Verified chip rendering and hover card against local registry data (PagerDuty tools).
