### PR TITLE
fix(registry): correct alertmedia search_users input schema

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/search_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/search_users.yml
@@ -27,17 +27,17 @@ definition:
       description: Phone number of the user to search for.
       default: ""
     has_email:
-      type: bool
+      type: bool | None
       description: Whether the user has an email.
-      default: ""
+      default: null
     has_phone:
-      type: bool
+      type: bool | None
       description: Whether the user has a phone number.
-      default: ""
+      default: null
     has_device:
-      type: bool
+      type: bool | None
       description: Whether the user has an registered device.
-      default: ""
+      default: null
     ordering:
       type: str
       description: Sort users in response by one of last_name, first_name, last_login, email, mobile_phone, date_updated. Add - before the field name to reverse the order (e.g. ?ordering=-last_name returns users sorted by last name Z-A)
@@ -59,6 +59,7 @@ definition:
           has_email: ${{ inputs.has_email }}
           has_phone: ${{ inputs.has_phone }}
           has_device: ${{ inputs.has_device }}
+          ordering: ${{ inputs.ordering }}
         headers:
           Item-Range: items=${{ inputs.item_range }}
           Authorization: Bearer ${{ SECRETS.alertmedia.ALERTMEDIA_API_KEY }}


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Two defects in `tools.alertmedia.search_users` where the declared inputs don't match what the action actually does:

1. **`has_email` / `has_phone` / `has_device` declare `type: bool` but `default: ""`.** The empty-string default violates the field's own type, so every validation of the default emits `PydanticSerializationUnexpectedValue` warnings and the generated schema advertises a boolean whose default isn't a boolean. Changed to `type: bool | None` with `default: null`, matching the `base_url` field pattern in the same file.

2. **`ordering` is declared in `expects` but never referenced by the template step**, so the documented sort control silently did nothing. It's now passed through to the `/api/users` query params.

## Related Issues

N/A — found while auditing template actions for `expects`/`steps` mismatches.

## Screenshots / Recordings

N/A (no UI changes)

## Steps to QA

Validate the template loads and its expects model behaves:

```python
from pathlib import Path
from tracecat.registry.actions.schemas import TemplateAction
from tracecat.expressions.expectations import create_expectation_model

ta = TemplateAction.from_yaml(Path("packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/search_users.yml"))
model = create_expectation_model(ta.definition.expects, "search_users")
model()                      # defaults validate with no serializer warnings
model(has_email=True)        # explicit booleans still work
```

Registry template validation (`uv run pytest tests/registry/test_templates.py`) covers schema loading in CI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `tools.alertmedia.search_users` template so input types are valid and the `ordering` parameter actually works. This removes schema warnings and enables server-side sorting.

- **Bug Fixes**
  - Set `has_email`, `has_phone`, and `has_device` to `bool | None` with `default: null` to replace invalid empty-string defaults.
  - Wire `ordering` through to the `/api/users` query params (was declared but unused).

<sup>Written for commit 5f87afcb4157f6ae3c5398571607b3fcddec7a5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

