### PR TITLE
feat(agent): add pinned_version_id columns and pin API

### DIFF
--- a/alembic/versions/a9c1d4e7f2b3_add_pinned_version_ids.py
+++ b/alembic/versions/a9c1d4e7f2b3_add_pinned_version_ids.py
@@ -1,0 +1,61 @@
+"""Add pinned version IDs to skills and agent presets.
+
+Revision ID: a9c1d4e7f2b3
+Revises: c6a8d4f3b2e1
+Create Date: 2026-07-08 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a9c1d4e7f2b3"
+down_revision: str | None = "c6a8d4f3b2e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_preset",
+        sa.Column("pinned_version_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        op.f("fk_agent_preset_pinned_version_id_agent_preset_version"),
+        "agent_preset",
+        "agent_preset_version",
+        ["pinned_version_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.add_column(
+        "skill",
+        sa.Column("pinned_version_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        op.f("fk_skill_pinned_version_id_skill_version"),
+        "skill",
+        "skill_version",
+        ["pinned_version_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_skill_pinned_version_id_skill_version"),
+        "skill",
+        type_="foreignkey",
+    )
+    op.drop_column("skill", "pinned_version_id")
+    op.drop_constraint(
+        op.f("fk_agent_preset_pinned_version_id_agent_preset_version"),
+        "agent_preset",
+        type_="foreignkey",
+    )
+    op.drop_column("agent_preset", "pinned_version_id")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2316,6 +2316,20 @@ export const $AgentPresetMoveToFolder = {
   description: "Payload for moving an agent preset to a folder.",
 } as const
 
+export const $AgentPresetPinVersion = {
+  properties: {
+    version_id: {
+      type: "string",
+      format: "uuid",
+      title: "Version Id",
+    },
+  },
+  type: "object",
+  required: ["version_id"],
+  title: "AgentPresetPinVersion",
+  description: "Payload for pinning a preset to an immutable version.",
+} as const
+
 export const $AgentPresetRead = {
   properties: {
     instructions: {
@@ -2490,6 +2504,18 @@ export const $AgentPresetRead = {
       ],
       title: "Current Version Id",
     },
+    pinned_version_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pinned Version Id",
+    },
     folder_id: {
       anyOf: [
         {
@@ -2604,6 +2630,18 @@ export const $AgentPresetReadMinimal = {
         },
       ],
       title: "Current Version Id",
+    },
+    pinned_version_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pinned Version Id",
     },
     capabilities: {
       items: {
@@ -23466,6 +23504,20 @@ export const $SkillFileEntry = {
     "Manifest entry for a skill file (used in both drafts and versions).",
 } as const
 
+export const $SkillPinVersion = {
+  properties: {
+    version_id: {
+      type: "string",
+      format: "uuid",
+      title: "Version Id",
+    },
+  },
+  type: "object",
+  required: ["version_id"],
+  title: "SkillPinVersion",
+  description: "Payload for pinning a skill to an immutable version.",
+} as const
+
 export const $SkillRead = {
   properties: {
     id: {
@@ -23508,6 +23560,18 @@ export const $SkillRead = {
         },
       ],
       title: "Current Version Id",
+    },
+    pinned_version_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pinned Version Id",
     },
     draft_revision: {
       type: "integer",
@@ -23619,6 +23683,18 @@ export const $SkillReadMinimal = {
         },
       ],
       title: "Current Version Id",
+    },
+    pinned_version_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pinned Version Id",
     },
     created_at: {
       type: "string",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -162,10 +162,14 @@ import type {
   AgentPresetsListPresetTagsResponse,
   AgentPresetsMoveAgentPresetToFolderData,
   AgentPresetsMoveAgentPresetToFolderResponse,
+  AgentPresetsPinAgentPresetVersionData,
+  AgentPresetsPinAgentPresetVersionResponse,
   AgentPresetsRemovePresetTagData,
   AgentPresetsRemovePresetTagResponse,
   AgentPresetsRestoreAgentPresetVersionData,
   AgentPresetsRestoreAgentPresetVersionResponse,
+  AgentPresetsUnpinAgentPresetVersionData,
+  AgentPresetsUnpinAgentPresetVersionResponse,
   AgentPresetsUpdateAgentPresetData,
   AgentPresetsUpdateAgentPresetResponse,
   AgentSessionsCancelSessionData,
@@ -216,10 +220,14 @@ import type {
   AgentSkillsListSkillVersionsResponse,
   AgentSkillsPatchSkillDraftData,
   AgentSkillsPatchSkillDraftResponse,
+  AgentSkillsPinSkillVersionData,
+  AgentSkillsPinSkillVersionResponse,
   AgentSkillsPublishSkillData,
   AgentSkillsPublishSkillResponse,
   AgentSkillsRestoreSkillVersionData,
   AgentSkillsRestoreSkillVersionResponse,
+  AgentSkillsUnpinSkillVersionData,
+  AgentSkillsUnpinSkillVersionResponse,
   AgentSkillsUploadSkillData,
   AgentSkillsUploadSkillResponse,
   AgentTagsCreateAgentTagData,
@@ -5603,6 +5611,59 @@ export const agentPresetsGetAgentPresetBySlug = (
 }
 
 /**
+ * Pin Agent Preset Version
+ * Pin an agent preset to an immutable version.
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentPresetRead Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsPinAgentPresetVersion = (
+  data: AgentPresetsPinAgentPresetVersionData
+): CancelablePromise<AgentPresetsPinAgentPresetVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "PUT",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/pin",
+    path: {
+      preset_id: data.presetId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Unpin Agent Preset Version
+ * Clear the pinned version for an agent preset.
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.workspaceId
+ * @returns AgentPresetRead Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsUnpinAgentPresetVersion = (
+  data: AgentPresetsUnpinAgentPresetVersionData
+): CancelablePromise<AgentPresetsUnpinAgentPresetVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/pin",
+    path: {
+      preset_id: data.presetId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
  * List Agent Preset Versions
  * List immutable versions for an agent preset.
  * @param data The data for the request.
@@ -6544,6 +6605,59 @@ export const agentSkillsRestoreSkillVersion = (
     path: {
       skill_id: data.skillId,
       version_id: data.versionId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Pin Skill Version
+ * Pin a skill to an immutable version.
+ * @param data The data for the request.
+ * @param data.skillId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns SkillReadMinimal Successful Response
+ * @throws ApiError
+ */
+export const agentSkillsPinSkillVersion = (
+  data: AgentSkillsPinSkillVersionData
+): CancelablePromise<AgentSkillsPinSkillVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "PUT",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/pin",
+    path: {
+      skill_id: data.skillId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Unpin Skill Version
+ * Clear the pinned version for a skill.
+ * @param data The data for the request.
+ * @param data.skillId
+ * @param data.workspaceId
+ * @returns SkillReadMinimal Successful Response
+ * @throws ApiError
+ */
+export const agentSkillsUnpinSkillVersion = (
+  data: AgentSkillsUnpinSkillVersionData
+): CancelablePromise<AgentSkillsUnpinSkillVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/pin",
+    path: {
+      skill_id: data.skillId,
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -587,6 +587,13 @@ export type AgentPresetMoveToFolder = {
 }
 
 /**
+ * Payload for pinning a preset to an immutable version.
+ */
+export type AgentPresetPinVersion = {
+  version_id: string
+}
+
+/**
  * API model for reading agent presets.
  */
 export type AgentPresetRead = {
@@ -612,6 +619,7 @@ export type AgentPresetRead = {
   slug: string
   description?: string | null
   current_version_id?: string | null
+  pinned_version_id?: string | null
   folder_id?: string | null
   skills?: Array<AgentPresetSkillBindingRead>
   created_at: string
@@ -632,6 +640,7 @@ export type AgentPresetReadMinimal = {
   folder_id?: string | null
   tags?: Array<TagRead>
   current_version_id?: string | null
+  pinned_version_id?: string | null
   capabilities?: Array<AgentPresetCapability>
   current_version_subagent_eligibility?: AgentPresetSubagentEligibility
   created_at: string
@@ -7023,6 +7032,13 @@ export type SkillFileEntry = {
 }
 
 /**
+ * Payload for pinning a skill to an immutable version.
+ */
+export type SkillPinVersion = {
+  version_id: string
+}
+
+/**
  * Full response model for a workspace skill.
  */
 export type SkillRead = {
@@ -7032,6 +7048,7 @@ export type SkillRead = {
   slug: string
   description?: string | null
   current_version_id?: string | null
+  pinned_version_id?: string | null
   draft_revision: number
   created_at: string
   updated_at: string
@@ -7056,6 +7073,7 @@ export type SkillReadMinimal = {
   slug: string
   description?: string | null
   current_version_id?: string | null
+  pinned_version_id?: string | null
   created_at: string
   updated_at: string
   deleted_at?: string | null
@@ -11247,6 +11265,21 @@ export type AgentPresetsGetAgentPresetBySlugData = {
 
 export type AgentPresetsGetAgentPresetBySlugResponse = AgentPresetRead
 
+export type AgentPresetsPinAgentPresetVersionData = {
+  presetId: string
+  requestBody: AgentPresetPinVersion
+  workspaceId: string
+}
+
+export type AgentPresetsPinAgentPresetVersionResponse = AgentPresetRead
+
+export type AgentPresetsUnpinAgentPresetVersionData = {
+  presetId: string
+  workspaceId: string
+}
+
+export type AgentPresetsUnpinAgentPresetVersionResponse = AgentPresetRead
+
 export type AgentPresetsListAgentPresetVersionsData = {
   cursor?: string | null
   limit?: number
@@ -11536,6 +11569,21 @@ export type AgentSkillsRestoreSkillVersionData = {
 }
 
 export type AgentSkillsRestoreSkillVersionResponse = SkillReadMinimal
+
+export type AgentSkillsPinSkillVersionData = {
+  requestBody: SkillPinVersion
+  skillId: string
+  workspaceId: string
+}
+
+export type AgentSkillsPinSkillVersionResponse = SkillReadMinimal
+
+export type AgentSkillsUnpinSkillVersionData = {
+  skillId: string
+  workspaceId: string
+}
+
+export type AgentSkillsUnpinSkillVersionResponse = SkillReadMinimal
 
 export type AgentSessionsCreateSessionData = {
   requestBody: AgentSessionCreate
@@ -16224,6 +16272,34 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/pin": {
+    put: {
+      req: AgentPresetsPinAgentPresetVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentPresetRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AgentPresetsUnpinAgentPresetVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentPresetRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
   "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions": {
     get: {
       req: AgentPresetsListAgentPresetVersionsData
@@ -16702,6 +16778,34 @@ export type $OpenApiTs = {
   "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions/{version_id}/restore": {
     post: {
       req: AgentSkillsRestoreSkillVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: SkillReadMinimal
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/pin": {
+    put: {
+      req: AgentSkillsPinSkillVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: SkillReadMinimal
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AgentSkillsUnpinSkillVersionData
       res: {
         /**
          * Successful Response

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -9,6 +9,7 @@ from typing import cast
 import pytest
 from dotenv import dotenv_values
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from tests.database import TEST_DB_CONFIG
@@ -732,6 +733,141 @@ class TestAgentPresetService:
         assert current_version.id == created_preset.current_version_id
         assert current_version.version == 1
         assert [version.version for version in versions.items] == [1]
+
+    async def test_pin_and_unpin_version_round_trips_through_preset_reads(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: pinning is exposed on reads and unpinning clears the pointer."""
+
+        created_preset = await agent_preset_service.create_preset(
+            agent_preset_create_params
+        )
+        version_id = created_preset.current_version_id
+        assert version_id is not None
+
+        pinned = await agent_preset_service.pin_version(
+            preset_id=created_preset.id,
+            version_id=version_id,
+        )
+        read = await agent_preset_service.build_preset_read(pinned)
+
+        assert pinned.pinned_version_id == version_id
+        assert read.pinned_version_id == version_id
+
+        unpinned = await agent_preset_service.unpin_version(created_preset.id)
+        read_after_unpin = await agent_preset_service.build_preset_read(unpinned)
+
+        assert unpinned.pinned_version_id is None
+        assert read_after_unpin.pinned_version_id is None
+
+    async def test_pin_version_rejects_version_from_another_preset(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: pinning another preset's version fails with a validation code."""
+
+        first = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "First pinned preset", "slug": "first-pinned-preset"}
+            )
+        )
+        second = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Second pinned preset", "slug": "second-pinned-preset"}
+            )
+        )
+        second_version_id = second.current_version_id
+        assert second_version_id is not None
+
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await agent_preset_service.pin_version(
+                preset_id=first.id,
+                version_id=second_version_id,
+            )
+
+        assert exc_info.value.detail == {
+            "code": "version_resource_mismatch",
+            "resource_type": "agent_preset",
+            "preset_id": str(first.id),
+            "version_id": str(second_version_id),
+        }
+
+    async def test_pin_version_rejects_soft_deleted_preset(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: pinning on a soft-deleted preset is treated as not found."""
+
+        created_preset = await agent_preset_service.create_preset(
+            agent_preset_create_params
+        )
+        version_id = created_preset.current_version_id
+        assert version_id is not None
+        await agent_preset_service.delete_preset(created_preset)
+
+        with pytest.raises(
+            TracecatNotFoundError,
+            match=f"Agent preset '{created_preset.id}' not found",
+        ):
+            await agent_preset_service.pin_version(
+                preset_id=created_preset.id,
+                version_id=version_id,
+            )
+
+    async def test_delete_pinned_version_is_blocked_by_restrict(
+        self,
+        session: AsyncSession,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: deleting a pinned preset version is blocked by the DB FK."""
+
+        created_preset = await agent_preset_service.create_preset(
+            agent_preset_create_params
+        )
+        version_id = created_preset.current_version_id
+        assert version_id is not None
+        await agent_preset_service.pin_version(
+            preset_id=created_preset.id,
+            version_id=version_id,
+        )
+
+        version_row = await agent_preset_service.get_version(version_id)
+        assert version_row is not None
+        await session.delete(version_row)
+        with pytest.raises(IntegrityError):
+            await session.flush()
+        await session.rollback()
+
+    async def test_pin_survives_preset_rename(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: renaming a preset does not clear its pinned version pointer."""
+
+        created_preset = await agent_preset_service.create_preset(
+            agent_preset_create_params
+        )
+        version_id = created_preset.current_version_id
+        assert version_id is not None
+        await agent_preset_service.pin_version(
+            preset_id=created_preset.id,
+            version_id=version_id,
+        )
+
+        renamed = await agent_preset_service.update_preset(
+            created_preset,
+            AgentPresetUpdate(name="Pinned Preset Renamed"),
+        )
+        read = await agent_preset_service.build_preset_read(renamed)
+
+        assert read.name == "Pinned Preset Renamed"
+        assert read.pinned_version_id == version_id
 
     async def test_update_preset_execution_fields_create_new_version(
         self,

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -2359,6 +2359,129 @@ class TestSkillService:
 
         assert lock_calls == 1
 
+    async def test_pin_and_unpin_version_round_trips_through_skill_reads(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Invariant: pinning is exposed on reads and unpinning clears the pointer."""
+
+        created = await skill_service.create_skill(SkillCreate(name="pin-read-skill"))
+        version = await skill_service.publish_skill(created.id)
+
+        pinned = await skill_service.pin_version(
+            skill_id=created.id,
+            version_id=version.id,
+        )
+        read = await skill_service.get_skill_read(created.id)
+
+        assert pinned.pinned_version_id == version.id
+        assert read is not None
+        assert read.pinned_version_id == version.id
+
+        unpinned = await skill_service.unpin_version(created.id)
+        read_after_unpin = await skill_service.get_skill_read(created.id)
+
+        assert unpinned.pinned_version_id is None
+        assert read_after_unpin is not None
+        assert read_after_unpin.pinned_version_id is None
+
+    async def test_pin_version_rejects_version_from_another_skill(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Invariant: pinning another skill's version fails with a validation code."""
+
+        first = await skill_service.create_skill(SkillCreate(name="pin-first-skill"))
+        second = await skill_service.create_skill(SkillCreate(name="pin-second-skill"))
+        second_version = await skill_service.publish_skill(second.id)
+
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await skill_service.pin_version(
+                skill_id=first.id,
+                version_id=second_version.id,
+            )
+
+        assert exc_info.value.detail == {
+            "code": "version_resource_mismatch",
+            "resource_type": "skill",
+            "skill_id": str(first.id),
+            "version_id": str(second_version.id),
+        }
+
+    async def test_pin_version_rejects_soft_deleted_skill(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Invariant: pinning on a soft-deleted skill is treated as not found."""
+
+        created = await skill_service.create_skill(
+            SkillCreate(name="pin-deleted-skill")
+        )
+        version = await skill_service.publish_skill(created.id)
+        await skill_service.archive_skill(created.id)
+
+        with pytest.raises(TracecatNotFoundError, match=f"Skill '{created.id}'"):
+            await skill_service.pin_version(skill_id=created.id, version_id=version.id)
+
+    async def test_delete_pinned_version_is_blocked_by_restrict(
+        self,
+        session: AsyncSession,
+        skill_service: SkillService,
+    ) -> None:
+        """Invariant: deleting a pinned skill version is blocked by the DB FK."""
+
+        created = await skill_service.create_skill(
+            SkillCreate(name="pin-restrict-skill")
+        )
+        version = await skill_service.publish_skill(created.id)
+        await skill_service.pin_version(skill_id=created.id, version_id=version.id)
+
+        version_row = await skill_service.get_version(version.id)
+        assert version_row is not None
+        await session.delete(version_row)
+        with pytest.raises(IntegrityError):
+            await session.flush()
+        await session.rollback()
+
+    async def test_pin_survives_skill_rename(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Invariant: renaming a skill does not clear its pinned version pointer."""
+
+        created = await skill_service.create_skill(SkillCreate(name="pin-rename-skill"))
+        pinned_version = await skill_service.publish_skill(created.id)
+        await skill_service.pin_version(
+            skill_id=created.id,
+            version_id=pinned_version.id,
+        )
+
+        renamed_version = await skill_service.publish_skill_version(
+            skill_id=created.id,
+            params=SkillVersionPublish(
+                base_version_id=pinned_version.id,
+                files=[
+                    SkillUploadFile(
+                        path="SKILL.md",
+                        content_base64=base64.b64encode(
+                            b"---\n"
+                            b"name: renamed-pin-skill\n"
+                            b"description: Renamed while pinned\n"
+                            b"---\n\n"
+                            b"# renamed-pin-skill\n"
+                        ).decode(),
+                        content_type="text/markdown; charset=utf-8",
+                    )
+                ],
+            ),
+        )
+        read = await skill_service.get_skill_read(created.id)
+
+        assert read is not None
+        assert read.name == "renamed-pin-skill"
+        assert read.current_version_id == renamed_version.id
+        assert read.pinned_version_id == pinned_version.id
+
     async def test_archive_blocks_when_preset_head_references_skill(
         self,
         session: AsyncSession,

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -12,9 +12,13 @@ from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import ADMIN_SCOPES
 from tracecat.db.models import (
+    AgentPreset,
+    AgentPresetVersion,
     Membership,
     Organization,
     OrganizationMembership,
+    Skill,
+    SkillVersion,
     User,
     Workspace,
 )
@@ -100,6 +104,101 @@ class TestWorkspaceService:
         assert workspace.organization_id == svc_workspace.organization_id
         # Verify settings are preserved through validation
         assert workspace.settings is not None
+
+    async def test_delete_workspace_unpins_versions_before_teardown(
+        self,
+        session: AsyncSession,
+        svc_organization: Organization,
+    ) -> None:
+        """ORM teardown must null version pins before deleting version rows.
+
+        Workspace hard delete runs through active ORM cascades that emit
+        separate child DELETEs (version rows before their parents). The
+        pinned-version FKs are RESTRICT, so without the ``post_update``
+        ``pinned_version`` relationships the version DELETE fires while the
+        parent row still pins it and teardown fails. A raw single-statement
+        SQL cascade passes this scenario (RESTRICT checks at end of
+        statement) — the ORM path is the one that must be exercised.
+        """
+        workspace = Workspace(
+            name="pin-teardown-workspace",
+            organization_id=svc_organization.id,
+        )
+        # A second workspace so deletion passes the last-workspace guard.
+        other_workspace = Workspace(
+            name="pin-teardown-other",
+            organization_id=svc_organization.id,
+        )
+        session.add_all([workspace, other_workspace])
+        await session.flush()
+
+        preset = AgentPreset(
+            workspace_id=workspace.id,
+            name="pinned-preset",
+            slug="pinned-preset",
+            model_name="test-model",
+            model_provider="test-provider",
+        )
+        skill = Skill(
+            workspace_id=workspace.id,
+            name="pinned-skill",
+            slug="pinned-skill",
+        )
+        session.add_all([preset, skill])
+        await session.flush()
+
+        preset_version = AgentPresetVersion(
+            workspace_id=workspace.id,
+            preset_id=preset.id,
+            version=1,
+            model_name="test-model",
+            model_provider="test-provider",
+        )
+        skill_version = SkillVersion(
+            workspace_id=workspace.id,
+            skill_id=skill.id,
+            version=1,
+            name="pinned-skill",
+            manifest_sha256="0" * 64,
+            file_count=0,
+            total_size_bytes=0,
+        )
+        session.add_all([preset_version, skill_version])
+        await session.flush()
+
+        preset.pinned_version_id = preset_version.id
+        skill.pinned_version_id = skill_version.id
+        session.add_all([preset, skill])
+        await session.commit()
+
+        # Load the relationship collections so the ORM cascade path (per-row
+        # child DELETEs, versions before parents) is exercised instead of the
+        # single-statement DB cascade, which RESTRICT cannot catch.
+        await session.refresh(workspace, ["agent_presets", "skills"])
+        await session.refresh(preset, ["versions"])
+        await session.refresh(skill, ["versions"])
+
+        service = WorkspaceService(
+            session=session,
+            role=Role(
+                type="user",
+                workspace_id=workspace.id,
+                organization_id=svc_organization.id,
+                user_id=uuid.uuid4(),
+                service_id="tracecat-api",
+                scopes=ADMIN_SCOPES,
+            ),
+        )
+        await service.delete_workspace(workspace.id)
+
+        remaining_preset = await session.scalar(
+            select(AgentPreset).where(AgentPreset.workspace_id == workspace.id)
+        )
+        remaining_skill = await session.scalar(
+            select(Skill).where(Skill.workspace_id == workspace.id)
+        )
+        assert remaining_preset is None
+        assert remaining_skill is None
 
     async def test_delete_workspace_removes_memberships(
         self,

--- a/tracecat/agent/preset/router.py
+++ b/tracecat/agent/preset/router.py
@@ -7,6 +7,7 @@ from tracecat.agent.folders.service import AgentFolderService
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
     AgentPresetMoveToFolder,
+    AgentPresetPinVersion,
     AgentPresetRead,
     AgentPresetReadMinimal,
     AgentPresetUpdate,
@@ -120,6 +121,55 @@ async def update_agent_preset(
         # The preset can be soft-deleted between the lookup above and the
         # service's row lock; surface that race as a 404, not a 500.
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return await service.build_preset_read(preset)
+
+
+@router.put("/{preset_id}/pin", response_model=AgentPresetRead)
+@require_scope("agent:update")
+async def pin_agent_preset_version(
+    *,
+    preset_id: uuid.UUID,
+    params: AgentPresetPinVersion,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+) -> AgentPresetRead:
+    """Pin an agent preset to an immutable version."""
+    service = AgentPresetService(session, role=role)
+    try:
+        preset = await service.pin_version(
+            preset_id=preset_id,
+            version_id=params.version_id,
+        )
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except TracecatValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=exc.detail if exc.detail is not None else str(exc),
+        ) from exc
+    return await service.build_preset_read(preset)
+
+
+@router.delete("/{preset_id}/pin", response_model=AgentPresetRead)
+@require_scope("agent:update")
+async def unpin_agent_preset_version(
+    *,
+    preset_id: uuid.UUID,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+) -> AgentPresetRead:
+    """Clear the pinned version for an agent preset."""
+    service = AgentPresetService(session, role=role)
+    try:
+        preset = await service.unpin_version(preset_id)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
     return await service.build_preset_read(preset)
 
 

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -168,6 +168,7 @@ class AgentPresetReadMinimal(Schema):
     folder_id: uuid.UUID | None = None
     tags: list[TagRead] = Field(default_factory=list)
     current_version_id: uuid.UUID | None = None
+    pinned_version_id: uuid.UUID | None = None
     capabilities: list[AgentPresetCapability] = Field(default_factory=list)
     current_version_subagent_eligibility: AgentPresetSubagentEligibility = Field(
         default_factory=AgentPresetSubagentEligibility
@@ -270,6 +271,7 @@ class AgentPresetRead(AgentPresetExecutionConfig):
     slug: str
     description: str | None = Field(default=None, max_length=1000)
     current_version_id: uuid.UUID | None = None
+    pinned_version_id: uuid.UUID | None = None
     folder_id: uuid.UUID | None = None
     skills: list[AgentPresetSkillBindingRead] = Field(default_factory=list)
     created_at: datetime
@@ -295,6 +297,12 @@ class AgentPresetRead(AgentPresetExecutionConfig):
             enable_thinking=self.enable_thinking,
             enable_internet_access=self.enable_internet_access,
         )
+
+
+class AgentPresetPinVersion(Schema):
+    """Payload for pinning a preset to an immutable version."""
+
+    version_id: uuid.UUID
 
 
 class AgentPresetWithConfig(AgentPresetRead):

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -203,6 +203,7 @@ class AgentPresetService(BaseWorkspaceService):
             slug=preset.slug,
             description=preset.description,
             current_version_id=preset.current_version_id,
+            pinned_version_id=preset.pinned_version_id,
             folder_id=preset.folder_id,
             instructions=preset.instructions,
             model_name=preset.model_name,
@@ -1572,6 +1573,58 @@ class AgentPresetService(BaseWorkspaceService):
             version_id=version.id,
         )
         preset.current_version_id = version.id
+        self.session.add(preset)
+        await self.session.commit()
+        await self.session.refresh(preset)
+        return preset
+
+    @require_scope("agent:update")
+    @audit_log(resource_type="agent_preset", action="update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def pin_version(
+        self, *, preset_id: uuid.UUID, version_id: uuid.UUID
+    ) -> AgentPreset:
+        """Pin an active preset to one of its immutable versions."""
+
+        await self._lock_preset_row(preset_id)
+        preset = await self.get_preset(preset_id)
+        if preset is None:
+            raise TracecatNotFoundError(f"Agent preset '{preset_id}' not found")
+
+        version = await self.get_version(version_id)
+        if version is None:
+            raise TracecatNotFoundError(
+                f"Agent preset version '{version_id}' not found"
+            )
+        if version.preset_id != preset.id:
+            raise TracecatValidationError(
+                "Preset version does not belong to the selected preset",
+                detail={
+                    "code": "version_resource_mismatch",
+                    "resource_type": "agent_preset",
+                    "preset_id": str(preset.id),
+                    "version_id": str(version.id),
+                },
+            )
+
+        preset.pinned_version_id = version.id
+        self.session.add(preset)
+        await self.session.commit()
+        await self.session.refresh(preset)
+        return preset
+
+    @require_scope("agent:update")
+    @audit_log(resource_type="agent_preset", action="update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def unpin_version(self, preset_id: uuid.UUID) -> AgentPreset:
+        """Clear the pinned version pointer for an active preset."""
+
+        await self._lock_preset_row(preset_id)
+        preset = await self.get_preset(preset_id)
+        if preset is None:
+            raise TracecatNotFoundError(f"Agent preset '{preset_id}' not found")
+
+        preset.pinned_version_id = None
         self.session.add(preset)
         await self.session.commit()
         await self.session.refresh(preset)

--- a/tracecat/agent/skill/router.py
+++ b/tracecat/agent/skill/router.py
@@ -13,6 +13,7 @@ from tracecat.agent.skill.schemas import (
     SkillDraftFileRead,
     SkillDraftPatch,
     SkillDraftRead,
+    SkillPinVersion,
     SkillRead,
     SkillReadMinimal,
     SkillUpload,
@@ -340,6 +341,51 @@ async def restore_skill_version(
     service = SkillService(session, role=role)
     try:
         return await service.restore_version(skill_id=skill_id, version_id=version_id)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
+
+@router.put("/{skill_id}/pin", response_model=SkillReadMinimal)
+@require_scope("agent:update")
+async def pin_skill_version(
+    *,
+    skill_id: uuid.UUID,
+    params: SkillPinVersion,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+) -> SkillReadMinimal:
+    """Pin a skill to an immutable version."""
+
+    service = SkillService(session, role=role)
+    try:
+        return await service.pin_version(
+            skill_id=skill_id, version_id=params.version_id
+        )
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
+
+@router.delete("/{skill_id}/pin", response_model=SkillReadMinimal)
+@require_scope("agent:update")
+async def unpin_skill_version(
+    *,
+    skill_id: uuid.UUID,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+) -> SkillReadMinimal:
+    """Clear the pinned version for a skill."""
+
+    service = SkillService(session, role=role)
+    try:
+        return await service.unpin_version(skill_id)
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/tracecat/agent/skill/schemas.py
+++ b/tracecat/agent/skill/schemas.py
@@ -99,6 +99,7 @@ class SkillRead(Schema):
     slug: str
     description: str | None = Field(default=None)
     current_version_id: uuid.UUID | None = Field(default=None)
+    pinned_version_id: uuid.UUID | None = Field(default=None)
     draft_revision: int
     created_at: datetime
     updated_at: datetime
@@ -125,6 +126,7 @@ class SkillReadMinimal(Schema):
     slug: str
     description: str | None = Field(default=None)
     current_version_id: uuid.UUID | None = Field(default=None)
+    pinned_version_id: uuid.UUID | None = Field(default=None)
     created_at: datetime
     updated_at: datetime
     deleted_at: datetime | None = Field(default=None)
@@ -135,6 +137,12 @@ class SkillCreate(Schema):
 
     name: NewSkillName
     description: str | None = Field(default=None, max_length=4000)
+
+
+class SkillPinVersion(Schema):
+    """Payload for pinning a skill to an immutable version."""
+
+    version_id: uuid.UUID
 
 
 class SkillUploadFile(Schema):

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -1159,6 +1159,7 @@ class SkillService(BaseWorkspaceService):
             slug=skill.slug or skill.name,
             description=skill.description,
             current_version_id=skill.current_version_id,
+            pinned_version_id=skill.pinned_version_id,
             draft_revision=skill.draft_revision,
             created_at=skill.created_at,
             updated_at=skill.updated_at,
@@ -1182,6 +1183,7 @@ class SkillService(BaseWorkspaceService):
             slug=skill.slug or skill.name,
             description=skill.description,
             current_version_id=skill.current_version_id,
+            pinned_version_id=skill.pinned_version_id,
             created_at=skill.created_at,
             updated_at=skill.updated_at,
             deleted_at=skill.deleted_at or skill.archived_at,
@@ -2340,6 +2342,52 @@ class SkillService(BaseWorkspaceService):
         skill.current_version_id = version.id
         skill.name = version.name
         skill.description = version.description
+        self.session.add(skill)
+        await self.session.commit()
+        await self.session.refresh(skill)
+        return self._build_skill_read_minimal(skill)
+
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def pin_version(
+        self, *, skill_id: uuid.UUID, version_id: uuid.UUID
+    ) -> SkillReadMinimal:
+        """Pin an active skill to one of its immutable published versions."""
+
+        skill = await self._get_skill_for_update(skill_id)
+        if skill is None:
+            raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
+
+        version = await self.get_version(version_id)
+        if version is None:
+            raise TracecatNotFoundError(f"Skill version '{version_id}' not found")
+        if version.skill_id != skill.id:
+            raise TracecatValidationError(
+                "Skill version does not belong to the selected skill",
+                detail={
+                    "code": "version_resource_mismatch",
+                    "resource_type": "skill",
+                    "skill_id": str(skill.id),
+                    "version_id": str(version.id),
+                },
+            )
+
+        skill.pinned_version_id = version.id
+        self.session.add(skill)
+        await self.session.commit()
+        await self.session.refresh(skill)
+        return self._build_skill_read_minimal(skill)
+
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def unpin_version(self, skill_id: uuid.UUID) -> SkillReadMinimal:
+        """Clear the pinned version pointer for an active skill."""
+
+        skill = await self._get_skill_for_update(skill_id)
+        if skill is None:
+            raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
+
+        skill.pinned_version_id = None
         self.session.add(skill)
         await self.session.commit()
         await self.session.refresh(skill)

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3542,6 +3542,15 @@ class AgentPreset(SoftDeleteMixin, WorkspaceModel):
         nullable=True,
         doc="Current immutable version for this preset.",
     )
+    pinned_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("agent_preset_version.id", ondelete="RESTRICT"),
+        nullable=True,
+        doc=(
+            "Pinned immutable version for this preset. RESTRICT prevents deleting "
+            "a pinned version from silently unpinning the preset back to floating."
+        ),
+    )
     instructions: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
@@ -3641,6 +3650,15 @@ class AgentPreset(SoftDeleteMixin, WorkspaceModel):
     current_version: Mapped[AgentPresetVersion | None] = relationship(
         "AgentPresetVersion",
         foreign_keys=[current_version_id],
+        uselist=False,
+        post_update=True,
+    )
+    # post_update makes ORM teardown (workspace/org hard delete via active
+    # cascades) null the pin before deleting version rows; the RESTRICT FK
+    # still blocks direct deletes of a pinned version.
+    pinned_version: Mapped[AgentPresetVersion | None] = relationship(
+        "AgentPresetVersion",
+        foreign_keys=[pinned_version_id],
         uselist=False,
         post_update=True,
     )
@@ -3810,6 +3828,15 @@ class Skill(SoftDeleteMixin, WorkspaceModel):
         nullable=True,
         doc="Current published skill version",
     )
+    pinned_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("skill_version.id", ondelete="RESTRICT"),
+        nullable=True,
+        doc=(
+            "Pinned published skill version. RESTRICT prevents deleting a pinned "
+            "version from silently unpinning the skill back to floating."
+        ),
+    )
     draft_revision: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
@@ -3834,6 +3861,15 @@ class Skill(SoftDeleteMixin, WorkspaceModel):
     current_version: Mapped[SkillVersion | None] = relationship(
         "SkillVersion",
         foreign_keys=[current_version_id],
+        uselist=False,
+        post_update=True,
+    )
+    # post_update makes ORM teardown (workspace/org hard delete via active
+    # cascades) null the pin before deleting version rows; the RESTRICT FK
+    # still blocks direct deletes of a pinned version.
+    pinned_version: Mapped[SkillVersion | None] = relationship(
+        "SkillVersion",
+        foreign_keys=[pinned_version_id],
         uselist=False,
         post_update=True,
     )


### PR DESCRIPTION
## Summary

- Adds `pinned_version_id` to `Skill` and `AgentPreset` (nullable FK → the resource's version table, `ondelete=RESTRICT`) plus pin/unpin API (`PUT`/`DELETE /agent/{presets,skills}/{id}/pin`).
- Purely **additive**: nothing reads pins yet. Resolution semantics (`effective = pinned or current`, precedence `deleted > pinned > current`) land in the next stack-2 PR; the pin UI lands in stack 3.
- `RESTRICT` (not SET NULL like `current_version_id`) is deliberate: deleting a pinned version must never silently unpin a resource back to floating.

Part of ENG-1517 (ENG-1523). Stacks on #3001.

## Review guide

- **`tracecat/db/models.py`** — the two FK columns, mirroring `current_version_id`'s declaration pattern; doc comments state the RESTRICT rationale.
- **Migration `a9c1d4e7f2b3`** — additive columns + FKs; honest downgrade.
- **Services/routers** — `pin_version`/`unpin_version` with same-resource validation (a version belonging to another resource is rejected with a machine-readable code); soft-deleted resources 404; scope `agent:update`.
- **Tests**: pin→read→unpin roundtrip; cross-resource version rejection; soft-deleted 404; DB-level RESTRICT (IntegrityError on deleting a pinned version); pin survives rename.

## Back-compat / rollback

- Additive schema + new endpoints only; no existing behavior changes. Downgrade drops FKs + columns.

## Validation

- 143 tests passed (skill + preset service suites) on the restacked base; migration applied against a live cluster DB (single head `a9c1d4e7f2b3`); client regenerated with zero drift; `basedpyright --warnings` 0 errors; frontend typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pin/unpin support for agent presets and skills with `pinned_version_id` columns and pin APIs so teams can lock resources to immutable versions. Adds ORM safeguards so workspace/org deletion unpins before version rows are removed. Implements ENG-1523.

- **New Features**
  - Schema: added nullable `pinned_version_id` to `agent_preset` and `skill` with FK `RESTRICT`; read models now include `pinned_version_id`.
  - APIs and SDK: PUT/DELETE `/workspaces/{workspace_id}/agent/presets/{preset_id}/pin` and `/workspaces/{workspace_id}/agent/skills/{skill_id}/pin`; generated SDK methods `agentPresetsPinAgentPresetVersion`/`UnpinAgentPresetVersion` and `agentSkillsPinSkillVersion`/`UnpinSkillVersion`.
  - Validation and auth: reject cross-resource pins (`version_resource_mismatch` → 400), 404 on missing/archived, requires `agent:update` and `AGENT_ADDONS`.
  - Data model: added `pinned_version` relationships with `post_update` so ORM cascades null pins before deleting version rows; workspace/org hard deletes now succeed without violating `RESTRICT`.

<sup>Written for commit 7b92a55a55162f65ecd727298ba5e4e7d9c8aa94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

