### PR TITLE
fix(mcp): workflow editing feedback — env patch, docs, layout, rename UX, rebase

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -16,6 +16,8 @@
 
 <ResponseField name="edit_workflow" type="tool">
   Edit a draft workflow using RFC 6902 JSON Patch.
+
+  Patches always apply to the LATEST revision: if your ``base_revision`` was stale the patch is still applied to the current head and the response reports ``rebased: true``. Actions MUST be addressed by ref (slug), e.g. ``/definition/actions/parse_events/args/url``; numeric indexes into the actions array are rejected — use the ref (or ``/-`` to append). Ref paths also survive concurrent reorders. An op targeting a ref that a concurrent edit deleted or renamed fails loudly — re-fetch with ``get_workflow`` and retry. Whole-object replaces (an entire action, or a whole container like ``args``) and any op on ``/schedules`` or ``/layout`` are last-write-wins and can clobber a concurrent edit. Prefer field-level ops; to guarantee no clobber, precede the op with a JSON Patch ``test`` op asserting the expected current value (a ``test`` mismatch aborts the whole patch atomically). When adding a new action, also add its layout position in the same patch: append ``{"ref": "<ref>", "x": <x>, "y": <y>}`` to ``/layout/actions/-``, placed near/below its parent (nodes are ~300x300, so offset by at least that); without a layout entry new nodes stack at the origin. A patch that applies but changes nothing returns ``no_op: true``; otherwise ``changed_sections`` lists the document sections that changed.
 </ResponseField>
 
 <ResponseField name="update_workflow" type="tool">

--- a/packages/tracecat-registry/tracecat_registry/core/http.py
+++ b/packages/tracecat-registry/tracecat_registry/core/http.py
@@ -577,7 +577,14 @@ def _process_file_uploads(
 
 @registry.register(
     namespace="core",
-    description="Perform a HTTP request to a given URL.",
+    description=(
+        "Perform a HTTP request to a given URL. Returns an envelope "
+        "`{status_code, headers, data}`: the response body is under `.data` "
+        "(parsed JSON when the response is JSON, otherwise text, or `None` for "
+        "204). Access the body via `ACTIONS.<ref>.result.data`, and the status "
+        "code / headers via `ACTIONS.<ref>.result.status_code` / "
+        "`ACTIONS.<ref>.result.headers`."
+    ),
     default_title="HTTP request",
     secrets=[mtls_secret, ca_cert_secret],
 )
@@ -607,7 +614,14 @@ async def http_request(
     ] = False,
     verify_ssl: VerifySSL = True,
 ) -> HTTPResponse:
-    """Perform a HTTP request to a given URL."""
+    """Perform a HTTP request to a given URL.
+
+    Returns an envelope ``{status_code, headers, data}``. The response body is
+    under ``data`` (parsed JSON when the response is JSON, otherwise the raw
+    text, or ``None`` for a 204). Reference it downstream as
+    ``ACTIONS.<ref>.result.data`` (and ``.result.status_code`` /
+    ``.result.headers`` for the status code and headers).
+    """
 
     ignore_status_codes = ignore_status_codes or []
     basic_auth = httpx.BasicAuth(**auth) if auth else None

--- a/tests/registry/test_internal_workflow_router.py
+++ b/tests/registry/test_internal_workflow_router.py
@@ -5,15 +5,18 @@ These tests verify the request/response schemas for the internal workflow API.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 from fastapi import HTTPException
-from starlette.status import HTTP_400_BAD_REQUEST, HTTP_409_CONFLICT
+from starlette.status import HTTP_400_BAD_REQUEST
 
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.mcp.schemas import JsonPatchOperation
+from tracecat.workflow.executions import internal_router
 from tracecat.workflow.executions.internal_router import (
     InternalWorkflowCreateRequest,
     InternalWorkflowEditRequest,
@@ -240,6 +243,82 @@ class TestInternalWorkflowEditRequest:
         assert req.patch_ops[0].op == "add"
 
 
+class TestEditWorkflowDocument:
+    """Tests for the internal edit-document route."""
+
+    @pytest.mark.anyio
+    async def test_validate_only_reports_stale_no_op(self, monkeypatch):
+        workflow_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=workflow_id,
+            title="Example workflow",
+            description="Example description",
+            status="offline",
+            version=None,
+            alias=None,
+            entrypoint=None,
+            error_handler=None,
+            expects={},
+            returns=None,
+            config={},
+            actions=[],
+            schedules=[],
+            case_trigger=None,
+            graph_version=1,
+            trigger_position_x=0.0,
+            trigger_position_y=0.0,
+            viewport_x=0.0,
+            viewport_y=0.0,
+            viewport_zoom=1.0,
+        )
+
+        class _WorkflowService:
+            def __init__(self, session: object, role: object) -> None:
+                self.session = session
+                self.role = role
+
+            async def get_workflow(
+                self, wf_id: object, *, for_update: bool = False
+            ) -> object:
+                assert wf_id == workflow_id
+                assert for_update is True
+                return workflow
+
+        monkeypatch.setattr(
+            internal_router,
+            "WorkflowsManagementService",
+            _WorkflowService,
+        )
+        raw_edit_workflow_document = cast(
+            Any,
+            internal_router.edit_workflow_document,
+        ).__wrapped__
+
+        response = await raw_edit_workflow_document(
+            role=SimpleNamespace(),
+            session=object(),
+            workflow_id=workflow_id,
+            params=InternalWorkflowEditRequest(
+                base_revision="stale-revision",
+                patch_ops=[
+                    JsonPatchOperation(
+                        op="replace",
+                        path="/metadata/title",
+                        value=workflow.title,
+                    )
+                ],
+                validate_only=True,
+            ),
+        )
+        payload = response.model_dump(mode="json")
+
+        assert payload["valid"] is True
+        assert payload["validate_only"] is True
+        assert payload["changed_sections"] == []
+        assert payload["no_op"] is True
+        assert payload["rebased"] is True
+
+
 class TestBuildImportDataFromDefinitionYaml:
     """Tests for the copilot YAML -> import-data normalization."""
 
@@ -389,16 +468,6 @@ class TestBuildImportDataFromDefinitionYaml:
 
 class TestRaiseWorkflowEditHttpError:
     """Tests mapping the engine error onto HTTP responses."""
