### PR TITLE
feat(agent): make preset skill bindings head-only

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -398,13 +398,13 @@
 <ResponseField name="create_agent_preset" type="tool">
   Create an agent preset in the selected workspace.
 
-  Use `skills` to attach published skill versions. Each binding requires `skill_id` and `skill_version_id` from `list_skills` and `publish_skill`.
+  Use `skills` to attach published skills. Each binding contains `skill_id`.
 </ResponseField>
 
 <ResponseField name="update_agent_preset" type="tool">
   Update an existing agent preset in the selected workspace.
 
-  Use `skills` to replace attached published skill-version bindings. Each binding requires `skill_id` and `skill_version_id`. Omit `skills` to leave bindings unchanged, or pass an empty list to detach all skills.
+  Use `skills` to replace attached published skills. Each binding contains `skill_id`. Omit `skills` to leave bindings unchanged, or pass an empty list to detach all skills.
 </ResponseField>
 
 <ResponseField name="list_agent_tree" type="tool">

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2649,14 +2649,9 @@ export const $AgentPresetSkillBindingBase = {
       format: "uuid",
       title: "Skill Id",
     },
-    skill_version_id: {
-      type: "string",
-      format: "uuid",
-      title: "Skill Version Id",
-    },
   },
   type: "object",
-  required: ["skill_id", "skill_version_id"],
+  required: ["skill_id"],
   title: "AgentPresetSkillBindingBase",
   description: "Shared fields for preset skill bindings.",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -643,7 +643,6 @@ export type AgentPresetReadMinimal = {
  */
 export type AgentPresetSkillBindingBase = {
   skill_id: string
-  skill_version_id: string
 }
 
 /**

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -62,7 +62,6 @@ import type {
   AgentPresetVersionReadMinimal,
   AttachedSubagentRef,
   SkillReadMinimal,
-  SkillVersionRead,
 } from "@/client"
 import { AgentPresetDeleteDialog } from "@/components/agents/agent-preset-delete-dialog"
 import { AgentPresetVersionSelect } from "@/components/agents/agent-preset-version-select"
@@ -157,9 +156,10 @@ import {
 } from "@/hooks/use-chat"
 import { useEntitlements } from "@/hooks/use-entitlements"
 import { useFeatureFlag } from "@/hooks/use-feature-flags"
-import { useSkills, useSkillVersions } from "@/hooks/use-skills"
+import { useSkills } from "@/hooks/use-skills"
 import {
   type AgentPresetFormMode,
+  buildAgentPresetUpdatePayload,
   buildDuplicateAgentPresetPayload,
   buildSkillCommandItemValue,
 } from "@/lib/agent-presets"
@@ -249,7 +249,6 @@ const agentPresetSchema = z
       .array(
         z.object({
           skillId: z.string().trim().min(1, "Select a skill"),
-          skillVersionId: z.string().trim().min(1, "Select a version"),
         })
       )
       .default([]),
@@ -1591,7 +1590,10 @@ function AgentPresetForm({
         versionsByPresetId: subagentVersionsByPresetId,
       })
       if (mode === "edit" && preset) {
-        const updated = await onUpdate(preset.id, payload)
+        const updatePayload = buildAgentPresetUpdatePayload(payload, {
+          skillsChanged: Boolean(form.formState.dirtyFields.skills),
+        })
+        const updated = await onUpdate(preset.id, updatePayload)
         form.reset(presetToFormValues(updated))
       } else {
         const created = await onCreate(payload)
@@ -3132,7 +3134,6 @@ function AgentPresetSkillsPanel({
   function handleAddSkill(skillId: string) {
     onAddSkillBinding({
       skillId,
-      skillVersionId: "",
     })
     setIsPickerOpen(false)
   }
@@ -3145,7 +3146,7 @@ function AgentPresetSkillsPanel({
             <div className="space-y-1">
               <p className="text-sm font-medium">Attached skills</p>
               <p className="text-xs text-muted-foreground">
-                Pin published skill versions to this preset.
+                Attach published skills to this preset.
               </p>
             </div>
             <Button
@@ -3247,76 +3248,16 @@ function AgentPresetSkillBindingRow({
   onRemove: (index: number) => void
 }) {
   const skillFieldName = `skills.${index}.skillId` as const
-  const versionFieldName = `skills.${index}.skillVersionId` as const
   const selectedSkillId = form.watch(skillFieldName)
-  const selectedVersionId = form.watch(versionFieldName)
   const selectedSkill = availableSkills.find(
     (skill) => skill.id === selectedSkillId
   )
-  const { versions, versionsLoading, versionsError } = useSkillVersions(
-    workspaceId,
-    selectedSkillId || null
-  )
-  const versionOptions = useMemo(
-    () => [...(versions ?? [])].sort((a, b) => b.version - a.version),
-    [versions]
-  )
-
-  useEffect(() => {
-    if (!selectedSkillId) {
-      if (selectedVersionId) {
-        form.setValue(versionFieldName, "", { shouldDirty: true })
-      }
-      return
-    }
-
-    if (versionsLoading || versionOptions.length === 0) {
-      return
-    }
-
-    const hasSelectedVersion = versionOptions.some(
-      (version) => version.id === selectedVersionId
-    )
-    if (hasSelectedVersion) {
-      return
-    }
-
-    const preferredVersionId =
-      selectedSkill?.current_version_id ?? versionOptions[0]?.id ?? ""
-    if (!preferredVersionId) {
-      return
-    }
-
-    form.setValue(versionFieldName, preferredVersionId, { shouldDirty: true })
-  }, [
-    form,
-    selectedSkill?.current_version_id,
-    selectedSkillId,
-    selectedVersionId,
-    versionFieldName,
-    versionOptions,
-    versionsLoading,
-  ])
-
-  const selectedVersion = versionOptions.find((v) => v.id === selectedVersionId)
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
   const skillHref = selectedSkillId
     ? `/workspaces/${workspaceId}/skills/${selectedSkillId}`
     : null
-  const displaySkillName = selectedVersion?.name?.trim() || selectedSkill?.name
-  const displaySkillDescription =
-    selectedVersion?.description?.trim() ||
-    selectedSkill?.description?.trim() ||
-    null
-  let versionPlaceholder = "Version"
-  if (versionsLoading) {
-    versionPlaceholder = "..."
-  } else if (versionOptions.length === 0) {
-    versionPlaceholder = "No versions"
-  }
-  const selectedVersionLabel = selectedVersion
-    ? `v${selectedVersion.version}`
-    : versionPlaceholder
+  const displaySkillName = selectedSkill?.name
+  const displaySkillDescription = selectedSkill?.description?.trim() || null
 
   function handleOpenSkill() {
     if (!skillHref) {
@@ -3367,53 +3308,7 @@ function AgentPresetSkillBindingRow({
             </button>
           </div>
         ) : null}
-        {selectedSkillId && versionsError ? (
-          <p className="text-xs text-destructive">
-            {getApiErrorDetail(versionsError) ?? "Failed to load versions."}
-          </p>
-        ) : null}
-        {selectedSkillId && !versionsLoading && versionOptions.length === 0 ? (
-          <p className="text-xs text-muted-foreground">
-            No published versions yet.
-          </p>
-        ) : null}
       </div>
-      <FormField
-        control={form.control}
-        name={versionFieldName}
-        render={({ field }) => (
-          <FormItem className="shrink-0">
-            <Select
-              value={field.value || ""}
-              onValueChange={field.onChange}
-              disabled={
-                isSaving ||
-                !selectedSkillId ||
-                versionsLoading ||
-                versionOptions.length === 0
-              }
-            >
-              <FormControl>
-                <SelectTrigger className="h-7 w-auto gap-1.5 border-none bg-muted/50 px-2 text-xs shadow-none">
-                  <span aria-hidden>{selectedVersionLabel}</span>
-                  <SelectValue
-                    className="sr-only"
-                    placeholder={versionPlaceholder}
-                  />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                {versionOptions.map((version) => (
-                  <SelectItem key={version.id} value={version.id}>
-                    {formatSkillVersionLabel(version)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
       <Button
         type="button"
         variant="ghost"
@@ -3852,7 +3747,6 @@ function presetToFormValues(preset: AgentPresetRead): AgentPresetFormValues {
       preset.skills?.map(
         (binding): SkillBindingFormValue => ({
           skillId: binding.skill_id,
-          skillVersionId: binding.skill_version_id,
         })
       ) ?? [],
     retries: preset.retries ?? DEFAULT_RETRIES,
@@ -3894,7 +3788,6 @@ function formValuesToPayload(
     agents: formValuesToAgentsPayload(values, subagentContext),
     skills: values.skills.map((binding) => ({
       skill_id: binding.skillId,
-      skill_version_id: binding.skillVersionId,
     })),
     tool_approvals: toToolApprovalMap(values.toolApprovals),
     retries: values.retries,
@@ -3965,11 +3858,6 @@ function formValuesToAgentsPayload(
     enabled: true,
     subagents,
   }
-}
-
-function formatSkillVersionLabel(version: SkillVersionRead): string {
-  const name = version.name.trim()
-  return name ? `v${version.version} · ${name}` : `v${version.version}`
 }
 
 function normalizeOptional(value: string | null | undefined) {

--- a/frontend/src/lib/agent-presets.ts
+++ b/frontend/src/lib/agent-presets.ts
@@ -1,4 +1,8 @@
-import type { AgentPresetCreate, AgentPresetRead } from "@/client"
+import type {
+  AgentPresetCreate,
+  AgentPresetRead,
+  AgentPresetUpdate,
+} from "@/client"
 import { slugify } from "@/lib/utils"
 
 export type AgentPresetFormMode = "create" | "edit"
@@ -73,6 +77,17 @@ export function buildDuplicateAgentPresetPayload(
     enable_thinking: preset.enable_thinking,
     enable_internet_access: preset.enable_internet_access,
   }
+}
+
+export function buildAgentPresetUpdatePayload(
+  payload: AgentPresetCreate,
+  { skillsChanged }: { skillsChanged: boolean }
+): AgentPresetUpdate {
+  const updatePayload: AgentPresetUpdate = { ...payload }
+  if (!skillsChanged) {
+    delete updatePayload.skills
+  }
+  return updatePayload
 }
 
 export function canSubmitAgentPresetForm({

--- a/frontend/tests/agent-presets-builder.test.tsx
+++ b/frontend/tests/agent-presets-builder.test.tsx
@@ -1,9 +1,35 @@
 import {
+  buildAgentPresetUpdatePayload,
   buildDuplicateAgentPresetPayload,
   buildDuplicateAgentSlug,
   buildSkillCommandItemValue,
   canSubmitAgentPresetForm,
 } from "@/lib/agent-presets"
+
+const presetPayload = {
+  name: "Triage agent",
+  model_name: "gpt-4o-mini",
+  model_provider: "openai",
+  skills: [{ skill_id: "784dd826-072e-46f1-95a4-08d3417c784f" }],
+}
+
+describe("buildAgentPresetUpdatePayload", () => {
+  it("omits unchanged skill bindings from preset updates", () => {
+    const update = buildAgentPresetUpdatePayload(presetPayload, {
+      skillsChanged: false,
+    })
+
+    expect(update).not.toHaveProperty("skills")
+  })
+
+  it("includes changed skill bindings in preset updates", () => {
+    const update = buildAgentPresetUpdatePayload(presetPayload, {
+      skillsChanged: true,
+    })
+
+    expect(update.skills).toEqual(presetPayload.skills)
+  })
+})
 
 describe("canSubmitAgentPresetForm", () => {
   it("keeps save disabled for new presets until model config is present", () => {

--- a/packages/tracecat-registry/tracecat_registry/core/presets.py
+++ b/packages/tracecat-registry/tracecat_registry/core/presets.py
@@ -123,7 +123,7 @@ async def create_preset(
     ] = None,
     skills: Annotated[
         list[dict[str, Any]] | None,
-        Doc("Optional skill bindings for the preset."),
+        Doc("Optional skill bindings for the preset containing `skill_id`."),
     ] = None,
 ) -> dict[str, Any]:
     # Build kwargs, only including non-None values
@@ -302,7 +302,7 @@ async def update_preset(
     ] = None,
     skills: Annotated[
         list[dict[str, Any]] | None,
-        Doc("The updated skill bindings for the preset."),
+        Doc("The updated skill bindings for the preset containing `skill_id`."),
     ] = None,
 ) -> dict[str, Any]:
     # Build kwargs, only including non-None values

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -54,10 +54,10 @@ class CursorPage(TypedDict):
 
 
 class AgentPresetSkillBinding(TypedDict):
-    """Skill binding for attaching a published skill version to an agent preset."""
+    """Skill binding for attaching a published skill to an agent preset."""
 
     skill_id: str
-    skill_version_id: str
+    """Required skill identifier."""
 
 
 class SkillPublishFile(TypedDict):
@@ -603,7 +603,7 @@ class AgentsClient:
         retries: int | Unset = UNSET,
         enable_thinking: bool | Unset = UNSET,
         enable_internet_access: bool | Unset = UNSET,
-        skills: list[dict[str, Any]] | Unset = UNSET,
+        skills: list[AgentPresetSkillBinding] | Unset = UNSET,
     ) -> dict[str, Any]:
         """Create a new agent preset.
 
@@ -622,6 +622,7 @@ class AgentsClient:
             base_url: Custom API endpoint URL for the model.
             output_type: Expected output format (type string or JSON schema).
             actions: List of action identifiers the agent can use as tools.
+            skills: Skill bindings containing `skill_id`.
 
         Returns:
             Created preset data.
@@ -700,7 +701,7 @@ class AgentsClient:
         retries: int | Unset = UNSET,
         enable_thinking: bool | Unset = UNSET,
         enable_internet_access: bool | Unset = UNSET,
-        skills: list[dict[str, Any]] | Unset = UNSET,
+        skills: list[AgentPresetSkillBinding] | Unset = UNSET,
     ) -> dict[str, Any]:
         """Update an existing agent preset.
 
@@ -718,6 +719,7 @@ class AgentsClient:
             base_url: Updated custom API endpoint URL.
             output_type: Updated output format.
             actions: Updated list of action identifiers.
+            skills: Skill bindings containing `skill_id`.
 
         Returns:
             Updated preset data.

--- a/tests/registry/test_agents_sdk.py
+++ b/tests/registry/test_agents_sdk.py
@@ -226,7 +226,7 @@ async def test_update_preset_serializes_authoring_fields(
         instructions="Triage cases.",
         tool_approvals={"core.cases.update_case": True},
         agents={"enabled": True, "subagents": []},
-        skills=[{"slug": "triage", "settings": {}}],
+        skills=[{"skill_id": "11111111-1111-1111-1111-111111111111"}],
     )
 
     mock_tracecat_client.patch.assert_awaited_once_with(
@@ -235,6 +235,6 @@ async def test_update_preset_serializes_authoring_fields(
             "instructions": "Triage cases.",
             "tool_approvals": {"core.cases.update_case": True},
             "agents": {"enabled": True, "subagents": []},
-            "skills": [{"slug": "triage", "settings": {}}],
+            "skills": [{"skill_id": "11111111-1111-1111-1111-111111111111"}],
         },
     )

--- a/tests/unit/test_agent_preset_schemas.py
+++ b/tests/unit/test_agent_preset_schemas.py
@@ -13,6 +13,7 @@ from tracecat.agent.preset.internal_router import (
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
     AgentPresetRead,
+    AgentPresetSkillBindingRead,
     AgentPresetUpdate,
     AgentPresetVersionReadMinimal,
     build_agent_preset_read_minimal,
@@ -84,6 +85,55 @@ def test_agent_preset_create_rejects_catalog_without_legacy_model_fields() -> No
 def test_agent_preset_create_requires_model_fields_without_catalog_id() -> None:
     with pytest.raises(ValidationError):
         AgentPresetCreate.model_validate({"name": "Legacy preset"})
+
+
+def test_agent_preset_create_accepts_skill_binding_without_version() -> None:
+    skill_id = uuid.uuid4()
+
+    payload = AgentPresetCreate.model_validate(
+        {
+            "name": "Skill-only preset",
+            "model_name": "gpt-4o-mini",
+            "model_provider": "openai",
+            "skills": [{"skill_id": str(skill_id)}],
+        }
+    )
+
+    assert payload.skills is not None
+    assert payload.skills[0].skill_id == skill_id
+    assert payload.skills[0].model_dump(mode="json") == {"skill_id": str(skill_id)}
+
+
+def test_agent_preset_create_ignores_legacy_skill_version_id() -> None:
+    skill_id = uuid.uuid4()
+
+    payload = AgentPresetCreate.model_validate(
+        {
+            "name": "Legacy skill binding",
+            "model_name": "gpt-4o-mini",
+            "model_provider": "openai",
+            "skills": [
+                {
+                    "skill_id": str(skill_id),
+                    "skill_version_id": str(uuid.uuid4()),
+                }
+            ],
+        }
+    )
+
+    assert payload.skills is not None
+    assert payload.skills[0].model_dump(mode="json") == {"skill_id": str(skill_id)}
+
+
+def test_agent_preset_skill_binding_read_requires_stored_version() -> None:
+    with pytest.raises(ValidationError):
+        AgentPresetSkillBindingRead.model_validate(
+            {
+                "skill_id": str(uuid.uuid4()),
+                "skill_name": "triage-skill",
+                "skill_version": 1,
+            }
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import uuid
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from dotenv import dotenv_values
@@ -1023,12 +1023,7 @@ class TestAgentPresetService:
                 instructions="Use the selected skill version",
                 model_name="gpt-4o-mini",
                 model_provider="openai",
-                skills=[
-                    AgentPresetSkillBindingBase(
-                        skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
-                    )
-                ],
+                skills=[AgentPresetSkillBindingBase(skill_id=created_skill.id)],
             )
         )
         current_version = await agent_preset_service.get_current_version_for_preset(
@@ -1039,6 +1034,185 @@ class TestAgentPresetService:
         assert len(version_read.skills) == 1
         assert version_read.skills[0].skill_version_id == skill_version.id
         assert version_read.skills[0].skill_version == 1
+
+    async def test_create_preset_skill_binding_without_version_stores_current_version(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Skill-only authoring stores the server-derived current skill version."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        created_skill = await skill_service.create_skill(
+            SkillCreate(name="skill-only-current")
+        )
+        skill_version = await skill_service.publish_skill(created_skill.id)
+
+        created_preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Skill-only current preset",
+                instructions="Use the selected skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=created_skill.id)],
+            )
+        )
+        current_version = await agent_preset_service.get_current_version_for_preset(
+            created_preset
+        )
+        head_bindings = await agent_preset_service._list_head_skill_bindings(
+            created_preset.id
+        )
+        version_read = await agent_preset_service.build_version_read(current_version)
+
+        assert head_bindings[0].skill_version_id == skill_version.id
+        assert version_read.skills[0].skill_version_id == skill_version.id
+
+    async def test_update_preset_skill_binding_without_version_uses_current_version(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Skill-only updates store the current published Skill version."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        created_skill = await skill_service.create_skill(
+            SkillCreate(name="skill-only-current-update")
+        )
+        previous_version = await skill_service.publish_skill(created_skill.id)
+        draft = await skill_service.get_draft(created_skill.id)
+        assert draft is not None
+        await skill_service.patch_draft(
+            skill_id=created_skill.id,
+            params=SkillDraftPatch(
+                base_revision=draft.draft_revision,
+                operations=[
+                    SkillDraftUpsertTextFileOp(
+                        path="references/current.md",
+                        content="Current published version",
+                    )
+                ],
+            ),
+        )
+        current_version = await skill_service.publish_skill(created_skill.id)
+        assert current_version.id != previous_version.id
+
+        created_preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Skill-only update preset",
+                instructions="No skills yet",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+            )
+        )
+        await agent_preset_service.update_preset(
+            created_preset,
+            AgentPresetUpdate(
+                skills=[AgentPresetSkillBindingBase(skill_id=created_skill.id)]
+            ),
+        )
+        updated_version = await agent_preset_service.get_current_version_for_preset(
+            created_preset
+        )
+        head_bindings = await agent_preset_service._list_head_skill_bindings(
+            created_preset.id
+        )
+        version_read = await agent_preset_service.build_version_read(updated_version)
+
+        assert head_bindings[0].skill_version_id == current_version.id
+        assert version_read.skills[0].skill_version_id == current_version.id
+
+    async def test_client_supplied_stale_skill_version_is_ignored(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Legacy extra fields are ignored and cannot select a Skill version."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        created_skill = await skill_service.create_skill(
+            SkillCreate(name="ignore-stale-version")
+        )
+        stale_version = await skill_service.publish_skill(created_skill.id)
+        draft = await skill_service.get_draft(created_skill.id)
+        assert draft is not None
+        await skill_service.patch_draft(
+            skill_id=created_skill.id,
+            params=SkillDraftPatch(
+                base_revision=draft.draft_revision,
+                operations=[
+                    SkillDraftUpsertTextFileOp(
+                        path="references/current.md",
+                        content="Current published version",
+                    )
+                ],
+            ),
+        )
+        current_published_version = await skill_service.publish_skill(created_skill.id)
+
+        binding = AgentPresetSkillBindingBase.model_validate(
+            {
+                "skill_id": str(created_skill.id),
+                "skill_version_id": str(stale_version.id),
+            }
+        )
+        assert binding.model_dump(mode="json") == {"skill_id": str(created_skill.id)}
+
+        created_preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Ignore stale version preset",
+                instructions="Use the current Skill version",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[binding],
+            )
+        )
+        current_version = await agent_preset_service.get_current_version_for_preset(
+            created_preset
+        )
+        head_bindings = await agent_preset_service._list_head_skill_bindings(
+            created_preset.id
+        )
+        version_read = await agent_preset_service.build_version_read(current_version)
+
+        assert head_bindings[0].skill_version_id == current_published_version.id
+        assert version_read.skills[0].skill_version_id == current_published_version.id
+        assert current_published_version.id != stale_version.id
+
+    async def test_create_preset_rejects_unpublished_skill_binding(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Authoring rejects binding a Skill with no published version."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        created_skill = await skill_service.create_skill(
+            SkillCreate(name="unpublished-binding")
+        )
+
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await agent_preset_service.create_preset(
+                AgentPresetCreate(
+                    name="Unpublished skill preset",
+                    instructions="Use the selected skill",
+                    model_name="gpt-4o-mini",
+                    model_provider="openai",
+                    skills=[AgentPresetSkillBindingBase(skill_id=created_skill.id)],
+                )
+            )
+
+        detail = exc_info.value.detail
+        assert detail is not None
+        assert detail["code"] == "skill_not_published"
+        assert detail["skill_id"] == str(created_skill.id)
 
     async def test_resolve_config_uses_latest_skill_versions_when_setting_enabled(
         self,
@@ -1062,7 +1236,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="latest-skill-v1")
         )
-        skill_version_one = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -1074,7 +1248,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version_one.id,
                     )
                 ],
             )
@@ -1131,7 +1304,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="latest-archived-skill")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
                 name="Latest archived skill preset",
@@ -1142,7 +1315,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -1189,7 +1361,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="pinned-archived-skill")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
                 name="Pinned archived skill preset",
@@ -1200,7 +1372,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -1239,7 +1410,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="batched-skill")
         )
-        skill_version_one = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -1251,7 +1422,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version_one.id,
                     )
                 ],
             )
@@ -1271,7 +1441,7 @@ class TestAgentPresetService:
                 ],
             ),
         )
-        skill_version_two = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         await agent_preset_service.update_preset(
             created_preset,
@@ -1280,7 +1450,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version_two.id,
                     )
                 ],
             ),
@@ -1330,7 +1499,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version_one.id,
                     )
                 ],
             )
@@ -1363,7 +1531,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version_two.id,
                     )
                 ],
             ),
@@ -1390,20 +1557,33 @@ class TestAgentPresetService:
         assert len(restored_bindings) == 1
         assert restored_bindings[0].skill_version_id == skill_version_one.id
 
-    async def test_build_version_read_uses_pinned_skill_version_name(
+    async def test_build_version_read_uses_snapshot_skill_version_name(
         self,
         configure_minio_for_skills,
         session: AsyncSession,
         svc_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
-        """Preset version reads should expose the name from the pinned skill version."""
+        """Preset version reads expose the name from their Skill snapshot."""
 
         skill_service = SkillService(session=session, role=svc_role)
         created_skill = await skill_service.create_skill(
             SkillCreate(name="version-one")
         )
         skill_version_one = await skill_service.publish_skill(created_skill.id)
+
+        created_preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Snapshot skill name preset",
+                instructions="Use the selected Skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=created_skill.id)],
+            )
+        )
+        preset_version_one = await agent_preset_service.get_current_version_for_preset(
+            created_preset
+        )
 
         draft = await skill_service.get_draft(created_skill.id)
         assert draft is not None
@@ -1422,34 +1602,11 @@ class TestAgentPresetService:
         )
         skill_version_two = await skill_service.publish_skill(created_skill.id)
 
-        created_preset = await agent_preset_service.create_preset(
-            AgentPresetCreate(
-                name="Pinned skill name preset",
-                instructions="Use the selected skill version",
-                model_name="gpt-4o-mini",
-                model_provider="openai",
-                skills=[
-                    AgentPresetSkillBindingBase(
-                        skill_id=created_skill.id,
-                        skill_version_id=skill_version_one.id,
-                    )
-                ],
-            )
-        )
-        preset_version_one = await agent_preset_service.get_current_version_for_preset(
-            created_preset
-        )
-
         await agent_preset_service.update_preset(
             created_preset,
             AgentPresetUpdate(
-                instructions="Bind the newer skill version",
-                skills=[
-                    AgentPresetSkillBindingBase(
-                        skill_id=created_skill.id,
-                        skill_version_id=skill_version_two.id,
-                    )
-                ],
+                instructions="Snapshot the newer Skill version",
+                skills=[AgentPresetSkillBindingBase(skill_id=created_skill.id)],
             ),
         )
 
@@ -1468,38 +1625,12 @@ class TestAgentPresetService:
         configure_minio_for_skills,
         session: AsyncSession,
         svc_role: Role,
-        svc_admin_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
-        """Preset version creation rejects duplicate resolved skill names."""
+        """Preset version creation rejects duplicate current Skill names."""
 
-        settings_service = SettingsService(session=session, role=svc_admin_role)
-        await settings_service.update_app_settings(
-            AppSettingsUpdate(
-                app_versioned_resource_resolution_strategy=(
-                    VersionedResourceResolutionStrategy.PINNED
-                )
-            )
-        )
         skill_service = SkillService(session=session, role=svc_role)
         skill_a = await skill_service.create_skill(SkillCreate(name="shared-name"))
-        skill_a_shared = await skill_service.publish_skill(skill_a.id)
-
-        draft_a = await skill_service.get_draft(skill_a.id)
-        assert draft_a is not None
-        await skill_service.patch_draft(
-            skill_id=skill_a.id,
-            params=SkillDraftPatch(
-                base_revision=draft_a.draft_revision,
-                operations=[
-                    SkillDraftUpsertTextFileOp(
-                        path="SKILL.md",
-                        content="---\nname: skill-a-current\n---\n\n# skill-a-current\n",
-                        content_type="text/markdown; charset=utf-8",
-                    )
-                ],
-            ),
-        )
         await skill_service.publish_skill(skill_a.id)
 
         skill_b = await skill_service.create_skill(SkillCreate(name="skill-b-current"))
@@ -1520,7 +1651,7 @@ class TestAgentPresetService:
                 ],
             ),
         )
-        skill_b_shared = await skill_service.publish_skill(skill_b.id)
+        await skill_service.publish_skill(skill_b.id)
 
         with pytest.raises(
             TracecatValidationError,
@@ -1535,11 +1666,9 @@ class TestAgentPresetService:
                     skills=[
                         AgentPresetSkillBindingBase(
                             skill_id=skill_a.id,
-                            skill_version_id=skill_a_shared.id,
                         ),
                         AgentPresetSkillBindingBase(
                             skill_id=skill_b.id,
-                            skill_version_id=skill_b_shared.id,
                         ),
                     ],
                 )
@@ -1556,38 +1685,12 @@ class TestAgentPresetService:
         configure_minio_for_skills,
         session: AsyncSession,
         svc_role: Role,
-        svc_admin_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
         """Preset resolution fails before runtime if a snapshot contains duplicates."""
 
-        settings_service = SettingsService(session=session, role=svc_admin_role)
-        await settings_service.update_app_settings(
-            AppSettingsUpdate(
-                app_versioned_resource_resolution_strategy=(
-                    VersionedResourceResolutionStrategy.PINNED
-                )
-            )
-        )
         skill_service = SkillService(session=session, role=svc_role)
         skill_a = await skill_service.create_skill(SkillCreate(name="shared-name"))
-        skill_a_shared = await skill_service.publish_skill(skill_a.id)
-
-        draft_a = await skill_service.get_draft(skill_a.id)
-        assert draft_a is not None
-        await skill_service.patch_draft(
-            skill_id=skill_a.id,
-            params=SkillDraftPatch(
-                base_revision=draft_a.draft_revision,
-                operations=[
-                    SkillDraftUpsertTextFileOp(
-                        path="SKILL.md",
-                        content="---\nname: skill-a-current\n---\n\n# skill-a-current\n",
-                        content_type="text/markdown; charset=utf-8",
-                    )
-                ],
-            ),
-        )
         await skill_service.publish_skill(skill_a.id)
 
         skill_b = await skill_service.create_skill(SkillCreate(name="skill-b-current"))
@@ -1619,7 +1722,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=skill_a.id,
-                        skill_version_id=skill_a_shared.id,
                     )
                 ],
             )
@@ -1666,7 +1768,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="create-lock-skill")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         captured_for_update: list[bool] = []
         original_validate_binding_inputs = (
@@ -1697,7 +1799,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -1718,7 +1819,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="clear-skill-bindings")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -1730,7 +1831,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -1765,7 +1865,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="update-lock-skill")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -1802,7 +1902,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ]
             ),
@@ -1824,7 +1923,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="ordered-lock-skill")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -1854,9 +1953,10 @@ class TestAgentPresetService:
         async def instrumented_replace(
             preset_id: uuid.UUID,
             bindings: list[AgentPresetSkillBindingBase],
+            **kwargs: Any,
         ) -> None:
             call_order.append("replace")
-            await original_replace(preset_id, bindings)
+            await original_replace(preset_id, bindings, **kwargs)
 
         monkeypatch.setattr(
             agent_preset_service,
@@ -1880,7 +1980,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ]
             ),
@@ -1932,7 +2031,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="restore-ordered-lock-skill")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -1944,7 +2043,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -2003,7 +2101,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="archived-restore-skill")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -2015,7 +2113,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -2101,7 +2198,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="restore-lock-skill")
         )
-        skill_version = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -2113,7 +2210,6 @@ class TestAgentPresetService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created_skill.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1742,6 +1742,91 @@ class TestAgentPresetService:
         assert detail["skill_names"] == ["shared-name"]
         assert uuid.UUID(detail["preset_id"])
 
+    async def test_version_validation_and_snapshot_share_locked_skill_specs(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Validation and snapshotting consume one locked Skill resolution."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        created_skill = await skill_service.create_skill(
+            SkillCreate(name="atomic-snapshot-skill")
+        )
+        await skill_service.publish_skill(created_skill.id)
+        created_preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Atomic snapshot preset",
+                instructions="Use the selected Skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=created_skill.id)],
+            )
+        )
+
+        original_resolve = agent_preset_service._resolve_head_skill_binding_specs
+        original_validate = agent_preset_service._validate_unique_skill_binding_names
+        original_snapshot = agent_preset_service._snapshot_version_skill_bindings
+        calls: list[tuple[str, object]] = []
+
+        async def instrumented_resolve(
+            preset_id: uuid.UUID, *, for_update: bool = False
+        ) -> list[SkillBindingSpec]:
+            specs = await original_resolve(preset_id, for_update=for_update)
+            calls.append(("resolve_locked" if for_update else "resolve", specs))
+            return specs
+
+        async def instrumented_validate(
+            binding_specs: list[SkillBindingSpec], *, preset_id: uuid.UUID
+        ) -> None:
+            calls.append(("validate", binding_specs))
+            await original_validate(binding_specs, preset_id=preset_id)
+
+        async def instrumented_snapshot(
+            preset_id: uuid.UUID,
+            preset_version_id: uuid.UUID,
+            *,
+            binding_specs: list[SkillBindingSpec] | None = None,
+        ) -> None:
+            calls.append(("snapshot", binding_specs))
+            await original_snapshot(
+                preset_id,
+                preset_version_id,
+                binding_specs=binding_specs,
+            )
+
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_resolve_head_skill_binding_specs",
+            instrumented_resolve,
+        )
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_validate_unique_skill_binding_names",
+            instrumented_validate,
+        )
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_snapshot_version_skill_bindings",
+            instrumented_snapshot,
+        )
+
+        await agent_preset_service.update_preset(
+            created_preset,
+            AgentPresetUpdate(instructions="Create an atomic snapshot"),
+        )
+
+        assert [name for name, _value in calls] == [
+            "resolve_locked",
+            "validate",
+            "snapshot",
+        ]
+        assert calls[0][1] is calls[1][1]
+        assert calls[1][1] is calls[2][1]
+
     async def test_resolve_agent_preset_config_rejects_duplicate_skill_names(
         self,
         configure_minio_for_skills,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1620,6 +1620,68 @@ class TestAgentPresetService:
         assert head_bindings[0].skill_version_id == skill_version_two.id
         assert head_bindings[0].skill_name == "version-two"
 
+    async def test_non_skill_update_refreshes_head_and_version_skill_bindings(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """A new preset snapshot keeps its derived head binding in sync."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        created_skill = await skill_service.create_skill(
+            SkillCreate(name="head-binding-v1")
+        )
+        await skill_service.publish_skill(created_skill.id)
+
+        created_preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Head binding refresh preset",
+                instructions="Use the current Skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=created_skill.id)],
+            )
+        )
+
+        draft = await skill_service.get_draft(created_skill.id)
+        assert draft is not None
+        await skill_service.patch_draft(
+            skill_id=created_skill.id,
+            params=SkillDraftPatch(
+                base_revision=draft.draft_revision,
+                operations=[
+                    SkillDraftUpsertTextFileOp(
+                        path="SKILL.md",
+                        content=(
+                            "---\nname: head-binding-v2\n---\n\n# Head binding v2\n"
+                        ),
+                        content_type="text/markdown; charset=utf-8",
+                    )
+                ],
+            ),
+        )
+        skill_version_two = await skill_service.publish_skill(created_skill.id)
+
+        await agent_preset_service.update_preset(
+            created_preset,
+            AgentPresetUpdate(instructions="Use the refreshed current Skill"),
+        )
+
+        current_version = await agent_preset_service.get_current_version_for_preset(
+            created_preset
+        )
+        head_bindings = await agent_preset_service._list_head_skill_bindings(
+            created_preset.id
+        )
+        version_read = await agent_preset_service.build_version_read(current_version)
+
+        assert head_bindings[0].skill_version_id == skill_version_two.id
+        assert head_bindings[0].skill_name == "head-binding-v2"
+        assert version_read.skills[0].skill_version_id == skill_version_two.id
+        assert version_read.skills[0].skill_name == "head-binding-v2"
+
     async def test_create_preset_rejects_duplicate_bound_skill_names(
         self,
         configure_minio_for_skills,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -9230,7 +9230,6 @@ async def test_create_agent_preset_passes_skill_bindings(
     workspace_id = uuid.uuid4()
     catalog_id = uuid.uuid4()
     skill_id = uuid.uuid4()
-    skill_version_id = uuid.uuid4()
     role = SimpleNamespace(workspace_id=workspace_id)
     created: dict[str, Any] = {}
 
@@ -9304,7 +9303,6 @@ async def test_create_agent_preset_passes_skill_bindings(
         skills=[
             {
                 "skill_id": str(skill_id),
-                "skill_version_id": str(skill_version_id),
             }
         ],
     )
@@ -9312,7 +9310,7 @@ async def test_create_agent_preset_passes_skill_bindings(
     params = created["params"]
     assert len(params.skills) == 1
     assert params.skills[0].skill_id == skill_id
-    assert params.skills[0].skill_version_id == skill_version_id
+    assert params.skills[0].model_dump(mode="json") == {"skill_id": str(skill_id)}
 
 
 @pytest.mark.anyio
@@ -9321,7 +9319,6 @@ async def test_update_agent_preset_passes_skill_bindings(
 ) -> None:
     workspace_id = uuid.uuid4()
     skill_id = uuid.uuid4()
-    skill_version_id = uuid.uuid4()
     role = SimpleNamespace(workspace_id=workspace_id)
     captured: dict[str, Any] = {}
     now = datetime.now(UTC)
@@ -9378,7 +9375,6 @@ async def test_update_agent_preset_passes_skill_bindings(
         skills=[
             {
                 "skill_id": str(skill_id),
-                "skill_version_id": str(skill_version_id),
             }
         ],
     )
@@ -9386,7 +9382,7 @@ async def test_update_agent_preset_passes_skill_bindings(
     params = captured["params"]
     assert len(params.skills) == 1
     assert params.skills[0].skill_id == skill_id
-    assert params.skills[0].skill_version_id == skill_version_id
+    assert params.skills[0].model_dump(mode="json") == {"skill_id": str(skill_id)}
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -2368,7 +2368,7 @@ class TestSkillService:
         """Archiving is blocked while a preset head still binds the skill."""
 
         created = await skill_service.create_skill(SkillCreate(name="bound-skill"))
-        skill_version = await skill_service.publish_skill(created.id)
+        await skill_service.publish_skill(created.id)
 
         preset_service = AgentPresetService(session=session, role=svc_role)
         preset = await preset_service.create_preset(
@@ -2381,7 +2381,6 @@ class TestSkillService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -2402,7 +2401,7 @@ class TestSkillService:
         """Archiving only cares about active preset-head skill bindings."""
 
         created = await skill_service.create_skill(SkillCreate(name="history-skill"))
-        skill_version = await skill_service.publish_skill(created.id)
+        await skill_service.publish_skill(created.id)
 
         preset_service = AgentPresetService(session=session, role=svc_role)
         preset = await preset_service.create_preset(
@@ -2415,7 +2414,6 @@ class TestSkillService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -2440,7 +2438,7 @@ class TestSkillService:
         created = await skill_service.create_skill(
             SkillCreate(name="soft-deleted-preset")
         )
-        skill_version = await skill_service.publish_skill(created.id)
+        await skill_service.publish_skill(created.id)
 
         preset_service = AgentPresetService(session=session, role=svc_role)
         preset = await preset_service.create_preset(
@@ -2453,7 +2451,6 @@ class TestSkillService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -2513,7 +2510,7 @@ class TestSkillService:
         created = await skill_service.create_skill(
             SkillCreate(name="legacy-resolution")
         )
-        skill_version = await skill_service.publish_skill(created.id)
+        await skill_service.publish_skill(created.id)
         preset_service = AgentPresetService(session=session, role=svc_role)
         preset = await preset_service.create_preset(
             AgentPresetCreate(
@@ -2525,7 +2522,6 @@ class TestSkillService:
                 skills=[
                     AgentPresetSkillBindingBase(
                         skill_id=created.id,
-                        skill_version_id=skill_version.id,
                     )
                 ],
             )
@@ -2539,7 +2535,6 @@ class TestSkillService:
                 [
                     AgentPresetSkillBindingBase(
                         skill_id=created.id,
-                        skill_version_id=skill_version.id,
                     )
                 ]
             )

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -35,12 +35,13 @@ class AgentPresetSkillBindingBase(Schema):
     """Shared fields for preset skill bindings."""
 
     skill_id: uuid.UUID
-    skill_version_id: uuid.UUID
 
 
-class AgentPresetSkillBindingRead(AgentPresetSkillBindingBase):
+class AgentPresetSkillBindingRead(Schema):
     """Resolved preset skill binding with metadata."""
 
+    skill_id: uuid.UUID
+    skill_version_id: uuid.UUID
     skill_name: str
     skill_version: int
 

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -322,7 +322,15 @@ class AgentPresetService(BaseWorkspaceService):
             parent_slug=slug,
         )
         if params.skills is not None:
-            await self._replace_head_skill_bindings(preset.id, params.skills)
+            binding_specs = await self._binding_specs_from_inputs(
+                params.skills,
+                for_update=True,
+            )
+            await self._replace_head_skill_bindings(
+                preset.id,
+                params.skills,
+                binding_specs=binding_specs,
+            )
         version = await self._create_version_from_preset(preset)
         preset.current_version_id = version.id
         self.session.add(preset)
@@ -429,9 +437,16 @@ class AgentPresetService(BaseWorkspaceService):
                 for_update=True,
             )
             current_specs = await self._get_head_skill_binding_specs(preset.id)
-            requested_specs = self._binding_specs_from_inputs(requested_skills)
+            requested_specs = await self._binding_specs_from_inputs(
+                requested_skills,
+                for_update=True,
+            )
             if current_specs != requested_specs:
-                await self._replace_head_skill_bindings(preset.id, requested_skills)
+                await self._replace_head_skill_bindings(
+                    preset.id,
+                    requested_skills,
+                    binding_specs=requested_specs,
+                )
                 execution_changed = True
         effective_catalog_id = None
         if "catalog_id" in set_fields:
@@ -1356,15 +1371,17 @@ class AgentPresetService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return result.scalars().first()
 
-    @staticmethod
-    def _binding_specs_from_inputs(
+    async def _binding_specs_from_inputs(
+        self,
         bindings: Sequence[AgentPresetSkillBindingBase],
+        *,
+        for_update: bool = False,
     ) -> list[SkillBindingSpec]:
-        """Normalize mutable head skill bindings for equality checks."""
+        """Normalize authored Skill head bindings to current versions."""
 
-        return sorted(
-            SkillBindingSpec(binding.skill_id, binding.skill_version_id)
-            for binding in bindings
+        return await self._current_skill_binding_specs(
+            [binding.skill_id for binding in bindings],
+            for_update=for_update,
         )
 
     async def _get_head_skill_binding_specs(
@@ -1385,20 +1402,71 @@ class AgentPresetService(BaseWorkspaceService):
             for skill_id, skill_version_id in rows
         )
 
+    async def _current_skill_binding_specs(
+        self, skill_ids: Sequence[uuid.UUID], *, for_update: bool = False
+    ) -> list[SkillBindingSpec]:
+        """Return bindable Skill head IDs with their current versions."""
+
+        if not skill_ids:
+            return []
+        if len(set(skill_ids)) != len(skill_ids):
+            raise TracecatValidationError(
+                "Duplicate skills are not allowed on a preset",
+                detail={"code": "duplicate_skill_binding"},
+            )
+
+        normalized_ids = sorted(set(skill_ids), key=str)
+        stmt = select(Skill).where(
+            Skill.workspace_id == self.workspace_id,
+            Skill.id.in_(normalized_ids),
+            Skill.deleted_at.is_(None),
+            Skill.archived_at.is_(None),
+        )
+        if for_update:
+            stmt = stmt.order_by(Skill.id).with_for_update()
+        skills = {
+            skill.id: skill
+            for skill in (await self.session.execute(stmt)).scalars().all()
+        }
+        missing = [str(skill_id) for skill_id in skill_ids if skill_id not in skills]
+        if missing:
+            raise TracecatValidationError(
+                f"Some skills were not found in this workspace: {sorted(missing)}",
+                detail={"code": "skill_not_found", "missing_skill_ids": missing},
+            )
+
+        specs: list[SkillBindingSpec] = []
+        for skill_id in skill_ids:
+            skill = skills[skill_id]
+            if skill.current_version_id is None:
+                raise TracecatValidationError(
+                    f"Skill '{skill.name}' has no published version",
+                    detail={"code": "skill_not_published", "skill_id": str(skill.id)},
+                )
+            specs.append(SkillBindingSpec(skill_id, skill.current_version_id))
+        return sorted(specs)
+
     async def _replace_head_skill_bindings(
         self,
         preset_id: uuid.UUID,
         bindings: Sequence[AgentPresetSkillBindingBase],
+        *,
+        binding_specs: Sequence[SkillBindingSpec] | None = None,
     ) -> None:
         """Replace the mutable head skill bindings for a preset."""
 
+        specs = (
+            list(binding_specs)
+            if binding_specs is not None
+            else await self._binding_specs_from_inputs(bindings, for_update=True)
+        )
         await self.session.execute(
             sa.delete(AgentPresetSkill).where(
                 AgentPresetSkill.workspace_id == self.workspace_id,
                 AgentPresetSkill.preset_id == preset_id,
             )
         )
-        for binding in bindings:
+        for binding in specs:
             self.session.add(
                 AgentPresetSkill(
                     workspace_id=self.workspace_id,
@@ -1412,23 +1480,24 @@ class AgentPresetService(BaseWorkspaceService):
     async def _snapshot_version_skill_bindings(
         self, preset_id: uuid.UUID, preset_version_id: uuid.UUID
     ) -> None:
-        """Copy exact head skill versions into an immutable preset snapshot."""
+        """Write current Skill versions into an immutable preset snapshot."""
 
-        stmt = select(
-            AgentPresetSkill.skill_id,
-            AgentPresetSkill.skill_version_id,
-        ).where(
+        stmt = select(AgentPresetSkill.skill_id).where(
             AgentPresetSkill.workspace_id == self.workspace_id,
             AgentPresetSkill.preset_id == preset_id,
         )
-        rows = (await self.session.execute(stmt)).tuples().all()
-        for skill_id, skill_version_id in rows:
+        skill_ids = (await self.session.execute(stmt)).scalars().all()
+        specs = await self._current_skill_binding_specs(
+            list(skill_ids),
+            for_update=True,
+        )
+        for binding in specs:
             self.session.add(
                 AgentPresetVersionSkill(
                     workspace_id=self.workspace_id,
                     preset_version_id=preset_version_id,
-                    skill_id=skill_id,
-                    skill_version_id=skill_version_id,
+                    skill_id=binding.skill_id,
+                    skill_version_id=binding.skill_version_id,
                 )
             )
         await self.session.flush()
@@ -1448,11 +1517,8 @@ class AgentPresetService(BaseWorkspaceService):
         rows = (await self.session.execute(stmt)).tuples().all()
         await self.skills.validate_binding_inputs(
             [
-                AgentPresetSkillBindingBase(
-                    skill_id=skill_id,
-                    skill_version_id=skill_version_id,
-                )
-                for skill_id, skill_version_id in rows
+                AgentPresetSkillBindingBase(skill_id=skill_id)
+                for skill_id, _skill_version_id in rows
             ],
             for_update=True,
         )
@@ -1772,50 +1838,33 @@ class AgentPresetService(BaseWorkspaceService):
         """Create and flush a new immutable version from the preset head."""
         if not preset_locked:
             await self._lock_preset_row(preset.id)
-        if await self.use_latest_resource_versions():
-            duplicate_name_stmt = (
-                select(
-                    SkillVersion.name,
-                    func.count(AgentPresetSkill.id).label("binding_count"),
-                )
-                .join(
-                    Skill,
-                    sa.and_(
-                        AgentPresetSkill.workspace_id == Skill.workspace_id,
-                        AgentPresetSkill.skill_id == Skill.id,
-                    ),
-                )
-                .join(
-                    SkillVersion,
-                    sa.and_(
-                        SkillVersion.workspace_id == Skill.workspace_id,
-                        SkillVersion.skill_id == Skill.id,
-                        SkillVersion.id == Skill.current_version_id,
-                    ),
-                )
-                .where(
-                    AgentPresetSkill.workspace_id == self.workspace_id,
-                    AgentPresetSkill.preset_id == preset.id,
-                )
-                .group_by(SkillVersion.name)
-                .having(func.count(AgentPresetSkill.id) > 1)
+        duplicate_name_stmt = (
+            select(
+                SkillVersion.name,
+                func.count(AgentPresetSkill.id).label("binding_count"),
             )
-        else:
-            duplicate_name_stmt = (
-                select(
-                    SkillVersion.name,
-                    func.count(AgentPresetSkill.id).label("binding_count"),
-                )
-                .join(
-                    SkillVersion, AgentPresetSkill.skill_version_id == SkillVersion.id
-                )
-                .where(
-                    AgentPresetSkill.workspace_id == self.workspace_id,
-                    AgentPresetSkill.preset_id == preset.id,
-                )
-                .group_by(SkillVersion.name)
-                .having(func.count(AgentPresetSkill.id) > 1)
+            .join(
+                Skill,
+                sa.and_(
+                    AgentPresetSkill.workspace_id == Skill.workspace_id,
+                    AgentPresetSkill.skill_id == Skill.id,
+                ),
             )
+            .join(
+                SkillVersion,
+                sa.and_(
+                    SkillVersion.workspace_id == Skill.workspace_id,
+                    SkillVersion.skill_id == Skill.id,
+                    SkillVersion.id == Skill.current_version_id,
+                ),
+            )
+            .where(
+                AgentPresetSkill.workspace_id == self.workspace_id,
+                AgentPresetSkill.preset_id == preset.id,
+            )
+            .group_by(SkillVersion.name)
+            .having(func.count(AgentPresetSkill.id) > 1)
+        )
         duplicate_names = sorted(
             name
             for name, _count in (await self.session.execute(duplicate_name_stmt))

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -1492,6 +1492,15 @@ class AgentPresetService(BaseWorkspaceService):
             for_update=True,
         )
         for binding in specs:
+            await self.session.execute(
+                sa.update(AgentPresetSkill)
+                .where(
+                    AgentPresetSkill.workspace_id == self.workspace_id,
+                    AgentPresetSkill.preset_id == preset_id,
+                    AgentPresetSkill.skill_id == binding.skill_id,
+                )
+                .values(skill_version_id=binding.skill_version_id)
+            )
             self.session.add(
                 AgentPresetVersionSkill(
                     workspace_id=self.workspace_id,

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -1446,6 +1446,62 @@ class AgentPresetService(BaseWorkspaceService):
             specs.append(SkillBindingSpec(skill_id, skill.current_version_id))
         return sorted(specs)
 
+    async def _resolve_head_skill_binding_specs(
+        self, preset_id: uuid.UUID, *, for_update: bool = False
+    ) -> list[SkillBindingSpec]:
+        """Resolve a preset's Skill head edges to current immutable versions."""
+
+        stmt = select(AgentPresetSkill.skill_id).where(
+            AgentPresetSkill.workspace_id == self.workspace_id,
+            AgentPresetSkill.preset_id == preset_id,
+        )
+        skill_ids = (await self.session.execute(stmt)).scalars().all()
+        return await self._current_skill_binding_specs(
+            list(skill_ids),
+            for_update=for_update,
+        )
+
+    async def _validate_unique_skill_binding_names(
+        self,
+        binding_specs: Sequence[SkillBindingSpec],
+        *,
+        preset_id: uuid.UUID,
+    ) -> None:
+        """Reject duplicate names in one exact resolved Skill binding set."""
+
+        if not binding_specs:
+            return
+        duplicate_name_stmt = (
+            select(
+                SkillVersion.name,
+                func.count(SkillVersion.id).label("binding_count"),
+            )
+            .where(
+                SkillVersion.workspace_id == self.workspace_id,
+                SkillVersion.id.in_(
+                    [binding.skill_version_id for binding in binding_specs]
+                ),
+            )
+            .group_by(SkillVersion.name)
+            .having(func.count(SkillVersion.id) > 1)
+        )
+        duplicate_names = sorted(
+            name
+            for name, _count in (await self.session.execute(duplicate_name_stmt))
+            .tuples()
+            .all()
+            if name is not None
+        )
+        if duplicate_names:
+            raise TracecatValidationError(
+                "Agent preset version cannot include duplicate skill names",
+                detail={
+                    "code": "duplicate_skill_names",
+                    "skill_names": duplicate_names,
+                    "preset_id": str(preset_id),
+                },
+            )
+
     async def _replace_head_skill_bindings(
         self,
         preset_id: uuid.UUID,
@@ -1478,18 +1534,21 @@ class AgentPresetService(BaseWorkspaceService):
         await self.session.flush()
 
     async def _snapshot_version_skill_bindings(
-        self, preset_id: uuid.UUID, preset_version_id: uuid.UUID
+        self,
+        preset_id: uuid.UUID,
+        preset_version_id: uuid.UUID,
+        *,
+        binding_specs: Sequence[SkillBindingSpec] | None = None,
     ) -> None:
         """Write current Skill versions into an immutable preset snapshot."""
 
-        stmt = select(AgentPresetSkill.skill_id).where(
-            AgentPresetSkill.workspace_id == self.workspace_id,
-            AgentPresetSkill.preset_id == preset_id,
-        )
-        skill_ids = (await self.session.execute(stmt)).scalars().all()
-        specs = await self._current_skill_binding_specs(
-            list(skill_ids),
-            for_update=True,
+        specs = (
+            list(binding_specs)
+            if binding_specs is not None
+            else await self._resolve_head_skill_binding_specs(
+                preset_id,
+                for_update=True,
+            )
         )
         for binding in specs:
             await self.session.execute(
@@ -1847,49 +1906,14 @@ class AgentPresetService(BaseWorkspaceService):
         """Create and flush a new immutable version from the preset head."""
         if not preset_locked:
             await self._lock_preset_row(preset.id)
-        duplicate_name_stmt = (
-            select(
-                SkillVersion.name,
-                func.count(AgentPresetSkill.id).label("binding_count"),
-            )
-            .join(
-                Skill,
-                sa.and_(
-                    AgentPresetSkill.workspace_id == Skill.workspace_id,
-                    AgentPresetSkill.skill_id == Skill.id,
-                ),
-            )
-            .join(
-                SkillVersion,
-                sa.and_(
-                    SkillVersion.workspace_id == Skill.workspace_id,
-                    SkillVersion.skill_id == Skill.id,
-                    SkillVersion.id == Skill.current_version_id,
-                ),
-            )
-            .where(
-                AgentPresetSkill.workspace_id == self.workspace_id,
-                AgentPresetSkill.preset_id == preset.id,
-            )
-            .group_by(SkillVersion.name)
-            .having(func.count(AgentPresetSkill.id) > 1)
+        binding_specs = await self._resolve_head_skill_binding_specs(
+            preset.id,
+            for_update=True,
         )
-        duplicate_names = sorted(
-            name
-            for name, _count in (await self.session.execute(duplicate_name_stmt))
-            .tuples()
-            .all()
-            if name is not None
+        await self._validate_unique_skill_binding_names(
+            binding_specs,
+            preset_id=preset.id,
         )
-        if duplicate_names:
-            raise TracecatValidationError(
-                "Agent preset version cannot include duplicate skill names",
-                detail={
-                    "code": "duplicate_skill_names",
-                    "skill_names": duplicate_names,
-                    "preset_id": str(preset.id),
-                },
-            )
         stmt = (
             select(AgentPresetVersion.version)
             .where(
@@ -1924,7 +1948,11 @@ class AgentPresetService(BaseWorkspaceService):
         )
         self.session.add(version)
         await self.session.flush()
-        await self._snapshot_version_skill_bindings(preset.id, version.id)
+        await self._snapshot_version_skill_bindings(
+            preset.id,
+            version.id,
+            binding_specs=binding_specs,
+        )
         return version
 
     def _sync_preset_head_from_version(

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -2417,12 +2417,6 @@ class SkillService(BaseWorkspaceService):
                     f"Skill '{skill.name}' has no published version",
                     detail={"code": "skill_not_published", "skill_id": str(skill.id)},
                 )
-            selected_version = await self.get_version(binding.skill_version_id)
-            if selected_version is None or selected_version.skill_id != skill.id:
-                raise TracecatValidationError(
-                    "Selected skill version does not belong to the selected skill",
-                    detail={"code": "invalid_skill_binding"},
-                )
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_resolved_skill_refs_for_preset_version(

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -7785,9 +7785,7 @@ async def create_agent_preset(
 ) -> AgentPresetRead:
     """Create an agent preset in the selected workspace.
 
-    Use `skills` to attach published skill versions. Each binding requires
-    `skill_id` and `skill_version_id` from `list_skills` and
-    `publish_skill`.
+    Use `skills` to attach published skills. Each binding contains `skill_id`.
     """
 
     try:
@@ -7868,9 +7866,9 @@ async def update_agent_preset(
 ) -> AgentPresetRead:
     """Update an existing agent preset in the selected workspace.
 
-    Use `skills` to replace attached published skill-version bindings. Each
-    binding requires `skill_id` and `skill_version_id`. Omit `skills` to
-    leave bindings unchanged, or pass an empty list to detach all skills.
+    Use `skills` to replace attached published skills. Each binding contains
+    `skill_id`. Omit `skills` to leave bindings unchanged, or pass an empty list
+    to detach all skills.
     """
 
     try:


### PR DESCRIPTION
## Mental model

> Authored cross-resource edges point to ResourceHeads. Authoring identifies a skill by `skill_id`; it never selects a child ResourceVersion. Immutable parent versions may retain the child version observed at publish time as expand-window ledger data, but runtime resolution follows the child head.

## Summary

- Make preset skill authoring head-only across the API, SDK, MCP, registry action, generated client, and frontend.
- Accept and ignore legacy `skill_version_id` input for compatibility, while removing it from canonical request types and UI controls.
- Validate that every referenced skill exists in the workspace, is published, and appears only once.
- Continue dual-writing the child version observed at publish time into the existing snapshot relationship during the expand window; it is not an authored selector or runtime pin.

## Review guide

- `tracecat/agent/preset/service.py`: the single authoring validation and snapshot derivation path.
- Authoring schemas accept stale legacy payloads but expose only `skill_id` canonically.
- The preset builder has no version picker; users bind a skill head.
- Runtime head resolution and roll-forward restore are introduced later in the stack.

## Validation

- 345 focused backend tests passed.
- SDK registry tests and 504 frontend tests passed.
- Generated client is current.
- Ruff, basedpyright, and frontend typecheck passed.

Part of [ENG-1530](https://linear.app/tracecat/issue/ENG-1530/rearchitect-resource-version-resolution-around-workspace-heads). First branch in the Part 2 stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent preset skill bindings are now head-only. Clients send only `skill_id`; the server resolves to the current published version, validates against that locked set, updates head bindings to those versions, and uses the same set when snapshotting (ENG-1528).

- **New Features**
  - API: Removed `skill_version_id` from authoring; legacy inputs are accepted and ignored. Head bindings store the current published version; snapshots write the exact resolved versions; duplicate-name checks run against that exact set.
  - Validation: Rejects unpublished or missing skills (`skill_not_published`, `skill_not_found`) and duplicate skills; ignores stale client-supplied version IDs. Validation and snapshot share one locked resolution to prevent races.
  - UI/SDK/docs: Removed version picker and version lookups; update requests omit `skills` when unchanged. Client schemas/types drop `skill_version_id`; SDK `AgentPresetSkillBinding` now includes only `skill_id`; `tracecat-registry` and MCP docs updated.

- **Migration**
  - Stop sending `skill_version_id` in create/update preset requests; regenerate clients to the new schema.
  - No data migration needed; existing presets and snapshots remain valid.

<sup>Written for commit 48cebe7a60f7eae56abef27e60e51876331941e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

