### PR TITLE
feat(audit): add webhook test-fire endpoint and settings UI

### DIFF
--- a/docs/self-hosting/audit-logs.mdx
+++ b/docs/self-hosting/audit-logs.mdx
@@ -16,6 +16,12 @@ Tracecat adds these headers to each delivery:
 | `X-Tracecat-Event-Id` | The audit event `id`. |
 | `X-Tracecat-Timestamp` | The audit event `created_at` timestamp. |
 
+## Test webhook delivery
+
+Use the test action in audit log settings to send a synchronous test event to the configured webhook. Tracecat sends the request with the same headers, payload wrapper, custom payload, and TLS verification setting as normal delivery, but skips the Redis delivery buffer.
+
+The test delivery is marked with `X-Tracecat-Test: true`. The event also includes `data.test: true` unless a custom payload overrides `data`, and the UI shows the receiver status code or request error category.
+
 ## Envelope v1
 
 Audit events use this JSON envelope:

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5555,6 +5555,42 @@ export const $AuditSettingsUpdate = {
   description: "Settings for audit logging.",
 } as const
 
+export const $AuditWebhookTestResult = {
+  properties: {
+    ok: {
+      type: "boolean",
+      title: "Ok",
+    },
+    receiver_status_code: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Receiver Status Code",
+    },
+    error_category: {
+      anyOf: [
+        {
+          type: "string",
+          enum: ["receiver_error", "timeout", "request_error"],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Error Category",
+    },
+  },
+  type: "object",
+  required: ["ok"],
+  title: "AuditWebhookTestResult",
+  description: "Result of a synchronous audit webhook test-fire request.",
+} as const
+
 export const $AuthDiscoverRequest = {
   properties: {
     email: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -88,6 +88,7 @@ import type {
   AdminRevokeOrganizationInvitationResponse,
   AdminSyncOrgRepositoryData,
   AdminSyncOrgRepositoryResponse,
+  AdminTestAuditWebhookResponse,
   AdminUpdateAuditSettingsData,
   AdminUpdateAuditSettingsResponse,
   AdminUpdateOrganizationData,
@@ -694,6 +695,7 @@ import type {
   SettingsGetAuditSettingsResponse,
   SettingsGetGitSettingsResponse,
   SettingsGetSamlSettingsResponse,
+  SettingsTestAuditWebhookResponse,
   SettingsUpdateAgentSettingsData,
   SettingsUpdateAgentSettingsResponse,
   SettingsUpdateAppSettingsData,
@@ -7690,6 +7692,20 @@ export const adminUpdateAuditSettings = (
 }
 
 /**
+ * Test Audit Webhook
+ * Send a test event to the platform audit webhook.
+ * @returns AuditWebhookTestResult Successful Response
+ * @throws ApiError
+ */
+export const adminTestAuditWebhook =
+  (): CancelablePromise<AdminTestAuditWebhookResponse> => {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/admin/settings/audit/test",
+    })
+  }
+
+/**
  * Get Registry Settings
  * Get platform registry settings.
  * @returns PlatformRegistrySettingsRead Successful Response
@@ -8965,6 +8981,19 @@ export const settingsUpdateAuditSettings = (
     },
   })
 }
+
+/**
+ * Test Audit Webhook
+ * @returns AuditWebhookTestResult Successful Response
+ * @throws ApiError
+ */
+export const settingsTestAuditWebhook =
+  (): CancelablePromise<SettingsTestAuditWebhookResponse> => {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/settings/audit/test",
+    })
+  }
 
 /**
  * Get Agent Settings

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1401,6 +1401,15 @@ export type AuditSettingsUpdate = {
 }
 
 /**
+ * Result of a synchronous audit webhook test-fire request.
+ */
+export type AuditWebhookTestResult = {
+  ok: boolean
+  receiver_status_code?: number | null
+  error_category?: "receiver_error" | "timeout" | "request_error" | null
+}
+
+/**
  * Request payload for pre-auth discovery.
  */
 export type AuthDiscoverRequest = {
@@ -11911,6 +11920,8 @@ export type AdminUpdateAuditSettingsData = {
 
 export type AdminUpdateAuditSettingsResponse = PlatformAuditSettingsRead
 
+export type AdminTestAuditWebhookResponse = AuditWebhookTestResult
+
 export type AdminGetRegistrySettingsResponse = PlatformRegistrySettingsRead
 
 export type AdminUpdateRegistrySettingsData = {
@@ -12280,6 +12291,8 @@ export type SettingsUpdateAuditSettingsData = {
 }
 
 export type SettingsUpdateAuditSettingsResponse = void
+
+export type SettingsTestAuditWebhookResponse = AuditWebhookTestResult
 
 export type SettingsGetAgentSettingsResponse = AgentSettingsRead
 
@@ -17356,6 +17369,16 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/admin/settings/audit/test": {
+    post: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AuditWebhookTestResult
+      }
+    }
+  }
   "/admin/settings/registry": {
     get: {
       res: {
@@ -18098,6 +18121,16 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError
+      }
+    }
+  }
+  "/settings/audit/test": {
+    post: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AuditWebhookTestResult
       }
     }
   }