-
-    def test_conflict_maps_to_409(self):
-        err = WorkflowEditError(
-            "Draft revision mismatch", conflict=True, current_revision="rev9"
-        )
-        with pytest.raises(HTTPException) as exc:
-            _raise_workflow_edit_http_error(err)
-        assert exc.value.status_code == HTTP_409_CONFLICT
-        detail = cast(dict[str, Any], exc.value.detail)
-        assert detail["current_revision"] == "rev9"
 
     def test_validation_error_maps_to_400_with_details(self):
         err = WorkflowEditError(

--- a/tests/unit/test_dsl_common.py
+++ b/tests/unit/test_dsl_common.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
+import pytest
+
 from tracecat.dsl.common import build_action_statements_from_actions
 from tracecat.dsl.view import (
     RFEdge,
@@ -170,3 +172,49 @@ base_url: https://management.azure.com
     assert statements[0].args["api_version"] == "2025-09-01"
     validated_args = expectation_model.model_validate(statements[0].args)
     assert validated_args.model_dump()["api_version"] == "2025-09-01"
+
+
+def test_renamed_action_ref_error_names_missing_ref_and_lists_available() -> None:
+    """A stale ACTIONS.<old_ref> expression after a rename yields a helpful error.
+
+    Renaming an action changes its ref (the slugified title). Downstream
+    ``ACTIONS.<old_ref>`` expressions are NOT rewritten, so validation fails.
+    The error must name the missing ref, list the available refs, and hint at
+    the rename, and carry machine-readable ``detail`` (not string matching).
+    """
+    from tracecat.dsl.common import DSLEntrypoint, DSLInput
+    from tracecat.dsl.schemas import ActionStatement
+    from tracecat.exceptions import TracecatDSLError
+
+    with pytest.raises(TracecatDSLError) as exc_info:
+        DSLInput(
+            title="wf",
+            description="",
+            entrypoint=DSLEntrypoint(ref="parse_alerts"),
+            actions=[
+                ActionStatement(
+                    ref="parse_alerts",  # was "parse_events"; ref changed on rename
+                    action="core.transform.reshape",
+                    args={"value": 1},
+                ),
+                ActionStatement(
+                    ref="use_it",
+                    action="core.transform.reshape",
+                    args={"value": "${{ ACTIONS.parse_events.result }}"},
+                    depends_on=["parse_alerts"],
+                ),
+            ],
+        )
+
+    error = exc_info.value
+    message = str(error)
+    assert "parse_events" in message  # names the missing ref
+    assert "parse_alerts" in message  # lists an available ref
+    assert "renamed" in message.lower()  # hints at rename
+
+    detail = error.detail
+    assert isinstance(detail, dict)
+    assert detail["type"] == "unknown_action_ref"
+    assert detail["missing_ref"] == "parse_events"
+    assert detail["action_ref"] == "use_it"
+    assert detail["available_refs"] == ["parse_alerts", "use_it"]

--- a/tests/unit/test_mcp_json_patch.py
+++ b/tests/unit/test_mcp_json_patch.py
@@ -188,3 +188,246 @@ def test_apply_json_patch_operations_rejects_non_canonical_array_index(
             ),
             patch_ops=[patch_op],
         )
+
+
+def test_apply_json_patch_ref_addressed_replace() -> None:
+    """A ref token addresses an action by its ``ref`` field, not by index."""
+    document: dict[str, JsonValue] = {
+        "definition": {
+            "actions": [
+                {"ref": "step_a", "args": {"x": 1}},
+                {"ref": "step_b", "args": {"x": 2}},
+            ]
+        }
+    }
+
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[
+            _op(op="replace", path="/definition/actions/step_b/args/x", value=99)
+        ],
+    )
+
+    actions = _arr(_obj(patched["definition"])["actions"])
+    assert _obj(_obj(actions[1])["args"])["x"] == 99
+    assert _obj(_obj(actions[0])["args"])["x"] == 1
+
+
+def test_apply_json_patch_ref_addressed_remove_and_from() -> None:
+    """Ref tokens work for remove and for ``move``/``copy`` ``from`` paths."""
+    document: dict[str, JsonValue] = {
+        "definition": {
+            "actions": [
+                {"ref": "step_a", "args": {"x": 1}},
+                {"ref": "step_b", "args": {"x": 2}},
+                {"ref": "step_c", "args": {"x": 3}},
+            ]
+        }
+    }
+
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[
+            _op(
+                op="copy",
+                path="/definition/actions/-",
+                **{"from": "/definition/actions/step_a"},
+            ),
+            _op(op="remove", path="/definition/actions/step_b"),
+        ],
+    )
+
+    refs = [_obj(a)["ref"] for a in _arr(_obj(patched["definition"])["actions"])]
+    assert refs == ["step_a", "step_c", "step_a"]
+
+
+def test_apply_json_patch_rejects_numeric_action_index() -> None:
+    """A numeric index into /definition/actions with no matching ref is rejected."""
+    document: dict[str, JsonValue] = {
+        "definition": {"actions": [{"ref": "step_a"}, {"ref": "step_b"}]}
+    }
+
+    with pytest.raises(ToolError, match="Address actions by ref"):
+        apply_json_patch_operations(
+            document=document,
+            patch_ops=[_op(op="remove", path="/definition/actions/0")],
+        )
+
+
+def test_apply_json_patch_append_action_still_allowed() -> None:
+    document: dict[str, JsonValue] = {"definition": {"actions": [{"ref": "step_a"}]}}
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[
+            _op(op="add", path="/definition/actions/-", value={"ref": "step_b"})
+        ],
+    )
+    refs = [_obj(a)["ref"] for a in _arr(_obj(patched["definition"])["actions"])]
+    assert refs == ["step_a", "step_b"]
+
+
+def test_apply_json_patch_ref_not_found_raises() -> None:
+    document: dict[str, JsonValue] = {"definition": {"actions": [{"ref": "step_a"}]}}
+    with pytest.raises(ToolError, match="ref not found in array"):
+        apply_json_patch_operations(
+            document=document,
+            patch_ops=[_op(op="replace", path="/definition/actions/ghost", value={})],
+        )
+
+
+def test_apply_json_patch_all_digit_ref_resolves_by_ref() -> None:
+    """An all-digit token prefers a ref-match over numeric-index interpretation.
+
+    ``slugify("1") == "1"`` and MCP edit documents accept arbitrary slug refs,
+    so an action can legitimately have ref ``"1"``. When such a ref exists,
+    ``/definition/actions/1/...`` must address that action by ref, not index 1.
+    """
+    document: dict[str, JsonValue] = {
+        "definition": {
+            "actions": [
+                {"ref": "1", "args": {"x": 1}},
+                {"ref": "step_b", "args": {"x": 2}},
+            ]
+        }
+    }
+    # replace on a subpath: targets the action whose ref is "1" (index 0), NOT
+    # index 1 (step_b).
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[_op(op="replace", path="/definition/actions/1/args/x", value=99)],
+    )
+    actions = _arr(_obj(patched["definition"])["actions"])
+    assert _obj(_obj(actions[0])["args"])["x"] == 99
+    assert _obj(_obj(actions[1])["args"])["x"] == 2
+
+
+def test_apply_json_patch_all_digit_ref_remove_resolves_by_ref() -> None:
+    """Remove on an all-digit ref removes the ref-matched element, not the index."""
+    document: dict[str, JsonValue] = {
+        "definition": {"actions": [{"ref": "step_a"}, {"ref": "1"}, {"ref": "step_c"}]}
+    }
+    # ref "1" is at index 1 here too, but resolution is by ref: removing "/1"
+    # removes the action whose ref is "1".
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[_op(op="remove", path="/definition/actions/1")],
+    )
+    refs = [_obj(a)["ref"] for a in _arr(_obj(patched["definition"])["actions"])]
+    assert refs == ["step_a", "step_c"]
+
+
+def test_apply_json_patch_all_digit_ref_beats_index_position() -> None:
+    """Ref-match wins even when the ref sits at a different index than its value."""
+    document: dict[str, JsonValue] = {
+        "definition": {
+            "actions": [
+                {"ref": "step_a"},
+                {"ref": "step_b"},
+                {"ref": "1"},
+            ]
+        }
+    }
+    # "/1" would be index 1 (step_b) numerically, but ref "1" is at index 2.
+    # Ref-preference resolves to index 2.
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[_op(op="remove", path="/definition/actions/1")],
+    )
+    refs = [_obj(a)["ref"] for a in _arr(_obj(patched["definition"])["actions"])]
+    assert refs == ["step_a", "step_b"]
+
+
+def test_apply_json_patch_all_digit_add_subpath_resolves_by_ref() -> None:
+    """An all-digit ref resolves for add on a subpath under that action."""
+    document: dict[str, JsonValue] = {
+        "definition": {
+            "actions": [
+                {"ref": "01", "args": {}},
+                {"ref": "step_b", "args": {}},
+            ]
+        }
+    }
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[
+            _op(op="add", path="/definition/actions/01/args/new", value="v"),
+        ],
+    )
+    actions = _arr(_obj(patched["definition"])["actions"])
+    assert _obj(_obj(actions[0])["args"])["new"] == "v"
+
+
+def test_apply_json_patch_numeric_index_when_no_ref_collides() -> None:
+    """An all-digit token with no matching ref into /definition/actions is rejected."""
+    document: dict[str, JsonValue] = {
+        "definition": {"actions": [{"ref": "step_a"}, {"ref": "step_b"}]}
+    }
+    with pytest.raises(ToolError, match="Address actions by ref"):
+        apply_json_patch_operations(
+            document=document,
+            patch_ops=[_op(op="remove", path="/definition/actions/1")],
+        )
+
+
+def test_apply_json_patch_leading_zero_ref_resolves_by_ref() -> None:
+    """A leading-zero token like ``01`` resolves by ref when a ref ``01`` exists."""
+    document: dict[str, JsonValue] = {
+        "definition": {
+            "actions": [
+                {"ref": "step_a", "args": {"x": 1}},
+                {"ref": "01", "args": {"x": 2}},
+            ]
+        }
+    }
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[_op(op="replace", path="/definition/actions/01/args/x", value=42)],
+    )
+    actions = _arr(_obj(patched["definition"])["actions"])
+    assert _obj(_obj(actions[1])["args"])["x"] == 42
+
+
+def test_apply_json_patch_leading_zero_no_ref_still_errors() -> None:
+    """A leading-zero token with no matching ref into actions is rejected by ref."""
+    document: dict[str, JsonValue] = {
+        "definition": {"actions": [{"ref": "step_a"}, {"ref": "step_b"}]}
+    }
+    with pytest.raises(ToolError, match="Address actions by ref"):
+        apply_json_patch_operations(
+            document=document,
+            patch_ops=[_op(op="remove", path="/definition/actions/01")],
+        )
+
+
+def test_apply_json_patch_nested_arrays_do_not_resolve_refs() -> None:
+    document: dict[str, JsonValue] = {
+        "definition": {
+            "actions": [
+                {
+                    "ref": "step",
+                    "args": {
+                        "items": [
+                            {"ref": "1", "name": "first"},
+                            {"ref": "x", "name": "second"},
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+
+    patched = apply_json_patch_operations(
+        document=document,
+        patch_ops=[
+            _op(
+                op="replace",
+                path="/definition/actions/step/args/items/1/name",
+                value="updated",
+            )
+        ],
+    )
+
+    actions = _arr(_obj(patched["definition"])["actions"])
+    items = _arr(_obj(_obj(actions[0])["args"])["items"])
+    assert _obj(items[0])["name"] == "first"
+    assert _obj(items[1])["name"] == "updated"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -904,7 +904,6 @@ def test_build_workflow_edit_document_converts_short_legacy_title() -> None:
         )
 
     error = exc_info.value
-    assert not error.conflict
     assert error.code == "validation_error"
     assert error.details is not None
     assert error.details["type"] == "validation_error"
@@ -1258,7 +1257,56 @@ async def test_edit_workflow_validate_only_does_not_persist(monkeypatch):
 
     assert payload["valid"] is True
     assert payload["validate_only"] is True
+    assert payload["changed_sections"] == ["metadata"]
+    assert payload["no_op"] is False
+    assert payload["rebased"] is False
     assert workflow.title == "Example workflow"
+
+
+@pytest.mark.anyio
+async def test_edit_workflow_validate_only_reports_stale_no_op(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    workflow_id = uuid.uuid4()
+    workflow = _workflow_stub(id=workflow_id)
+
+    class _WorkflowService:
+        def __init__(self) -> None:
+            self.session = object()
+
+        async def get_workflow(self, _wf_id, *, for_update: bool = False):
+            _ = for_update
+            return workflow
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.WorkflowsManagementService,
+        "with_session",
+        lambda role: _AsyncContext(_WorkflowService()),
+    )
+
+    payload = _payload(
+        await _tool(mcp_server.edit_workflow)(
+            workspace_id=str(uuid.uuid4()),
+            workflow_id=str(workflow_id),
+            base_revision="stale-revision",
+            patch_ops=[
+                {
+                    "op": "replace",
+                    "path": "/metadata/title",
+                    "value": workflow.title,
+                }
+            ],
+            validate_only=True,
+        )
+    )
+
+    assert payload["valid"] is True
+    assert payload["validate_only"] is True
+    assert payload["changed_sections"] == []
+    assert payload["no_op"] is True
+    assert payload["rebased"] is True
 
 
 @pytest.mark.anyio
@@ -1839,7 +1887,7 @@ async def test_edit_workflow_validate_only_revision_drops_inert_case_trigger(
 
 
 @pytest.mark.anyio
-async def test_edit_workflow_rejects_stale_revision(monkeypatch):
+async def test_edit_workflow_rejects_numeric_action_index(monkeypatch):
     async def _resolve(_workspace_id):
         return uuid.uuid4(), SimpleNamespace()
 
@@ -1881,19 +1929,23 @@ async def test_edit_workflow_rejects_stale_revision(monkeypatch):
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
+    # Numeric indexes into the actions array are always rejected at apply time,
+    # regardless of staleness: actions must be addressed by ref.
     with pytest.raises(ToolError) as exc_info:
         await _tool(mcp_server.edit_workflow)(
             workspace_id=str(uuid.uuid4()),
             workflow_id=str(workflow_id),
             base_revision="stale-revision",
             patch_ops=[
-                {"op": "replace", "path": "/metadata/title", "value": "Updated flow"}
+                {
+                    "op": "replace",
+                    "path": "/definition/actions/0/args/value",
+                    "value": "Updated flow",
+                }
             ],
         )
 
-    payload = cast(dict[str, Any], exc_info.value.args[0])
-    assert payload["status"] == "conflict"
-    assert payload["current_revision"]
+    assert "Address actions by ref" in str(exc_info.value.args[0])
 
 
 @pytest.mark.parametrize(
@@ -10346,3 +10398,164 @@ def test_validate_patch_payload_wraps_nested_tracecat_validation_error() -> None
     assert error.details is not None
     assert error.details["type"] == "validation_error"
     assert "interaction" in error.message.lower()
+
+
+# --- Fix 1: action environment survives the edit round-trip ---------------
+
+
+def test_build_edit_document_preserves_action_environment() -> None:
+    """A control_flow.environment on an action survives build -> patch -> rebuild."""
+    action = _action_stub(control_flow={"environment": "prod"})
+    workflow = _workflow_stub(actions=[action])
+    document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
+    )
+    stmt = document.definition.actions[0]
+    assert stmt.environment == "prod"
+
+
+def test_patch_action_environment_changes_revision() -> None:
+    """Patching an action's environment yields a changed section + new revision."""
+    payload = _minimal_edit_document_payload()
+    original = draft.WorkflowEditDocument.model_validate(payload)
+    original_revision = draft.compute_workflow_edit_revision(original)
+
+    patched_payload = draft.apply_json_patch_operations(
+        document=draft.workflow_edit_document_payload(original),
+        patch_ops=[
+            mcp_server.JsonPatchOperation.model_validate(
+                {
+                    "op": "replace",
+                    "path": "/definition/actions/a/environment",
+                    "value": "staging",
+                }
+            )
+        ],
+    )
+    updated = draft.validate_workflow_patch_payload(patched_payload)
+
+    assert updated.definition.actions[0].environment == "staging"
+    changed = draft.workflow_edit_document_changed_sections(original, updated)
+    assert "definition" in changed
+    assert draft.compute_workflow_edit_revision(updated) != original_revision
+
+
+# --- Fix 5: rebase classification -----------------------------------------
+
+
+def _doc_with_action_refs(*refs: str) -> draft.WorkflowEditDocument:
+    payload = _minimal_edit_document_payload()
+    payload["definition"]["entrypoint"] = {"ref": refs[0], "expects": {}}
+    payload["definition"]["actions"] = [
+        {"ref": ref, "action": "core.transform.reshape", "args": {"value": i}}
+        for i, ref in enumerate(refs)
+    ]
+    return draft.WorkflowEditDocument.model_validate(payload)
+
+
+@pytest.mark.anyio
+async def test_validate_edit_document_surfaces_unknown_action_ref_details() -> None:
+    """A stale ``ACTIONS.<ref>`` expression (e.g. after a rename) surfaces the
+    structured ``unknown_action_ref`` detail through the edit path, not an opaque
+    message-only error.
+
+    ``workflow_edit_document_to_dsl`` builds a ``DSLInput`` whose validator raises
+    ``TracecatDSLError`` with a ``detail`` payload; ``validate_workflow_edit_document``
+    must forward it as ``details`` under the ``validation_error`` code. This is a
+    definition-shape check that does not require a DB, so ``validate_definition``
+    is left False.
+    """
+    payload = _minimal_edit_document_payload()
+    # Action ``b`` references ``old_ref`` which does not exist (it was renamed).
+    payload["definition"]["actions"] = [
+        {"ref": "a", "action": "core.transform.reshape", "args": {"value": 1}},
+        {
+            "ref": "b",
+            "action": "core.transform.reshape",
+            "args": {"value": "${{ ACTIONS.old_ref.result }}"},
+        },
+    ]
+    document = draft.WorkflowEditDocument.model_validate(payload)
+
+    with pytest.raises(draft.WorkflowEditError) as exc_info:
+        await draft.validate_workflow_edit_document(
+            document,
+            workflow_id=mcp_server.WorkflowUUID.new_uuid4(),
+            validate_definition=False,
+        )
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["type"] == "unknown_action_ref"
+    assert error.details["missing_ref"] == "old_ref"
+    assert "a" in error.details["available_refs"]
+    assert "b" in error.details["available_refs"]
+
+
+def test_apply_or_rebase_direct_when_revision_matches() -> None:
+    head = _doc_with_action_refs("a", "b")
+    revision = draft.compute_workflow_edit_revision(head)
+    request = draft.parse_workflow_edit_request(
+        base_revision=revision,
+        patch_ops=[
+            {"op": "replace", "path": "/definition/actions/b/args/value", "value": 9}
+        ],
+        validate_only=False,
+    )
+    updated, rebased = draft.apply_or_rebase_patch(
+        head_document=head, request=request, current_revision=revision
+    )
+    assert rebased is False
+    assert updated.definition.actions[1].args["value"] == 9
+
+
+def test_apply_or_rebase_replays_safe_ops_on_stale_base() -> None:
+    head = _doc_with_action_refs("a", "b")
+    revision = draft.compute_workflow_edit_revision(head)
+    request = draft.parse_workflow_edit_request(
+        base_revision="stale-revision",
+        patch_ops=[
+            {"op": "replace", "path": "/definition/actions/b/args/value", "value": 42}
+        ],
+        validate_only=False,
+    )
+    updated, rebased = draft.apply_or_rebase_patch(
+        head_document=head, request=request, current_revision=revision
+    )
+    assert rebased is True
+    assert updated.definition.actions[1].args["value"] == 42
+
+
+def test_apply_or_rebase_rejects_numeric_action_index() -> None:
+    head = _doc_with_action_refs("a", "b")
+    revision = draft.compute_workflow_edit_revision(head)
+    request = draft.parse_workflow_edit_request(
+        base_revision=revision,
+        patch_ops=[
+            {"op": "replace", "path": "/definition/actions/0/args/value", "value": 1}
+        ],
+        validate_only=False,
+    )
+    with pytest.raises(ToolError, match="Address actions by ref"):
+        draft.apply_or_rebase_patch(
+            head_document=head, request=request, current_revision=revision
+        )
+
+
+def test_apply_or_rebase_all_digit_ref_resolves_not_rejected() -> None:
+    head = _doc_with_action_refs("1", "b")  # action ref "1" exists
+    revision = draft.compute_workflow_edit_revision(head)
+    request = draft.parse_workflow_edit_request(
+        base_revision=revision,
+        patch_ops=[
+            {"op": "replace", "path": "/definition/actions/1/args/value", "value": 9}
+        ],
+        validate_only=False,
+    )
+    updated, rebased = draft.apply_or_rebase_patch(
+        head_document=head, request=request, current_revision=revision
+    )
+    assert rebased is False
+    action_1 = next(a for a in updated.definition.actions if a.ref == "1")
+    assert action_1.args["value"] == 9

--- a/tests/unit/test_workflow_edit_document_integration.py
+++ b/tests/unit/test_workflow_edit_document_integration.py
@@ -1,0 +1,215 @@
+"""DB-backed integration tests for the workflow edit-document persist path.
+
+Covers customer-feedback fixes:
+- Fix 1: action ``environment`` survives an edit-document round-trip.
+- Fix 5: server-side rebase of ref-addressed ops under a stale base revision.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tracecat.auth.types import Role
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.workflow.management.draft import (
+    apply_or_rebase_patch,
+    build_workflow_edit_document,
+    compute_workflow_edit_revision,
+    parse_workflow_edit_request,
+    persist_workflow_edit_document,
+)
+from tracecat.workflow.management.management import WorkflowsManagementService
+from tracecat.workflow.management.schemas import ExternalWorkflowDefinition
+
+pytestmark = pytest.mark.usefixtures("registry_version_with_manifest")
+
+
+def _import_definition() -> dict[str, Any]:
+    dsl = ExternalWorkflowDefinition.model_validate(
+        {
+            "workflow_id": WorkflowUUID.new_uuid4(),
+            "definition": {
+                "title": "Edit round-trip workflow",
+                "description": "",
+                "entrypoint": {"expects": {}, "ref": "a"},
+                "actions": [
+                    {
+                        "ref": "a",
+                        "action": "core.transform.reshape",
+                        "args": {"value": 1},
+                    },
+                    {
+                        "ref": "b",
+                        "action": "core.transform.reshape",
+                        "args": {"value": 2},
+                        "depends_on": ["a"],
+                    },
+                ],
+            },
+        }
+    )
+    return dsl.model_dump(mode="json")
+
+
+async def _create_workflow(service: WorkflowsManagementService):
+    return await service.create_workflow_from_external_definition(_import_definition())
+
+
+@pytest.mark.anyio
+async def test_environment_patch_survives_persist(test_role: Role) -> None:
+    """Fix 1: patching an action's environment persists and bumps the revision."""
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await _create_workflow(service)
+
+        document = build_workflow_edit_document(workflow)
+        original_revision = compute_workflow_edit_revision(document)
+
+        request = parse_workflow_edit_request(
+            base_revision=original_revision,
+            patch_ops=[
+                {
+                    "op": "replace",
+                    "path": "/definition/actions/b/environment",
+                    "value": "prod",
+                }
+            ],
+            validate_only=False,
+        )
+        updated_document, _ = apply_or_rebase_patch(
+            head_document=document,
+            request=request,
+            current_revision=original_revision,
+        )
+        changed = await persist_workflow_edit_document(
+            role=test_role,
+            service=service,
+            workflow=workflow,
+            original_document=document,
+            updated_document=updated_document,
+        )
+        assert "definition" in changed
+
+        await service.session.refresh(workflow, ["actions"])
+        rebuilt = build_workflow_edit_document(workflow)
+        action_b = next(a for a in rebuilt.definition.actions if a.ref == "b")
+        assert action_b.environment == "prod"
+        assert compute_workflow_edit_revision(rebuilt) != original_revision
+
+
+@pytest.mark.anyio
+async def test_no_op_patch_returns_empty_changed_sections(test_role: Role) -> None:
+    """Fix 1: a patch that changes nothing persists no sections (no_op signal)."""
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await _create_workflow(service)
+
+        document = build_workflow_edit_document(workflow)
+        # Replace a value with its current value -> no net change.
+        current_value = next(
+            a for a in document.definition.actions if a.ref == "b"
+        ).args["value"]
+        revision = compute_workflow_edit_revision(document)
+        request = parse_workflow_edit_request(
+            base_revision=revision,
+            patch_ops=[
+                {
+                    "op": "replace",
+                    "path": "/definition/actions/b/args/value",
+                    "value": current_value,
+                }
+            ],
+            validate_only=False,
+        )
+        updated_document, _ = apply_or_rebase_patch(
+            head_document=document, request=request, current_revision=revision
+        )
+        changed = await persist_workflow_edit_document(
+            role=test_role,
+            service=service,
+            workflow=workflow,
+            original_document=document,
+            updated_document=updated_document,
+        )
+        assert changed == set()
+
+
+@pytest.mark.anyio
+async def test_stale_base_ref_addressed_patch_rebases(test_role: Role) -> None:
+    """Fix 5: a ref-addressed definition patch on a stale base auto-rebases."""
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await _create_workflow(service)
+        document = build_workflow_edit_document(workflow)
+        head_revision = compute_workflow_edit_revision(document)
+
+        # Simulate the client holding a stale base revision (a concurrent
+        # layout-only change happened). The ref-addressed op is safe to replay.
+        request = parse_workflow_edit_request(
+            base_revision="stale-client-revision",
+            patch_ops=[
+                {
+                    "op": "replace",
+                    "path": "/definition/actions/b/args/value",
+                    "value": 99,
+                }
+            ],
+            validate_only=False,
+        )
+        updated_document, rebased = apply_or_rebase_patch(
+            head_document=document,
+            request=request,
+            current_revision=head_revision,
+        )
+        assert rebased is True
+
+        changed = await persist_workflow_edit_document(
+            role=test_role,
+            service=service,
+            workflow=workflow,
+            original_document=document,
+            updated_document=updated_document,
+        )
+        assert "definition" in changed
+        await service.session.refresh(workflow, ["actions"])
+        rebuilt = build_workflow_edit_document(workflow)
+        action_b = next(a for a in rebuilt.definition.actions if a.ref == "b")
+        assert action_b.args["value"] == 99
+
+
+@pytest.mark.anyio
+async def test_graph_version_bumps_on_rebased_definition_persist(
+    test_role: Role,
+) -> None:
+    """Fix 5: a rebased definition persist bumps graph_version."""
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await _create_workflow(service)
+        before_version = workflow.graph_version
+        document = build_workflow_edit_document(workflow)
+        head_revision = compute_workflow_edit_revision(document)
+
+        request = parse_workflow_edit_request(
+            base_revision="stale-client-revision",
+            patch_ops=[
+                {
+                    "op": "replace",
+                    "path": "/definition/actions/b/args/value",
+                    "value": 7,
+                }
+            ],
+            validate_only=False,
+        )
+        updated_document, rebased = apply_or_rebase_patch(
+            head_document=document,
+            request=request,
+            current_revision=head_revision,
+        )
+        assert rebased is True
+        await persist_workflow_edit_document(
+            role=test_role,
+            service=service,
+            workflow=workflow,
+            original_document=document,
+            updated_document=updated_document,
+        )
+        await service.session.refresh(workflow)
+        assert workflow.graph_version == before_version + 1

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -233,8 +233,22 @@ class DSLInput(BaseModel):
                 expr_ctxs = extract_expressions(value)
                 for dep in expr_ctxs[ExprContext.ACTIONS]:
                     if dep not in valid_action_refs:
+                        field = key2loc(key)
+                        available = sorted(valid_action_refs)
                         raise TracecatDSLError(
-                            f"Action '{action.ref}' has an expression in field '{key2loc(key)}' that references unknown action '{dep}'"
+                            f"Action '{action.ref}' references unknown action "
+                            f"'{dep}' in field '{field}'. Was '{dep}' renamed? "
+                            "Renaming an action changes its ref (the slugified "
+                            "title), which does not update `ACTIONS.<ref>` "
+                            "expressions that point at it. Update the expression "
+                            f"to a valid ref. Available refs: {available}.",
+                            detail={
+                                "type": "unknown_action_ref",
+                                "action_ref": action.ref,
+                                "field": field,
+                                "missing_ref": dep,
+                                "available_refs": available,
+                            },
                         )
 
     def _validate_scatter_gather_scopes(self) -> None:

--- a/tracecat/mcp/json_patch.py
+++ b/tracecat/mcp/json_patch.py
@@ -50,36 +50,83 @@ def _decode_json_pointer(path: str) -> list[str]:
     return [part.replace("~1", "/").replace("~0", "~") for part in path.split("/")[1:]]
 
 
+def is_numeric_index_token(token: str) -> bool:
+    """Return True if a token is a well-formed JSON Pointer array index."""
+    return token == "0" or (
+        token.isascii() and token.isdigit() and not token.startswith("0")
+    )
+
+
+def _is_actions_array_prefix(tokens: list[str], depth: int) -> bool:
+    """True when tokens[:depth] addresses the /definition/actions array."""
+    return depth == 2 and tokens[0] == "definition" and tokens[1] == "actions"
+
+
 def _json_pointer_array_index(
     token: str,
     *,
     length: int,
     allow_end: bool = False,
+    array: JsonArray | None = None,
+    reject_numeric_index: bool = False,
 ) -> int:
-    """Convert an array JSON Pointer token to an integer index."""
+    """Convert an array JSON Pointer token to an integer index.
+
+    In addition to RFC 6902 numeric indexes (and ``-`` for append when
+    ``allow_end``), a token may be an **action ref** (a slug) that addresses an
+    element of the array by its ``ref`` field. Refs may be all-digits, so a
+    ref-match takes precedence over numeric-index interpretation. Ref resolution
+    requires the array elements (``array``) and happens against the array being
+    patched at apply time.
+
+    When ``reject_numeric_index`` is set (the ``/definition/actions`` array),
+    an all-digit token that does not match an existing ref is rejected: actions
+    must be addressed by ref, never by positional index.
+    """
     if allow_end and token == "-":
         return length
-    if token != "0" and (
-        not token.isascii() or not token.isdigit() or token.startswith("0")
-    ):
+    # Ref-match wins over index interpretation.
+    if array is not None:
+        for idx, element in enumerate(array):
+            if isinstance(element, dict) and element.get("ref") == token:
+                return idx
+    if reject_numeric_index and token.isascii() and token.isdigit():
+        raise ToolError(
+            f"Address actions by ref, not by numeric index: {token!r}. The "
+            "/definition/actions array does not accept positional indexes; use "
+            "the action's ref (or '-' to append)."
+        )
+    if is_numeric_index_token(token):
+        index = int(token)
+        max_index = length if allow_end else length - 1
+        if index < 0 or index > max_index:
+            raise ToolError(f"Patch array index out of range: {token!r}")
+        return index
+    # Unmatched all-digit non-canonical tokens (e.g. "01") are malformed indexes.
+    if token.isascii() and token.isdigit():
         raise ToolError(f"Invalid array index in patch path: {token!r}")
-    index = int(token)
-    max_index = length if allow_end else length - 1
-    if index < 0 or index > max_index:
-        raise ToolError(f"Patch array index out of range: {token!r}")
-    return index
+    if array is not None:
+        raise ToolError(f"Patch path ref not found in array: {token!r}")
+    raise ToolError(f"Invalid array index in patch path: {token!r}")
 
 
 def _json_pointer_get(document: JsonValue, path: str) -> JsonValue:
     """Resolve a JSON Pointer path against a document."""
     current = document
-    for token in _decode_json_pointer(path):
+    tokens = _decode_json_pointer(path)
+    for depth, token in enumerate(tokens):
         if isinstance(current, dict):
             if token not in current:
                 raise ToolError(f"Patch path not found: {path!r}")
             current = current[token]
         elif isinstance(current, list):
-            index = _json_pointer_array_index(token, length=len(current))
+            ref_lookup = _is_actions_array_prefix(tokens, depth)
+            index = _json_pointer_array_index(
+                token,
+                length=len(current),
+                array=current if ref_lookup else None,
+                reject_numeric_index=ref_lookup,
+            )
             current = current[index]
         else:
             raise ToolError(f"Patch path not found: {path!r}")
@@ -94,19 +141,30 @@ def _json_pointer_get_parent(
     if not tokens:
         raise ToolError("Patching the document root is not supported")
     parent = document
-    for token in tokens[:-1]:
+    for depth, token in enumerate(tokens[:-1]):
         if isinstance(parent, dict):
             if token not in parent:
                 raise ToolError(f"Patch path not found: {path!r}")
             parent = parent[token]
         elif isinstance(parent, list):
-            index = _json_pointer_array_index(token, length=len(parent))
+            ref_lookup = _is_actions_array_prefix(tokens, depth)
+            index = _json_pointer_array_index(
+                token,
+                length=len(parent),
+                array=parent if ref_lookup else None,
+                reject_numeric_index=ref_lookup,
+            )
             parent = parent[index]
         else:
             raise ToolError(f"Patch path not found: {path!r}")
     if not isinstance(parent, (dict, list)):
         raise ToolError(f"Patch path not found: {path!r}")
     return parent, tokens[-1]
+
+
+def _final_token_targets_actions_array(path: str) -> bool:
+    """True when the final token of ``path`` indexes /definition/actions."""
+    return _decode_json_pointer(path)[:-1] == ["definition", "actions"]
 
 
 def _json_pointer_add(document: JsonValue, path: str, value: JsonValue) -> None:
@@ -116,7 +174,14 @@ def _json_pointer_add(document: JsonValue, path: str, value: JsonValue) -> None:
         parent[token] = value
         return
     if isinstance(parent, list):
-        index = _json_pointer_array_index(token, length=len(parent), allow_end=True)
+        ref_lookup = _final_token_targets_actions_array(path)
+        index = _json_pointer_array_index(
+            token,
+            length=len(parent),
+            allow_end=True,
+            array=parent if ref_lookup else None,
+            reject_numeric_index=ref_lookup,
+        )
         parent.insert(index, value)
         return
     raise ToolError(f"Patch path not found: {path!r}")
@@ -130,7 +195,13 @@ def _json_pointer_remove(document: JsonValue, path: str) -> JsonValue:
             raise ToolError(f"Patch path not found: {path!r}")
         return parent.pop(token)
     if isinstance(parent, list):
-        index = _json_pointer_array_index(token, length=len(parent))
+        ref_lookup = _final_token_targets_actions_array(path)
+        index = _json_pointer_array_index(
+            token,
+            length=len(parent),
+            array=parent if ref_lookup else None,
+            reject_numeric_index=ref_lookup,
+        )
         return parent.pop(index)
     raise ToolError(f"Patch path not found: {path!r}")
 
@@ -144,7 +215,13 @@ def _json_pointer_replace(document: JsonValue, path: str, value: JsonValue) -> N
         parent[token] = value
         return
     if isinstance(parent, list):
-        index = _json_pointer_array_index(token, length=len(parent))
+        ref_lookup = _final_token_targets_actions_array(path)
+        index = _json_pointer_array_index(
+            token,
+            length=len(parent),
+            array=parent if ref_lookup else None,
+            reject_numeric_index=ref_lookup,
+        )
         parent[index] = value
         return
     raise ToolError(f"Patch path not found: {path!r}")

--- a/tracecat/mcp/schemas.py
+++ b/tracecat/mcp/schemas.py
@@ -307,6 +307,12 @@ class WorkflowEditResponse(BaseModel):
     draft_revision: str
     valid: bool | None = None
     validate_only: bool = False
+    changed_sections: list[str] = Field(default_factory=list)
+    """Top-level document sections that changed (e.g. definition, layout)."""
+    no_op: bool = False
+    """True when the patch applied cleanly but produced no change to the document."""
+    rebased: bool = False
+    """True when the patch was replayed against a newer head revision (auto-rebase)."""
 
 
 class WorkflowAuthoringContextRequest(BaseModel):

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -193,7 +193,6 @@ from tracecat.mcp.config import (
     TRACECAT_MCP__RATE_LIMIT_BURST,
     TRACECAT_MCP__RATE_LIMIT_RPS,
 )
-from tracecat.mcp.json_patch import apply_json_patch_operations
 from tracecat.mcp.middleware import (
     MCPInputSizeLimitMiddleware,
     MCPTimeoutMiddleware,
@@ -261,6 +260,7 @@ from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.draft import (
     WorkflowEditError,
     apply_layout_to_workflow,
+    apply_or_rebase_patch,
     build_workflow_edit_document,
     compute_workflow_edit_revision,
     extract_layout_positions,
@@ -270,9 +270,7 @@ from tracecat.workflow.management.draft import (
     replace_workflow_definition_from_dsl,
     replace_workflow_schedules,
     validate_workflow_edit_document,
-    validate_workflow_patch_payload,
     workflow_edit_document_changed_sections,
-    workflow_edit_document_payload,
 )
 from tracecat.workflow.management.folders.service import WorkflowFolderService
 from tracecat.workflow.management.layout import (
@@ -1376,7 +1374,7 @@ def _workflow_edit_error_to_tool_error(error: WorkflowEditError) -> ToolError:
     before the edit-document engine was extracted: structured validation errors
     are JSON-encoded, everything else uses the plain message.
     """
-    if error.code == "validation_error" and error.details is not None:
+    if error.details is not None and error.code == "validation_error":
         return ToolError(json.dumps(error.details, default=str))
     return ToolError(error.message)
 
@@ -2105,12 +2103,32 @@ them and create the smallest RFC 6902 patch that changes the intended fields.
 Call `get_workflow` only when the latest draft is missing, stale, or a revision
 conflict says the draft changed.
 - Patch paths are rooted at `draft_document`, so action edits use
-`/definition/actions/N/...`, not `/actions/N/...`.
+`/definition/actions/...`, not `/actions/...`.
+- Patches always apply to the LATEST revision. If your `base_revision` was stale
+the patch is still applied to the current head and the response reports
+`rebased: true`.
+- Actions MUST be addressed by ref (slug), e.g.
+`/definition/actions/parse_event/args/url`. Numeric indexes into the actions
+array are rejected — use the ref (or `/-` to append). Ref paths also survive
+concurrent reorders.
+- Ops targeting a ref that a concurrent edit deleted/renamed fail loudly —
+refetch with `get_workflow` and retry.
+- Whole-object replaces (an entire action, or a whole container like `args`) and
+any op on `/schedules` or `/layout` are last-write-wins and can clobber a
+concurrent edit. Prefer field-level ops; to guarantee no clobber precede the op
+with a JSON Patch `test` op (a `test` mismatch aborts the whole patch
+atomically).
 - `patch_ops` are applied sequentially. Every successful write returns a new \
-`draft_revision`; use it as the next `base_revision`, or refetch.
+`draft_revision`; use it as the next `base_revision`, or refetch. A patch that \
+changes nothing returns `no_op: true`; a real change lists `changed_sections`.
 - For nontrivial patches, run `edit_workflow(validate_only=true)`, then repeat \
 the same patch with `validate_only=false` and the same `base_revision`.
-- RFC 6902 array rules apply: `/-` appends, and indexes shift after array edits.
+- RFC 6902 array rules apply: `/-` appends. Address actions by ref, never by \
+numeric index.
+- When adding a new action, also add its layout position in the same patch: \
+append `{"ref": "<ref>", "x": <x>, "y": <y>}` to `/layout/actions/-`, placed \
+near/below its parent. Nodes are ~300x300, so offset by at least that; without \
+a layout entry new nodes stack at the origin.
 - Use `update_workflow` without `definition_yaml` for metadata-only updates. Use \
 inline YAML on `create_workflow`/`update_workflow` only for creation or intentional \
 bulk replacement.
@@ -2122,7 +2140,7 @@ bulk replacement.
   "patch_ops": [
     {
       "op": "replace",
-      "path": "/definition/actions/2/args/script",
+      "path": "/definition/actions/parse_event/args/script",
       "value": "def main(): return {'ok': True}"
     },
     {
@@ -2476,15 +2494,24 @@ action: tools.<integration_slug>.search
 ## Common Workflow Patterns
 
 ### HTTP Request
+`core.http_request` returns an envelope `{status_code, headers, data}`. The
+response body is under `.data` (parsed JSON, or text, or `null` for a 204), so
+reference the body as `ACTIONS.<ref>.result.data` — NOT `ACTIONS.<ref>.result`.
+Use `.result.status_code` and `.result.headers` for the status code and headers.
 ```yaml
 actions:
-  - ref: fetch_data
+  - ref: call_api
     action: core.http_request
     args:
       url: "https://api.example.com/data"
       method: GET
       headers:
         Authorization: "Bearer ${{ SECRETS.api_creds.API_TOKEN }}"
+  - ref: use_items
+    action: core.transform.reshape
+    depends_on: [call_api]
+    args:
+      value: ${{ ACTIONS.call_api.result.data.items }}
 ```
 
 ### Scatter/Gather (Parallel Fan-out/Fan-in)
@@ -2564,8 +2591,11 @@ actions:
 ```
 
 ### HTTP Pagination
-`core.http_paginate` returns a list of items from `items_jsonpath`; reference
-`ACTIONS.<ref>.result` directly as the list, not `.items` or `.data`.
+`core.http_paginate` returns the already-unwrapped list of items from
+`items_jsonpath`; reference `ACTIONS.<ref>.result` directly as the list, NOT
+`.items` or `.data`. This contrasts with `core.http_request`, which wraps the
+response body under `.data` (`ACTIONS.<ref>.result.data`) — paginate does the
+unwrapping for you, http_request does not.
 `stop_condition` and `next_request` are Python lambda strings.
 ```yaml
 actions:
@@ -3288,7 +3318,27 @@ async def edit_workflow(
     patch_ops: list[JsonPatchOperation],
     validate_only: bool = False,
 ) -> WorkflowEditResponse:
-    """Edit a draft workflow using RFC 6902 JSON Patch."""
+    """Edit a draft workflow using RFC 6902 JSON Patch.
+
+    Patches always apply to the LATEST revision: if your ``base_revision`` was
+    stale the patch is still applied to the current head and the response reports
+    ``rebased: true``. Actions MUST be addressed by ref (slug), e.g.
+    ``/definition/actions/parse_events/args/url``; numeric indexes into the
+    actions array are rejected — use the ref (or ``/-`` to append). Ref paths also
+    survive concurrent reorders. An op targeting a ref that a concurrent edit
+    deleted or renamed fails loudly — re-fetch with ``get_workflow`` and retry.
+    Whole-object replaces (an entire action, or a whole container like ``args``)
+    and any op on ``/schedules`` or ``/layout`` are last-write-wins and can
+    clobber a concurrent edit. Prefer field-level ops; to guarantee no clobber,
+    precede the op with a JSON Patch ``test`` op asserting the expected current
+    value (a ``test`` mismatch aborts the whole patch atomically). When adding a
+    new action, also add its layout
+    position in the same patch: append ``{"ref": "<ref>", "x": <x>, "y": <y>}``
+    to ``/layout/actions/-``, placed near/below its parent (nodes are ~300x300,
+    so offset by at least that); without a layout entry new nodes stack at the
+    origin. A patch that applies but changes nothing returns ``no_op: true``;
+    otherwise ``changed_sections`` lists the document sections that changed.
+    """
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
@@ -3306,21 +3356,11 @@ async def edit_workflow(
 
             draft_document = build_workflow_edit_document(workflow)
             current_revision = compute_workflow_edit_revision(draft_document)
-            if request.base_revision != current_revision:
-                raise ToolError(
-                    {
-                        "type": "conflict",
-                        "status": "conflict",
-                        "message": "Draft revision mismatch",
-                        "current_revision": current_revision,
-                    }
-                )
-
-            patched_payload = apply_json_patch_operations(
-                document=workflow_edit_document_payload(draft_document),
-                patch_ops=request.patch_ops,
+            updated_document, rebased = apply_or_rebase_patch(
+                head_document=draft_document,
+                request=request,
+                current_revision=current_revision,
             )
-            updated_document = validate_workflow_patch_payload(patched_payload)
             changed_sections = workflow_edit_document_changed_sections(
                 draft_document,
                 updated_document,
@@ -3348,15 +3388,29 @@ async def edit_workflow(
                             updated_document
                         )
                     ),
+                    changed_sections=sorted(changed_sections),
+                    no_op=not changed_sections,
+                    rebased=rebased,
                 )
 
-            await persist_workflow_edit_document(
+            persisted_sections = await persist_workflow_edit_document(
                 role=role,
                 service=svc,
                 workflow=workflow,
                 original_document=draft_document,
                 updated_document=updated_document,
             )
+            if not persisted_sections:
+                return WorkflowEditResponse(
+                    message=(
+                        "no changes detected — document unchanged after applying patch"
+                    ),
+                    workflow_id=str(workflow.id),
+                    draft_revision=current_revision,
+                    no_op=True,
+                    changed_sections=[],
+                    rebased=rebased,
+                )
             await svc.session.refresh(
                 workflow,
                 ["actions", "schedules", "case_trigger"],
@@ -3366,6 +3420,8 @@ async def edit_workflow(
                 message=f"Workflow {workflow_id} updated successfully",
                 workflow_id=str(workflow.id),
                 draft_revision=compute_workflow_edit_revision(refreshed_document),
+                changed_sections=sorted(persisted_sections),
+                rebased=rebased,
             )
     except WorkflowEditError as e:
         raise _workflow_edit_error_to_tool_error(e) from e

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -15,7 +15,6 @@ from starlette.status import (
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
     HTTP_404_NOT_FOUND,
-    HTTP_409_CONFLICT,
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
@@ -45,7 +44,6 @@ from tracecat.identifiers.workflow import (
     WorkflowUUID,
 )
 from tracecat.logger import logger
-from tracecat.mcp.json_patch import apply_json_patch_operations
 from tracecat.mcp.schemas import (
     JsonPatchOperation,
     WorkflowAuthoringContextRequest,
@@ -65,15 +63,14 @@ from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.draft import (
     WorkflowEditError,
+    apply_or_rebase_patch,
     build_workflow_edit_document,
     compute_workflow_edit_revision,
     normalize_workflow_edit_document_for_persisted_revision,
     parse_workflow_edit_request,
     persist_workflow_edit_document,
     validate_workflow_edit_document,
-    validate_workflow_patch_payload,
     workflow_edit_document_changed_sections,
-    workflow_edit_document_payload,
 )
 from tracecat.workflow.management.layout import (
     WorkflowActionLayoutInput,
@@ -393,22 +390,7 @@ class InternalWorkflowEditRequest(BaseModel):
 
 
 def _raise_workflow_edit_http_error(error: WorkflowEditError) -> None:
-    """Map a transport-neutral edit error onto an HTTP error.
-
-    Revision conflicts become 409 (carrying ``current_revision`` so the caller
-    can refetch and retry); everything else becomes 400 with the same message
-    or structured ``details`` payload the engine produced.
-    """
-    if error.conflict:
-        raise HTTPException(
-            status_code=HTTP_409_CONFLICT,
-            detail={
-                "type": "conflict",
-                "status": "conflict",
-                "message": error.message,
-                "current_revision": error.current_revision,
-            },
-        )
+    """Map a transport-neutral edit error onto a 400 HTTP error."""
     raise HTTPException(
         status_code=HTTP_400_BAD_REQUEST,
         detail=error.details if error.details is not None else error.message,
@@ -457,7 +439,8 @@ async def edit_workflow_document(
     """Apply RFC 6902 JSON Patch operations to a workflow draft.
 
     Mirrors the MCP ``edit_workflow`` tool, reusing the shared edit-document
-    engine so behavior matches exactly. A stale ``base_revision`` yields 409.
+    engine so behavior matches exactly. A stale ``base_revision`` is rebased
+    onto the current head (``rebased: true``).
     """
     wf_id = workflow_id  # AnyWorkflowIDPath validates the id -> 422 not 500
     service = WorkflowsManagementService(session, role)
@@ -477,18 +460,11 @@ async def edit_workflow_document(
 
         draft_document = build_workflow_edit_document(workflow)
         current_revision = compute_workflow_edit_revision(draft_document)
-        if request.base_revision != current_revision:
-            raise WorkflowEditError(
-                "Draft revision mismatch",
-                conflict=True,
-                current_revision=current_revision,
-            )
-
-        patched_payload = apply_json_patch_operations(
-            document=workflow_edit_document_payload(draft_document),
-            patch_ops=request.patch_ops,
+        updated_document, rebased = apply_or_rebase_patch(
+            head_document=draft_document,
+            request=request,
+            current_revision=current_revision,
         )
-        updated_document = validate_workflow_patch_payload(patched_payload)
         changed_sections = workflow_edit_document_changed_sections(
             draft_document,
             updated_document,
@@ -516,15 +492,29 @@ async def edit_workflow_document(
                         updated_document
                     )
                 ),
+                changed_sections=sorted(changed_sections),
+                no_op=not changed_sections,
+                rebased=rebased,
             )
 
-        await persist_workflow_edit_document(
+        persisted_sections = await persist_workflow_edit_document(
             role=role,
             service=service,
             workflow=workflow,
             original_document=draft_document,
             updated_document=updated_document,
         )
+        if not persisted_sections:
+            return WorkflowEditResponse(
+                message=(
+                    "no changes detected — document unchanged after applying patch"
+                ),
+                workflow_id=str(workflow.id),
+                draft_revision=current_revision,
+                no_op=True,
+                changed_sections=[],
+                rebased=rebased,
+            )
         await service.session.refresh(
             workflow,
             ["actions", "schedules", "case_trigger"],
@@ -534,13 +524,15 @@ async def edit_workflow_document(
             message=f"Workflow {wf_id} updated successfully",
             workflow_id=str(workflow.id),
             draft_revision=compute_workflow_edit_revision(refreshed_document),
+            changed_sections=sorted(persisted_sections),
+            rebased=rebased,
         )
     except WorkflowEditError as e:
         _raise_workflow_edit_http_error(e)
         raise  # unreachable; satisfies type checker
     except ToolError as e:
-        # apply_json_patch_operations raises ToolError on bad patch application
-        # (bad path/index, failed `test`). Mirror the MCP tool: 400 not 500.
+        # Patch application (inside apply_or_rebase_patch) raises ToolError on a
+        # bad path/index or failed `test`. Mirror the MCP tool: 400 not 500.
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
             detail=str(e),

--- a/tracecat/workflow/management/draft.py
+++ b/tracecat/workflow/management/draft.py
@@ -39,7 +39,10 @@ from tracecat.dsl.common import (
 from tracecat.dsl.schemas import DSLConfig
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.identifiers.workflow import WorkflowUUID
-from tracecat.mcp.json_patch import validate_patch_paths
+from tracecat.mcp.json_patch import (
+    apply_json_patch_operations,
+    validate_patch_paths,
+)
 from tracecat.mcp.schemas import (
     JsonPatchOperation,
     WorkflowEditDefinition,
@@ -72,9 +75,8 @@ class WorkflowEditError(Exception):
 
     Callers map this onto their transport error type while preserving the
     message and structured payload. ``code``/``details`` reconstruct the
-    JSON payloads that the MCP server previously embedded directly in
-    ``ToolError`` (``{"type": "validation_error", ...}`` and
-    ``{"type": "conflict", ...}``).
+    ``{"type": "validation_error", ...}`` JSON payload that the MCP server
+    previously embedded directly in ``ToolError``.
     """
 
     def __init__(
@@ -83,15 +85,11 @@ class WorkflowEditError(Exception):
         *,
         code: str | None = None,
         details: dict[str, Any] | None = None,
-        conflict: bool = False,
-        current_revision: str | None = None,
     ) -> None:
         super().__init__(message)
         self.message = message
         self.code = code
         self.details = details
-        self.conflict = conflict
-        self.current_revision = current_revision
 
 
 _WORKFLOW_EDITABLE_TOP_LEVEL_PATHS = frozenset(
@@ -703,6 +701,15 @@ async def validate_workflow_edit_document(
         try:
             dsl = workflow_edit_document_to_dsl(document)
         except (TracecatValidationError, ValidationError, ValueError) as exc:
+            # Forward structured validator detail (e.g. unknown_action_ref) so
+            # MCP/REST clients receive it.
+            detail = getattr(exc, "detail", None)
+            if isinstance(detail, dict):
+                raise WorkflowEditError(
+                    f"Invalid workflow definition: {exc}",
+                    code="validation_error",
+                    details=detail,
+                ) from exc
             raise WorkflowEditError(f"Invalid workflow definition: {exc}") from exc
         if validate_definition:
             if session is None or role is None:
@@ -844,6 +851,33 @@ def parse_workflow_edit_request(
     return request
 
 
+def apply_or_rebase_patch(
+    *,
+    head_document: WorkflowEditDocument,
+    request: WorkflowEditRequest,
+    current_revision: str,
+) -> tuple[WorkflowEditDocument, bool]:
+    """Apply the request's patch to the current head document.
+
+    Patches always apply to the latest head, so a stale ``base_revision`` is not
+    an error: it just means the patch is rebased onto the current head and
+    ``rebased`` is ``True``. Actions must be addressed by ref (numeric indexes
+    into ``/definition/actions`` are rejected at apply time); ops on refs deleted
+    by a concurrent edit fail loudly so the caller refetches and retries.
+    Whole-object replaces and ``/schedules``//``/layout`` ops are last-write-wins.
+
+    Returns ``(updated_document, rebased)``. Raises :class:`WorkflowEditError` on
+    an invalid patched payload.
+    """
+    rebased = request.base_revision != current_revision
+    patched_payload = apply_json_patch_operations(
+        document=workflow_edit_document_payload(head_document),
+        patch_ops=request.patch_ops,
+    )
+    updated_document = validate_workflow_patch_payload(patched_payload)
+    return updated_document, rebased
+
+
 async def persist_workflow_edit_document(
     *,
     role: Any,
@@ -851,14 +885,18 @@ async def persist_workflow_edit_document(
     workflow: Workflow,
     original_document: WorkflowEditDocument,
     updated_document: WorkflowEditDocument,
-) -> None:
-    """Persist changes from the editable workflow document back to the draft."""
+) -> set[str]:
+    """Persist changes from the editable workflow document back to the draft.
+
+    Returns the set of top-level document sections that changed (empty when the
+    patch was a no-op).
+    """
     changed_sections = workflow_edit_document_changed_sections(
         original_document,
         updated_document,
     )
     if not changed_sections:
-        return
+        return changed_sections
 
     workflow_id = WorkflowUUID.new(workflow.id)
     layout_payload = updated_document.layout.model_dump(mode="json", exclude_none=False)
@@ -984,6 +1022,7 @@ async def persist_workflow_edit_document(
         await service.session.refresh(workflow, ["schedules"])
     if "case_trigger" in changed_sections:
         await service.session.refresh(workflow, ["case_trigger"])
+    return changed_sections
 
 
 async def replace_workflow_definition_from_dsl(

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1559,6 +1559,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 start_delay=act_stmt.start_delay,
                 wait_until=act_stmt.wait_until,
                 join_strategy=act_stmt.join_strategy,
+                environment=act_stmt.environment,
                 mask_output=act_stmt.mask_output,
             )
             pos = (action_positions or {}).get(act_stmt.ref)


### PR DESCRIPTION
Five fixes driven by customer feedback about the Tracecat MCP workflow-authoring experience. All in one branch.

## Fix 1 — action `environment` dropped on edit persist (bug)

**Root cause:** `create_actions_from_dsl` built `ActionControlFlow(...)` without `environment=act_stmt.environment`, so a JSON patch on an action's `environment` via MCP `edit_workflow` validated but persisted as `None`. The change-detector then saw no change and returned the same revision — the edit silently vanished.

**Change:** Add `environment=act_stmt.environment` to the construction. A field-by-field audit of the construction against `ActionControlFlow` found `environment` was the only omission (all other control-flow fields were already present). Also surface no-ops: `edit_workflow` and its REST twin now return `no_op: true` with the message "no changes detected — document unchanged after applying patch" and an (empty) `changed_sections`, instead of a bare success that looks identical to a real edit. Successful edits now list the `changed_sections`.

**Tests:** DB-backed round-trip asserting `environment` survives build → patch → persist → rebuild and the revision hash changes; a no-op persist returns empty `changed_sections`.

## Fix 2 — document the `core.http_request` response envelope

**Root cause:** The action returns `{status_code, headers, data}` but its description/docstring did not say so, so authors referenced `ACTIONS.<ref>.result` instead of `ACTIONS.<ref>.result.data`.

**Change:** Document the envelope in the registry action description and docstring, and in the MCP `_DSL_REFERENCE_TEXT` HTTP section (with a worked `ACTIONS.call_api.result.data.items` example). Also fixed the `core.http_paginate` note to explicitly contrast the two: paginate returns the already-unwrapped list, `http_request` wraps the body under `.data`.

**Tests:** Existing `core.http` action tests pass; the description is read from the decorator at runtime (no generated artifact to regenerate).

## Fix 3 — incremental layout for actions added via `edit_workflow`

**Root cause:** New refs (present in the definition, absent from the layout) defaulted to `{x:0, y:0}` and stacked on top of the trigger; the edit-persist path never ran auto-layout.

**Change:** Added `place_new_nodes(new_refs, actions, existing_layout)` in `layout.py`: place a new node one row below its positioned parents, centered on their midpoint; orphans go below the bottom-most existing node; empty layouts fall back to `auto_generate_layout` rows; a collision nudge shifts right by `NODE_WIDTH` until clear. Wired into the persist path for **genuinely-new** refs only (relative to the original document), so a deliberate layout reset on an existing action still falls back to `(0,0)`. Existing positions are never moved. The `validate_only` revision uses the same placement so dry-run and post-persist revisions agree (otherwise the next edit would 409). The graph `add_node` REST path is untouched (the UI sends positions).

**Tests:** `place_new_nodes` unit tests (single/multi-parent, orphan, collision, existing-untouched); DB-backed integration asserting a newly added action is off-origin while existing positions are unchanged.

## Fix 4 — rename validation UX (spike, then minimal fix)

**Repro finding:** In a workflow where action B references `ACTIONS.<a_ref>` in its args, renaming action A so its ref changes (e.g. `parse_events` → `parse_alerts`) leaves B's stale expression pointing at the old ref. Validation fails in `DSLInput._all_action_expressions_valid` with:

> `Action 'use_it' has an expression in field 'inputs' that references unknown action 'parse_events'`

The message named neither the valid refs nor the rename cause. Separately, a **dangling `entrypoint.ref` is not validated at all** (no error), so there was no entrypoint check to relax.

**Change:** The stale-expression error now names the missing ref, lists the available refs, hints that renaming an action changes its ref, and carries a machine-readable `detail` (`type: unknown_action_ref`, `action_ref`, `field`, `missing_ref`, `available_refs`) — structured fields, not string matching. No rename propagation into expressions was added.

**Tests:** Repro test asserting the new message and structured `detail`.

## Fix 5 — server-side rebase for `edit_workflow` revision conflicts

**Change:**
- **Ref-addressed action paths:** `json_patch` resolves an action-array path segment addressed by ref (slug) to its index at apply time, against the document being patched. Refs are never all-digits, so numeric indexes stay unambiguous (a leading-zero token like `01` is still a malformed index, never a ref). Supported for `add/remove/replace/move/copy/test` and `from` paths; numeric indexes keep working.
- **Bounded rebase loop:** On a revision mismatch, `edit_workflow` and its REST twin classify ops against head. Safe to replay: ref-addressed actions ops whose ref exists at head, ops on non-action sections, and appends (`/-`). Unsafe: numeric-index actions ops, ops whose target ref no longer exists, and whole-actions-array rewrites. All-safe → replay against head and persist with `rebased: true` and the new revision. Any unsafe op raises the structured conflict enriched with `unrebasable_op_index` and machine-readable `reason` (`numeric_index` / `ref_deleted` / `whole_actions_array`) plus guidance to re-fetch and use ref-addressed paths. Bounded to 3 attempts (converges in one under the row lock).
- **Serialization finding:** Both edit paths already acquire a `FOR UPDATE` lock on the workflow row via `get_workflow(for_update=True)`, and the graph service's `apply_operations` locks the same row in the same order — so check-replay-persist is already atomic and **no additional locking was needed**.
- **Docs:** `edit_workflow` docstring and the MCP DSL reference now tell agents to prefer ref-addressed paths.

**Tests:** pointer-resolution unit tests (ref paths, numeric paths, all-digit-ref impossibility, `from` paths, ref-not-found); rebase classification and `apply_or_rebase_patch` (safe replay, numeric-index and deleted-ref structured conflicts); DB-backed integration (stale-base ref-addressed patch auto-rebases; `graph_version` bumps on a rebased definition persist).

## Verification

- `uv run ruff check .` — clean; `uv run ruff format --check .` — clean.
- `uv run basedpyright --warnings --threads 4` — 0 errors, 0 warnings.
- `uv run pytest tests/unit -n auto` — 6071 passed; the only 2 failures are pre-existing, environment-specific agent-sandbox tests (`test_agent_sandbox_litellm`, `test_agent_sandbox_nsjail`) unrelated to this change.
- Frontend client regen produced no diff (the `WorkflowEditResponse` fields live on the executor-internal router, not the public client); `pnpm -C frontend run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves MCP workflow editing: patches always apply to the latest draft (auto‑rebase), action edits must target actions by `ref`, and responses now include `changed_sections`, `no_op`, and `rebased` across MCP and the internal REST route.

- **New Features**
  - JSON Patch: resolve `/definition/actions/<ref>` for add/remove/replace/move/copy/test (and `from`); reject numeric indexes into the actions array; `/-` appends. All‑digit tokens resolve by `ref` when present; nested arrays are not ref‑aware.
  - Auto‑rebase: stale `base_revision` patches replay on head and return `rebased: true`; `validate_only` mirrors this. No‑op patches return `no_op: true`; real changes list `changed_sections`.
  - API/docs: `WorkflowEditResponse` adds `changed_sections`, `no_op`, `rebased`. `edit_workflow` docs emphasize ref paths, latest‑head apply, and adding layout positions when creating actions. `core.http_request` docs clarify the `{status_code, headers, data}` envelope and contrast with `core.http_paginate`.

- **Bug Fixes**
  - Preserve action `environment` through edit/persist; changes persist and bump the revision.
  - Rename validation UX: errors now name the missing ref, list available refs, hint at rename, and include structured `detail` (`type: unknown_action_ref`).

<sup>Written for commit 98374535238396a1d533bba2c00655180461797d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

