### PR TITLE
feat(db): add global soft-delete query filter

### DIFF
--- a/tests/unit/test_soft_delete_filter.py
+++ b/tests/unit/test_soft_delete_filter.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from tracecat.db.engine import (
+    get_async_engine,
+    get_async_session_bypass_rls_context_manager,
+)
+from tracecat.db.models import AgentFolder, AgentPreset, Workspace
+from tracecat.db.soft_delete import (
+    assert_soft_delete_listener_registered,
+    with_deleted,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+def _slug(label: str) -> str:
+    return f"soft-delete-{label}-{uuid.uuid4().hex[:8]}"
+
+
+def _agent_preset(
+    workspace_id: uuid.UUID,
+    *,
+    slug: str,
+    folder_id: uuid.UUID | None = None,
+    deleted: bool = False,
+) -> AgentPreset:
+    return AgentPreset(
+        workspace_id=workspace_id,
+        name=slug,
+        slug=slug,
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        folder_id=folder_id,
+        deleted_at=datetime.now(UTC) if deleted else None,
+    )
+
+
+async def _create_live_and_deleted_presets(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> tuple[str, str]:
+    live_slug = _slug("live")
+    deleted_slug = _slug("deleted")
+    session.add_all(
+        [
+            _agent_preset(workspace_id, slug=live_slug),
+            _agent_preset(workspace_id, slug=deleted_slug, deleted=True),
+        ]
+    )
+    await session.commit()
+    return live_slug, deleted_slug
+
+
+@pytest.mark.anyio
+async def test_entity_select_hides_tombstones_and_with_deleted_opts_out(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+) -> None:
+    """Entity selects hide tombstones unless the statement opts out."""
+    live_slug, deleted_slug = await _create_live_and_deleted_presets(
+        session,
+        svc_workspace.id,
+    )
+    stmt = (
+        select(AgentPreset)
+        .where(AgentPreset.slug.in_([live_slug, deleted_slug]))
+        .order_by(AgentPreset.slug)
+    )
+
+    active = (await session.scalars(stmt)).all()
+    all_rows = (await session.scalars(with_deleted(stmt))).all()
+
+    assert [preset.slug for preset in active] == [live_slug]
+    assert [preset.slug for preset in all_rows] == sorted([live_slug, deleted_slug])
+
+
+@pytest.mark.anyio
+async def test_mapped_column_tuple_select_is_filtered(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+) -> None:
+    """Mapped-column tuple selects are filtered by the ORM criteria."""
+    live_slug, deleted_slug = await _create_live_and_deleted_presets(
+        session,
+        svc_workspace.id,
+    )
+
+    result = await session.execute(
+        select(AgentPreset.id, AgentPreset.slug)
+        .where(AgentPreset.slug.in_([live_slug, deleted_slug]))
+        .order_by(AgentPreset.slug)
+    )
+    rows = result.tuples().all()
+
+    # SQLAlchemy keeps mapped-column tuples ORM-enabled, so the global criteria
+    # applies; explicit active-only predicates still stay on service projections.
+    assert [slug for _preset_id, slug in rows] == [live_slug]
+
+
+@pytest.mark.anyio
+async def test_joined_entity_filters_aliased_soft_deleted_rows(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+) -> None:
+    """Aliased joins to soft-deletable entities filter tombstones."""
+    live_folder = AgentFolder(
+        workspace_id=svc_workspace.id,
+        name=_slug("live-folder"),
+        path=f"/{_slug('live-folder')}/",
+    )
+    deleted_folder = AgentFolder(
+        workspace_id=svc_workspace.id,
+        name=_slug("deleted-folder"),
+        path=f"/{_slug('deleted-folder')}/",
+    )
+    session.add_all([live_folder, deleted_folder])
+    await session.flush()
+
+    session.add_all(
+        [
+            _agent_preset(
+                svc_workspace.id,
+                slug=_slug("joined-live"),
+                folder_id=live_folder.id,
+            ),
+            _agent_preset(
+                svc_workspace.id,
+                slug=_slug("joined-deleted"),
+                folder_id=deleted_folder.id,
+                deleted=True,
+            ),
+        ]
+    )
+    await session.commit()
+
+    preset_alias = aliased(AgentPreset)
+    result = await session.scalars(
+        select(AgentFolder)
+        .join(preset_alias, preset_alias.folder_id == AgentFolder.id)
+        .where(AgentFolder.id.in_([live_folder.id, deleted_folder.id]))
+        .order_by(AgentFolder.name)
+    )
+
+    assert [folder.id for folder in result.all()] == [live_folder.id]
+
+
+@pytest.mark.anyio
+async def test_relationship_loads_see_tombstones(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+) -> None:
+    """Relationship loads that reach AgentPreset rows see tombstones."""
+    live_slug, deleted_slug = await _create_live_and_deleted_presets(
+        session,
+        svc_workspace.id,
+    )
+
+    session.expire(svc_workspace, ["agent_presets"])
+    await session.refresh(svc_workspace, ["agent_presets"])
+
+    relationship_slugs = {
+        preset.slug
+        for preset in svc_workspace.agent_presets
+        if preset.slug in {live_slug, deleted_slug}
+    }
+    assert relationship_slugs == {live_slug, deleted_slug}
+
+
+@pytest.mark.anyio
+async def test_session_get_cold_filters_and_warm_identity_map_bypasses(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+) -> None:
+    """Cold Session.get filters tombstones; warm identity-map hits return them."""
+    deleted_preset = _agent_preset(
+        svc_workspace.id,
+        slug=_slug("get-cold-deleted"),
+        deleted=True,
+    )
+    live_preset = _agent_preset(svc_workspace.id, slug=_slug("get-warm-live"))
+    session.add_all([deleted_preset, live_preset])
+    await session.commit()
+    deleted_pk = deleted_preset.surrogate_id
+    live_pk = live_preset.surrogate_id
+
+    session.expunge_all()
+    cold_deleted = await session.get(AgentPreset, deleted_pk)
+    assert cold_deleted is None
+
+    loaded = await session.get(AgentPreset, live_pk)
+    assert loaded is not None
+    loaded.deleted_at = datetime.now(UTC)
+    await session.flush()
+
+    warm_deleted = await session.get(AgentPreset, live_pk)
+    assert warm_deleted is loaded
+    assert warm_deleted is not None
+    assert warm_deleted.deleted_at is not None
+
+
+@pytest.mark.anyio
+async def test_bypass_rls_session_still_filters_soft_deleted_rows(
+    svc_workspace: Workspace,
+) -> None:
+    """RLS-bypass sessions still filter tombstones unless opted out."""
+    live_slug = _slug("bypass-live")
+    deleted_slug = _slug("bypass-deleted")
+    slugs = [live_slug, deleted_slug]
+
+    async with get_async_session_bypass_rls_context_manager() as bypass_session:
+        try:
+            bypass_session.add_all(
+                [
+                    _agent_preset(svc_workspace.id, slug=live_slug),
+                    _agent_preset(svc_workspace.id, slug=deleted_slug, deleted=True),
+                ]
+            )
+            await bypass_session.commit()
+
+            stmt = (
+                select(AgentPreset)
+                .where(
+                    AgentPreset.workspace_id == svc_workspace.id,
+                    AgentPreset.slug.in_(slugs),
+                )
+                .order_by(AgentPreset.slug)
+            )
+            active = (await bypass_session.scalars(stmt)).all()
+            all_rows = (await bypass_session.scalars(with_deleted(stmt))).all()
+
+            assert [preset.slug for preset in active] == [live_slug]
+            assert [preset.slug for preset in all_rows] == sorted(slugs)
+        finally:
+            await bypass_session.execute(
+                delete(AgentPreset).where(
+                    AgentPreset.workspace_id == svc_workspace.id,
+                    AgentPreset.slug.in_(slugs),
+                )
+            )
+            await bypass_session.commit()
+
+
+@pytest.mark.anyio
+async def test_update_and_delete_statements_are_unfiltered(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+) -> None:
+    """ORM UPDATE and DELETE statements do not receive soft-delete criteria."""
+    update_slug = _slug("update-deleted")
+    delete_slug = _slug("delete-deleted")
+    session.add_all(
+        [
+            _agent_preset(svc_workspace.id, slug=update_slug, deleted=True),
+            _agent_preset(svc_workspace.id, slug=delete_slug, deleted=True),
+        ]
+    )
+    await session.commit()
+
+    updated_ids = (
+        await session.scalars(
+            update(AgentPreset)
+            .where(AgentPreset.slug == update_slug)
+            .values(name="updated tombstone")
+            .returning(AgentPreset.id)
+            .execution_options(synchronize_session=False)
+        )
+    ).all()
+    deleted_ids = (
+        await session.scalars(
+            delete(AgentPreset)
+            .where(AgentPreset.slug == delete_slug)
+            .returning(AgentPreset.id)
+            .execution_options(synchronize_session=False)
+        )
+    ).all()
+    await session.commit()
+
+    updated = await session.scalar(
+        with_deleted(select(AgentPreset).where(AgentPreset.slug == update_slug))
+    )
+    deleted = await session.scalar(
+        with_deleted(select(AgentPreset).where(AgentPreset.slug == delete_slug))
+    )
+
+    assert len(updated_ids) == 1
+    assert len(deleted_ids) == 1
+    assert updated is not None
+    assert updated.name == "updated tombstone"
+    assert deleted is None
+
+
+def test_soft_delete_listener_startup_assertion_passes() -> None:
+    """Startup assertion passes when the global listener is imported."""
+    assert_soft_delete_listener_registered()
+
+
+@pytest.mark.anyio
+async def test_direct_engine_session_uses_soft_delete_filter(
+    svc_workspace: Workspace,
+) -> None:
+    """Brand-new engine sessions use the listener without conftest sessions."""
+    live_slug = _slug("direct-live")
+    deleted_slug = _slug("direct-deleted")
+    slugs = [live_slug, deleted_slug]
+
+    async with AsyncSession(
+        get_async_engine(), expire_on_commit=False
+    ) as direct_session:
+        try:
+            direct_session.add_all(
+                [
+                    _agent_preset(svc_workspace.id, slug=live_slug),
+                    _agent_preset(svc_workspace.id, slug=deleted_slug, deleted=True),
+                ]
+            )
+            await direct_session.commit()
+
+            stmt = (
+                select(AgentPreset)
+                .where(
+                    AgentPreset.workspace_id == svc_workspace.id,
+                    AgentPreset.slug.in_(slugs),
+                )
+                .order_by(AgentPreset.slug)
+            )
+            active = (await direct_session.scalars(stmt)).all()
+            all_rows = (await direct_session.scalars(with_deleted(stmt))).all()
+
+            assert [preset.slug for preset in active] == [live_slug]
+            assert [preset.slug for preset in all_rows] == sorted(slugs)
+        finally:
+            await direct_session.execute(
+                delete(AgentPreset).where(
+                    AgentPreset.workspace_id == svc_workspace.id,
+                    AgentPreset.slug.in_(slugs),
+                )
+            )
+            await direct_session.commit()

--- a/tests/unit/test_soft_delete_filter.py
+++ b/tests/unit/test_soft_delete_filter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 import uuid
 from datetime import UTC, datetime
 
@@ -300,6 +302,26 @@ async def test_update_and_delete_statements_are_unfiltered(
 def test_soft_delete_listener_startup_assertion_passes() -> None:
     """Startup assertion passes when the global listener is imported."""
     assert_soft_delete_listener_registered()
+
+
+def test_engine_import_wires_listener_in_fresh_interpreter() -> None:
+    """Importing tracecat.db.engine alone registers the listener (fresh interpreter).
+
+    This test process already imported tracecat.db.soft_delete, so in-process
+    checks cannot detect a lost side-effect import in engine.py. A subprocess
+    proves the engine import chain does the wiring on its own.
+    """
+    code = (
+        "import sys\n"
+        "import tracecat.db.engine\n"
+        "assert 'tracecat.db.soft_delete' in sys.modules, (\n"
+        "    'tracecat.db.engine no longer imports tracecat.db.soft_delete; '\n"
+        "    'the global soft-delete listener would be unregistered in prod'\n"
+        ")\n"
+        "from tracecat.db.soft_delete import assert_soft_delete_listener_registered\n"
+        "assert_soft_delete_listener_registered()\n"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True, timeout=60)
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -56,6 +56,7 @@ from tracecat.db.models import (
     Skill,
     SkillVersion,
 )
+from tracecat.db.soft_delete import with_deleted
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.executor.service import get_workspace_variables
@@ -1142,6 +1143,8 @@ class AgentPresetService(BaseWorkspaceService):
         if not include_deleted:
             predicates.append(AgentPreset.deleted_at.is_(None))
         stmt = select(AgentPreset).where(*predicates)
+        if include_deleted:
+            stmt = with_deleted(stmt)
         result = await self.session.execute(stmt)
         return result.scalars().first()
 
@@ -1157,6 +1160,8 @@ class AgentPresetService(BaseWorkspaceService):
         if not include_deleted:
             predicates.append(AgentPreset.deleted_at.is_(None))
         stmt = select(AgentPreset).where(*predicates)
+        if include_deleted:
+            stmt = with_deleted(stmt)
         result = await self.session.execute(stmt)
         return result.scalars().first()
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -116,6 +116,7 @@ from tracecat.db.engine import (
     get_async_session_bypass_rls_context_manager,
 )
 from tracecat.db.rls import set_rls_context_from_role
+from tracecat.db.soft_delete import assert_soft_delete_listener_registered
 from tracecat.deduplicate.internal_router import (
     router as internal_deduplicate_router,
 )
@@ -201,6 +202,7 @@ async def lifespan(app: FastAPI):
     # (not in create_app) because the app module is imported at collection time
     # by tests and OpenAPI generation, before secrets are available.
     get_user_auth_secret()
+    assert_soft_delete_listener_registered()
 
     # Temporal
     # Run in background to avoid blocking startup

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -13,6 +13,7 @@ from tracecat import config
 from tracecat.contexts import ctx_role
 from tracecat.db import (
     session_events,  # noqa: F401  # pyright: ignore[reportUnusedImport] - side effect import to register listeners
+    soft_delete,  # noqa: F401  # pyright: ignore[reportUnusedImport] - side effect import to register listeners
 )
 from tracecat.db.rls import set_rls_context, set_rls_context_from_role
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -120,8 +120,8 @@ class SoftDeleteMixin:
     """Columns-only soft-delete contract.
 
     NULL means the row is live; set means the row is a soft-deleted tombstone.
-    UUID lookups of tombstoned rows remain valid, and a global query filter
-    arrives in a later PR.
+    UUID lookups of tombstoned rows remain valid. Global ORM SELECT filtering
+    lives in ``tracecat.db.soft_delete``.
     """
 
     deleted_at: Mapped[datetime | None] = mapped_column(

--- a/tracecat/db/soft_delete.py
+++ b/tracecat/db/soft_delete.py
@@ -1,0 +1,74 @@
+"""Global ORM criteria for columns-only soft-deleted rows.
+
+Soft-delete state is encoded as ``deleted_at IS NULL`` for live rows and a
+non-NULL timestamp for tombstones. This listener applies only to ORM SELECT
+statements that are not column-refresh or relationship-loader queries; pure
+Core/text statements, relationship loads, UPDATE, and DELETE statements are
+deliberately unfiltered. Relationship loads remain unfiltered so UUID and
+historical access paths can still reach tombstones through already-known
+objects. Warm ``Session.get()`` identity-map hits also bypass SQL and therefore
+bypass this filter.
+
+Use ``with_deleted()`` only for narrow staging, provenance,
+sync-reconciliation, and erasure helpers that intentionally need tombstones.
+Other opt-outs are a review smell. Active-only product paths should keep their
+explicit ``deleted_at IS NULL`` predicates even though this listener makes them
+redundant, so rollback remains safe.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import sqlalchemy.orm
+from sqlalchemy import event
+from sqlalchemy.orm import ORMExecuteState, with_loader_criteria
+from sqlalchemy.sql import Executable
+from sqlalchemy.sql.elements import ColumnElement
+
+from tracecat.db.models import SoftDeleteMixin
+
+INCLUDE_DELETED: Final[str] = "include_deleted"
+
+
+def with_deleted[StatementT: Executable](stmt: StatementT) -> StatementT:
+    """Opt a statement out of the global soft-delete criteria."""
+    return stmt.execution_options(**{INCLUDE_DELETED: True})
+
+
+def _not_deleted_criteria(cls: type[SoftDeleteMixin]) -> ColumnElement[bool]:
+    return cls.deleted_at.is_(None)
+
+
+@event.listens_for(sqlalchemy.orm.Session, "do_orm_execute")
+def _add_soft_delete_criteria(
+    execute_state: ORMExecuteState,
+) -> None:
+    """Apply live-row criteria to top-level ORM SELECT statements."""
+    if (
+        not execute_state.is_select
+        or execute_state.is_column_load
+        or execute_state.is_relationship_load
+        or execute_state.execution_options.get(INCLUDE_DELETED) is True
+    ):
+        return
+
+    execute_state.statement = execute_state.statement.options(
+        with_loader_criteria(
+            SoftDeleteMixin,
+            _not_deleted_criteria,
+            include_aliases=True,
+            propagate_to_loaders=False,
+        )
+    )
+
+
+def assert_soft_delete_listener_registered() -> None:
+    """Fail fast if the global soft-delete listener was not imported."""
+    if event.contains(
+        sqlalchemy.orm.Session,
+        "do_orm_execute",
+        _add_soft_delete_criteria,
+    ):
+        return
+    raise RuntimeError("Global soft-delete ORM listener is not registered")


### PR DESCRIPTION
## Summary

- Adds a global ORM soft-delete filter: a `do_orm_execute` listener on `Session` applies `with_loader_criteria(SoftDeleteMixin, deleted_at IS NULL, include_aliases=True)` to top-level ORM SELECTs, so soft-deleted rows disappear from product queries by default.
- Opt-out is explicit and narrow: `with_deleted(stmt)` / the `include_deleted` execution option, reserved for staging/provenance/sync-reconciliation/erasure helpers (later PRs). Other uses are a review smell.
- Ships a behavior-pinning coverage suite (9 tests) so the filter's exact semantics are documented executable behavior, not tribal knowledge.

Part of ENG-1517 (version-less resource refs). Stacks on #2931, which introduced `SoftDeleteMixin` (columns-only) on `AgentPreset`. This addresses the `with_loader_criteria` suggestion raised in #2931's review — including its caveats, which are pinned as tests here.

## Review guide

- **Start with `tracecat/db/soft_delete.py`** (~80 lines, the whole mechanism): listener guards (`is_select and not is_column_load and not is_relationship_load`), `propagate_to_loaders=False`, the `INCLUDE_DELETED` execution option, and `assert_soft_delete_listener_registered()`.
- **The contract, stated in the module docstring**: relationship loads are deliberately unfiltered (UUID/historical paths must keep reaching tombstones); warm `Session.get()` identity-map hits bypass SQL and therefore the filter; UPDATE/DELETE are unfiltered; Core/text statements are unfiltered.
- **Wiring** (`db/engine.py`, `api/app.py`): registration is an import side-effect mirroring `session_events`; the API lifespan asserts registration at startup so a missing import fails fast in prod instead of silently no-op'ing. Worker processes get registration transitively via `engine.py`.
- **`tests/unit/test_soft_delete_filter.py`**: one test per pinned behavior — entity selects, mapped-column tuple selects (filtered — verified), aliased joins, relationship loads (see tombstones), cold vs warm `Session.get()`, RLS-bypass sessions (still filtered), UPDATE/DELETE (unfiltered), direct-engine sessions (import wiring canary).
- **Audit**: `AgentPresetService.get_preset(include_deleted=True)` / `get_preset_by_slug(include_deleted=True)` now also set the execution option. All other `deleted_at` predicates were audited and deliberately left in place — redundant filtering is rollback-safe, and they're stripped only in a later cleanup once this suite has baked. `File`/case-comment `deleted_at` columns don't inherit the mixin and are untouched.

## Note
We will be updating the explicit filters introduced in the original PR upstream

## Back-compat / rollback

- No schema change, no API change. Existing explicit predicates keep every active-only path correct even if this PR is reverted.
- Behavior-neutrality verified: 281 existing tests across preset/skill/channels/folders/sync-contract/session-versioning suites pass unchanged with the listener active.

## Validation

- `uv run pytest tests/unit/test_soft_delete_filter.py` — 9 passed
- Regression suites (preset, skill, channels, folders, sync acceptance contract, session versioning) — 281 passed
- `uv run ruff check .` / `format --check` clean; `uv run basedpyright --warnings` — 0 errors, 0 warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global ORM SELECT filter to hide soft-deleted rows by default, with a `with_deleted()` escape hatch. Part of ENG-1519.

- **New Features**
  - Global criteria on `SoftDeleteMixin` adds `deleted_at IS NULL` to ORM SELECTs; relationship loads and UPDATE/DELETE remain unfiltered.
  - `with_deleted(stmt)` for narrow opt-outs; `AgentPresetService` uses it when `include_deleted=True`.
  - Listener registered via side-effect import in `tracecat.db.engine`; `api/app.py` asserts with `assert_soft_delete_listener_registered()`. Tests cover SELECTs, joins, relationship loads, cold/warm `Session.get()`, RLS-bypass, direct-engine sessions, and a subprocess check for engine wiring.

- **Migration**
  - No action needed. Only wrap queries with `with_deleted(stmt)` when tombstones are intentionally required.

<sup>Written for commit ab533d68ef9ffcf08e690b7b221025f7c48cb0ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



