### PR TITLE
feat(agents): record per-turn resource provenance

### DIFF
--- a/alembic/versions/b4e6c8a2d0f1_add_agent_turn_provenance.py
+++ b/alembic/versions/b4e6c8a2d0f1_add_agent_turn_provenance.py
@@ -1,0 +1,78 @@
+"""Add agent turn provenance snapshots.
+
+Revision ID: b4e6c8a2d0f1
+Revises: 44320bf05445
+Create Date: 2026-07-08 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_workspace_table_rls,
+    enable_workspace_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "b4e6c8a2d0f1"
+down_revision: str | None = "44320bf05445"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_turn_provenance",
+        sa.Column("surrogate_id", sa.Integer(), sa.Identity(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("session_id", sa.UUID(), nullable=False),
+        sa.Column("wf_exec_id", sa.String(), nullable=False),
+        sa.Column(
+            "resolved_refs",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_agent_turn_provenance_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_turn_provenance")),
+    )
+    op.create_index(
+        op.f("ix_agent_turn_provenance_workspace_id"),
+        "agent_turn_provenance",
+        ["workspace_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_agent_turn_provenance_session_id"),
+        "agent_turn_provenance",
+        ["session_id"],
+        unique=False,
+    )
+    op.execute(enable_workspace_table_rls("agent_turn_provenance"))
+
+
+def downgrade() -> None:
+    op.execute(disable_workspace_table_rls("agent_turn_provenance"))
+    op.drop_index(
+        op.f("ix_agent_turn_provenance_session_id"),
+        table_name="agent_turn_provenance",
+    )
+    op.drop_index(
+        op.f("ix_agent_turn_provenance_workspace_id"),
+        table_name="agent_turn_provenance",
+    )
+    op.drop_table("agent_turn_provenance")

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -630,6 +630,8 @@ class DurableAgentWorkflow:
             activity_input = (
                 ResolveAgentPresetConfigActivityInput(
                     role=self.role,
+                    preset_id=args.agent_preset_id,
+                    preset_slug=args.agent_args.preset_slug,
                     preset_version_id=args.agent_preset_version_id,
                     session_id=args.agent_args.session_id,
                     wf_exec_id=wf_exec_id,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -460,6 +460,11 @@ LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-histo
 PRESERVE_RESUMED_AGENT_BINDINGS_PATCH = (
     "durable-agent-preserve-resumed-agent-bindings-v1"
 )
+PERSIST_EMPTY_BINDING_PROVENANCE_PATCH = (
+    # Keep the recorded patch ID stable now that enabled-empty bindings share
+    # the same replay-safe deferred-write path as legacy disabled bindings.
+    "durable-agent-persist-disabled-binding-provenance-v1"
+)
 
 
 def _agents_config_from_binding(
@@ -483,6 +488,21 @@ def _preserved_agents_binding(
     if load_result.agents_binding is not None:
         return load_result.agents_binding
     return ResolvedAgentsConfig()
+
+
+def _needs_empty_binding_provenance_activity(
+    cfg: AgentConfig,
+    preserved_binding: ResolvedAgentsConfig,
+) -> bool:
+    """Whether an empty preserved binding still needs the deferred refs write."""
+
+    return (
+        not preserved_binding.subagents
+        and cfg.agents.enabled
+        and bool(cfg.agents.subagents)
+        and cfg.resolved_refs is not None
+        and bool(cfg.resolved_refs.refs)
+    )
 
 
 FINALIZE_TURN_PATCH = "durable-agent-finalize-turn-v1"
@@ -589,17 +609,36 @@ class DurableAgentWorkflow:
             has_base_url=bool(cfg.base_url),
         )
 
+    def _turn_wf_exec_id(self, args: AgentWorkflowArgs) -> str:
+        """Per-turn identifier for ``agent_turn_provenance`` rows.
+
+        Chat callers mint a fresh ``curr_run_id`` per turn. DSL/workflow
+        callers leave it unset and reuse ``agent/<session_id>`` as the
+        workflow ID across continuing turns, so falling back to the session
+        id would collapse every continuing turn into one ``wf_exec_id``.
+        Fall back to the Temporal run ID instead: unique per execution
+        (i.e. per turn) and replay-safe via ``workflow.info()``.
+        """
+        if args.agent_args.curr_run_id is not None:
+            return str(args.agent_args.curr_run_id)
+        return workflow.info().run_id
+
     async def _build_config(self, args: AgentWorkflowArgs) -> AgentConfig:
         if args.agent_args.preset_slug:
+            wf_exec_id = self._turn_wf_exec_id(args)
             activity_input = (
                 ResolveAgentPresetConfigActivityInput(
                     role=self.role,
                     preset_version_id=args.agent_preset_version_id,
+                    session_id=args.agent_args.session_id,
+                    wf_exec_id=wf_exec_id,
                 )
                 if args.agent_preset_version_id is not None
                 else ResolveAgentPresetConfigActivityInput(
                     role=self.role,
                     preset_slug=args.agent_args.preset_slug,
+                    session_id=args.agent_args.session_id,
+                    wf_exec_id=wf_exec_id,
                 )
             )
             preset_config_payload = await workflow.execute_activity(
@@ -646,12 +685,16 @@ class DurableAgentWorkflow:
         agents: AgentSubagentsConfig | None = None,
         follow_latest_versions: bool | None = None,
         preserve_resolved_versions: bool = False,
+        persist_provenance: bool = False,
     ) -> ResolvedAgentsRuntimeConfig:
         agents_config = agents if agents is not None else cfg.agents
-        if not agents_config.enabled:
-            return ResolvedAgentsRuntimeConfig()
-        if not agents_config.subagents:
-            return ResolvedAgentsRuntimeConfig(enabled=True)
+        if not agents_config.enabled and not persist_provenance:
+            return ResolvedAgentsRuntimeConfig(resolved_refs=cfg.resolved_refs)
+        if not agents_config.subagents and not persist_provenance:
+            return ResolvedAgentsRuntimeConfig(
+                enabled=True,
+                resolved_refs=cfg.resolved_refs,
+            )
         return await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(
@@ -661,6 +704,9 @@ class DurableAgentWorkflow:
                 parent_slug=args.agent_args.preset_slug,
                 follow_latest_versions=follow_latest_versions,
                 preserve_resolved_versions=preserve_resolved_versions,
+                session_id=args.agent_args.session_id,
+                wf_exec_id=self._turn_wf_exec_id(args),
+                parent_resolved_refs=cfg.resolved_refs,
             ),
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
@@ -1111,6 +1157,10 @@ class DurableAgentWorkflow:
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )
             if preserved_binding := _preserved_agents_binding(load_result):
+                persist_empty_binding_provenance = (
+                    _needs_empty_binding_provenance_activity(cfg, preserved_binding)
+                    and workflow.patched(PERSIST_EMPTY_BINDING_PROVENANCE_PATCH)
+                )
                 # preserve_resolved_versions rebuilds the stored binding
                 # verbatim (exact version IDs, with_deleted). The session
                 # activity fails the run on any binding mismatch, so this
@@ -1123,6 +1173,7 @@ class DurableAgentWorkflow:
                     agents=_agents_config_from_binding(preserved_binding),
                     follow_latest_versions=False,
                     preserve_resolved_versions=True,
+                    persist_provenance=persist_empty_binding_provenance,
                 )
             else:
                 agents_result = await self._resolve_agents_config(args, cfg)

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -56,6 +56,7 @@ with workflow.unsafe.imports_passed_through():
         resolve_agents_config_activity,
         resolve_custom_model_provider_config_activity,
     )
+    from tracecat.agent.preset.resolved_refs import without_subagent_refs
     from tracecat.agent.preset.resolver import (
         ResolvedAgentsRuntimeConfig,
         ResolvedSubagentConfig,
@@ -695,6 +696,15 @@ class DurableAgentWorkflow:
                 enabled=True,
                 resolved_refs=cfg.resolved_refs,
             )
+        parent_resolved_refs = cfg.resolved_refs
+        if agents is not None:
+            # A preserved session binding overrides the preset's current
+            # topology, and the runtime pass rebuilds that stored binding
+            # verbatim. The root snapshot's subagent entries describe the
+            # preset's *current* children; merging them would record
+            # children that never ran this turn (an empty preserved binding
+            # would even persist the fresh snapshot wholesale).
+            parent_resolved_refs = without_subagent_refs(parent_resolved_refs)
         return await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(
@@ -706,7 +716,7 @@ class DurableAgentWorkflow:
                 preserve_resolved_versions=preserve_resolved_versions,
                 session_id=args.agent_args.session_id,
                 wf_exec_id=self._turn_wf_exec_id(args),
-                parent_resolved_refs=cfg.resolved_refs,
+                parent_resolved_refs=parent_resolved_refs,
             ),
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -57,6 +57,7 @@ with workflow.unsafe.imports_passed_through():
         resolve_agents_config_activity,
         resolve_custom_model_provider_config_activity,
     )
+    from tracecat.agent.preset.resolved_refs import without_subagent_refs
     from tracecat.agent.preset.resolver import (
         ResolvedAgentsRuntimeConfig,
         ResolvedSubagentConfig,
@@ -727,6 +728,15 @@ class DurableAgentWorkflow:
                 enabled=True,
                 resolved_refs=cfg.resolved_refs,
             )
+        parent_resolved_refs = cfg.resolved_refs
+        if agents is not None:
+            # A preserved session binding overrides the preset's current
+            # topology, and the runtime pass rebuilds that stored binding
+            # verbatim. The root snapshot's subagent entries describe the
+            # preset's *current* children; merging them would record
+            # children that never ran this turn (an empty preserved binding
+            # would even persist the fresh snapshot wholesale).
+            parent_resolved_refs = without_subagent_refs(parent_resolved_refs)
         return await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(
@@ -738,7 +748,7 @@ class DurableAgentWorkflow:
                 preserve_resolved_versions=preserve_resolved_versions,
                 session_id=args.agent_args.session_id,
                 wf_exec_id=self._turn_wf_exec_id(args),
-                parent_resolved_refs=cfg.resolved_refs,
+                parent_resolved_refs=parent_resolved_refs,
             ),
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -490,6 +490,11 @@ LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-histo
 PRESERVE_RESUMED_AGENT_BINDINGS_PATCH = (
     "durable-agent-preserve-resumed-agent-bindings-v1"
 )
+PERSIST_EMPTY_BINDING_PROVENANCE_PATCH = (
+    # Keep the recorded patch ID stable now that enabled-empty bindings share
+    # the same replay-safe deferred-write path as legacy disabled bindings.
+    "durable-agent-persist-disabled-binding-provenance-v1"
+)
 
 
 def _agents_config_from_binding(
@@ -513,6 +518,21 @@ def _preserved_agents_binding(
     if load_result.agents_binding is not None:
         return load_result.agents_binding
     return ResolvedAgentsConfig()
+
+
+def _needs_empty_binding_provenance_activity(
+    cfg: AgentConfig,
+    preserved_binding: ResolvedAgentsConfig,
+) -> bool:
+    """Whether an empty preserved binding still needs the deferred refs write."""
+
+    return (
+        not preserved_binding.subagents
+        and cfg.agents.enabled
+        and bool(cfg.agents.subagents)
+        and cfg.resolved_refs is not None
+        and bool(cfg.resolved_refs.refs)
+    )
 
 
 FINALIZE_TURN_PATCH = "durable-agent-finalize-turn-v1"
@@ -621,17 +641,36 @@ class DurableAgentWorkflow:
             has_base_url=bool(cfg.base_url),
         )
 
+    def _turn_wf_exec_id(self, args: AgentWorkflowArgs) -> str:
+        """Per-turn identifier for ``agent_turn_provenance`` rows.
+
+        Chat callers mint a fresh ``curr_run_id`` per turn. DSL/workflow
+        callers leave it unset and reuse ``agent/<session_id>`` as the
+        workflow ID across continuing turns, so falling back to the session
+        id would collapse every continuing turn into one ``wf_exec_id``.
+        Fall back to the Temporal run ID instead: unique per execution
+        (i.e. per turn) and replay-safe via ``workflow.info()``.
+        """
+        if args.agent_args.curr_run_id is not None:
+            return str(args.agent_args.curr_run_id)
+        return workflow.info().run_id
+
     async def _build_config(self, args: AgentWorkflowArgs) -> AgentConfig:
         if args.agent_args.preset_slug:
+            wf_exec_id = self._turn_wf_exec_id(args)
             activity_input = (
                 ResolveAgentPresetConfigActivityInput(
                     role=self.role,
                     preset_version_id=args.agent_preset_version_id,
+                    session_id=args.agent_args.session_id,
+                    wf_exec_id=wf_exec_id,
                 )
                 if args.agent_preset_version_id is not None
                 else ResolveAgentPresetConfigActivityInput(
                     role=self.role,
                     preset_slug=args.agent_args.preset_slug,
+                    session_id=args.agent_args.session_id,
+                    wf_exec_id=wf_exec_id,
                 )
             )
             preset_config_payload = await workflow.execute_activity(
@@ -678,12 +717,16 @@ class DurableAgentWorkflow:
         agents: AgentSubagentsConfig | None = None,
         follow_latest_versions: bool | None = None,
         preserve_resolved_versions: bool = False,
+        persist_provenance: bool = False,
     ) -> ResolvedAgentsRuntimeConfig:
         agents_config = agents if agents is not None else cfg.agents
-        if not agents_config.enabled:
-            return ResolvedAgentsRuntimeConfig()
-        if not agents_config.subagents:
-            return ResolvedAgentsRuntimeConfig(enabled=True)
+        if not agents_config.enabled and not persist_provenance:
+            return ResolvedAgentsRuntimeConfig(resolved_refs=cfg.resolved_refs)
+        if not agents_config.subagents and not persist_provenance:
+            return ResolvedAgentsRuntimeConfig(
+                enabled=True,
+                resolved_refs=cfg.resolved_refs,
+            )
         return await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(
@@ -693,6 +736,9 @@ class DurableAgentWorkflow:
                 parent_slug=args.agent_args.preset_slug,
                 follow_latest_versions=follow_latest_versions,
                 preserve_resolved_versions=preserve_resolved_versions,
+                session_id=args.agent_args.session_id,
+                wf_exec_id=self._turn_wf_exec_id(args),
+                parent_resolved_refs=cfg.resolved_refs,
             ),
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
@@ -1240,6 +1286,10 @@ class DurableAgentWorkflow:
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )
             if preserved_binding := _preserved_agents_binding(load_result):
+                persist_empty_binding_provenance = (
+                    _needs_empty_binding_provenance_activity(cfg, preserved_binding)
+                    and workflow.patched(PERSIST_EMPTY_BINDING_PROVENANCE_PATCH)
+                )
                 # preserve_resolved_versions rebuilds the stored binding
                 # verbatim (exact version IDs, with_deleted). The session
                 # activity fails the run on any binding mismatch, so this
@@ -1252,6 +1302,7 @@ class DurableAgentWorkflow:
                     agents=_agents_config_from_binding(preserved_binding),
                     follow_latest_versions=False,
                     preserve_resolved_versions=True,
+                    persist_provenance=persist_empty_binding_provenance,
                 )
             else:
                 agents_result = await self._resolve_agents_config(args, cfg)

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -662,6 +662,8 @@ class DurableAgentWorkflow:
             activity_input = (
                 ResolveAgentPresetConfigActivityInput(
                     role=self.role,
+                    preset_id=args.agent_preset_id,
+                    preset_slug=args.agent_args.preset_slug,
                     preset_version_id=args.agent_preset_version_id,
                     session_id=args.agent_args.session_id,
                     wf_exec_id=wf_exec_id,

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -60,7 +60,11 @@ from tracecat.agent.executor.activity import (
     AgentExecutorResult,
     ToolExecutionResult,
 )
-from tracecat.agent.preset.activities import ResolveAgentsConfigActivityInput
+from tracecat.agent.preset.activities import (
+    ResolveAgentPresetConfigActivityInput,
+    ResolveAgentsConfigActivityInput,
+)
+from tracecat.agent.preset.resolved_refs import ResolvedRef, ResolvedRefs
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
     ResolvedSubagentConfig,
@@ -69,6 +73,7 @@ from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.session.activities import (
     CreateSessionInput,
     CreateSessionResult,
+    FinalizeTurnInput,
     LoadSessionInput,
     LoadSessionMessagesInput,
     LoadSessionMessagesResult,
@@ -91,6 +96,7 @@ from tracecat.agent.subagents import (
 from tracecat.agent.tokens import UserMCPServerClaim
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_config import agent_config_to_payload
+from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.chat.schemas import ChatMessage
@@ -834,6 +840,153 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
     assert len(agent_inputs) == 1
     assert agent_inputs[0].sdk_session_id == "sdk-session"
     assert [subagent.alias for subagent in agent_inputs[0].subagents] == ["analyst"]
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "stored_binding",
+    [None, ResolvedAgentsConfig(enabled=True)],
+    ids=["legacy-disabled", "enabled-empty"],
+)
+async def test_agent_workflow_persists_refs_for_empty_binding_on_resume(
+    svc_role: Role,
+    temporal_client: Client,
+    agent_worker_factory,
+    mock_session_id: uuid.UUID,
+    stored_binding: ResolvedAgentsConfig | None,
+) -> None:
+    """Empty preserved bindings still schedule the deferred provenance write."""
+
+    queue = f"test-agent-queue-{mock_session_id}"
+    expected_binding = stored_binding or ResolvedAgentsConfig()
+    expected_agents = AgentSubagentsConfig.model_validate(
+        expected_binding.model_dump(mode="json")
+    )
+    parent_preset_id = uuid.uuid4()
+    root_refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                resource_id=parent_preset_id,
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+    preset_config = AgentConfig(
+        model_name="claude-3-5-sonnet-20241022",
+        model_provider="anthropic",
+        actions=[],
+        agents=AgentSubagentsConfig.model_validate(
+            {
+                "enabled": True,
+                "subagents": [{"preset": "analyst"}],
+            }
+        ),
+        resolved_refs=root_refs,
+    )
+    resolve_inputs: list[ResolveAgentsConfigActivityInput] = []
+    create_inputs: list[CreateSessionInput] = []
+
+    @activity.defn(name="resolve_agent_preset_config_activity")
+    async def mock_resolve_agent_preset_config_activity(
+        input: ResolveAgentPresetConfigActivityInput,
+    ) -> AgentConfigPayload:
+        assert input.preset_slug == "root-agent"
+        return agent_config_to_payload(preset_config)
+
+    @activity.defn(name="load_session_activity")
+    async def mock_load_session_activity(
+        input: LoadSessionInput,
+    ) -> LoadSessionResult:
+        assert input.session_id == mock_session_id
+        return LoadSessionResult(
+            found=True,
+            sdk_session_id="legacy-sdk-session",
+            agents_binding=stored_binding,
+            has_resume_state=True,
+        )
+
+    @activity.defn(name="resolve_agents_config_activity")
+    async def mock_resolve_agents_config_activity(
+        input: ResolveAgentsConfigActivityInput,
+    ) -> ResolvedAgentsRuntimeConfig:
+        resolve_inputs.append(input)
+        assert input.agents == expected_agents
+        assert input.preserve_resolved_versions is True
+        assert input.parent_resolved_refs == root_refs
+        return ResolvedAgentsRuntimeConfig(
+            enabled=input.agents.enabled,
+            resolved_refs=input.parent_resolved_refs,
+        )
+
+    @activity.defn(name="create_session_activity")
+    async def mock_create_session_activity(
+        input: CreateSessionInput,
+    ) -> CreateSessionResult:
+        create_inputs.append(input)
+        assert input.agents_binding == expected_binding
+        return CreateSessionResult(session_id=input.session_id, success=True)
+
+    @activity.defn(name="finalize_turn_activity")
+    async def mock_finalize_turn_activity(input: FinalizeTurnInput) -> None:
+        assert input.session_id == mock_session_id
+
+    workflow_args = AgentWorkflowArgs(
+        role=svc_role,
+        agent_args=RunAgentArgs(
+            session_id=mock_session_id,
+            user_prompt="Continue the legacy session",
+            preset_slug="root-agent",
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+        agent_preset_id=parent_preset_id,
+    )
+
+    def mock_executor(
+        call_count: int, input: AgentExecutorInput
+    ) -> AgentExecutorResult:
+        assert call_count == 0
+        assert input.sdk_session_id == "legacy-sdk-session"
+        assert input.subagents == []
+        return AgentExecutorResult(success=True, output={"status": "ok"})
+
+    activities = [
+        mock_resolve_agent_preset_config_activity,
+        mock_load_session_activity,
+        mock_resolve_agents_config_activity,
+        mock_create_session_activity,
+        mock_finalize_turn_activity,
+        create_mock_load_session_messages_activity(),
+        create_mock_build_tool_definitions_activity(),
+        create_mock_run_agent_activity(mock_executor),
+        create_mock_execute_action_activity(),
+        create_mock_reconcile_tool_results_activity(),
+        *ApprovalManager.get_activities(),
+    ]
+
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
+    ):
+        handle = await temporal_client.start_workflow(
+            DurableAgentWorkflow.run,
+            workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
+        result = await handle.result()
+        history = await handle.fetch_history()
+        await replay_durable_agent_workflow_history(temporal_client, history)
+
+    assert result.output == {"status": "ok"}
+    assert len(resolve_inputs) == 1
+    assert resolve_inputs[0].parent_resolved_refs == root_refs
+    assert len(create_inputs) == 1
+    assert create_inputs[0].agents_binding == expected_binding
 
 
 @pytest.mark.anyio

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -67,7 +67,11 @@ from tracecat.agent.executor.activity import (
     AgentExecutorResult,
     ToolExecutionResult,
 )
-from tracecat.agent.preset.activities import ResolveAgentsConfigActivityInput
+from tracecat.agent.preset.activities import (
+    ResolveAgentPresetConfigActivityInput,
+    ResolveAgentsConfigActivityInput,
+)
+from tracecat.agent.preset.resolved_refs import ResolvedRef, ResolvedRefs
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
     ResolvedSubagentConfig,
@@ -100,6 +104,7 @@ from tracecat.agent.subagents import (
 from tracecat.agent.tokens import UserMCPServerClaim
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_config import agent_config_to_payload
+from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.chat.enums import MessageKind
@@ -1544,6 +1549,153 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
     assert len(agent_inputs) == 1
     assert agent_inputs[0].sdk_session_id == "sdk-session"
     assert [subagent.alias for subagent in agent_inputs[0].subagents] == ["analyst"]
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "stored_binding",
+    [None, ResolvedAgentsConfig(enabled=True)],
+    ids=["legacy-disabled", "enabled-empty"],
+)
+async def test_agent_workflow_persists_refs_for_empty_binding_on_resume(
+    svc_role: Role,
+    temporal_client: Client,
+    agent_worker_factory,
+    mock_session_id: uuid.UUID,
+    stored_binding: ResolvedAgentsConfig | None,
+) -> None:
+    """Empty preserved bindings still schedule the deferred provenance write."""
+
+    queue = f"test-agent-queue-{mock_session_id}"
+    expected_binding = stored_binding or ResolvedAgentsConfig()
+    expected_agents = AgentSubagentsConfig.model_validate(
+        expected_binding.model_dump(mode="json")
+    )
+    parent_preset_id = uuid.uuid4()
+    root_refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                resource_id=parent_preset_id,
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+    preset_config = AgentConfig(
+        model_name="claude-3-5-sonnet-20241022",
+        model_provider="anthropic",
+        actions=[],
+        agents=AgentSubagentsConfig.model_validate(
+            {
+                "enabled": True,
+                "subagents": [{"preset": "analyst"}],
+            }
+        ),
+        resolved_refs=root_refs,
+    )
+    resolve_inputs: list[ResolveAgentsConfigActivityInput] = []
+    create_inputs: list[CreateSessionInput] = []
+
+    @activity.defn(name="resolve_agent_preset_config_activity")
+    async def mock_resolve_agent_preset_config_activity(
+        input: ResolveAgentPresetConfigActivityInput,
+    ) -> AgentConfigPayload:
+        assert input.preset_slug == "root-agent"
+        return agent_config_to_payload(preset_config)
+
+    @activity.defn(name="load_session_activity")
+    async def mock_load_session_activity(
+        input: LoadSessionInput,
+    ) -> LoadSessionResult:
+        assert input.session_id == mock_session_id
+        return LoadSessionResult(
+            found=True,
+            sdk_session_id="legacy-sdk-session",
+            agents_binding=stored_binding,
+            has_resume_state=True,
+        )
+
+    @activity.defn(name="resolve_agents_config_activity")
+    async def mock_resolve_agents_config_activity(
+        input: ResolveAgentsConfigActivityInput,
+    ) -> ResolvedAgentsRuntimeConfig:
+        resolve_inputs.append(input)
+        assert input.agents == expected_agents
+        assert input.preserve_resolved_versions is True
+        assert input.parent_resolved_refs == root_refs
+        return ResolvedAgentsRuntimeConfig(
+            enabled=input.agents.enabled,
+            resolved_refs=input.parent_resolved_refs,
+        )
+
+    @activity.defn(name="create_session_activity")
+    async def mock_create_session_activity(
+        input: CreateSessionInput,
+    ) -> CreateSessionResult:
+        create_inputs.append(input)
+        assert input.agents_binding == expected_binding
+        return CreateSessionResult(session_id=input.session_id, success=True)
+
+    @activity.defn(name="finalize_turn_activity")
+    async def mock_finalize_turn_activity(input: FinalizeTurnInput) -> None:
+        assert input.session_id == mock_session_id
+
+    workflow_args = AgentWorkflowArgs(
+        role=svc_role,
+        agent_args=RunAgentArgs(
+            session_id=mock_session_id,
+            user_prompt="Continue the legacy session",
+            preset_slug="root-agent",
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+        agent_preset_id=parent_preset_id,
+    )
+
+    def mock_executor(
+        call_count: int, input: AgentExecutorInput
+    ) -> AgentExecutorResult:
+        assert call_count == 0
+        assert input.sdk_session_id == "legacy-sdk-session"
+        assert input.subagents == []
+        return AgentExecutorResult(success=True, output={"status": "ok"})
+
+    activities = [
+        mock_resolve_agent_preset_config_activity,
+        mock_load_session_activity,
+        mock_resolve_agents_config_activity,
+        mock_create_session_activity,
+        mock_finalize_turn_activity,
+        create_mock_load_session_messages_activity(),
+        create_mock_build_tool_definitions_activity(),
+        create_mock_run_agent_activity(mock_executor),
+        create_mock_execute_action_activity(),
+        create_mock_reconcile_tool_results_activity(),
+        *ApprovalManager.get_activities(),
+    ]
+
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
+    ):
+        handle = await temporal_client.start_workflow(
+            DurableAgentWorkflow.run,
+            workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
+        result = await handle.result()
+        history = await handle.fetch_history()
+        await replay_durable_agent_workflow_history(temporal_client, history)
+
+    assert result.output == {"status": "ok"}
+    assert len(resolve_inputs) == 1
+    assert resolve_inputs[0].parent_resolved_refs == root_refs
+    assert len(create_inputs) == 1
+    assert create_inputs[0].agents_binding == expected_binding
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -25,7 +25,10 @@ from tracecat_ee.agent.activities import (
     BuildAgentToolDefsArgs,
     BuildToolDefsArgs,
 )
-from tracecat_ee.agent.workflows.durable import _preserved_agents_binding
+from tracecat_ee.agent.workflows.durable import (
+    _needs_empty_binding_provenance_activity,
+    _preserved_agents_binding,
+)
 
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import HarnessType
@@ -39,6 +42,7 @@ from tracecat.agent.executor.activity import (
     run_agent_activity,
 )
 from tracecat.agent.executor.loopback import LoopbackResult
+from tracecat.agent.preset.resolved_refs import ResolvedRef, ResolvedRefs
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.session.activities import (
     CreateSessionInput,
@@ -54,7 +58,7 @@ from tracecat.agent.session.activities import (
 )
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.skill.types import ResolvedSkillRef
-from tracecat.agent.subagents import ResolvedAgentsConfig
+from tracecat.agent.subagents import AgentSubagentsConfig, ResolvedAgentsConfig
 from tracecat.agent.tools import BuildToolsResult
 from tracecat.agent.types import AgentConfig, Tool
 from tracecat.auth.types import Role
@@ -1044,6 +1048,92 @@ class TestPreservedAgentsBinding:
             found=True, sdk_session_id="sdk-session-1", has_resume_state=True
         )
         assert _preserved_agents_binding(result) == ResolvedAgentsConfig()
+
+    def test_empty_preserved_bindings_need_deferred_provenance_activity(
+        self,
+    ) -> None:
+        cfg = AgentConfig(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            agents=AgentSubagentsConfig.model_validate(
+                {
+                    "enabled": True,
+                    "subagents": [{"preset": "analyst"}],
+                }
+            ),
+            resolved_refs=ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        resource_id=uuid.uuid4(),
+                        resolved_version_id=uuid.uuid4(),
+                        status="ok",
+                    )
+                ]
+            ),
+        )
+
+        assert _needs_empty_binding_provenance_activity(cfg, ResolvedAgentsConfig())
+        assert _needs_empty_binding_provenance_activity(
+            cfg, ResolvedAgentsConfig(enabled=True)
+        )
+
+    def test_nonempty_preserved_binding_does_not_force_provenance_activity(
+        self,
+    ) -> None:
+        cfg = AgentConfig(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            agents=AgentSubagentsConfig.model_validate(
+                {
+                    "enabled": True,
+                    "subagents": [{"preset": "analyst"}],
+                }
+            ),
+            resolved_refs=ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        resource_id=uuid.uuid4(),
+                        resolved_version_id=uuid.uuid4(),
+                        status="ok",
+                    )
+                ]
+            ),
+        )
+        binding = ResolvedAgentsConfig.model_validate(
+            {
+                "enabled": True,
+                "subagents": [
+                    {
+                        "preset": "analyst",
+                        "preset_version": 1,
+                        "preset_id": uuid.uuid4(),
+                        "preset_version_id": uuid.uuid4(),
+                    }
+                ],
+            }
+        )
+
+        assert not _needs_empty_binding_provenance_activity(cfg, binding)
+
+    def test_root_only_config_does_not_duplicate_provenance_activity(self) -> None:
+        cfg = AgentConfig(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            resolved_refs=ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        resource_id=uuid.uuid4(),
+                        resolved_version_id=uuid.uuid4(),
+                        status="ok",
+                    )
+                ]
+            ),
+        )
+
+        assert not _needs_empty_binding_provenance_activity(cfg, ResolvedAgentsConfig())
 
     def test_missing_session_resolves_fresh(self) -> None:
         assert _preserved_agents_binding(LoadSessionResult(found=False)) is None

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -27,7 +27,10 @@ from tracecat_ee.agent.activities import (
     EmitSessionDoneInputs,
     EmitSessionErrorInputs,
 )
-from tracecat_ee.agent.workflows.durable import _preserved_agents_binding
+from tracecat_ee.agent.workflows.durable import (
+    _needs_empty_binding_provenance_activity,
+    _preserved_agents_binding,
+)
 
 from tracecat.agent.common.config import build_agent_runtime_uv_env
 from tracecat.agent.common.fs import force_rmtree
@@ -43,6 +46,7 @@ from tracecat.agent.executor.activity import (
     run_agent_activity,
 )
 from tracecat.agent.executor.loopback import LoopbackResult
+from tracecat.agent.preset.resolved_refs import ResolvedRef, ResolvedRefs
 from tracecat.agent.runtime.session_paths import job_uv_state_dir
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.session.activities import (
@@ -59,7 +63,7 @@ from tracecat.agent.session.activities import (
 )
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.skill.types import ResolvedSkillRef
-from tracecat.agent.subagents import ResolvedAgentsConfig
+from tracecat.agent.subagents import AgentSubagentsConfig, ResolvedAgentsConfig
 from tracecat.agent.tools import BuildToolsResult
 from tracecat.agent.types import AgentConfig, Tool, clamp_agent_timeout_seconds
 from tracecat.auth.types import Role
@@ -1072,6 +1076,92 @@ class TestPreservedAgentsBinding:
             found=True, sdk_session_id="sdk-session-1", has_resume_state=True
         )
         assert _preserved_agents_binding(result) == ResolvedAgentsConfig()
+
+    def test_empty_preserved_bindings_need_deferred_provenance_activity(
+        self,
+    ) -> None:
+        cfg = AgentConfig(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            agents=AgentSubagentsConfig.model_validate(
+                {
+                    "enabled": True,
+                    "subagents": [{"preset": "analyst"}],
+                }
+            ),
+            resolved_refs=ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        resource_id=uuid.uuid4(),
+                        resolved_version_id=uuid.uuid4(),
+                        status="ok",
+                    )
+                ]
+            ),
+        )
+
+        assert _needs_empty_binding_provenance_activity(cfg, ResolvedAgentsConfig())
+        assert _needs_empty_binding_provenance_activity(
+            cfg, ResolvedAgentsConfig(enabled=True)
+        )
+
+    def test_nonempty_preserved_binding_does_not_force_provenance_activity(
+        self,
+    ) -> None:
+        cfg = AgentConfig(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            agents=AgentSubagentsConfig.model_validate(
+                {
+                    "enabled": True,
+                    "subagents": [{"preset": "analyst"}],
+                }
+            ),
+            resolved_refs=ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        resource_id=uuid.uuid4(),
+                        resolved_version_id=uuid.uuid4(),
+                        status="ok",
+                    )
+                ]
+            ),
+        )
+        binding = ResolvedAgentsConfig.model_validate(
+            {
+                "enabled": True,
+                "subagents": [
+                    {
+                        "preset": "analyst",
+                        "preset_version": 1,
+                        "preset_id": uuid.uuid4(),
+                        "preset_version_id": uuid.uuid4(),
+                    }
+                ],
+            }
+        )
+
+        assert not _needs_empty_binding_provenance_activity(cfg, binding)
+
+    def test_root_only_config_does_not_duplicate_provenance_activity(self) -> None:
+        cfg = AgentConfig(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            resolved_refs=ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        resource_id=uuid.uuid4(),
+                        resolved_version_id=uuid.uuid4(),
+                        status="ok",
+                    )
+                ]
+            ),
+        )
+
+        assert not _needs_empty_binding_provenance_activity(cfg, ResolvedAgentsConfig())
 
     def test_missing_session_resolves_fresh(self) -> None:
         assert _preserved_agents_binding(LoadSessionResult(found=False)) is None

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -4,7 +4,7 @@ import uuid
 from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -14,6 +14,11 @@ from tracecat.agent.preset.activities import (
     resolve_agent_preset_version_ref_activity,
     resolve_agents_config_activity,
     resolve_custom_model_provider_config_activity,
+)
+from tracecat.agent.preset.resolved_refs import (
+    ResolvedRef,
+    ResolvedRefs,
+    merge_resolved_refs,
 )
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
@@ -37,7 +42,7 @@ class _AsyncContext:
     async def __aenter__(self) -> object:
         return self._value
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
         return None
 
 
@@ -134,6 +139,332 @@ def test_resolve_agents_config_result_derives_session_binding() -> None:
     assert agents_binding.subagents == [binding]
 
 
+def test_merge_resolved_refs_runtime_pass_wins_per_node() -> None:
+    """Invariant: one entry per node identity; the later pass is authoritative.
+
+    On a resumed session the root pass resolves a subagent's current head
+    while the runtime pass restores the stored binding
+    verbatim — the merged snapshot must carry exactly one entry for that
+    node, the runtime one.
+    """
+
+    subagent_id = uuid.uuid4()
+    root_version = uuid.uuid4()
+    restored_version = uuid.uuid4()
+    root_pass = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=subagent_id,
+                resolved_version_id=root_version,
+                status="ok",
+            )
+        ]
+    )
+    runtime_pass = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=subagent_id,
+                resolved_version_id=restored_version,
+                status="ok",
+            )
+        ]
+    )
+
+    merged = merge_resolved_refs(root_pass, runtime_pass)
+
+    assert merged is not None
+    assert len(merged.refs) == 1
+    assert merged.refs[0].resolved_version_id == restored_version
+
+
+def test_merge_resolved_refs_earlier_only_nodes_survive() -> None:
+    """Invariant: a root-pass skip record with no runtime counterpart survives.
+
+    A subagent skipped at root resolution never reaches the runtime binding,
+    so its skip record exists only in the earlier pass and must not be
+    dropped by the merge. Slug-keyed identities (no resource_id) count too,
+    and first-seen order is preserved.
+    """
+
+    skipped_id = uuid.uuid4()
+    resolved_id = uuid.uuid4()
+    root_pass = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=skipped_id,
+                status="skipped",
+                code="deleted",
+                successor_id=uuid.uuid4(),
+            ),
+            ResolvedRef(
+                resource_kind="subagent",
+                slug="slug-only-skip",
+                status="skipped",
+                code="not_found",
+            ),
+        ]
+    )
+    runtime_pass = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=resolved_id,
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+
+    merged = merge_resolved_refs(root_pass, runtime_pass)
+
+    assert merged is not None
+    assert [(ref.resource_id or ref.slug, ref.status) for ref in merged.refs] == [
+        (skipped_id, "skipped"),
+        ("slug-only-skip", "skipped"),
+        (resolved_id, "ok"),
+    ]
+
+
+def test_merge_resolved_refs_id_entry_supersedes_slug_only_provisional() -> None:
+    """Invariant: a slug-only entry is provisional for the same kind+slug.
+
+    A slug-only skip (unresolved slug-ref) followed by an id-bearing entry
+    carrying the same slug is one node observed twice — the id-bearing pass
+    supersedes in place instead of leaving a contradictory pair.
+    """
+
+    resolved_id = uuid.uuid4()
+    slug_only = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                slug="shared-slug",
+                status="skipped",
+                code="not_found",
+            )
+        ]
+    )
+    id_bearing = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=resolved_id,
+                slug="shared-slug",
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+
+    merged = merge_resolved_refs(slug_only, id_bearing)
+
+    assert merged is not None
+    assert len(merged.refs) == 1
+    assert merged.refs[0].resource_id == resolved_id
+    assert merged.refs[0].status == "ok"
+
+
+def test_merge_resolved_refs_distinct_ids_never_merge_via_slug() -> None:
+    """Invariant: slug reuse never conflates distinct resources.
+
+    A live successor that reused a deleted node's slug is a different
+    resource — its ok entry must not replace the deleted node's skip record
+    (or erase its successor_id annotation).
+    """
+
+    deleted_id = uuid.uuid4()
+    successor_id = uuid.uuid4()
+    earlier = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=deleted_id,
+                slug="reused-slug",
+                status="skipped",
+                code="deleted",
+                successor_id=successor_id,
+            )
+        ]
+    )
+    later = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=successor_id,
+                slug="reused-slug",
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+
+    merged = merge_resolved_refs(earlier, later)
+
+    assert merged is not None
+    assert [(ref.resource_id, ref.status) for ref in merged.refs] == [
+        (deleted_id, "skipped"),
+        (successor_id, "ok"),
+    ]
+    assert merged.refs[0].successor_id == successor_id
+
+
+def test_merge_resolved_refs_preserves_root_skill_across_passes() -> None:
+    """Invariant: skill entries from different tree positions both survive.
+
+    The root preset and a subagent can share a skill. The root activity
+    freezes the version the root agent actually runs with; a later subagent
+    activity may resolve the same skill after its head advances. Those
+    are two true observations of different tree positions — the child's
+    entry must not clobber the root's, while the subagent node itself is
+    still replaced by the runtime pass.
+    """
+
+    skill_id = uuid.uuid4()
+    root_skill_version = uuid.uuid4()
+    child_skill_version = uuid.uuid4()
+    subagent_id = uuid.uuid4()
+    preset_id = uuid.uuid4()
+
+    root_pass = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                resource_id=preset_id,
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            ),
+            ResolvedRef(
+                resource_kind="skill",
+                resource_id=skill_id,
+                resolved_version_id=root_skill_version,
+                status="ok",
+            ),
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=subagent_id,
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            ),
+        ]
+    )
+    runtime_subagent_version = uuid.uuid4()
+    runtime_pass = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="subagent",
+                resource_id=subagent_id,
+                resolved_version_id=runtime_subagent_version,
+                status="ok",
+            ),
+            ResolvedRef(
+                resource_kind="skill",
+                resource_id=skill_id,
+                resolved_version_id=child_skill_version,
+                status="ok",
+            ),
+        ]
+    )
+
+    merged = merge_resolved_refs(root_pass, runtime_pass)
+
+    assert merged is not None
+    assert [(ref.resource_kind, ref.resolved_version_id) for ref in merged.refs] == [
+        ("preset", root_pass.refs[0].resolved_version_id),
+        ("skill", root_skill_version),
+        ("subagent", runtime_subagent_version),
+        ("skill", child_skill_version),
+    ]
+
+
+def test_merge_resolved_refs_identical_entries_collapse() -> None:
+    """Invariant: duplicate entries for the same node collapse to one."""
+
+    ref = ResolvedRef(
+        resource_kind="skill",
+        resource_id=uuid.uuid4(),
+        resolved_version_id=uuid.uuid4(),
+        status="ok",
+    )
+
+    merged = merge_resolved_refs(
+        ResolvedRefs(refs=[ref]), ResolvedRefs(refs=[ref.model_copy()])
+    )
+
+    assert merged is not None
+    assert merged.refs == [ref]
+
+
+def test_resolution_outputs_parse_pre_2_2_payloads_without_resolved_refs() -> None:
+    """Invariant: pre-2.2 activity histories deserialize without new fields."""
+
+    runtime_config = ResolvedAgentsRuntimeConfig.model_validate(
+        {"enabled": False, "subagents": []}
+    )
+    payload = AgentConfigPayload.model_validate(
+        {
+            "model_name": "gpt-4o-mini",
+            "model_provider": "openai",
+            "retries": 3,
+        }
+    )
+
+    assert runtime_config.resolved_refs is None
+    assert payload.resolved_refs is None
+
+
+@pytest.mark.anyio
+async def test_disabled_agents_activity_persists_parent_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    root_refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                resource_id=uuid.uuid4(),
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+    )
+    db_session = SimpleNamespace(add=MagicMock(), commit=AsyncMock())
+    service = SimpleNamespace(role=role, session=db_session)
+
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    result = await resolve_agents_config_activity(
+        ResolveAgentsConfigActivityInput(
+            role=role,
+            agents=AgentSubagentsConfig(),
+            session_id=session_id,
+            wf_exec_id="turn-1",
+            parent_resolved_refs=root_refs,
+        )
+    )
+
+    assert result.enabled is False
+    assert result.resolved_refs == root_refs
+    provenance = db_session.add.call_args.args[0]
+    assert provenance.workspace_id == workspace_id
+    assert provenance.session_id == session_id
+    assert provenance.wf_exec_id == "turn-1"
+    assert provenance.resolved_refs == root_refs.model_dump(mode="json")
+    db_session.commit.assert_awaited_once_with()
+
+
 @pytest.mark.anyio
 async def test_resolve_preset_subagent_configs_uses_preset_id_ref() -> None:
     role = Role(
@@ -160,6 +491,9 @@ async def test_resolve_preset_subagent_configs_uses_preset_id_ref() -> None:
     # The edge-authoritative ban check hits the DB; stub it for the double.
     service._get_version_agents_config = AsyncMock(  # type: ignore[method-assign]
         return_value=AgentSubagentsConfig(enabled=False)
+    )
+    service.get_preset = AsyncMock(  # type: ignore[method-assign]
+        return_value=SimpleNamespace(slug="old-analyst-slug", description=None)
     )
 
     result = await service._resolve_preset_subagent_configs(
@@ -208,7 +542,11 @@ async def test_resolve_agents_config_resolves_persisted_ref_by_preset_id(
         _get_version_agents_config=AsyncMock(
             return_value=AgentSubagentsConfig(enabled=False)
         ),
-        get_preset=AsyncMock(return_value=SimpleNamespace(description="Child preset")),
+        get_preset=AsyncMock(
+            return_value=SimpleNamespace(
+                slug="child-preset", description="Child preset"
+            )
+        ),
         resolve_agent_preset_config=AsyncMock(
             return_value=AgentConfig(
                 model_name="gpt-4o-mini",
@@ -276,7 +614,11 @@ async def test_resolve_agents_config_ignores_legacy_follow_latest_flag(
         _get_version_agents_config=AsyncMock(
             return_value=AgentSubagentsConfig(enabled=False)
         ),
-        get_preset=AsyncMock(return_value=SimpleNamespace(description="Child preset")),
+        get_preset=AsyncMock(
+            return_value=SimpleNamespace(
+                slug="child-preset", description="Child preset"
+            )
+        ),
         resolve_agent_preset_config=AsyncMock(
             return_value=AgentConfig(
                 model_name="gpt-4o-mini",

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -19,6 +19,7 @@ from tracecat.agent.preset.resolved_refs import (
     ResolvedRef,
     ResolvedRefs,
     merge_resolved_refs,
+    without_subagent_refs,
 )
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
@@ -32,7 +33,7 @@ from tracecat.agent.subagents import (
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 
 
 class _AsyncContext:
@@ -91,6 +92,75 @@ async def test_resolve_agent_preset_version_ref_activity_ignores_legacy_version(
     assert result.preset_version_id == version.id
 
 
+@pytest.mark.anyio
+async def test_preflight_records_failure_refs_before_reraising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: DSL preflight failures still leave turn provenance.
+
+    ai.preset_agent resolves the preset slug before the agent child workflow
+    exists; a missing/deleted/unpublished slug must record classified
+    failure refs (like the config activity's resolution-error path) instead
+    of failing with zero provenance rows.
+    """
+
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    failure_refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                slug="missing-preset",
+                status="skipped",
+                code="not_found",
+            )
+        ]
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+    )
+    no_rows = SimpleNamespace(scalar_one_or_none=MagicMock(return_value=None))
+    db_session = SimpleNamespace(
+        execute=AsyncMock(return_value=no_rows),
+        add=MagicMock(),
+        commit=AsyncMock(),
+    )
+    service = SimpleNamespace(
+        role=role,
+        session=db_session,
+        resolve_agent_preset_version=AsyncMock(
+            side_effect=TracecatNotFoundError("Preset not found")
+        ),
+        build_root_preset_failure_refs=AsyncMock(return_value=failure_refs),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    with pytest.raises(TracecatNotFoundError):
+        await resolve_agent_preset_version_ref_activity(
+            ResolveAgentPresetVersionRefActivityInput(
+                role=role,
+                preset_slug="missing-preset",
+                session_id=session_id,
+                wf_exec_id="wf-dsl-exec-1",
+            )
+        )
+
+    service.build_root_preset_failure_refs.assert_awaited_once_with(
+        slug="missing-preset",
+    )
+    provenance = db_session.add.call_args.args[0]
+    assert provenance.session_id == session_id
+    assert provenance.wf_exec_id == "wf-dsl-exec-1"
+    assert provenance.resolved_refs == failure_refs.model_dump(mode="json")
+    db_session.commit.assert_awaited_once_with()
+
+
 def test_resolve_agents_config_input_defaults_preserve_resolved_versions() -> None:
     """Workflow histories recorded before the flag existed must deserialize,
     defaulting to fresh current-head resolution."""
@@ -137,6 +207,40 @@ def test_resolve_agents_config_result_derives_session_binding() -> None:
     agents_binding = result.to_agents_binding()
     assert agents_binding.enabled is True
     assert agents_binding.subagents == [binding]
+
+
+def test_without_subagent_refs_keeps_non_subagent_entries() -> None:
+    """Invariant: preserved-binding turns must not inherit fresh subagent refs.
+
+    When a preserved session binding overrides the preset's current topology,
+    the root snapshot's subagent entries describe children that will not run
+    this turn; only preset/skill entries may flow into the merge. An empty
+    preserved binding would otherwise persist the fresh snapshot wholesale.
+    """
+
+    preset_id = uuid.uuid4()
+    refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(resource_kind="preset", resource_id=preset_id, status="ok"),
+            ResolvedRef(resource_kind="skill", resource_id=uuid.uuid4(), status="ok"),
+            ResolvedRef(
+                resource_kind="subagent", resource_id=uuid.uuid4(), status="ok"
+            ),
+            ResolvedRef(
+                resource_kind="subagent",
+                slug="gone-child",
+                status="skipped",
+                code="deleted",
+            ),
+        ]
+    )
+
+    filtered = without_subagent_refs(refs)
+
+    assert filtered is not None
+    assert [ref.resource_kind for ref in filtered.refs] == ["preset", "skill"]
+    assert filtered.refs[0].resource_id == preset_id
+    assert without_subagent_refs(None) is None
 
 
 def test_merge_resolved_refs_runtime_pass_wins_per_node() -> None:

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -3192,10 +3192,13 @@ class TestAgentPresetService:
 
     async def test_root_preset_missing_version_id_classified_not_found(
         self,
+        session: AsyncSession,
+        svc_role: Role,
         agent_preset_service: AgentPresetService,
         agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A stale pinned version ID is missing, not unpublished."""
+        """A stale pinned version records anchored not-found provenance."""
 
         preset = await agent_preset_service.create_preset(
             agent_preset_create_params.model_copy(
@@ -3203,17 +3206,41 @@ class TestAgentPresetService:
             )
         )
         assert preset.current_version_id is not None
+        stale_version_id = uuid.uuid4()
+        session_id = uuid.uuid4()
 
-        missing_version_refs = (
-            await agent_preset_service.build_root_preset_failure_refs(
-                slug=preset.slug,
-                preset_version_id=uuid.uuid4(),
-            )
+        management_service = AgentManagementService(session, role=svc_role)
+        management_service.presets = agent_preset_service
+        monkeypatch.setattr(
+            "tracecat.agent.preset.activities.AgentManagementService.with_session",
+            lambda **_: _AsyncContext(management_service),
         )
 
-        assert missing_version_refs.refs[0].resource_id == preset.id
-        assert missing_version_refs.refs[0].status == "skipped"
-        assert missing_version_refs.refs[0].code == "not_found"
+        with pytest.raises(TracecatNotFoundError):
+            await resolve_agent_preset_config_activity(
+                ResolveAgentPresetConfigActivityInput(
+                    role=svc_role,
+                    preset_id=preset.id,
+                    preset_slug=preset.slug,
+                    preset_version_id=stale_version_id,
+                    session_id=session_id,
+                    wf_exec_id="turn-stale-pinned-root",
+                )
+            )
+
+        row = (
+            await session.execute(
+                select(AgentTurnProvenance).where(
+                    AgentTurnProvenance.session_id == session_id
+                )
+            )
+        ).scalar_one()
+        [failure_ref] = row.resolved_refs["refs"]
+
+        assert failure_ref["resource_id"] == str(preset.id)
+        assert failure_ref["slug"] == preset.slug
+        assert failure_ref["status"] == "skipped"
+        assert failure_ref["code"] == "not_found"
 
     async def test_resolution_activity_writes_immutable_turn_provenance_snapshot(
         self,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1,6 +1,7 @@
 """Tests for AgentPresetService."""
 
 import asyncio
+import copy
 import os
 import uuid
 from datetime import UTC, datetime
@@ -21,6 +22,10 @@ from tracecat.agent.channels.schemas import (
     SlackChannelTokenConfig,
 )
 from tracecat.agent.channels.service import PENDING_SLACK_BOT_TOKEN, AgentChannelService
+from tracecat.agent.preset.activities import (
+    ResolveAgentsConfigActivityInput,
+    resolve_agents_config_activity,
+)
 from tracecat.agent.preset.resolver import resolve_agents_config
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
@@ -54,6 +59,7 @@ from tracecat.db.models import (
     AgentPresetVersion,
     AgentPresetVersionSkill,
     AgentPresetVersionSubagent,
+    AgentTurnProvenance,
     Organization,
     RegistryAction,
     RegistryIndex,
@@ -108,6 +114,17 @@ async def agent_preset_service(
 ) -> AgentPresetService:
     """Create an agent preset service instance for testing."""
     return AgentPresetService(session=session, role=svc_role)
+
+
+class _AsyncContext:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    async def __aenter__(self) -> object:
+        return self._value
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
 
 
 @pytest.fixture
@@ -1315,6 +1332,159 @@ class TestAgentPresetService:
         )
 
         assert config.resolved_skills == []
+
+    async def test_historical_preset_deleted_skill_records_successor(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Invariant: runs without a deleted skill and records the failure."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        deleted_skill = await skill_service.create_skill(
+            SkillCreate(name="provenance-deleted-skill")
+        )
+        await skill_service.publish_skill(deleted_skill.id)
+        preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Historical provenance preset",
+                instructions="Use the selected skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=deleted_skill.id)],
+            )
+        )
+        preset_version = await agent_preset_service.get_current_version_for_preset(
+            preset
+        )
+        await agent_preset_service.update_preset(
+            preset,
+            AgentPresetUpdate(skills=None),
+        )
+        await skill_service.archive_skill(deleted_skill.id)
+        successor = await skill_service.create_skill(
+            SkillCreate(name="provenance-deleted-skill")
+        )
+
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=preset.id,
+            preset_version_id=preset_version.id,
+        )
+
+        assert config.resolved_skills == []
+        assert config.resolved_refs is not None
+        deleted_ref = next(
+            ref
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill" and ref.status == "skipped"
+        )
+        assert deleted_ref.resource_id == deleted_skill.id
+        assert deleted_ref.code == "deleted"
+        assert deleted_ref.successor_id == successor.id
+
+    async def test_deleted_skill_slug_reclaimed_does_not_relink_binding(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Invariant: a reclaimed slug is not silently substituted."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        deleted_skill = await skill_service.create_skill(
+            SkillCreate(name="no-silent-substitution")
+        )
+        await skill_service.publish_skill(deleted_skill.id)
+        preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="No relink preset",
+                instructions="Use the selected skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=deleted_skill.id)],
+            )
+        )
+        historical_version = await agent_preset_service.get_current_version_for_preset(
+            preset
+        )
+        await agent_preset_service.update_preset(
+            preset,
+            AgentPresetUpdate(skills=None),
+        )
+        await skill_service.archive_skill(deleted_skill.id)
+        successor = await skill_service.create_skill(
+            SkillCreate(name="no-silent-substitution")
+        )
+
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=preset.id,
+            preset_version_id=historical_version.id,
+        )
+
+        assert config.resolved_skills == []
+        assert config.resolved_refs is not None
+        assert all(
+            ref.resource_id != successor.id
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill"
+        )
+        deleted_ref = next(
+            ref
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill" and ref.status == "skipped"
+        )
+        assert deleted_ref.resource_id == deleted_skill.id
+        assert deleted_ref.successor_id == successor.id
+
+    async def test_deleted_skill_unclaimed_slug_records_no_successor(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Invariant: an unclaimed deleted slug records no successor."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        deleted_skill = await skill_service.create_skill(
+            SkillCreate(name="unclaimed-deleted-skill")
+        )
+        await skill_service.publish_skill(deleted_skill.id)
+        preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Unclaimed deleted skill preset",
+                instructions="Use the selected skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=deleted_skill.id)],
+            )
+        )
+        historical_version = await agent_preset_service.get_current_version_for_preset(
+            preset
+        )
+        await agent_preset_service.update_preset(
+            preset,
+            AgentPresetUpdate(skills=None),
+        )
+        await skill_service.archive_skill(deleted_skill.id)
+
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=preset.id,
+            preset_version_id=historical_version.id,
+        )
+
+        assert config.resolved_refs is not None
+        deleted_ref = next(
+            ref
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill" and ref.status == "skipped"
+        )
+        assert deleted_ref.resource_id == deleted_skill.id
+        assert deleted_ref.code == "deleted"
+        assert deleted_ref.successor_id is None
 
     async def test_list_versions_returns_metadata_without_skill_lookups(
         self,
@@ -2879,6 +3049,224 @@ class TestAgentPresetService:
                     }
                 )
             )
+
+    async def test_resolve_agents_config_skips_only_failed_flat_tree_node(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: per-node failures skip only the failed node."""
+
+        live_child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Live Child", "slug": "live-child"}
+            )
+        )
+        deleted_child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Deleted Child", "slug": "deleted-child"}
+            )
+        )
+        parent = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={
+                    "name": "Flat Tree Parent",
+                    "slug": "flat-tree-parent",
+                    "agents": AgentSubagentsConfig.model_validate(
+                        {
+                            "enabled": True,
+                            "subagents": [
+                                {"preset": live_child.slug},
+                                {"preset": deleted_child.slug},
+                            ],
+                        }
+                    ),
+                }
+            )
+        )
+        parent_v1 = await agent_preset_service.get_current_version_for_preset(parent)
+        await agent_preset_service.update_preset(
+            parent, AgentPresetUpdate(agents=AgentSubagentsConfig())
+        )
+        await agent_preset_service.delete_preset(deleted_child)
+
+        resolved = await resolve_agents_config(
+            agent_preset_service,
+            agents=AgentSubagentsConfig.model_validate(parent_v1.agents),
+            parent_preset_id=parent.id,
+            parent_slug=parent.slug,
+            include_runtime_config=True,
+        )
+
+        assert len(resolved.subagents) == 1
+        assert resolved.subagents[0].binding.preset_id == live_child.id
+        assert len(resolved.skipped) == 1
+        assert resolved.skipped[0].preset_id == deleted_child.id
+        assert resolved.resolved_refs is not None
+        skipped_refs = [
+            ref
+            for ref in resolved.resolved_refs.refs
+            if ref.resource_kind == "subagent" and ref.status == "skipped"
+        ]
+        ok_refs = [
+            ref
+            for ref in resolved.resolved_refs.refs
+            if ref.resource_kind == "subagent" and ref.status == "ok"
+        ]
+        assert [ref.resource_id for ref in ok_refs] == [live_child.id]
+        assert [ref.resource_id for ref in skipped_refs] == [deleted_child.id]
+
+    async def test_root_preset_deleted_and_not_found_fail_with_codes(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: root preset failures fail the turn, not skip it."""
+
+        deleted = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Deleted Root", "slug": "deleted-root"}
+            )
+        )
+        await agent_preset_service.delete_preset(deleted)
+
+        with pytest.raises(TracecatNotFoundError):
+            await agent_preset_service.resolve_agent_preset_config(preset_id=deleted.id)
+        deleted_refs = await agent_preset_service.build_root_preset_failure_refs(
+            preset_id=deleted.id
+        )
+
+        missing_id = uuid.uuid4()
+        with pytest.raises(TracecatNotFoundError):
+            await agent_preset_service.resolve_agent_preset_config(preset_id=missing_id)
+        missing_refs = await agent_preset_service.build_root_preset_failure_refs(
+            preset_id=missing_id
+        )
+
+        assert deleted_refs.refs[0].resource_id == deleted.id
+        assert deleted_refs.refs[0].status == "skipped"
+        assert deleted_refs.refs[0].code == "deleted"
+        assert missing_refs.refs[0].resource_id == missing_id
+        assert missing_refs.refs[0].status == "skipped"
+        assert missing_refs.refs[0].code == "not_found"
+
+    async def test_root_preset_missing_version_number_classified_not_found(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: failure codes describe the actual ref-resolution state.
+
+        A live preset that lacks the requested version number failed on the
+        version request — that is ``not_found``; ``unpublished`` covers only
+        publish state when no specific version was requested.
+        """
+
+        preset = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Live Root", "slug": "live-root"}
+            )
+        )
+
+        missing_version_refs = (
+            await agent_preset_service.build_root_preset_failure_refs(
+                slug=preset.slug,
+                preset_version=999,
+            )
+        )
+
+        assert missing_version_refs.refs[0].resource_id == preset.id
+        assert missing_version_refs.refs[0].status == "skipped"
+        assert missing_version_refs.refs[0].code == "not_found"
+
+    async def test_resolution_activity_writes_immutable_turn_provenance_snapshot(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invariant: provenance is a value snapshot, not a mutable resource link."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        root_skill = await skill_service.create_skill(
+            SkillCreate(name="snapshot-root-skill")
+        )
+        root_skill_version = await skill_service.publish_skill(root_skill.id)
+        child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Snapshot Child", "slug": "snapshot-child"}
+            )
+        )
+        parent = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Snapshot Parent",
+                slug="snapshot-parent",
+                instructions="Use the selected skill and child.",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=root_skill.id)],
+                agents=AgentSubagentsConfig.model_validate(
+                    {
+                        "enabled": True,
+                        "subagents": [{"preset": child.slug}],
+                    }
+                ),
+            )
+        )
+        parent_config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=parent.id
+        )
+        session_id = uuid.uuid4()
+
+        monkeypatch.setattr(
+            "tracecat.agent.preset.activities.AgentPresetService.with_session",
+            lambda **_: _AsyncContext(agent_preset_service),
+        )
+
+        result = await resolve_agents_config_activity(
+            ResolveAgentsConfigActivityInput(
+                role=svc_role,
+                agents=parent_config.agents,
+                parent_preset_id=parent.id,
+                session_id=session_id,
+                wf_exec_id="turn-1",
+                parent_resolved_refs=parent_config.resolved_refs,
+            )
+        )
+
+        row = (
+            await session.execute(
+                select(AgentTurnProvenance).where(
+                    AgentTurnProvenance.session_id == session_id
+                )
+            )
+        ).scalar_one()
+        snapshot = copy.deepcopy(row.resolved_refs)
+        await agent_preset_service.update_preset(
+            parent,
+            AgentPresetUpdate(skills=None),
+        )
+        await skill_service.archive_skill(root_skill.id)
+        row_after = (
+            await session.execute(
+                select(AgentTurnProvenance).where(
+                    AgentTurnProvenance.session_id == session_id
+                )
+            )
+        ).scalar_one()
+
+        assert result.resolved_refs is not None
+        assert snapshot == result.resolved_refs.model_dump(mode="json")
+        assert any(
+            ref["resource_kind"] == "skill"
+            and ref["resource_id"] == str(root_skill.id)
+            and ref["resolved_version_id"] == str(root_skill_version.id)
+            for ref in snapshot["refs"]
+        )
+        assert row_after.resolved_refs == snapshot
 
     async def test_delete_preset_ignores_resolved_reference_with_reused_slug(
         self,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1289,6 +1289,13 @@ class TestAgentPresetService:
         resolved_skill = config.resolved_skills[0]
         assert resolved_skill.skill_version_id == skill_version_two.id
         assert resolved_skill.skill_name == "latest-skill-v2"
+        assert config.resolved_refs is not None
+        resolved_ref = next(
+            ref
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill" and ref.status == "ok"
+        )
+        assert resolved_ref.slug == resolved_skill.skill_name
 
     async def test_resolve_config_skips_archived_skill_head(
         self,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -6,6 +6,7 @@ import os
 import uuid
 from datetime import UTC, datetime
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 import sqlalchemy as sa
@@ -23,7 +24,9 @@ from tracecat.agent.channels.schemas import (
 )
 from tracecat.agent.channels.service import PENDING_SLACK_BOT_TOKEN, AgentChannelService
 from tracecat.agent.preset.activities import (
+    ResolveAgentPresetConfigActivityInput,
     ResolveAgentsConfigActivityInput,
+    resolve_agent_preset_config_activity,
     resolve_agents_config_activity,
 )
 from tracecat.agent.preset.resolver import resolve_agents_config
@@ -35,6 +38,7 @@ from tracecat.agent.preset.schemas import (
 )
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.preset.types import SkillBindingSpec
+from tracecat.agent.service import AgentManagementService
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.skill.schemas import (
     SkillCreate,
@@ -3274,6 +3278,160 @@ class TestAgentPresetService:
             for ref in snapshot["refs"]
         )
         assert row_after.resolved_refs == snapshot
+
+    async def test_preset_resolution_activity_records_root_refs_for_subagent_presets(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invariant: root resolution always records root refs, even for
+        subagent presets whose merged refs are appended by a later activity.
+
+        A turn that fails between root resolution and subagent resolution
+        (custom-provider credentials, session load, subagent validation) must
+        still leave a provenance row carrying the resolved root refs. The
+        later subagent activity appends a second, merged snapshot; the row
+        with the highest ``surrogate_id`` is the final one.
+        """
+
+        skill_service = SkillService(session=session, role=svc_role)
+        root_skill = await skill_service.create_skill(
+            SkillCreate(name="root-refs-skill")
+        )
+        root_skill_version = await skill_service.publish_skill(root_skill.id)
+        child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Root Refs Child", "slug": "root-refs-child"}
+            )
+        )
+        parent = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Root Refs Parent",
+                slug="root-refs-parent",
+                instructions="Use the selected skill and child.",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=root_skill.id)],
+                agents=AgentSubagentsConfig.model_validate(
+                    {
+                        "enabled": True,
+                        "subagents": [{"preset": child.slug}],
+                    }
+                ),
+            )
+        )
+        session_id = uuid.uuid4()
+
+        management_service = AgentManagementService(session, role=svc_role)
+        management_service.presets = agent_preset_service
+        monkeypatch.setattr(
+            management_service,
+            "get_workspace_runtime_provider_credentials",
+            AsyncMock(return_value={"OPENAI_API_KEY": "test-key"}),
+        )
+        monkeypatch.setattr(
+            "tracecat.agent.preset.activities.AgentManagementService.with_session",
+            lambda **_: _AsyncContext(management_service),
+        )
+
+        payload = await resolve_agent_preset_config_activity(
+            ResolveAgentPresetConfigActivityInput(
+                role=svc_role,
+                preset_id=parent.id,
+                session_id=session_id,
+                wf_exec_id="turn-1",
+            )
+        )
+
+        rows = (
+            (
+                await session.execute(
+                    select(AgentTurnProvenance).where(
+                        AgentTurnProvenance.session_id == session_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        assert payload.resolved_refs is not None
+        assert len(rows) == 1
+        assert rows[0].resolved_refs == payload.resolved_refs.model_dump(mode="json")
+        assert any(
+            ref["resource_kind"] == "skill"
+            and ref["resource_id"] == str(root_skill.id)
+            and ref["resolved_version_id"] == str(root_skill_version.id)
+            for ref in rows[0].resolved_refs["refs"]
+        )
+
+    async def test_preset_resolution_activity_records_root_refs_before_credentials(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invariant: root refs are persisted at resolution-success time.
+
+        Credential loading happens inside ``with_preset_config`` before the
+        config is yielded; a preset that resolves but has no provider
+        credentials must still leave its root-refs provenance row behind.
+        """
+
+        preset = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "No Creds Preset", "slug": "no-creds-preset"}
+            )
+        )
+        session_id = uuid.uuid4()
+
+        management_service = AgentManagementService(session, role=svc_role)
+        management_service.presets = agent_preset_service
+        for method in (
+            "get_workspace_runtime_provider_credentials",
+            "get_runtime_provider_credentials",
+        ):
+            monkeypatch.setattr(
+                management_service, method, AsyncMock(return_value=None)
+            )
+        monkeypatch.setattr(
+            "tracecat.agent.preset.activities.AgentManagementService.with_session",
+            lambda **_: _AsyncContext(management_service),
+        )
+
+        with pytest.raises(TracecatNotFoundError, match="No credentials"):
+            await resolve_agent_preset_config_activity(
+                ResolveAgentPresetConfigActivityInput(
+                    role=svc_role,
+                    preset_id=preset.id,
+                    session_id=session_id,
+                    wf_exec_id="turn-1",
+                )
+            )
+
+        rows = (
+            (
+                await session.execute(
+                    select(AgentTurnProvenance).where(
+                        AgentTurnProvenance.session_id == session_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        assert len(rows) == 1
+        assert any(
+            ref["resource_kind"] == "preset" and ref["resource_id"] == str(preset.id)
+            for ref in rows[0].resolved_refs["refs"]
+        )
 
     async def test_delete_preset_ignores_resolved_reference_with_reused_slug(
         self,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -3190,6 +3190,31 @@ class TestAgentPresetService:
         assert missing_version_refs.refs[0].status == "skipped"
         assert missing_version_refs.refs[0].code == "not_found"
 
+    async def test_root_preset_missing_version_id_classified_not_found(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """A stale pinned version ID is missing, not unpublished."""
+
+        preset = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Live Pinned Root", "slug": "live-pinned-root"}
+            )
+        )
+        assert preset.current_version_id is not None
+
+        missing_version_refs = (
+            await agent_preset_service.build_root_preset_failure_refs(
+                slug=preset.slug,
+                preset_version_id=uuid.uuid4(),
+            )
+        )
+
+        assert missing_version_refs.refs[0].resource_id == preset.id
+        assert missing_version_refs.refs[0].status == "skipped"
+        assert missing_version_refs.refs[0].code == "not_found"
+
     async def test_resolution_activity_writes_immutable_turn_provenance_snapshot(
         self,
         configure_minio_for_skills,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -3373,6 +3373,31 @@ class TestAgentPresetService:
         assert missing_version_refs.refs[0].status == "skipped"
         assert missing_version_refs.refs[0].code == "not_found"
 
+    async def test_root_preset_missing_version_id_classified_not_found(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """A stale pinned version ID is missing, not unpublished."""
+
+        preset = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Live Pinned Root", "slug": "live-pinned-root"}
+            )
+        )
+        assert preset.current_version_id is not None
+
+        missing_version_refs = (
+            await agent_preset_service.build_root_preset_failure_refs(
+                slug=preset.slug,
+                preset_version_id=uuid.uuid4(),
+            )
+        )
+
+        assert missing_version_refs.refs[0].resource_id == preset.id
+        assert missing_version_refs.refs[0].status == "skipped"
+        assert missing_version_refs.refs[0].code == "not_found"
+
     async def test_resolution_activity_writes_immutable_turn_provenance_snapshot(
         self,
         configure_minio_for_skills,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -3375,10 +3375,13 @@ class TestAgentPresetService:
 
     async def test_root_preset_missing_version_id_classified_not_found(
         self,
+        session: AsyncSession,
+        svc_role: Role,
         agent_preset_service: AgentPresetService,
         agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A stale pinned version ID is missing, not unpublished."""
+        """A stale pinned version records anchored not-found provenance."""
 
         preset = await agent_preset_service.create_preset(
             agent_preset_create_params.model_copy(
@@ -3386,17 +3389,41 @@ class TestAgentPresetService:
             )
         )
         assert preset.current_version_id is not None
+        stale_version_id = uuid.uuid4()
+        session_id = uuid.uuid4()
 
-        missing_version_refs = (
-            await agent_preset_service.build_root_preset_failure_refs(
-                slug=preset.slug,
-                preset_version_id=uuid.uuid4(),
-            )
+        management_service = AgentManagementService(session, role=svc_role)
+        management_service.presets = agent_preset_service
+        monkeypatch.setattr(
+            "tracecat.agent.preset.activities.AgentManagementService.with_session",
+            lambda **_: _AsyncContext(management_service),
         )
 
-        assert missing_version_refs.refs[0].resource_id == preset.id
-        assert missing_version_refs.refs[0].status == "skipped"
-        assert missing_version_refs.refs[0].code == "not_found"
+        with pytest.raises(TracecatNotFoundError):
+            await resolve_agent_preset_config_activity(
+                ResolveAgentPresetConfigActivityInput(
+                    role=svc_role,
+                    preset_id=preset.id,
+                    preset_slug=preset.slug,
+                    preset_version_id=stale_version_id,
+                    session_id=session_id,
+                    wf_exec_id="turn-stale-pinned-root",
+                )
+            )
+
+        row = (
+            await session.execute(
+                select(AgentTurnProvenance).where(
+                    AgentTurnProvenance.session_id == session_id
+                )
+            )
+        ).scalar_one()
+        [failure_ref] = row.resolved_refs["refs"]
+
+        assert failure_ref["resource_id"] == str(preset.id)
+        assert failure_ref["slug"] == preset.slug
+        assert failure_ref["status"] == "skipped"
+        assert failure_ref["code"] == "not_found"
 
     async def test_resolution_activity_writes_immutable_turn_provenance_snapshot(
         self,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1472,6 +1472,13 @@ class TestAgentPresetService:
         resolved_skill = config.resolved_skills[0]
         assert resolved_skill.skill_version_id == skill_version_two.id
         assert resolved_skill.skill_name == "latest-skill-v2"
+        assert config.resolved_refs is not None
+        resolved_ref = next(
+            ref
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill" and ref.status == "ok"
+        )
+        assert resolved_ref.slug == resolved_skill.skill_name
 
     async def test_resolve_config_skips_archived_skill_head(
         self,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -6,6 +6,7 @@ import os
 import uuid
 from datetime import UTC, datetime
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 import sqlalchemy as sa
@@ -23,7 +24,9 @@ from tracecat.agent.channels.schemas import (
 )
 from tracecat.agent.channels.service import PENDING_SLACK_BOT_TOKEN, AgentChannelService
 from tracecat.agent.preset.activities import (
+    ResolveAgentPresetConfigActivityInput,
     ResolveAgentsConfigActivityInput,
+    resolve_agent_preset_config_activity,
     resolve_agents_config_activity,
 )
 from tracecat.agent.preset.resolver import resolve_agents_config
@@ -35,6 +38,7 @@ from tracecat.agent.preset.schemas import (
 )
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.preset.types import SkillBindingSpec
+from tracecat.agent.service import AgentManagementService
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.skill.schemas import (
     SkillCreate,
@@ -3457,6 +3461,160 @@ class TestAgentPresetService:
             for ref in snapshot["refs"]
         )
         assert row_after.resolved_refs == snapshot
+
+    async def test_preset_resolution_activity_records_root_refs_for_subagent_presets(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invariant: root resolution always records root refs, even for
+        subagent presets whose merged refs are appended by a later activity.
+
+        A turn that fails between root resolution and subagent resolution
+        (custom-provider credentials, session load, subagent validation) must
+        still leave a provenance row carrying the resolved root refs. The
+        later subagent activity appends a second, merged snapshot; the row
+        with the highest ``surrogate_id`` is the final one.
+        """
+
+        skill_service = SkillService(session=session, role=svc_role)
+        root_skill = await skill_service.create_skill(
+            SkillCreate(name="root-refs-skill")
+        )
+        root_skill_version = await skill_service.publish_skill(root_skill.id)
+        child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Root Refs Child", "slug": "root-refs-child"}
+            )
+        )
+        parent = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Root Refs Parent",
+                slug="root-refs-parent",
+                instructions="Use the selected skill and child.",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=root_skill.id)],
+                agents=AgentSubagentsConfig.model_validate(
+                    {
+                        "enabled": True,
+                        "subagents": [{"preset": child.slug}],
+                    }
+                ),
+            )
+        )
+        session_id = uuid.uuid4()
+
+        management_service = AgentManagementService(session, role=svc_role)
+        management_service.presets = agent_preset_service
+        monkeypatch.setattr(
+            management_service,
+            "get_workspace_runtime_provider_credentials",
+            AsyncMock(return_value={"OPENAI_API_KEY": "test-key"}),
+        )
+        monkeypatch.setattr(
+            "tracecat.agent.preset.activities.AgentManagementService.with_session",
+            lambda **_: _AsyncContext(management_service),
+        )
+
+        payload = await resolve_agent_preset_config_activity(
+            ResolveAgentPresetConfigActivityInput(
+                role=svc_role,
+                preset_id=parent.id,
+                session_id=session_id,
+                wf_exec_id="turn-1",
+            )
+        )
+
+        rows = (
+            (
+                await session.execute(
+                    select(AgentTurnProvenance).where(
+                        AgentTurnProvenance.session_id == session_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        assert payload.resolved_refs is not None
+        assert len(rows) == 1
+        assert rows[0].resolved_refs == payload.resolved_refs.model_dump(mode="json")
+        assert any(
+            ref["resource_kind"] == "skill"
+            and ref["resource_id"] == str(root_skill.id)
+            and ref["resolved_version_id"] == str(root_skill_version.id)
+            for ref in rows[0].resolved_refs["refs"]
+        )
+
+    async def test_preset_resolution_activity_records_root_refs_before_credentials(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invariant: root refs are persisted at resolution-success time.
+
+        Credential loading happens inside ``with_preset_config`` before the
+        config is yielded; a preset that resolves but has no provider
+        credentials must still leave its root-refs provenance row behind.
+        """
+
+        preset = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "No Creds Preset", "slug": "no-creds-preset"}
+            )
+        )
+        session_id = uuid.uuid4()
+
+        management_service = AgentManagementService(session, role=svc_role)
+        management_service.presets = agent_preset_service
+        for method in (
+            "get_workspace_runtime_provider_credentials",
+            "get_runtime_provider_credentials",
+        ):
+            monkeypatch.setattr(
+                management_service, method, AsyncMock(return_value=None)
+            )
+        monkeypatch.setattr(
+            "tracecat.agent.preset.activities.AgentManagementService.with_session",
+            lambda **_: _AsyncContext(management_service),
+        )
+
+        with pytest.raises(TracecatNotFoundError, match="No credentials"):
+            await resolve_agent_preset_config_activity(
+                ResolveAgentPresetConfigActivityInput(
+                    role=svc_role,
+                    preset_id=preset.id,
+                    session_id=session_id,
+                    wf_exec_id="turn-1",
+                )
+            )
+
+        rows = (
+            (
+                await session.execute(
+                    select(AgentTurnProvenance).where(
+                        AgentTurnProvenance.session_id == session_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        assert len(rows) == 1
+        assert any(
+            ref["resource_kind"] == "preset" and ref["resource_id"] == str(preset.id)
+            for ref in rows[0].resolved_refs["refs"]
+        )
 
     async def test_delete_preset_ignores_resolved_reference_with_reused_slug(
         self,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1,6 +1,7 @@
 """Tests for AgentPresetService."""
 
 import asyncio
+import copy
 import os
 import uuid
 from datetime import UTC, datetime
@@ -21,6 +22,10 @@ from tracecat.agent.channels.schemas import (
     SlackChannelTokenConfig,
 )
 from tracecat.agent.channels.service import PENDING_SLACK_BOT_TOKEN, AgentChannelService
+from tracecat.agent.preset.activities import (
+    ResolveAgentsConfigActivityInput,
+    resolve_agents_config_activity,
+)
 from tracecat.agent.preset.resolver import resolve_agents_config
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
@@ -54,6 +59,7 @@ from tracecat.db.models import (
     AgentPresetVersion,
     AgentPresetVersionSkill,
     AgentPresetVersionSubagent,
+    AgentTurnProvenance,
     MCPIntegration,
     Organization,
     RegistryAction,
@@ -129,6 +135,17 @@ async def _create_stdio_mcp_integration(
     await session.flush()
     await session.refresh(integration)
     return integration
+
+
+class _AsyncContext:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    async def __aenter__(self) -> object:
+        return self._value
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
 
 
 @pytest.fixture
@@ -1498,6 +1515,159 @@ class TestAgentPresetService:
         )
 
         assert config.resolved_skills == []
+
+    async def test_historical_preset_deleted_skill_records_successor(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Invariant: runs without a deleted skill and records the failure."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        deleted_skill = await skill_service.create_skill(
+            SkillCreate(name="provenance-deleted-skill")
+        )
+        await skill_service.publish_skill(deleted_skill.id)
+        preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Historical provenance preset",
+                instructions="Use the selected skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=deleted_skill.id)],
+            )
+        )
+        preset_version = await agent_preset_service.get_current_version_for_preset(
+            preset
+        )
+        await agent_preset_service.update_preset(
+            preset,
+            AgentPresetUpdate(skills=None),
+        )
+        await skill_service.archive_skill(deleted_skill.id)
+        successor = await skill_service.create_skill(
+            SkillCreate(name="provenance-deleted-skill")
+        )
+
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=preset.id,
+            preset_version_id=preset_version.id,
+        )
+
+        assert config.resolved_skills == []
+        assert config.resolved_refs is not None
+        deleted_ref = next(
+            ref
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill" and ref.status == "skipped"
+        )
+        assert deleted_ref.resource_id == deleted_skill.id
+        assert deleted_ref.code == "deleted"
+        assert deleted_ref.successor_id == successor.id
+
+    async def test_deleted_skill_slug_reclaimed_does_not_relink_binding(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Invariant: a reclaimed slug is not silently substituted."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        deleted_skill = await skill_service.create_skill(
+            SkillCreate(name="no-silent-substitution")
+        )
+        await skill_service.publish_skill(deleted_skill.id)
+        preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="No relink preset",
+                instructions="Use the selected skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=deleted_skill.id)],
+            )
+        )
+        historical_version = await agent_preset_service.get_current_version_for_preset(
+            preset
+        )
+        await agent_preset_service.update_preset(
+            preset,
+            AgentPresetUpdate(skills=None),
+        )
+        await skill_service.archive_skill(deleted_skill.id)
+        successor = await skill_service.create_skill(
+            SkillCreate(name="no-silent-substitution")
+        )
+
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=preset.id,
+            preset_version_id=historical_version.id,
+        )
+
+        assert config.resolved_skills == []
+        assert config.resolved_refs is not None
+        assert all(
+            ref.resource_id != successor.id
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill"
+        )
+        deleted_ref = next(
+            ref
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill" and ref.status == "skipped"
+        )
+        assert deleted_ref.resource_id == deleted_skill.id
+        assert deleted_ref.successor_id == successor.id
+
+    async def test_deleted_skill_unclaimed_slug_records_no_successor(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Invariant: an unclaimed deleted slug records no successor."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        deleted_skill = await skill_service.create_skill(
+            SkillCreate(name="unclaimed-deleted-skill")
+        )
+        await skill_service.publish_skill(deleted_skill.id)
+        preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Unclaimed deleted skill preset",
+                instructions="Use the selected skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=deleted_skill.id)],
+            )
+        )
+        historical_version = await agent_preset_service.get_current_version_for_preset(
+            preset
+        )
+        await agent_preset_service.update_preset(
+            preset,
+            AgentPresetUpdate(skills=None),
+        )
+        await skill_service.archive_skill(deleted_skill.id)
+
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=preset.id,
+            preset_version_id=historical_version.id,
+        )
+
+        assert config.resolved_refs is not None
+        deleted_ref = next(
+            ref
+            for ref in config.resolved_refs.refs
+            if ref.resource_kind == "skill" and ref.status == "skipped"
+        )
+        assert deleted_ref.resource_id == deleted_skill.id
+        assert deleted_ref.code == "deleted"
+        assert deleted_ref.successor_id is None
 
     async def test_list_versions_returns_metadata_without_skill_lookups(
         self,
@@ -3062,6 +3232,224 @@ class TestAgentPresetService:
                     }
                 )
             )
+
+    async def test_resolve_agents_config_skips_only_failed_flat_tree_node(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: per-node failures skip only the failed node."""
+
+        live_child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Live Child", "slug": "live-child"}
+            )
+        )
+        deleted_child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Deleted Child", "slug": "deleted-child"}
+            )
+        )
+        parent = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={
+                    "name": "Flat Tree Parent",
+                    "slug": "flat-tree-parent",
+                    "agents": AgentSubagentsConfig.model_validate(
+                        {
+                            "enabled": True,
+                            "subagents": [
+                                {"preset": live_child.slug},
+                                {"preset": deleted_child.slug},
+                            ],
+                        }
+                    ),
+                }
+            )
+        )
+        parent_v1 = await agent_preset_service.get_current_version_for_preset(parent)
+        await agent_preset_service.update_preset(
+            parent, AgentPresetUpdate(agents=AgentSubagentsConfig())
+        )
+        await agent_preset_service.delete_preset(deleted_child)
+
+        resolved = await resolve_agents_config(
+            agent_preset_service,
+            agents=AgentSubagentsConfig.model_validate(parent_v1.agents),
+            parent_preset_id=parent.id,
+            parent_slug=parent.slug,
+            include_runtime_config=True,
+        )
+
+        assert len(resolved.subagents) == 1
+        assert resolved.subagents[0].binding.preset_id == live_child.id
+        assert len(resolved.skipped) == 1
+        assert resolved.skipped[0].preset_id == deleted_child.id
+        assert resolved.resolved_refs is not None
+        skipped_refs = [
+            ref
+            for ref in resolved.resolved_refs.refs
+            if ref.resource_kind == "subagent" and ref.status == "skipped"
+        ]
+        ok_refs = [
+            ref
+            for ref in resolved.resolved_refs.refs
+            if ref.resource_kind == "subagent" and ref.status == "ok"
+        ]
+        assert [ref.resource_id for ref in ok_refs] == [live_child.id]
+        assert [ref.resource_id for ref in skipped_refs] == [deleted_child.id]
+
+    async def test_root_preset_deleted_and_not_found_fail_with_codes(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: root preset failures fail the turn, not skip it."""
+
+        deleted = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Deleted Root", "slug": "deleted-root"}
+            )
+        )
+        await agent_preset_service.delete_preset(deleted)
+
+        with pytest.raises(TracecatNotFoundError):
+            await agent_preset_service.resolve_agent_preset_config(preset_id=deleted.id)
+        deleted_refs = await agent_preset_service.build_root_preset_failure_refs(
+            preset_id=deleted.id
+        )
+
+        missing_id = uuid.uuid4()
+        with pytest.raises(TracecatNotFoundError):
+            await agent_preset_service.resolve_agent_preset_config(preset_id=missing_id)
+        missing_refs = await agent_preset_service.build_root_preset_failure_refs(
+            preset_id=missing_id
+        )
+
+        assert deleted_refs.refs[0].resource_id == deleted.id
+        assert deleted_refs.refs[0].status == "skipped"
+        assert deleted_refs.refs[0].code == "deleted"
+        assert missing_refs.refs[0].resource_id == missing_id
+        assert missing_refs.refs[0].status == "skipped"
+        assert missing_refs.refs[0].code == "not_found"
+
+    async def test_root_preset_missing_version_number_classified_not_found(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Invariant: failure codes describe the actual ref-resolution state.
+
+        A live preset that lacks the requested version number failed on the
+        version request — that is ``not_found``; ``unpublished`` covers only
+        publish state when no specific version was requested.
+        """
+
+        preset = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Live Root", "slug": "live-root"}
+            )
+        )
+
+        missing_version_refs = (
+            await agent_preset_service.build_root_preset_failure_refs(
+                slug=preset.slug,
+                preset_version=999,
+            )
+        )
+
+        assert missing_version_refs.refs[0].resource_id == preset.id
+        assert missing_version_refs.refs[0].status == "skipped"
+        assert missing_version_refs.refs[0].code == "not_found"
+
+    async def test_resolution_activity_writes_immutable_turn_provenance_snapshot(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invariant: provenance is a value snapshot, not a mutable resource link."""
+
+        skill_service = SkillService(session=session, role=svc_role)
+        root_skill = await skill_service.create_skill(
+            SkillCreate(name="snapshot-root-skill")
+        )
+        root_skill_version = await skill_service.publish_skill(root_skill.id)
+        child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={"name": "Snapshot Child", "slug": "snapshot-child"}
+            )
+        )
+        parent = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Snapshot Parent",
+                slug="snapshot-parent",
+                instructions="Use the selected skill and child.",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=root_skill.id)],
+                agents=AgentSubagentsConfig.model_validate(
+                    {
+                        "enabled": True,
+                        "subagents": [{"preset": child.slug}],
+                    }
+                ),
+            )
+        )
+        parent_config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=parent.id
+        )
+        session_id = uuid.uuid4()
+
+        monkeypatch.setattr(
+            "tracecat.agent.preset.activities.AgentPresetService.with_session",
+            lambda **_: _AsyncContext(agent_preset_service),
+        )
+
+        result = await resolve_agents_config_activity(
+            ResolveAgentsConfigActivityInput(
+                role=svc_role,
+                agents=parent_config.agents,
+                parent_preset_id=parent.id,
+                session_id=session_id,
+                wf_exec_id="turn-1",
+                parent_resolved_refs=parent_config.resolved_refs,
+            )
+        )
+
+        row = (
+            await session.execute(
+                select(AgentTurnProvenance).where(
+                    AgentTurnProvenance.session_id == session_id
+                )
+            )
+        ).scalar_one()
+        snapshot = copy.deepcopy(row.resolved_refs)
+        await agent_preset_service.update_preset(
+            parent,
+            AgentPresetUpdate(skills=None),
+        )
+        await skill_service.archive_skill(root_skill.id)
+        row_after = (
+            await session.execute(
+                select(AgentTurnProvenance).where(
+                    AgentTurnProvenance.session_id == session_id
+                )
+            )
+        ).scalar_one()
+
+        assert result.resolved_refs is not None
+        assert snapshot == result.resolved_refs.model_dump(mode="json")
+        assert any(
+            ref["resource_kind"] == "skill"
+            and ref["resource_id"] == str(root_skill.id)
+            and ref["resolved_version_id"] == str(root_skill_version.id)
+            for ref in snapshot["refs"]
+        )
+        assert row_after.resolved_refs == snapshot
 
     async def test_delete_preset_ignores_resolved_reference_with_reused_slug(
         self,

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from tracecat.agent.preset.resolved_refs import ResolvedRef, ResolvedRefs
 from tracecat.agent.session.schemas import AgentSessionCreate, AgentSessionUpdate
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
@@ -241,14 +242,12 @@ async def test_resolve_session_mcp_servers_requires_agent_addons_entitlement() -
 
 
 @pytest.mark.anyio
-async def test_create_session_derives_agents_binding_from_pinned_preset_version() -> (
-    None
-):
+async def test_create_session_derives_binding_from_selected_preset_version() -> None:
     service, session, _role = _build_service()
     preset_id = uuid.uuid4()
-    pinned_version_id = uuid.uuid4()
+    selected_version_id = uuid.uuid4()
     agents_binding = {"enabled": True, "subagents": []}
-    validate_mock = AsyncMock(return_value=pinned_version_id)
+    validate_mock = AsyncMock(return_value=selected_version_id)
     agents_binding_mock = AsyncMock(return_value=agents_binding)
     service._validate_preset_version_for_assignment = validate_mock
     service._resolve_agents_binding_for_preset_version_id = agents_binding_mock
@@ -259,7 +258,7 @@ async def test_create_session_derives_agents_binding_from_pinned_preset_version(
             entity_type=AgentSessionEntity.CASE,
             entity_id=uuid.uuid4(),
             agent_preset_id=preset_id,
-            agent_preset_version_id=pinned_version_id,
+            agent_preset_version_id=selected_version_id,
         )
     )
 
@@ -267,26 +266,24 @@ async def test_create_session_derives_agents_binding_from_pinned_preset_version(
         entity_type=AgentSessionEntity.CASE,
         entity_id=created.entity_id,
         agent_preset_id=preset_id,
-        agent_preset_version_id=pinned_version_id,
+        agent_preset_version_id=selected_version_id,
     )
     assert created.agent_preset_id == preset_id
-    assert created.agent_preset_version_id == pinned_version_id
+    assert created.agent_preset_version_id == selected_version_id
     assert created.agents_binding == agents_binding
-    agents_binding_mock.assert_awaited_once_with(pinned_version_id)
+    agents_binding_mock.assert_awaited_once_with(selected_version_id)
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(created)
 
 
 @pytest.mark.anyio
-async def test_create_session_prefers_provided_agents_binding_for_pinned_preset() -> (
-    None
-):
+async def test_create_session_prefers_provided_binding_for_selected_version() -> None:
     service, session, _role = _build_service()
     preset_id = uuid.uuid4()
-    pinned_version_id = uuid.uuid4()
+    selected_version_id = uuid.uuid4()
     child_preset_id = uuid.uuid4()
     child_version_id = uuid.uuid4()
-    validate_mock = AsyncMock(return_value=pinned_version_id)
+    validate_mock = AsyncMock(return_value=selected_version_id)
     agents_binding_mock = AsyncMock(
         side_effect=AssertionError("should not derive binding when provided")
     )
@@ -312,7 +309,7 @@ async def test_create_session_prefers_provided_agents_binding_for_pinned_preset(
             entity_type=AgentSessionEntity.CASE,
             entity_id=uuid.uuid4(),
             agent_preset_id=preset_id,
-            agent_preset_version_id=pinned_version_id,
+            agent_preset_version_id=selected_version_id,
         ),
         agents_binding=agents_binding,
     )
@@ -321,10 +318,10 @@ async def test_create_session_prefers_provided_agents_binding_for_pinned_preset(
         entity_type=AgentSessionEntity.CASE,
         entity_id=created.entity_id,
         agent_preset_id=preset_id,
-        agent_preset_version_id=pinned_version_id,
+        agent_preset_version_id=selected_version_id,
     )
     assert created.agent_preset_id == preset_id
-    assert created.agent_preset_version_id == pinned_version_id
+    assert created.agent_preset_version_id == selected_version_id
     assert created.agents_binding == agents_binding.model_dump(mode="json")
     agents_binding_mock.assert_not_called()
     session.commit.assert_awaited_once()
@@ -442,20 +439,20 @@ async def test_validate_preset_assignment_preserves_null_without_resolving_curre
             Mock(return_value=preset_service),
         )
 
-        pinned_version_id = await service._validate_preset_version_for_assignment(
+        selected_version_id = await service._validate_preset_version_for_assignment(
             entity_type=AgentSessionEntity.AGENT_PRESET,
             entity_id=preset_id,
             agent_preset_id=None,
             agent_preset_version_id=None,
         )
 
-    assert pinned_version_id is None
+    assert selected_version_id is None
     preset_service.get_preset.assert_awaited_once_with(preset_id)
     preset_service.resolve_agent_preset_version.assert_not_awaited()
 
 
 @pytest.mark.anyio
-async def test_update_session_allows_version_only_repin_for_preset_sessions() -> None:
+async def test_update_session_allows_exact_version_change_for_preset_sessions() -> None:
     service, session, role = _build_service()
     preset_id = uuid.uuid4()
     new_version_id = uuid.uuid4()
@@ -493,7 +490,7 @@ async def test_update_session_allows_version_only_repin_for_preset_sessions() ->
 
 
 @pytest.mark.anyio
-async def test_update_session_clears_pinned_version_to_follow_current() -> None:
+async def test_update_session_clears_selected_version_to_follow_current() -> None:
     service, session, role = _build_service()
     preset_id = uuid.uuid4()
     agent_session = AgentSession(
@@ -685,6 +682,66 @@ async def test_workspace_chat_preset_config_scope_filters_actions() -> None:
             assert resolved.actions == ["core.workflow.get_workflow"]
             # Instructions still combine preset + entity context.
             assert resolved.instructions == "preset instructions\n\nentity instructions"
+
+
+@pytest.mark.anyio
+async def test_forked_preset_config_carries_resolved_refs() -> None:
+    """Invariant: preset-backed forked turns keep one-row-per-turn provenance.
+
+    The forked branch rebuilds a stripped config (no tools/skills/subagents)
+    from the parent's preset resolution. It must carry the resolution's
+    ``resolved_refs`` through — the value-only snapshot records what
+    resolution saw, and without it the provenance staging guard drops the
+    row for every forked turn.
+    """
+    service, _session, role = _build_service()
+    workspace_id = role.workspace_id
+    assert workspace_id is not None
+    parent_id = uuid.uuid4()
+    agent_session = AgentSession(
+        workspace_id=workspace_id,
+        entity_type=AgentSessionEntity.WORKFLOW.value,
+        entity_id=uuid.uuid4(),
+        parent_session_id=parent_id,
+    )
+    parent_session = SimpleNamespace(
+        agent_preset_id=uuid.uuid4(),
+        agent_preset_version_id=None,
+    )
+    service.get_session = AsyncMock(return_value=parent_session)  # type: ignore[method-assign]
+
+    refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                slug="parent-preset",
+                resource_id=uuid.uuid4(),
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+    preset_config = AgentConfig(
+        model_name="test-model",
+        model_provider="test-provider",
+        instructions="preset instructions",
+        actions=["core.workflow.get_workflow"],
+        resolved_refs=refs,
+    )
+
+    @contextlib.asynccontextmanager
+    async def _fake_with_preset_config(**_kwargs: Any):
+        yield preset_config
+
+    with patch(
+        "tracecat.agent.session.service.AgentManagementService"
+    ) as agent_svc_cls:
+        agent_svc_cls.return_value = SimpleNamespace(
+            with_preset_config=_fake_with_preset_config
+        )
+        async with service._build_agent_config(agent_session) as resolved:
+            assert resolved.actions == []
+            assert resolved.resolved_refs == refs
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from tracecat.agent.preset.resolved_refs import ResolvedRef, ResolvedRefs
 from tracecat.agent.session.schemas import AgentSessionCreate, AgentSessionUpdate
 from tracecat.agent.session.service import (
     AGENT_SESSION_EXECUTION_SCOPES,
@@ -267,14 +268,12 @@ async def test_resolve_session_mcp_servers_requires_agent_addons_entitlement() -
 
 
 @pytest.mark.anyio
-async def test_create_session_derives_agents_binding_from_pinned_preset_version() -> (
-    None
-):
+async def test_create_session_derives_binding_from_selected_preset_version() -> None:
     service, session, _role = _build_service()
     preset_id = uuid.uuid4()
-    pinned_version_id = uuid.uuid4()
+    selected_version_id = uuid.uuid4()
     agents_binding = {"enabled": True, "subagents": []}
-    validate_mock = AsyncMock(return_value=pinned_version_id)
+    validate_mock = AsyncMock(return_value=selected_version_id)
     agents_binding_mock = AsyncMock(return_value=agents_binding)
     service._validate_preset_version_for_assignment = validate_mock
     service._resolve_agents_binding_for_preset_version_id = agents_binding_mock
@@ -285,7 +284,7 @@ async def test_create_session_derives_agents_binding_from_pinned_preset_version(
             entity_type=AgentSessionEntity.CASE,
             entity_id=uuid.uuid4(),
             agent_preset_id=preset_id,
-            agent_preset_version_id=pinned_version_id,
+            agent_preset_version_id=selected_version_id,
         )
     )
 
@@ -293,26 +292,24 @@ async def test_create_session_derives_agents_binding_from_pinned_preset_version(
         entity_type=AgentSessionEntity.CASE,
         entity_id=created.entity_id,
         agent_preset_id=preset_id,
-        agent_preset_version_id=pinned_version_id,
+        agent_preset_version_id=selected_version_id,
     )
     assert created.agent_preset_id == preset_id
-    assert created.agent_preset_version_id == pinned_version_id
+    assert created.agent_preset_version_id == selected_version_id
     assert created.agents_binding == agents_binding
-    agents_binding_mock.assert_awaited_once_with(pinned_version_id)
+    agents_binding_mock.assert_awaited_once_with(selected_version_id)
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(created)
 
 
 @pytest.mark.anyio
-async def test_create_session_prefers_provided_agents_binding_for_pinned_preset() -> (
-    None
-):
+async def test_create_session_prefers_provided_binding_for_selected_version() -> None:
     service, session, _role = _build_service()
     preset_id = uuid.uuid4()
-    pinned_version_id = uuid.uuid4()
+    selected_version_id = uuid.uuid4()
     child_preset_id = uuid.uuid4()
     child_version_id = uuid.uuid4()
-    validate_mock = AsyncMock(return_value=pinned_version_id)
+    validate_mock = AsyncMock(return_value=selected_version_id)
     agents_binding_mock = AsyncMock(
         side_effect=AssertionError("should not derive binding when provided")
     )
@@ -338,7 +335,7 @@ async def test_create_session_prefers_provided_agents_binding_for_pinned_preset(
             entity_type=AgentSessionEntity.CASE,
             entity_id=uuid.uuid4(),
             agent_preset_id=preset_id,
-            agent_preset_version_id=pinned_version_id,
+            agent_preset_version_id=selected_version_id,
         ),
         agents_binding=agents_binding,
     )
@@ -347,10 +344,10 @@ async def test_create_session_prefers_provided_agents_binding_for_pinned_preset(
         entity_type=AgentSessionEntity.CASE,
         entity_id=created.entity_id,
         agent_preset_id=preset_id,
-        agent_preset_version_id=pinned_version_id,
+        agent_preset_version_id=selected_version_id,
     )
     assert created.agent_preset_id == preset_id
-    assert created.agent_preset_version_id == pinned_version_id
+    assert created.agent_preset_version_id == selected_version_id
     assert created.agents_binding == agents_binding.model_dump(mode="json")
     agents_binding_mock.assert_not_called()
     session.commit.assert_awaited_once()
@@ -468,20 +465,20 @@ async def test_validate_preset_assignment_preserves_null_without_resolving_curre
             Mock(return_value=preset_service),
         )
 
-        pinned_version_id = await service._validate_preset_version_for_assignment(
+        selected_version_id = await service._validate_preset_version_for_assignment(
             entity_type=AgentSessionEntity.AGENT_PRESET,
             entity_id=preset_id,
             agent_preset_id=None,
             agent_preset_version_id=None,
         )
 
-    assert pinned_version_id is None
+    assert selected_version_id is None
     preset_service.get_preset.assert_awaited_once_with(preset_id)
     preset_service.resolve_agent_preset_version.assert_not_awaited()
 
 
 @pytest.mark.anyio
-async def test_update_session_allows_version_only_repin_for_preset_sessions() -> None:
+async def test_update_session_allows_exact_version_change_for_preset_sessions() -> None:
     service, session, role = _build_service()
     preset_id = uuid.uuid4()
     new_version_id = uuid.uuid4()
@@ -519,7 +516,7 @@ async def test_update_session_allows_version_only_repin_for_preset_sessions() ->
 
 
 @pytest.mark.anyio
-async def test_update_session_clears_pinned_version_to_follow_current() -> None:
+async def test_update_session_clears_selected_version_to_follow_current() -> None:
     service, session, role = _build_service()
     preset_id = uuid.uuid4()
     agent_session = AgentSession(
@@ -719,6 +716,66 @@ async def test_workspace_chat_preset_config_scope_filters_actions() -> None:
         assert service.role.scopes == frozenset(
             {"agent:execute", "action:core.workflow.get_workflow:execute"}
         )
+
+
+@pytest.mark.anyio
+async def test_forked_preset_config_carries_resolved_refs() -> None:
+    """Invariant: preset-backed forked turns keep one-row-per-turn provenance.
+
+    The forked branch rebuilds a stripped config (no tools/skills/subagents)
+    from the parent's preset resolution. It must carry the resolution's
+    ``resolved_refs`` through — the value-only snapshot records what
+    resolution saw, and without it the provenance staging guard drops the
+    row for every forked turn.
+    """
+    service, _session, role = _build_service()
+    workspace_id = role.workspace_id
+    assert workspace_id is not None
+    parent_id = uuid.uuid4()
+    agent_session = AgentSession(
+        workspace_id=workspace_id,
+        entity_type=AgentSessionEntity.WORKFLOW.value,
+        entity_id=uuid.uuid4(),
+        parent_session_id=parent_id,
+    )
+    parent_session = SimpleNamespace(
+        agent_preset_id=uuid.uuid4(),
+        agent_preset_version_id=None,
+    )
+    service.get_session = AsyncMock(return_value=parent_session)  # type: ignore[method-assign]
+
+    refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                slug="parent-preset",
+                resource_id=uuid.uuid4(),
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+    preset_config = AgentConfig(
+        model_name="test-model",
+        model_provider="test-provider",
+        instructions="preset instructions",
+        actions=["core.workflow.get_workflow"],
+        resolved_refs=refs,
+    )
+
+    @contextlib.asynccontextmanager
+    async def _fake_with_preset_config(**_kwargs: Any):
+        yield preset_config
+
+    with patch(
+        "tracecat.agent.session.service.AgentManagementService"
+    ) as agent_svc_cls:
+        agent_svc_cls.return_value = SimpleNamespace(
+            with_preset_config=_fake_with_preset_config
+        )
+        async with service._build_agent_config(agent_session) as resolved:
+            assert resolved.actions == []
+            assert resolved.resolved_refs == refs
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from temporalio.exceptions import ActivityError, ApplicationError
@@ -14,6 +14,7 @@ from temporalio.exceptions import ActivityError, ApplicationError
 import tracecat.dsl.workflow as dsl_workflow_module
 from tracecat import config
 from tracecat.auth.types import Role
+from tracecat.contexts import ctx_stream_id
 from tracecat.dsl.action import DSLActivities, _evaluate_loop_iterations
 from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.enums import FailStrategy, PlatformAction, WaitStrategy
@@ -25,6 +26,7 @@ from tracecat.dsl.schemas import (
     DSLConfig,
     ExecutionContext,
     RunContext,
+    StreamID,
     TaskResult,
 )
 from tracecat.dsl.workflow import DSLWorkflow
@@ -98,6 +100,103 @@ def _child_dsl() -> DSLInput:
         ],
         triggers=[],
     )
+
+
+async def _run_failing_preset_preflight(
+    *,
+    patched: bool,
+    stream_id: StreamID,
+) -> tuple[AsyncMock, MagicMock, uuid.UUID]:
+    workflow = _build_workflow()
+    workflow.dsl = _child_dsl()
+    workflow.scheduler.streams[stream_id] = workflow.context
+    task = ActionStatement(
+        ref="preset_agent",
+        action=PlatformAction.AI_PRESET_AGENT,
+        args={"preset": "missing-preset", "user_prompt": "Investigate"},
+    )
+    session_id = uuid.uuid4()
+    uuid4_mock = MagicMock(return_value=session_id)
+    execute_activity_mock = AsyncMock()
+
+    async def execute_activity(activity: object, arg: object, **_: object) -> object:
+        if activity is DSLActivities.build_preset_agent_args_activity:
+            return SimpleNamespace(
+                preset="missing-preset",
+                session_id=None,
+            )
+
+        assert uuid4_mock.call_count == int(patched)
+        raise RuntimeError("preset preflight failed")
+
+    execute_activity_mock.side_effect = execute_activity
+    token = ctx_stream_id.set(stream_id)
+    try:
+        with (
+            patch.object(workflow, "_handle_timers", new=AsyncMock()),
+            patch.object(workflow, "_set_logical_time_context"),
+            patch.object(
+                workflow,
+                "_build_action_context",
+                return_value=workflow.context,
+            ),
+            patch(
+                "tracecat.dsl.workflow.workflow.execute_activity",
+                new=execute_activity_mock,
+            ),
+            patch(
+                "tracecat.dsl.workflow.workflow.patched",
+                return_value=patched,
+            ),
+            patch(
+                "tracecat.dsl.workflow.workflow.uuid4",
+                new=uuid4_mock,
+            ),
+            patch(
+                "tracecat.dsl.workflow.workflow.info",
+                return_value=SimpleNamespace(workflow_id=workflow.wf_exec_id),
+            ),
+        ):
+            with pytest.raises(ApplicationError, match="preset preflight failed"):
+                await workflow._execute_task(task)
+    finally:
+        ctx_stream_id.reset(token)
+
+    return execute_activity_mock, uuid4_mock, session_id
+
+
+@pytest.mark.anyio
+async def test_preset_preflight_patch_mints_stream_scoped_provenance_before_failure() -> (
+    None
+):
+    stream_id = StreamID.new("scatter", 2)
+
+    execute_activity, uuid4_mock, session_id = await _run_failing_preset_preflight(
+        patched=True,
+        stream_id=stream_id,
+    )
+
+    preflight_input = execute_activity.await_args_list[1].args[1]
+    assert preflight_input.session_id == session_id
+    assert preflight_input.wf_exec_id == (
+        "wf-00000000000000000000000000000001:"
+        "exec-00000000000000000000000000000001:"
+        f"preset_agent:{stream_id}:{session_id}"
+    )
+    uuid4_mock.assert_called_once_with()
+
+
+@pytest.mark.anyio
+async def test_preset_preflight_legacy_path_preserves_preflight_before_mint() -> None:
+    execute_activity, uuid4_mock, _ = await _run_failing_preset_preflight(
+        patched=False,
+        stream_id=ROOT_STREAM,
+    )
+
+    preflight_input = execute_activity.await_args_list[1].args[1]
+    assert preflight_input.session_id is None
+    assert preflight_input.wf_exec_id is None
+    uuid4_mock.assert_not_called()
 
 
 def _prepared_subflow_stub(

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -384,10 +384,12 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
         scopes=frozenset({"agent:execute", "secret:read"}),
     )
     resolved_version_id = uuid.uuid4()
+    run_id = uuid.uuid4()
     workflow_args = AgentWorkflowArgs(
         role=role,
         agent_args=RunAgentArgs(
             session_id=uuid.uuid4(),
+            curr_run_id=run_id,
             user_prompt="hello",
             preset_slug="triage-agent",
             config=cast(
@@ -425,6 +427,7 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
     assert call_args[1].preset_version_id == resolved_version_id
     assert call_args[1].preset_slug is None
     assert call_args[1].preset_version is None
+    assert call_args[1].wf_exec_id == str(run_id)
     assert cfg.model_name == resolved_config.model_name
     assert cfg.model_provider == resolved_config.model_provider
     assert cfg.actions == ["core.http_request"]

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -383,6 +383,7 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
         user_id=uuid.uuid4(),
         scopes=frozenset({"agent:execute", "secret:read"}),
     )
+    resolved_preset_id = uuid.uuid4()
     resolved_version_id = uuid.uuid4()
     run_id = uuid.uuid4()
     workflow_args = AgentWorkflowArgs(
@@ -404,6 +405,7 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
         ),
         entity_type=AgentSessionEntity.WORKSPACE_CHAT,
         entity_id=uuid.uuid4(),
+        agent_preset_id=resolved_preset_id,
         agent_preset_version_id=resolved_version_id,
     )
     workflow_instance = DurableAgentWorkflow(workflow_args)
@@ -424,8 +426,9 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
     assert execute_activity_mock.await_args is not None
     call_args = execute_activity_mock.await_args.args
     assert isinstance(call_args[1], ResolveAgentPresetConfigActivityInput)
+    assert call_args[1].preset_id == resolved_preset_id
     assert call_args[1].preset_version_id == resolved_version_id
-    assert call_args[1].preset_slug is None
+    assert call_args[1].preset_slug == "triage-agent"
     assert call_args[1].preset_version is None
     assert call_args[1].wf_exec_id == str(run_id)
     assert cfg.model_name == resolved_config.model_name

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -743,10 +743,12 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
         scopes=frozenset({"agent:execute", "secret:read"}),
     )
     resolved_version_id = uuid.uuid4()
+    run_id = uuid.uuid4()
     workflow_args = AgentWorkflowArgs(
         role=role,
         agent_args=RunAgentArgs(
             session_id=uuid.uuid4(),
+            curr_run_id=run_id,
             user_prompt="hello",
             preset_slug="triage-agent",
             config=cast(
@@ -784,6 +786,7 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
     assert call_args[1].preset_version_id == resolved_version_id
     assert call_args[1].preset_slug is None
     assert call_args[1].preset_version is None
+    assert call_args[1].wf_exec_id == str(run_id)
     assert cfg.model_name == resolved_config.model_name
     assert cfg.model_provider == resolved_config.model_provider
     assert cfg.actions == ["core.http_request"]

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -742,6 +742,7 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
         user_id=uuid.uuid4(),
         scopes=frozenset({"agent:execute", "secret:read"}),
     )
+    resolved_preset_id = uuid.uuid4()
     resolved_version_id = uuid.uuid4()
     run_id = uuid.uuid4()
     workflow_args = AgentWorkflowArgs(
@@ -763,6 +764,7 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
         ),
         entity_type=AgentSessionEntity.WORKSPACE_CHAT,
         entity_id=uuid.uuid4(),
+        agent_preset_id=resolved_preset_id,
         agent_preset_version_id=resolved_version_id,
     )
     workflow_instance = DurableAgentWorkflow(workflow_args)
@@ -783,8 +785,9 @@ async def test_build_config_prefers_resolved_preset_version_id() -> None:
     assert execute_activity_mock.await_args is not None
     call_args = execute_activity_mock.await_args.args
     assert isinstance(call_args[1], ResolveAgentPresetConfigActivityInput)
+    assert call_args[1].preset_id == resolved_preset_id
     assert call_args[1].preset_version_id == resolved_version_id
-    assert call_args[1].preset_slug is None
+    assert call_args[1].preset_slug == "triage-agent"
     assert call_args[1].preset_version is None
     assert call_args[1].wf_exec_id == str(run_id)
     assert cfg.model_name == resolved_config.model_name

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -2598,6 +2598,45 @@ class TestSkillService:
         ):
             await skill_service.archive_skill(created.id)
 
+    async def test_reclaimed_skill_slug_does_not_relink_version_binding(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        skill_service: SkillService,
+    ) -> None:
+        """Invariant: old UUID bindings do not resolve to reclaimed slugs."""
+
+        deleted = await skill_service.create_skill(
+            SkillCreate(name="skill-reclaimed-no-relink")
+        )
+        await skill_service.publish_skill(deleted.id)
+        preset_service = AgentPresetService(session=session, role=svc_role)
+        preset = await preset_service.create_preset(
+            AgentPresetCreate(
+                name="Skill reclaimed no relink preset",
+                description="Preset with a skill whose slug is reclaimed",
+                instructions="Use the skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[AgentPresetSkillBindingBase(skill_id=deleted.id)],
+            )
+        )
+        assert preset.current_version_id is not None
+
+        await _legacy_archive_skill(session, deleted.id)
+        successor = await skill_service.create_skill(
+            SkillCreate(name="skill-reclaimed-no-relink")
+        )
+        resolved = await skill_service.get_resolved_skill_refs_for_preset_version(
+            preset.current_version_id
+        )
+
+        assert resolved.refs == []
+        assert len(resolved.skipped) == 1
+        assert resolved.skipped[0].skill_id == deleted.id
+        assert resolved.skipped[0].skill_id != successor.id
+        assert resolved.skipped[0].reason == "deleted"
+
     async def test_archive_allows_when_only_preset_history_references_skill(
         self,
         session: AsyncSession,

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from tracecat.agent.preset.resolved_refs import ResolvedRefs, merge_resolved_refs
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
     resolve_agents_config,
@@ -15,10 +16,12 @@ from tracecat.agent.preset.resolver import (
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.subagents import AgentSubagentsConfig
+from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
-from tracecat.db.models import AgentCatalog
+from tracecat.db.models import AgentCatalog, AgentTurnProvenance
+from tracecat.exceptions import TracecatNotFoundError
 
 
 class ResolveAgentPresetConfigActivityInput(BaseModel):
@@ -27,6 +30,8 @@ class ResolveAgentPresetConfigActivityInput(BaseModel):
     preset_id: uuid.UUID | None = None
     preset_version_id: uuid.UUID | None = None
     preset_version: int | None = None
+    session_id: uuid.UUID | None = None
+    wf_exec_id: str | None = None
 
     @model_validator(mode="after")
     def ensure_identifier(self) -> ResolveAgentPresetConfigActivityInput:
@@ -64,6 +69,48 @@ class ResolveAgentsConfigActivityInput(BaseModel):
     # deserialize; only the durable resume path sets it. PR 2.3a (dispatch-time
     # resolution) may subsume or remove this flag.
     preserve_resolved_versions: bool = False
+    session_id: uuid.UUID | None = None
+    wf_exec_id: str | None = None
+    parent_resolved_refs: ResolvedRefs | None = None
+
+
+def _has_runtime_subagents(agents: AgentSubagentsConfig) -> bool:
+    """Return whether a later subagent activity will persist merged refs."""
+
+    return agents.enabled and bool(agents.subagents)
+
+
+async def _write_agent_turn_provenance(
+    service: AgentPresetService | AgentManagementService,
+    *,
+    session_id: uuid.UUID | None,
+    wf_exec_id: str | None,
+    resolved_refs: ResolvedRefs | None,
+) -> None:
+    """Persist one append-only per-turn resolution snapshot when identifiers exist.
+
+    Not idempotent by design: the calling activities are scheduled with
+    ``activity:fail_fast`` (``maximum_attempts=1``), so no Temporal retry can
+    re-execute a committed insert, and replay reads activity results from
+    history instead of re-running them. Revisit if a caller ever gains a
+    retry policy.
+    """
+
+    if session_id is None or wf_exec_id is None or resolved_refs is None:
+        return
+    workspace_id = service.role.workspace_id
+    if workspace_id is None:
+        return
+
+    service.session.add(
+        AgentTurnProvenance(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            wf_exec_id=wf_exec_id,
+            resolved_refs=resolved_refs.model_dump(mode="json"),
+        )
+    )
+    await service.session.commit()
 
 
 @activity.defn
@@ -71,13 +118,43 @@ async def resolve_agent_preset_config_activity(
     args: ResolveAgentPresetConfigActivityInput,
 ) -> AgentConfigPayload:
     async with AgentManagementService.with_session(role=args.role) as service:
+
+        async def write_failure_refs(_err: TracecatNotFoundError) -> None:
+            if service.presets is None:
+                return
+            failure_refs = await service.presets.build_root_preset_failure_refs(
+                preset_id=args.preset_id,
+                slug=args.preset_slug,
+                preset_version_id=args.preset_version_id,
+                preset_version=args.preset_version,
+            )
+            await _write_agent_turn_provenance(
+                service,
+                session_id=args.session_id,
+                wf_exec_id=args.wf_exec_id,
+                resolved_refs=failure_refs,
+            )
+
+        config: AgentConfig | None = None
         async with service.with_preset_config(
             preset_id=args.preset_id,
             slug=args.preset_slug,
             preset_version_id=args.preset_version_id,
             preset_version=args.preset_version,
-        ) as config:
-            return agent_config_to_payload(config)
+            on_resolution_error=write_failure_refs,
+        ) as resolved_config:
+            config = resolved_config
+
+        assert config is not None
+        payload = agent_config_to_payload(config)
+        if not _has_runtime_subagents(config.agents):
+            await _write_agent_turn_provenance(
+                service,
+                session_id=args.session_id,
+                wf_exec_id=args.wf_exec_id,
+                resolved_refs=payload.resolved_refs,
+            )
+        return payload
 
 
 @activity.defn
@@ -107,7 +184,18 @@ async def resolve_agents_config_activity(
             include_runtime_config=True,
             preserve_resolved_versions=args.preserve_resolved_versions,
         )
-        return resolved.to_runtime_config()
+        runtime_config = resolved.to_runtime_config()
+        runtime_config.resolved_refs = merge_resolved_refs(
+            args.parent_resolved_refs,
+            runtime_config.resolved_refs,
+        )
+        await _write_agent_turn_provenance(
+            service,
+            session_id=args.session_id,
+            wf_exec_id=args.wf_exec_id,
+            resolved_refs=runtime_config.resolved_refs,
+        )
+        return runtime_config
 
 
 class CustomModelProviderConfigResult(BaseModel):

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -22,6 +22,7 @@ from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentCatalog, AgentTurnProvenance
 from tracecat.exceptions import TracecatNotFoundError
+from tracecat.logger import logger
 
 
 class ResolveAgentPresetConfigActivityInput(BaseModel):
@@ -51,6 +52,8 @@ class ResolveAgentPresetVersionRefActivityInput(BaseModel):
 
     role: Role
     preset_slug: str
+    session_id: uuid.UUID | None = None
+    wf_exec_id: str | None = None
 
 
 class AgentPresetVersionRef(BaseModel):
@@ -74,12 +77,6 @@ class ResolveAgentsConfigActivityInput(BaseModel):
     parent_resolved_refs: ResolvedRefs | None = None
 
 
-def _has_runtime_subagents(agents: AgentSubagentsConfig) -> bool:
-    """Return whether a later subagent activity will persist merged refs."""
-
-    return agents.enabled and bool(agents.subagents)
-
-
 async def _write_agent_turn_provenance(
     service: AgentPresetService | AgentManagementService,
     *,
@@ -87,7 +84,13 @@ async def _write_agent_turn_provenance(
     wf_exec_id: str | None,
     resolved_refs: ResolvedRefs | None,
 ) -> None:
-    """Persist one append-only per-turn resolution snapshot when identifiers exist.
+    """Persist an append-only per-turn resolution snapshot when identifiers exist.
+
+    A turn may accumulate more than one snapshot: root-preset resolution
+    always records the root refs, and the later subagent-resolution activity
+    appends a merged snapshot when it runs. The row with the highest
+    ``surrogate_id`` for a ``wf_exec_id`` is the final snapshot; earlier rows
+    preserve provenance for turns that fail between the two activities.
 
     Not idempotent by design: the calling activities are scheduled with
     ``activity:fail_fast`` (``maximum_attempts=1``), so no Temporal retry can
@@ -135,6 +138,20 @@ async def resolve_agent_preset_config_activity(
                 resolved_refs=failure_refs,
             )
 
+        async def write_root_refs(resolved: AgentConfig) -> None:
+            # Always record root refs at resolution-success time, before
+            # credential loading and even when a later subagent activity
+            # appends a merged snapshot: anything that fails afterwards
+            # (provider credentials, custom-provider config, session load,
+            # subagent resolution) would otherwise leave the turn with no
+            # provenance row.
+            await _write_agent_turn_provenance(
+                service,
+                session_id=args.session_id,
+                wf_exec_id=args.wf_exec_id,
+                resolved_refs=resolved.resolved_refs,
+            )
+
         config: AgentConfig | None = None
         async with service.with_preset_config(
             preset_id=args.preset_id,
@@ -142,19 +159,12 @@ async def resolve_agent_preset_config_activity(
             preset_version_id=args.preset_version_id,
             preset_version=args.preset_version,
             on_resolution_error=write_failure_refs,
+            on_resolved=write_root_refs,
         ) as resolved_config:
             config = resolved_config
 
         assert config is not None
-        payload = agent_config_to_payload(config)
-        if not _has_runtime_subagents(config.agents):
-            await _write_agent_turn_provenance(
-                service,
-                session_id=args.session_id,
-                wf_exec_id=args.wf_exec_id,
-                resolved_refs=payload.resolved_refs,
-            )
-        return payload
+        return agent_config_to_payload(config)
 
 
 @activity.defn
@@ -162,9 +172,28 @@ async def resolve_agent_preset_version_ref_activity(
     args: ResolveAgentPresetVersionRefActivityInput,
 ) -> AgentPresetVersionRef:
     async with AgentPresetService.with_session(role=args.role) as service:
-        version = await service.resolve_agent_preset_version(
-            slug=args.preset_slug,
-        )
+        try:
+            version = await service.resolve_agent_preset_version(
+                slug=args.preset_slug,
+            )
+        except TracecatNotFoundError:
+            # DSL preflight failures happen before the agent child workflow
+            # exists; record the classified failure refs so the turn still
+            # leaves provenance, then let the domain error propagate.
+            try:
+                failure_refs = await service.build_root_preset_failure_refs(
+                    slug=args.preset_slug,
+                )
+                await _write_agent_turn_provenance(
+                    service,
+                    session_id=args.session_id,
+                    wf_exec_id=args.wf_exec_id,
+                    resolved_refs=failure_refs,
+                )
+            except Exception:
+                # A provenance write failure must never mask the domain error.
+                logger.exception("Failed to record preset preflight failure refs")
+            raise
         return AgentPresetVersionRef(
             preset_id=version.preset_id,
             preset_version_id=version.id,

--- a/tracecat/agent/preset/resolved_refs.py
+++ b/tracecat/agent/preset/resolved_refs.py
@@ -1,0 +1,132 @@
+"""Structured provenance for preset resource resolution.
+
+The invariant is value-only provenance: entries describe what resolution saw,
+including skipped nodes, without providing a fallback binding path. Callers may
+opt out by leaving ``ResolvedRefs`` fields as ``None`` for pre-2.2 histories.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+type SkippedAgentPresetRefReason = Literal["deleted", "unpublished", "not_found"]
+type ResolvedRefResourceKind = Literal["preset", "skill", "subagent"]
+type ResolvedRefStatus = Literal["ok", "skipped"]
+
+
+class SkippedAgentPresetRef(BaseModel):
+    """Preset-backed subagent ref intentionally omitted from resolution."""
+
+    preset_id: uuid.UUID | None = None
+    preset_slug: str | None = None
+    reason: SkippedAgentPresetRefReason
+
+
+class ResolvedRef(BaseModel):
+    """One value snapshot entry for a resolved or skipped resource node."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    resource_kind: ResolvedRefResourceKind
+    slug: str | None = None
+    resource_id: uuid.UUID | None = None
+    resolved_version_id: uuid.UUID | None = None
+    manifest_sha256: str | None = None
+    status: ResolvedRefStatus
+    code: SkippedAgentPresetRefReason | None = None
+    successor_id: uuid.UUID | None = None
+
+    @model_validator(mode="after")
+    def _validate_skip_code(self) -> Self:
+        """Enforce the persisted format: ``code`` iff ``status == "skipped"``."""
+
+        if self.status == "skipped" and self.code is None:
+            raise ValueError("skipped refs must carry a skip code")
+        if self.status == "ok" and self.code is not None:
+            raise ValueError("resolved refs must not carry a skip code")
+        return self
+
+
+class ResolvedRefs(BaseModel):
+    """Append-only resolution snapshot; ``successor_id`` is informational only."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    refs: list[ResolvedRef] = Field(default_factory=list)
+
+
+def merge_resolved_refs(*parts: ResolvedRefs | None) -> ResolvedRefs | None:
+    """Merge snapshots for one turn with kind-scoped deduplication.
+
+    Only ``subagent`` nodes are re-resolved across activity passes (the root
+    pass records a provisional entry; the runtime pass records what was
+    actually resolved or restored), so only they merge by node identity —
+    ``(resource_id)``, slug fallback — with the later pass replacing the
+    earlier entry in place. Subagent nodes seen only in an earlier pass
+    survive unchanged (e.g. a root-resolution skip record with no runtime
+    counterpart). A later id-bearing subagent entry supersedes a provisional
+    slug-only entry for the same slug, but entries with distinct
+    ``resource_id`` values never merge via slug — a live successor that
+    reused a deleted node's slug is a distinct resource and must not erase
+    the deleted node's skip record.
+
+    ``skill`` and ``preset`` entries union with exact-duplicate collapse:
+    those kinds are never re-resolved across passes, so same-id entries from
+    different passes are distinct tree positions that are both true (the
+    root's actually-used skill version must survive alongside a child's
+    later resolution of the same skill). Entries with neither
+    ``resource_id`` nor ``slug`` are appended as-is. First-seen entry order
+    is preserved.
+    """
+
+    merged: list[ResolvedRef] = []
+    index_by_key: dict[tuple[object, ...], int] = {}
+    slug_only_index: dict[str, int] = {}
+    seen_exact: set[tuple[object, ...]] = set()
+    for part in parts:
+        if part is None:
+            continue
+        for ref in part.refs:
+            if ref.resource_kind != "subagent":
+                exact = (
+                    ref.resource_kind,
+                    ref.slug,
+                    ref.resource_id,
+                    ref.resolved_version_id,
+                    ref.manifest_sha256,
+                    ref.status,
+                    ref.code,
+                    ref.successor_id,
+                )
+                if exact in seen_exact:
+                    continue
+                seen_exact.add(exact)
+                merged.append(ref)
+                continue
+            if ref.resource_id is not None:
+                key = ("id", ref.resource_id)
+                if key not in index_by_key and ref.slug is not None:
+                    provisional = slug_only_index.pop(ref.slug, None)
+                    if provisional is not None:
+                        merged[provisional] = ref
+                        index_by_key[key] = provisional
+                        continue
+            elif ref.slug is not None:
+                key = ("slug", ref.slug)
+            else:
+                merged.append(ref)
+                continue
+            existing = index_by_key.get(key)
+            if existing is not None:
+                merged[existing] = ref
+            else:
+                index_by_key[key] = len(merged)
+                merged.append(ref)
+                if ref.resource_id is None and ref.slug is not None:
+                    slug_only_index[ref.slug] = index_by_key[key]
+    if not merged:
+        return None
+    return ResolvedRefs(refs=merged)

--- a/tracecat/agent/preset/resolved_refs.py
+++ b/tracecat/agent/preset/resolved_refs.py
@@ -58,6 +58,22 @@ class ResolvedRefs(BaseModel):
     refs: list[ResolvedRef] = Field(default_factory=list)
 
 
+def without_subagent_refs(refs: ResolvedRefs | None) -> ResolvedRefs | None:
+    """Drop ``subagent``-kind entries from a snapshot.
+
+    Used when a preserved session binding overrides the preset's current
+    topology: the runtime pass rebuilds the stored binding verbatim, so the
+    root snapshot's subagent entries (the preset's *current* children) must
+    not be merged into the turn's provenance as if they ran.
+    """
+
+    if refs is None:
+        return None
+    return ResolvedRefs(
+        refs=[ref for ref in refs.refs if ref.resource_kind != "subagent"]
+    )
+
+
 def merge_resolved_refs(*parts: ResolvedRefs | None) -> ResolvedRefs | None:
     """Merge snapshots for one turn with kind-scoped deduplication.
 

--- a/tracecat/agent/preset/resolver.py
+++ b/tracecat/agent/preset/resolver.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Awaitable
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from pydantic import BaseModel, Field
 
+from tracecat.agent.preset.resolved_refs import (
+    ResolvedRef,
+    ResolvedRefs,
+    SkippedAgentPresetRef,
+    merge_resolved_refs,
+)
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
     AttachedSubagentRef,
@@ -24,8 +30,6 @@ from tracecat.exceptions import TracecatValidationError
 if TYPE_CHECKING:
     from tracecat.agent.types import AgentConfig
     from tracecat.db.models import AgentPreset, AgentPresetVersion
-
-type SkippedAgentPresetRefReason = Literal["deleted", "unpublished", "not_found"]
 
 
 class AgentPresetResolutionService(Protocol):
@@ -72,6 +76,13 @@ class AgentPresetResolutionService(Protocol):
         self, version: AgentPresetVersion
     ) -> Awaitable[AgentSubagentsConfig]: ...
 
+    def get_successor_id_for_deleted_preset_ref(
+        self,
+        *,
+        preset_id: uuid.UUID | None = None,
+        slug: str | None = None,
+    ) -> Awaitable[uuid.UUID | None]: ...
+
 
 class ResolvedSubagentConfig(BaseModel):
     """Runtime-ready resolved subagent configuration."""
@@ -109,20 +120,13 @@ class ResolvedSubagentResolution(BaseModel):
         )
 
 
-class SkippedAgentPresetRef(BaseModel):
-    """Preset-backed subagent ref intentionally omitted from resolution."""
-
-    preset_id: uuid.UUID | None = None
-    preset_slug: str | None = None
-    reason: SkippedAgentPresetRefReason
-
-
 class ResolvedAgentsConfigResult(BaseModel):
     """Resolved preset-backed subagent bindings."""
 
     enabled: bool = False
     subagents: list[ResolvedSubagentResolution] = Field(default_factory=list)
     skipped: list[SkippedAgentPresetRef] = Field(default_factory=list)
+    resolved_refs: ResolvedRefs | None = None
 
     def to_agents_binding(self) -> ResolvedAgentsConfig:
         return ResolvedAgentsConfig(
@@ -136,6 +140,7 @@ class ResolvedAgentsConfigResult(BaseModel):
             subagents=[
                 subagent.require_runtime_config() for subagent in self.subagents
             ],
+            resolved_refs=self.resolved_refs,
         )
 
 
@@ -144,6 +149,7 @@ class ResolvedAgentsRuntimeConfig(BaseModel):
 
     enabled: bool = False
     subagents: list[ResolvedSubagentConfig] = Field(default_factory=list)
+    resolved_refs: ResolvedRefs | None = None
 
     def to_agents_binding(self) -> ResolvedAgentsConfig:
         return ResolvedAgentsConfig(
@@ -181,6 +187,7 @@ async def resolve_agents_config(
     aliases: set[str] = set()
     resolved_subagents: list[ResolvedSubagentResolution] = []
     skipped: list[SkippedAgentPresetRef] = []
+    resolved_ref_entries: list[ResolvedRef] = []
     for ref in config.subagents:
         alias = ref.alias
         try:
@@ -236,6 +243,24 @@ async def resolve_agents_config(
                 )
         if isinstance(version_or_skip, SkippedAgentPresetRef):
             skipped.append(version_or_skip)
+            successor_id = (
+                await service.get_successor_id_for_deleted_preset_ref(
+                    preset_id=version_or_skip.preset_id,
+                    slug=version_or_skip.preset_slug,
+                )
+                if version_or_skip.reason == "deleted"
+                else None
+            )
+            resolved_ref_entries.append(
+                ResolvedRef(
+                    resource_kind="subagent",
+                    slug=version_or_skip.preset_slug,
+                    resource_id=version_or_skip.preset_id,
+                    status="skipped",
+                    code=version_or_skip.reason,
+                    successor_id=successor_id,
+                )
+            )
             continue
         version = version_or_skip
         references_parent_id = (
@@ -265,6 +290,21 @@ async def resolve_agents_config(
                 "which are not supported for subagents yet."
             )
 
+        # On the resumed-session restore path a soft-deleted child preset
+        # must still enrich the runtime config (with_deleted read).
+        preset = await service.get_preset(
+            version.preset_id, include_deleted=preserve_resolved_versions
+        )
+        resolved_ref_entries.append(
+            ResolvedRef(
+                resource_kind="subagent",
+                slug=preset.slug if preset is not None else ref.preset,
+                resource_id=version.preset_id,
+                resolved_version_id=version.id,
+                status="ok",
+            )
+        )
+
         binding = ResolvedAttachedSubagentRef(
             preset=ref.preset,
             preset_version=version.version,
@@ -275,11 +315,6 @@ async def resolve_agents_config(
             preset_version_id=version.id,
         )
         if include_runtime_config:
-            # On the resumed-session restore path a soft-deleted child preset
-            # must still enrich the runtime config (with_deleted read).
-            preset = await service.get_preset(
-                version.preset_id, include_deleted=preserve_resolved_versions
-            )
             child_config = await service.resolve_agent_preset_config(
                 preset_version_id=version.id,
                 include_deleted_preset=preserve_resolved_versions,
@@ -297,6 +332,12 @@ async def resolve_agents_config(
                     config=agent_config_to_payload(child_config),
                 )
             )
+            if child_config.resolved_refs is not None:
+                resolved_ref_entries.extend(
+                    child_ref
+                    for child_ref in child_config.resolved_refs.refs
+                    if child_ref.resource_kind != "preset"
+                )
         else:
             resolved_subagents.append(ResolvedSubagentResolution(binding=binding))
 
@@ -304,6 +345,7 @@ async def resolve_agents_config(
         enabled=True,
         subagents=resolved_subagents,
         skipped=skipped,
+        resolved_refs=merge_resolved_refs(ResolvedRefs(refs=resolved_ref_entries)),
     )
 
 

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -18,7 +18,13 @@ from sqlalchemy.orm import selectinload
 from tracecat.agent.access.service import AgentModelAccessService
 from tracecat.agent.channels.service import AgentChannelService
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPServerConfig
+from tracecat.agent.preset.resolved_refs import (
+    ResolvedRef,
+    ResolvedRefs,
+    merge_resolved_refs,
+)
 from tracecat.agent.preset.resolver import (
+    ResolvedAgentsConfigResult,
     SkippedAgentPresetRef,
     resolve_agents_config,
 )
@@ -41,6 +47,7 @@ from tracecat.agent.preset.schemas import (
 )
 from tracecat.agent.preset.types import SkillBindingSpec
 from tracecat.agent.skill.service import SkillService
+from tracecat.agent.skill.types import ResolvedSkillRefsResult
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
     HeadAttachedSubagentRef,
@@ -443,13 +450,20 @@ class AgentPresetService(BaseWorkspaceService):
     ) -> ResolvedAgentsConfig:
         """Resolve a preset version's snapshotted ResourceHead edges."""
 
-        resolved = await resolve_agents_config(
+        resolved = await self._resolve_version_subagents(version)
+        return resolved.to_agents_binding()
+
+    async def _resolve_version_subagents(
+        self, version: AgentPresetVersion
+    ) -> ResolvedAgentsConfigResult:
+        """Resolve a preset version's snapshotted ResourceHead edges and refs."""
+
+        return await resolve_agents_config(
             self,
             agents=await self._get_version_agents_config(version),
             parent_preset_id=version.preset_id,
             include_runtime_config=False,
         )
-        return resolved.to_agents_binding()
 
     async def build_preset_read(self, preset: AgentPreset) -> AgentPresetRead:
         """Build the response model for a preset."""
@@ -998,6 +1012,134 @@ class AgentPresetService(BaseWorkspaceService):
             .limit(1)
         )
         return (await self.session.execute(with_deleted(stmt))).scalar_one_or_none()
+
+    async def get_successor_id_for_deleted_preset_ref(
+        self,
+        *,
+        preset_id: uuid.UUID | None = None,
+        slug: str | None = None,
+    ) -> uuid.UUID | None:
+        """Return the live owner of a deleted preset slug, without rebinding."""
+
+        if slug is None and preset_id is not None:
+            tombstone = await self._get_preset_for_head_resolution(preset_id=preset_id)
+            slug = tombstone.slug if tombstone is not None else None
+        if slug is None:
+            return None
+
+        predicates = [
+            AgentPreset.workspace_id == self.workspace_id,
+            AgentPreset.slug == slug,
+            AgentPreset.deleted_at.is_(None),
+        ]
+        if preset_id is not None:
+            predicates.append(AgentPreset.id != preset_id)
+        stmt = (
+            select(AgentPreset.id)
+            .where(*predicates)
+            .order_by(AgentPreset.created_at.desc())
+            .limit(1)
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def build_root_preset_failure_refs(
+        self,
+        *,
+        preset_id: uuid.UUID | None = None,
+        slug: str | None = None,
+        preset_version_id: uuid.UUID | None = None,
+        preset_version: int | None = None,
+    ) -> ResolvedRefs:
+        """Classify a failing root preset lookup without making it non-fatal."""
+
+        preset: AgentPreset | None = None
+        if preset_version_id is not None:
+            stmt = (
+                select(AgentPreset)
+                .join(
+                    AgentPresetVersion,
+                    sa.and_(
+                        AgentPresetVersion.workspace_id == AgentPreset.workspace_id,
+                        AgentPresetVersion.preset_id == AgentPreset.id,
+                    ),
+                )
+                .where(
+                    AgentPreset.workspace_id == self.workspace_id,
+                    AgentPresetVersion.id == preset_version_id,
+                )
+            )
+            preset = (
+                await self.session.execute(with_deleted(stmt))
+            ).scalar_one_or_none()
+        if preset is None and (preset_id is not None or slug is not None):
+            preset = await self._get_preset_for_head_resolution(
+                preset_id=preset_id,
+                slug=slug,
+            )
+
+        if preset is None:
+            return ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        slug=slug,
+                        resource_id=preset_id,
+                        status="skipped",
+                        code="not_found",
+                    )
+                ]
+            )
+
+        if preset.deleted_at is not None:
+            successor_id = await self.get_successor_id_for_deleted_preset_ref(
+                preset_id=preset.id,
+                slug=preset.slug,
+            )
+            return ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        slug=preset.slug,
+                        resource_id=preset.id,
+                        status="skipped",
+                        code="deleted",
+                        successor_id=successor_id,
+                    )
+                ]
+            )
+
+        if (
+            preset_version is not None
+            and await self.get_version_by_number(
+                preset_id=preset.id, version=preset_version
+            )
+            is None
+        ):
+            # The preset is live but the requested version number does not
+            # exist — the failure is the version request, not publish state.
+            return ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        slug=preset.slug,
+                        resource_id=preset.id,
+                        status="skipped",
+                        code="not_found",
+                    )
+                ]
+            )
+
+        return ResolvedRefs(
+            refs=[
+                ResolvedRef(
+                    resource_kind="preset",
+                    slug=preset.slug,
+                    resource_id=preset.id,
+                    status="skipped",
+                    code="unpublished",
+                )
+            ]
+        )
 
     def _log_skipped_agent_preset_ref(self, skipped_ref: SkippedAgentPresetRef) -> None:
         """Record a non-fatal child-head resolution skip."""
