### PR TITLE
fix(cases): serialize attachment quota checks per case

### DIFF
--- a/tests/unit/test_case_attachments_service.py
+++ b/tests/unit/test_case_attachments_service.py
@@ -1,11 +1,14 @@
+import asyncio
 import base64
 import os
 import uuid
+from datetime import UTC, datetime
 from io import BytesIO
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 from dotenv import dotenv_values
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
@@ -16,6 +19,8 @@ from tracecat.cases.attachments.service import CaseAttachmentService
 from tracecat.cases.enums import CaseEventType, CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.schemas import CaseCreate
 from tracecat.cases.service import CaseEventsService, CasesService
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.models import Case, CaseAttachment, CaseEvent, File
 from tracecat.exceptions import TracecatAuthorizationError, TracecatException
 from tracecat.storage.blob import ensure_bucket_exists
 from tracecat.storage.exceptions import (
@@ -472,3 +477,77 @@ async def test_cross_case_dedup_shares_file(
 
     assert a1.id != a2.id
     assert a1.file_id == a2.file_id
+
+
+@pytest.mark.anyio
+async def test_concurrent_uploads_cannot_exceed_attachment_limit(
+    configure_minio_for_attachments,
+    svc_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Concurrent uploads to the same case must not exceed the case limits.
+
+    Regression test for the attachment quota race: the count/storage checks
+    read aggregate state, so two uploads racing on separate database
+    connections could both pass the check before either commits. Uses real
+    sessions (not the savepoint-bound test session) so each upload holds its
+    own connection and transaction, like concurrent API requests do.
+    """
+    monkeypatch.setattr(config, "TRACECAT__MAX_ATTACHMENTS_PER_CASE", 1)
+
+    now = datetime.now(UTC)
+    case = Case(
+        workspace_id=svc_role.workspace_id,
+        summary="Concurrent attachment uploads",
+        description="Case for testing concurrent upload quota checks",
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.LOW,
+        status=CaseStatus.NEW,
+        created_at=now,
+        updated_at=now,
+    )
+
+    async def upload(tag: str) -> CaseAttachment:
+        content = f"racing attachment content {tag}".encode()
+        params = CaseAttachmentCreate(
+            file_name=f"race-{tag}.txt",
+            content_type="text/plain",
+            size=len(content),
+            content=content,
+        )
+        async with get_async_session_context_manager() as upload_session:
+            svc = CaseAttachmentService(session=upload_session, role=svc_role)
+            return await svc.create_attachment(case, params)
+
+    try:
+        async with get_async_session_context_manager() as setup_session:
+            setup_session.add(case)
+            await setup_session.commit()
+            await setup_session.refresh(case)
+
+        results = await asyncio.gather(upload("a"), upload("b"), return_exceptions=True)
+
+        successes = [r for r in results if isinstance(r, CaseAttachment)]
+        rejected = [r for r in results if isinstance(r, MaxAttachmentsExceededError)]
+        assert len(successes) == 1, f"Expected exactly one upload to win: {results}"
+        assert len(rejected) == 1, f"Expected exactly one upload rejected: {results}"
+
+        async with get_async_session_context_manager() as verify_session:
+            svc = CaseAttachmentService(session=verify_session, role=svc_role)
+            attachments = await svc.list_attachments(case)
+            assert len(attachments) == 1
+    finally:
+        # This test writes through real connections, so its rows survive the
+        # savepoint rollback and must be removed before workspace teardown.
+        async with get_async_session_context_manager() as cleanup_session:
+            await cleanup_session.execute(
+                delete(CaseAttachment).where(CaseAttachment.case_id == case.id)
+            )
+            await cleanup_session.execute(
+                delete(CaseEvent).where(CaseEvent.case_id == case.id)
+            )
+            await cleanup_session.execute(delete(Case).where(Case.id == case.id))
+            await cleanup_session.execute(
+                delete(File).where(File.workspace_id == svc_role.workspace_id)
+            )
+            await cleanup_session.commit()

--- a/tracecat/cases/attachments/service.py
+++ b/tracecat/cases/attachments/service.py
@@ -239,6 +239,14 @@ class CaseAttachmentService(BaseWorkspaceService):
                 f"({config.TRACECAT__MAX_ATTACHMENT_SIZE_BYTES / 1024 / 1024}MB)"
             )
 
+        # Serialize concurrent uploads for the same case: the limit checks below
+        # read aggregate state, so without a lock two in-flight uploads can both
+        # observe pre-insert counts/storage and exceed the case limits. The lock
+        # is released when this transaction commits or rolls back.
+        await self.session.execute(
+            select(Case.id).where(Case.id == case.id).with_for_update()
+        )
+
         # Validate case-level limits (count + storage) efficiently using actual size
         await self._assert_case_limits(case, actual_size)
 


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

`CaseAttachmentService.create_attachment` validates the per-case attachment count and storage limits with aggregate reads (`COUNT(*)` / `SUM(size)`) before inserting the new attachment. Nothing serializes concurrent uploads for the same case, so two requests can both observe the same pre-insert aggregates, both pass `_assert_case_limits`, and both commit — leaving the case over its configured limits.

This PR takes a row-level lock on the case (`SELECT ... FOR UPDATE`) right before the limit checks, mirroring what other case mutation paths already do via `CasesService.get_case(..., for_update=True)`. The lock is scoped to the upload transaction, so concurrent uploads to the same case queue behind each other and each one decides against committed state, while uploads to different cases stay fully parallel.

## Related Issues

Fixes #2970

## Screenshots / Recordings

N/A (no UI changes)

## Steps to QA

Added a regression test that reproduces the race with real concurrency — two uploads racing on independent database connections (not the savepoint-bound test session), with `TRACECAT__MAX_ATTACHMENTS_PER_CASE=1`:

```
uv run pytest tests/unit/test_case_attachments_service.py
```

- `test_concurrent_uploads_cannot_exceed_attachment_limit`: exactly one upload wins, the other gets `MaxAttachmentsExceededError`, and the case ends with exactly one attachment.
- The other 12 tests in the file pass unchanged, confirming single-uploader behavior is untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize per-case attachment quota checks by taking a row-level lock on the case in `CaseAttachmentService.create_attachment`. Concurrent uploads to the same case now queue, enforcing count/storage limits correctly; includes a regression test proving only one upload succeeds when the per-case limit is 1.

<sup>Written for commit bb1645e8ea3f6fe4a96fbf778e4ea972bddf0c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

