### PR TITLE
feat(agents): session search recall tools for agent sessions

### DIFF
--- a/alembic/versions/24b2f4a4d6c9_add_agent_session_history_search.py
+++ b/alembic/versions/24b2f4a4d6c9_add_agent_session_history_search.py
@@ -1,0 +1,238 @@
+"""add agent session history search
+
+Revision ID: 24b2f4a4d6c9
+Revises: 11d479597e08
+Create Date: 2026-07-07 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "24b2f4a4d6c9"
+down_revision: str | None = "11d479597e08"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_BATCH_SIZE = 1000
+_MAX_SEARCH_TEXT_CHARS = 8000
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _collapse_and_cap(text: str) -> str | None:
+    collapsed = _WHITESPACE_RE.sub(" ", text).strip()
+    if not collapsed:
+        return None
+    return collapsed[:_MAX_SEARCH_TEXT_CHARS]
+
+
+def _compact_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"), default=str)
+    except Exception:
+        try:
+            return str(value)
+        except Exception:
+            return None
+
+
+def _media_placeholder(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return "[binary]"
+    block_type = value.get("type") or value.get("kind")
+    media_type = value.get("media_type") or value.get("mediaType")
+    marker = f"{block_type or ''} {media_type or ''}".lower()
+    if "image" in marker:
+        return "[image]"
+    if "audio" in marker:
+        return "[audio]"
+    if "video" in marker:
+        return "[video]"
+    if "document" in marker:
+        return "[document]"
+    return "[binary]"
+
+
+def _extract_content(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            parts.extend(_extract_content_item(item))
+        return parts
+    if isinstance(value, Mapping):
+        return _extract_content_item(value)
+    return []
+
+
+def _extract_content_item(item: Any) -> list[str]:
+    if isinstance(item, str):
+        return [item]
+    if not isinstance(item, Mapping):
+        return []
+
+    block_type = item.get("type") or item.get("kind") or item.get("part_kind")
+    if block_type in {"image", "image-url", "binary"}:
+        return [_media_placeholder(item)]
+    if block_type in {"audio", "audio-url", "video", "video-url", "document-url"}:
+        return [_media_placeholder(item)]
+    if text := item.get("text"):
+        return [text] if isinstance(text, str) else []
+    if content := item.get("content"):
+        return _extract_content(content)
+    return []
+
+
+def _extract_part(part: Any) -> list[str]:
+    if not isinstance(part, Mapping):
+        return []
+
+    part_kind = part.get("part_kind") or part.get("type") or part.get("kind")
+    match part_kind:
+        case "user-prompt":
+            return _extract_content(part.get("content"))
+        case "text":
+            text = part.get("content") or part.get("text")
+            return [text] if isinstance(text, str) else []
+        case "tool-call" | "tool_use":
+            name = part.get("tool_name") or part.get("name")
+            args = part.get("args") if "args" in part else part.get("input")
+            text = " ".join(
+                value
+                for value in (
+                    str(name) if name else None,
+                    _compact_value(args),
+                )
+                if value
+            )
+            return [text] if text else []
+        case "tool-return" | "tool_result":
+            values: list[str] = []
+            if name := part.get("tool_name"):
+                values.append(str(name))
+            values.extend(_extract_content(part.get("content")))
+            return values
+        case _:
+            return _extract_content_item(part)
+
+
+def _extract_message_payload(payload: Mapping[str, Any]) -> list[str]:
+    if message := payload.get("message"):
+        if isinstance(message, Mapping):
+            return _extract_message_payload(message)
+
+    if parts := payload.get("parts"):
+        if isinstance(parts, list):
+            extracted: list[str] = []
+            for part in parts:
+                extracted.extend(_extract_part(part))
+            return extracted
+
+    if "content" in payload:
+        return _extract_content(payload.get("content"))
+
+    return []
+
+
+def _extract_search_text(content: Any) -> str | None:
+    if not isinstance(content, Mapping):
+        return None
+    try:
+        parts = _extract_message_payload(content)
+    except Exception:
+        return None
+    return _collapse_and_cap(" ".join(parts))
+
+
+def _backfill_search_text() -> None:
+    connection = op.get_bind()
+    last_surrogate_id = 0
+
+    while True:
+        rows = (
+            connection.execute(
+                sa.text("""
+                    SELECT surrogate_id, content
+                    FROM agent_session_history
+                    WHERE surrogate_id > :last_surrogate_id
+                      AND search_text IS NULL
+                    ORDER BY surrogate_id
+                    LIMIT :limit
+                """),
+                {
+                    "last_surrogate_id": last_surrogate_id,
+                    "limit": _BATCH_SIZE,
+                },
+            )
+            .mappings()
+            .all()
+        )
+        if not rows:
+            break
+
+        updates = [
+            {
+                "surrogate_id": row["surrogate_id"],
+                "search_text": search_text,
+            }
+            for row in rows
+            if (search_text := _extract_search_text(row["content"])) is not None
+        ]
+        if updates:
+            connection.execute(
+                sa.text("""
+                    UPDATE agent_session_history
+                    SET search_text = :search_text
+                    WHERE surrogate_id = :surrogate_id
+                """),
+                updates,
+            )
+
+        last_surrogate_id = rows[-1]["surrogate_id"]
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_session_history",
+        sa.Column("search_text", sa.Text(), nullable=True),
+    )
+    op.execute("""
+        ALTER TABLE agent_session_history
+        ADD COLUMN search_tsv tsvector
+        GENERATED ALWAYS AS (
+            to_tsvector('english', coalesce(search_text, ''))
+        ) STORED
+    """)
+    _backfill_search_text()
+    op.create_index(
+        "ix_agent_session_history_search_tsv",
+        "agent_session_history",
+        ["search_tsv"],
+        unique=False,
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_agent_session_history_search_tsv",
+        table_name="agent_session_history",
+    )
+    op.drop_column("agent_session_history", "search_tsv")
+    op.drop_column("agent_session_history", "search_text")

--- a/alembic/versions/24b2f4a4d6c9_add_agent_session_history_search.py
+++ b/alembic/versions/24b2f4a4d6c9_add_agent_session_history_search.py
@@ -88,6 +88,10 @@ def _extract_content_item(item: Any) -> list[str]:
         return []
 
     block_type = item.get("type") or item.get("kind") or item.get("part_kind")
+    # Claude SDK content blocks carry tool calls inline in message.content;
+    # route them through the part extractor so tool names/args are indexed.
+    if block_type in {"tool-call", "tool_use", "tool-return", "tool_result"}:
+        return _extract_part(item)
     if block_type in {"image", "image-url", "binary"}:
         return [_media_placeholder(item)]
     if block_type in {"audio", "audio-url", "video", "video-url", "document-url"}:

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -20,9 +20,10 @@ from tracecat.agent.common.types import (
     is_http_mcp_server,
 )
 from tracecat.agent.mcp.internal_tools import (
+    AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
     BUILDER_BUNDLED_ACTIONS,
     BUILDER_INTERNAL_TOOL_NAMES,
-    get_builder_internal_tool_definitions,
+    get_internal_tool_definitions,
 )
 from tracecat.agent.mcp.utils import (
     REGISTRY_MCP_SERVER_NAME,
@@ -219,8 +220,16 @@ class AgentActivities:
             and args.internal_tool_context.entity_type == "agent_preset_builder"
         )
 
-        # For builder sessions, add bundled actions to the tool filters
-        actions_to_build = list(args.tool_filters.actions or [])
+        # For builder sessions, add bundled actions to the tool filters.
+        # Internal tools are compiled separately below; they are not registry
+        # actions and must not be passed to build_agent_tools.
+        requested_actions = list(args.tool_filters.actions or [])
+        requested_internal_tools = [
+            action for action in requested_actions if action.startswith("internal.")
+        ]
+        actions_to_build = [
+            action for action in requested_actions if not action.startswith("internal.")
+        ]
         if is_builder:
             # Add bundled registry actions for builder (core.table.*, tools.exa.*)
             for action in BUILDER_BUNDLED_ACTIONS:
@@ -249,17 +258,44 @@ class AgentActivities:
                 parameters_json_schema=tool.parameters_json_schema,
             )
 
-        # Add internal tools for builder assistant
-        allowed_internal_tools: list[str] | None = None
+        internal_definitions = get_internal_tool_definitions()
+        allowed_internal_tools: list[str] = []
         if is_builder:
-            # Add builder internal tools to definitions
-            internal_defs = get_builder_internal_tool_definitions()
-            defs.update(internal_defs)
-            allowed_internal_tools = list(BUILDER_INTERNAL_TOOL_NAMES)
+            allowed_internal_tools.extend(BUILDER_INTERNAL_TOOL_NAMES)
+
+        for tool_name in requested_internal_tools:
+            if tool_name not in internal_definitions:
+                raise ApplicationError(
+                    f"Unknown internal tool: {tool_name}",
+                    type="AgentToolDefinitionError",
+                    non_retryable=True,
+                )
+            # Builder tools are privileged: sessions may only request internal
+            # tools from the generally-available recall set; anything else must
+            # come from the entity-based grant above (builder sessions).
+            if (
+                tool_name not in allowed_internal_tools
+                and tool_name not in AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES
+            ):
+                raise ApplicationError(
+                    f"Internal tool not permitted for this session: {tool_name}",
+                    type="AgentToolDefinitionError",
+                    non_retryable=True,
+                )
+            if tool_name not in allowed_internal_tools:
+                allowed_internal_tools.append(tool_name)
+
+        if allowed_internal_tools:
+            defs.update(
+                {
+                    tool_name: internal_definitions[tool_name]
+                    for tool_name in allowed_internal_tools
+                }
+            )
             logger.info(
-                "Added builder internal tools",
-                tool_count=len(internal_defs),
-                tools=list(internal_defs.keys()),
+                "Added internal tools",
+                tool_count=len(allowed_internal_tools),
+                tools=allowed_internal_tools,
             )
 
         # Discover user MCP tools if configured
@@ -453,7 +489,7 @@ class AgentActivities:
             tool_definitions=defs,
             registry_lock=registry_lock,
             user_mcp_claims=user_mcp_claims,
-            allowed_internal_tools=allowed_internal_tools,
+            allowed_internal_tools=allowed_internal_tools or None,
             tool_approvals=effective_tool_approvals or None,
         )
 

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -8,6 +8,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from tracecat.agent.mcp.internal_tools import (
+    AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
+)
 from tracecat.agent.session.schemas import AgentSessionCreate, AgentSessionUpdate
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
@@ -681,8 +684,13 @@ async def test_workspace_chat_preset_config_scope_filters_actions() -> None:
         )
         async with service._build_agent_config(agent_session) as resolved:
             # Only the one action the user is scoped for survives; the privileged
-            # workflow-edit and case-delete tools are stripped.
-            assert resolved.actions == ["core.workflow.get_workflow"]
+            # workflow-edit and case-delete tools are stripped. Session-recall
+            # internal tools are always merged in -- they are not registry
+            # actions and only read the caller's own past sessions.
+            assert resolved.actions == [
+                "core.workflow.get_workflow",
+                *AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
+            ]
             # Instructions still combine preset + entity context.
             assert resolved.instructions == "preset instructions\n\nentity instructions"
 
@@ -730,4 +738,7 @@ async def test_workspace_chat_preset_config_superuser_keeps_all_actions() -> Non
             with_preset_config=_fake_with_preset_config
         )
         async with service._build_agent_config(agent_session) as resolved:
-            assert resolved.actions == actions
+            assert resolved.actions == [
+                *actions,
+                *AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
+            ]

--- a/tests/unit/test_agent_session_search.py
+++ b/tests/unit/test_agent_session_search.py
@@ -108,6 +108,36 @@ def test_extract_search_text_replaces_image_and_binary_content() -> None:
     assert "image-bytes" not in text
 
 
+def test_extract_search_text_tool_return_media_becomes_placeholder() -> None:
+    # Media in tool returns must be redacted, never JSON-serialized (review P2).
+    text = extract_search_text(
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="tools.browser.screenshot",
+                    content=BinaryContent(
+                        data=b"raw-image-bytes", media_type="image/png"
+                    ),
+                    tool_call_id="call_media",
+                ),
+                ToolReturnPart(
+                    tool_name="tools.browser.snapshot",
+                    content=[
+                        "Page loaded.",
+                        ImageUrl(url="https://example.test/s.png"),
+                    ],
+                    tool_call_id="call_mixed",
+                ),
+            ]
+        )
+    )
+
+    assert text is not None
+    assert "raw-image-bytes" not in text
+    assert text.count("[image]") == 2
+    assert "Page loaded." in text
+
+
 def test_extract_search_text_caps_oversized_content() -> None:
     text = extract_search_text(ModelResponse(parts=[TextPart(content="alpha " * 3000)]))
 

--- a/tests/unit/test_agent_session_search.py
+++ b/tests/unit/test_agent_session_search.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import cast
+
+from claude_agent_sdk.types import (
+    AssistantMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+from pydantic_ai.messages import (
+    BinaryContent,
+    ImageUrl,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from tracecat.agent.session.search import MAX_SEARCH_TEXT_CHARS, extract_search_text
+from tracecat.agent.types import UnifiedMessage
+
+
+def test_extract_search_text_from_pydantic_ai_text_tool_call_and_return() -> None:
+    response_text = extract_search_text(
+        ModelResponse(
+            parts=[
+                TextPart(content="I will look this up."),
+                ToolCallPart(
+                    tool_name="core.cases.search_cases",
+                    args={"query": "alpha incident"},
+                    tool_call_id="call_1",
+                ),
+            ]
+        )
+    )
+    request_text = extract_search_text(
+        ModelRequest(
+            parts=[
+                UserPromptPart(content="Find the alpha incident."),
+                ToolReturnPart(
+                    tool_name="core.cases.search_cases",
+                    content={"rows": [{"title": "Alpha incident"}]},
+                    tool_call_id="call_1",
+                ),
+            ]
+        )
+    )
+
+    assert response_text is not None
+    assert "I will look this up." in response_text
+    assert "core.cases.search_cases" in response_text
+    assert "alpha incident" in response_text
+    assert request_text is not None
+    assert "Find the alpha incident." in request_text
+    assert "Alpha incident" in request_text
+
+
+def test_extract_search_text_from_claude_sdk_message() -> None:
+    text = extract_search_text(
+        AssistantMessage(
+            content=[
+                TextBlock(text="We decided to rotate the key."),
+                ToolUseBlock(
+                    id="toolu_1",
+                    name="core.table.lookup",
+                    input={"table": "decisions", "key": "rotation"},
+                ),
+                ToolResultBlock(
+                    tool_use_id="toolu_1",
+                    content="Rotation decision recorded.",
+                ),
+            ],
+            model="claude-sonnet-4",
+        )
+    )
+
+    assert text is not None
+    assert "We decided to rotate the key." in text
+    assert "core.table.lookup" in text
+    assert "Rotation decision recorded." in text
+
+
+def test_extract_search_text_replaces_image_and_binary_content() -> None:
+    text = extract_search_text(
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        "Please inspect this.",
+                        ImageUrl(url="https://example.test/screenshot.png"),
+                        BinaryContent(data=b"image-bytes", media_type="image/png"),
+                    ]
+                )
+            ]
+        )
+    )
+
+    assert text is not None
+    assert "Please inspect this." in text
+    assert text.count("[image]") == 2
+    assert "image-bytes" not in text
+
+
+def test_extract_search_text_caps_oversized_content() -> None:
+    text = extract_search_text(ModelResponse(parts=[TextPart(content="alpha " * 3000)]))
+
+    assert text is not None
+    assert len(text) == MAX_SEARCH_TEXT_CHARS
+
+
+def test_extract_search_text_returns_none_for_garbage_input() -> None:
+    assert extract_search_text(cast(UnifiedMessage, object())) is None

--- a/tests/unit/test_agent_session_search.py
+++ b/tests/unit/test_agent_session_search.py
@@ -19,7 +19,11 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
-from tracecat.agent.session.search import MAX_SEARCH_TEXT_CHARS, extract_search_text
+from tracecat.agent.session.search import (
+    MAX_SEARCH_TEXT_CHARS,
+    extract_search_text,
+    extract_search_text_from_history_content,
+)
 from tracecat.agent.types import UnifiedMessage
 
 
@@ -113,3 +117,36 @@ def test_extract_search_text_caps_oversized_content() -> None:
 
 def test_extract_search_text_returns_none_for_garbage_input() -> None:
     assert extract_search_text(cast(UnifiedMessage, object())) is None
+
+
+def test_extract_history_content_indexes_claude_tool_blocks() -> None:
+    # Persisted Claude SDK rows carry tool calls inline in message.content;
+    # tool names and args must be searchable (Codex review P2).
+    text = extract_search_text_from_history_content(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Looking that up."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "core.cases.get_case",
+                        "input": {"case_id": "CASE-1234"},
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": [{"type": "text", "text": "Case found."}],
+                    },
+                ],
+            },
+        }
+    )
+
+    assert text is not None
+    assert "Looking that up." in text
+    assert "core.cases.get_case" in text
+    assert "CASE-1234" in text
+    assert "Case found." in text

--- a/tests/unit/test_agent_session_search_service.py
+++ b/tests/unit/test_agent_session_search_service.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.agent.session.service import AgentSessionService
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.auth.types import Role
+from tracecat.chat.enums import MessageKind
+from tracecat.db.models import AgentSession, AgentSessionHistory, User, Workspace
+from tracecat.exceptions import TracecatNotFoundError
+
+
+async def _add_user(
+    session: AsyncSession, user_id: uuid.UUID | None = None
+) -> uuid.UUID:
+    user = User(
+        id=user_id or uuid.uuid4(),
+        email=f"recall-user-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user.id
+
+
+@pytest.fixture(autouse=True)
+async def seed_role_user(session: AsyncSession, svc_role: Role) -> None:
+    assert svc_role.user_id is not None
+    await _add_user(session, svc_role.user_id)
+
+
+async def _add_session(
+    session: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    created_by: uuid.UUID | None,
+    entity_type: AgentSessionEntity = AgentSessionEntity.CASE,
+    parent_session_id: uuid.UUID | None = None,
+    title: str = "Prior session",
+) -> AgentSession:
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        title=title,
+        created_by=created_by,
+        entity_type=entity_type.value,
+        entity_id=uuid.uuid4(),
+        parent_session_id=parent_session_id,
+    )
+    session.add(agent_session)
+    await session.flush()
+    return agent_session
+
+
+async def _add_history(
+    session: AsyncSession,
+    *,
+    agent_session: AgentSession,
+    text: str,
+) -> AgentSessionHistory:
+    entry = AgentSessionHistory(
+        session_id=agent_session.id,
+        workspace_id=agent_session.workspace_id,
+        content={"type": "user", "message": {"role": "user", "content": text}},
+        search_text=text,
+        kind=MessageKind.CHAT_MESSAGE.value,
+    )
+    session.add(entry)
+    await session.flush()
+    await session.refresh(entry)
+    return entry
+
+
+@pytest.mark.anyio
+async def test_search_session_messages_returns_snippet(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    assert svc_role.workspace_id is not None
+    agent_session = await _add_session(
+        session, workspace_id=svc_role.workspace_id, created_by=svc_role.user_id
+    )
+    entry = await _add_history(
+        session,
+        agent_session=agent_session,
+        text="We decided to use Hermes style recall for agent session search.",
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    results = await service.search_session_messages("Hermes recall")
+
+    assert len(results) == 1
+    assert results[0].session_id == agent_session.id
+    assert results[0].surrogate_id == entry.surrogate_id
+    assert ">>>" in results[0].snippet
+    assert "<<<" in results[0].snippet
+
+
+@pytest.mark.anyio
+async def test_search_session_messages_is_workspace_scoped(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    assert svc_role.workspace_id is not None
+    assert svc_role.organization_id is not None
+    other_workspace = Workspace(
+        name="other-workspace",
+        organization_id=svc_role.organization_id,
+    )
+    session.add(other_workspace)
+    await session.flush()
+    other_session = await _add_session(
+        session, workspace_id=other_workspace.id, created_by=svc_role.user_id
+    )
+    await _add_history(
+        session,
+        agent_session=other_session,
+        text="needle appears only in another workspace",
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    results = await service.search_session_messages("needle")
+
+    assert results == []
+
+
+@pytest.mark.anyio
+async def test_search_session_messages_excludes_other_users_sessions(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    assert svc_role.workspace_id is not None
+    other_user_id = await _add_user(session)
+    other_user_session = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=other_user_id,
+        title="Another user's session",
+    )
+    await _add_history(
+        session,
+        agent_session=other_user_session,
+        text="visibility needle in another user's session",
+    )
+    own_session = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        title="My session",
+    )
+    await _add_history(
+        session,
+        agent_session=own_session,
+        text="visibility needle in my own session",
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    results = await service.search_session_messages("visibility needle")
+
+    assert [result.session_id for result in results] == [own_session.id]
+
+
+@pytest.mark.anyio
+async def test_get_session_window_hides_other_users_sessions(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    assert svc_role.workspace_id is not None
+    other_user_id = await _add_user(session)
+    other_user_session = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=other_user_id,
+        title="Another user's session",
+    )
+    entry = await _add_history(
+        session,
+        agent_session=other_user_session,
+        text="private message",
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    with pytest.raises(TracecatNotFoundError):
+        await service.get_session_window(
+            other_user_session.id,
+            anchor_surrogate_id=entry.surrogate_id,
+        )
+
+
+@pytest.mark.anyio
+async def test_search_session_messages_excludes_current_lineage(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    assert svc_role.workspace_id is not None
+    parent = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        title="Parent session",
+    )
+    child = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        parent_session_id=parent.id,
+        title="Child session",
+    )
+    unrelated = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        title="Unrelated session",
+    )
+    await _add_history(
+        session,
+        agent_session=parent,
+        text="lineage exclusion should hide this recall needle",
+    )
+    await _add_history(
+        session,
+        agent_session=child,
+        text="lineage exclusion should also hide this recall needle",
+    )
+    await _add_history(
+        session,
+        agent_session=unrelated,
+        text="unrelated recall needle remains searchable",
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    results = await service.search_session_messages(
+        "recall needle",
+        exclude_session_id=child.id,
+    )
+
+    assert [result.session_id for result in results] == [unrelated.id]
+
+
+@pytest.mark.anyio
+async def test_search_session_messages_clamps_limit(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    assert svc_role.workspace_id is not None
+    for index in range(30):
+        agent_session = await _add_session(
+            session,
+            workspace_id=svc_role.workspace_id,
+            created_by=svc_role.user_id,
+            title=f"Session {index}",
+        )
+        await _add_history(
+            session,
+            agent_session=agent_session,
+            text=f"shared clamp needle number {index}",
+        )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    results = await service.search_session_messages("shared clamp needle", limit=100)
+
+    assert len(results) == 25
+
+
+@pytest.mark.anyio
+async def test_get_session_window_returns_boundary_counts(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    assert svc_role.workspace_id is not None
+    agent_session = await _add_session(
+        session, workspace_id=svc_role.workspace_id, created_by=svc_role.user_id
+    )
+    entries = [
+        await _add_history(
+            session,
+            agent_session=agent_session,
+            text=f"message {index}",
+        )
+        for index in range(1, 7)
+    ]
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    window = await service.get_session_window(
+        agent_session.id,
+        anchor_surrogate_id=entries[2].surrogate_id,
+        window=2,
+    )
+
+    assert [message.text for message in window.messages] == [
+        "message 2",
+        "message 3",
+        "message 4",
+        "message 5",
+    ]
+    assert window.messages_before == 1
+    assert window.messages_after == 1
+
+
+@pytest.mark.anyio
+async def test_get_session_window_clamps_window(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    assert svc_role.workspace_id is not None
+    agent_session = await _add_session(
+        session, workspace_id=svc_role.workspace_id, created_by=svc_role.user_id
+    )
+    entries = [
+        await _add_history(
+            session,
+            agent_session=agent_session,
+            text=f"clamped message {index}",
+        )
+        for index in range(1, 5)
+    ]
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    window = await service.get_session_window(
+        agent_session.id,
+        anchor_surrogate_id=entries[1].surrogate_id,
+        window=0,
+    )
+
+    assert [message.text for message in window.messages] == [
+        "clamped message 2",
+        "clamped message 3",
+    ]
+    assert window.messages_before == 1
+    assert window.messages_after == 1

--- a/tests/unit/test_agent_session_search_service.py
+++ b/tests/unit/test_agent_session_search_service.py
@@ -63,13 +63,14 @@ async def _add_history(
     *,
     agent_session: AgentSession,
     text: str,
+    kind: str = MessageKind.CHAT_MESSAGE.value,
 ) -> AgentSessionHistory:
     entry = AgentSessionHistory(
         session_id=agent_session.id,
         workspace_id=agent_session.workspace_id,
         content={"type": "user", "message": {"role": "user", "content": text}},
         search_text=text,
-        kind=MessageKind.CHAT_MESSAGE.value,
+        kind=kind,
     )
     session.add(entry)
     await session.flush()
@@ -216,6 +217,13 @@ async def test_search_session_messages_excludes_current_lineage(
         parent_session_id=parent.id,
         title="Child session",
     )
+    sibling = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        parent_session_id=parent.id,
+        title="Sibling fork",
+    )
     unrelated = await _add_session(
         session,
         workspace_id=svc_role.workspace_id,
@@ -234,6 +242,11 @@ async def test_search_session_messages_excludes_current_lineage(
     )
     await _add_history(
         session,
+        agent_session=sibling,
+        text="sibling fork recall needle is part of the same tree",
+    )
+    await _add_history(
+        session,
         agent_session=unrelated,
         text="unrelated recall needle remains searchable",
     )
@@ -246,6 +259,100 @@ async def test_search_session_messages_excludes_current_lineage(
     )
 
     assert [result.session_id for result in results] == [unrelated.id]
+
+
+@pytest.mark.anyio
+async def test_recall_hides_internal_kind_rows(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    # INTERNAL rows (continuation prompts, interrupt artifacts) are hidden from
+    # the UI timeline and must be invisible to recall too (review P2).
+    assert svc_role.workspace_id is not None
+    agent_session = await _add_session(
+        session, workspace_id=svc_role.workspace_id, created_by=svc_role.user_id
+    )
+    first = await _add_history(
+        session, agent_session=agent_session, text="visible kind needle one"
+    )
+    await _add_history(
+        session,
+        agent_session=agent_session,
+        text="hidden internal kind needle",
+        kind=MessageKind.INTERNAL.value,
+    )
+    await _add_history(
+        session, agent_session=agent_session, text="visible kind needle two"
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+
+    search_results = await service.search_session_messages("internal kind needle")
+    assert search_results == []
+
+    window = await service.get_session_window(
+        agent_session.id,
+        anchor_surrogate_id=first.surrogate_id,
+        window=5,
+    )
+    assert [message.text for message in window.messages] == [
+        "visible kind needle one",
+        "visible kind needle two",
+    ]
+
+
+@pytest.mark.anyio
+async def test_search_paginates_past_large_fork_lineage(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    # A fork tree with many sibling sessions must not fill the scan window and
+    # hide unrelated lineages (Codex review P2, second pass).
+    assert svc_role.workspace_id is not None
+    unrelated = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        title="Unrelated session",
+    )
+    await _add_history(
+        session,
+        agent_session=unrelated,
+        text="fork pagination needle outside the tree",
+    )
+    root = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        title="Fork root",
+    )
+    await _add_history(
+        session, agent_session=root, text="fork pagination needle root mention"
+    )
+    for index in range(30):
+        fork = await _add_session(
+            session,
+            workspace_id=svc_role.workspace_id,
+            created_by=svc_role.user_id,
+            parent_session_id=root.id,
+            title=f"Fork {index}",
+        )
+        await _add_history(
+            session,
+            agent_session=fork,
+            text=f"fork pagination needle sibling mention {index}",
+        )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    # limit=2 -> page size 25 < 31 tree hits; the older unrelated session sorts
+    # last and is only reachable by paginating past the fork tree.
+    results = await service.search_session_messages("fork pagination needle", limit=2)
+
+    root_ids = {result.session_id for result in results}
+    assert unrelated.id in root_ids
+    assert len(results) == 2
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_search_service.py
+++ b/tests/unit/test_agent_session_search_service.py
@@ -249,6 +249,45 @@ async def test_search_session_messages_excludes_current_lineage(
 
 
 @pytest.mark.anyio
+async def test_search_session_messages_chatty_session_does_not_starve_others(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    # One session with many high-ranking hits must not fill the scan window
+    # and hide other matching sessions (Codex review P2).
+    assert svc_role.workspace_id is not None
+    chatty = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        title="Chatty session",
+    )
+    for index in range(60):
+        await _add_history(
+            session,
+            agent_session=chatty,
+            text=f"starvation needle repeated mention {index}",
+        )
+    quiet = await _add_session(
+        session,
+        workspace_id=svc_role.workspace_id,
+        created_by=svc_role.user_id,
+        title="Quiet session",
+    )
+    await _add_history(
+        session,
+        agent_session=quiet,
+        text="starvation needle single mention",
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    results = await service.search_session_messages("starvation needle", limit=10)
+
+    assert {result.session_id for result in results} == {chatty.id, quiet.id}
+
+
+@pytest.mark.anyio
 async def test_search_session_messages_clamps_limit(
     session: AsyncSession,
     svc_role: Role,

--- a/tests/unit/test_agent_session_search_service.py
+++ b/tests/unit/test_agent_session_search_service.py
@@ -64,6 +64,7 @@ async def _add_history(
     agent_session: AgentSession,
     text: str,
     kind: str = MessageKind.CHAT_MESSAGE.value,
+    curr_run_id: uuid.UUID | None = None,
 ) -> AgentSessionHistory:
     entry = AgentSessionHistory(
         session_id=agent_session.id,
@@ -71,6 +72,7 @@ async def _add_history(
         content={"type": "user", "message": {"role": "user", "content": text}},
         search_text=text,
         kind=kind,
+        curr_run_id=curr_run_id,
     )
     session.add(entry)
     await session.flush()
@@ -300,6 +302,49 @@ async def test_recall_hides_internal_kind_rows(
         "visible kind needle one",
         "visible kind needle two",
     ]
+
+
+@pytest.mark.anyio
+async def test_recall_hides_active_turn_rows(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    # While a turn is live, its partial rows are durability-only and hidden
+    # from the UI timeline; recall must hide them too (Codex review P2).
+    assert svc_role.workspace_id is not None
+    live_run_id = uuid.uuid4()
+    agent_session = await _add_session(
+        session, workspace_id=svc_role.workspace_id, created_by=svc_role.user_id
+    )
+    agent_session.curr_run_id = live_run_id
+    finished = await _add_history(
+        session,
+        agent_session=agent_session,
+        text="active turn needle from a finished run",
+        curr_run_id=uuid.uuid4(),
+    )
+    await _add_history(
+        session,
+        agent_session=agent_session,
+        text="active turn needle from the live run",
+        curr_run_id=live_run_id,
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+
+    results = await service.search_session_messages("active turn needle")
+    assert [result.surrogate_id for result in results] == [finished.surrogate_id]
+
+    window = await service.get_session_window(
+        agent_session.id,
+        anchor_surrogate_id=finished.surrogate_id,
+        window=5,
+    )
+    assert [message.text for message in window.messages] == [
+        "active turn needle from a finished run"
+    ]
+    assert window.messages_after == 0
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_chat_tools.py
+++ b/tests/unit/test_chat_tools.py
@@ -1,5 +1,8 @@
 import uuid
 
+from tracecat.agent.mcp.internal_tools import (
+    AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
+)
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.auth.types import Role
 from tracecat.chat.tools import (
@@ -61,6 +64,8 @@ def test_workspace_chat_default_tools_include_authoring_actions() -> None:
         "core.workflow.publish",
         "core.workflow.run",
         "core.workflow.execute",
+        "internal.agent.search_sessions",
+        "internal.agent.read_session_window",
     ]
 
 
@@ -79,14 +84,16 @@ def test_workspace_chat_default_tools_exclude_agent_actions_without_entitlement(
 
 def test_scope_filter_strips_all_tools_without_action_execute() -> None:
     # A role that can start chat (agent:execute) but holds no action:*:execute
-    # must not be offered ANY tool -- otherwise agent:execute would let the agent
-    # run actions (create agents, edit workflows, delete cases) the user cannot.
+    # must not be offered ANY registry action -- otherwise agent:execute would
+    # let the agent run actions (create agents, edit workflows, delete cases)
+    # the user cannot. Session-recall internal tools are exempt: they are not
+    # registry actions and only read the caller's own past sessions.
     tools = get_default_tools(AgentSessionEntity.WORKSPACE_CHAT.value)
     filtered = filter_workspace_chat_tools_for_scopes(
         tools, role=_role("agent:execute")
     )
 
-    assert filtered == []
+    assert filtered == AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES
 
 
 def test_scope_filter_action_wildcard_keeps_everything() -> None:
@@ -121,11 +128,15 @@ def test_scope_filter_specific_action_scope_keeps_only_that_tool() -> None:
         role=_role("agent:execute", "action:core.workflow.edit_workflow:execute"),
     )
 
-    assert filtered == ["core.workflow.edit_workflow"]
+    assert filtered == [
+        "core.workflow.edit_workflow",
+        *AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
+    ]
 
 
 def test_scope_filter_none_scopes_strips_all_tools() -> None:
-    # An unresolved/empty scope set denies every tool, matching the executor.
+    # An unresolved/empty scope set denies every registry action, matching the
+    # executor. Session-recall internal tools survive (see above).
     role = Role(
         type="user",
         service_id="tracecat-api",
@@ -137,7 +148,7 @@ def test_scope_filter_none_scopes_strips_all_tools() -> None:
     tools = get_default_tools(AgentSessionEntity.WORKSPACE_CHAT.value)
     filtered = filter_workspace_chat_tools_for_scopes(tools, role=role)
 
-    assert filtered == []
+    assert filtered == AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES
 
 
 def test_scope_filter_superuser_wildcard_keeps_everything() -> None:

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -36,6 +36,7 @@ from tracecat.agent.common.stream_types import (
     ToolCallContent,
     UnifiedStreamEvent,
 )
+from tracecat.agent.session.search import extract_search_text_from_history_content
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.stream.artifacts import artifact_stream_event
@@ -1071,10 +1072,12 @@ class LoopbackHandler:
             ):
                 kind = "compaction"
 
+            content = _session_line_db_content(line_data)
             history_entry = AgentSessionHistory(
                 session_id=self.input.session_id,
                 workspace_id=self.input.workspace_id,
-                content=_session_line_db_content(line_data),
+                content=content,
+                search_text=extract_search_text_from_history_content(content),
                 kind=kind,
                 curr_run_id=self.input.curr_run_id,
             )

--- a/tracecat/agent/mcp/internal_tools.py
+++ b/tracecat/agent/mcp/internal_tools.py
@@ -6,8 +6,8 @@ Internal tools are system-level tools that:
 - Are authorized via JWT claims (allowed_internal_tools)
 - Receive context from JWT claims (preset_id, workspace_id, etc.)
 
-This module provides the builder assistant tools that help users
-configure agent presets through natural language.
+This module provides trusted service-layer tools for builder assistants and
+agent session recall.
 """
 
 from __future__ import annotations