@@ -2302,6 +2444,80 @@ class AgentPresetService(BaseWorkspaceService):
             total_changes=total_changes,
         )
 
+    async def _get_live_skill_successor_id(
+        self,
+        *,
+        skill_id: uuid.UUID,
+        slug: str | None,
+    ) -> uuid.UUID | None:
+        """Return the live owner of a deleted skill slug, without rebinding."""
+
+        if slug is None:
+            return None
+        stmt = (
+            select(Skill.id)
+            .where(
+                Skill.workspace_id == self.workspace_id,
+                Skill.slug == slug,
+                Skill.id != skill_id,
+                Skill.deleted_at.is_(None),
+                Skill.archived_at.is_(None),
+            )
+            .order_by(Skill.created_at.desc())
+            .limit(1)
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def _build_skill_resolved_refs(
+        self,
+        resolved_skill_refs: ResolvedSkillRefsResult,
+    ) -> ResolvedRefs | None:
+        """Build value-only skill refs from the effective resolution result."""
+
+        skill_ids = {ref.skill_id for ref in resolved_skill_refs.refs}
+        skill_ids.update(ref.skill_id for ref in resolved_skill_refs.skipped)
+        if not skill_ids:
+            return None
+
+        stmt = select(Skill.id, Skill.slug).where(
+            Skill.workspace_id == self.workspace_id,
+            Skill.id.in_(skill_ids),
+        )
+        rows = (await self.session.execute(with_deleted(stmt))).tuples().all()
+        slug_by_id = dict(rows)
+        refs: list[ResolvedRef] = []
+        for skill_ref in resolved_skill_refs.refs:
+            refs.append(
+                ResolvedRef(
+                    resource_kind="skill",
+                    slug=slug_by_id.get(skill_ref.skill_id),
+                    resource_id=skill_ref.skill_id,
+                    resolved_version_id=skill_ref.skill_version_id,
+                    manifest_sha256=skill_ref.manifest_sha256,
+                    status="ok",
+                )
+            )
+        for skipped_ref in resolved_skill_refs.skipped:
+            successor_id = (
+                await self._get_live_skill_successor_id(
+                    skill_id=skipped_ref.skill_id,
+                    slug=skipped_ref.skill_slug,
+                )
+                if skipped_ref.reason == "deleted"
+                else None
+            )
+            refs.append(
+                ResolvedRef(
+                    resource_kind="skill",
+                    slug=skipped_ref.skill_slug,
+                    resource_id=skipped_ref.skill_id,
+                    status="skipped",
+                    code=skipped_ref.reason,
+                    successor_id=successor_id,
+                )
+            )
+        return ResolvedRefs(refs=refs)
+
     async def _version_to_agent_config(
         self, version: AgentPresetVersion
     ) -> AgentConfig:
@@ -2309,11 +2525,29 @@ class AgentPresetService(BaseWorkspaceService):
         # AgentConfig is safe to cross Temporal boundaries. Trusted callers
         # (build_tool_definitions, trusted MCP server) re-resolve secrets
         # per use via resolve_mcp_integration_secrets.
+        # Enrichment lookup, not a liveness check: callers decided liveness
+        # before handing us a version (the resumed-session restore path
+        # resolves soft-deleted child presets on purpose).
+        preset = await self.get_preset(version.preset_id, include_deleted=True)
+        if preset is None:
+            raise TracecatNotFoundError(f"Agent preset '{version.preset_id}' not found")
+        root_resolved_refs = ResolvedRefs(
+            refs=[
+                ResolvedRef(
+                    resource_kind="preset",
+                    slug=preset.slug,
+                    resource_id=preset.id,
+                    resolved_version_id=version.id,
+                    status="ok",
+                )
+            ]
+        )
         mcp_servers = await self.resolve_mcp_integration_refs(version.mcp_integrations)
         model_settings: dict[str, Any] = {}
         skill_resolution = await self.skills.get_resolved_skill_refs_for_preset_version(
             version.id
         )
+        skill_resolved_refs = await self._build_skill_resolved_refs(skill_resolution)
         resolved_skills = skill_resolution.refs
         duplicate_skill_names = sorted(
             name
@@ -2334,12 +2568,13 @@ class AgentPresetService(BaseWorkspaceService):
         # Only disable parallel tool calls if tools will be present
         if version.actions or mcp_servers:
             model_settings["parallel_tool_calls"] = False
-        # Normalized edges are authoritative for runtime membership; the raw
-        # JSON is only the mixed-version compatibility payload.
-        # get_version_subagent_binding resolves through the edges and already
-        # validates children (deleted or unpublished children are rejected
-        # before a binding escapes).
-        binding = await self.get_version_subagent_binding(version)
+        resolved_agents = await self._resolve_version_subagents(version)
+        resolved_refs = merge_resolved_refs(
+            root_resolved_refs,
+            skill_resolved_refs,
+            resolved_agents.resolved_refs,
+        )
+        binding = resolved_agents.to_agents_binding()
         agents = AgentSubagentsConfig(
             enabled=binding.enabled,
             subagents=list(binding.subagents),
@@ -2361,6 +2596,7 @@ class AgentPresetService(BaseWorkspaceService):
             enable_thinking=version.enable_thinking,
             enable_internet_access=version.enable_internet_access,
             resolved_skills=resolved_skills,
+            resolved_refs=resolved_refs,
         )
 
     async def _create_version_from_preset(

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -1129,6 +1129,27 @@ class AgentPresetService(BaseWorkspaceService):
                 ]
             )
 
+        if preset_version_id is not None and (
+            await self.get_active_version(
+                version_id=preset_version_id,
+                preset_id=preset.id,
+            )
+            is None
+        ):
+            # The preset is live but the requested version ID does not exist
+            # for it, so the version ref is missing rather than unpublished.
+            return ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        slug=preset.slug,
+                        resource_id=preset.id,
+                        status="skipped",
+                        code="not_found",
+                    )
+                ]
+            )
+
         return ResolvedRefs(
             refs=[
                 ResolvedRef(

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -2474,23 +2474,14 @@ class AgentPresetService(BaseWorkspaceService):
     ) -> ResolvedRefs | None:
         """Build value-only skill refs from the effective resolution result."""
 
-        skill_ids = {ref.skill_id for ref in resolved_skill_refs.refs}
-        skill_ids.update(ref.skill_id for ref in resolved_skill_refs.skipped)
-        if not skill_ids:
+        if not resolved_skill_refs.refs and not resolved_skill_refs.skipped:
             return None
-
-        stmt = select(Skill.id, Skill.slug).where(
-            Skill.workspace_id == self.workspace_id,
-            Skill.id.in_(skill_ids),
-        )
-        rows = (await self.session.execute(with_deleted(stmt))).tuples().all()
-        slug_by_id = dict(rows)
         refs: list[ResolvedRef] = []
         for skill_ref in resolved_skill_refs.refs:
             refs.append(
                 ResolvedRef(
                     resource_kind="skill",
-                    slug=slug_by_id.get(skill_ref.skill_id),
+                    slug=skill_ref.skill_name,
                     resource_id=skill_ref.skill_id,
                     resolved_version_id=skill_ref.skill_version_id,
                     manifest_sha256=skill_ref.manifest_sha256,

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -24,7 +24,13 @@ from tracecat.agent.common.types import (
     MCPServerToolSummary,
     MCPStdioServerConfig,
 )
+from tracecat.agent.preset.resolved_refs import (
+    ResolvedRef,
+    ResolvedRefs,
+    merge_resolved_refs,
+)
 from tracecat.agent.preset.resolver import (
+    ResolvedAgentsConfigResult,
     SkippedAgentPresetRef,
     resolve_agents_config,
 )
@@ -47,6 +53,7 @@ from tracecat.agent.preset.schemas import (
 )
 from tracecat.agent.preset.types import SkillBindingSpec
 from tracecat.agent.skill.service import SkillService
+from tracecat.agent.skill.types import ResolvedSkillRefsResult
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
     HeadAttachedSubagentRef,
@@ -451,13 +458,20 @@ class AgentPresetService(BaseWorkspaceService):
     ) -> ResolvedAgentsConfig:
         """Resolve a preset version's snapshotted ResourceHead edges."""
 
-        resolved = await resolve_agents_config(
+        resolved = await self._resolve_version_subagents(version)
+        return resolved.to_agents_binding()
+
+    async def _resolve_version_subagents(
+        self, version: AgentPresetVersion
+    ) -> ResolvedAgentsConfigResult:
+        """Resolve a preset version's snapshotted ResourceHead edges and refs."""
+
+        return await resolve_agents_config(
             self,
             agents=await self._get_version_agents_config(version),
             parent_preset_id=version.preset_id,
             include_runtime_config=False,
         )
-        return resolved.to_agents_binding()
 
     async def build_preset_read(self, preset: AgentPreset) -> AgentPresetRead:
         """Build the response model for a preset."""
@@ -1024,6 +1038,134 @@ class AgentPresetService(BaseWorkspaceService):
             .limit(1)
         )
         return (await self.session.execute(with_deleted(stmt))).scalar_one_or_none()
+
+    async def get_successor_id_for_deleted_preset_ref(
+        self,
+        *,
+        preset_id: uuid.UUID | None = None,
+        slug: str | None = None,
+    ) -> uuid.UUID | None:
+        """Return the live owner of a deleted preset slug, without rebinding."""
+
+        if slug is None and preset_id is not None:
+            tombstone = await self._get_preset_for_head_resolution(preset_id=preset_id)
+            slug = tombstone.slug if tombstone is not None else None
+        if slug is None:
+            return None
+
+        predicates = [
+            AgentPreset.workspace_id == self.workspace_id,
+            AgentPreset.slug == slug,
+            AgentPreset.deleted_at.is_(None),
+        ]
+        if preset_id is not None:
+            predicates.append(AgentPreset.id != preset_id)
+        stmt = (
+            select(AgentPreset.id)
+            .where(*predicates)
+            .order_by(AgentPreset.created_at.desc())
+            .limit(1)
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def build_root_preset_failure_refs(
+        self,
+        *,
+        preset_id: uuid.UUID | None = None,
+        slug: str | None = None,
+        preset_version_id: uuid.UUID | None = None,
+        preset_version: int | None = None,
+    ) -> ResolvedRefs:
+        """Classify a failing root preset lookup without making it non-fatal."""
+
+        preset: AgentPreset | None = None
+        if preset_version_id is not None:
+            stmt = (
+                select(AgentPreset)
+                .join(
+                    AgentPresetVersion,
+                    sa.and_(
+                        AgentPresetVersion.workspace_id == AgentPreset.workspace_id,
+                        AgentPresetVersion.preset_id == AgentPreset.id,
+                    ),
+                )
+                .where(
+                    AgentPreset.workspace_id == self.workspace_id,
+                    AgentPresetVersion.id == preset_version_id,
+                )
+            )
+            preset = (
+                await self.session.execute(with_deleted(stmt))
+            ).scalar_one_or_none()
+        if preset is None and (preset_id is not None or slug is not None):
+            preset = await self._get_preset_for_head_resolution(
+                preset_id=preset_id,
+                slug=slug,
+            )
+
+        if preset is None:
+            return ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        slug=slug,
+                        resource_id=preset_id,
+                        status="skipped",
+                        code="not_found",
+                    )
+                ]
+            )
+
+        if preset.deleted_at is not None:
+            successor_id = await self.get_successor_id_for_deleted_preset_ref(
+                preset_id=preset.id,
+                slug=preset.slug,
+            )
+            return ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        slug=preset.slug,
+                        resource_id=preset.id,
+                        status="skipped",
+                        code="deleted",
+                        successor_id=successor_id,
+                    )
+                ]
+            )
+
+        if (
+            preset_version is not None
+            and await self.get_version_by_number(
+                preset_id=preset.id, version=preset_version
+            )
+            is None
+        ):
+            # The preset is live but the requested version number does not
+            # exist — the failure is the version request, not publish state.
+            return ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        slug=preset.slug,
+                        resource_id=preset.id,
+                        status="skipped",
+                        code="not_found",
+                    )
+                ]
+            )
+
+        return ResolvedRefs(
+            refs=[
+                ResolvedRef(
+                    resource_kind="preset",
+                    slug=preset.slug,
+                    resource_id=preset.id,
+                    status="skipped",
+                    code="unpublished",
+                )
+            ]
+        )
 
     def _log_skipped_agent_preset_ref(self, skipped_ref: SkippedAgentPresetRef) -> None:
         """Record a non-fatal child-head resolution skip."""
