### PR TITLE
feat(agents): resolve resource graph at dispatch

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -90,6 +90,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.agent.types import AgentConfig
     from tracecat.agent.workflow_config import agent_config_from_payload
+    from tracecat.agent.workflow_schemas import AgentConfigPayload
     from tracecat.auth.types import Role
     from tracecat.chat.schemas import ChatMessage
     from tracecat.contexts import ctx_role
@@ -427,6 +428,10 @@ class AgentWorkflowArgs(BaseModel):
         default=False,
         description=("If true, session_id is caller-supplied and must already exist."),
     )
+    resolved_agent_config: AgentConfigPayload | None = Field(
+        default=None,
+        description="Dispatch-time resolved root config. None for legacy executions.",
+    )
 
 
 class WorkflowApprovalSubmission(BaseModel):
@@ -625,7 +630,9 @@ class DurableAgentWorkflow:
         return workflow.info().run_id
 
     async def _build_config(self, args: AgentWorkflowArgs) -> AgentConfig:
-        if args.agent_args.preset_slug:
+        if args.resolved_agent_config is not None:
+            cfg = agent_config_from_payload(args.resolved_agent_config)
+        elif args.agent_args.preset_slug:
             wf_exec_id = self._turn_wf_exec_id(args)
             activity_input = (
                 ResolveAgentPresetConfigActivityInput(
@@ -691,6 +698,13 @@ class DurableAgentWorkflow:
         persist_provenance: bool = False,
     ) -> ResolvedAgentsRuntimeConfig:
         agents_config = agents if agents is not None else cfg.agents
+        if (
+            agents is None
+            and follow_latest_versions is None
+            and not preserve_resolved_versions
+            and args.agent_args.resolved_agents_config is not None
+        ):
+            return args.agent_args.resolved_agents_config
         if not agents_config.enabled and not persist_provenance:
             return ResolvedAgentsRuntimeConfig(resolved_refs=cfg.resolved_refs)
         if not agents_config.subagents and not persist_provenance:
@@ -1158,7 +1172,11 @@ class DurableAgentWorkflow:
             workflow.info().workflow_id
         ).session_id
         load_result: LoadSessionResult | None = None
-        if workflow.patched(PRESERVE_RESUMED_AGENT_BINDINGS_PATCH):
+        dispatch_resolved_agents = args.agent_args.resolved_agents_config
+        has_dispatch_resolved_agents = dispatch_resolved_agents is not None
+        if dispatch_resolved_agents is not None:
+            agents_result = dispatch_resolved_agents
+        elif workflow.patched(PRESERVE_RESUMED_AGENT_BINDINGS_PATCH):
             # Load session topology before resolving agents. A resumed session's
             # stored binding is the stable runtime contract, even if the preset
             # now follows a newer child version.
@@ -1207,7 +1225,11 @@ class DurableAgentWorkflow:
                 tools=args.tools,
                 agent_preset_id=args.agent_preset_id,
                 agent_preset_version_id=args.agent_preset_version_id,
-                agents_binding=agents_result.to_agents_binding(),
+                agents_binding=(
+                    None
+                    if has_dispatch_resolved_agents
+                    else agents_result.to_agents_binding()
+                ),
                 harness_type=HarnessType(self.harness_type),
                 curr_run_id=curr_run_id,
                 initial_user_prompt=args.agent_args.user_prompt,
@@ -1256,6 +1278,7 @@ class DurableAgentWorkflow:
                 start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )
+        assert load_result is not None
 
         if load_result.found and load_result.sdk_session_id:
             logger.info(

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -93,6 +93,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.agent.types import AgentConfig, clamp_agent_timeout_seconds
     from tracecat.agent.workflow_config import agent_config_from_payload
+    from tracecat.agent.workflow_schemas import AgentConfigPayload
     from tracecat.auth.types import Role
     from tracecat.chat.schemas import ChatMessage
     from tracecat.contexts import ctx_role
@@ -448,6 +449,10 @@ class AgentWorkflowArgs(BaseModel):
         default=False,
         description=("If true, session_id is caller-supplied and must already exist."),
     )
+    resolved_agent_config: AgentConfigPayload | None = Field(
+        default=None,
+        description="Dispatch-time resolved root config. None for legacy executions.",
+    )
 
 
 class WorkflowApprovalSubmission(BaseModel):
@@ -657,7 +662,9 @@ class DurableAgentWorkflow:
         return workflow.info().run_id
 
     async def _build_config(self, args: AgentWorkflowArgs) -> AgentConfig:
-        if args.agent_args.preset_slug:
+        if args.resolved_agent_config is not None:
+            cfg = agent_config_from_payload(args.resolved_agent_config)
+        elif args.agent_args.preset_slug:
             wf_exec_id = self._turn_wf_exec_id(args)
             activity_input = (
                 ResolveAgentPresetConfigActivityInput(
@@ -723,6 +730,13 @@ class DurableAgentWorkflow:
         persist_provenance: bool = False,
     ) -> ResolvedAgentsRuntimeConfig:
         agents_config = agents if agents is not None else cfg.agents
+        if (
+            agents is None
+            and follow_latest_versions is None
+            and not preserve_resolved_versions
+            and args.agent_args.resolved_agents_config is not None
+        ):
+            return args.agent_args.resolved_agents_config
         if not agents_config.enabled and not persist_provenance:
             return ResolvedAgentsRuntimeConfig(resolved_refs=cfg.resolved_refs)
         if not agents_config.subagents and not persist_provenance:
@@ -1287,7 +1301,11 @@ class DurableAgentWorkflow:
             workflow.info().workflow_id
         ).session_id
         load_result: LoadSessionResult | None = None
-        if workflow.patched(PRESERVE_RESUMED_AGENT_BINDINGS_PATCH):
+        dispatch_resolved_agents = args.agent_args.resolved_agents_config
+        has_dispatch_resolved_agents = dispatch_resolved_agents is not None
+        if dispatch_resolved_agents is not None:
+            agents_result = dispatch_resolved_agents
+        elif workflow.patched(PRESERVE_RESUMED_AGENT_BINDINGS_PATCH):
             # Load session topology before resolving agents. A resumed session's
             # stored binding is the stable runtime contract, even if the preset
             # now follows a newer child version.
@@ -1336,7 +1354,11 @@ class DurableAgentWorkflow:
                 tools=args.tools,
                 agent_preset_id=args.agent_preset_id,
                 agent_preset_version_id=args.agent_preset_version_id,
-                agents_binding=agents_result.to_agents_binding(),
+                agents_binding=(
+                    None
+                    if has_dispatch_resolved_agents
+                    else agents_result.to_agents_binding()
+                ),
                 harness_type=HarnessType(self.harness_type),
                 curr_run_id=curr_run_id,
                 initial_user_prompt=args.agent_args.user_prompt,
@@ -1386,6 +1408,7 @@ class DurableAgentWorkflow:
                 start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )
+        assert load_result is not None
 
         if load_result.found and load_result.sdk_session_id:
             logger.info(

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -991,6 +991,106 @@ async def test_agent_workflow_persists_refs_for_empty_binding_on_resume(
 
 @pytest.mark.anyio
 @pytest.mark.integration
+async def test_agent_workflow_uses_dispatch_resolved_agents_without_legacy_activity(
+    svc_role: Role,
+    temporal_client: Client,
+    agent_worker_factory,
+    mock_session_id: uuid.UUID,
+) -> None:
+    """Invariant: dispatch-resolved turns do not schedule legacy resolution."""
+    queue = f"test-agent-queue-{mock_session_id}"
+    child_ref = ResolvedAttachedSubagentRef(
+        preset="analyst",
+        preset_version=1,
+        preset_id=uuid.uuid4(),
+        preset_version_id=uuid.uuid4(),
+    )
+    root_config = AgentConfig(
+        model_name="claude-3-5-sonnet-20241022",
+        model_provider="anthropic",
+        actions=[],
+        agents=AgentSubagentsConfig(enabled=True, subagents=[child_ref]),
+    )
+    resolved_agents = ResolvedAgentsRuntimeConfig(
+        enabled=True,
+        subagents=[
+            ResolvedSubagentConfig(
+                binding=child_ref,
+                description="Stored analyst",
+                prompt="Complete the delegated analysis.",
+                config=agent_config_to_payload(
+                    AgentConfig(
+                        model_name="claude-3-5-sonnet-20241022",
+                        model_provider="anthropic",
+                        actions=[],
+                    )
+                ),
+            )
+        ],
+    )
+    create_inputs: list[CreateSessionInput] = []
+    agent_inputs: list[AgentExecutorInput] = []
+
+    @activity.defn(name="create_session_activity")
+    async def mock_create_session_activity(
+        input: CreateSessionInput,
+    ) -> CreateSessionResult:
+        create_inputs.append(input)
+        return CreateSessionResult(session_id=input.session_id, success=True)
+
+    @activity.defn(name="run_agent_activity")
+    async def mock_run_agent_activity(
+        input: AgentExecutorInput,
+    ) -> AgentExecutorResult:
+        agent_inputs.append(input)
+        return AgentExecutorResult(success=True, output={"status": "ok"})
+
+    workflow_args = AgentWorkflowArgs(
+        role=svc_role,
+        agent_args=RunAgentArgs(
+            session_id=mock_session_id,
+            user_prompt="Use the dispatch snapshot",
+            config=root_config,
+            resolved_agents_config=resolved_agents,
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+        resolved_agent_config=agent_config_to_payload(root_config),
+    )
+
+    activities = [
+        mock_create_session_activity,
+        create_mock_load_session_activity(),
+        create_mock_load_session_messages_activity(),
+        create_mock_build_tool_definitions_activity(),
+        mock_run_agent_activity,
+        create_mock_execute_action_activity(),
+        create_mock_reconcile_tool_results_activity(),
+        *ApprovalManager.get_activities(),
+    ]
+
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
+    ):
+        result = await temporal_client.execute_workflow(
+            DurableAgentWorkflow.run,
+            workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
+
+    assert result.session_id == mock_session_id
+    assert result.output == {"status": "ok"}
+    assert len(create_inputs) == 1
+    assert create_inputs[0].agents_binding is None
+    assert len(agent_inputs) == 1
+    assert [subagent.alias for subagent in agent_inputs[0].subagents] == ["analyst"]
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
 async def test_agent_workflow_preserves_legacy_activity_message_history(
     svc_role: Role,
     temporal_client: Client,

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -1700,6 +1700,106 @@ async def test_agent_workflow_persists_refs_for_empty_binding_on_resume(
 
 @pytest.mark.anyio
 @pytest.mark.integration
+async def test_agent_workflow_uses_dispatch_resolved_agents_without_legacy_activity(
+    svc_role: Role,
+    temporal_client: Client,
+    agent_worker_factory,
+    mock_session_id: uuid.UUID,
+) -> None:
+    """Invariant: dispatch-resolved turns do not schedule legacy resolution."""
+    queue = f"test-agent-queue-{mock_session_id}"
+    child_ref = ResolvedAttachedSubagentRef(
+        preset="analyst",
+        preset_version=1,
+        preset_id=uuid.uuid4(),
+        preset_version_id=uuid.uuid4(),
+    )
+    root_config = AgentConfig(
+        model_name="claude-3-5-sonnet-20241022",
+        model_provider="anthropic",
+        actions=[],
+        agents=AgentSubagentsConfig(enabled=True, subagents=[child_ref]),
+    )
+    resolved_agents = ResolvedAgentsRuntimeConfig(
+        enabled=True,
+        subagents=[
+            ResolvedSubagentConfig(
+                binding=child_ref,
+                description="Stored analyst",
+                prompt="Complete the delegated analysis.",
+                config=agent_config_to_payload(
+                    AgentConfig(
+                        model_name="claude-3-5-sonnet-20241022",
+                        model_provider="anthropic",
+                        actions=[],
+                    )
+                ),
+            )
+        ],
+    )
+    create_inputs: list[CreateSessionInput] = []
+    agent_inputs: list[AgentExecutorInput] = []
+
+    @activity.defn(name="create_session_activity")
+    async def mock_create_session_activity(
+        input: CreateSessionInput,
+    ) -> CreateSessionResult:
+        create_inputs.append(input)
+        return CreateSessionResult(session_id=input.session_id, success=True)
+
+    @activity.defn(name="run_agent_activity")
+    async def mock_run_agent_activity(
+        input: AgentExecutorInput,
+    ) -> AgentExecutorResult:
+        agent_inputs.append(input)
+        return AgentExecutorResult(success=True, output={"status": "ok"})
+
+    workflow_args = AgentWorkflowArgs(
+        role=svc_role,
+        agent_args=RunAgentArgs(
+            session_id=mock_session_id,
+            user_prompt="Use the dispatch snapshot",
+            config=root_config,
+            resolved_agents_config=resolved_agents,
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+        resolved_agent_config=agent_config_to_payload(root_config),
+    )
+
+    activities = [
+        mock_create_session_activity,
+        create_mock_load_session_activity(),
+        create_mock_load_session_messages_activity(),
+        create_mock_build_tool_definitions_activity(),
+        mock_run_agent_activity,
+        create_mock_execute_action_activity(),
+        create_mock_reconcile_tool_results_activity(),
+        *ApprovalManager.get_activities(),
+    ]
+
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
+    ):
+        result = await temporal_client.execute_workflow(
+            DurableAgentWorkflow.run,
+            workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
+
+    assert result.session_id == mock_session_id
+    assert result.output == {"status": "ok"}
+    assert len(create_inputs) == 1
+    assert create_inputs[0].agents_binding is None
+    assert len(agent_inputs) == 1
+    assert [subagent.alias for subagent in agent_inputs[0].subagents] == ["analyst"]
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
 async def test_agent_workflow_preserves_legacy_activity_message_history(
     svc_role: Role,
     temporal_client: Client,

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -777,8 +777,8 @@ class TestCreateSessionActivity:
                 None,
                 None,
                 True,
-                True,
-                id="never-run-overwrites-with-disabled-binding",
+                False,
+                id="dispatch-resolved-turn-does-not-reconcile-shared-binding",
             ),
             pytest.param(
                 ResolvedAgentsConfig.model_validate({"enabled": True, "subagents": []}),
@@ -843,7 +843,7 @@ class TestCreateSessionActivity:
             with pytest.raises(ApplicationError) as exc_info:
                 await create_session_activity(input)
             assert exc_info.value.message == (
-                "Agent session was created with a different agents binding"
+                "Agent session turn was dispatched with a different agents binding"
             )
             assert exc_info.value.non_retryable is True
 

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -804,8 +804,8 @@ class TestCreateSessionActivity:
                 None,
                 None,
                 True,
-                True,
-                id="never-run-overwrites-with-disabled-binding",
+                False,
+                id="dispatch-resolved-turn-does-not-reconcile-shared-binding",
             ),
             pytest.param(
                 ResolvedAgentsConfig.model_validate({"enabled": True, "subagents": []}),
@@ -870,7 +870,7 @@ class TestCreateSessionActivity:
             with pytest.raises(ApplicationError) as exc_info:
                 await create_session_activity(input)
             assert exc_info.value.message == (
-                "Agent session was created with a different agents binding"
+                "Agent session turn was dispatched with a different agents binding"
             )
             assert exc_info.value.non_retryable is True
 

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from tracecat_ee.agent.workflows.durable import AgentWorkflowArgs
 
 from tracecat.agent.preset.activities import (
     ResolveAgentPresetVersionRefActivityInput,
@@ -26,6 +27,8 @@ from tracecat.agent.preset.resolver import (
     ResolvedSubagentConfig,
 )
 from tracecat.agent.preset.service import AgentPresetService
+from tracecat.agent.schemas import RunAgentArgs
+from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
     ResolvedAttachedSubagentRef,
@@ -174,6 +177,37 @@ def test_resolve_agents_config_input_defaults_preserve_resolved_versions() -> No
     payload.pop("preserve_resolved_versions")
     parsed = ResolveAgentsConfigActivityInput.model_validate(payload)
     assert parsed.preserve_resolved_versions is False
+
+
+def test_agent_workflow_args_default_dispatch_resolution_fields() -> None:
+    """Invariant: pre-2.3a workflow payloads deserialize and use legacy routing."""
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    args = AgentWorkflowArgs(
+        role=role,
+        agent_args=RunAgentArgs(
+            user_prompt="hello",
+            session_id=uuid.uuid4(),
+            config=AgentConfig(
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+            ),
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+    )
+    payload = args.model_dump(mode="json")
+    payload.pop("resolved_agent_config")
+    payload["agent_args"].pop("resolved_agents_config")
+
+    parsed = AgentWorkflowArgs.model_validate(payload)
+
+    assert parsed.resolved_agent_config is None
+    assert parsed.agent_args.resolved_agents_config is None
 
 
 def test_resolve_agents_config_result_derives_session_binding() -> None:
@@ -520,6 +554,124 @@ def test_resolution_outputs_parse_pre_2_2_payloads_without_resolved_refs() -> No
 
 
 @pytest.mark.anyio
+async def test_merged_provenance_appends_over_existing_root_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: legacy fallback turns supersede the root row.
+
+    DSL preset agents and histories predating dispatch-time resolution run
+    the root activity (which writes root refs) and then the subagent
+    activity with the same ``wf_exec_id``. The merged snapshot must append
+    so the highest ``surrogate_id`` row is the merged one; a blanket
+    skip-if-exists would freeze the turn at root-only provenance.
+    """
+
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    root_refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                resource_id=uuid.uuid4(),
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+    )
+    # The root activity already wrote a row with a different snapshot.
+    stale_row = SimpleNamespace(scalar_one_or_none=MagicMock(return_value={"refs": []}))
+    db_session = SimpleNamespace(
+        execute=AsyncMock(return_value=stale_row),
+        add=MagicMock(),
+        commit=AsyncMock(),
+    )
+    service = SimpleNamespace(role=role, session=db_session)
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    result = await resolve_agents_config_activity(
+        ResolveAgentsConfigActivityInput(
+            role=role,
+            agents=AgentSubagentsConfig(),
+            session_id=session_id,
+            wf_exec_id="turn-1",
+            parent_resolved_refs=root_refs,
+        )
+    )
+
+    assert result.resolved_refs == root_refs
+    provenance = db_session.add.call_args.args[0]
+    assert provenance.resolved_refs == root_refs.model_dump(mode="json")
+    db_session.commit.assert_awaited_once_with()
+
+
+@pytest.mark.anyio
+async def test_merged_provenance_skips_identical_latest_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: dispatch-staged turns do not duplicate the same snapshot.
+
+    When dispatch-time staging already persisted the identical merged refs,
+    the activity's merged write is a no-op instead of appending a duplicate
+    row.
+    """
+
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    root_refs = ResolvedRefs(
+        refs=[
+            ResolvedRef(
+                resource_kind="preset",
+                resource_id=uuid.uuid4(),
+                resolved_version_id=uuid.uuid4(),
+                status="ok",
+            )
+        ]
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+    )
+    identical_row = SimpleNamespace(
+        scalar_one_or_none=MagicMock(return_value=root_refs.model_dump(mode="json"))
+    )
+    db_session = SimpleNamespace(
+        execute=AsyncMock(return_value=identical_row),
+        add=MagicMock(),
+        commit=AsyncMock(),
+    )
+    service = SimpleNamespace(role=role, session=db_session)
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    result = await resolve_agents_config_activity(
+        ResolveAgentsConfigActivityInput(
+            role=role,
+            agents=AgentSubagentsConfig(),
+            session_id=session_id,
+            wf_exec_id="turn-1",
+            parent_resolved_refs=root_refs,
+        )
+    )
+
+    assert result.resolved_refs == root_refs
+    db_session.add.assert_not_called()
+    db_session.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_disabled_agents_activity_persists_parent_provenance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -541,7 +693,12 @@ async def test_disabled_agents_activity_persists_parent_provenance(
         workspace_id=workspace_id,
         organization_id=uuid.uuid4(),
     )
-    db_session = SimpleNamespace(add=MagicMock(), commit=AsyncMock())
+    existing_result = SimpleNamespace(scalar_one_or_none=MagicMock(return_value=None))
+    db_session = SimpleNamespace(
+        execute=AsyncMock(return_value=existing_result),
+        add=MagicMock(),
+        commit=AsyncMock(),
+    )
     service = SimpleNamespace(role=role, session=db_session)
 
     monkeypatch.setattr(
@@ -566,6 +723,7 @@ async def test_disabled_agents_activity_persists_parent_provenance(
     assert provenance.session_id == session_id
     assert provenance.wf_exec_id == "turn-1"
     assert provenance.resolved_refs == root_refs.model_dump(mode="json")
+    db_session.execute.assert_awaited_once()
     db_session.commit.assert_awaited_once_with()
 
 

--- a/tests/unit/test_agent_session_activities.py
+++ b/tests/unit/test_agent_session_activities.py
@@ -6,10 +6,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from tracecat.agent.session.activities import (
+    CreateSessionInput,
     PendingToolResult,
     ReconcileToolResultsInput,
+    create_session_activity,
     reconcile_tool_results_activity,
 )
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.auth.types import Role
 from tracecat.storage.object import ExternalObject, ObjectRef
 
@@ -175,3 +179,58 @@ async def test_reconcile_tool_results_appends_artifact_side_effect(
     assert apply_args[0] == input.session_id
     assert len(apply_args[1]) == 1
     assert apply_args[1][0].op == "upsert"
+
+
+@pytest.mark.anyio
+async def test_create_session_activity_accepts_matching_legacy_session_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy workflows can verify a matching stored session binding."""
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    agents_binding = ResolvedAgentsConfig.model_validate(
+        {"enabled": True, "subagents": []}
+    )
+    agent_session = MagicMock()
+    agent_session.id = uuid.uuid4()
+    agent_session.agents_binding = agents_binding.model_dump(mode="json")
+    agent_session.sdk_session_id = "sdk-session"
+    agent_session.parent_session_id = None
+
+    service = MagicMock()
+    service.get_or_create_session = AsyncMock(return_value=(agent_session, False))
+    service.session.add = MagicMock()
+    service.session.commit = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = service
+    stream = MagicMock()
+    stream.clear_buffer = AsyncMock()
+
+    monkeypatch.setattr(
+        "tracecat.agent.session.activities.AgentSessionService.with_session",
+        MagicMock(return_value=ctx),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.session.activities.AgentStream.new",
+        AsyncMock(return_value=stream),
+    )
+
+    result = await create_session_activity(
+        CreateSessionInput(
+            role=role,
+            session_id=agent_session.id,
+            entity_type=AgentSessionEntity.WORKFLOW,
+            entity_id=uuid.uuid4(),
+            agents_binding=agents_binding,
+            curr_run_id=uuid.uuid4(),
+        )
+    )
+
+    assert result.success is True
+    service.session.add.assert_called_with(agent_session)
+    service.session.commit.assert_awaited_once()
+    stream.clear_buffer.assert_awaited_once()

--- a/tests/unit/test_agent_session_activities.py
+++ b/tests/unit/test_agent_session_activities.py
@@ -6,12 +6,16 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from tracecat.agent.session.activities import (
+    CreateSessionInput,
     FinalizeTurnInput,
     PendingToolResult,
     ReconcileToolResultsInput,
+    create_session_activity,
     finalize_turn_activity,
     reconcile_tool_results_activity,
 )
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.auth.types import Role
 from tracecat.storage.object import ExternalObject, ObjectRef
 
@@ -230,3 +234,58 @@ async def test_reconcile_tool_results_appends_artifact_side_effect(
     assert apply_args[0] == input.session_id
     assert len(apply_args[1]) == 1
     assert apply_args[1][0].op == "upsert"
+
+
+@pytest.mark.anyio
+async def test_create_session_activity_accepts_matching_legacy_session_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy workflows can verify a matching stored session binding."""
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    agents_binding = ResolvedAgentsConfig.model_validate(
+        {"enabled": True, "subagents": []}
+    )
+    agent_session = MagicMock()
+    agent_session.id = uuid.uuid4()
+    agent_session.agents_binding = agents_binding.model_dump(mode="json")
+    agent_session.sdk_session_id = "sdk-session"
+    agent_session.parent_session_id = None
+
+    service = MagicMock()
+    service.get_or_create_session = AsyncMock(return_value=(agent_session, False))
+    service.session.add = MagicMock()
+    service.session.commit = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = service
+    stream = MagicMock()
+    stream.clear_buffer = AsyncMock()
+
+    monkeypatch.setattr(
+        "tracecat.agent.session.activities.AgentSessionService.with_session",
+        MagicMock(return_value=ctx),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.session.activities.AgentStream.new",
+        AsyncMock(return_value=stream),
+    )
+
+    result = await create_session_activity(
+        CreateSessionInput(
+            role=role,
+            session_id=agent_session.id,
+            entity_type=AgentSessionEntity.WORKFLOW,
+            entity_id=uuid.uuid4(),
+            agents_binding=agents_binding,
+            curr_run_id=uuid.uuid4(),
+        )
+    )
+
+    assert result.success is True
+    service.session.add.assert_called_with(agent_session)
+    service.session.commit.assert_awaited_once()
+    stream.clear_buffer.assert_awaited_once()

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -7,16 +7,26 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.preset.resolved_refs import ResolvedRef, ResolvedRefs
+from tracecat.agent.preset.resolver import ResolvedAgentsRuntimeConfig
+from tracecat.agent.preset.schemas import AgentPresetCreate, AgentPresetUpdate
+from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.session.schemas import AgentSessionCreate, AgentSessionUpdate
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
-from tracecat.agent.subagents import ResolvedAgentsConfig
+from tracecat.agent.subagents import (
+    AgentSubagentsConfig,
+    ResolvedAgentsConfig,
+    ResolvedAttachedSubagentRef,
+)
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
+from tracecat.chat.enums import MessageKind
+from tracecat.chat.schemas import BasicChatRequest
 from tracecat.chat.tools import WORKSPACE_CHAT_DEFAULT_TOOLS, get_default_tools
-from tracecat.db.models import AgentSession
+from tracecat.db.models import AgentSession, AgentSessionHistory, AgentTurnProvenance
 from tracecat.exceptions import TracecatValidationError
 from tracecat.tiers.enums import Entitlement
 
@@ -55,6 +65,32 @@ def _build_service() -> tuple[_TestAgentSessionService, SimpleNamespace, Role]:
     )
     service = _TestAgentSessionService(cast(Any, session), role)
     return service, session, role
+
+
+def _agent_preset_create(
+    *,
+    name: str,
+    slug: str,
+    instructions: str,
+    agents: AgentSubagentsConfig | None = None,
+) -> AgentPresetCreate:
+    return AgentPresetCreate(
+        name=name,
+        slug=slug,
+        description=f"{name} description",
+        instructions=instructions,
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        base_url=None,
+        output_type=None,
+        actions=None,
+        namespaces=None,
+        tool_approvals=None,
+        mcp_integrations=None,
+        agents=agents if agents is not None else AgentSubagentsConfig(),
+        retries=3,
+        enable_thinking=True,
+    )
 
 
 @pytest.mark.anyio
@@ -788,3 +824,195 @@ async def test_workspace_chat_preset_config_superuser_keeps_all_actions() -> Non
         )
         async with service._build_agent_config(agent_session) as resolved:
             assert resolved.actions == actions
+
+
+@pytest.mark.anyio
+async def test_run_turn_dispatch_stages_one_full_tree_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: dispatch-resolved turns stage one provenance row and args snapshot."""
+    service, session, role = _build_service()
+    workspace_id = role.workspace_id
+    assert workspace_id is not None
+    session_id = uuid.uuid4()
+    preset_id = uuid.uuid4()
+    agent_session = AgentSession(
+        workspace_id=workspace_id,
+        title="Dispatch chat",
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=preset_id,
+        agent_preset_id=preset_id,
+    )
+    agent_session.id = session_id
+    config = AgentConfig(
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        resolved_refs=ResolvedRefs(
+            refs=[
+                ResolvedRef(
+                    resource_kind="preset",
+                    resource_id=preset_id,
+                    resolved_version_id=uuid.uuid4(),
+                    status="ok",
+                )
+            ]
+        ),
+    )
+    resolved_agents = ResolvedAgentsRuntimeConfig(
+        enabled=True,
+        resolved_refs=ResolvedRefs(
+            refs=[
+                ResolvedRef(
+                    resource_kind="preset",
+                    resource_id=preset_id,
+                    resolved_version_id=uuid.uuid4(),
+                    status="ok",
+                ),
+                ResolvedRef(
+                    resource_kind="skill",
+                    resource_id=uuid.uuid4(),
+                    resolved_version_id=uuid.uuid4(),
+                    manifest_sha256="0" * 64,
+                    status="ok",
+                ),
+            ]
+        ),
+    )
+
+    @contextlib.asynccontextmanager
+    async def _fake_build_agent_config(_agent_session: AgentSession):
+        yield config
+
+    client = SimpleNamespace(start_workflow=AsyncMock())
+    service.validate_turn_request = AsyncMock(return_value=agent_session)  # type: ignore[method-assign]
+    service.auto_title_session_on_first_prompt = AsyncMock()  # type: ignore[method-assign]
+    service._build_agent_config = _fake_build_agent_config  # type: ignore[method-assign]
+    service._resolve_dispatch_agents_config = AsyncMock(return_value=resolved_agents)  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "tracecat.agent.session.service.get_temporal_client",
+        AsyncMock(return_value=client),
+    )
+
+    response = await service.run_turn(
+        session_id,
+        BasicChatRequest(message="hello"),
+        active_stream_id=uuid.uuid4(),
+    )
+
+    provenance_rows = [
+        call.args[0]
+        for call in session.add.call_args_list
+        if isinstance(call.args[0], AgentTurnProvenance)
+    ]
+    assert response is not None
+    assert len(provenance_rows) == 1
+    assert resolved_agents.resolved_refs is not None
+    assert provenance_rows[0].resolved_refs == resolved_agents.resolved_refs.model_dump(
+        mode="json"
+    )
+    assert agent_session.agents_binding is None
+    workflow_args = client.start_workflow.await_args.args[1]
+    assert workflow_args.resolved_agent_config is not None
+    assert workflow_args.agent_args.resolved_agents_config == resolved_agents
+
+
+@pytest.mark.anyio
+async def test_new_dispatch_turn_follows_child_head_after_session_history(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """A new run resolves current heads even when the chat has SDK history."""
+    workspace_id = svc_role.workspace_id
+    assert workspace_id is not None
+    preset_service = AgentPresetService(session=session, role=svc_role)
+    child = await preset_service.create_preset(
+        _agent_preset_create(
+            name="Resume child",
+            slug="resume-child",
+            instructions="Stored child instructions",
+        )
+    )
+    parent = await preset_service.create_preset(
+        _agent_preset_create(
+            name="Resume parent",
+            slug="resume-parent",
+            instructions="Parent instructions",
+            agents=AgentSubagentsConfig.model_validate(
+                {
+                    "enabled": True,
+                    "subagents": [{"preset": child.slug}],
+                }
+            ),
+        )
+    )
+    stored_binding = ResolvedAgentsConfig.model_validate(parent.agents)
+    assert len(stored_binding.subagents) == 1
+    stored_child_version_id = stored_binding.subagents[0].preset_version_id
+
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        title="Resumed dispatch chat",
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=parent.id,
+        agent_preset_id=parent.id,
+        sdk_session_id="sdk-session-resume",
+        agents_binding=stored_binding.model_dump(mode="json"),
+    )
+    session.add(agent_session)
+    session.add(
+        AgentSessionHistory(
+            workspace_id=workspace_id,
+            session_id=agent_session.id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={"type": "user", "message": {"content": "previous turn"}},
+        )
+    )
+    await session.commit()
+
+    await preset_service.update_preset(
+        child,
+        AgentPresetUpdate(instructions="Advanced child instructions"),
+    )
+    child_v2 = await preset_service.get_current_version_for_preset(child)
+    assert child_v2.id != stored_child_version_id
+    fresh_config = await preset_service.resolve_agent_preset_config(
+        preset_id=parent.id,
+    )
+    fresh_ref = fresh_config.agents.subagents[0]
+    assert isinstance(fresh_ref, ResolvedAttachedSubagentRef)
+    assert fresh_ref.preset_version_id == child_v2.id
+
+    service = AgentSessionService(session=session, role=svc_role)
+    fake_client = SimpleNamespace(start_workflow=AsyncMock(return_value=None))
+    with (
+        patch(
+            "tracecat.agent.service.AgentManagementService.get_workspace_runtime_provider_credentials",
+            AsyncMock(return_value={"OPENAI_API_KEY": "test-key"}),
+        ),
+        patch(
+            "tracecat.agent.service.AgentManagementService.get_runtime_provider_credentials",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "tracecat.agent.session.service.get_temporal_client",
+            AsyncMock(return_value=fake_client),
+        ),
+    ):
+        response = await service.run_turn(
+            agent_session.id,
+            BasicChatRequest(message="continue"),
+            active_stream_id=uuid.uuid4(),
+        )
+
+    assert response is not None
+    workflow_args = fake_client.start_workflow.await_args.args[1]
+    resolved_agents = workflow_args.agent_args.resolved_agents_config
+    assert resolved_agents is not None
+    assert resolved_agents.subagents[0].binding.preset_version_id == child_v2.id
+    assert resolved_agents.to_agents_binding() != stored_binding
+    await session.refresh(agent_session)
+    assert (
+        ResolvedAgentsConfig.model_validate(agent_session.agents_binding)
+        == stored_binding
+    )

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -7,19 +7,29 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.preset.resolved_refs import ResolvedRef, ResolvedRefs
+from tracecat.agent.preset.resolver import ResolvedAgentsRuntimeConfig
+from tracecat.agent.preset.schemas import AgentPresetCreate, AgentPresetUpdate
+from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.session.schemas import AgentSessionCreate, AgentSessionUpdate
 from tracecat.agent.session.service import (
     AGENT_SESSION_EXECUTION_SCOPES,
     AgentSessionService,
 )
 from tracecat.agent.session.types import AgentSessionEntity
-from tracecat.agent.subagents import ResolvedAgentsConfig
+from tracecat.agent.subagents import (
+    AgentSubagentsConfig,
+    ResolvedAgentsConfig,
+    ResolvedAttachedSubagentRef,
+)
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
+from tracecat.chat.enums import MessageKind
+from tracecat.chat.schemas import BasicChatRequest
 from tracecat.chat.tools import WORKSPACE_CHAT_DEFAULT_TOOLS, get_default_tools
-from tracecat.db.models import AgentSession
+from tracecat.db.models import AgentSession, AgentSessionHistory, AgentTurnProvenance
 from tracecat.exceptions import TracecatValidationError
 from tracecat.tiers.enums import Entitlement
 
@@ -80,6 +90,32 @@ def test_execution_role_adds_only_agent_runtime_scopes() -> None:
             "secret:read",
             "workflow:execute",
         }
+    )
+
+
+def _agent_preset_create(
+    *,
+    name: str,
+    slug: str,
+    instructions: str,
+    agents: AgentSubagentsConfig | None = None,
+) -> AgentPresetCreate:
+    return AgentPresetCreate(
+        name=name,
+        slug=slug,
+        description=f"{name} description",
+        instructions=instructions,
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        base_url=None,
+        output_type=None,
+        actions=None,
+        namespaces=None,
+        tool_approvals=None,
+        mcp_integrations=None,
+        agents=agents if agents is not None else AgentSubagentsConfig(),
+        retries=3,
+        enable_thinking=True,
     )
 
 
@@ -822,3 +858,195 @@ async def test_workspace_chat_preset_config_superuser_keeps_all_actions() -> Non
         )
         async with service._build_agent_config(agent_session) as resolved:
             assert resolved.actions == actions
+
+
+@pytest.mark.anyio
+async def test_run_turn_dispatch_stages_one_full_tree_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: dispatch-resolved turns stage one provenance row and args snapshot."""
+    service, session, role = _build_service()
+    workspace_id = role.workspace_id
+    assert workspace_id is not None
+    session_id = uuid.uuid4()
+    preset_id = uuid.uuid4()
+    agent_session = AgentSession(
+        workspace_id=workspace_id,
+        title="Dispatch chat",
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=preset_id,
+        agent_preset_id=preset_id,
+    )
+    agent_session.id = session_id
+    config = AgentConfig(
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        resolved_refs=ResolvedRefs(
+            refs=[
+                ResolvedRef(
+                    resource_kind="preset",
+                    resource_id=preset_id,
+                    resolved_version_id=uuid.uuid4(),
+                    status="ok",
+                )
+            ]
+        ),
+    )
+    resolved_agents = ResolvedAgentsRuntimeConfig(
+        enabled=True,
+        resolved_refs=ResolvedRefs(
+            refs=[
+                ResolvedRef(
+                    resource_kind="preset",
+                    resource_id=preset_id,
+                    resolved_version_id=uuid.uuid4(),
+                    status="ok",
+                ),
+                ResolvedRef(
+                    resource_kind="skill",
+                    resource_id=uuid.uuid4(),
+                    resolved_version_id=uuid.uuid4(),
+                    manifest_sha256="0" * 64,
+                    status="ok",
+                ),
+            ]
+        ),
+    )
+
+    @contextlib.asynccontextmanager
+    async def _fake_build_agent_config(_agent_session: AgentSession):
+        yield config
+
+    client = SimpleNamespace(start_workflow=AsyncMock())
+    service.validate_turn_request = AsyncMock(return_value=agent_session)  # type: ignore[method-assign]
+    service.auto_title_session_on_first_prompt = AsyncMock()  # type: ignore[method-assign]
+    service._build_agent_config = _fake_build_agent_config  # type: ignore[method-assign]
+    service._resolve_dispatch_agents_config = AsyncMock(return_value=resolved_agents)  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "tracecat.agent.session.service.get_temporal_client",
+        AsyncMock(return_value=client),
+    )
+
+    response = await service.run_turn(
+        session_id,
+        BasicChatRequest(message="hello"),
+        active_stream_id=uuid.uuid4(),
+    )
+
+    provenance_rows = [
+        call.args[0]
+        for call in session.add.call_args_list
+        if isinstance(call.args[0], AgentTurnProvenance)
+    ]
+    assert response is not None
+    assert len(provenance_rows) == 1
+    assert resolved_agents.resolved_refs is not None
+    assert provenance_rows[0].resolved_refs == resolved_agents.resolved_refs.model_dump(
+        mode="json"
+    )
+    assert agent_session.agents_binding is None
+    workflow_args = client.start_workflow.await_args.args[1]
+    assert workflow_args.resolved_agent_config is not None
+    assert workflow_args.agent_args.resolved_agents_config == resolved_agents
+
+
+@pytest.mark.anyio
+async def test_new_dispatch_turn_follows_child_head_after_session_history(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """A new run resolves current heads even when the chat has SDK history."""
+    workspace_id = svc_role.workspace_id
+    assert workspace_id is not None
+    preset_service = AgentPresetService(session=session, role=svc_role)
+    child = await preset_service.create_preset(
+        _agent_preset_create(
+            name="Resume child",
+            slug="resume-child",
+            instructions="Stored child instructions",
+        )
+    )
+    parent = await preset_service.create_preset(
+        _agent_preset_create(
+            name="Resume parent",
+            slug="resume-parent",
+            instructions="Parent instructions",
+            agents=AgentSubagentsConfig.model_validate(
+                {
+                    "enabled": True,
+                    "subagents": [{"preset": child.slug}],
+                }
+            ),
+        )
+    )
+    stored_binding = ResolvedAgentsConfig.model_validate(parent.agents)
+    assert len(stored_binding.subagents) == 1
+    stored_child_version_id = stored_binding.subagents[0].preset_version_id
+
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        title="Resumed dispatch chat",
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=parent.id,
+        agent_preset_id=parent.id,
+        sdk_session_id="sdk-session-resume",
+        agents_binding=stored_binding.model_dump(mode="json"),
+    )
+    session.add(agent_session)
+    session.add(
+        AgentSessionHistory(
+            workspace_id=workspace_id,
+            session_id=agent_session.id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={"type": "user", "message": {"content": "previous turn"}},
+        )
+    )
+    await session.commit()
+
+    await preset_service.update_preset(
+        child,
+        AgentPresetUpdate(instructions="Advanced child instructions"),
+    )
+    child_v2 = await preset_service.get_current_version_for_preset(child)
+    assert child_v2.id != stored_child_version_id
+    fresh_config = await preset_service.resolve_agent_preset_config(
+        preset_id=parent.id,
+    )
+    fresh_ref = fresh_config.agents.subagents[0]
+    assert isinstance(fresh_ref, ResolvedAttachedSubagentRef)
+    assert fresh_ref.preset_version_id == child_v2.id
+
+    service = AgentSessionService(session=session, role=svc_role)
+    fake_client = SimpleNamespace(start_workflow=AsyncMock(return_value=None))
+    with (
+        patch(
+            "tracecat.agent.service.AgentManagementService.get_workspace_runtime_provider_credentials",
+            AsyncMock(return_value={"OPENAI_API_KEY": "test-key"}),
+        ),
+        patch(
+            "tracecat.agent.service.AgentManagementService.get_runtime_provider_credentials",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "tracecat.agent.session.service.get_temporal_client",
+            AsyncMock(return_value=fake_client),
+        ),
+    ):
+        response = await service.run_turn(
+            agent_session.id,
+            BasicChatRequest(message="continue"),
+            active_stream_id=uuid.uuid4(),
+        )
+
+    assert response is not None
+    workflow_args = fake_client.start_workflow.await_args.args[1]
+    resolved_agents = workflow_args.agent_args.resolved_agents_config
+    assert resolved_agents is not None
+    assert resolved_agents.subagents[0].binding.preset_version_id == child_v2.id
+    assert resolved_agents.to_agents_binding() != stored_binding
+    await session.refresh(agent_session)
+    assert (
+        ResolvedAgentsConfig.model_validate(agent_session.agents_binding)
+        == stored_binding
+    )

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -83,20 +83,26 @@ async def _write_agent_turn_provenance(
     session_id: uuid.UUID | None,
     wf_exec_id: str | None,
     resolved_refs: ResolvedRefs | None,
+    skip_if_exists: bool,
 ) -> None:
     """Persist an append-only per-turn resolution snapshot when identifiers exist.
 
-    A turn may accumulate more than one snapshot: root-preset resolution
-    always records the root refs, and the later subagent-resolution activity
-    appends a merged snapshot when it runs. The row with the highest
-    ``surrogate_id`` for a ``wf_exec_id`` is the final snapshot; earlier rows
-    preserve provenance for turns that fail between the two activities.
+    A turn may accumulate more than one snapshot; the row with the highest
+    ``surrogate_id`` for a ``wf_exec_id`` is the final snapshot. Two write
+    policies keep that contract under mixed-version overlap:
 
-    Not idempotent by design: the calling activities are scheduled with
-    ``activity:fail_fast`` (``maximum_attempts=1``), so no Temporal retry can
-    re-execute a committed insert, and replay reads activity results from
-    history instead of re-running them. Revisit if a caller ever gains a
-    retry policy.
+    - ``skip_if_exists=True`` (root and resolution-failure writes): these are
+      the weakest snapshots and must never land after — and thereby become
+      "latest" over — a dispatch-time or merged snapshot, e.g. an old
+      worker's root write racing the new dispatch staging.
+    - ``skip_if_exists=False`` (merged subagent write): appends so the merged
+      snapshot supersedes the root row on the legacy fallback path (DSL
+      preset agents, pre-dispatch-resolution histories); skipped only when
+      the latest row already carries identical refs (dispatch staging wrote
+      the same snapshot).
+
+    Calling activities still use ``activity:fail_fast`` and replay reads
+    their recorded result instead of re-running the insert.
     """
 
     if session_id is None or wf_exec_id is None or resolved_refs is None:
@@ -105,12 +111,31 @@ async def _write_agent_turn_provenance(
     if workspace_id is None:
         return
 
+    dumped_refs = resolved_refs.model_dump(mode="json")
+    latest_refs = (
+        await service.session.execute(
+            select(AgentTurnProvenance.resolved_refs)
+            .where(
+                AgentTurnProvenance.workspace_id == workspace_id,
+                AgentTurnProvenance.session_id == session_id,
+                AgentTurnProvenance.wf_exec_id == wf_exec_id,
+            )
+            .order_by(AgentTurnProvenance.surrogate_id.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if latest_refs is not None:
+        if skip_if_exists:
+            return
+        if latest_refs == dumped_refs:
+            return
+
     service.session.add(
         AgentTurnProvenance(
             workspace_id=workspace_id,
             session_id=session_id,
             wf_exec_id=wf_exec_id,
-            resolved_refs=resolved_refs.model_dump(mode="json"),
+            resolved_refs=dumped_refs,
         )
     )
     await service.session.commit()
@@ -136,6 +161,7 @@ async def resolve_agent_preset_config_activity(
                 session_id=args.session_id,
                 wf_exec_id=args.wf_exec_id,
                 resolved_refs=failure_refs,
+                skip_if_exists=True,
             )
 
         async def write_root_refs(resolved: AgentConfig) -> None:
@@ -150,6 +176,7 @@ async def resolve_agent_preset_config_activity(
                 session_id=args.session_id,
                 wf_exec_id=args.wf_exec_id,
                 resolved_refs=resolved.resolved_refs,
+                skip_if_exists=True,
             )
 
         config: AgentConfig | None = None
@@ -171,6 +198,7 @@ async def resolve_agent_preset_config_activity(
 async def resolve_agent_preset_version_ref_activity(
     args: ResolveAgentPresetVersionRefActivityInput,
 ) -> AgentPresetVersionRef:
+    # Legacy fallback; remove after workflow drain.
     async with AgentPresetService.with_session(role=args.role) as service:
         try:
             version = await service.resolve_agent_preset_version(
@@ -189,6 +217,7 @@ async def resolve_agent_preset_version_ref_activity(
                     session_id=args.session_id,
                     wf_exec_id=args.wf_exec_id,
                     resolved_refs=failure_refs,
+                    skip_if_exists=True,
                 )
             except Exception:
                 # A provenance write failure must never mask the domain error.
@@ -223,6 +252,10 @@ async def resolve_agents_config_activity(
             session_id=args.session_id,
             wf_exec_id=args.wf_exec_id,
             resolved_refs=runtime_config.resolved_refs,
+            # Legacy fallback turns (DSL preset agents, histories predating
+            # dispatch-time resolution) write the root row first; the merged
+            # snapshot must append over it, not be dropped.
+            skip_if_exists=False,
         )
         return runtime_config
 

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -16,6 +16,7 @@ from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import DeferredToolResults
 
+from tracecat.agent.preset.resolver import ResolvedAgentsRuntimeConfig
 from tracecat.agent.subagents import AgentSubagentsConfig
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
@@ -64,6 +65,8 @@ class RunAgentArgs(BaseModel):
     rows. None for legacy executions."""
     config: AgentConfig | None = None
     """Configuration for the agent. Required if preset_slug is not provided."""
+    resolved_agents_config: ResolvedAgentsRuntimeConfig | None = None
+    """Dispatch-time resolved runtime subagent tree. None for legacy executions."""
     preset_slug: str | None = None
     """Slug for the preset configuration (if using a preset)."""
     max_requests: int | None = None

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -47,6 +47,12 @@ class CreateSessionInput(BaseModel):
     agent_preset_id: uuid.UUID | None = None
     agent_preset_version_id: uuid.UUID | None = None
     agents_binding: ResolvedAgentsConfig | None = None
+    """Legacy session binding to backfill or verify.
+
+    Dispatch-resolved workflows carry their binding in ``RunAgentArgs`` and
+    leave this unset so concurrent turns never share a per-turn snapshot through
+    ``AgentSession``.
+    """
     harness_type: HarnessType = HarnessType.CLAUDE_CODE
     # Workflow run tracking (for approval lookups)
     curr_run_id: uuid.UUID | None = None
@@ -163,30 +169,22 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                     agents_binding=input.agents_binding,
                 )
 
-            # Reconcile agents_binding for pre-existing sessions. Chat-created
-            # sessions may be inserted before the durable workflow resolves the
-            # current preset's subagent bindings, so a fresh session can have a
-            # NULL binding even though this run already has a concrete binding.
-            # Backfill that first-run case. Once an SDK session exists, or the
-            # row forks from a parent SDK history, the binding is part of the
-            # resumable runtime topology and explicit mismatches must continue
-            # to fail.
+            # Reconcile agents_binding only for legacy workflows. Dispatch-resolved
+            # workflows keep the per-turn binding in their immutable workflow input
+            # and leave this unset, avoiding a race through the shared session row.
             if not created:
-                disabled_agents_binding = ResolvedAgentsConfig()
-                requested_agents_binding = (
-                    input.agents_binding or disabled_agents_binding
-                )
+                requested_agents_binding = input.agents_binding
+                binding_to_backfill: ResolvedAgentsConfig | None = None
                 has_resume_state = (
                     agent_session.sdk_session_id is not None
                     or agent_session.parent_session_id is not None
                 )
                 if agent_session.agents_binding is None:
-                    should_backfill_agents_binding = input.agents_binding is not None
-                    stored_agents_binding = (
-                        requested_agents_binding
-                        if should_backfill_agents_binding and not has_resume_state
-                        else disabled_agents_binding
-                    )
+                    if requested_agents_binding is not None and not has_resume_state:
+                        stored_agents_binding = requested_agents_binding
+                        binding_to_backfill = requested_agents_binding
+                    else:
+                        stored_agents_binding = ResolvedAgentsConfig()
                 else:
                     stored_agents_binding = ResolvedAgentsConfig.model_validate(
                         agent_session.agents_binding
@@ -197,22 +195,26 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                     # instead of failing the mismatch. Sessions with resume
                     # state keep the hard failure below: their stored binding
                     # is resumable runtime topology.
-                    should_backfill_agents_binding = (
-                        not has_resume_state
+                    if (
+                        requested_agents_binding is not None
+                        and not has_resume_state
                         and stored_agents_binding != requested_agents_binding
-                    )
-                    if should_backfill_agents_binding:
+                    ):
                         stored_agents_binding = requested_agents_binding
+                        binding_to_backfill = requested_agents_binding
 
-                if stored_agents_binding != requested_agents_binding:
+                if (
+                    requested_agents_binding is not None
+                    and stored_agents_binding != requested_agents_binding
+                ):
                     # Non-retryable: retrying with the same mismatched input
                     # will deterministically fail; surface to the caller.
                     raise ApplicationError(
-                        "Agent session was created with a different agents binding",
+                        "Agent session turn was dispatched with a different agents binding",
                         non_retryable=True,
                     )
-                if should_backfill_agents_binding:
-                    agent_session.agents_binding = stored_agents_binding.model_dump(
+                if binding_to_backfill is not None:
+                    agent_session.agents_binding = binding_to_backfill.model_dump(
                         mode="json"
                     )
                     service.session.add(agent_session)

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -46,6 +46,11 @@ from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.llm import LLMCompletionError
 from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.preset.prompts import AgentPresetBuilderPrompt
+from tracecat.agent.preset.resolved_refs import ResolvedRefs, merge_resolved_refs
+from tracecat.agent.preset.resolver import (
+    ResolvedAgentsRuntimeConfig,
+    resolve_agents_config,
+)
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.runtime.claude_code.session_lines import (
     APPROVAL_INTERRUPT_CONTENT_EXACT,
@@ -68,10 +73,9 @@ from tracecat.agent.session.types import (
     TurnLifecycle,
     TurnLifecycleResult,
 )
-from tracecat.agent.subagents import (
-    ResolvedAgentsConfig,
-)
+from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.agent.types import AgentConfig, ClaudeSDKMessageTA, StreamKey
+from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.artifacts.bindings import ArtifactSideEffect
 from tracecat.artifacts.schemas import Artifact, ArtifactAdapter, ArtifactType
 from tracecat.audit.logger import audit_log
@@ -147,23 +151,16 @@ class AgentSessionService(BaseWorkspaceService):
 
     service_name = "agent-session"
 
-    def _stage_root_turn_provenance(
+    def _stage_turn_provenance(
         self,
         *,
         session_id: uuid.UUID,
         run_id: uuid.UUID,
-        config: AgentConfig,
+        resolved_refs: ResolvedRefs | None,
     ) -> None:
-        """Stage the root resolution snapshot for a spawned turn.
+        """Stage the dispatch-time whole-tree resolution snapshot for this turn."""
 
-        Always staged, even when a later subagent activity will append a
-        merged snapshot: any failure between spawn and that write (custom
-        model provider config, session load, subagent resolution) must still
-        leave the turn's root refs on record. The highest ``surrogate_id``
-        per ``wf_exec_id`` is the final snapshot.
-        """
-
-        if config.resolved_refs is None:
+        if resolved_refs is None:
             return
 
         self.session.add(
@@ -171,9 +168,39 @@ class AgentSessionService(BaseWorkspaceService):
                 workspace_id=self.workspace_id,
                 session_id=session_id,
                 wf_exec_id=str(run_id),
-                resolved_refs=config.resolved_refs.model_dump(mode="json"),
+                resolved_refs=resolved_refs.model_dump(mode="json"),
             )
         )
+
+    async def _resolve_dispatch_agents_config(
+        self,
+        *,
+        agent_session: AgentSession,
+        config: AgentConfig,
+    ) -> ResolvedAgentsRuntimeConfig:
+        """Resolve the runtime agents tree before Temporal dispatch."""
+
+        agents_config = config.agents
+        if not agents_config.enabled:
+            return ResolvedAgentsRuntimeConfig(resolved_refs=config.resolved_refs)
+        if not agents_config.subagents:
+            return ResolvedAgentsRuntimeConfig(
+                enabled=True,
+                resolved_refs=config.resolved_refs,
+            )
+
+        resolved = await resolve_agents_config(
+            AgentPresetService(self.session, self.role),
+            agents=agents_config,
+            parent_preset_id=agent_session.agent_preset_id,
+            include_runtime_config=True,
+        )
+        runtime_config = resolved.to_runtime_config()
+        runtime_config.resolved_refs = merge_resolved_refs(
+            config.resolved_refs,
+            runtime_config.resolved_refs,
+        )
+        return runtime_config
 
     async def _get_default_tools(self, entity_type: AgentSessionEntity) -> list[str]:
         """Get entitlement-aware default tools for a session entity type."""
@@ -1464,10 +1491,14 @@ class AgentSessionService(BaseWorkspaceService):
                 await check_entitlement(
                     self.session, self.role, Entitlement.AGENT_ADDONS
                 )
-            self._stage_root_turn_provenance(
+            resolved_agents_config = await self._resolve_dispatch_agents_config(
+                agent_session=agent_session,
+                config=agent_config,
+            )
+            self._stage_turn_provenance(
                 session_id=session_id,
                 run_id=run_id,
-                config=agent_config,
+                resolved_refs=resolved_agents_config.resolved_refs,
             )
 
             args = RunAgentArgs(
@@ -1476,6 +1507,7 @@ class AgentSessionService(BaseWorkspaceService):
                 active_stream_id=stream_id,
                 curr_run_id=run_id,
                 config=agent_config,
+                resolved_agents_config=resolved_agents_config,
             )
 
             client = await get_temporal_client()
@@ -1490,6 +1522,7 @@ class AgentSessionService(BaseWorkspaceService):
                 tools=agent_session.tools,
                 agent_preset_id=agent_session.agent_preset_id,
                 agent_preset_version_id=agent_session.agent_preset_version_id,
+                resolved_agent_config=agent_config_to_payload(agent_config),
             )
 
             # Pin run_id (approval lookups) and the per-turn stream id before

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -66,6 +66,11 @@ from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.llm import LLMCompletionError
 from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.preset.prompts import AgentPresetBuilderPrompt
+from tracecat.agent.preset.resolved_refs import ResolvedRefs, merge_resolved_refs
+from tracecat.agent.preset.resolver import (
+    ResolvedAgentsRuntimeConfig,
+    resolve_agents_config,
+)
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.runtime.claude_code.session_lines import (
     APPROVAL_INTERRUPT_CONTENT_EXACT,
@@ -99,10 +104,9 @@ from tracecat.agent.session.types import (
     is_session_readonly,
 )
 from tracecat.agent.stream.connector import AgentStream
-from tracecat.agent.subagents import (
-    ResolvedAgentsConfig,
-)
+from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.agent.types import AgentConfig, ClaudeSDKMessageTA
+from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.artifacts.bindings import ArtifactSideEffect
 from tracecat.artifacts.schemas import Artifact, ArtifactAdapter, ArtifactType
 from tracecat.audit.logger import audit_log
@@ -414,23 +418,16 @@ class AgentSessionService(BaseWorkspaceService):
         scopes = (self.role.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
         return self.role.model_copy(update={"scopes": scopes})
 
-    def _stage_root_turn_provenance(
+    def _stage_turn_provenance(
         self,
         *,
         session_id: uuid.UUID,
         run_id: uuid.UUID,
-        config: AgentConfig,
+        resolved_refs: ResolvedRefs | None,
     ) -> None:
-        """Stage the root resolution snapshot for a spawned turn.
+        """Stage the dispatch-time whole-tree resolution snapshot for this turn."""
 
-        Always staged, even when a later subagent activity will append a
-        merged snapshot: any failure between spawn and that write (custom
-        model provider config, session load, subagent resolution) must still
-        leave the turn's root refs on record. The highest ``surrogate_id``
-        per ``wf_exec_id`` is the final snapshot.
-        """
-
-        if config.resolved_refs is None:
+        if resolved_refs is None:
             return
 
         self.session.add(
@@ -438,9 +435,39 @@ class AgentSessionService(BaseWorkspaceService):
                 workspace_id=self.workspace_id,
                 session_id=session_id,
                 wf_exec_id=str(run_id),
-                resolved_refs=config.resolved_refs.model_dump(mode="json"),
+                resolved_refs=resolved_refs.model_dump(mode="json"),
             )
         )
+
+    async def _resolve_dispatch_agents_config(
+        self,
+        *,
+        agent_session: AgentSession,
+        config: AgentConfig,
+    ) -> ResolvedAgentsRuntimeConfig:
+        """Resolve the runtime agents tree before Temporal dispatch."""
+
+        agents_config = config.agents
+        if not agents_config.enabled:
+            return ResolvedAgentsRuntimeConfig(resolved_refs=config.resolved_refs)
+        if not agents_config.subagents:
+            return ResolvedAgentsRuntimeConfig(
+                enabled=True,
+                resolved_refs=config.resolved_refs,
+            )
+
+        resolved = await resolve_agents_config(
+            AgentPresetService(self.session, self.role),
+            agents=agents_config,
+            parent_preset_id=agent_session.agent_preset_id,
+            include_runtime_config=True,
+        )
+        runtime_config = resolved.to_runtime_config()
+        runtime_config.resolved_refs = merge_resolved_refs(
+            config.resolved_refs,
+            runtime_config.resolved_refs,
+        )
+        return runtime_config
 
     async def _get_default_tools(self, entity_type: AgentSessionEntity) -> list[str]:
         """Get entitlement-aware default tools for a session entity type."""
@@ -2145,10 +2172,14 @@ class AgentSessionService(BaseWorkspaceService):
                 await check_entitlement(
                     self.session, self.role, Entitlement.AGENT_ADDONS
                 )
-            self._stage_root_turn_provenance(
+            resolved_agents_config = await self._resolve_dispatch_agents_config(
+                agent_session=agent_session,
+                config=agent_config,
+            )
+            self._stage_turn_provenance(
                 session_id=session_id,
                 run_id=run_id,
-                config=agent_config,
+                resolved_refs=resolved_agents_config.resolved_refs,
             )
 
             args = RunAgentArgs(
@@ -2157,6 +2188,7 @@ class AgentSessionService(BaseWorkspaceService):
                 active_stream_id=stream_id,
                 curr_run_id=run_id,
                 config=agent_config,
+                resolved_agents_config=resolved_agents_config,
             )
 
             client = await get_temporal_client()
@@ -2171,6 +2203,7 @@ class AgentSessionService(BaseWorkspaceService):
                 tools=agent_session.tools,
                 agent_preset_id=agent_session.agent_preset_id,
                 agent_preset_version_id=agent_session.agent_preset_version_id,
+                resolved_agent_config=agent_config_to_payload(agent_config),
             )
 
             # Pin run_id (approval lookups) and the per-turn stream id before


### PR DESCRIPTION
## Mental model

Resources float within a workspace. A new run resolves current ResourceHeads once at dispatch, then carries exact ResourceVersion IDs for that run. Later turns resolve heads again by default. An explicitly selected historical root version remains a preview/restore input, not a dependency closure: its child edges still resolve through heads. Existing in-flight Temporal histories may restore their recorded exact bindings.

## Summary

- Resolve the complete root, skill, and subagent graph in `AgentSessionService` before `start_workflow`.
- Pass the exact root config and resolved subagent tree through optional workflow payload fields, so new histories schedule no resolution activities.
- Stage one whole-tree provenance snapshot and one per-turn `agents_binding` before dispatch.
- Resolve heads again for every new turn, including sessions with existing SDK history.
- Preserve the legacy activity and stored-binding path only for histories created before the new dispatch fields existed.
- Guard the legacy activity-side provenance writer against sequential duplicate inserts.

## Temporal compatibility

- New payload fields are optional and default to `None`.
- Old histories continue down the command sequence already recorded in history.
- New histories branch only on payload data fixed at workflow start.
- No database migration is required.

## Rolling-deploy window

During a rolling deploy of this PR, API pods and agent workers upgrade
independently on the same task queue. A new API pod attaches the
dispatch-time resource snapshot (`resolved_agents_config` /
`resolved_agent_config`) to the workflow input; a not-yet-upgraded worker
deserializes those args with `extra="ignore"`, drops the snapshot, and falls
back to the pre-existing preserved-session resolution path (the session's
stored binding). Two consequences, both bounded to the window:

- A turn dispatched with freshly resolved child configuration may execute
  the session's stored (older) subagent graph — i.e. old workers keep
  pre-dispatch-resolution semantics.
- The per-turn provenance row is staged at dispatch with the fresh
  resolution, so for such turns provenance can record a newer resolution
  than the one the old worker actually executed.

This is a deliberate, bounded rolling-deploy artifact: it self-heals as soon
as old workers drain, requires no operator action, and is consistent with
the expand-window posture used across this stack (old pods keep old
semantics until drained). Worker build-id versioning was considered and
declined for this release.

**Deploy notes (include in the release notes for this PR's release):**

```
Agent workers: during the rolling window, turns picked up by
not-yet-upgraded workers resolve subagents from the session's stored binding
rather than the dispatch-time snapshot, and per-turn provenance may record
the dispatch-time resolution instead of the executed one. Self-heals when
all workers are upgraded; no action required. Drain or restart old agent
workers promptly to minimize the window.
```

## Verification

- `uv run pytest -q tests/unit/test_agent_session_preset_versioning.py tests/unit/test_agent_session_activities.py tests/unit/test_agent_preset_activities.py` — 43 passed
- `uv run pytest -q tests/temporal/test_durable_agent_workflow.py -x` — 17 passed, 4 skipped
- Ruff check and format check on all changed Python files
- Focused basedpyright on all changed Python files — 0 errors, 0 warnings
- `uv run alembic heads` — `b4e6c8a2d0f1`

Part of ENG-1530. Stacks on #3007.