--- a/frontend/src/components/admin/platform-audit-settings.tsx
+++ b/frontend/src/components/admin/platform-audit-settings.tsx
@@ -10,6 +10,8 @@ export function PlatformAuditSettings() {
     auditSettingsError,
     updateAuditSettings,
     updateAuditSettingsIsPending,
+    testAuditWebhook,
+    testAuditWebhookIsPending,
   } = useAdminAuditSettings()
 
   return (
@@ -19,6 +21,8 @@ export function PlatformAuditSettings() {
       auditSettingsError={auditSettingsError}
       updateAuditSettings={updateAuditSettings}
       updateAuditSettingsIsPending={updateAuditSettingsIsPending}
+      testAuditWebhook={testAuditWebhook}
+      testAuditWebhookIsPending={testAuditWebhookIsPending}
       decryptFailureTitle="Unable to decrypt platform settings"
     />
   )

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2Icon,
   LogsIcon,
   PlusIcon,
+  SendIcon,
   Trash2Icon,
   UnlinkIcon,
 } from "lucide-react"
@@ -150,6 +151,8 @@ interface AuditSettingsFormProps {
     requestBody: AuditSettingsUpdateBody
   }) => Promise<unknown>
   updateAuditSettingsIsPending: boolean
+  testAuditWebhook: () => void
+  testAuditWebhookIsPending: boolean
   decryptFailureTitle?: string
 }
 
@@ -245,6 +248,8 @@ export function AuditSettingsForm({
   auditSettingsError,
   updateAuditSettings,
   updateAuditSettingsIsPending,
+  testAuditWebhook,
+  testAuditWebhookIsPending,
   decryptFailureTitle = "Unable to decrypt organization settings",
 }: AuditSettingsFormProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -408,41 +413,56 @@ export function AuditSettingsForm({
         </Alert>
       )}
 
-      <div className="flex items-center justify-between rounded-lg border p-4">
-        <div className="flex items-center gap-3">
+      <div className="space-y-2">
+        <div className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            {isConnected ? (
+              <CheckCircle2Icon className="size-5 text-green-500" />
+            ) : (
+              <LogsIcon className="size-5 text-muted-foreground" />
+            )}
+            <div>
+              <p className="text-sm font-medium">Audit logs endpoint</p>
+              <p className="text-xs text-muted-foreground">
+                {connectionDescription}
+              </p>
+            </div>
+          </div>
           {isConnected ? (
-            <CheckCircle2Icon className="size-5 text-green-500" />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => testAuditWebhook()}
+                disabled={
+                  testAuditWebhookIsPending || updateAuditSettingsIsPending
+                }
+                className="gap-2"
+              >
+                <SendIcon className="size-3.5" />
+                {testAuditWebhookIsPending ? "Testing..." : "Test"}
+              </Button>
+              <Button size="sm" onClick={() => handleDialogOpenChange(true)}>
+                Update
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={handleDisconnect}
+                disabled={updateAuditSettingsIsPending}
+              >
+                <UnlinkIcon className="size-3.5" />
+                <span className="sr-only">Disconnect audit logs endpoint</span>
+              </Button>
+            </div>
           ) : (
-            <LogsIcon className="size-5 text-muted-foreground" />
-          )}
-          <div>
-            <p className="text-sm font-medium">Audit logs endpoint</p>
-            <p className="text-xs text-muted-foreground">
-              {connectionDescription}
-            </p>
-          </div>
-        </div>
-        {isConnected ? (
-          <div className="flex items-center gap-2">
             <Button size="sm" onClick={() => handleDialogOpenChange(true)}>
-              Update
+              Connect
             </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              size="sm"
-              onClick={handleDisconnect}
-              disabled={updateAuditSettingsIsPending}
-            >
-              <UnlinkIcon className="size-3.5" />
-              <span className="sr-only">Disconnect audit logs endpoint</span>
-            </Button>
-          </div>
-        ) : (
-          <Button size="sm" onClick={() => handleDialogOpenChange(true)}>
-            Connect
-          </Button>
-        )}
+          )}
+        </div>
       </div>
 
       <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