@@ -49,6 +49,11 @@ BUILDER_INTERNAL_TOOL_NAMES = [
     "internal.builder.update_preset",
     "internal.builder.list_sessions",
     "internal.builder.get_session",
+]
+
+AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES = [
+    "internal.agent.search_sessions",
+    "internal.agent.read_session_window",
 ]
 
 # Registry actions that are bundled with the builder assistant
@@ -491,6 +496,100 @@ async def get_session(args: dict[str, Any], claims: MCPTokenClaims) -> dict[str,
         raise InternalToolError(f"Unable to retrieve session {session_id_str}.") from e
 
 
+async def search_sessions(
+    args: dict[str, Any],
+    claims: MCPTokenClaims,
+) -> dict[str, Any]:
+    """Search past agent session messages in the caller's workspace."""
+    from tracecat.agent.session.service import AgentSessionService
+
+    role = _build_role(claims)
+    ctx_role.set(role)
+
+    query = args.get("query")
+    if not isinstance(query, str) or not query.strip():
+        raise InternalToolError("query parameter is required")
+
+    limit = args.get("limit", 10)
+    if not isinstance(limit, int):
+        limit = 10
+
+    entity_type: AgentSessionEntity | None = None
+    entity_type_value = args.get("entity_type")
+    if entity_type_value is not None:
+        if not isinstance(entity_type_value, str):
+            raise InternalToolError("entity_type must be a string")
+        try:
+            entity_type = AgentSessionEntity(entity_type_value)
+        except ValueError as exc:
+            raise InternalToolError(
+                f"Unsupported entity_type: {entity_type_value}"
+            ) from exc
+
+    try:
+        async with AgentSessionService.with_session(role=role) as service:
+            results = await service.search_session_messages(
+                query,
+                limit=limit,
+                entity_type=entity_type,
+                exclude_session_id=claims.session_id,
+            )
+            return {"results": [result.model_dump(mode="json") for result in results]}
+    except InternalToolError:
+        raise
+    except Exception as e:
+        logger.error("Failed to search sessions", error=str(e))
+        raise InternalToolError("Unable to search sessions at this time.") from e
+
+
+async def read_session_window(
+    args: dict[str, Any],
+    claims: MCPTokenClaims,
+) -> dict[str, Any]:
+    """Read compact messages around a session search hit."""
+    from tracecat.agent.session.service import AgentSessionService
+
+    role = _build_role(claims)
+    ctx_role.set(role)
+
+    session_id_str = args.get("session_id")
+    if not isinstance(session_id_str, str):
+        raise InternalToolError("session_id parameter is required")
+    try:
+        session_id = uuid.UUID(session_id_str)
+    except ValueError as exc:
+        raise InternalToolError(f"Invalid session_id format: {session_id_str}") from exc
+
+    anchor_surrogate_id = args.get("anchor_surrogate_id")
+    if not isinstance(anchor_surrogate_id, int):
+        raise InternalToolError("anchor_surrogate_id parameter is required")
+
+    window = args.get("window", 5)
+    if not isinstance(window, int):
+        window = 5
+
+    try:
+        async with AgentSessionService.with_session(role=role) as service:
+            session_window = await service.get_session_window(
+                session_id,
+                anchor_surrogate_id=anchor_surrogate_id,
+                window=window,
+                exclude_session_id=claims.session_id,
+            )
+            return session_window.model_dump(mode="json")
+    except InternalToolError:
+        raise
+    except Exception as e:
+        logger.error(
+            "Failed to read session window",
+            error=str(e),
+            session_id=session_id_str,
+        )
+        raise InternalToolError(
+            f"Unable to read session window for {session_id_str}."
+        ) from e
+
+
 # -----------------------------------------------------------------------------
 # Internal Tool Registry
 # -----------------------------------------------------------------------------
@@ -501,6 +600,8 @@ INTERNAL_TOOL_HANDLERS: dict[str, InternalToolHandler] = {
     "internal.builder.update_preset": update_preset,
     "internal.builder.list_sessions": list_sessions,
     "internal.builder.get_session": get_session,
+    "internal.agent.search_sessions": search_sessions,
+    "internal.agent.read_session_window": read_session_window,
 }
 
 
@@ -537,6 +638,47 @@ class _GetSessionParams(BaseModel):
     session_id: str = Field(
         ...,
         description="The UUID of the session to retrieve.",
+    )
+
+
+class _SearchSessionsParams(BaseModel):
+    """Parameters for search_sessions."""
+
+    query: str = Field(
+        ...,
+        description="Keyword search query. Supports web-search syntax.",
+        min_length=1,
+        max_length=300,
+    )
+    limit: int = Field(
+        default=10,
+        description="Maximum number of search hits to return.",
+        ge=1,
+        le=25,
+    )
+    entity_type: AgentSessionEntity | None = Field(
+        default=None,
+        description="Optional session entity type to restrict search results.",
+    )
+
+
+class _ReadSessionWindowParams(BaseModel):
+    """Parameters for read_session_window."""
+
+    session_id: str = Field(
+        ...,
+        description="The UUID of the session containing the search hit.",
+    )
+    anchor_surrogate_id: int = Field(
+        ...,
+        description="The surrogate_id anchor returned by search_sessions.",
+        ge=1,
+    )
+    window: int = Field(
+        default=5,
+        description="Number of messages before and after the anchor.",
+        ge=1,
+        le=20,
     )
 
 
@@ -584,4 +726,42 @@ def get_builder_internal_tool_definitions() -> dict[str, MCPToolDefinition]:
             description="Get the full message history and metadata for a specific agent session.",
             parameters_json_schema=_GetSessionParams.model_json_schema(),
         ),
