### PR TITLE
fix(mcp): preserve body keys and templated values

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -15953,6 +15953,34 @@ export const $MCPIntegrationRead = {
       ],
       title: "Stdio Args",
     },
+    stdio_env_keys: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Stdio Env Keys",
+    },
+    stdio_env: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: "string",
+          },
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Stdio Env",
+    },
     has_stdio_env: {
       type: "boolean",
       title: "Has Stdio Env",
@@ -16274,6 +16302,22 @@ export const $MCPIntegrationUpdate = {
       ],
       title: "Stdio Env",
       description: "Environment variables for stdio-type servers",
+    },
+    stdio_env_preserve_keys: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Stdio Env Preserve Keys",
+      description:
+        "Existing stdio env keys to preserve when stdio_env only contains visible or replaced values.",
     },
     timeout: {
       anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4919,6 +4919,10 @@ export type MCPIntegrationRead = {
   state: "not_configured" | "configured" | "connected" | "error"
   stdio_command: string | null
   stdio_args: Array<string> | null
+  stdio_env_keys?: Array<string> | null
+  stdio_env?: {
+    [key: string]: string
+  } | null
   has_stdio_env?: boolean
   timeout: number | null
   tools?: Array<MCPToolSummary> | null
@@ -4989,6 +4993,10 @@ export type MCPIntegrationUpdate = {
   stdio_env?: {
     [key: string]: string
   } | null
+  /**
+   * Existing stdio env keys to preserve when stdio_env only contains visible or replaced values.
+   */
+  stdio_env_preserve_keys?: Array<string> | null
   /**
    * Timeout in seconds
    */

--- a/frontend/src/components/editor/codemirror/common.tsx
+++ b/frontend/src/components/editor/codemirror/common.tsx
@@ -1186,6 +1186,8 @@ export const TEMPLATE_SUGGESTIONS = [
   },
 ]
 
+const WORKSPACE_TEMPLATE_SUGGESTION_LABELS = new Set(["FN", "SECRETS", "VARS"])
+
 // Custom keymap for @ key to trigger completions
 export function createAtKeyCompletion() {
   return keymap.of([
@@ -1229,9 +1231,11 @@ export function createExitEditModeKeyHandler() {
 }
 
 // Completion functions
-export function createMentionCompletion(): (
-  context: CompletionContext
-) => CompletionResult | null {
+export function createMentionCompletion({
+  includeWorkflowCompletions = true,
+}: {
+  includeWorkflowCompletions?: boolean
+} = {}): (context: CompletionContext) => CompletionResult | null {
   return (context: CompletionContext): CompletionResult | null => {
     const word = context.matchBefore(/@\w*/)
     if (!word) return null
@@ -1241,10 +1245,15 @@ export function createMentionCompletion(): (
     const cursorPos = context.pos
     const templateRange = findTemplateAt(context.state, cursorPos)
     const isInsideTemplate = templateRange !== null
+    const suggestions = includeWorkflowCompletions
+      ? TEMPLATE_SUGGESTIONS
+      : TEMPLATE_SUGGESTIONS.filter((suggestion) =>
+          WORKSPACE_TEMPLATE_SUGGESTION_LABELS.has(suggestion.label)
+        )
 
     return {
       from: word.from,
-      options: TEMPLATE_SUGGESTIONS.map((suggestion) => ({
+      options: suggestions.map((suggestion) => ({
         label: `@${suggestion.label}`,
         detail: suggestion.detail,
         info: suggestion.info,
@@ -2051,21 +2060,29 @@ export function createAutocomplete({
   workspaceId,
   actions,
   forEach,
+  includeWorkflowCompletions = true,
 }: {
   workspaceId: string
   actions: Record<string, ActionRead>
   forEach: string | string[] | null | undefined
+  includeWorkflowCompletions?: boolean
 }) {
-  return autocompletion({
-    override: [
-      createMentionCompletion(),
-      createFunctionCompletion(workspaceId),
+  const overrides = [
+    createMentionCompletion({ includeWorkflowCompletions }),
+    createFunctionCompletion(workspaceId),
+    createSecretsCompletion(workspaceId),
+    createVarsCompletion(workspaceId),
+  ]
+  if (includeWorkflowCompletions) {
+    overrides.push(
       createActionCompletion(Object.values(actions).map((a) => a)),
       createVarCompletion(forEach),
-      createSecretsCompletion(workspaceId),
-      createVarsCompletion(workspaceId),
-      createEnvCompletion(),
-    ],
+      createEnvCompletion()
+    )
+  }
+
+  return autocompletion({
+    override: overrides,
   })
 }
 

--- a/frontend/src/components/editor/expression-input.tsx
+++ b/frontend/src/components/editor/expression-input.tsx
@@ -26,8 +26,10 @@ import { ExpressionErrorBoundary } from "@/components/error-boundaries"
 import { Input } from "@/components/ui/input"
 import { createTemplateRegex } from "@/lib/expressions"
 import { cn } from "@/lib/utils"
-import { useWorkflow } from "@/providers/workflow"
+import { useOptionalWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
+
+const EMPTY_ACTIONS = {} as Record<string, ActionRead>
 
 // Single-line expression linter
 function expressionLinter(view: EditorView): Diagnostic[] {
@@ -74,6 +76,7 @@ export interface ExpressionInputProps {
   className?: string
   disabled?: boolean
   defaultHeight?: "input" | "text-area"
+  completionScope?: "workflow" | "workspace"
 }
 
 // Simple fallback input component for when ExpressionInput fails
@@ -112,13 +115,20 @@ function ExpressionInputCore({
   className,
   disabled = false,
   defaultHeight = "input",
+  completionScope,
 }: ExpressionInputProps) {
   const { resolvedTheme } = useTheme()
   const codeMirrorTheme = resolvedTheme === "dark" ? "dark" : "light"
   const workspaceId = useWorkspaceId()
-  const { workflow } = useWorkflow()
+  const workflowContext = useOptionalWorkflow()
   const methods = useFormContext()
-  const actions = workflow?.actions || ({} as Record<string, ActionRead>)
+  const effectiveCompletionScope =
+    completionScope ?? (workflowContext ? "workflow" : "workspace")
+  const includeWorkflowCompletions = effectiveCompletionScope === "workflow"
+  const actions =
+    includeWorkflowCompletions && workflowContext?.workflow?.actions
+      ? workflowContext.workflow.actions
+      : EMPTY_ACTIONS
   const forEach = useMemo(() => methods.watch("for_each"), [methods])
 
   // Safe value conversion with error handling
@@ -252,7 +262,12 @@ function ExpressionInputCore({
       linter(expressionLinter),
       bracketMatching(),
       closeBrackets(),
-      createAutocomplete({ workspaceId, actions, forEach }),
+      createAutocomplete({
+        workspaceId,
+        actions,
+        forEach: includeWorkflowCompletions ? forEach : null,
+        includeWorkflowCompletions,
+      }),
       placeholder(placeholderText),
       templatePlugin,
       templatePillTheme,
@@ -260,7 +275,14 @@ function ExpressionInputCore({
     ]
 
     return baseExtensions.concat([createCoreKeymap()])
-  }, [workspaceId, actions, placeholderText, forEach, defaultHeight])
+  }, [
+    workspaceId,
+    actions,
+    placeholderText,
+    forEach,
+    defaultHeight,
+    includeWorkflowCompletions,
+  ])
 
   const handleChange = useCallback(
     (val: string) => {

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -31,18 +31,25 @@ import type {
 } from "@/client/types.gen"
 import { useScopeCheck } from "@/components/auth/scope-guard"
 import { CodeEditor } from "@/components/editor/codemirror/code-editor"
+import { ExpressionInput } from "@/components/editor/expression-input"
 import { getMcpProviderIconId, ProviderIcon } from "@/components/icons"
 import {
   ALLOWED_COMMANDS,
   AUTH_TYPES,
   buildMcpIntegrationFormSchema,
+  buildStdioArgsLine,
   catalogEntryToFormValues,
   isAllowedCommand,
   MCP_INTEGRATION_FORM_DEFAULTS,
   type MCPIntegrationFormValues,
   missingRequiredOAuthClientCredentials,
   normalizeOAuthClientKey,
+  parseStdioArgsLine,
   SERVER_TYPES,
+  shouldSendStdioFields,
+  stdioEnvReadToRows,
+  stdioEnvRowsToPreserveKeys,
+  stdioEnvRowsToRecord,
   urlTypedStdioEnvKeys,
 } from "@/components/integrations/mcp-integration-schema"
 import {
@@ -409,6 +416,11 @@ export function MCPIntegrationDialog({
   const canUpdate = useScopeCheck("integration:update") === true
   const [internalOpen, setInternalOpen] = useState(false)
   const [isEditHydrated, setIsEditHydrated] = useState(false)
+  // Set when a catalog connection option's template is applied in edit mode.
+  // Switching options calls form.reset(nextValues), which clears dirtyFields,
+  // so the freshly-applied option's stdio env and args would otherwise be
+  // gated out of the update. Cleared on close and on edit-mode rehydration.
+  const [stdioTemplateApplied, setStdioTemplateApplied] = useState(false)
   const [catalogOAuthClientIsPending, setCatalogOAuthClientIsPending] =
     useState(false)
   const open = controlledOpen ?? internalOpen
@@ -436,13 +448,13 @@ export function MCPIntegrationDialog({
     defaultValues: MCP_INTEGRATION_FORM_DEFAULTS,
   })
   const {
-    fields: stdioArgFields,
-    append: appendStdioArg,
-    remove: removeStdioArg,
-    replace: replaceStdioArgs,
+    fields: stdioEnvFields,
+    append: appendStdioEnv,
+    remove: removeStdioEnv,
+    replace: replaceStdioEnv,
   } = useFieldArray({
     control: form.control,
-    name: "stdio_args",
+    name: "stdio_env",
   })
 
   const serverType = form.watch("server_type")
@@ -568,8 +580,10 @@ export function MCPIntegrationDialog({
       if (mcpIntegration.id !== mcpIntegrationId) {
         return
       }
-      const hydratedStdioArgs =
-        mcpIntegration.stdio_args?.map((arg) => ({ value: arg })) || []
+      const hydratedStdioEnv = stdioEnvReadToRows(
+        mcpIntegration.stdio_env,
+        mcpIntegration.stdio_env_keys
+      )
       form.reset({
         name: mcpIntegration.name,
         description: mcpIntegration.description || "",
@@ -583,8 +597,8 @@ export function MCPIntegrationDialog({
         oauth_client_credentials: "",
         custom_credentials: "", // Don't populate for security
         stdio_command: mcpIntegration.stdio_command || "",
-        stdio_args: hydratedStdioArgs,
-        stdio_env: "", // Env vars are not returned from API for security
+        stdio_args_line: buildStdioArgsLine(mcpIntegration.stdio_args),
+        stdio_env: hydratedStdioEnv,
         timeout: mcpIntegration.timeout || 30,
         catalog_slug: catalogEntry?.slug || "",
         connection_option_id: catalogOptionIdForIntegration(
@@ -593,7 +607,8 @@ export function MCPIntegrationDialog({
         ),
       })
       // Explicitly sync field-array state; reset() can lag on first mount.
-      replaceStdioArgs(hydratedStdioArgs)
+      replaceStdioEnv(hydratedStdioEnv)
+      setStdioTemplateApplied(false)
       setIsEditHydrated(true)
     }
   }, [
@@ -603,7 +618,7 @@ export function MCPIntegrationDialog({
     mcpIntegrationId,
     catalogEntry,
     form,
-    replaceStdioArgs,
+    replaceStdioEnv,
   ])
 
   // Prefill from a catalog entry when opening in create mode. Keyed on the
@@ -615,7 +630,7 @@ export function MCPIntegrationDialog({
     const defaultOptionId = catalogEntry.connection_options?.[0]?.id
     const values = catalogEntryToFormValues(catalogEntry, defaultOptionId)
     form.reset(values)
-    replaceStdioArgs(values.stdio_args)
+    replaceStdioEnv(values.stdio_env)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEditMode, open, catalogEntry?.slug])
 
@@ -625,8 +640,10 @@ export function MCPIntegrationDialog({
       mcpIntegration &&
       mcpIntegration.id === mcpIntegrationId
     ) {
-      const hydratedStdioArgs =
-        mcpIntegration.stdio_args?.map((arg) => ({ value: arg })) || []
+      const hydratedStdioEnv = stdioEnvReadToRows(
+        mcpIntegration.stdio_env,
+        mcpIntegration.stdio_env_keys
+      )
       form.reset({
         name: mcpIntegration.name,
         description: mcpIntegration.description || "",
@@ -640,8 +657,8 @@ export function MCPIntegrationDialog({
         oauth_client_credentials: "",
         custom_credentials: "",
         stdio_command: mcpIntegration.stdio_command || "",
-        stdio_args: hydratedStdioArgs,
-        stdio_env: "", // Env vars are not returned from API for security
+        stdio_args_line: buildStdioArgsLine(mcpIntegration.stdio_args),
+        stdio_env: hydratedStdioEnv,
         timeout: mcpIntegration.timeout || 30,
         catalog_slug: catalogEntry?.slug || "",
         connection_option_id: catalogOptionIdForIntegration(
@@ -649,11 +666,13 @@ export function MCPIntegrationDialog({
           mcpIntegration
         ),
       })
-      replaceStdioArgs(hydratedStdioArgs)
+      replaceStdioEnv(hydratedStdioEnv)
+      setStdioTemplateApplied(false)
       setIsEditHydrated(true)
     } else {
       form.reset(MCP_INTEGRATION_FORM_DEFAULTS)
-      replaceStdioArgs([])
+      replaceStdioEnv([])
+      setStdioTemplateApplied(false)
       setIsEditHydrated(false)
     }
   }
@@ -672,16 +691,22 @@ export function MCPIntegrationDialog({
   const onSubmit = async (values: MCPIntegrationFormValues) => {
     let hookHandledError = false
     try {
-      // Parse stdio_args list to string array
-      const stdioArgs = values.stdio_args
-        .map((arg) => arg.value.trim())
-        .filter(Boolean)
-
-      // Parse stdio_env from JSON string to object (only for stdio-type servers)
+      const stdioCommand = values.stdio_command?.trim() ?? ""
+      const stdioArgs = parseStdioArgsLine(values.stdio_args_line)
       const stdioEnv =
-        values.server_type === "stdio" && values.stdio_env?.trim()
-          ? (JSON.parse(values.stdio_env) as Record<string, string>)
+        values.server_type === "stdio"
+          ? stdioEnvRowsToRecord(values.stdio_env)
           : undefined
+      const stdioEnvPreserveKeys =
+        values.server_type === "stdio"
+          ? stdioEnvRowsToPreserveKeys(values.stdio_env)
+          : []
+      const { sendEnv: stdioEnvWasEdited, sendArgs: stdioArgsWasEdited } =
+        shouldSendStdioFields({
+          envDirty: Boolean(form.formState.dirtyFields.stdio_env),
+          argsDirty: Boolean(form.formState.dirtyFields.stdio_args_line),
+          templateApplied: stdioTemplateApplied,
+        })
 
       const baseParams = {
         name: values.name.trim(),
@@ -718,9 +743,18 @@ export function MCPIntegrationDialog({
             ? {
                 ...baseParams,
                 server_type: "stdio",
-                stdio_command: values.stdio_command?.trim() ?? "",
-                stdio_args: stdioArgs,
-                stdio_env: stdioEnv,
+                stdio_command: stdioCommand,
+                // Re-serializing the args line is lossy (embedded whitespace,
+                // no quoting), so only send args when the line was edited or a
+                // new option template was applied. Omitting stdio_args tells the
+                // backend to preserve the stored value verbatim.
+                ...(stdioArgsWasEdited ? { stdio_args: stdioArgs } : {}),
+                ...(stdioEnvWasEdited
+                  ? {
+                      stdio_env: stdioEnv ?? {},
+                      stdio_env_preserve_keys: stdioEnvPreserveKeys,
+                    }
+                  : {}),
               }
             : {
                 ...baseParams,
@@ -746,7 +780,7 @@ export function MCPIntegrationDialog({
           const params: MCPStdioIntegrationCreate = {
             ...createBaseParams,
             server_type: "stdio",
-            stdio_command: values.stdio_command?.trim() ?? "",
+            stdio_command: stdioCommand,
             stdio_args: stdioArgs.length > 0 ? stdioArgs : undefined,
             stdio_env: stdioEnv,
           }
@@ -1072,10 +1106,15 @@ export function MCPIntegrationDialog({
                                             values.catalog_slug,
                                         }
                                         form.reset(nextValues)
-                                        replaceStdioArgs(nextValues.stdio_args)
+                                        replaceStdioEnv(nextValues.stdio_env)
+                                        // reset() clears dirtyFields, so flag
+                                        // the applied template to force the new
+                                        // option's stdio env and args into the
+                                        // update payload.
+                                        setStdioTemplateApplied(true)
                                       } else {
                                         form.reset(values)
-                                        replaceStdioArgs(values.stdio_args)
+                                        replaceStdioEnv(values.stdio_env)
                                       }
                                     }}
                                   >
@@ -1289,7 +1328,7 @@ export function MCPIntegrationDialog({
                         name="stdio_command"
                         render={({ field }) => (
                           <FormItem>
-                            <FormLabel>Stdio command</FormLabel>
+                            <FormLabel>Command</FormLabel>
                             <FormControl>
                               {(() => {
                                 const currentCommand = (
@@ -1313,7 +1352,7 @@ export function MCPIntegrationDialog({
                                     }
                                   >
                                     <SelectTrigger>
-                                      <SelectValue placeholder="Select stdio command">
+                                      <SelectValue placeholder="Select command">
                                         {hasLegacyValue
                                           ? `Legacy (${currentCommand})`
                                           : currentCommand || null}
@@ -1336,7 +1375,7 @@ export function MCPIntegrationDialog({
                               })()}
                             </FormControl>
                             <FormDescription className="text-xs">
-                              Stdio command to run the MCP server. Only{" "}
+                              Command to run the MCP server. Only{" "}
                               {ALLOWED_COMMANDS.join(", ")} are allowed.
                             </FormDescription>
                             <FormMessage />
@@ -1345,35 +1384,118 @@ export function MCPIntegrationDialog({
                       />
                       <FormField
                         control={form.control}
-                        name="stdio_args"
+                        name="stdio_args_line"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Arguments</FormLabel>
+                            <FormControl>
+                              <Input
+                                {...field}
+                                placeholder="@modelcontextprotocol/server-github"
+                                className="font-mono text-xs"
+                              />
+                            </FormControl>
+                            <FormDescription className="text-xs">
+                              Space-separated arguments. Quoting is not
+                              supported; each token is passed as a separate
+                              argument.
+                            </FormDescription>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="stdio_env"
                         render={() => (
                           <FormItem>
-                            <FormLabel>Stdio arguments</FormLabel>
+                            <FormLabel>Environment variables</FormLabel>
                             <div className="space-y-2">
-                              {stdioArgFields.length === 0 && (
+                              {stdioEnvFields.length === 0 ? (
                                 <p className="text-xs text-muted-foreground">
-                                  No arguments configured.
+                                  {isEditMode && mcpIntegration?.has_stdio_env
+                                    ? "Stored variables include raw values and are hidden."
+                                    : "No environment variables configured."}
                                 </p>
-                              )}
-                              {stdioArgFields.map((argField, index) => (
+                              ) : null}
+                              {stdioEnvFields.map((envField, index) => (
                                 <div
-                                  key={argField.id}
-                                  className="grid grid-cols-[1fr_auto] gap-2"
+                                  key={envField.id}
+                                  className="grid gap-2 sm:grid-cols-[minmax(140px,200px)_minmax(0,1fr)_auto]"
                                 >
                                   <FormField
                                     control={form.control}
-                                    name={`stdio_args.${index}.value`}
+                                    name={`stdio_env.${index}.key`}
                                     render={({ field }) => (
                                       <FormItem>
                                         <FormControl>
                                           <Input
                                             {...field}
-                                            placeholder={
-                                              index === 0
-                                                ? "@modelcontextprotocol/server-github"
-                                                : "Additional argument"
-                                            }
+                                            onChange={(event) => {
+                                              field.onChange(event)
+                                              // Renaming a hidden row breaks the
+                                              // link to the stored value (kept
+                                              // server-side under original_key),
+                                              // so it can no longer be preserved.
+                                              // Reveal it as a normal row so the
+                                              // user must enter a replacement.
+                                              const originalKey =
+                                                form.getValues(
+                                                  `stdio_env.${index}.original_key`
+                                                )
+                                              if (
+                                                form.getValues(
+                                                  `stdio_env.${index}.value_hidden`
+                                                ) === true &&
+                                                event.target.value.trim() !==
+                                                  originalKey
+                                              ) {
+                                                form.setValue(
+                                                  `stdio_env.${index}.value_hidden`,
+                                                  false,
+                                                  { shouldDirty: true }
+                                                )
+                                              }
+                                            }}
+                                            placeholder="GITHUB_TOKEN"
                                             className="font-mono text-xs"
+                                          />
+                                        </FormControl>
+                                        <FormMessage />
+                                      </FormItem>
+                                    )}
+                                  />
+                                  <FormField
+                                    control={form.control}
+                                    name={`stdio_env.${index}.value`}
+                                    render={({ field }) => (
+                                      <FormItem>
+                                        <FormControl>
+                                          <ExpressionInput
+                                            value={field.value}
+                                            onChange={(value) => {
+                                              field.onChange(value)
+                                              if (
+                                                form.getValues(
+                                                  `stdio_env.${index}.value_hidden`
+                                                ) === true
+                                              ) {
+                                                form.setValue(
+                                                  `stdio_env.${index}.value_hidden`,
+                                                  false,
+                                                  { shouldDirty: true }
+                                                )
+                                              }
+                                            }}
+                                            placeholder={
+                                              form.getValues(
+                                                `stdio_env.${index}.value_hidden`
+                                              ) === true
+                                                ? "Stored value hidden - enter replacement"
+                                                : "Type @ to begin an expression..."
+                                            }
+                                            completionScope="workspace"
+                                            className="min-w-0"
                                           />
                                         </FormControl>
                                         <FormMessage />
@@ -1384,11 +1506,11 @@ export function MCPIntegrationDialog({
                                     type="button"
                                     variant="ghost"
                                     size="icon"
-                                    onClick={() => removeStdioArg(index)}
+                                    onClick={() => removeStdioEnv(index)}
                                   >
                                     <Trash2 className="size-4" />
                                     <span className="sr-only">
-                                      Remove argument
+                                      Remove variable
                                     </span>
                                   </Button>
                                 </div>
@@ -1397,44 +1519,16 @@ export function MCPIntegrationDialog({
                                 type="button"
                                 variant="outline"
                                 size="sm"
-                                onClick={() => appendStdioArg({ value: "" })}
+                                onClick={() =>
+                                  appendStdioEnv({ key: "", value: "" })
+                                }
                               >
                                 <Plus className="mr-2 size-4" />
-                                Add argument
+                                Add variable
                               </Button>
                             </div>
                             <FormDescription className="text-xs">
-                              Add each command argument as a separate list item,
-                              in order.
-                            </FormDescription>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FormField
-                        control={form.control}
-                        name="stdio_env"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Stdio environment variables</FormLabel>
-                            <FormControl>
-                              <CodeEditor
-                                value={field.value || ""}
-                                onChange={field.onChange}
-                                language="json"
-                                className="font-mono text-xs [&_.cm-content]:text-xs [&_.cm-editor]:min-h-[80px]"
-                              />
-                            </FormControl>
-                            <FormDescription className="text-xs">
-                              JSON object with environment variables for the
-                              stdio command. Template expressions are supported,
-                              for example{" "}
-                              <code>
-                                {
-                                  '{"GITHUB_TOKEN": "${{ SECRETS.github.TOKEN }}"}'
-                                }
-                              </code>
-                              .
+                              Use template expressions for secret-backed values.
                             </FormDescription>
                             <FormMessage />
                           </FormItem>

--- a/frontend/src/components/integrations/mcp-integration-schema.ts
+++ b/frontend/src/components/integrations/mcp-integration-schema.ts
@@ -135,28 +135,19 @@ export function urlTypedStdioEnvKeys(
  * parse — shape errors are reported by {@link isValidStringMap} instead.
  */
 export function invalidUrlEnvKeys(
-  value: string,
+  rows: MCPStdioEnvRow[],
   urlKeys: Set<string>
 ): string[] {
   if (urlKeys.size === 0) {
     return []
   }
-  let parsed: Record<string, unknown>
-  try {
-    parsed = JSON.parse(value) as Record<string, unknown>
-  } catch {
-    return []
-  }
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    return []
-  }
   const invalid: string[] = []
   for (const key of urlKeys) {
-    const entryValue = parsed[key]
-    if (typeof entryValue !== "string") {
+    const row = rows.find((candidate) => candidate.key.trim() === key)
+    if (!row || (row.value_hidden && row.value.trim() === "")) {
       continue
     }
-    const trimmed = entryValue.trim()
+    const trimmed = row.value.trim()
     if (trimmed === "" || isExpression(trimmed)) {
       continue
     }
@@ -165,6 +156,156 @@ export function invalidUrlEnvKeys(
     }
   }
   return invalid
+}
+
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+export type MCPStdioEnvRow = {
+  key: string
+  value: string
+  value_hidden?: boolean
+  /**
+   * The key this row was seeded with from the server, tracked so a hidden row
+   * whose key is later renamed can be detected. A hidden row is only preserved
+   * server-side under its `original_key`; renaming it (without entering a
+   * replacement value) would otherwise send a preserve key the backend cannot
+   * resolve, silently dropping the stored secret.
+   */
+  original_key?: string
+}
+
+/**
+ * Whether a hidden row still points at the server key it was seeded with. Only
+ * such rows can be safely preserved (their value lives in the stored env under
+ * `original_key`). A renamed hidden row must be treated like a new entry.
+ */
+function isPreservableHiddenRow(row: MCPStdioEnvRow): boolean {
+  return (
+    row.value_hidden === true &&
+    row.value.trim() === "" &&
+    row.original_key !== undefined &&
+    row.key.trim() === row.original_key
+  )
+}
+
+/**
+ * Join stored args into the single editable arguments line. The command is
+ * selected separately from {@link ALLOWED_COMMANDS}, so it is not included.
+ */
+export function buildStdioArgsLine(args: string[] | null | undefined): string {
+  return (args ?? [])
+    .map((arg) => arg.trim())
+    .filter(Boolean)
+    .join(" ")
+}
+
+/**
+ * Split the editable arguments line into individual args on whitespace. Shell
+ * quoting is not honored; the command itself is gated via a separate Select.
+ */
+export function parseStdioArgsLine(value: string | null | undefined): string[] {
+  return (value ?? "").trim().split(/\s+/).filter(Boolean)
+}
+
+/**
+ * Decide which stdio fields an edit-mode update should include.
+ *
+ * `stdio_env` and `stdio_args` round-trip lossily through the form:
+ * - hidden env values are not re-sent unless the user edits them, and
+ * - args are re-serialized by {@link buildStdioArgsLine}/{@link parseStdioArgsLine},
+ *   which lose embedded whitespace and shell quoting.
+ *
+ * So both must only be sent when the value was actually edited. A plain
+ * react-hook-form `reset(nextValues)` (used when switching catalog connection
+ * options in edit mode) clears `dirtyFields`, so `templateApplied` is ORed in
+ * to force the freshly-applied option's env and args to be sent. The backend
+ * preserves omitted (`None`) stdio fields, so leaving them out is a no-op.
+ */
+export function shouldSendStdioFields({
+  envDirty,
+  argsDirty,
+  templateApplied,
+}: {
+  envDirty: boolean
+  argsDirty: boolean
+  templateApplied: boolean
+}): { sendEnv: boolean; sendArgs: boolean } {
+  return {
+    sendEnv: envDirty || templateApplied,
+    sendArgs: argsDirty || templateApplied,
+  }
+}
+
+export function stdioEnvRowsToRecord(
+  rows: MCPStdioEnvRow[]
+): Record<string, string> | undefined {
+  const entries = rows
+    .filter((row) => {
+      // Preservable hidden rows carry no value to send; every other row
+      // (including a renamed hidden row, which is no longer preservable) is
+      // serialized so its value is written and validation can catch an
+      // empty one.
+      if (isPreservableHiddenRow(row)) {
+        return false
+      }
+      return row.key.trim() !== "" || row.value.trim() !== ""
+    })
+    .map((row) => [row.key.trim(), row.value] as const)
+  if (entries.length === 0) {
+    return undefined
+  }
+  return Object.fromEntries(entries)
+}
+
+export function stdioEnvRowsToPreserveKeys(rows: MCPStdioEnvRow[]): string[] {
+  return rows
+    .filter(isPreservableHiddenRow)
+    .map((row) => row.key.trim())
+    .filter(Boolean)
+}
+
+export function stdioEnvReadToRows(
+  env: Record<string, string> | null | undefined,
+  keys: string[] | null | undefined = null
+): MCPStdioEnvRow[] {
+  const rowsByKey = new Map<string, MCPStdioEnvRow>()
+  for (const key of keys ?? []) {
+    rowsByKey.set(key, {
+      key,
+      value: "",
+      value_hidden: true,
+      original_key: key,
+    })
+  }
+  for (const [key, value] of Object.entries(env ?? {})) {
+    rowsByKey.set(key, { key, value })
+  }
+  return Array.from(rowsByKey.values())
+}
+
+function stdioEnvRowsAreValid(rows: MCPStdioEnvRow[]): boolean {
+  const keys = new Set<string>()
+  for (const row of rows) {
+    const key = row.key.trim()
+    const value = row.value.trim()
+    if (key === "" && value === "") {
+      continue
+    }
+    if (key === "") {
+      return false
+    }
+    // An empty value is only acceptable when the stored value is being
+    // preserved verbatim (a hidden row still pointing at its server key). A
+    // visible row, or a hidden row that was renamed, must carry a value.
+    if (value === "" && !isPreservableHiddenRow(row)) {
+      return false
+    }
+    if (!ENV_KEY_PATTERN.test(key) || keys.has(key)) {
+      return false
+    }
+    keys.add(key)
+  }
+  return true
 }
 
 /**
@@ -239,12 +380,15 @@ const mcpIntegrationFormObjectSchema = z.object({
   custom_credentials: z.string().trim().optional().or(z.literal("")),
   // Stdio-type fields
   stdio_command: z.string().trim().optional().or(z.literal("")),
-  stdio_args: z.array(
+  stdio_args_line: z.string().trim().optional().or(z.literal("")),
+  stdio_env: z.array(
     z.object({
+      key: z.string(),
       value: z.string(),
+      value_hidden: z.boolean().optional(),
+      original_key: z.string().optional(),
     })
   ),
-  stdio_env: z.string().trim().optional().or(z.literal("")),
   // General fields
   timeout: z.coerce.number().int().min(1).max(300).optional(),
   catalog_slug: z.string().optional().or(z.literal("")),
@@ -367,10 +511,11 @@ export function buildMcpIntegrationFormSchema(
       .refine(
         (data) => {
           if (data.server_type === "stdio") {
-            if (!data.stdio_command || data.stdio_command.trim() === "") {
+            const command = data.stdio_command?.trim() ?? ""
+            if (!command) {
               return false
             }
-            return isAllowedCommand(data.stdio_command.trim())
+            return isAllowedCommand(command)
           }
           return true
         },
@@ -381,18 +526,14 @@ export function buildMcpIntegrationFormSchema(
       )
       .refine(
         (data) => {
-          if (
-            data.server_type === "stdio" &&
-            data.stdio_env &&
-            data.stdio_env.trim() !== ""
-          ) {
-            return isValidStringMap(data.stdio_env)
+          if (data.server_type === "stdio") {
+            return stdioEnvRowsAreValid(data.stdio_env)
           }
           return true
         },
         {
           message:
-            "Environment variables must be a valid JSON object with string values",
+            "Environment variables need unique names and non-empty values",
           path: ["stdio_env"],
         }
       )
@@ -401,11 +542,10 @@ export function buildMcpIntegrationFormSchema(
       .refine(
         (data) =>
           data.server_type !== "stdio" ||
-          !data.stdio_env ||
           invalidUrlEnvKeys(data.stdio_env, urlEnvKeys).length === 0,
         (data) => ({
           message: `Must start with http:// or https://: ${invalidUrlEnvKeys(
-            data.stdio_env ?? "",
+            data.stdio_env,
             urlEnvKeys
           ).join(", ")}`,
           path: ["stdio_env"],
@@ -429,8 +569,8 @@ export const MCP_INTEGRATION_FORM_DEFAULTS: MCPIntegrationFormValues = {
   oauth_client_credentials: "",
   custom_credentials: "",
   stdio_command: "",
-  stdio_args: [],
-  stdio_env: "",
+  stdio_args_line: "",
+  stdio_env: [],
   timeout: 30,
   catalog_slug: "",
   connection_option_id: "",
@@ -470,7 +610,9 @@ function hasConfigTarget(
   )
 }
 
-function stdioEnvTemplate(spec: MCPConnectionSpec | null | undefined): string {
+function stdioEnvTemplate(
+  spec: MCPConnectionSpec | null | undefined
+): MCPStdioEnvRow[] {
   const obj: Record<string, string> = {}
   for (const cred of spec?.credentials ?? []) {
     if (cred.target === "stdio_env" && cred.required) {
@@ -487,7 +629,7 @@ function stdioEnvTemplate(spec: MCPConnectionSpec | null | undefined): string {
       obj[key] ??= ""
     }
   }
-  return Object.keys(obj).length > 0 ? JSON.stringify(obj, null, 2) : ""
+  return stdioEnvReadToRows(obj)
 }
 
 /**
@@ -546,7 +688,7 @@ export function catalogEntryToFormValues(
   const oauthClientCredentialsJson = credentialsTemplate(spec, ["oauth_client"])
   const requiresExistingOAuth =
     authType === "OAUTH2" && hasConfigTarget(spec, "oauth_client")
-  const stdioEnvJson = stdioEnvTemplate(spec)
+  const stdioEnvRows = stdioEnvTemplate(spec)
   const stdio = serverType === "stdio" ? pickStdioCommand(spec) : null
   const serverUri =
     spec?.server_type === "http" && "server_uri" in spec ? spec.server_uri : ""
@@ -564,8 +706,8 @@ export function catalogEntryToFormValues(
     // HTTP CUSTOM/OAUTH2 headers OR stdio env get the credential-key template.
     custom_credentials: serverType === "http" ? httpCredentialsJson : "",
     stdio_command: stdio?.command ?? "",
-    stdio_args: (stdio?.args ?? []).map((value) => ({ value })),
-    stdio_env: serverType === "stdio" ? stdioEnvJson : "",
+    stdio_args_line: buildStdioArgsLine(stdio?.args ?? []),
+    stdio_env: serverType === "stdio" ? stdioEnvRows : [],
     catalog_slug: entry.slug,
     connection_option_id: option?.id ?? "",
   }

--- a/frontend/src/providers/workflow.tsx
+++ b/frontend/src/providers/workflow.tsx
@@ -282,8 +282,10 @@ export function WorkflowProvider({
   )
 }
 
+export const useOptionalWorkflow = () => useContext(WorkflowContext)
+
 export const useWorkflow = () => {
-  const context = useContext(WorkflowContext)
+  const context = useOptionalWorkflow()
   if (context === undefined) {
     throw new Error("useWorkflow must be used within a WorkflowProvider")
   }

--- a/frontend/tests/mcp-integration-schema.test.ts
+++ b/frontend/tests/mcp-integration-schema.test.ts
@@ -1,10 +1,17 @@
 import type { MCPConnectionSpec } from "@/client"
+import type { MCPStdioEnvRow } from "@/components/integrations/mcp-integration-schema"
 import {
   buildMcpIntegrationFormSchema,
+  buildStdioArgsLine,
   catalogEntryToFormValues,
   invalidUrlEnvKeys,
   MCP_INTEGRATION_FORM_DEFAULTS,
   missingRequiredOAuthClientCredentials,
+  parseStdioArgsLine,
+  shouldSendStdioFields,
+  stdioEnvReadToRows,
+  stdioEnvRowsToPreserveKeys,
+  stdioEnvRowsToRecord,
   urlTypedStdioEnvKeys,
 } from "@/components/integrations/mcp-integration-schema"
 
@@ -167,37 +174,276 @@ describe("invalidUrlEnvKeys", () => {
   const urlKeys = new Set(["VAULT_ADDR"])
 
   it("flags a scheme-less value", () => {
-    const value = JSON.stringify({ VAULT_ADDR: "acme.example.net" })
+    const value = [{ key: "VAULT_ADDR", value: "acme.example.net" }]
     expect(invalidUrlEnvKeys(value, urlKeys)).toEqual(["VAULT_ADDR"])
   })
 
   it("accepts an http(s):// value", () => {
-    const value = JSON.stringify({ VAULT_ADDR: "https://vault.example.net" })
+    const value = [{ key: "VAULT_ADDR", value: "https://vault.example.net" }]
     expect(invalidUrlEnvKeys(value, urlKeys)).toEqual([])
   })
 
   it("skips empty and templated values", () => {
     expect(
-      invalidUrlEnvKeys(JSON.stringify({ VAULT_ADDR: "" }), urlKeys)
+      invalidUrlEnvKeys([{ key: "VAULT_ADDR", value: "" }], urlKeys)
     ).toEqual([])
     expect(
       invalidUrlEnvKeys(
-        JSON.stringify({ VAULT_ADDR: "${{ SECRETS.vault.ADDR }}" }),
+        [{ key: "VAULT_ADDR", value: "${{ SECRETS.vault.ADDR }}" }],
+        urlKeys
+      )
+    ).toEqual([])
+  })
+
+  it("skips hidden values", () => {
+    expect(
+      invalidUrlEnvKeys(
+        [{ key: "VAULT_ADDR", value: "", value_hidden: true }],
         urlKeys
       )
     ).toEqual([])
   })
 
   it("ignores keys outside urlKeys", () => {
-    const value = JSON.stringify({ VAULT_TOKEN: "not-a-url" })
+    const value = [{ key: "VAULT_TOKEN", value: "not-a-url" }]
     expect(invalidUrlEnvKeys(value, urlKeys)).toEqual([])
   })
 
-  it("returns [] when there are no url keys or the JSON is unparseable", () => {
-    expect(invalidUrlEnvKeys("not json", urlKeys)).toEqual([])
+  it("returns [] when there are no url keys", () => {
     expect(
-      invalidUrlEnvKeys(JSON.stringify({ VAULT_ADDR: "x" }), new Set())
+      invalidUrlEnvKeys([{ key: "VAULT_ADDR", value: "x" }], new Set())
     ).toEqual([])
+  })
+})
+
+describe("stdio args line helpers", () => {
+  it("joins args into the editable line", () => {
+    expect(buildStdioArgsLine(["--yes", "@example/server"])).toBe(
+      "--yes @example/server"
+    )
+  })
+
+  it("splits args on simple whitespace without shell quoting", () => {
+    expect(parseStdioArgsLine('-m "quoted server"')).toEqual([
+      "-m",
+      '"quoted',
+      'server"',
+    ])
+  })
+
+  it("round-trips args without embedded whitespace losslessly", () => {
+    const args = ["--yes", "@example/server", "--port=8080"]
+    expect(parseStdioArgsLine(buildStdioArgsLine(args))).toEqual(args)
+  })
+
+  it("documents that args with embedded whitespace round-trip lossily", () => {
+    // An arg created via the API can hold embedded whitespace, e.g. a header
+    // value. Joining on spaces then re-splitting on whitespace shreds it into
+    // multiple tokens — the reason edit mode must not re-send unedited args.
+    const args = ["--header=Authorization: Bearer x"]
+    const line = buildStdioArgsLine(args)
+    expect(line).toBe("--header=Authorization: Bearer x")
+    expect(parseStdioArgsLine(line)).toEqual([
+      "--header=Authorization:",
+      "Bearer",
+      "x",
+    ])
+  })
+})
+
+describe("shouldSendStdioFields", () => {
+  it("sends neither field when nothing changed", () => {
+    expect(
+      shouldSendStdioFields({
+        envDirty: false,
+        argsDirty: false,
+        templateApplied: false,
+      })
+    ).toEqual({ sendEnv: false, sendArgs: false })
+  })
+
+  it("sends only the edited field", () => {
+    expect(
+      shouldSendStdioFields({
+        envDirty: true,
+        argsDirty: false,
+        templateApplied: false,
+      })
+    ).toEqual({ sendEnv: true, sendArgs: false })
+    expect(
+      shouldSendStdioFields({
+        envDirty: false,
+        argsDirty: true,
+        templateApplied: false,
+      })
+    ).toEqual({ sendEnv: false, sendArgs: true })
+  })
+
+  it("forces both fields when a connection option template was applied", () => {
+    // Switching options in edit mode resets the form and clears dirtyFields,
+    // so the applied-template flag must send the new option's env and args.
+    expect(
+      shouldSendStdioFields({
+        envDirty: false,
+        argsDirty: false,
+        templateApplied: true,
+      })
+    ).toEqual({ sendEnv: true, sendArgs: true })
+  })
+})
+
+describe("stdio env row helpers", () => {
+  it("shows keys for hidden values and safe template values", () => {
+    expect(
+      stdioEnvReadToRows({ API_TOKEN: "${{ SECRETS.api.TOKEN }}" }, [
+        "API_TOKEN",
+        "RAW_TOKEN",
+      ])
+    ).toEqual([
+      { key: "API_TOKEN", value: "${{ SECRETS.api.TOKEN }}" },
+      {
+        key: "RAW_TOKEN",
+        value: "",
+        value_hidden: true,
+        original_key: "RAW_TOKEN",
+      },
+    ])
+  })
+
+  it("preserves hidden values without serializing them as updates", () => {
+    const rows = [
+      { key: "API_TOKEN", value: "${{ SECRETS.api.TOKEN }}" },
+      {
+        key: "RAW_TOKEN",
+        value: "",
+        value_hidden: true,
+        original_key: "RAW_TOKEN",
+      },
+    ]
+    expect(stdioEnvRowsToRecord(rows)).toEqual({
+      API_TOKEN: "${{ SECRETS.api.TOKEN }}",
+    })
+    expect(stdioEnvRowsToPreserveKeys(rows)).toEqual(["RAW_TOKEN"])
+  })
+
+  it("seeds hidden rows from server keys with an original_key", () => {
+    expect(stdioEnvReadToRows(null, ["RAW_TOKEN"])).toEqual([
+      {
+        key: "RAW_TOKEN",
+        value: "",
+        value_hidden: true,
+        original_key: "RAW_TOKEN",
+      },
+    ])
+  })
+
+  it("still preserves an unchanged hidden row", () => {
+    const rows = stdioEnvReadToRows(null, ["API_TOKEN"])
+    expect(stdioEnvRowsToPreserveKeys(rows)).toEqual(["API_TOKEN"])
+    expect(stdioEnvRowsToRecord(rows)).toBeUndefined()
+  })
+
+  it("does not preserve a renamed hidden row under its new key", () => {
+    // The row was seeded from server key API_TOKEN then renamed to NEW_TOKEN
+    // without entering a value. It must not emit NEW_TOKEN as a preserve key
+    // (the backend cannot resolve it, silently dropping the secret).
+    const rows: MCPStdioEnvRow[] = [
+      {
+        key: "NEW_TOKEN",
+        value: "",
+        value_hidden: true,
+        original_key: "API_TOKEN",
+      },
+    ]
+    expect(stdioEnvRowsToPreserveKeys(rows)).toEqual([])
+  })
+
+  it("does not preserve a hidden row renamed to another stored hidden key", () => {
+    // Renaming API_TOKEN -> RAW_TOKEN must not preserve the wrong value under
+    // RAW_TOKEN. Only the genuinely-unchanged RAW_TOKEN row is preserved.
+    const rows: MCPStdioEnvRow[] = [
+      {
+        key: "RAW_TOKEN",
+        value: "",
+        value_hidden: true,
+        original_key: "API_TOKEN",
+      },
+      {
+        key: "RAW_TOKEN",
+        value: "",
+        value_hidden: true,
+        original_key: "RAW_TOKEN",
+      },
+    ]
+    expect(stdioEnvRowsToPreserveKeys(rows)).toEqual(["RAW_TOKEN"])
+  })
+})
+
+describe("stdioEnvRowsAreValid via schema", () => {
+  const baseStdio = {
+    ...MCP_INTEGRATION_FORM_DEFAULTS,
+    name: "Vault",
+    server_type: "stdio" as const,
+    stdio_command: "npx",
+    stdio_args_line: "mcp-vault",
+  }
+
+  it("accepts an unchanged hidden row with an empty value", () => {
+    const result = buildMcpIntegrationFormSchema().safeParse({
+      ...baseStdio,
+      stdio_env: [
+        {
+          key: "API_TOKEN",
+          value: "",
+          value_hidden: true,
+          original_key: "API_TOKEN",
+        },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a renamed hidden row left without a replacement value", () => {
+    const result = buildMcpIntegrationFormSchema().safeParse({
+      ...baseStdio,
+      stdio_env: [
+        {
+          key: "NEW_TOKEN",
+          value: "",
+          value_hidden: true,
+          original_key: "API_TOKEN",
+        },
+      ],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === "stdio_env")
+      expect(issue).toBeDefined()
+    }
+  })
+
+  it("accepts a renamed hidden row once a replacement value is entered", () => {
+    // In the dialog, entering a key or value clears value_hidden; model that
+    // here as a plain visible row carrying the new value.
+    const result = buildMcpIntegrationFormSchema().safeParse({
+      ...baseStdio,
+      stdio_env: [
+        {
+          key: "NEW_TOKEN",
+          value: "${{ SECRETS.new.TOKEN }}",
+          original_key: "API_TOKEN",
+        },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a visible row with an empty value", () => {
+    const result = buildMcpIntegrationFormSchema().safeParse({
+      ...baseStdio,
+      stdio_env: [{ key: "PLAIN", value: "" }],
+    })
+    expect(result.success).toBe(false)
   })
 })
 
@@ -207,13 +453,14 @@ describe("buildMcpIntegrationFormSchema url validation", () => {
     name: "Vault",
     server_type: "stdio" as const,
     stdio_command: "npx",
+    stdio_args_line: "mcp-vault",
   }
   const urlEnvKeys = new Set(["VAULT_ADDR"])
 
   it("rejects a scheme-less url-typed stdio env var", () => {
     const result = buildMcpIntegrationFormSchema(urlEnvKeys).safeParse({
       ...baseStdio,
-      stdio_env: JSON.stringify({ VAULT_ADDR: "acme.example.net" }),
+      stdio_env: [{ key: "VAULT_ADDR", value: "acme.example.net" }],
     })
     expect(result.success).toBe(false)
     if (!result.success) {
@@ -225,7 +472,7 @@ describe("buildMcpIntegrationFormSchema url validation", () => {
   it("accepts a well-formed url-typed stdio env var", () => {
     const result = buildMcpIntegrationFormSchema(urlEnvKeys).safeParse({
       ...baseStdio,
-      stdio_env: JSON.stringify({ VAULT_ADDR: "https://vault.example.net" }),
+      stdio_env: [{ key: "VAULT_ADDR", value: "https://vault.example.net" }],
     })
     expect(result.success).toBe(true)
   })
@@ -233,7 +480,22 @@ describe("buildMcpIntegrationFormSchema url validation", () => {
   it("does not validate url shape when the spec declares no url keys", () => {
     const result = buildMcpIntegrationFormSchema(new Set()).safeParse({
       ...baseStdio,
-      stdio_env: JSON.stringify({ VAULT_ADDR: "acme.example.net" }),
+      stdio_env: [{ key: "VAULT_ADDR", value: "acme.example.net" }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts hidden stdio env values on edit", () => {
+    const result = buildMcpIntegrationFormSchema(urlEnvKeys).safeParse({
+      ...baseStdio,
+      stdio_env: [
+        {
+          key: "VAULT_ADDR",
+          value: "",
+          value_hidden: true,
+          original_key: "VAULT_ADDR",
+        },
+      ],
     })
     expect(result.success).toBe(true)
   })
@@ -276,5 +538,49 @@ describe("catalogEntryToFormValues", () => {
       "Wiz-Client-Id": "",
       "X-Wiz-MCP-Mode": "gateway",
     })
+  })
+
+  it("prefills stdio command and environment rows", () => {
+    const values = catalogEntryToFormValues({
+      slug: "vault-mcp",
+      name: "Vault",
+      description: "Query Vault",
+      connection_spec: {
+        kind: "stdio_custom",
+        server_type: "stdio",
+        auth_type: "CUSTOM",
+        stdio_command: "npx",
+        stdio_args: ["mcp-vault"],
+        stdio_env: [],
+        packages: [],
+        config_fields: [],
+        credentials: [
+          {
+            key: "VAULT_ADDR",
+            label: "Vault URL",
+            description: "Vault base URL",
+            required: true,
+            secret: false,
+            target: "stdio_env",
+            placeholder: "https://vault.example.net",
+          },
+          {
+            key: "VAULT_TOKEN",
+            label: "Vault token",
+            description: "Vault auth token",
+            required: true,
+            secret: true,
+            target: "stdio_env",
+          },
+        ],
+      },
+    } as unknown as Parameters<typeof catalogEntryToFormValues>[0])
+
+    expect(values.stdio_command).toBe("npx")
+    expect(values.stdio_args_line).toBe("mcp-vault")
+    expect(values.stdio_env).toEqual([
+      { key: "VAULT_ADDR", value: "https://vault.example.net" },
+      { key: "VAULT_TOKEN", value: "" },
+    ])
   })
 })

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -1319,6 +1319,363 @@ class TestMCPIntegrationCRUD:
         assert updated is not None
         assert updated.encrypted_stdio_env is not None
 
+    async def test_readable_stdio_env_returns_safe_values(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        catalog = _catalog_entry(
+            slug="readable-stdio-env-mcp",
+            name="Readable stdio env MCP",
+            description="Test stdio env read-back",
+            connection_spec={
+                "kind": "stdio_custom",
+                "server_type": "stdio",
+                "auth_type": "CUSTOM",
+                "stdio_command": "uvx",
+                "stdio_args": ["example-mcp"],
+                "stdio_env": [],
+                "credentials": [
+                    {
+                        "key": "CONSOLE_BASE_URL",
+                        "label": "Console URL",
+                        "description": "Console base URL",
+                        "target": "stdio_env",
+                        "required": True,
+                        "secret": False,
+                    },
+                    {
+                        "key": "EXAMPLE_TOKEN",
+                        "label": "Example token",
+                        "description": "API token",
+                        "target": "stdio_env",
+                        "required": True,
+                        "secret": True,
+                    },
+                ],
+            },
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name=catalog.name,
+                description=catalog.description,
+                catalog_slug=catalog.slug,
+                stdio_command="uvx",
+                stdio_args=["example-mcp"],
+                stdio_env={
+                    "CONSOLE_BASE_URL": "https://console.example.net",
+                    "EXAMPLE_TOKEN": "${{ SECRETS.example.TOKEN }}",
+                },
+            )
+        )
+
+        assert integration_service.readable_stdio_env(created) == {
+            "CONSOLE_BASE_URL": "https://console.example.net",
+            "EXAMPLE_TOKEN": "${{ SECRETS.example.TOKEN }}",
+        }
+        assert integration_service.stdio_env_keys(created) == [
+            "CONSOLE_BASE_URL",
+            "EXAMPLE_TOKEN",
+        ]
+
+    async def test_readable_stdio_env_hides_raw_values(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="Hidden stdio env MCP",
+                stdio_command="uvx",
+                stdio_args=["example-mcp"],
+                stdio_env={"EXAMPLE_TOKEN": "raw-token"},
+            )
+        )
+
+        assert integration_service.readable_stdio_env(created) is None
+        assert integration_service.stdio_env_keys(created) == ["EXAMPLE_TOKEN"]
+
+    async def test_readable_stdio_env_hides_non_reference_templates(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Only standalone SECRETS/VARS references are shown; other templates hide.
+
+        A ``${{ FN.to_base64("user:password") }}`` value would leak the embedded
+        literal if echoed back, so anything that is not a plain SECRETS/VARS
+        attribute reference must be treated like a raw secret and omitted from
+        ``readable_stdio_env`` while still appearing in ``stdio_env_keys``.
+        """
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="Non-reference template stdio env MCP",
+                stdio_command="uvx",
+                stdio_args=["example-mcp"],
+                stdio_env={
+                    # Embeds a literal that must not leak.
+                    "FN_TOKEN": '${{ FN.to_base64("user:password") }}',
+                    # A standalone template wrapping a bare literal.
+                    "LITERAL_TOKEN": '${{ "raw" }}',
+                    # Mixed content: template is not standalone.
+                    "MIXED_TOKEN": "prefix ${{ SECRETS.example.TOKEN }}",
+                    # Arithmetic / concatenation inside a standalone template.
+                    "CONCAT_TOKEN": '${{ SECRETS.example.USER + ":" + SECRETS.example.PASS }}',
+                    # Legitimate safe references remain visible.
+                    "SECRET_TOKEN": "${{ SECRETS.example.TOKEN }}",
+                    "VAR_TOKEN": "${{ VARS.foo }}",
+                },
+            )
+        )
+
+        assert integration_service.readable_stdio_env(created) == {
+            "SECRET_TOKEN": "${{ SECRETS.example.TOKEN }}",
+            "VAR_TOKEN": "${{ VARS.foo }}",
+        }
+        assert integration_service.stdio_env_keys(created) == [
+            "FN_TOKEN",
+            "LITERAL_TOKEN",
+            "MIXED_TOKEN",
+            "CONCAT_TOKEN",
+            "SECRET_TOKEN",
+            "VAR_TOKEN",
+        ]
+
+    async def test_readable_stdio_env_shows_catalog_non_secret_keys(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Catalog-declared non-secret keys stay visible even as raw values.
+
+        The tightened reference check only gates templated values; keys the
+        catalog marks non-secret are shown verbatim regardless of their shape.
+        """
+        catalog = _catalog_entry(
+            slug="catalog-non-secret-stdio-env-mcp",
+            name="Catalog non-secret stdio env MCP",
+            description="Catalog row with a non-secret stdio env key",
+            connection_spec={
+                "kind": "stdio_custom",
+                "server_type": "stdio",
+                "auth_type": "CUSTOM",
+                "stdio_command": "uvx",
+                "stdio_args": ["example-mcp"],
+                "stdio_env": [],
+                "credentials": [
+                    {
+                        "key": "CONSOLE_BASE_URL",
+                        "label": "Console URL",
+                        "description": "Console base URL",
+                        "target": "stdio_env",
+                        "required": True,
+                        "secret": False,
+                    },
+                    {
+                        "key": "EXAMPLE_TOKEN",
+                        "label": "Example token",
+                        "description": "API token",
+                        "target": "stdio_env",
+                        "required": True,
+                        "secret": True,
+                    },
+                ],
+            },
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name=catalog.name,
+                description=catalog.description,
+                catalog_slug=catalog.slug,
+                stdio_command="uvx",
+                stdio_args=["example-mcp"],
+                stdio_env={
+                    # Non-secret catalog key: shown verbatim (raw, non-templated).
+                    "CONSOLE_BASE_URL": "https://console.example.net",
+                    # Secret catalog key holding a raw secret: hidden.
+                    "EXAMPLE_TOKEN": "raw-token",
+                },
+            )
+        )
+
+        assert integration_service.readable_stdio_env(created) == {
+            "CONSOLE_BASE_URL": "https://console.example.net",
+        }
+        assert integration_service.stdio_env_keys(created) == [
+            "CONSOLE_BASE_URL",
+            "EXAMPLE_TOKEN",
+        ]
+
+    async def test_stdio_env_accessors_allow_create_only_scope(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+    ) -> None:
+        """A create-only role can create a stdio MCP and read its env metadata.
+
+        Regression: the create route shapes its response with
+        ``stdio_env_keys``/``readable_stdio_env``/``decrypt_stdio_env``. When
+        those accessors required ``integration:read`` a create-only RBAC role
+        would persist the row and then 403 on response shaping, orphaning the
+        integration.
+        """
+        create_only_role = Role(
+            type="user",
+            workspace_id=svc_role.workspace_id,
+            organization_id=svc_role.organization_id,
+            user_id=svc_role.user_id,
+            service_id="tracecat-api",
+            scopes=frozenset({"integration:create"}),
+        )
+        service = IntegrationService(session=session, role=create_only_role)
+
+        created = await service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="Create-only stdio MCP",
+                stdio_command="uvx",
+                stdio_args=["example-mcp"],
+                stdio_env={
+                    "EXAMPLE_TOKEN": "raw-token",
+                    "VISIBLE_TOKEN": "${{ SECRETS.example.VISIBLE_TOKEN }}",
+                },
+            )
+        )
+
+        # These are the exact accessors the create route calls to shape the
+        # response; each must succeed under a create-only role.
+        assert service.decrypt_stdio_env(created) == {
+            "EXAMPLE_TOKEN": "raw-token",
+            "VISIBLE_TOKEN": "${{ SECRETS.example.VISIBLE_TOKEN }}",
+        }
+        assert service.readable_stdio_env(created) == {
+            "VISIBLE_TOKEN": "${{ SECRETS.example.VISIBLE_TOKEN }}",
+        }
+        assert service.stdio_env_keys(created) == ["EXAMPLE_TOKEN", "VISIBLE_TOKEN"]
+
+    async def test_stdio_env_accessors_allow_update_only_scope(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        integration_service: IntegrationService,
+    ) -> None:
+        """An update-only role can update a stdio MCP and read its env metadata.
+
+        Regression: ``_merged_stdio_env_for_update`` calls
+        ``decrypt_stdio_env`` and the update route shapes its response with the
+        readable accessors. When those required ``integration:read`` an
+        update-only role would break mid-update.
+        """
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="Update-only stdio MCP",
+                stdio_command="uvx",
+                stdio_args=["example-mcp"],
+                stdio_env={
+                    "EXAMPLE_TOKEN": "raw-token",
+                    "VISIBLE_TOKEN": "${{ SECRETS.example.VISIBLE_TOKEN }}",
+                },
+            )
+        )
+
+        update_only_role = Role(
+            type="user",
+            workspace_id=svc_role.workspace_id,
+            organization_id=svc_role.organization_id,
+            user_id=svc_role.user_id,
+            service_id="tracecat-api",
+            scopes=frozenset({"integration:update"}),
+        )
+        service = IntegrationService(session=session, role=update_only_role)
+
+        updated = await service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(
+                stdio_env={"VISIBLE_TOKEN": "${{ SECRETS.example.UPDATED_TOKEN }}"},
+                stdio_env_preserve_keys=["EXAMPLE_TOKEN"],
+            ),
+        )
+        assert updated is not None
+
+        assert service.decrypt_stdio_env(updated) == {
+            "EXAMPLE_TOKEN": "raw-token",
+            "VISIBLE_TOKEN": "${{ SECRETS.example.UPDATED_TOKEN }}",
+        }
+        assert service.readable_stdio_env(updated) == {
+            "VISIBLE_TOKEN": "${{ SECRETS.example.UPDATED_TOKEN }}",
+        }
+        assert service.stdio_env_keys(updated) == ["EXAMPLE_TOKEN", "VISIBLE_TOKEN"]
+
+    async def test_list_response_includes_stdio_env_metadata(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """List responses expose the same readable stdio env as GET-by-id.
+
+        Mirrors the router shaping: ``list_mcp_integrations`` must populate
+        ``stdio_env_keys``/``stdio_env`` from the read-scoped accessors so the
+        list matches the GET-by-id response.
+        """
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="List env metadata MCP",
+                stdio_command="uvx",
+                stdio_args=["example-mcp"],
+                stdio_env={
+                    "EXAMPLE_TOKEN": "raw-token",
+                    "VISIBLE_TOKEN": "${{ SECRETS.example.VISIBLE_TOKEN }}",
+                },
+            )
+        )
+
+        rows = await integration_service.list_mcp_integrations_with_state()
+        listed = next(
+            item.integration for item in rows if item.integration.id == created.id
+        )
+
+        # The list route shapes these fields exactly as GET-by-id does.
+        expected_keys = ["EXAMPLE_TOKEN", "VISIBLE_TOKEN"]
+        expected_env = {"VISIBLE_TOKEN": "${{ SECRETS.example.VISIBLE_TOKEN }}"}
+
+        assert integration_service.stdio_env_keys(listed) == expected_keys
+        assert integration_service.readable_stdio_env(listed) == expected_env
+        # Consistency with the GET-by-id shaping.
+        assert integration_service.stdio_env_keys(
+            created
+        ) == integration_service.stdio_env_keys(listed)
+        assert integration_service.readable_stdio_env(
+            created
+        ) == integration_service.readable_stdio_env(listed)
+
+    async def test_update_mcp_integration_preserves_hidden_stdio_env_keys(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="Preserve stdio env MCP",
+                stdio_command="uvx",
+                stdio_args=["example-mcp"],
+                stdio_env={
+                    "EXAMPLE_TOKEN": "raw-token",
+                    "VISIBLE_TOKEN": "${{ SECRETS.example.VISIBLE_TOKEN }}",
+                },
+            )
+        )
+
+        updated = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(
+                stdio_env={"VISIBLE_TOKEN": "${{ SECRETS.example.UPDATED_TOKEN }}"},
+                stdio_env_preserve_keys=["EXAMPLE_TOKEN"],
+            ),
+        )
+
+        assert updated is not None
+        assert integration_service.decrypt_stdio_env(updated) == {
+            "EXAMPLE_TOKEN": "raw-token",
+            "VISIBLE_TOKEN": "${{ SECRETS.example.UPDATED_TOKEN }}",
+        }
+
     async def test_catalog_url_typed_stdio_env_requires_scheme(
         self,
         integration_service: IntegrationService,

--- a/tracecat/expressions/patterns.py
+++ b/tracecat/expressions/patterns.py
@@ -7,3 +7,18 @@ TEMPLATE_STRING = re.compile(
 
 STANDALONE_TEMPLATE = re.compile(r"^\${{\s*(?:(?!\${{).)*?\s*}}$")
 """Pattern that matches a standalone template expression."""
+
+STANDALONE_SAFE_REFERENCE = re.compile(
+    r"^\$\{\{\s*(?:SECRETS|VARS)\.[a-zA-Z0-9_.]+\s*\}\}$"
+)
+"""Pattern that matches a standalone ``SECRETS.*`` or ``VARS.*`` reference.
+
+Unlike :data:`STANDALONE_TEMPLATE`, this only matches a single template whose
+entire inner expression is a plain ``SECRETS``/``VARS`` attribute path (e.g.
+``${{ SECRETS.example.TOKEN }}`` or ``${{ VARS.foo }}``). It rejects anything
+that could embed a literal, such as function calls, arithmetic, string
+literals, or concatenations, so it is safe to echo the raw value back to the
+client. Attribute-path segments follow the expression grammar's ``CNAME``
+tokens (``[a-zA-Z_][a-zA-Z0-9_]*``), which also covers the ``[a-z0-9_]``
+secret-name and ``[a-zA-Z0-9_]`` secret-key alphabets.
+"""

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -89,6 +89,8 @@ def _mcp_integration_read(
     mcp_integration: MCPIntegration,
     *,
     state: PlatformMCPCatalogState,
+    stdio_env_keys: list[str] | None = None,
+    stdio_env: dict[str, str] | None = None,
 ) -> MCPIntegrationRead:
     return MCPIntegrationRead(
         id=mcp_integration.id,
@@ -105,6 +107,8 @@ def _mcp_integration_read(
         server_type=cast(MCPServerType, mcp_integration.server_type),
         stdio_command=mcp_integration.stdio_command,
         stdio_args=mcp_integration.stdio_args,
+        stdio_env_keys=stdio_env_keys,
+        stdio_env=stdio_env,
         has_stdio_env=bool(mcp_integration.encrypted_stdio_env),
         timeout=mcp_integration.timeout,
         tools=MCPToolSummary.validate_stored(
@@ -167,6 +171,8 @@ async def _mcp_catalog_connect_response(
         mcp_read = _mcp_integration_read(
             mcp_integration,
             state=await svc.mcp_integration_state(mcp_integration=mcp_integration),
+            stdio_env_keys=svc.stdio_env_keys(mcp_integration),
+            stdio_env=svc.readable_stdio_env(mcp_integration),
         )
     return MCPCatalogConnectResponse(
         status="oauth_redirect" if oauth_connect else "connected",
@@ -979,6 +985,8 @@ async def create_mcp_integration(
     return _mcp_integration_read(
         mcp_integration,
         state=await svc.mcp_integration_state(mcp_integration=mcp_integration),
+        stdio_env_keys=svc.stdio_env_keys(mcp_integration),
+        stdio_env=svc.readable_stdio_env(mcp_integration),
     )
 
 
@@ -1011,6 +1019,8 @@ async def list_mcp_integrations(
         _mcp_integration_read(
             item.integration,
             state=item.state,
+            stdio_env_keys=svc.stdio_env_keys(item.integration),
+            stdio_env=svc.readable_stdio_env(item.integration),
         )
         for item in integrations
     ]
@@ -1118,6 +1128,8 @@ async def connect_mcp_integration(
         mcp_integration=_mcp_integration_read(
             mcp_integration,
             state=await svc.mcp_integration_state(mcp_integration=mcp_integration),
+            stdio_env_keys=svc.stdio_env_keys(mcp_integration),
+            stdio_env=svc.readable_stdio_env(mcp_integration),
         ),
     )
 
@@ -1147,6 +1159,8 @@ async def get_mcp_integration(
     return _mcp_integration_read(
         integration,
         state=await svc.mcp_integration_state(mcp_integration=integration),
+        stdio_env_keys=svc.stdio_env_keys(integration),
+        stdio_env=svc.readable_stdio_env(integration),
     )
 
 
@@ -1194,6 +1208,8 @@ async def update_mcp_integration(
     return _mcp_integration_read(
         integration,
         state=await svc.mcp_integration_state(mcp_integration=integration),
+        stdio_env_keys=svc.stdio_env_keys(integration),
+        stdio_env=svc.readable_stdio_env(integration),
     )
 
 

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -543,6 +543,13 @@ class MCPIntegrationUpdate(BaseModel):
         default=None,
         description="Environment variables for stdio-type servers",
     )
+    stdio_env_preserve_keys: list[str] | None = Field(
+        default=None,
+        description=(
+            "Existing stdio env keys to preserve when stdio_env only contains "
+            "visible or replaced values."
+        ),
+    )
     # General fields
     timeout: int | None = Field(
         default=None,
@@ -866,9 +873,12 @@ class MCPIntegrationRead(BaseModel):
     # Stdio-type server fields
     stdio_command: str | None
     stdio_args: list[str] | None
-    # NOTE: stdio_env is write-only to avoid exposing secrets in API responses
+    stdio_env_keys: list[str] | None = None
+    """Configured stdio environment variable keys, without exposing raw values."""
+    stdio_env: dict[str, str] | None = None
+    """Safe-to-display stdio environment variable values, if available."""
     has_stdio_env: bool = False
-    """Whether stdio_env is configured (actual values are not exposed)."""
+    """Whether stdio_env is configured, including values hidden from the response."""
     # General fields
     timeout: int | None
     tools: list[MCPToolSummary] | None = None

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -33,6 +33,7 @@ from tracecat.db.models import (
     OAuthStateDB,
     WorkspaceOAuthProvider,
 )
+from tracecat.expressions.patterns import STANDALONE_SAFE_REFERENCE
 from tracecat.identifiers import UserID
 from tracecat.integrations.catalog.loader import (
     get_platform_mcp_catalog_entries,
@@ -49,6 +50,7 @@ from tracecat.integrations.mcp_validation import (
     MCPValidationError,
     sanitize_urls_in_text,
     validate_mcp_command_config,
+    validate_mcp_env_key,
 )
 from tracecat.integrations.providers import get_provider_class
 from tracecat.integrations.providers.base import (
@@ -1850,11 +1852,23 @@ class IntegrationService(BaseWorkspaceService):
             "utf-8"
         )
 
-    @require_scope("integration:read")
+    @require_scope(
+        "integration:read",
+        "integration:create",
+        "integration:update",
+        require_all=False,
+    )
     def decrypt_stdio_env(
         self, mcp_integration: MCPIntegration
     ) -> dict[str, str] | None:
-        """Decrypt and return stdio_env for an MCP integration."""
+        """Decrypt and return stdio_env for an MCP integration.
+
+        Read/create/update all satisfy this accessor: any actor allowed to
+        create or update an MCP integration already supplies or mutates its
+        env, and response shaping on those routes needs to echo the readable
+        values back. Which endpoints exist is still governed by route-level
+        scoping.
+        """
         if not mcp_integration.encrypted_stdio_env:
             return None
         if not is_set(mcp_integration.encrypted_stdio_env):
@@ -1872,6 +1886,89 @@ class IntegrationService(BaseWorkspaceService):
                 return None
             env[key] = value
         return env
+
+    @staticmethod
+    def _non_secret_stdio_env_keys(catalog_slug: str | None) -> set[str]:
+        """Return catalog-declared stdio env keys that are safe to display."""
+        if not catalog_slug:
+            return set()
+        catalog_entry = get_platform_mcp_catalog_entry_by_slug(
+            catalog_slug, include_private=True
+        )
+        if catalog_entry is None:
+            return set()
+
+        specs: list[MCPConnectionSpec] = []
+        if catalog_entry.connection_spec is not None:
+            specs.append(catalog_entry.connection_spec)
+        specs.extend(
+            option.connection_spec for option in catalog_entry.connection_options or []
+        )
+        return {
+            cred.key
+            for spec in specs
+            for cred in spec.credentials
+            if cred.target == "stdio_env" and not cred.secret
+        }
+
+    @require_scope(
+        "integration:read",
+        "integration:create",
+        "integration:update",
+        require_all=False,
+    )
+    def readable_stdio_env(
+        self, mcp_integration: MCPIntegration
+    ) -> dict[str, str] | None:
+        """Return stdio env values that can be shown in edit forms.
+
+        Raw env values may be credentials. Only standalone ``SECRETS.*`` or
+        ``VARS.*`` references (safe indirections that never embed a literal)
+        or catalog-declared non-secret fields are returned. Any other
+        templated value — function calls, literals, arithmetic, or partial
+        templates — is treated like a raw secret and omitted.
+        """
+        env = self.decrypt_stdio_env(mcp_integration)
+        if not env:
+            return None
+
+        non_secret_keys = self._non_secret_stdio_env_keys(mcp_integration.catalog_slug)
+        readable: dict[str, str] = {}
+        for key, value in env.items():
+            if key in non_secret_keys or STANDALONE_SAFE_REFERENCE.match(value.strip()):
+                readable[key] = value
+        return readable or None
+
+    @require_scope(
+        "integration:read",
+        "integration:create",
+        "integration:update",
+        require_all=False,
+    )
+    def stdio_env_keys(self, mcp_integration: MCPIntegration) -> list[str] | None:
+        """Return configured stdio env keys without exposing raw values."""
+        env = self.decrypt_stdio_env(mcp_integration)
+        if not env:
+            return None
+        return list(env.keys())
+
+    def _merged_stdio_env_for_update(
+        self, *, mcp_integration: MCPIntegration, params: MCPIntegrationUpdate
+    ) -> dict[str, str] | None:
+        """Merge visible env updates with hidden keys the client preserves."""
+        if params.stdio_env is None and params.stdio_env_preserve_keys is None:
+            return None
+
+        current_env = self.decrypt_stdio_env(mcp_integration) or {}
+        merged: dict[str, str] = {}
+        for key in params.stdio_env_preserve_keys or []:
+            validate_mcp_env_key(key)
+            if key in current_env:
+                merged[key] = current_env[key]
+
+        if params.stdio_env:
+            merged.update(params.stdio_env)
+        return merged
 
     @require_scope("integration:create", "integration:update", require_all=False)
     async def store_provider_config(
@@ -3527,6 +3624,16 @@ class IntegrationService(BaseWorkspaceService):
         oauth_integration_id_was_provided = (
             "oauth_integration_id" in params.model_fields_set
         )
+        stdio_env_was_provided = (
+            params.stdio_env is not None or params.stdio_env_preserve_keys is not None
+        )
+        target_stdio_env = (
+            self._merged_stdio_env_for_update(
+                mcp_integration=mcp_integration, params=params
+            )
+            if stdio_env_was_provided
+            else None
+        )
 
         if target_server_type == "http":
             target_server_uri = params.server_uri or mcp_integration.server_uri
@@ -3588,7 +3695,7 @@ class IntegrationService(BaseWorkspaceService):
             server_type_changed
             or params.stdio_command is not None
             or params.stdio_args is not None
-            or params.stdio_env is not None
+            or stdio_env_was_provided
         ):
             self._validate_stdio_server_config(
                 command=(
@@ -3601,12 +3708,12 @@ class IntegrationService(BaseWorkspaceService):
                     if params.stdio_args is not None
                     else mcp_integration.stdio_args
                 ),
-                env=params.stdio_env,
+                env=target_stdio_env,
             )
-            if params.stdio_env is not None:
+            if stdio_env_was_provided and target_stdio_env is not None:
                 self._validate_stdio_env_against_catalog(
                     catalog_slug=mcp_integration.catalog_slug,
-                    stdio_env=params.stdio_env,
+                    stdio_env=target_stdio_env,
                 )
 
         # Update fields
@@ -3649,10 +3756,10 @@ class IntegrationService(BaseWorkspaceService):
             )
         if target_server_type == "stdio" and params.stdio_args is not None:
             mcp_integration.stdio_args = params.stdio_args
-        if target_server_type == "stdio" and params.stdio_env is not None:
-            if params.stdio_env:
+        if target_server_type == "stdio" and stdio_env_was_provided:
+            if target_stdio_env:
                 mcp_integration.encrypted_stdio_env = self._encrypt_token(
-                    orjson.dumps(params.stdio_env).decode()
+                    orjson.dumps(target_stdio_env).decode()
                 )
             else:
                 # Empty dict means clear the env vars


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves MCP stdio env keys and safe templated values across reads and updates, and replaces the JSON env editor with simple key/value rows that support workspace expressions. Avoids lossy round-trips by only sending edited args/env (or when a new option template is applied) and fixes RBAC so create/update flows can shape env metadata.

- **New Features**
  - API returns `stdio_env_keys` and safe `stdio_env` in read/list/create/connect responses. Raw secrets stay hidden; only standalone `SECRETS.*`/`VARS.*` refs and catalog-declared non-secret keys are echoed.
  - Updates accept `stdio_env_preserve_keys`; backend merges preserved hidden keys with visible updates. Unchanged args/env are omitted; option template apply forces sending both.
  - UI switches to key/value env rows with workspace-only expression input. Hidden values show “stored value hidden”; renaming a hidden key reveals it so a replacement is required.
  - Arguments are edited as a single line (`stdio_args_line`, space-separated, no quoting) and parsed into `stdio_args` when changed.
  - Validation: URL-typed env keys must use http(s); env rows require unique, valid names and non-empty values.

- **Migration**
  - When updating stdio env, include `stdio_env_preserve_keys` for any keys whose values remain hidden and unchanged.
  - On reads, use `stdio_env` for safe-to-display values and `stdio_env_keys` for the full set. No changes needed if you ignore these fields.

<sup>Written for commit be813700fc7779aab140f91214ab69741dab8e5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