@@ -2432,6 +2574,80 @@ class AgentPresetService(BaseWorkspaceService):
             total_changes=total_changes,
         )
 
+    async def _get_live_skill_successor_id(
+        self,
+        *,
+        skill_id: uuid.UUID,
+        slug: str | None,
+    ) -> uuid.UUID | None:
+        """Return the live owner of a deleted skill slug, without rebinding."""
+
+        if slug is None:
+            return None
+        stmt = (
+            select(Skill.id)
+            .where(
+                Skill.workspace_id == self.workspace_id,
+                Skill.slug == slug,
+                Skill.id != skill_id,
+                Skill.deleted_at.is_(None),
+                Skill.archived_at.is_(None),
+            )
+            .order_by(Skill.created_at.desc())
+            .limit(1)
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def _build_skill_resolved_refs(
+        self,
+        resolved_skill_refs: ResolvedSkillRefsResult,
+    ) -> ResolvedRefs | None:
+        """Build value-only skill refs from the effective resolution result."""
+
+        skill_ids = {ref.skill_id for ref in resolved_skill_refs.refs}
+        skill_ids.update(ref.skill_id for ref in resolved_skill_refs.skipped)
+        if not skill_ids:
+            return None
+
+        stmt = select(Skill.id, Skill.slug).where(
+            Skill.workspace_id == self.workspace_id,
+            Skill.id.in_(skill_ids),
+        )
+        rows = (await self.session.execute(with_deleted(stmt))).tuples().all()
+        slug_by_id = dict(rows)
+        refs: list[ResolvedRef] = []
+        for skill_ref in resolved_skill_refs.refs:
+            refs.append(
+                ResolvedRef(
+                    resource_kind="skill",
+                    slug=slug_by_id.get(skill_ref.skill_id),
+                    resource_id=skill_ref.skill_id,
+                    resolved_version_id=skill_ref.skill_version_id,
+                    manifest_sha256=skill_ref.manifest_sha256,
+                    status="ok",
+                )
+            )
+        for skipped_ref in resolved_skill_refs.skipped:
+            successor_id = (
+                await self._get_live_skill_successor_id(
+                    skill_id=skipped_ref.skill_id,
+                    slug=skipped_ref.skill_slug,
+                )
+                if skipped_ref.reason == "deleted"
+                else None
+            )
+            refs.append(
+                ResolvedRef(
+                    resource_kind="skill",
+                    slug=skipped_ref.skill_slug,
+                    resource_id=skipped_ref.skill_id,
+                    status="skipped",
+                    code=skipped_ref.reason,
+                    successor_id=successor_id,
+                )
+            )
+        return ResolvedRefs(refs=refs)
+
     async def _version_to_agent_config(
         self, version: AgentPresetVersion
     ) -> AgentConfig:
@@ -2439,11 +2655,29 @@ class AgentPresetService(BaseWorkspaceService):
         # AgentConfig is safe to cross Temporal boundaries. Trusted callers
         # (build_tool_definitions, trusted MCP server) re-resolve secrets
         # per use via resolve_mcp_integration_secrets.
+        # Enrichment lookup, not a liveness check: callers decided liveness
+        # before handing us a version (the resumed-session restore path
+        # resolves soft-deleted child presets on purpose).
+        preset = await self.get_preset(version.preset_id, include_deleted=True)
+        if preset is None:
+            raise TracecatNotFoundError(f"Agent preset '{version.preset_id}' not found")
+        root_resolved_refs = ResolvedRefs(
+            refs=[
+                ResolvedRef(
+                    resource_kind="preset",
+                    slug=preset.slug,
+                    resource_id=preset.id,
+                    resolved_version_id=version.id,
+                    status="ok",
+                )
+            ]
+        )
         mcp_servers = await self.resolve_mcp_integration_refs(version.mcp_integrations)
         model_settings: dict[str, Any] = {}
         skill_resolution = await self.skills.get_resolved_skill_refs_for_preset_version(
             version.id
         )
+        skill_resolved_refs = await self._build_skill_resolved_refs(skill_resolution)
         resolved_skills = skill_resolution.refs
         duplicate_skill_names = sorted(
             name
@@ -2464,12 +2698,13 @@ class AgentPresetService(BaseWorkspaceService):
         # Only disable parallel tool calls if tools will be present
         if version.actions or mcp_servers:
             model_settings["parallel_tool_calls"] = False
-        # Normalized edges are authoritative for runtime membership; the raw
-        # JSON is only the mixed-version compatibility payload.
-        # get_version_subagent_binding resolves through the edges and already
-        # validates children (deleted or unpublished children are rejected
-        # before a binding escapes).
-        binding = await self.get_version_subagent_binding(version)
+        resolved_agents = await self._resolve_version_subagents(version)
+        resolved_refs = merge_resolved_refs(
+            root_resolved_refs,
+            skill_resolved_refs,
+            resolved_agents.resolved_refs,
+        )
+        binding = resolved_agents.to_agents_binding()
         agents = AgentSubagentsConfig(
             enabled=binding.enabled,
             subagents=list(binding.subagents),
@@ -2491,6 +2726,7 @@ class AgentPresetService(BaseWorkspaceService):
             enable_thinking=version.enable_thinking,
             enable_internet_access=version.enable_internet_access,
             resolved_skills=resolved_skills,
+            resolved_refs=resolved_refs,
         )
 
     async def _create_version_from_preset(

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -1155,6 +1155,27 @@ class AgentPresetService(BaseWorkspaceService):
                 ]
             )
 
+        if preset_version_id is not None and (
+            await self.get_active_version(
+                version_id=preset_version_id,
+                preset_id=preset.id,
+            )
+            is None
+        ):
+            # The preset is live but the requested version ID does not exist
+            # for it, so the version ref is missing rather than unpublished.
+            return ResolvedRefs(
+                refs=[
+                    ResolvedRef(
+                        resource_kind="preset",
+                        slug=preset.slug,
+                        resource_id=preset.id,
+                        status="skipped",
+                        code="not_found",
+                    )
+                ]
+            )
+
         return ResolvedRefs(
             refs=[
                 ResolvedRef(

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -2604,23 +2604,14 @@ class AgentPresetService(BaseWorkspaceService):
     ) -> ResolvedRefs | None:
         """Build value-only skill refs from the effective resolution result."""
 
-        skill_ids = {ref.skill_id for ref in resolved_skill_refs.refs}
-        skill_ids.update(ref.skill_id for ref in resolved_skill_refs.skipped)
-        if not skill_ids:
+        if not resolved_skill_refs.refs and not resolved_skill_refs.skipped:
             return None
-
-        stmt = select(Skill.id, Skill.slug).where(
-            Skill.workspace_id == self.workspace_id,
-            Skill.id.in_(skill_ids),
-        )
-        rows = (await self.session.execute(with_deleted(stmt))).tuples().all()
-        slug_by_id = dict(rows)
         refs: list[ResolvedRef] = []
         for skill_ref in resolved_skill_refs.refs:
             refs.append(
                 ResolvedRef(
                     resource_kind="skill",
-                    slug=slug_by_id.get(skill_ref.skill_id),
+                    slug=skill_ref.skill_name,
                     resource_id=skill_ref.skill_id,
                     resolved_version_id=skill_ref.skill_version_id,
                     manifest_sha256=skill_ref.manifest_sha256,

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import uuid
-from collections.abc import AsyncIterator, Iterator, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Literal, NamedTuple, TypeGuard
@@ -41,7 +41,10 @@ from tracecat.db.models import (
     OrganizationSecret,
     Secret,
 )
-from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatNotFoundError,
+)
 from tracecat.integrations.aws_assume_role import build_workspace_external_id
 from tracecat.logger import logger
 from tracecat.secrets import secrets_manager
@@ -1081,6 +1084,8 @@ class AgentManagementService(BaseOrgService):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        on_resolution_error: Callable[[TracecatNotFoundError], Awaitable[None]]
+        | None = None,
     ) -> AsyncIterator[AgentConfig]:
         """Yield an agent preset configuration with provider credentials loaded.
 
@@ -1100,12 +1105,28 @@ class AgentManagementService(BaseOrgService):
                 "Agent presets require a workspace role",
             )
 
-        preset_config = await self.presets.resolve_agent_preset_config(
-            preset_id=preset_id,
-            slug=slug,
-            preset_version_id=preset_version_id,
-            preset_version=preset_version,
-        )
+        try:
+            preset_config = await self.presets.resolve_agent_preset_config(
+                preset_id=preset_id,
+                slug=slug,
+                preset_version_id=preset_version_id,
+                preset_version=preset_version,
+            )
+        except TracecatNotFoundError as err:
+            # Only ref-state failures feed the provenance classifier: every
+            # genuine not_found / deleted / unpublished outcome arrives as
+            # NotFound (unpublished roots raise NotFound from
+            # get_effective_version_for_preset). Post-resolution validation
+            # errors (e.g. duplicate skill names) are not resolution outcomes
+            # and must not be classified into failure refs.
+            if on_resolution_error is not None:
+                try:
+                    await on_resolution_error(err)
+                except Exception:
+                    # A provenance write failure must never mask the domain
+                    # error; record it and let the original propagate.
+                    logger.exception("Failed to record preset resolution failure refs")
+            raise
 
         credentials: dict[str, str] | None = None
         workspace_credentials_checked = False

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -1086,6 +1086,7 @@ class AgentManagementService(BaseOrgService):
         preset_version: int | None = None,
         on_resolution_error: Callable[[TracecatNotFoundError], Awaitable[None]]
         | None = None,
+        on_resolved: Callable[[AgentConfig], Awaitable[None]] | None = None,
     ) -> AsyncIterator[AgentConfig]:
         """Yield an agent preset configuration with provider credentials loaded.
 
@@ -1099,6 +1100,10 @@ class AgentManagementService(BaseOrgService):
             slug: Agent preset slug to load (alternative to preset_id)
             preset_version_id: Exact version ID from a run or restore snapshot
             preset_version: Exact version number for legacy replay
+            on_resolution_error: Awaited when resolution itself fails.
+            on_resolved: Awaited immediately after resolution succeeds and
+                before credential loading, so callers can persist resolution
+                outcomes that must survive credential failures.
         """
         if self.presets is None:
             raise TracecatAuthorizationError(
@@ -1127,6 +1132,9 @@ class AgentManagementService(BaseOrgService):
                     # error; record it and let the original propagate.
                     logger.exception("Failed to record preset resolution failure refs")
             raise
+
+        if on_resolved is not None:
+            await on_resolved(preset_config)
 
         credentials: dict[str, str] | None = None
         workspace_credentials_checked = False

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -1084,6 +1084,7 @@ class AgentManagementService(BaseOrgService):
         preset_version: int | None = None,
         on_resolution_error: Callable[[TracecatNotFoundError], Awaitable[None]]
         | None = None,
+        on_resolved: Callable[[AgentConfig], Awaitable[None]] | None = None,
     ) -> AsyncIterator[AgentConfig]:
         """Yield an agent preset configuration with provider credentials loaded.
 
@@ -1097,6 +1098,10 @@ class AgentManagementService(BaseOrgService):
             slug: Agent preset slug to load (alternative to preset_id)
             preset_version_id: Exact version ID from a run or restore snapshot
             preset_version: Exact version number for legacy replay
+            on_resolution_error: Awaited when resolution itself fails.
+            on_resolved: Awaited immediately after resolution succeeds and
+                before credential loading, so callers can persist resolution
+                outcomes that must survive credential failures.
         """
         if self.presets is None:
             raise TracecatAuthorizationError(
@@ -1125,6 +1130,9 @@ class AgentManagementService(BaseOrgService):
                     # error; record it and let the original propagate.
                     logger.exception("Failed to record preset resolution failure refs")
             raise
+
+        if on_resolved is not None:
+            await on_resolved(preset_config)
 
         credentials: dict[str, str] | None = None
         workspace_credentials_checked = False

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import uuid
-from collections.abc import AsyncIterator, Iterator, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Literal, NamedTuple, TypeGuard
@@ -41,7 +41,10 @@ from tracecat.db.models import (
     OrganizationSecret,
     Secret,
 )
-from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatNotFoundError,
+)
 from tracecat.integrations.aws_assume_role import build_workspace_external_id
 from tracecat.logger import logger
 from tracecat.secrets import secrets_manager
@@ -1079,6 +1082,8 @@ class AgentManagementService(BaseOrgService):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        on_resolution_error: Callable[[TracecatNotFoundError], Awaitable[None]]
+        | None = None,
     ) -> AsyncIterator[AgentConfig]:
         """Yield an agent preset configuration with provider credentials loaded.
 
@@ -1098,12 +1103,28 @@ class AgentManagementService(BaseOrgService):
                 "Agent presets require a workspace role",
             )
 
-        preset_config = await self.presets.resolve_agent_preset_config(
-            preset_id=preset_id,
-            slug=slug,
-            preset_version_id=preset_version_id,
-            preset_version=preset_version,
-        )
+        try:
+            preset_config = await self.presets.resolve_agent_preset_config(
+                preset_id=preset_id,
+                slug=slug,
+                preset_version_id=preset_version_id,
+                preset_version=preset_version,
+            )
+        except TracecatNotFoundError as err:
+            # Only ref-state failures feed the provenance classifier: every
+            # genuine not_found / deleted / unpublished outcome arrives as
+            # NotFound (unpublished roots raise NotFound from
+            # get_effective_version_for_preset). Post-resolution validation
+            # errors (e.g. duplicate skill names) are not resolution outcomes
+            # and must not be classified into failure refs.
+            if on_resolution_error is not None:
+                try:
+                    await on_resolution_error(err)
+                except Exception:
+                    # A provenance write failure must never mask the domain
+                    # error; record it and let the original propagate.
+                    logger.exception("Failed to record preset resolution failure refs")
+            raise
 
         credentials: dict[str, str] | None = None
         workspace_credentials_checked = False

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -147,18 +147,23 @@ class AgentSessionService(BaseWorkspaceService):
 
     service_name = "agent-session"
 
-    def _stage_root_only_turn_provenance(
+    def _stage_root_turn_provenance(
         self,
         *,
         session_id: uuid.UUID,
         run_id: uuid.UUID,
         config: AgentConfig,
     ) -> None:
-        """Stage root-only resolution provenance when no subagent activity will run."""
+        """Stage the root resolution snapshot for a spawned turn.
+
+        Always staged, even when a later subagent activity will append a
+        merged snapshot: any failure between spawn and that write (custom
+        model provider config, session load, subagent resolution) must still
+        leave the turn's root refs on record. The highest ``surrogate_id``
+        per ``wf_exec_id`` is the final snapshot.
+        """
 
         if config.resolved_refs is None:
-            return
-        if config.agents.enabled and config.agents.subagents:
             return
 
         self.session.add(
@@ -1459,7 +1464,7 @@ class AgentSessionService(BaseWorkspaceService):
                 await check_entitlement(
                     self.session, self.role, Entitlement.AGENT_ADDONS
                 )
-            self._stage_root_only_turn_provenance(
+            self._stage_root_turn_provenance(
                 session_id=session_id,
                 run_id=run_id,
                 config=agent_config,

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -99,6 +99,7 @@ from tracecat.chat.tools import (
 from tracecat.db.models import (
     AgentSession,
     AgentSessionHistory,
+    AgentTurnProvenance,
     Approval,
     Case,
     Chat,
@@ -145,6 +146,29 @@ class AgentSessionService(BaseWorkspaceService):
     """Service for managing agent sessions and history."""
 
     service_name = "agent-session"
+
+    def _stage_root_only_turn_provenance(
+        self,
+        *,
+        session_id: uuid.UUID,
+        run_id: uuid.UUID,
+        config: AgentConfig,
+    ) -> None:
+        """Stage root-only resolution provenance when no subagent activity will run."""
+
+        if config.resolved_refs is None:
+            return
+        if config.agents.enabled and config.agents.subagents:
+            return
+
+        self.session.add(
+            AgentTurnProvenance(
+                workspace_id=self.workspace_id,
+                session_id=session_id,
+                wf_exec_id=str(run_id),
+                resolved_refs=config.resolved_refs.model_dump(mode="json"),
+            )
+        )
 
     async def _get_default_tools(self, entity_type: AgentSessionEntity) -> list[str]:
         """Get entitlement-aware default tools for a session entity type."""
@@ -283,7 +307,7 @@ class AgentSessionService(BaseWorkspaceService):
             entity_id=args.entity_id,
             agent_preset_id=args.agent_preset_id,
         )
-        pinned_preset_version_id = await self._validate_preset_version_for_assignment(
+        selected_preset_version_id = await self._validate_preset_version_for_assignment(
             entity_type=args.entity_type,
             entity_id=args.entity_id,
             agent_preset_id=args.agent_preset_id,
@@ -294,7 +318,7 @@ class AgentSessionService(BaseWorkspaceService):
         else:
             resolved_agents_binding = (
                 await self._resolve_agents_binding_for_preset_version_id(
-                    pinned_preset_version_id
+                    selected_preset_version_id
                 )
             )
         await self._validate_session_mcp_integrations(args.mcp_integrations)
@@ -310,7 +334,7 @@ class AgentSessionService(BaseWorkspaceService):
             tools=tools,
             mcp_integrations=args.mcp_integrations,
             agent_preset_id=logical_preset_id,
-            agent_preset_version_id=pinned_preset_version_id,
+            agent_preset_version_id=selected_preset_version_id,
             agents_binding=resolved_agents_binding,
             # Harness
             harness_type=args.harness_type,
@@ -347,7 +371,7 @@ class AgentSessionService(BaseWorkspaceService):
         agent_preset_id: uuid.UUID | None,
         agent_preset_version_id: uuid.UUID | None,
     ) -> uuid.UUID | None:
-        """Validate and return the pinned preset version for a session assignment."""
+        """Validate and return an exact preset version selected for a session."""
         logical_preset_id = self._resolve_logical_preset_id(
             entity_type=entity_type,
             entity_id=entity_id,
@@ -378,7 +402,7 @@ class AgentSessionService(BaseWorkspaceService):
     async def _resolve_agents_binding_for_preset_version_id(
         self, preset_version_id: uuid.UUID | None
     ) -> dict[str, Any] | None:
-        """Resolve the normalized subagent binding for a pinned preset version."""
+        """Resolve the normalized subagent binding for an exact preset version."""
         if preset_version_id is None:
             return None
 
@@ -731,7 +755,7 @@ class AgentSessionService(BaseWorkspaceService):
                 if preset_id_updated and (
                     requested_preset_id != agent_session.agent_preset_id
                 ):
-                    pinned_version_id = (
+                    selected_version_id = (
                         await self._validate_preset_version_for_assignment(
                             entity_type=entity_type,
                             entity_id=agent_session.entity_id,
@@ -742,9 +766,9 @@ class AgentSessionService(BaseWorkspaceService):
                         )
                     )
                 elif version_id_updated and requested_version_id is None:
-                    pinned_version_id = None
+                    selected_version_id = None
                 elif version_id_updated:
-                    pinned_version_id = (
+                    selected_version_id = (
                         await self._validate_preset_version_for_assignment(
                             entity_type=entity_type,
                             entity_id=agent_session.entity_id,
@@ -753,12 +777,12 @@ class AgentSessionService(BaseWorkspaceService):
                         )
                     )
                 else:
-                    pinned_version_id = requested_version_id
+                    selected_version_id = requested_version_id
                 agent_session.agent_preset_id = logical_preset_id
-                agent_session.agent_preset_version_id = pinned_version_id
+                agent_session.agent_preset_version_id = selected_version_id
                 agent_session.agents_binding = (
                     await self._resolve_agents_binding_for_preset_version_id(
-                        pinned_version_id
+                        selected_version_id
                     )
                 )
 
@@ -1413,6 +1437,13 @@ class AgentSessionService(BaseWorkspaceService):
         if user_prompt is not None:
             await self.auto_title_session_on_first_prompt(agent_session, user_prompt)
 
+        run_id = uuid.uuid4()
+        # Per-turn stream id: use the HTTP-minted id when provided, else mint
+        # one. Pinned into the workflow input so the worker producer writes to
+        # the same per-turn Redis key the reader joins (immune to the
+        # stale-turn overwrite race).
+        stream_id = active_stream_id or uuid.uuid4()
+
         # Build agent config and spawn workflow for new turn
         async with self._build_agent_config(agent_session) as agent_config:
             if request_instructions:
@@ -1428,12 +1459,11 @@ class AgentSessionService(BaseWorkspaceService):
                 await check_entitlement(
                     self.session, self.role, Entitlement.AGENT_ADDONS
                 )
-            run_id = uuid.uuid4()
-            # Per-turn stream id: use the HTTP-minted id when provided, else mint
-            # one. Pinned into the workflow input so the worker producer writes to
-            # the same per-turn Redis key the reader joins (immune to the
-            # stale-turn overwrite race).
-            stream_id = active_stream_id or uuid.uuid4()
+            self._stage_root_only_turn_provenance(
+                session_id=session_id,
+                run_id=run_id,
+                config=agent_config,
+            )
 
             args = RunAgentArgs(
                 user_prompt=user_prompt or "",
@@ -1997,6 +2027,10 @@ class AgentSessionService(BaseWorkspaceService):
                             catalog_id=preset_config.catalog_id,
                             actions=[],  # No tools for forked sessions
                             enable_thinking=preset_config.enable_thinking,
+                            # Value-only snapshot of what resolution saw; the
+                            # fork still strips tools/skills/subagents from
+                            # the runtime config itself.
+                            resolved_refs=preset_config.resolved_refs,
                         )
                 else:
                     # No preset - use org default model with fork context

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -414,18 +414,23 @@ class AgentSessionService(BaseWorkspaceService):
         scopes = (self.role.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
         return self.role.model_copy(update={"scopes": scopes})
 
-    def _stage_root_only_turn_provenance(
+    def _stage_root_turn_provenance(
         self,
         *,
         session_id: uuid.UUID,
         run_id: uuid.UUID,
         config: AgentConfig,
     ) -> None:
-        """Stage root-only resolution provenance when no subagent activity will run."""
+        """Stage the root resolution snapshot for a spawned turn.
+
+        Always staged, even when a later subagent activity will append a
+        merged snapshot: any failure between spawn and that write (custom
+        model provider config, session load, subagent resolution) must still
+        leave the turn's root refs on record. The highest ``surrogate_id``
+        per ``wf_exec_id`` is the final snapshot.
+        """
 
         if config.resolved_refs is None:
-            return
-        if config.agents.enabled and config.agents.subagents:
             return
 
         self.session.add(
@@ -2140,7 +2145,7 @@ class AgentSessionService(BaseWorkspaceService):
                 await check_entitlement(
                     self.session, self.role, Entitlement.AGENT_ADDONS
                 )
-            self._stage_root_only_turn_provenance(
+            self._stage_root_turn_provenance(
                 session_id=session_id,
                 run_id=run_id,
                 config=agent_config,

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -130,6 +130,7 @@ from tracecat.db.models import (
     APPROVAL_STATUS_ENUM,
     AgentSession,
     AgentSessionHistory,
+    AgentTurnProvenance,
     Approval,
     Case,
     Chat,
@@ -413,6 +414,29 @@ class AgentSessionService(BaseWorkspaceService):
         scopes = (self.role.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
         return self.role.model_copy(update={"scopes": scopes})
 
+    def _stage_root_only_turn_provenance(
+        self,
+        *,
+        session_id: uuid.UUID,
+        run_id: uuid.UUID,
+        config: AgentConfig,
+    ) -> None:
+        """Stage root-only resolution provenance when no subagent activity will run."""
+
+        if config.resolved_refs is None:
+            return
+        if config.agents.enabled and config.agents.subagents:
+            return
+
+        self.session.add(
+            AgentTurnProvenance(
+                workspace_id=self.workspace_id,
+                session_id=session_id,
+                wf_exec_id=str(run_id),
+                resolved_refs=config.resolved_refs.model_dump(mode="json"),
+            )
+        )
+
     async def _get_default_tools(self, entity_type: AgentSessionEntity) -> list[str]:
         """Get entitlement-aware default tools for a session entity type."""
         agent_addons_enabled = True
@@ -550,7 +574,7 @@ class AgentSessionService(BaseWorkspaceService):
             entity_id=args.entity_id,
             agent_preset_id=args.agent_preset_id,
         )
-        pinned_preset_version_id = await self._validate_preset_version_for_assignment(
+        selected_preset_version_id = await self._validate_preset_version_for_assignment(
             entity_type=args.entity_type,
             entity_id=args.entity_id,
             agent_preset_id=args.agent_preset_id,
@@ -561,7 +585,7 @@ class AgentSessionService(BaseWorkspaceService):
         else:
             resolved_agents_binding = (
                 await self._resolve_agents_binding_for_preset_version_id(
-                    pinned_preset_version_id
+                    selected_preset_version_id
                 )
             )
         await self._validate_session_mcp_integrations(args.mcp_integrations)
@@ -577,7 +601,7 @@ class AgentSessionService(BaseWorkspaceService):
             tools=tools,
             mcp_integrations=args.mcp_integrations,
             agent_preset_id=logical_preset_id,
-            agent_preset_version_id=pinned_preset_version_id,
+            agent_preset_version_id=selected_preset_version_id,
             agents_binding=resolved_agents_binding,
             # Harness
             harness_type=args.harness_type,
@@ -614,7 +638,7 @@ class AgentSessionService(BaseWorkspaceService):
         agent_preset_id: uuid.UUID | None,
         agent_preset_version_id: uuid.UUID | None,
     ) -> uuid.UUID | None:
-        """Validate and return the pinned preset version for a session assignment."""
+        """Validate and return an exact preset version selected for a session."""
         logical_preset_id = self._resolve_logical_preset_id(
             entity_type=entity_type,
             entity_id=entity_id,
@@ -645,7 +669,7 @@ class AgentSessionService(BaseWorkspaceService):
     async def _resolve_agents_binding_for_preset_version_id(
         self, preset_version_id: uuid.UUID | None
     ) -> dict[str, Any] | None:
-        """Resolve the normalized subagent binding for a pinned preset version."""
+        """Resolve the normalized subagent binding for an exact preset version."""
         if preset_version_id is None:
             return None
 
@@ -1005,7 +1029,7 @@ class AgentSessionService(BaseWorkspaceService):
                 if preset_id_updated and (
                     requested_preset_id != agent_session.agent_preset_id
                 ):
-                    pinned_version_id = (
+                    selected_version_id = (
                         await self._validate_preset_version_for_assignment(
                             entity_type=entity_type,
                             entity_id=agent_session.entity_id,
@@ -1016,9 +1040,9 @@ class AgentSessionService(BaseWorkspaceService):
                         )
                     )
                 elif version_id_updated and requested_version_id is None:
-                    pinned_version_id = None
+                    selected_version_id = None
                 elif version_id_updated:
-                    pinned_version_id = (
+                    selected_version_id = (
                         await self._validate_preset_version_for_assignment(
                             entity_type=entity_type,
                             entity_id=agent_session.entity_id,
@@ -1027,12 +1051,12 @@ class AgentSessionService(BaseWorkspaceService):
                         )
                     )
                 else:
-                    pinned_version_id = requested_version_id
+                    selected_version_id = requested_version_id
                 agent_session.agent_preset_id = logical_preset_id
-                agent_session.agent_preset_version_id = pinned_version_id
+                agent_session.agent_preset_version_id = selected_version_id
                 agent_session.agents_binding = (
                     await self._resolve_agents_binding_for_preset_version_id(
-                        pinned_version_id
+                        selected_version_id
                     )
                 )
 
@@ -2094,6 +2118,13 @@ class AgentSessionService(BaseWorkspaceService):
         # Snapshot here so the detached task cannot overwrite a mid-flight rename.
         expected_title = agent_session.title
 
+        run_id = uuid.uuid4()
+        # Per-turn stream id: use the HTTP-minted id when provided, else mint
+        # one. Pinned into the workflow input so the worker producer writes to
+        # the same per-turn Redis key the reader joins (immune to the
+        # stale-turn overwrite race).
+        stream_id = active_stream_id or uuid.uuid4()
+
         # Build agent config and spawn workflow for new turn
         async with self._build_agent_config(agent_session) as agent_config:
             if request_instructions:
@@ -2109,12 +2140,11 @@ class AgentSessionService(BaseWorkspaceService):
                 await check_entitlement(
                     self.session, self.role, Entitlement.AGENT_ADDONS
                 )
-            run_id = uuid.uuid4()
-            # Per-turn stream id: use the HTTP-minted id when provided, else mint
-            # one. Pinned into the workflow input so the worker producer writes to
-            # the same per-turn Redis key the reader joins (immune to the
-            # stale-turn overwrite race).
-            stream_id = active_stream_id or uuid.uuid4()
+            self._stage_root_only_turn_provenance(
+                session_id=session_id,
+                run_id=run_id,
+                config=agent_config,
+            )
 
             args = RunAgentArgs(
                 user_prompt=user_prompt or "",
@@ -2876,6 +2906,10 @@ class AgentSessionService(BaseWorkspaceService):
                             catalog_id=preset_config.catalog_id,
                             actions=[],  # No tools for forked sessions
                             enable_thinking=preset_config.enable_thinking,
+                            # Value-only snapshot of what resolution saw; the
+                            # fork still strips tools/skills/subagents from
+                            # the runtime config itself.
+                            resolved_refs=preset_config.resolved_refs,
                         )
                 else:
                     # No preset - use org default model with fork context

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -17,6 +17,7 @@ from pydantic import Discriminator, TypeAdapter
 
 from tracecat.agent.common.stream_types import ToolCallContent
 from tracecat.agent.common.types import MCPServerConfig
+from tracecat.agent.preset.resolved_refs import ResolvedRefs
 from tracecat.agent.skill.types import ResolvedSkillRef
 from tracecat.agent.subagents import AgentSubagentsConfig
 from tracecat.config import TRACECAT__AGENT_MAX_RETRIES
@@ -146,6 +147,7 @@ class AgentConfig:
     enable_thinking: bool = True
     enable_internet_access: bool = False
     resolved_skills: list[ResolvedSkillRef] | None = None
+    resolved_refs: ResolvedRefs | None = None
     builtin_skills: list[str] | None = None
     """Names of built-in platform skills to stage into the agent's skills
     directory, independent of preset-bound ``resolved_skills``. Names only (not

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -18,6 +18,7 @@ from pydantic import Discriminator, TypeAdapter
 from tracecat.agent.common.stream_types import ToolCallContent
 from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.constants import AGENT_TIMEOUT_SECONDS_DEFAULT
+from tracecat.agent.preset.resolved_refs import ResolvedRefs
 from tracecat.agent.skill.types import ResolvedSkillRef
 from tracecat.agent.subagents import AgentSubagentsConfig
 from tracecat.config import (
@@ -163,6 +164,7 @@ class AgentConfig:
     enable_thinking: bool = True
     enable_internet_access: bool = False
     resolved_skills: list[ResolvedSkillRef] | None = None
+    resolved_refs: ResolvedRefs | None = None
     builtin_skills: list[str] | None = None
     """Names of built-in platform skills to stage into the agent's skills
     directory, independent of preset-bound ``resolved_skills``. Names only (not

--- a/tracecat/agent/workflow_config.py
+++ b/tracecat/agent/workflow_config.py
@@ -157,6 +157,7 @@ def agent_config_to_payload(config: AgentConfig) -> AgentConfigPayload:
             if config.resolved_skills
             else None
         ),
+        resolved_refs=config.resolved_refs,
         builtin_skills=config.builtin_skills,
     )
 
@@ -189,5 +190,6 @@ def agent_config_from_payload(payload: AgentConfigPayload) -> AgentConfig:
             if payload.resolved_skills
             else None
         ),
+        resolved_refs=payload.resolved_refs,
         builtin_skills=payload.builtin_skills,
     )

--- a/tracecat/agent/workflow_config.py
+++ b/tracecat/agent/workflow_config.py
@@ -137,6 +137,7 @@ def agent_config_to_payload(config: AgentConfig) -> AgentConfigPayload:
             if config.resolved_skills
             else None
         ),
+        resolved_refs=config.resolved_refs,
         builtin_skills=config.builtin_skills,
     )
 
@@ -169,5 +170,6 @@ def agent_config_from_payload(payload: AgentConfigPayload) -> AgentConfig:
             if payload.resolved_skills
             else None
         ),
+        resolved_refs=payload.resolved_refs,
         builtin_skills=payload.builtin_skills,
     )

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, model_validator
 
+from tracecat.agent.preset.resolved_refs import ResolvedRefs
 from tracecat.agent.subagents import AgentSubagentsConfig
 from tracecat.integrations.schemas import MCPToolStatus
 
@@ -140,4 +141,5 @@ class AgentConfigPayload(BaseModel):
     enable_thinking: bool = Field(default=True)
     enable_internet_access: bool = Field(default=False)
     resolved_skills: list[ResolvedSkillRefPayload] | None = Field(default=None)
+    resolved_refs: ResolvedRefs | None = Field(default=None)
     builtin_skills: list[str] | None = Field(default=None)

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, model_validator
 
+from tracecat.agent.preset.resolved_refs import ResolvedRefs
 from tracecat.agent.subagents import AgentSubagentsConfig
 
 _LEGACY_AGENT_CONFIG_KEYS = frozenset({"deps_type", "custom_tools"})
@@ -124,4 +125,5 @@ class AgentConfigPayload(BaseModel):
     enable_thinking: bool = Field(default=True)
     enable_internet_access: bool = Field(default=False)
     resolved_skills: list[ResolvedSkillRefPayload] | None = Field(default=None)
+    resolved_refs: ResolvedRefs | None = Field(default=None)
     builtin_skills: list[str] | None = Field(default=None)

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2900,7 +2900,7 @@ class AgentSession(WorkspaceModel):
         UUID,
         ForeignKey("agent_preset_version.id", ondelete="SET NULL"),
         nullable=True,
-        doc="Pinned agent preset version used for this session (if any)",
+        doc="Exact agent preset version selected for this session (if any)",
     )
     agents_binding: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB,
@@ -3031,6 +3031,57 @@ class AgentSessionHistory(WorkspaceModel):
     session: Mapped[AgentSession] = relationship(
         "AgentSession",
         back_populates="history",
+    )
+
+
+class AgentTurnProvenance(Base):
+    """Per-turn resource resolution snapshot for agent execution.
+
+    ``AgentSessionHistory`` stores per-message transcript rows. This table
+    stores one append-only per-turn resolution snapshot and deliberately keeps
+    resource references as JSONB values so provenance outlives deleted skills,
+    presets, sessions, and versions.
+    """
+
+    __tablename__ = "agent_turn_provenance"
+
+    surrogate_id: Mapped[int] = mapped_column(
+        Integer,
+        Identity(),
+        primary_key=True,
+        nullable=False,
+    )
+    workspace_id: Mapped[WorkspaceID] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        nullable=False,
+        index=True,
+        doc="Plain agent session UUID; no FK so provenance survives session deletion.",
+    )
+    wf_exec_id: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        doc=(
+            "Per-turn workflow/run identifier. Deliberately string-typed so "
+            "non-chat contexts (e.g. DSL workflow executions with string exec "
+            "ids) can write this table; chat turns store the stringified "
+            "AgentSession.curr_run_id UUID."
+        ),
+    )
+    resolved_refs: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        doc="Serialized ResolvedRefs value snapshot for this turn.",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        nullable=False,
     )
 
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3038,9 +3038,12 @@ class AgentTurnProvenance(Base):
     """Per-turn resource resolution snapshot for agent execution.
 
     ``AgentSessionHistory`` stores per-message transcript rows. This table
-    stores one append-only per-turn resolution snapshot and deliberately keeps
+    stores append-only per-turn resolution snapshots and deliberately keeps
     resource references as JSONB values so provenance outlives deleted skills,
-    presets, sessions, and versions.
+    presets, sessions, and versions. A turn may append more than one row:
+    root resolution always records root refs, and subagent resolution appends
+    a merged snapshot; the highest ``surrogate_id`` per ``wf_exec_id`` is the
+    final snapshot for that turn.
     """
 
     __tablename__ = "agent_turn_provenance"

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3076,7 +3076,7 @@ class AgentSession(WorkspaceModel):
         UUID,
         ForeignKey("agent_preset_version.id", ondelete="SET NULL"),
         nullable=True,
-        doc="Pinned agent preset version used for this session (if any)",
+        doc="Exact agent preset version selected for this session (if any)",
     )
     agents_binding: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB,
@@ -3212,6 +3212,57 @@ class AgentSessionHistory(WorkspaceModel):
     session: Mapped[AgentSession] = relationship(
         "AgentSession",
         back_populates="history",
+    )
+
+
+class AgentTurnProvenance(Base):
+    """Per-turn resource resolution snapshot for agent execution.
+
+    ``AgentSessionHistory`` stores per-message transcript rows. This table
+    stores one append-only per-turn resolution snapshot and deliberately keeps
+    resource references as JSONB values so provenance outlives deleted skills,
+    presets, sessions, and versions.
+    """
+
+    __tablename__ = "agent_turn_provenance"
+
+    surrogate_id: Mapped[int] = mapped_column(
+        Integer,
+        Identity(),
+        primary_key=True,
+        nullable=False,
+    )
+    workspace_id: Mapped[WorkspaceID] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        nullable=False,
+        index=True,
+        doc="Plain agent session UUID; no FK so provenance survives session deletion.",
+    )
+    wf_exec_id: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        doc=(
+            "Per-turn workflow/run identifier. Deliberately string-typed so "
+            "non-chat contexts (e.g. DSL workflow executions with string exec "
+            "ids) can write this table; chat turns store the stringified "
+            "AgentSession.curr_run_id UUID."
+        ),
+    )
+    resolved_refs: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        doc="Serialized ResolvedRefs value snapshot for this turn.",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        nullable=False,
     )
 
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3219,9 +3219,12 @@ class AgentTurnProvenance(Base):
     """Per-turn resource resolution snapshot for agent execution.
 
     ``AgentSessionHistory`` stores per-message transcript rows. This table
-    stores one append-only per-turn resolution snapshot and deliberately keeps
+    stores append-only per-turn resolution snapshots and deliberately keeps
     resource references as JSONB values so provenance outlives deleted skills,
-    presets, sessions, and versions.
+    presets, sessions, and versions. A turn may append more than one row:
+    root resolution always records root refs, and subagent resolution appends
+    a merged snapshot; the highest ``surrogate_id`` per ``wf_exec_id`` is the
+    final snapshot for that turn.
     """
 
     __tablename__ = "agent_turn_provenance"

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -87,6 +87,7 @@ POST_RLS_WORKSPACE_SCOPED_TABLES = (
     "agent_preset_subagent",
     "agent_preset_version_subagent",
     "workspace_sync_resource_mapping",
+    "agent_turn_provenance",
 )
 
 POST_RLS_ORG_SCOPED_TABLES = (

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -90,6 +90,7 @@ POST_RLS_WORKSPACE_SCOPED_TABLES = (
     "agent_preset_subagent",
     "agent_preset_version_subagent",
     "workspace_sync_resource_mapping",
+    "agent_turn_provenance",
 )
 
 POST_RLS_ORG_SCOPED_TABLES = (

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -1098,11 +1098,26 @@ class DSLWorkflow:
                         start_to_close_timeout=timedelta(seconds=60),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
                     )
+                    # Mint the session id before the preflight so a failed
+                    # slug resolution can still record turn provenance
+                    # against the session/execution. Same single RNG draw as
+                    # before, so in-flight histories replay identically.
+                    session_id = preset_action_args.session_id or workflow.uuid4()
                     preset_ref = await workflow.execute_activity(
                         resolve_agent_preset_version_ref_activity,
                         ResolveAgentPresetVersionRefActivityInput(
                             role=self.role,
                             preset_slug=preset_action_args.preset,
+                            session_id=session_id,
+                            # Per-action turn id built from replay-stable parts
+                            # (no extra RNG draws, which would shift later
+                            # session mints on replay): the bare parent
+                            # workflow id would collapse every failed
+                            # preflight in one run into a single provenance
+                            # stream under the highest-surrogate_id contract.
+                            wf_exec_id=(
+                                f"{workflow.info().workflow_id}:{task.ref}:{session_id}"
+                            ),
                         ),
                         start_to_close_timeout=timedelta(seconds=30),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
@@ -1124,7 +1139,6 @@ class DSLWorkflow:
                     child_search_attributes = _build_agent_child_search_attributes(
                         wf_info, task.ref
                     )
-                    session_id = preset_action_args.session_id or workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
                         agent_args=RunAgentArgs(

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -1098,30 +1098,39 @@ class DSLWorkflow:
                         start_to_close_timeout=timedelta(seconds=60),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
                     )
-                    # Mint the session id before the preflight so a failed
-                    # slug resolution can still record turn provenance
-                    # against the session/execution. Same single RNG draw as
-                    # before, so in-flight histories replay identically.
-                    session_id = preset_action_args.session_id or workflow.uuid4()
-                    preset_ref = await workflow.execute_activity(
-                        resolve_agent_preset_version_ref_activity,
-                        ResolveAgentPresetVersionRefActivityInput(
-                            role=self.role,
-                            preset_slug=preset_action_args.preset,
-                            session_id=session_id,
-                            # Per-action turn id built from replay-stable parts
-                            # (no extra RNG draws, which would shift later
-                            # session mints on replay): the bare parent
-                            # workflow id would collapse every failed
-                            # preflight in one run into a single provenance
-                            # stream under the highest-surrogate_id contract.
-                            wf_exec_id=(
-                                f"{workflow.info().workflow_id}:{task.ref}:{session_id}"
+                    if workflow.patched("dsl-preset-preflight-provenance-v1"):
+                        # New histories mint first so failed preflights can record
+                        # session-scoped provenance. Include the deterministic
+                        # stream id so parallel instances of the same action do
+                        # not collapse when a caller supplies a static session id.
+                        session_id = preset_action_args.session_id or workflow.uuid4()
+                        preset_ref = await workflow.execute_activity(
+                            resolve_agent_preset_version_ref_activity,
+                            ResolveAgentPresetVersionRefActivityInput(
+                                role=self.role,
+                                preset_slug=preset_action_args.preset,
+                                session_id=session_id,
+                                wf_exec_id=(
+                                    f"{workflow.info().workflow_id}:{task.ref}:"
+                                    f"{stream_id or ROOT_STREAM}:{session_id}"
+                                ),
                             ),
-                        ),
-                        start_to_close_timeout=timedelta(seconds=30),
-                        retry_policy=RETRY_POLICIES["activity:fail_fast"],
-                    )
+                            start_to_close_timeout=timedelta(seconds=30),
+                            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                        )
+                    else:
+                        # Preserve the pre-patch command and RNG order during
+                        # replay: preflight first, then mint the session id.
+                        preset_ref = await workflow.execute_activity(
+                            resolve_agent_preset_version_ref_activity,
+                            ResolveAgentPresetVersionRefActivityInput(
+                                role=self.role,
+                                preset_slug=preset_action_args.preset,
+                            ),
+                            start_to_close_timeout=timedelta(seconds=30),
+                            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                        )
+                        session_id = preset_action_args.session_id or workflow.uuid4()
 
                     # Create override config with placeholder model/provider
                     # These will be ignored by DurableAgentWorkflow when preset_slug is present

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -1105,11 +1105,26 @@ class DSLWorkflow:
                         start_to_close_timeout=timedelta(seconds=60),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
                     )
+                    # Mint the session id before the preflight so a failed
+                    # slug resolution can still record turn provenance
+                    # against the session/execution. Same single RNG draw as
+                    # before, so in-flight histories replay identically.
+                    session_id = preset_action_args.session_id or workflow.uuid4()
                     preset_ref = await workflow.execute_activity(
                         resolve_agent_preset_version_ref_activity,
                         ResolveAgentPresetVersionRefActivityInput(
                             role=self.role,
                             preset_slug=preset_action_args.preset,
+                            session_id=session_id,
+                            # Per-action turn id built from replay-stable parts
+                            # (no extra RNG draws, which would shift later
+                            # session mints on replay): the bare parent
+                            # workflow id would collapse every failed
+                            # preflight in one run into a single provenance
+                            # stream under the highest-surrogate_id contract.
+                            wf_exec_id=(
+                                f"{workflow.info().workflow_id}:{task.ref}:{session_id}"
+                            ),
                         ),
                         start_to_close_timeout=timedelta(seconds=30),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
@@ -1131,7 +1146,6 @@ class DSLWorkflow:
                     child_search_attributes = _build_agent_child_search_attributes(
                         wf_info, task.ref
                     )
-                    session_id = preset_action_args.session_id or workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
                         agent_args=RunAgentArgs(

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -1105,30 +1105,39 @@ class DSLWorkflow:
                         start_to_close_timeout=timedelta(seconds=60),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
                     )
-                    # Mint the session id before the preflight so a failed
-                    # slug resolution can still record turn provenance
-                    # against the session/execution. Same single RNG draw as
-                    # before, so in-flight histories replay identically.
-                    session_id = preset_action_args.session_id or workflow.uuid4()
-                    preset_ref = await workflow.execute_activity(
-                        resolve_agent_preset_version_ref_activity,
-                        ResolveAgentPresetVersionRefActivityInput(
-                            role=self.role,
-                            preset_slug=preset_action_args.preset,
-                            session_id=session_id,
-                            # Per-action turn id built from replay-stable parts
-                            # (no extra RNG draws, which would shift later
-                            # session mints on replay): the bare parent
-                            # workflow id would collapse every failed
-                            # preflight in one run into a single provenance
-                            # stream under the highest-surrogate_id contract.
-                            wf_exec_id=(
-                                f"{workflow.info().workflow_id}:{task.ref}:{session_id}"
+                    if workflow.patched("dsl-preset-preflight-provenance-v1"):
+                        # New histories mint first so failed preflights can record
+                        # session-scoped provenance. Include the deterministic
+                        # stream id so parallel instances of the same action do
+                        # not collapse when a caller supplies a static session id.
+                        session_id = preset_action_args.session_id or workflow.uuid4()
+                        preset_ref = await workflow.execute_activity(
+                            resolve_agent_preset_version_ref_activity,
+                            ResolveAgentPresetVersionRefActivityInput(
+                                role=self.role,
+                                preset_slug=preset_action_args.preset,
+                                session_id=session_id,
+                                wf_exec_id=(
+                                    f"{workflow.info().workflow_id}:{task.ref}:"
+                                    f"{stream_id or ROOT_STREAM}:{session_id}"
+                                ),
                             ),
-                        ),
-                        start_to_close_timeout=timedelta(seconds=30),
-                        retry_policy=RETRY_POLICIES["activity:fail_fast"],
-                    )
+                            start_to_close_timeout=timedelta(seconds=30),
+                            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                        )
+                    else:
+                        # Preserve the pre-patch command and RNG order during
+                        # replay: preflight first, then mint the session id.
+                        preset_ref = await workflow.execute_activity(
+                            resolve_agent_preset_version_ref_activity,
+                            ResolveAgentPresetVersionRefActivityInput(
+                                role=self.role,
+                                preset_slug=preset_action_args.preset,
+                            ),
+                            start_to_close_timeout=timedelta(seconds=30),
+                            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                        )
+                        session_id = preset_action_args.session_id or workflow.uuid4()
 
                     # Create override config with placeholder model/provider
                     # These will be ignored by DurableAgentWorkflow when preset_slug is present


### PR DESCRIPTION
## Mental model

> Workspace heads define deployable state. Each run freezes the exact ResourceVersions it actually resolved, and provenance records that immutable execution snapshot without becoming another source of deployment state.

## Summary

- Add `ResolvedRefs`, a structured value snapshot for root presets, skills, and subagents with stable resource IDs, exact resolved version IDs, status, failure code, and optional successor metadata.
- Add append-only `agent_turn_provenance` rows keyed by workspace/session/run context. Provenance deliberately has no foreign key to sessions or resources, so it survives deletion.
- Record one whole-tree snapshot per turn, including root-resolution failures before the turn is failed.
- Preserve exact refs when resuming an existing run; fresh resolution continues to follow ResourceHeads from #3006.
- Keep failure asymmetry explicit: a missing root fails, while deleted, missing, or unpublished child resources are skipped and recorded.
- Retarget the additive migration to `44320bf05445`; the reverted, unreleased pinning migration is no longer in the chain.

Part of [ENG-1530](https://linear.app/tracecat/issue/ENG-1530/rearchitect-resource-version-resolution-around-workspace-heads). Stacks on #3006.

## Review guide

- `tracecat/agent/preset/resolved_refs.py`: snapshot contract and deterministic merge behavior.
- `tracecat/agent/preset/resolver.py`: per-node resolved/skipped refs during head and resume resolution.
- `tracecat/agent/preset/activities.py`: whole-turn provenance write sites and root-failure recording.
- `tracecat/db/models.py` and migration `b4e6c8a2d0f1`: append-only persistence model.
- `packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py`: run ID selection and resume plumbing.

## Validation

- 190 focused preset, skill, session, and provenance tests passed.
- 68 activity and durable-workflow unit tests passed.
- 16 Temporal tests passed; 4 approval tests were skipped by their existing conditions.
- Alembic reports `b4e6c8a2d0f1` as the single head.
- Ruff and basedpyright passed for all changed Python files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-turn resource provenance with immutable `resolved_refs` snapshots so each agent turn records exactly which resource versions it resolved, including root-resolution failures before the turn fails. Runs Alembic migration `b4e6c8a2d0f1`.

- **New Features**
  - Append-only `agent_turn_provenance` (RLS) stores snapshots keyed by `wf_exec_id`; the highest `surrogate_id` is the final snapshot for a turn.
  - `ResolvedRefs` on `AgentConfig` captures preset/skill/subagent entries and the resolved skill package; preserved-binding turns strip subagent refs via `without_subagent_refs`, and empty bindings persist under `durable-agent-persist-disabled-binding-provenance-v1`.
  - DSL `ai.preset_agent` preflight records failure-classified root refs, with the session id minted before preflight and the stream discriminator in `wf_exec_id`, gated by `dsl-preset-preflight-provenance-v1`.

- **Bug Fixes**
  - Root refs are written through an `on_resolved` hook before credential loading, closing the gap where failing turns recorded no provenance; the subagent activity appends the merged snapshot.
  - Pinned-config resolution is anchored to preset id and slug so a stale `preset_version_id` records `not_found` for the selected preset.
  - Reliability: dedupe resumed subagents, prevent relinking to reclaimed slugs, return HTTP 409 for `skill_in_use`, and update workspace sync and RLS.

<sup>Written for commit 217ba208b1a6cce63db0be6f4d7cf7ee596d9790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