+    }
+
+
+def get_agent_internal_tool_definitions() -> dict[str, MCPToolDefinition]:
+    """Return MCPToolDefinition for agent recall internal tools."""
+    return {
+        "internal.agent.search_sessions": MCPToolDefinition(
+            name="internal.agent.search_sessions",
+            description=(
+                "Search your own past agent sessions in this workspace by keyword. "
+                "Use web-search syntax: quoted phrases, OR, and -exclusion. "
+                "Returns snippets with >>>match<<< highlighting plus a surrogate_id "
+                "anchor. Use internal.agent.read_session_window to read around a hit. "
+                "Use this when the user references a past conversation, such as "
+                "'did we discuss X' or 'what did we decide about Y', before asking "
+                "them to repeat themselves. Results exclude the current session."
+            ),
+            parameters_json_schema=_SearchSessionsParams.model_json_schema(),
+        ),
+        "internal.agent.read_session_window": MCPToolDefinition(
+            name="internal.agent.read_session_window",
+            description=(
+                "Return compact messages around a session-search anchor with "
+                "messages_before and messages_after counts. Scroll forward by "
+                "passing the last returned message's surrogate_id as the next "
+                "anchor, and backward with the first returned message's surrogate_id. "
+                "Refuses to read the current session."
+            ),
+            parameters_json_schema=_ReadSessionWindowParams.model_json_schema(),
+        ),
+    }
+
+
+def get_internal_tool_definitions() -> dict[str, MCPToolDefinition]:
+    """Return MCPToolDefinition for all internal tools."""
+    return {
+        **get_builder_internal_tool_definitions(),
+        **get_agent_internal_tool_definitions(),
     }