@@ -638,6 +658,8 @@ export function OrgSettingsAuditForm() {
     auditSettingsError,
     updateAuditSettings,
     updateAuditSettingsIsPending,
+    testAuditWebhook,
+    testAuditWebhookIsPending,
   } = useOrgAuditSettings()
 
   return (
@@ -647,6 +669,8 @@ export function OrgSettingsAuditForm() {
       auditSettingsError={auditSettingsError}
       updateAuditSettings={updateAuditSettings}
       updateAuditSettingsIsPending={updateAuditSettingsIsPending}
+      testAuditWebhook={testAuditWebhook}
+      testAuditWebhookIsPending={testAuditWebhookIsPending}
     />
   )
 }

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -20,6 +20,7 @@ import {
   type AdminUserRead,
   type AgentCatalogListResponse,
   type AgentCatalogRead,
+  type AuditWebhookTestResult,
   adminCreateOrganization,
   adminCreateOrganizationDomain,
   adminCreateOrganizationInvitation,
@@ -55,6 +56,7 @@ import {
   adminRegistrySyncRepository,
   adminRevokeOrganizationInvitation,
   adminSyncOrgRepository,
+  adminTestAuditWebhook,
   adminUpdateAuditSettings,
   adminUpdateOrganization,
   adminUpdateOrganizationDomain,
@@ -80,7 +82,16 @@ import {
   type TierUpdate,
 } from "@/client"
 import { request as apiRequest } from "@/client/core/request"
-import { retryHandler, type TracecatApiError } from "@/lib/errors"
+import { toast } from "@/components/ui/use-toast"
+import {
+  getAuditWebhookTestDescription,
+  getAuditWebhookTestTitle,
+} from "@/lib/audit-webhook-test"
+import {
+  getApiErrorDetail,
+  retryHandler,
+  type TracecatApiError,
+} from "@/lib/errors"
 
 export interface AdminPlatformCatalogEntry {
   id: string
@@ -888,6 +899,25 @@ export function useAdminAuditSettings() {
     },
   })
 
+  const { mutate: testAuditWebhook, isPending: testAuditWebhookIsPending } =
+    useMutation<AuditWebhookTestResult, TracecatApiError>({
+      mutationFn: adminTestAuditWebhook,
+      onSuccess: (result) => {
+        toast({
+          title: getAuditWebhookTestTitle(result),
+          description: getAuditWebhookTestDescription(result),
+          variant: result.ok ? "default" : "destructive",
+        })
+      },
+      onError: (error) => {
+        console.error("Failed to test platform audit webhook", error)
+        toast({
+          title: "Failed to test audit webhook",
+          description: getApiErrorDetail(error) ?? "Unknown error",
+        })
+      },
+    })
+
   return {
     auditSettings,
     auditSettingsIsLoading,
@@ -895,6 +925,8 @@ export function useAdminAuditSettings() {
     updateAuditSettings,
     updateAuditSettingsIsPending,
     updateAuditSettingsError,
+    testAuditWebhook,
+    testAuditWebhookIsPending,
   }
 }
 

--- a/frontend/src/lib/audit-webhook-test.ts
+++ b/frontend/src/lib/audit-webhook-test.ts
@@ -1,0 +1,31 @@
+import type { AuditWebhookTestResult } from "@/client"
+
+function formatErrorCategory(category: string | null | undefined): string {
+  switch (category) {
+    case "receiver_error":
+      return "receiver error"
+    case "timeout":
+      return "timeout"
+    case "request_error":
+      return "request error"
+    default:
+      return "request failed"
+  }
+}
+
+export function getAuditWebhookTestTitle(
+  result: AuditWebhookTestResult
+): string {
+  return result.ok
+    ? "Audit webhook test succeeded"
+    : "Audit webhook test failed"
+}
+
+export function getAuditWebhookTestDescription(
+  result: AuditWebhookTestResult
+): string {
+  if (result.receiver_status_code != null) {
+    return `Receiver returned ${result.receiver_status_code}.`
+  }
+  return `Tracecat could not reach the receiver: ${formatErrorCategory(result.error_category)}.`
+}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -24,6 +24,7 @@ import {
   ApiError,
   type AppSettingsRead,
   type AuditSettingsRead,
+  type AuditWebhookTestResult,
   type AwsAssumeRoleAccessRead,
   actionsDeleteAction,
   actionsGetAction,
@@ -251,6 +252,7 @@ import {
   settingsGetAuditSettings,
   settingsGetGitSettings,
   settingsGetSamlSettings,
+  settingsTestAuditWebhook,
   settingsUpdateAgentSettings,
   settingsUpdateAppSettings,
   settingsUpdateAuditSettings,
@@ -372,6 +374,10 @@ import {
 import { toast } from "@/components/ui/use-toast"
 import { type AgentSessionWithStatus, enrichAgentSession } from "@/lib/agents"
 import { client as apiClient, getBaseUrl } from "@/lib/api"
+import {
+  getAuditWebhookTestDescription,
+  getAuditWebhookTestTitle,
+} from "@/lib/audit-webhook-test"
 import {
   listCaseDurationDefinitions,
   listCaseDurations,
@@ -3041,6 +3047,34 @@ export function useOrgAuditSettings() {
     },
   })
 
+  const { mutate: testAuditWebhook, isPending: testAuditWebhookIsPending } =
+    useMutation<AuditWebhookTestResult, TracecatApiError>({
+      mutationFn: settingsTestAuditWebhook,
+      onSuccess: (result) => {
+        toast({
+          title: getAuditWebhookTestTitle(result),
+          description: getAuditWebhookTestDescription(result),
+          variant: result.ok ? "default" : "destructive",
+        })
+      },
+      onError: (error: TracecatApiError) => {
+        switch (error.status) {
+          case 403:
+            toast({
+              title: "Forbidden",
+              description: "You cannot perform this action",
+            })
+            break
+          default:
+            console.error("Failed to test audit webhook", error)
+            toast({
+              title: "Failed to test audit webhook",
+              description: getApiErrorDetail(error) ?? "Unknown error",
+            })
+        }
+      },
+    })
+
   return {
     // Get
     auditSettings,
@@ -3050,6 +3084,9 @@ export function useOrgAuditSettings() {
     updateAuditSettings,
     updateAuditSettingsIsPending,
     updateAuditSettingsError,
+    // Test
+    testAuditWebhook,
+    testAuditWebhookIsPending,
   }
 }
 

--- a/packages/tracecat-ee/tracecat_ee/admin/settings/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/settings/router.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 
+from tracecat.audit.test_fire import (
+    AuditWebhookNotConfiguredError,
+    AuditWebhookTestResult,
+    test_fire_audit_webhook,
+)
 from tracecat.auth.credentials import SuperuserRole
 from tracecat.db.dependencies import AsyncDBSessionBypass
 from tracecat_ee.admin.settings.schemas import (
@@ -36,6 +41,26 @@ async def update_audit_settings(
     """Update platform audit settings."""
     service = AdminSettingsService(session, role)
     return await service.update_audit_settings(params)
+
+
+@router.post("/audit/test", response_model=AuditWebhookTestResult)
+async def test_audit_webhook(
+    role: SuperuserRole,
+    session: AsyncDBSessionBypass,
+) -> AuditWebhookTestResult:
+    """Send a test event to the platform audit webhook."""
+    try:
+        return await test_fire_audit_webhook(
+            sink="platform",
+            organization_id=None,
+            role=role,
+            session=session,
+        )
+    except AuditWebhookNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Audit webhook is not configured",
+        ) from exc
 
 
 @router.get("/registry", response_model=PlatformRegistrySettingsRead)

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -515,6 +515,7 @@ def test_org_settings_routes_remain_user_only() -> None:
         settings_router.update_app_settings,
         settings_router.get_audit_settings,
         settings_router.update_audit_settings,
+        settings_router.test_audit_webhook,
         settings_router.get_agent_settings,
         settings_router.update_agent_settings,
     ]

--- a/tests/unit/api/test_api_audit_webhook_test.py
+++ b/tests/unit/api/test_api_audit_webhook_test.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.audit.service import AuditWebhookConfig
+from tracecat.auth.types import Role
+
+
+class FakeAuditWebhookClient:
+    status_code = status.HTTP_200_OK
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, *, timeout: float, verify: bool) -> None:
+        self.timeout = timeout
+        self.verify = verify
+
+    async def __aenter__(self) -> FakeAuditWebhookClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str],
+    ) -> httpx.Response:
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": self.timeout,
+                "verify": self.verify,
+            }
+        )
+        return httpx.Response(self.status_code)
+
+
+class HangingAuditWebhookClient(FakeAuditWebhookClient):
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str],
+    ) -> httpx.Response:
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": self.timeout,
+                "verify": self.verify,
+            }
+        )
+        await asyncio.Event().wait()
+        raise AssertionError("wall-clock timeout should cancel the request")
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_client() -> None:
+    FakeAuditWebhookClient.status_code = status.HTTP_200_OK
+    FakeAuditWebhookClient.calls = []
+    HangingAuditWebhookClient.calls = []
+
+
+@pytest.fixture
+def sink_config() -> AuditWebhookConfig:
+    return AuditWebhookConfig(
+        webhook_url="https://audit.example.test/ingest",
+        custom_headers={
+            "X-Custom-Audit": "secret-value",
+            "x-tracecat-test": "false",
+        },
+        custom_payload={"customer_field": "customer-value"},
+        verify_ssl=False,
+        payload_attribute="event",
+    )
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_posts_marked_event(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_config: AuditWebhookConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_config = AsyncMock(return_value=sink_config)
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.resolve_audit_sink_config", resolve_config
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "ok": True,
+        "receiver_status_code": status.HTTP_200_OK,
+        "error_category": None,
+    }
+    resolve_config.assert_awaited_once()
+    resolve_call = resolve_config.await_args
+    assert resolve_call is not None
+    assert resolve_call.kwargs["sink"] == "organization"
+    assert resolve_call.kwargs["organization_id"] == test_admin_role.organization_id
+    assert resolve_call.kwargs["session"] is not None
+    assert len(FakeAuditWebhookClient.calls) == 1
+    call = FakeAuditWebhookClient.calls[0]
+    assert call["url"] == "https://audit.example.test/ingest"
+    assert call["verify"] is False
+    assert call["timeout"] == 5.0
+    assert call["headers"]["X-Custom-Audit"] == "secret-value"
+    assert "x-tracecat-test" not in call["headers"]
+    assert call["headers"]["X-Tracecat-Test"] == "true"
+    assert "X-Tracecat-Event-Id" in call["headers"]
+    assert "X-Tracecat-Timestamp" in call["headers"]
+    event = call["json"]["event"]
+    assert event["organization_id"] == str(test_admin_role.organization_id)
+    assert event["actor_id"] == str(test_admin_role.user_id)
+    assert event["resource_type"] == "organization_setting"
+    assert event["resource_id"] is None
+    assert event["action"] == "connect"
+    assert event["data"] == {"test": True}
+    assert event["customer_field"] == "customer-value"
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_surfaces_receiver_error(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_config: AuditWebhookConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeAuditWebhookClient.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.resolve_audit_sink_config",
+        AsyncMock(return_value=sink_config),
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "ok": False,
+        "receiver_status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "error_category": "receiver_error",
+    }
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_enforces_wall_clock_timeout(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_config: AuditWebhookConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire._AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.resolve_audit_sink_config",
+        AsyncMock(return_value=sink_config),
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.httpx.AsyncClient", HangingAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "ok": False,
+        "receiver_status_code": None,
+        "error_category": "timeout",
+    }
+    assert len(HangingAuditWebhookClient.calls) == 1
+    assert HangingAuditWebhookClient.calls[0]["headers"]["X-Tracecat-Test"] == "true"
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_returns_400_when_unconfigured(
+    client: TestClient,
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.resolve_audit_sink_config",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Audit webhook is not configured"}
+    assert FakeAuditWebhookClient.calls == []
+
+
+@pytest.mark.anyio
+async def test_platform_audit_webhook_test_posts_platform_event(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_config: AuditWebhookConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_config = AsyncMock(return_value=sink_config)
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.resolve_audit_sink_config", resolve_config
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.test_fire.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/admin/settings/audit/test")
+
+    assert response.status_code == status.HTTP_200_OK
+    resolve_config.assert_awaited_once()
+    resolve_call = resolve_config.await_args
+    assert resolve_call is not None
+    assert resolve_call.kwargs["sink"] == "platform"
+    assert resolve_call.kwargs["organization_id"] is None
+    assert resolve_call.kwargs["session"] is not None
+    assert len(FakeAuditWebhookClient.calls) == 1
+    event = FakeAuditWebhookClient.calls[0]["json"]["event"]
+    assert event["organization_id"] is None
+    assert event["actor_id"] == str(test_admin_role.user_id)
+    assert event["resource_type"] == "platform_setting"
+    assert event["resource_id"] is None
+    assert event["data"] == {"test": True}

--- a/tracecat/audit/delivery.py
+++ b/tracecat/audit/delivery.py
@@ -12,6 +12,7 @@ import orjson
 from cryptography.fernet import InvalidToken
 from pydantic import ValidationError
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
 from tracecat.audit.constants import (
@@ -49,6 +50,125 @@ _AUDIT_WEBHOOK_SETTING_KEYS = (
     _WEBHOOK_VERIFY_SSL_KEY,
     _WEBHOOK_PAYLOAD_ATTRIBUTE_KEY,
 )
+
+
+async def resolve_audit_sink_config(
+    session: AsyncSession,
+    sink: AuditSink,
+    organization_id: uuid.UUID | None,
+) -> AuditWebhookConfig | None:
+    """Resolve and validate the webhook config used for audit delivery."""
+    values = await get_audit_sink_settings(session, sink, organization_id)
+    return build_audit_sink_config(values)
+
+
+async def get_audit_sink_settings(
+    session: AsyncSession,
+    sink: AuditSink,
+    organization_id: uuid.UUID | None,
+) -> dict[str, Any]:
+    if sink == "platform":
+        return await get_platform_audit_sink_settings(session)
+    if organization_id is None:
+        return {}
+
+    role = get_audit_sink_service_role(organization_id)
+    return {
+        _WEBHOOK_URL_KEY: await get_setting(
+            _WEBHOOK_URL_KEY, role=role, session=session
+        ),
+        _WEBHOOK_CUSTOM_HEADERS_KEY: await get_setting(
+            _WEBHOOK_CUSTOM_HEADERS_KEY, role=role, session=session
+        ),
+        _WEBHOOK_CUSTOM_PAYLOAD_KEY: await get_setting(
+            _WEBHOOK_CUSTOM_PAYLOAD_KEY, role=role, session=session
+        ),
+        _WEBHOOK_VERIFY_SSL_KEY: await get_setting(
+            _WEBHOOK_VERIFY_SSL_KEY,
+            role=role,
+            session=session,
+            default=True,
+        ),
+        _WEBHOOK_PAYLOAD_ATTRIBUTE_KEY: await get_setting(
+            _WEBHOOK_PAYLOAD_ATTRIBUTE_KEY, role=role, session=session
+        ),
+    }
+
+
+async def get_platform_audit_sink_settings(
+    session: AsyncSession,
+) -> dict[str, Any]:
+    result = await session.execute(
+        select(PlatformSetting).where(
+            PlatformSetting.key.in_(_AUDIT_WEBHOOK_SETTING_KEYS)
+        )
+    )
+    values: dict[str, Any] = {}
+    for setting in result.scalars().all():
+        value = setting.value
+        if setting.is_encrypted:
+            try:
+                value = decrypt_value(value, key=get_db_encryption_key())
+            except (InvalidToken, ValueError) as exc:
+                logger.warning(
+                    "Failed to decrypt platform audit setting",
+                    key=setting.key,
+                    error_type=type(exc).__name__,
+                )
+                continue
+        values[setting.key] = orjson.loads(value)
+    return values
+
+
+def build_audit_sink_config(values: dict[str, Any]) -> AuditWebhookConfig | None:
+    webhook_url = clean_audit_sink_string(values.get(_WEBHOOK_URL_KEY))
+    if webhook_url is None:
+        return None
+
+    custom_headers = values.get(_WEBHOOK_CUSTOM_HEADERS_KEY)
+    if custom_headers is not None and not isinstance(custom_headers, dict):
+        logger.warning("audit_webhook_custom_headers must be a dict")
+        custom_headers = None
+
+    custom_payload = values.get(_WEBHOOK_CUSTOM_PAYLOAD_KEY)
+    if custom_payload is not None and not isinstance(custom_payload, dict):
+        logger.warning("audit_webhook_custom_payload must be a dict")
+        custom_payload = None
+
+    verify_ssl = values.get(_WEBHOOK_VERIFY_SSL_KEY, True)
+    if not isinstance(verify_ssl, bool):
+        logger.warning("audit_webhook_verify_ssl must be a bool")
+        verify_ssl = True
+
+    payload_attribute = clean_audit_sink_string(
+        values.get(_WEBHOOK_PAYLOAD_ATTRIBUTE_KEY)
+    )
+
+    return AuditWebhookConfig(
+        webhook_url=webhook_url,
+        custom_headers=custom_headers,
+        custom_payload=custom_payload,
+        verify_ssl=verify_ssl,
+        payload_attribute=payload_attribute,
+    )
+
+
+def clean_audit_sink_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def get_audit_sink_service_role(organization_id: uuid.UUID) -> Role:
+    return Role(
+        type="service",
+        workspace_id=None,
+        organization_id=organization_id,
+        user_id=None,
+        service_id="tracecat-api",
+        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-api"],
+    )
 
 
 class AuditDeliveryConsumer:
@@ -335,106 +455,13 @@ class AuditDeliveryConsumer:
                 return sink_config
 
         async with get_async_session_bypass_rls_context_manager() as session:
-            if sink == "platform":
-                values = await self._get_platform_settings(session)
-            elif organization_id is not None:
-                role = self._get_service_role(organization_id)
-                values = {
-                    _WEBHOOK_URL_KEY: await get_setting(
-                        _WEBHOOK_URL_KEY, role=role, session=session
-                    ),
-                    _WEBHOOK_CUSTOM_HEADERS_KEY: await get_setting(
-                        _WEBHOOK_CUSTOM_HEADERS_KEY, role=role, session=session
-                    ),
-                    _WEBHOOK_CUSTOM_PAYLOAD_KEY: await get_setting(
-                        _WEBHOOK_CUSTOM_PAYLOAD_KEY, role=role, session=session
-                    ),
-                    _WEBHOOK_VERIFY_SSL_KEY: await get_setting(
-                        _WEBHOOK_VERIFY_SSL_KEY,
-                        role=role,
-                        session=session,
-                        default=True,
-                    ),
-                    _WEBHOOK_PAYLOAD_ATTRIBUTE_KEY: await get_setting(
-                        _WEBHOOK_PAYLOAD_ATTRIBUTE_KEY, role=role, session=session
-                    ),
-                }
-            else:
-                values = {}
-
-        sink_config = self._build_sink_config(values)
+            sink_config = await resolve_audit_sink_config(
+                session=session,
+                sink=sink,
+                organization_id=organization_id,
+            )
         self._config_cache[cache_key] = (now + _CONFIG_CACHE_TTL_SECONDS, sink_config)
         return sink_config
-
-    async def _get_platform_settings(self, session) -> dict[str, Any]:
-        result = await session.execute(
-            select(PlatformSetting).where(
-                PlatformSetting.key.in_(_AUDIT_WEBHOOK_SETTING_KEYS)
-            )
-        )
-        values: dict[str, Any] = {}
-        for setting in result.scalars().all():
-            value = setting.value
-            if setting.is_encrypted:
-                try:
-                    value = decrypt_value(value, key=get_db_encryption_key())
-                except (InvalidToken, ValueError) as exc:
-                    logger.warning(
-                        "Failed to decrypt platform audit setting",
-                        key=setting.key,
-                        error_type=type(exc).__name__,
-                    )
-                    continue
-            values[setting.key] = orjson.loads(value)
-        return values
-
-    def _build_sink_config(self, values: dict[str, Any]) -> AuditWebhookConfig | None:
-        webhook_url = self._clean_string(values.get(_WEBHOOK_URL_KEY))
-        if webhook_url is None:
-            return None
-
-        custom_headers = values.get(_WEBHOOK_CUSTOM_HEADERS_KEY)
-        if custom_headers is not None and not isinstance(custom_headers, dict):
-            logger.warning("audit_webhook_custom_headers must be a dict")
-            custom_headers = None
-
-        custom_payload = values.get(_WEBHOOK_CUSTOM_PAYLOAD_KEY)
-        if custom_payload is not None and not isinstance(custom_payload, dict):
-            logger.warning("audit_webhook_custom_payload must be a dict")
-            custom_payload = None
-
-        verify_ssl = values.get(_WEBHOOK_VERIFY_SSL_KEY, True)
-        if not isinstance(verify_ssl, bool):
-            logger.warning("audit_webhook_verify_ssl must be a bool")
-            verify_ssl = True
-
-        payload_attribute = self._clean_string(
-            values.get(_WEBHOOK_PAYLOAD_ATTRIBUTE_KEY)
-        )
-
-        return AuditWebhookConfig(
-            webhook_url=webhook_url,
-            custom_headers=custom_headers,
-            custom_payload=custom_payload,
-            verify_ssl=verify_ssl,
-            payload_attribute=payload_attribute,
-        )
-
-    def _clean_string(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        cleaned = value.strip()
-        return cleaned or None
-
-    def _get_service_role(self, organization_id: uuid.UUID) -> Role:
-        return Role(
-            type="service",
-            workspace_id=None,
-            organization_id=organization_id,
-            user_id=None,
-            service_id="tracecat-api",
-            scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-api"],
-        )
 
     async def _is_circuit_open(
         self, sink: AuditSink, organization_id: uuid.UUID | None

--- a/tracecat/audit/test_fire.py
+++ b/tracecat/audit/test_fire.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Literal
+
+import httpx
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.audit.delivery import resolve_audit_sink_config
+from tracecat.audit.enums import AuditEventActor, AuditEventStatus
+from tracecat.audit.service import AuditableRole, build_audit_webhook_request
+from tracecat.audit.types import AuditEvent, AuditSink
+from tracecat.contexts import ctx_client_ip, ctx_request_id, ctx_user_agent
+from tracecat.logger import logger
+
+AuditWebhookTestErrorCategory = Literal[
+    "receiver_error",
+    "timeout",
+    "request_error",
+]
+
+_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS = 5.0
+
+
+class AuditWebhookNotConfiguredError(Exception):
+    """Raised when an audit webhook test is requested without a sink."""
+
+
+class AuditWebhookTestResult(BaseModel):
+    """Result of a synchronous audit webhook test-fire request."""
+
+    ok: bool
+    receiver_status_code: int | None = None
+    error_category: AuditWebhookTestErrorCategory | None = None
+
+
+async def test_fire_audit_webhook(
+    *,
+    sink: AuditSink,
+    organization_id: uuid.UUID | None,
+    role: AuditableRole,
+    session: AsyncSession,
+) -> AuditWebhookTestResult:
+    sink_config = await resolve_audit_sink_config(
+        session=session,
+        sink=sink,
+        organization_id=organization_id,
+    )
+    if sink_config is None:
+        raise AuditWebhookNotConfiguredError
+
+    event = _build_test_event(sink=sink, organization_id=organization_id, role=role)
+    body, headers = build_audit_webhook_request(payload=event, config=sink_config)
+    headers = {
+        key: value for key, value in headers.items() if key.lower() != "x-tracecat-test"
+    }
+    headers["X-Tracecat-Test"] = "true"
+
+    try:
+        async with asyncio.timeout(_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS):
+            async with httpx.AsyncClient(
+                timeout=_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS,
+                verify=sink_config.verify_ssl,
+            ) as client:
+                response = await client.post(
+                    sink_config.webhook_url,
+                    json=body,
+                    headers=headers,
+                )
+    except (TimeoutError, httpx.TimeoutException) as exc:
+        logger.warning(
+            "Audit webhook test timed out",
+            sink=sink,
+            error_type=type(exc).__name__,
+        )
+        return AuditWebhookTestResult(ok=False, error_category="timeout")
+    except httpx.RequestError as exc:
+        logger.warning(
+            "Audit webhook test request failed",
+            sink=sink,
+            error_type=type(exc).__name__,
+        )
+        return AuditWebhookTestResult(ok=False, error_category="request_error")
+
+    ok = response.is_success
+    return AuditWebhookTestResult(
+        ok=ok,
+        receiver_status_code=response.status_code,
+        error_category=None if ok else "receiver_error",
+    )
+
+
+def _build_test_event(
+    *,
+    sink: AuditSink,
+    organization_id: uuid.UUID | None,
+    role: AuditableRole,
+) -> AuditEvent:
+    actor_id = role.actor_id
+    if actor_id is None:
+        raise ValueError("Audit webhook test requires an auditable actor")
+    resource_type = "platform_setting" if sink == "platform" else "organization_setting"
+    return AuditEvent(
+        organization_id=organization_id,
+        workspace_id=getattr(role, "workspace_id", None),
+        actor_type=AuditEventActor.USER,
+        actor_id=actor_id,
+        actor_label=None,
+        ip_address=ctx_client_ip.get(),
+        user_agent=ctx_user_agent.get(),
+        request_id=ctx_request_id.get(),
+        resource_type=resource_type,
+        resource_id=None,
+        action="connect",
+        status=AuditEventStatus.SUCCESS,
+        data={"test": True},
+    )

--- a/tracecat/settings/router.py
+++ b/tracecat/settings/router.py
@@ -3,6 +3,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
+from tracecat.audit.test_fire import (
+    AuditWebhookNotConfiguredError,
+    AuditWebhookTestResult,
+    test_fire_audit_webhook,
+)
 from tracecat.auth.dependencies import OrgUserRole
 from tracecat.auth.enums import AuthType
 from tracecat.authz.controls import require_scope
@@ -226,6 +231,27 @@ async def update_audit_settings(
 ) -> None:
     service = SettingsService(session, role)
     await service.update_audit_settings(params)
+
+
+@router.post("/audit/test", response_model=AuditWebhookTestResult)
+@require_scope("org:settings:update")
+async def test_audit_webhook(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+) -> AuditWebhookTestResult:
+    try:
+        return await test_fire_audit_webhook(
+            sink="organization",
+            organization_id=role.organization_id,
+            role=role,
+            session=session,
+        )
+    except AuditWebhookNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Audit webhook is not configured",
+        ) from exc
 
 
 @router.get("/agent", response_model=AgentSettingsRead)


### PR DESCRIPTION
## Summary

PR 3 of the ENG-1514 audit-logs overhaul (stacked on #3011): audit webhook **test-fire**.

- `POST /settings/audit/test` (org; `org:settings:update` scope) and `POST /admin/settings/audit/test` (EE platform; superuser) synchronously send a clearly-marked test event to the configured audit webhook and return the receiver's status to the caller — validating the customer's receiver end-to-end.
- The test delivery goes through the **same payload builder, custom-payload merge, custom headers, and TLS verification** as real delivery, but bypasses the Redis buffer. Sink-config resolution is shared with the delivery consumer (factored, behavior-identical).
- Test deliveries are reliably discriminated by an additive `X-Tracecat-Test: true` header (a `data.test` marker is included best-effort but customer custom payloads may override `data`).
- Wall-clock capped with `asyncio.timeout` (httpx timeouts alone are per-operation — a byte-dripping receiver cannot pin the request). Unconfigured sink → 400. Receiver failures categorized (`receiver_error` / timeout / connection) with the receiver status code surfaced; sink URLs and raw httpx errors are never logged or returned.
- The test event is contract-valid v1 with `resource_id=null` (no fabricated ids for SIEMs to correlate against).
- Frontend: Test button on the shared audit settings form (org + platform admin surfaces), result via the standard mutation toasts; regenerated client.

<img width="1124" height="720" alt="image" src="https://github.com/user-attachments/assets/0ebc40b4-bb58-41c9-bf01-24c597797d1b" />


## Verification
- `ruff` / `basedpyright --warnings`: clean. Backend endpoint tests (happy path, receiver 500, unconfigured 400, role boundaries): pass. `biome` + frontend typecheck: pass.

Part of ENG-1514. Reviewed pre-submit by two independent adversarial review passes; all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
