### PR TITLE
refactor(agent): resolve skill identifiers by id then live slug

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -23593,6 +23593,10 @@ export const $SkillReadMinimal = {
       type: "string",
       title: "Name",
     },
+    slug: {
+      type: "string",
+      title: "Slug",
+    },
     description: {
       anyOf: [
         {
@@ -23640,9 +23644,13 @@ export const $SkillReadMinimal = {
     },
   },
   type: "object",
-  required: ["id", "workspace_id", "name", "created_at", "updated_at"],
+  required: ["id", "workspace_id", "name", "slug", "created_at", "updated_at"],
   title: "SkillReadMinimal",
-  description: "Minimal response model for listing workspace skills.",
+  description: `Minimal response model for listing workspace skills.
+
+\`\`slug\`\` is the late-binding handle every skill API accepts; list
+responses must expose it so callers never have to guess it from \`\`name\`\`
+(names are not unique — slugs are, per live row).`,
 } as const
 
 export const $SkillUpload = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -7044,11 +7044,16 @@ export type SkillRead = {
 
 /**
  * Minimal response model for listing workspace skills.
+ *
+ * ``slug`` is the late-binding handle every skill API accepts; list
+ * responses must expose it so callers never have to guess it from ``name``
+ * (names are not unique — slugs are, per live row).
  */
 export type SkillReadMinimal = {
   id: string
   workspace_id: string
   name: string
+  slug: string
   description?: string | null
   current_version_id?: string | null
   created_at: string

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -45,12 +45,12 @@ async def create_skill(
 @registry.register(
     default_title="Get agent skill",
     display_group="Agent Skills",
-    description="Get one workspace agent skill by skill ID, with an optional UUID override.",
+    description="Get one workspace agent skill by slug, with an optional UUID override.",
     namespace="ai.skill",
     required_entitlements=["agent_addons"],
 )
 async def get_skill(
-    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_id: Annotated[str, Doc("Skill slug in kebab-case.")],
     skill_uuid: Annotated[
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
     ] = None,
@@ -66,7 +66,7 @@ async def get_skill(
     required_entitlements=["agent_addons"],
 )
 async def list_skill_versions(
-    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_id: Annotated[str, Doc("Skill slug in kebab-case.")],
     skill_uuid: Annotated[
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
     ] = None,
@@ -93,7 +93,7 @@ async def list_skill_versions(
     required_entitlements=["agent_addons"],
 )
 async def get_skill_version(
-    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_id: Annotated[str, Doc("Skill slug in kebab-case.")],
     version_id: Annotated[uuid.UUID, Doc("Skill version UUID.")],
     skill_uuid: Annotated[
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
@@ -114,7 +114,7 @@ async def get_skill_version(
     required_entitlements=["agent_addons"],
 )
 async def publish_skill_version(
-    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_id: Annotated[str, Doc("Skill slug in kebab-case.")],
     files: Annotated[
         list[dict[str, Any]],
         Doc(
@@ -147,7 +147,7 @@ async def publish_skill_version(
     required_entitlements=["agent_addons"],
 )
 async def restore_skill_version(
-    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_id: Annotated[str, Doc("Skill slug in kebab-case.")],
     version_id: Annotated[uuid.UUID, Doc("Skill version UUID.")],
     skill_uuid: Annotated[
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
@@ -168,7 +168,7 @@ async def restore_skill_version(
     required_entitlements=["agent_addons"],
 )
 async def archive_skill(
-    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_id: Annotated[str, Doc("Skill slug in kebab-case.")],
     skill_uuid: Annotated[
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
     ] = None,

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -69,6 +69,8 @@ class SkillPublishFile(TypedDict):
 
 
 def _skill_identifier(skill_id: str, skill_uuid: str | uuid.UUID | None = None) -> str:
+    """Return the skill route identifier, preferring stable UUID over authoring slug."""
+
     return str(skill_uuid) if skill_uuid is not None else skill_id
 
 

--- a/tests/unit/test_agent_skill_internal_router.py
+++ b/tests/unit/test_agent_skill_internal_router.py
@@ -122,6 +122,30 @@ async def test_get_skill_resolves_slug_identifier() -> None:
 
 
 @pytest.mark.anyio
+async def test_get_skill_unknown_identifier_returns_http_404() -> None:
+    """Unknown skill identifiers remain HTTP 404s."""
+
+    mock_service = AsyncMock()
+    mock_service.get_skill_by_identifier.return_value = None
+
+    with patch(
+        "tracecat.agent.skill.internal_router.SkillService",
+        return_value=mock_service,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            raw_get_skill = cast(Any, get_skill).__wrapped__
+            await raw_get_skill(
+                skill_id="missing-skill",
+                role=_executor_role(),
+                session=AsyncMock(),
+            )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Skill 'missing-skill' not found"
+    mock_service.get_skill_by_identifier.assert_awaited_once_with("missing-skill")
+
+
+@pytest.mark.anyio
 async def test_get_skill_version_returns_snapshot_for_udfs() -> None:
     resolved_skill_id = uuid.uuid4()
     version_id = uuid.uuid4()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -9477,6 +9477,7 @@ async def test_list_skills_uses_workspace_skill_service(
                         id=skill_id,
                         workspace_id=workspace_id,
                         name="botsv3-ir",
+                        slug="botsv3-ir",
                         description="BOTSv3 IR skill",
                         current_version_id=uuid.uuid4(),
                         created_at=now,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -9507,6 +9507,7 @@ async def test_list_skills_uses_workspace_skill_service(
     assert captured["params"].limit == 10
     assert payload["items"][0]["id"] == str(skill_id)
     assert payload["items"][0]["name"] == "botsv3-ir"
+    assert payload["items"][0]["slug"] == "botsv3-ir"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -919,6 +919,39 @@ class TestSkillService:
         assert resolved_exact is not None
         assert resolved_exact.id == exact.id
 
+    async def test_get_skill_by_identifier_ambiguous_legacy_rows_raise(
+        self,
+        skill_service: SkillService,
+        session: AsyncSession,
+    ) -> None:
+        """Two live legacy rows projecting the same fallback slug fail loud.
+
+        ``uq_skill_workspace_slug_active`` does not constrain NULL slugs and
+        old pods enforced no name uniqueness, so the expand window can leave
+        two live same-name slugless rows. Resolving one silently would be a
+        silent substitution; the lookup must raise instead. The edge
+        disappears at contract when slugs are backfilled NOT NULL.
+        """
+
+        first = await skill_service.create_skill(SkillCreate(name="legacy-dup"))
+        second = await skill_service.create_skill(SkillCreate(name="legacy-dup"))
+        rows = (
+            (
+                await session.execute(
+                    select(Skill).where(Skill.id.in_([first.id, second.id]))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            row.name = "legacy-dup"
+            row.slug = None
+        await session.commit()
+
+        with pytest.raises(TracecatValidationError, match="ambiguous"):
+            await skill_service.get_skill_by_identifier("legacy-dup")
+
     async def test_get_skill_by_identifier_prefers_id_over_matching_slug(
         self,
         skill_service: SkillService,

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -847,83 +847,126 @@ class TestSkillService:
         assert listing.items[0].id == active.id
         assert listing.items[0].name == active.name
 
-    async def test_get_skill_by_identifier_accepts_uuid_or_name(
+    async def test_get_skill_by_identifier_accepts_uuid_or_slug(
         self,
         skill_service: SkillService,
     ) -> None:
+        """Identifiers resolve by UUID or live slug."""
+
         created = await skill_service.create_skill(SkillCreate(name="lookup-skill"))
 
         by_uuid = await skill_service.get_skill_by_identifier(created.id)
         by_uuid_string = await skill_service.get_skill_by_identifier(str(created.id))
-        by_name = await skill_service.get_skill_by_identifier("lookup-skill")
+        by_slug = await skill_service.get_skill_by_identifier(created.slug)
 
         assert by_uuid is not None
         assert by_uuid.id == created.id
         assert by_uuid_string is not None
         assert by_uuid_string.id == created.id
-        assert by_name is not None
-        assert by_name.id == created.id
+        assert by_slug is not None
+        assert by_slug.id == created.id
 
-    async def test_get_skill_by_identifier_falls_back_to_uuid_like_name(
+    async def test_get_skill_by_identifier_falls_back_to_uuid_like_slug(
         self,
         skill_service: SkillService,
     ) -> None:
-        uuid_like_name = "00000000-0000-4000-8000-000000000001"
-        created = await skill_service.create_skill(SkillCreate(name=uuid_like_name))
+        """UUID-shaped slugs remain reachable when no skill ID matches."""
 
-        by_uuid_like_name = await skill_service.get_skill_by_identifier(uuid_like_name)
+        uuid_like_slug = "00000000-0000-4000-8000-000000000001"
+        created = await skill_service.create_skill(SkillCreate(name=uuid_like_slug))
 
-        assert by_uuid_like_name is not None
-        assert by_uuid_like_name.id == created.id
+        by_uuid_like_slug = await skill_service.get_skill_by_identifier(uuid_like_slug)
 
-    async def test_get_skill_by_identifier_rejects_ambiguous_names(
+        assert by_uuid_like_slug is not None
+        assert by_uuid_like_slug.id == created.id
+
+    async def test_get_skill_by_identifier_resolves_slugless_legacy_row(
         self,
         skill_service: SkillService,
         session: AsyncSession,
     ) -> None:
-        session.add_all(
-            [
-                Skill(
-                    workspace_id=skill_service.workspace_id,
-                    name="duplicate-skill",
-                    slug="duplicate-skill-a",
-                    draft_revision=0,
-                ),
-                Skill(
-                    workspace_id=skill_service.workspace_id,
-                    name="duplicate-skill",
-                    slug="duplicate-skill-b",
-                    draft_revision=0,
-                ),
-            ]
-        )
+        """Live legacy rows without a slug stay reachable by their name.
+
+        Old pods insert skills with ``slug IS NULL`` during the expand
+        window; reads advertise their name as the slug, so identifier
+        lookup must honor it. An exact slug match wins over the fallback.
+        """
+
+        legacy = await skill_service.create_skill(SkillCreate(name="legacy-lookup"))
+        legacy_row = (
+            await session.execute(select(Skill).where(Skill.id == legacy.id))
+        ).scalar_one()
+        legacy_row.slug = None
         await session.commit()
 
-        with pytest.raises(TracecatValidationError) as exc_info:
-            await skill_service.get_skill_by_identifier("duplicate-skill")
+        resolved = await skill_service.get_skill_by_identifier("legacy-lookup")
 
-        assert exc_info.value.detail == {
-            "code": "ambiguous_skill_id",
-            "skill_id": "duplicate-skill",
-        }
+        assert resolved is not None
+        assert resolved.id == legacy.id
 
-    async def test_get_skill_by_identifier_rejects_id_name_collision(
+        exact = await skill_service.create_skill(SkillCreate(name="legacy-lookup"))
+        assert exact.slug == "legacy-lookup-2"
+        exact_row = (
+            await session.execute(select(Skill).where(Skill.id == exact.id))
+        ).scalar_one()
+        exact_row.slug = "legacy-lookup"
+        await session.commit()
+
+        resolved_exact = await skill_service.get_skill_by_identifier("legacy-lookup")
+
+        assert resolved_exact is not None
+        assert resolved_exact.id == exact.id
+
+    async def test_get_skill_by_identifier_prefers_id_over_matching_slug(
         self,
         skill_service: SkillService,
     ) -> None:
-        """A UUID-like identifier matching one skill's id and a different
-        skill's name must be reported as ambiguous, not silently resolved."""
+        """A UUID string matching one ID and another slug resolves to the ID."""
 
         by_id = await skill_service.create_skill(SkillCreate(name="collision-id"))
-        await skill_service.create_skill(SkillCreate(name=str(by_id.id)))
+        by_slug = await skill_service.create_skill(SkillCreate(name=str(by_id.id)))
 
-        with pytest.raises(TracecatValidationError) as exc_info:
-            await skill_service.get_skill_by_identifier(str(by_id.id))
+        resolved = await skill_service.get_skill_by_identifier(str(by_id.id))
 
-        assert exc_info.value.detail == {
-            "code": "ambiguous_skill_id",
-            "skill_id": str(by_id.id),
-        }
+        assert resolved is not None
+        assert resolved.id == by_id.id
+        assert resolved.id != by_slug.id
+
+    async def test_get_skill_by_identifier_excludes_soft_deleted_slugs(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Slug lookup ignores soft-deleted rows."""
+
+        deleted = await skill_service.create_skill(SkillCreate(name="deleted-lookup"))
+
+        await skill_service.archive_skill(deleted.id)
+
+        assert await skill_service.get_skill_by_identifier(deleted.slug) is None
+
+    async def test_get_skill_by_identifier_recreated_slug_resolves_to_new_skill(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Reused slugs resolve to the new live skill, not the tombstone."""
+
+        deleted = await skill_service.create_skill(SkillCreate(name="recreated-lookup"))
+        await skill_service.archive_skill(deleted.id)
+        recreated = await skill_service.create_skill(SkillCreate(name=deleted.slug))
+
+        resolved = await skill_service.get_skill_by_identifier(deleted.slug)
+
+        assert resolved is not None
+        assert resolved.id == recreated.id
+        assert resolved.id != deleted.id
+
+    async def test_get_skill_by_identifier_unknown_returns_none(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Unknown identifiers remain not found."""
+
+        assert await skill_service.get_skill_by_identifier("missing-skill") is None
 
     async def test_patch_draft_enforces_revision(
         self,
@@ -2421,7 +2464,7 @@ class TestSkillService:
         assert [skill.id for skill in listing.items] == [active.id]
         assert await skill_service.get_skill(created.id) is None
         assert await skill_service.get_skill_by_identifier(created.id) is None
-        assert await skill_service.get_skill_by_identifier(created.name) is None
+        assert await skill_service.get_skill_by_identifier(created.slug) is None
         assert await skill_service.get_skill_read(created.id) is None
 
     async def test_legacy_archived_skill_binding_and_resolution_treat_as_archived(

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -824,6 +824,8 @@ class TestSkillService:
         assert isinstance(listing.items[0], SkillReadMinimal)
         assert listing.items[0].id == created.id
         assert listing.items[0].name == created.name
+        # List responses expose the late-binding handle callers bind with.
+        assert listing.items[0].slug == created.slug
 
     async def test_list_skills_excludes_archived_skills(
         self,

--- a/tracecat/agent/skill/schemas.py
+++ b/tracecat/agent/skill/schemas.py
@@ -50,10 +50,8 @@ _SKILL_NAME_CONSTRAINTS = StringConstraints(
     pattern=r"^[a-z0-9-]+$",
 )
 
-# Identifier-shaped skill name. Used for lookups (e.g. name-based skill routes),
-# so it accepts reserved-prefix names — workspaces may hold legacy skills named
-# ``tracecat-*`` from before the prefix was reserved, and those must remain
-# readable by name.
+# Identifier-shaped skill name/slug. Slug lookups use this lenient shape so
+# legacy ``tracecat-*`` rows from before the prefix was reserved remain readable.
 SkillName = Annotated[
     str,
     _SKILL_NAME_CONSTRAINTS,

--- a/tracecat/agent/skill/schemas.py
+++ b/tracecat/agent/skill/schemas.py
@@ -112,11 +112,17 @@ class SkillRead(Schema):
 
 
 class SkillReadMinimal(Schema):
-    """Minimal response model for listing workspace skills."""
+    """Minimal response model for listing workspace skills.
+
+    ``slug`` is the late-binding handle every skill API accepts; list
+    responses must expose it so callers never have to guess it from ``name``
+    (names are not unique — slugs are, per live row).
+    """
 
     id: uuid.UUID
     workspace_id: WorkspaceID
     name: str
+    slug: str
     description: str | None = Field(default=None)
     current_version_id: uuid.UUID | None = Field(default=None)
     created_at: datetime

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -83,8 +83,8 @@ SKILL_SLUG_MAX_LENGTH = 64
 SKILL_SLUG_INSERT_ATTEMPTS = 3
 SKILL_SLUG_UNIQUE_CONSTRAINT = "uq_skill_workspace_slug_active"
 POSTGRES_UNIQUE_VIOLATION_SQLSTATE = "23505"
-# Lenient adapter for name-based lookups: accepts legacy reserved-prefix names.
-SKILL_NAME_ADAPTER = TypeAdapter(SkillName)
+# Lenient adapter for slug lookups: accepts legacy reserved-prefix identifiers.
+SKILL_SLUG_ADAPTER = TypeAdapter(SkillName)
 # Strict adapter for draft/publish manifest validation: rejects reserved names.
 NEW_SKILL_NAME_ADAPTER = TypeAdapter(NewSkillName)
 
@@ -1348,53 +1348,55 @@ class SkillService(BaseWorkspaceService):
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_skill_by_identifier(
-        self, skill_id: str | uuid.UUID, *, include_archived: bool = False
+        self, identifier: str | uuid.UUID
     ) -> Skill | None:
-        """Return a skill by UUID or kebab-case skill name."""
+        """Return a skill by UUID first, then by live slug.
 
-        if isinstance(skill_id, uuid.UUID):
-            return await self.get_skill(skill_id, include_archived=include_archived)
+        UUID objects and UUID-shaped strings resolve by ``Skill.id`` first. If a
+        UUID-shaped string does not match an ID, the live skill whose slug equals
+        that string remains reachable. Non-UUID strings resolve by live slug.
+        """
+
+        if isinstance(identifier, uuid.UUID):
+            return await self.get_skill(identifier)
         try:
-            parsed_skill_id = uuid.UUID(skill_id)
+            parsed_skill_id = uuid.UUID(identifier)
         except ValueError:
             parsed_skill_id = None
 
-        uuid_match: Skill | None = None
         if parsed_skill_id is not None:
-            uuid_match = await self.get_skill(
-                parsed_skill_id, include_archived=include_archived
-            )
+            if uuid_match := await self.get_skill(parsed_skill_id):
+                return uuid_match
 
         try:
-            skill_name = SKILL_NAME_ADAPTER.validate_python(skill_id)
+            skill_slug = SKILL_SLUG_ADAPTER.validate_python(identifier)
         except ValidationError:
-            return uuid_match
-        predicates = [
-            Skill.workspace_id == self.workspace_id,
-            Skill.name == skill_name,
-        ]
-        if not include_archived:
-            predicates.extend((Skill.deleted_at.is_(None), Skill.archived_at.is_(None)))
-        stmt = select(Skill).where(*predicates)
-        if include_archived:
-            stmt = with_deleted(stmt)
-        skills = (await self.session.execute(stmt)).scalars().all()
-
-        # A UUID string is also a valid skill name and names are not unique, so
-        # the identifier is ambiguous if multiple skills share the name, or if
-        # the id match and a name match point at different skills.
-        resolved_ids = {skill.id for skill in skills}
-        if uuid_match is not None:
-            resolved_ids.add(uuid_match.id)
-        if len(resolved_ids) > 1:
-            raise TracecatValidationError(
-                "Skill identifier is ambiguous",
-                detail={
-                    "code": "ambiguous_skill_id",
-                    "skill_id": skill_name,
-                },
-            ) from None
-        return uuid_match or (skills[0] if skills else None)
+            return None
+        # Legacy rows inserted by old pods during the expand window have
+        # ``slug IS NULL`` and project their name as the slug (see
+        # ``_build_skill_read``), so they must stay reachable by that slug.
+        # If both an exact-slug row and a legacy row match, the exact slug
+        # wins; ties order like the backfill migration (created_at, id).
+        stmt = (
+            select(Skill)
+            .options(selectinload(Skill.current_version))
+            .where(
+                Skill.workspace_id == self.workspace_id,
+                sa.or_(
+                    Skill.slug == skill_slug,
+                    sa.and_(Skill.slug.is_(None), Skill.name == skill_slug),
+                ),
+                Skill.deleted_at.is_(None),
+                Skill.archived_at.is_(None),
+            )
+            .order_by(
+                sa.case((Skill.slug == skill_slug, 0), else_=1),
+                Skill.created_at.asc(),
+                Skill.id.asc(),
+            )
+            .limit(1)
+        )
+        return (await self.session.execute(stmt)).scalars().first()
 
     async def _get_active_version(
         self, *, skill_id: uuid.UUID, version_id: uuid.UUID

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -1177,6 +1177,9 @@ class SkillService(BaseWorkspaceService):
             id=skill.id,
             workspace_id=skill.workspace_id,
             name=skill.name,
+            # Same expand-window projection as SkillRead: legacy rows inserted
+            # without a slug present their name as the slug.
+            slug=skill.slug or skill.name,
             description=skill.description,
             current_version_id=skill.current_version_id,
             created_at=skill.created_at,

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -1397,9 +1397,26 @@ class SkillService(BaseWorkspaceService):
                 Skill.created_at.asc(),
                 Skill.id.asc(),
             )
-            .limit(1)
+            .limit(2)
         )
-        return (await self.session.execute(stmt)).scalars().first()
+        skills = (await self.session.execute(stmt)).scalars().all()
+        if not skills:
+            return None
+        if skills[0].slug == skill_slug:
+            # Exact slug matches are unique among live rows
+            # (``uq_skill_workspace_slug_active``), so this is deterministic.
+            return skills[0]
+        # Only legacy (``slug IS NULL``) rows matched. The partial unique index
+        # does not constrain NULL slugs and old pods enforced no name
+        # uniqueness, so multiple live rows can project the same fallback slug.
+        # Binding one silently would be a silent substitution; fail loud. This
+        # edge self-extinguishes at contract when slugs are backfilled NOT NULL.
+        if len(skills) > 1:
+            raise TracecatValidationError(
+                "Skill identifier is ambiguous",
+                detail={"code": "ambiguous_skill_id"},
+            ) from None
+        return skills[0]
 
     async def _get_active_version(
         self, *, skill_id: uuid.UUID, version_id: uuid.UUID


### PR DESCRIPTION
## Summary

- Replaces the UUID-vs-name ambiguity machinery in `get_skill_by_identifier` with deterministic resolution: identifier parses as UUID → lookup by id; otherwise (or on id miss) → lookup by **live slug**, which the partial unique index guarantees resolves to at most one row. The `ambiguous_skill_id` error path is gone.
- Precedence is `id > slug`, with UUID-shaped strings still falling through to slug lookup on id miss — preserving today's "a UUID string can be a name" reachability without the ambiguity accumulation.
- Callers audited: the internal SDK route (only production caller) now resolves UUID-or-slug; registry tool docs updated from "ID/name" to "slug" (`skill_uuid` stays the canonical stable-binding override); MCP mutation tools already require UUIDs and are untouched.

Part of ENG-1517 (ENG-1522). Stacks on #3001 (requires the slug column + live uniqueness).

## Review guide

- **`tracecat/agent/skill/service.py`** — `get_skill_by_identifier` rewrite; docstring states the precedence contract. Active-only semantics unchanged (soft-deleted rows never resolve here).
- **Spec invariant covered**: a recreated slug resolves to the NEW live skill — never silently relinks to the tombstoned one (test-pinned).
- **Tests**: id-precedence when a slug equals another skill's UUID string; soft-deleted slug exclusion; recreated-slug-resolves-new; unknown identifier 404.

## Back-compat / rollback

- No schema change, no route change. Identifier strings that resolved before still resolve (or 404 identically); only the multi-match error path (which required non-unique names) is unreachable now that slugs are live-unique.

## Validation

- 305 tests passed (skill service, internal router, MCP server suites) on the restacked base; `basedpyright --warnings` 0 errors; ruff clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors skill identifier resolution to prefer UUIDs, then live slugs, and adds `slug` to list responses so clients can bind by slug. Aligns with ENG-1522 and builds on ENG-1521.

- **Refactors**
  - Resolve by UUID first, then by live slug; UUID-shaped strings fall back to slug on ID miss; UUID wins over matching slug.
  - Legacy rows with `slug IS NULL` stay reachable via their advertised slug; exact slug wins; docs/registry now say “skill slug,” and `_skill_identifier` prefers UUID.

- **Bug Fixes**
  - Expose `slug` on list responses via `SkillReadMinimal` (API/SDK/frontend/MCP) using the same expand-window projection as `SkillRead`.
  - Fail loud on ambiguous legacy slugless lookups (`ambiguous_skill_id`); slug lookups ignore archived/deleted rows, and reused slugs resolve to the new skill.

<sup>Written for commit 7750831411aa2a66e84cc4dc98e8dbec6e73c9e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