--- a/tracecat/agent/mcp/internal_tools.py
+++ b/tracecat/agent/mcp/internal_tools.py
@@ -33,6 +33,7 @@ from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.contexts import ctx_role
 from tracecat.exceptions import (
+    TracecatNotFoundError,
     TracecatValidationError,
 )
 from tracecat.integrations.enums import OAuthGrantType
@@ -579,6 +580,10 @@ async def read_session_window(
             return session_window.model_dump(mode="json")
     except InternalToolError:
         raise
+    except (TracecatNotFoundError, TracecatValidationError) as e:
+        # Surface domain errors verbatim so the agent can distinguish
+        # "not found" / "this is your active session" from platform failures.
+        raise InternalToolError(str(e)) from e
     except Exception as e:
         logger.error(
             "Failed to read session window",

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -39,7 +39,7 @@ from tracecat.agent.mcp.executor import (
 from tracecat.agent.mcp.internal_tools import (
     INTERNAL_TOOL_HANDLERS,
     InternalToolError,
-    get_builder_internal_tool_definitions,
+    get_internal_tool_definitions,
 )
 from tracecat.agent.mcp.metadata import (
     build_registry_tool_schema,
@@ -348,7 +348,7 @@ async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
                 )
             )
 
-    internal_definitions = get_builder_internal_tool_definitions()
+    internal_definitions = get_internal_tool_definitions()
     for tool_name in _internal_tool_names(claims):
         if definition := internal_definitions.get(tool_name):
             tools.append(

--- a/tracecat/agent/session/schemas.py
+++ b/tracecat/agent/session/schemas.py
@@ -115,6 +115,40 @@ class AgentSessionHistoryRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class SessionSearchResult(BaseModel):
+    """Search hit for a past agent session message."""
+
+    session_id: uuid.UUID
+    session_title: str
+    entity_type: AgentSessionEntity
+    entity_id: uuid.UUID
+    surrogate_id: int
+    snippet: str
+    message_created_at: datetime
+    rank: float
+
+
+class SessionWindowMessage(BaseModel):
+    """Compact message returned when reading around a session-search hit."""
+
+    role: str
+    kind: str
+    text: str | None
+    surrogate_id: int
+    created_at: datetime
+
+
+class SessionWindow(BaseModel):
+    """Window of compact messages around a session-history anchor."""
+
+    session_id: uuid.UUID
+    session_title: str
+    anchor_surrogate_id: int
+    messages: list[SessionWindowMessage]
+    messages_before: int
+    messages_after: int
+
+
 class AgentSessionRead(BaseModel):
     """Response schema for agent session."""
 

--- a/tracecat/agent/session/search.py
+++ b/tracecat/agent/session/search.py
@@ -101,17 +101,29 @@ def _extract_user_content(content: Any) -> list[str]:
     return []
 
 
+_MEDIA_CONTENT_TYPES = (ImageUrl, AudioUrl, VideoUrl, DocumentUrl, BinaryContent)
+
+
 def _extract_tool_return_content(content: Any) -> list[str]:
     if isinstance(content, str):
         return [content]
+    # Media objects must become placeholders, never be JSON-serialized.
+    if isinstance(content, _MEDIA_CONTENT_TYPES):
+        return _extract_user_content(content)
     if isinstance(content, Sequence) and not isinstance(
         content, str | bytes | bytearray
     ):
         chunks: list[str] = []
         for item in content:
-            chunks.extend(_extract_mapping_content_item(item))
+            if isinstance(item, _MEDIA_CONTENT_TYPES):
+                chunks.extend(_extract_user_content(item))
+            else:
+                chunks.extend(_extract_mapping_content_item(item))
         if chunks:
             return chunks
+    if isinstance(content, Mapping):
+        if mapped := _extract_mapping_content_item(content):
+            return mapped
     if compacted := _compact_value(content):
         return [compacted]
     return []

--- a/tracecat/agent/session/search.py
+++ b/tracecat/agent/session/search.py
@@ -1,0 +1,333 @@
+"""Search text extraction helpers for agent session history."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import orjson
+from claude_agent_sdk.types import (
+    AssistantMessage,
+    ResultMessage,
+    SystemMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+from pydantic_ai.messages import (
+    AudioUrl,
+    BinaryContent,
+    DocumentUrl,
+    ImageUrl,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+    VideoUrl,
+)
+
+from tracecat.agent.types import UnifiedMessage
+from tracecat.logger import logger
+
+MAX_SEARCH_TEXT_CHARS = 8000
+MAX_WINDOW_MESSAGE_CHARS = 1500
+_WHITESPACE_RE = re.compile(r"\s+")
+_JSON_DUMP_OPTIONS = orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS
+
+
+def _collapse_and_cap(
+    text: str, *, max_chars: int = MAX_SEARCH_TEXT_CHARS
+) -> str | None:
+    collapsed = _WHITESPACE_RE.sub(" ", text).strip()
+    if not collapsed:
+        return None
+    return collapsed[:max_chars]
+
+
+def _compact_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return orjson.dumps(value, option=_JSON_DUMP_OPTIONS, default=str).decode()
+    except Exception:
+        try:
+            return str(value)
+        except Exception:
+            return None
+
+
+def _media_placeholder(kind: str | None, media_type: str | None = None) -> str:
+    marker = f"{kind or ''} {media_type or ''}".lower()
+    if "image" in marker:
+        return "[image]"
+    if "audio" in marker:
+        return "[audio]"
+    if "video" in marker:
+        return "[video]"
+    if "document" in marker or "pdf" in marker:
+        return "[document]"
+    return "[binary]"
+
+
+def _append_if_text(chunks: list[str], value: Any) -> None:
+    if isinstance(value, str) and value:
+        chunks.append(value)
+
+
+def _extract_user_content(content: Any) -> list[str]:
+    if isinstance(content, str):
+        return [content]
+    if isinstance(content, ImageUrl):
+        return ["[image]"]
+    if isinstance(content, AudioUrl):
+        return ["[audio]"]
+    if isinstance(content, VideoUrl):
+        return ["[video]"]
+    if isinstance(content, DocumentUrl):
+        return ["[document]"]
+    if isinstance(content, BinaryContent):
+        return [_media_placeholder("binary", content.media_type)]
+    if isinstance(content, Sequence) and not isinstance(content, bytes | bytearray):
+        chunks: list[str] = []
+        for item in content:
+            chunks.extend(_extract_user_content(item))
+        return chunks
+    return []
+
+
+def _extract_tool_return_content(content: Any) -> list[str]:
+    if isinstance(content, str):
+        return [content]
+    if isinstance(content, Sequence) and not isinstance(
+        content, str | bytes | bytearray
+    ):
+        chunks: list[str] = []
+        for item in content:
+            chunks.extend(_extract_mapping_content_item(item))
+        if chunks:
+            return chunks
+    if compacted := _compact_value(content):
+        return [compacted]
+    return []
+
+
+def _extract_pydantic_ai_message(message: ModelRequest | ModelResponse) -> list[str]:
+    chunks: list[str] = []
+    for part in message.parts:
+        if isinstance(part, UserPromptPart):
+            chunks.extend(_extract_user_content(part.content))
+        elif isinstance(part, TextPart):
+            chunks.append(part.content)
+        elif isinstance(part, ToolCallPart):
+            chunks.append(
+                " ".join(
+                    value
+                    for value in (part.tool_name, _compact_value(part.args))
+                    if value
+                )
+            )
+        elif isinstance(part, ToolReturnPart):
+            chunks.append(part.tool_name)
+            chunks.extend(_extract_tool_return_content(part.content))
+    return chunks
+
+
+def _extract_claude_block(block: Any) -> list[str]:
+    if isinstance(block, TextBlock):
+        return [block.text]
+    if isinstance(block, ToolUseBlock):
+        return [
+            " ".join(
+                value for value in (block.name, _compact_value(block.input)) if value
+            )
+        ]
+    if isinstance(block, ToolResultBlock):
+        return _extract_tool_return_content(block.content)
+    return []
+
+
+def _extract_claude_message(message: UnifiedMessage) -> list[str]:
+    if isinstance(message, UserMessage):
+        if isinstance(message.content, str):
+            return [message.content]
+        user_chunks: list[str] = []
+        for block in message.content:
+            user_chunks.extend(_extract_claude_block(block))
+        return user_chunks
+    if isinstance(message, AssistantMessage):
+        assistant_chunks: list[str] = []
+        for block in message.content:
+            assistant_chunks.extend(_extract_claude_block(block))
+        return assistant_chunks
+    if isinstance(message, SystemMessage):
+        return [text] if isinstance(text := message.data.get("text"), str) else []
+    if isinstance(message, ResultMessage):
+        return [message.result] if message.result else []
+    return []
+
+
+def extract_search_text(message: UnifiedMessage) -> str | None:
+    """Extract capped plain text from a unified agent message for FTS indexing."""
+    try:
+        if isinstance(message, ModelRequest | ModelResponse):
+            chunks = _extract_pydantic_ai_message(message)
+        else:
+            chunks = _extract_claude_message(message)
+        return _collapse_and_cap(" ".join(chunk for chunk in chunks if chunk))
+    except Exception as exc:
+        logger.debug(
+            "Failed to extract agent session search text",
+            error_type=type(exc).__name__,
+        )
+        return None
+
+
+def _extract_mapping_content(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        chunks: list[str] = []
+        for item in value:
+            chunks.extend(_extract_mapping_content_item(item))
+        return chunks
+    if isinstance(value, Mapping):
+        return _extract_mapping_content_item(value)
+    return []
+
+
+def _extract_mapping_content_item(item: Any) -> list[str]:
+    if isinstance(item, str):
+        return [item]
+    if not isinstance(item, Mapping):
+        return []
+
+    kind = item.get("type") or item.get("kind") or item.get("part_kind")
+    if isinstance(kind, str) and kind in {
+        "image",
+        "image-url",
+        "binary",
+        "audio",
+        "audio-url",
+        "video",
+        "video-url",
+        "document-url",
+    }:
+        media_type = item.get("media_type") or item.get("mediaType")
+        return [
+            _media_placeholder(
+                kind, media_type if isinstance(media_type, str) else None
+            )
+        ]
+
+    chunks: list[str] = []
+    _append_if_text(chunks, item.get("text"))
+    if chunks:
+        return chunks
+    if "content" in item:
+        return _extract_mapping_content(item.get("content"))
+    return []
+
+
+def _extract_mapping_part(part: Any) -> list[str]:
+    if not isinstance(part, Mapping):
+        return []
+
+    part_kind = part.get("part_kind") or part.get("type") or part.get("kind")
+    match part_kind:
+        case "user-prompt":
+            return _extract_mapping_content(part.get("content"))
+        case "text":
+            text = part.get("content") or part.get("text")
+            return [text] if isinstance(text, str) else []
+        case "tool-call" | "tool_use":
+            name = part.get("tool_name") or part.get("name")
+            args = part.get("args") if "args" in part else part.get("input")
+            rendered = " ".join(
+                value
+                for value in (
+                    str(name) if name else None,
+                    _compact_value(args),
+                )
+                if value
+            )
+            return [rendered] if rendered else []
+        case "tool-return" | "tool_result":
+            chunks: list[str] = []
+            if name := part.get("tool_name"):
+                chunks.append(str(name))
+            chunks.extend(_extract_mapping_content(part.get("content")))
+            return chunks
+        case _:
+            return _extract_mapping_content_item(part)
+
+
+def _extract_mapping_message(payload: Mapping[str, Any]) -> list[str]:
+    if message := payload.get("message"):
+        if isinstance(message, Mapping):
+            return _extract_mapping_message(message)
+
+    if parts := payload.get("parts"):
+        if isinstance(parts, Sequence) and not isinstance(
+            parts, str | bytes | bytearray
+        ):
+            chunks: list[str] = []
+            for part in parts:
+                chunks.extend(_extract_mapping_part(part))
+            return chunks
+
+    if "content" in payload:
+        return _extract_mapping_content(payload.get("content"))
+
+    return []
+
+
+def extract_search_text_from_history_content(
+    content: Mapping[str, Any],
+    *,
+    max_chars: int = MAX_SEARCH_TEXT_CHARS,
+) -> str | None:
+    """Extract capped plain text from a persisted AgentSessionHistory JSONB row."""
+    try:
+        chunks = _extract_mapping_message(content)
+        return _collapse_and_cap(
+            " ".join(chunk for chunk in chunks if chunk), max_chars=max_chars
+        )
+    except Exception as exc:
+        logger.debug(
+            "Failed to extract persisted session search text",
+            error_type=type(exc).__name__,
+        )
+        return None
+
+
+def infer_message_role(content: Mapping[str, Any], *, kind: str) -> str:
+    """Infer a compact display role from a persisted history payload."""
+    msg_type = content.get("type")
+    if isinstance(msg_type, str) and msg_type in {"user", "assistant", "system"}:
+        return msg_type
+    message = content.get("message")
+    if isinstance(message, Mapping):
+        role = message.get("role")
+        if isinstance(role, str):
+            return role
+    payload_kind = content.get("kind")
+    if payload_kind == "request":
+        return "user"
+    if payload_kind == "response":
+        return "assistant"
+    return kind
+
+
+def compact_window_text(text: str | None) -> str | None:
+    """Collapse and cap a message body for session-window responses."""
+    if text is None:
+        return None
+    return _collapse_and_cap(text, max_chars=MAX_WINDOW_MESSAGE_CHARS)

--- a/tracecat/agent/session/search.py
+++ b/tracecat/agent/session/search.py
@@ -210,6 +210,15 @@ def _extract_mapping_content_item(item: Any) -> list[str]:
         return []
 
     kind = item.get("type") or item.get("kind") or item.get("part_kind")
+    # Claude SDK content blocks carry tool calls inline in message.content;
+    # route them through the part extractor so tool names/args are indexed.
+    if isinstance(kind, str) and kind in {
+        "tool-call",
+        "tool_use",
+        "tool-return",
+        "tool_result",
+    }:
+        return _extract_mapping_part(item)
     if isinstance(kind, str) and kind in {
         "image",
         "image-url",

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -27,7 +27,6 @@ from sqlalchemy import (
     literal,
     or_,
     select,
-    true,
     update,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -493,14 +492,18 @@ class AgentSessionService(BaseWorkspaceService):
         window = max(1, min(window, 20))
         # Mirror list_messages: while a turn is live, the active run's partial
         # rows are durability-only and hidden from the timeline; hide them from
-        # recall windows and boundary counts as well.
-        hide_active_turn = (
-            or_(
-                AgentSessionHistory.curr_run_id.is_(None),
-                AgentSessionHistory.curr_run_id != agent_session.curr_run_id,
-            )
-            if agent_session.curr_run_id is not None
-            else true()
+        # recall windows and boundary counts as well. Read the live run pointer
+        # inline (scalar subquery) rather than snapshotting it in Python, so a
+        # turn starting or finalizing between queries cannot skew the window.
+        live_run_id = (
+            select(AgentSession.curr_run_id)
+            .where(AgentSession.id == session_id)
+            .scalar_subquery()
+        )
+        hide_active_turn = or_(
+            live_run_id.is_(None),
+            AgentSessionHistory.curr_run_id.is_(None),
+            AgentSessionHistory.curr_run_id != live_run_id,
         )
         before_stmt = (
             select(AgentSessionHistory)

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -337,7 +337,11 @@ class AgentSessionService(BaseWorkspaceService):
             func.row_number()
             .over(
                 partition_by=AgentSessionHistory.session_id,
-                order_by=(rank.desc(), AgentSessionHistory.created_at.desc()),
+                order_by=(
+                    rank.desc(),
+                    AgentSessionHistory.created_at.desc(),
+                    AgentSessionHistory.surrogate_id.desc(),
+                ),
             )
             .label("per_session_rank")
         )
@@ -370,7 +374,11 @@ class AgentSessionService(BaseWorkspaceService):
         stmt = (
             select(ranked)
             .where(ranked.c.per_session_rank == 1)
-            .order_by(ranked.c.rank.desc(), ranked.c.message_created_at.desc())
+            .order_by(
+                ranked.c.rank.desc(),
+                ranked.c.message_created_at.desc(),
+                ranked.c.surrogate_id.desc(),
+            )
             .limit(min(limit * 4, 100))
         )
 

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     literal,
     or_,
     select,
+    true,
     update,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -370,6 +371,13 @@ class AgentSessionService(BaseWorkspaceService):
                 AgentSession.workspace_id == self.workspace_id,
                 self._recall_visibility_clause(),
                 AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
+                # Mirror list_messages: rows from a session's live turn are
+                # durability-only until the turn finalizes; hide them here too.
+                or_(
+                    AgentSession.curr_run_id.is_(None),
+                    AgentSessionHistory.curr_run_id.is_(None),
+                    AgentSessionHistory.curr_run_id != AgentSession.curr_run_id,
+                ),
                 AgentSessionHistory.search_text.is_not(None),
                 AgentSessionHistory.search_tsv.op("@@")(tsquery),
             )
@@ -483,12 +491,24 @@ class AgentSessionService(BaseWorkspaceService):
                 )
 
         window = max(1, min(window, 20))
+        # Mirror list_messages: while a turn is live, the active run's partial
+        # rows are durability-only and hidden from the timeline; hide them from
+        # recall windows and boundary counts as well.
+        hide_active_turn = (
+            or_(
+                AgentSessionHistory.curr_run_id.is_(None),
+                AgentSessionHistory.curr_run_id != agent_session.curr_run_id,
+            )
+            if agent_session.curr_run_id is not None
+            else true()
+        )
         before_stmt = (
             select(AgentSessionHistory)
             .where(
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
                 AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
+                hide_active_turn,
                 AgentSessionHistory.surrogate_id <= anchor_surrogate_id,
             )
             .order_by(AgentSessionHistory.surrogate_id.desc())
@@ -503,6 +523,7 @@ class AgentSessionService(BaseWorkspaceService):
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
                 AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
+                hide_active_turn,
                 AgentSessionHistory.surrogate_id > anchor_surrogate_id,
             )
             .order_by(AgentSessionHistory.surrogate_id)
@@ -516,6 +537,7 @@ class AgentSessionService(BaseWorkspaceService):
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
                 AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
+                hide_active_turn,
                 AgentSessionHistory.surrogate_id < before_entries[0].surrogate_id,
             )
         else:
@@ -523,6 +545,7 @@ class AgentSessionService(BaseWorkspaceService):
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
                 AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
+                hide_active_turn,
                 AgentSessionHistory.surrogate_id <= anchor_surrogate_id,
             )
         messages_before = await self.session.scalar(messages_before_stmt)
@@ -532,6 +555,7 @@ class AgentSessionService(BaseWorkspaceService):
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
                 AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
+                hide_active_turn,
                 AgentSessionHistory.surrogate_id > after_entries[-1].surrogate_id,
             )
         else:
@@ -539,6 +563,7 @@ class AgentSessionService(BaseWorkspaceService):
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
                 AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
+                hide_active_turn,
                 AgentSessionHistory.surrogate_id > anchor_surrogate_id,
             )
         messages_after = await self.session.scalar(messages_after_stmt)

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -141,6 +141,16 @@ AUTO_TITLE_SERVICE_ID = "tracecat-api"
 APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
 
 
+# Recall (session search / window reads) must only surface rows the UI
+# timeline shows; INTERNAL rows (continuation prompts, interrupt artifacts)
+# and approval bubbles stay hidden.
+_RECALL_VISIBLE_KINDS = (
+    MessageKind.CHAT_MESSAGE.value,
+    MessageKind.COMPACTION.value,
+    MessageKind.CANCELLED.value,
+)
+
+
 def _dedupe_tool_names(tools: Sequence[str]) -> list[str]:
     deduped: list[str] = []
     for tool in tools:
@@ -260,29 +270,27 @@ class AgentSessionService(BaseWorkspaceService):
                 children_by_id.setdefault(parent_session_id, []).append(session_id)
         return parent_by_id, children_by_id
 
-    @staticmethod
+    @classmethod
     def _lineage_ids(
+        cls,
         session_id: uuid.UUID,
         parent_by_id: dict[uuid.UUID, uuid.UUID | None],
         children_by_id: dict[uuid.UUID, list[uuid.UUID]],
     ) -> set[uuid.UUID]:
-        lineage = {session_id}
+        """Return the whole fork tree containing ``session_id``.
 
-        current = session_id
-        while parent_id := parent_by_id.get(current):
-            if parent_id in lineage:
-                break
-            lineage.add(parent_id)
-            current = parent_id
-
-        stack = list(children_by_id.get(session_id, []))
+        Walks down from the resolved root so sibling forks are included,
+        keeping current-lineage exclusion aligned with the root-based dedupe.
+        """
+        lineage: set[uuid.UUID] = set()
+        stack = [cls._root_session_id(session_id, parent_by_id)]
         while stack:
-            child_id = stack.pop()
-            if child_id in lineage:
+            node_id = stack.pop()
+            if node_id in lineage:
                 continue
-            lineage.add(child_id)
-            stack.extend(children_by_id.get(child_id, []))
-
+            lineage.add(node_id)
+            stack.extend(children_by_id.get(node_id, []))
+        lineage.add(session_id)
         return lineage
 
     @staticmethod
@@ -361,6 +369,7 @@ class AgentSessionService(BaseWorkspaceService):
             .where(
                 AgentSession.workspace_id == self.workspace_id,
                 self._recall_visibility_clause(),
+                AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
                 AgentSessionHistory.search_text.is_not(None),
                 AgentSessionHistory.search_tsv.op("@@")(tsquery),
             )
@@ -379,31 +388,39 @@ class AgentSessionService(BaseWorkspaceService):
                 ranked.c.message_created_at.desc(),
                 ranked.c.surrogate_id.desc(),
             )
-            .limit(min(limit * 4, 100))
         )
 
-        result = await self.session.execute(stmt)
-        rows = result.mappings().all()
-
+        # Root-lineage dedupe happens in Python, so page through best-per-session
+        # hits until enough distinct lineages are found; otherwise one fork tree
+        # with many sibling sessions could fill a single fixed scan window.
+        page_size = min(max(limit * 4, 25), 100)
+        max_pages = 5
         results_by_root: dict[uuid.UUID, SessionSearchResult] = {}
-        for row in rows:
-            session_id = row["session_id"]
-            root_id = self._root_session_id(session_id, parent_by_id)
-            if root_id in results_by_root:
-                continue
-            if not row["snippet"]:
-                continue
-            results_by_root[root_id] = SessionSearchResult(
-                session_id=session_id,
-                session_title=row["session_title"],
-                entity_type=AgentSessionEntity(row["entity_type"]),
-                entity_id=row["entity_id"],
-                surrogate_id=row["surrogate_id"],
-                snippet=row["snippet"],
-                message_created_at=row["message_created_at"],
-                rank=float(row["rank"] or 0.0),
+        for page in range(max_pages):
+            result = await self.session.execute(
+                stmt.offset(page * page_size).limit(page_size)
             )
-            if len(results_by_root) >= limit:
+            rows = result.mappings().all()
+            for row in rows:
+                session_id = row["session_id"]
+                root_id = self._root_session_id(session_id, parent_by_id)
+                if root_id in results_by_root:
+                    continue
+                if not row["snippet"]:
+                    continue
+                results_by_root[root_id] = SessionSearchResult(
+                    session_id=session_id,
+                    session_title=row["session_title"],
+                    entity_type=AgentSessionEntity(row["entity_type"]),
+                    entity_id=row["entity_id"],
+                    surrogate_id=row["surrogate_id"],
+                    snippet=row["snippet"],
+                    message_created_at=row["message_created_at"],
+                    rank=float(row["rank"] or 0.0),
+                )
+                if len(results_by_root) >= limit:
+                    break
+            if len(results_by_root) >= limit or len(rows) < page_size:
                 break
 
         return list(results_by_root.values())
@@ -471,6 +488,7 @@ class AgentSessionService(BaseWorkspaceService):
             .where(
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
                 AgentSessionHistory.surrogate_id <= anchor_surrogate_id,
             )
             .order_by(AgentSessionHistory.surrogate_id.desc())
@@ -484,6 +502,7 @@ class AgentSessionService(BaseWorkspaceService):
             .where(
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
                 AgentSessionHistory.surrogate_id > anchor_surrogate_id,
             )
             .order_by(AgentSessionHistory.surrogate_id)
@@ -496,12 +515,14 @@ class AgentSessionService(BaseWorkspaceService):
             messages_before_stmt = select(func.count()).where(
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
                 AgentSessionHistory.surrogate_id < before_entries[0].surrogate_id,
             )
         else:
             messages_before_stmt = select(func.count()).where(
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
                 AgentSessionHistory.surrogate_id <= anchor_surrogate_id,
             )
         messages_before = await self.session.scalar(messages_before_stmt)
@@ -510,12 +531,14 @@ class AgentSessionService(BaseWorkspaceService):
             messages_after_stmt = select(func.count()).where(
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
                 AgentSessionHistory.surrogate_id > after_entries[-1].surrogate_id,
             )
         else:
             messages_after_stmt = select(func.count()).where(
                 AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.kind.in_(_RECALL_VISIBLE_KINDS),
                 AgentSessionHistory.surrogate_id > anchor_surrogate_id,
             )
         messages_after = await self.session.scalar(messages_after_stmt)

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -331,7 +331,17 @@ class AgentSessionService(BaseWorkspaceService):
             "StartSel=>>>, StopSel=<<<, MaxWords=40, MinWords=10, "
             'MaxFragments=2, FragmentDelimiter=" ... "',
         ).label("snippet")
-        stmt = (
+        # Rank hits per session so one chatty session cannot fill the scan
+        # window and starve other matching sessions before the lineage dedupe.
+        per_session_rank = (
+            func.row_number()
+            .over(
+                partition_by=AgentSessionHistory.session_id,
+                order_by=(rank.desc(), AgentSessionHistory.created_at.desc()),
+            )
+            .label("per_session_rank")
+        )
+        inner = (
             select(
                 AgentSessionHistory.session_id,
                 AgentSessionHistory.surrogate_id,
@@ -341,6 +351,7 @@ class AgentSessionService(BaseWorkspaceService):
                 AgentSession.entity_id,
                 rank,
                 snippet,
+                per_session_rank,
             )
             .join(AgentSession, AgentSession.id == AgentSessionHistory.session_id)
             .where(
@@ -349,13 +360,19 @@ class AgentSessionService(BaseWorkspaceService):
                 AgentSessionHistory.search_text.is_not(None),
                 AgentSessionHistory.search_tsv.op("@@")(tsquery),
             )
-            .order_by(rank.desc(), AgentSessionHistory.created_at.desc())
-            .limit(min(limit * 4, 100))
         )
         if entity_type is not None:
-            stmt = stmt.where(AgentSession.entity_type == entity_type.value)
+            inner = inner.where(AgentSession.entity_type == entity_type.value)
         if exclude_ids:
-            stmt = stmt.where(AgentSessionHistory.session_id.notin_(exclude_ids))
+            inner = inner.where(AgentSessionHistory.session_id.notin_(exclude_ids))
+
+        ranked = inner.subquery()
+        stmt = (
+            select(ranked)
+            .where(ranked.c.per_session_rank == 1)
+            .order_by(ranked.c.rank.desc(), ranked.c.message_created_at.desc())
+            .limit(min(limit * 4, 100))
+        )
 
         result = await self.session.execute(stmt)
         rows = result.mappings().all()

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -18,6 +18,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.tools import ToolApproved, ToolDenied
 from sqlalchemy import (
+    ColumnElement,
     and_,
     case,
     column,
@@ -61,6 +62,14 @@ from tracecat.agent.session.schemas import (
     AgentSessionCreate,
     AgentSessionRead,
     AgentSessionUpdate,
+    SessionSearchResult,
+    SessionWindow,
+    SessionWindowMessage,
+)
+from tracecat.agent.session.search import (
+    compact_window_text,
+    extract_search_text_from_history_content,
+    infer_message_role,
 )
 from tracecat.agent.session.title_generator import generate_session_title
 from tracecat.agent.session.types import (
@@ -132,6 +141,14 @@ AUTO_TITLE_SERVICE_ID = "tracecat-api"
 APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
 
 
+def _dedupe_tool_names(tools: Sequence[str]) -> list[str]:
+    deduped: list[str] = []
+    for tool in tools:
+        if tool not in deduped:
+            deduped.append(tool)
+    return deduped
+
+
 @dataclass
 class SessionHistoryData:
     """Data structure for session history loaded from DB."""
@@ -193,7 +210,7 @@ class AgentSessionService(BaseWorkspaceService):
         """
         defaults = await self._get_default_tools(AgentSessionEntity.WORKSPACE_CHAT)
         extras = agent_session.tools or []
-        merged = list(dict.fromkeys([*defaults, *extras]))
+        merged = _dedupe_tool_names([*defaults, *extras])
         # Chat tools execute under the executor service principal, which the
         # internal API routes authorize against the service allowlist rather than
         # the chat user's RBAC. Enforce the caller's action scopes here -- the
@@ -216,6 +233,278 @@ class AgentSessionService(BaseWorkspaceService):
             return None
         return await agent_svc.presets.resolve_mcp_integration_refs(
             agent_session.mcp_integrations
+        )
+
+    def _recall_visibility_clause(self) -> ColumnElement[bool]:
+        """Restrict session recall to sessions the caller can already list.
+
+        Mirrors the sessions list API: user roles see their own sessions,
+        creator-less roles (e.g. workflow-initiated) see creator-less sessions.
+        """
+        if self.role.user_id is not None:
+            return AgentSession.created_by == self.role.user_id
+        return AgentSession.created_by.is_(None)
+
+    async def _load_session_lineage_maps(
+        self,
+    ) -> tuple[dict[uuid.UUID, uuid.UUID | None], dict[uuid.UUID, list[uuid.UUID]]]:
+        stmt = select(AgentSession.id, AgentSession.parent_session_id).where(
+            AgentSession.workspace_id == self.workspace_id
+        )
+        result = await self.session.execute(stmt)
+        parent_by_id: dict[uuid.UUID, uuid.UUID | None] = {}
+        children_by_id: dict[uuid.UUID, list[uuid.UUID]] = {}
+        for session_id, parent_session_id in result.tuples().all():
+            parent_by_id[session_id] = parent_session_id
+            if parent_session_id is not None:
+                children_by_id.setdefault(parent_session_id, []).append(session_id)
+        return parent_by_id, children_by_id
+
+    @staticmethod
+    def _lineage_ids(
+        session_id: uuid.UUID,
+        parent_by_id: dict[uuid.UUID, uuid.UUID | None],
+        children_by_id: dict[uuid.UUID, list[uuid.UUID]],
+    ) -> set[uuid.UUID]:
+        lineage = {session_id}
+
+        current = session_id
+        while parent_id := parent_by_id.get(current):
+            if parent_id in lineage:
+                break
+            lineage.add(parent_id)
+            current = parent_id
+
+        stack = list(children_by_id.get(session_id, []))
+        while stack:
+            child_id = stack.pop()
+            if child_id in lineage:
+                continue
+            lineage.add(child_id)
+            stack.extend(children_by_id.get(child_id, []))
+
+        return lineage
+
+    @staticmethod
+    def _root_session_id(
+        session_id: uuid.UUID,
+        parent_by_id: dict[uuid.UUID, uuid.UUID | None],
+    ) -> uuid.UUID:
+        root_id = session_id
+        seen = {session_id}
+        while parent_id := parent_by_id.get(root_id):
+            if parent_id in seen:
+                break
+            seen.add(parent_id)
+            root_id = parent_id
+        return root_id
+
+    async def search_session_messages(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        entity_type: AgentSessionEntity | None = None,
+        exclude_session_id: uuid.UUID | None = None,
+    ) -> list[SessionSearchResult]:
+        """Search workspace agent-session history using PostgreSQL FTS."""
+        query = query.strip()
+        if not query:
+            return []
+
+        limit = max(1, min(limit, 25))
+        parent_by_id, children_by_id = await self._load_session_lineage_maps()
+        exclude_ids: set[uuid.UUID] = set()
+        if exclude_session_id is not None:
+            exclude_ids = self._lineage_ids(
+                exclude_session_id,
+                parent_by_id,
+                children_by_id,
+            )
+
+        tsquery = func.websearch_to_tsquery("english", query)
+        rank = func.ts_rank(AgentSessionHistory.search_tsv, tsquery).label("rank")
+        snippet = func.ts_headline(
+            "english",
+            AgentSessionHistory.search_text,
+            tsquery,
+            "StartSel=>>>, StopSel=<<<, MaxWords=40, MinWords=10, "
+            'MaxFragments=2, FragmentDelimiter=" ... "',
+        ).label("snippet")
+        stmt = (
+            select(
+                AgentSessionHistory.session_id,
+                AgentSessionHistory.surrogate_id,
+                AgentSessionHistory.created_at.label("message_created_at"),
+                AgentSession.title.label("session_title"),
+                AgentSession.entity_type,
+                AgentSession.entity_id,
+                rank,
+                snippet,
+            )
+            .join(AgentSession, AgentSession.id == AgentSessionHistory.session_id)
+            .where(
+                AgentSession.workspace_id == self.workspace_id,
+                self._recall_visibility_clause(),
+                AgentSessionHistory.search_text.is_not(None),
+                AgentSessionHistory.search_tsv.op("@@")(tsquery),
+            )
+            .order_by(rank.desc(), AgentSessionHistory.created_at.desc())
+            .limit(min(limit * 4, 100))
+        )
+        if entity_type is not None:
+            stmt = stmt.where(AgentSession.entity_type == entity_type.value)
+        if exclude_ids:
+            stmt = stmt.where(AgentSessionHistory.session_id.notin_(exclude_ids))
+
+        result = await self.session.execute(stmt)
+        rows = result.mappings().all()
+
+        results_by_root: dict[uuid.UUID, SessionSearchResult] = {}
+        for row in rows:
+            session_id = row["session_id"]
+            root_id = self._root_session_id(session_id, parent_by_id)
+            if root_id in results_by_root:
+                continue
+            if not row["snippet"]:
+                continue
+            results_by_root[root_id] = SessionSearchResult(
+                session_id=session_id,
+                session_title=row["session_title"],
+                entity_type=AgentSessionEntity(row["entity_type"]),
+                entity_id=row["entity_id"],
+                surrogate_id=row["surrogate_id"],
+                snippet=row["snippet"],
+                message_created_at=row["message_created_at"],
+                rank=float(row["rank"] or 0.0),
+            )
+            if len(results_by_root) >= limit:
+                break
+
+        return list(results_by_root.values())
+
+    @staticmethod
+    def _history_content_fallback(content: dict[str, Any]) -> str | None:
+        try:
+            return orjson.dumps(content, option=orjson.OPT_SORT_KEYS).decode()
+        except Exception:
+            try:
+                return repr(content)
+            except Exception:
+                return None
+
+    def _window_message_from_history(
+        self,
+        entry: AgentSessionHistory,
+    ) -> SessionWindowMessage:
+        text = entry.search_text or self._history_content_fallback(entry.content)
+        return SessionWindowMessage(
+            role=infer_message_role(entry.content, kind=entry.kind),
+            kind=entry.kind,
+            text=compact_window_text(text),
+            surrogate_id=entry.surrogate_id,
+            created_at=entry.created_at,
+        )
+
+    async def get_session_window(
+        self,
+        session_id: uuid.UUID,
+        *,
+        anchor_surrogate_id: int,
+        window: int = 5,
+        exclude_session_id: uuid.UUID | None = None,
+    ) -> SessionWindow:
+        """Return a compact message window around a session-history anchor."""
+        agent_session = await self.get_session(session_id)
+        if agent_session is None:
+            raise TracecatNotFoundError(f"Session with ID {session_id} not found")
+        visible = (
+            agent_session.created_by == self.role.user_id
+            if self.role.user_id is not None
+            else agent_session.created_by is None
+        )
+        if not visible:
+            # Not-found rather than forbidden: don't leak session existence.
+            raise TracecatNotFoundError(f"Session with ID {session_id} not found")
+
+        parent_by_id, children_by_id = await self._load_session_lineage_maps()
+        if exclude_session_id is not None:
+            exclude_ids = self._lineage_ids(
+                exclude_session_id,
+                parent_by_id,
+                children_by_id,
+            )
+            if session_id in exclude_ids:
+                raise TracecatValidationError(
+                    "Cannot read this session window: this is your active session - "
+                    "its messages are already in context."
+                )
+
+        window = max(1, min(window, 20))
+        before_stmt = (
+            select(AgentSessionHistory)
+            .where(
+                AgentSessionHistory.workspace_id == self.workspace_id,
+                AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.surrogate_id <= anchor_surrogate_id,
+            )
+            .order_by(AgentSessionHistory.surrogate_id.desc())
+            .limit(window)
+        )
+        before_result = await self.session.execute(before_stmt)
+        before_entries = list(reversed(before_result.scalars().all()))
+
+        after_stmt = (
+            select(AgentSessionHistory)
+            .where(
+                AgentSessionHistory.workspace_id == self.workspace_id,
+                AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.surrogate_id > anchor_surrogate_id,
+            )
+            .order_by(AgentSessionHistory.surrogate_id)
+            .limit(window)
+        )
+        after_result = await self.session.execute(after_stmt)
+        after_entries = list(after_result.scalars().all())
+
+        if before_entries:
+            messages_before_stmt = select(func.count()).where(
+                AgentSessionHistory.workspace_id == self.workspace_id,
+                AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.surrogate_id < before_entries[0].surrogate_id,
+            )
+        else:
+            messages_before_stmt = select(func.count()).where(
+                AgentSessionHistory.workspace_id == self.workspace_id,
+                AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.surrogate_id <= anchor_surrogate_id,
+            )
+        messages_before = await self.session.scalar(messages_before_stmt)
+
+        if after_entries:
+            messages_after_stmt = select(func.count()).where(
+                AgentSessionHistory.workspace_id == self.workspace_id,
+                AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.surrogate_id > after_entries[-1].surrogate_id,
+            )
+        else:
+            messages_after_stmt = select(func.count()).where(
+                AgentSessionHistory.workspace_id == self.workspace_id,
+                AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.surrogate_id > anchor_surrogate_id,
+            )
+        messages_after = await self.session.scalar(messages_after_stmt)
+
+        return SessionWindow(
+            session_id=agent_session.id,
+            session_title=agent_session.title,
+            anchor_surrogate_id=anchor_surrogate_id,
+            messages=[
+                self._window_message_from_history(entry)
+                for entry in [*before_entries, *after_entries]
+            ],
+            messages_before=int(messages_before or 0),
+            messages_after=int(messages_after or 0),
         )
 
     async def _validate_session_mcp_integrations(
@@ -875,6 +1164,7 @@ class AgentSessionService(BaseWorkspaceService):
                 session_id=session_id,
                 workspace_id=self.workspace_id,
                 content=content,
+                search_text=extract_search_text_from_history_content(content),
                 kind=MessageKind.CANCELLED.value,
                 curr_run_id=curr_run_id
                 if curr_run_id is not None
@@ -1855,6 +2145,12 @@ class AgentSessionService(BaseWorkspaceService):
 
         if session_entity is AgentSessionEntity.CASE:
             entity_instructions = await self._entity_to_prompt(agent_session)
+            default_case_tools = await self._get_default_tools(AgentSessionEntity.CASE)
+            case_internal_tools = [
+                tool
+                for tool in [*default_case_tools, *(agent_session.tools or [])]
+                if tool.startswith("internal.")
+            ]
             if agent_session.agent_preset_id:
                 async with agent_svc.with_preset_config(
                     preset_id=agent_session.agent_preset_id,
@@ -1865,17 +2161,31 @@ class AgentSessionService(BaseWorkspaceService):
                         if preset_config.instructions
                         else entity_instructions
                     )
-                    config = replace(preset_config, instructions=combined_instructions)
+                    actions = (
+                        _dedupe_tool_names(
+                            [*(preset_config.actions or []), *case_internal_tools]
+                        )
+                        if case_internal_tools
+                        else preset_config.actions
+                    )
+                    config = replace(
+                        preset_config,
+                        instructions=combined_instructions,
+                        actions=actions,
+                    )
                     yield config
             else:
                 # Case chat without preset uses the org's default model
                 async with agent_svc.with_model_config() as model_config:
+                    actions = _dedupe_tool_names(
+                        [*(agent_session.tools or []), *case_internal_tools]
+                    )
                     yield AgentConfig(
                         instructions=entity_instructions,
                         model_name=model_config.name,
                         model_provider=model_config.provider,
                         catalog_id=model_config.catalog_id,
-                        actions=agent_session.tools,
+                        actions=actions,
                     )
         elif session_entity is AgentSessionEntity.AGENT_PRESET:
             async with agent_svc.with_preset_config(
@@ -1940,6 +2250,21 @@ class AgentSessionService(BaseWorkspaceService):
                         if preset_config.actions is not None
                         else None
                     )
+                    workspace_chat_internal_tools = [
+                        tool
+                        for tool in (
+                            await self._resolve_workspace_chat_actions(agent_session)
+                            or []
+                        )
+                        if tool.startswith("internal.")
+                    ]
+                    if workspace_chat_internal_tools:
+                        scoped_actions = _dedupe_tool_names(
+                            [
+                                *(scoped_actions or []),
+                                *workspace_chat_internal_tools,
+                            ]
+                        )
                     config = replace(
                         preset_config,
                         instructions=combined_instructions,
@@ -2412,6 +2737,7 @@ class AgentSessionService(BaseWorkspaceService):
                 session_id=session_id,
                 workspace_id=self.workspace_id,
                 content=entry_content,
+                search_text=extract_search_text_from_history_content(entry_content),
                 kind=MessageKind.CHAT_MESSAGE.value,
                 curr_run_id=session.curr_run_id,
             )

--- a/tracecat/chat/tools.py
+++ b/tracecat/chat/tools.py
@@ -1,5 +1,8 @@
 # Store default tools for each entity type
-from tracecat.agent.mcp.internal_tools import BUILDER_INTERNAL_TOOL_NAMES
+from tracecat.agent.mcp.internal_tools import (
+    AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
+    BUILDER_INTERNAL_TOOL_NAMES,
+)
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.auth.types import Role
 from tracecat.authz.controls import has_scope
@@ -50,6 +53,7 @@ WORKSPACE_CHAT_BASE_DEFAULT_TOOLS = [
 WORKSPACE_CHAT_DEFAULT_TOOLS = [
     *WORKSPACE_CHAT_AGENT_DEFAULT_TOOLS,
     *WORKSPACE_CHAT_BASE_DEFAULT_TOOLS,
+    *AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
 ]
 
 TOOL_DEFAULTS = {
@@ -59,6 +63,7 @@ TOOL_DEFAULTS = {
         "core.cases.update_case",
         "core.cases.create_comment",
         "core.cases.list_comments",
+        *AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES,
     ],
     AgentSessionEntity.AGENT_PRESET: [],
     AgentSessionEntity.AGENT_PRESET_BUILDER: BUILDER_INTERNAL_TOOL_NAMES,
@@ -103,7 +108,15 @@ def filter_workspace_chat_tools_for_scopes(
     bypass and wildcard grants (``action:*:execute``, ``action:core.*:execute``).
     """
     granted = role.scopes or frozenset()
-    return [tool for tool in tools if has_scope(granted, f"action:{tool}:execute")]
+    return [
+        tool
+        for tool in tools
+        # Internal tools are not registry actions and carry no action scope.
+        # Only the generally-available recall set may pass; privileged internal
+        # tools (e.g. builder tools) are granted by entity type, not requested.
+        if tool in AGENT_SESSION_SEARCH_INTERNAL_TOOL_NAMES
+        or has_scope(granted, f"action:{tool}:execute")
+    ]
 
 
 def get_default_tools(

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     TIMESTAMP,
     Boolean,
     CheckConstraint,
+    Computed,
     Enum,
     FetchedValue,
     Float,
@@ -36,7 +37,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import (
@@ -2976,6 +2977,7 @@ class AgentSessionHistory(WorkspaceModel):
     """
 
     __tablename__ = "agent_session_history"
+    __serialization_exclude__ = {"surrogate_id", "search_tsv"}
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID,
@@ -2994,6 +2996,20 @@ class AgentSessionHistory(WorkspaceModel):
         JSONB,
         nullable=False,
         doc="Harness-specific message content",
+    )
+    search_text: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        doc="Plain extracted message text used for full-text search",
+    )
+    search_tsv: Mapped[str | None] = mapped_column(
+        TSVECTOR,
+        Computed(
+            "to_tsvector('english', coalesce(search_text, ''))",
+            persisted=True,
+        ),
+        nullable=True,
+        doc="Generated PostgreSQL full-text search vector for search_text",
     )
     kind: Mapped[str] = mapped_column(
         String(50),

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2977,7 +2977,7 @@ class AgentSessionHistory(WorkspaceModel):
     """
 
     __tablename__ = "agent_session_history"
-    __serialization_exclude__ = {"surrogate_id", "search_tsv"}
+    __serialization_exclude__ = {"surrogate_id", "search_text", "search_tsv"}
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID,


### PR DESCRIPTION
## What

Adds Hermes-style session recall for Tracecat agents: two internal MCP tools that let an agent search its user's past agent sessions by keyword and read message windows around a hit.

- `internal.agent.search_sessions` — PostgreSQL FTS (`websearch_to_tsquery` + `ts_rank`) over extracted transcript text, returning `ts_headline` snippets (`>>>match<<<`) plus a `surrogate_id` anchor. Results dedupe by fork lineage and always exclude the current session.
- `internal.agent.read_session_window` — surrogate_id-anchored message window with `messages_before`/`messages_after` counts for scroll-style pagination; refuses the caller's active session.

Both tools are added to the default tool sets for `workspace_chat` and `case` sessions.

## How

- **Schema** (`24b2f4a4d6c9`): adds nullable `search_text` and a stored generated `search_tsv tsvector` column with a GIN index on `agent_session_history`, plus a self-contained batched backfill for existing rows. No extensions required.
- **Write path**: `tracecat/agent/session/search.py` extracts plain text from both harness envelopes (pydantic-ai `ModelMessage` and Claude SDK messages) at insert time — tool names/args included, images and binary content replaced with placeholders, capped at 8k chars, never raises. Wired into all `AgentSessionHistory` insert sites.
- **Tool plumbing**: the EE tool-definition activity now separates requested `internal.*` tools from registry actions and mints `allowed_internal_tools` claims for them; the trusted MCP server serves the combined internal-tool catalog.

## Security / authz

- **Visibility matches the sessions API**: user roles can only search/read their own sessions (`created_by`); creator-less roles (workflow-initiated) see creator-less sessions. Other users' sessions return not-found, not forbidden.
- **Internal-tool allowlist**: non-builder sessions may only request the two recall tools; privileged internal tools (e.g. `internal.builder.update_preset`) remain builder-entity-only. The workspace-chat scope filter passes only the recall tools through, since they are not registry actions and carry no `action:*:execute` scope.

## Testing

- 5 extractor unit tests (both harness formats, media placeholders, caps, garbage input).
- 8 DB-backed service tests: snippet highlighting, workspace isolation, per-user visibility (search + window), current-lineage exclusion, limit/window clamping, boundary counts.
- Existing chat-tools scope-filter tests updated to encode the new internal-tool contract.
- Migration verified against a live cluster (`alembic` head applied, generated column + GIN index present).
- `ruff`, `ruff format`, `basedpyright --warnings`: clean.

## Out of scope (follow-ups)

- Registry UDF surface (`core.agent.search_sessions`) for workflows via a new `/internal/agent/sessions/search` route.
- System-prompt guidance teaching presets when to reach for recall.
- Workspace-wide (cross-user) recall — deliberate product decision, currently scoped to own sessions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds session recall to agents with two internal MCP tools that search and read past sessions using PostgreSQL full‑text search. Default‑enabled for workspace chat and case, with strict visibility, deterministic results, and UI‑aligned behavior (hides live‑turn rows; reads the live‑run pointer inline to avoid skew).

- **New Features**
  - Internal tools: `internal.agent.search_sessions` (web‑search FTS, `>>>match<<<` snippets, optional `entity_type`, per‑session anti‑starvation ranking, root‑lineage dedupe + pagination, deterministic tie‑break, excludes current session) and `internal.agent.read_session_window` (anchor‑based window with compact role/kind/text plus before/after counts; refuses current session).
  - Text extraction on write: builds `search_text` from both harnesses; indexes Claude SDK `tool_use`/`tool_result` names/args; media → placeholders; 8k cap; tolerant to bad input; applied across inserts, cancellations, interrupt replacements, and loopback persistence.
  - Tool routing/auth: recall tools added to default sets for workspace chat and case; workspace‑chat scope filter keeps only these internal recall tools (not registry actions); internal catalog unified via `get_internal_tool_definitions`; non‑builder sessions may request only recall tools; unknown/privileged internal tools are rejected.
  - Visibility/correctness: users can search/read only their own sessions; creator‑less roles see creator‑less sessions; `INTERNAL` kinds and live‑turn rows are hidden to match the UI; live‑run pointer is read inline in window queries; current lineage (root and forks) excluded; chatty sessions cannot starve others; large fork trees cannot hide unrelated matches; `limit` clamped to 25 and window to 1–20.

- **Migration**
  - Alembic revision adds nullable `search_text` and stored `search_tsv` (GIN index) on `agent_session_history`, with batched backfill. No PostgreSQL extensions required.

<sup>Written for commit eef3acd9ec95b9d1edf91d3d1f103152b299f5ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

