### PR TITLE
fix(api): return adjacent page for reverse cursor pagination

### DIFF
--- a/tests/unit/test_case_table_rows_service.py
+++ b/tests/unit/test_case_table_rows_service.py
@@ -312,3 +312,76 @@ async def test_list_rows_cursor_uses_created_at_and_id_order(
         include_row_data=False,
     )
     assert [item.id for item in legacy_page.items] == [older_small_id, oldest_small_id]
+
+
+@pytest.mark.anyio
+async def test_list_rows_reverse_pagination_cursors_point_forward_and_back(
+    session: AsyncSession,
+    cases_service: CasesService,
+    case_rows_service: CaseTableRowsService,
+    tables_service: TablesService,
+) -> None:
+    """After paging backward, next/prev cursors must keep their meaning.
+
+    Regression test: cursors were computed from the already-reversed items and
+    then swapped again, so after one backward page "next" pointed at the
+    previous page and "prev" pointed at the next page.
+    """
+    case = await _create_case(cases_service)
+    table_id, _ = await _create_table_with_row(
+        tables_service,
+        name=f"case_rows_reverse_{uuid.uuid4().hex[:8]}",
+        value="seed",
+    )
+
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    links = [
+        CaseTableRow(
+            workspace_id=case_rows_service.workspace_id,
+            case_id=case.id,
+            table_id=table_id,
+            row_id=uuid.uuid4(),
+            created_at=base_time + timedelta(minutes=i),
+            updated_at=base_time + timedelta(minutes=i),
+        )
+        for i in range(6)
+    ]
+    session.add_all(links)
+    await session.commit()
+
+    # Display order is created_at desc: newest link first
+    display_ids = [
+        link.id for link in sorted(links, key=lambda x: x.created_at, reverse=True)
+    ]
+
+    async def page(cursor: str | None = None, reverse: bool = False):
+        return await case_rows_service.list_rows(
+            case_id=case.id,
+            limit=2,
+            cursor=cursor,
+            reverse=reverse,
+            include_row_data=False,
+        )
+
+    page1 = await page()
+    assert [item.id for item in page1.items] == display_ids[0:2]
+    page2 = await page(cursor=page1.next_cursor)
+    assert [item.id for item in page2.items] == display_ids[2:4]
+    page3 = await page(cursor=page2.next_cursor)
+    assert [item.id for item in page3.items] == display_ids[4:6]
+    assert page3.prev_cursor is not None
+
+    # Going back from page 3 must return page 2
+    back = await page(cursor=page3.prev_cursor, reverse=True)
+    assert [item.id for item in back.items] == display_ids[2:4]
+    assert back.has_more is True
+    assert back.has_previous is True
+
+    # next continues forward to page 3, prev continues backward to page 1
+    forward_again = await page(cursor=back.next_cursor)
+    assert [item.id for item in forward_again.items] == display_ids[4:6]
+
+    back_to_first = await page(cursor=back.prev_cursor, reverse=True)
+    assert [item.id for item in back_to_first.items] == display_ids[0:2]
+    assert back_to_first.has_more is True
+    assert back_to_first.has_previous is False

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1500,3 +1500,61 @@ class TestCasesService:
         # Verify the case was NOT created (entire transaction rolled back)
         cases = await _list_cases(cases_service)
         assert len(cases) == 0, "Case should not exist if fields creation failed"
+
+
+@pytest.mark.anyio
+async def test_search_cases_reverse_pagination_returns_adjacent_page(
+    cases_service: CasesService,
+) -> None:
+    """Paging backward must return the rows immediately before the cursor.
+
+    Regression test: without flipping the scan direction for reverse
+    pagination, LIMIT keeps the first rows of the whole backward prefix, so
+    "previous page" jumped to page 1 from any page 3 or deeper.
+    """
+    for i in range(9):
+        await cases_service.create_case(
+            CaseCreate(
+                summary=f"Reverse pagination case {i}",
+                description="Case for reverse pagination test",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+
+    async def page(cursor: str | None = None, reverse: bool = False):
+        return await cases_service.search_cases(
+            params=CursorPaginationParams(limit=3, cursor=cursor, reverse=reverse)
+        )
+
+    all_ids = [
+        c.id
+        for c in (
+            await cases_service.search_cases(params=CursorPaginationParams(limit=20))
+        ).items
+    ]
+    assert len(all_ids) == 9
+
+    page1 = await page()
+    assert [c.id for c in page1.items] == all_ids[0:3]
+    page2 = await page(cursor=page1.next_cursor)
+    assert [c.id for c in page2.items] == all_ids[3:6]
+    page3 = await page(cursor=page2.next_cursor)
+    assert [c.id for c in page3.items] == all_ids[6:9]
+    assert page3.prev_cursor is not None
+
+    # Going back from page 3 must return page 2, not page 1
+    back = await page(cursor=page3.prev_cursor, reverse=True)
+    assert [c.id for c in back.items] == all_ids[3:6]
+    assert back.has_more is True
+    assert back.has_previous is True
+
+    # The swapped cursors must keep pointing the right way
+    forward_again = await page(cursor=back.next_cursor)
+    assert [c.id for c in forward_again.items] == all_ids[6:9]
+
+    back_to_first = await page(cursor=back.prev_cursor, reverse=True)
+    assert [c.id for c in back_to_first.items] == all_ids[0:3]
+    assert back_to_first.has_more is True
+    assert back_to_first.has_previous is False

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -1434,6 +1434,54 @@ class TestTableRows:
         assert reverse_page.has_more is True
         assert reverse_page.has_previous is False
 
+    async def test_list_rows_reverse_pagination_returns_adjacent_page(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Paging backward must return the rows immediately before the cursor.
+
+        Regression test: without flipping the scan direction for reverse
+        pagination, LIMIT kept the first rows of the whole backward prefix,
+        so "previous page" jumped to page 1 from any page 3 or deeper.
+        """
+        for i in range(7):
+            await tables_service.insert_row(
+                table, TableRowInsert(data={"name": f"User{i}", "age": i})
+            )
+
+        all_rows = await _list_rows(tables_service, table)
+        ids = [row["id"] for row in all_rows]
+
+        page1 = await _list_rows_page(tables_service, table, limit=2)
+        page2 = await _list_rows_page(
+            tables_service, table, limit=2, cursor=page1.next_cursor
+        )
+        page3 = await _list_rows_page(
+            tables_service, table, limit=2, cursor=page2.next_cursor
+        )
+        assert [row["id"] for row in page3.items] == ids[4:6]
+        assert page3.prev_cursor is not None
+
+        # Going back from page 3 must return page 2, not page 1
+        back = await _list_rows_page(
+            tables_service, table, limit=2, cursor=page3.prev_cursor, reverse=True
+        )
+        assert [row["id"] for row in back.items] == ids[2:4]
+        assert back.has_more is True
+        assert back.has_previous is True
+
+        # The swapped cursors must keep pointing the right way
+        forward_again = await _list_rows_page(
+            tables_service, table, limit=2, cursor=back.next_cursor
+        )
+        assert [row["id"] for row in forward_again.items] == ids[4:6]
+
+        back_to_first = await _list_rows_page(
+            tables_service, table, limit=2, cursor=back.prev_cursor, reverse=True
+        )
+        assert [row["id"] for row in back_to_first.items] == ids[0:2]
+        assert back_to_first.has_more is True
+        assert back_to_first.has_previous is False
+
     async def test_table_editor_list_rows_reverse_pagination_flags(
         self, tables_service: TablesService, table: Table
     ) -> None:

--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -98,7 +98,9 @@ class CaseTableRowsService(BaseWorkspaceService):
                         ),
                     )
                 )
-                stmt = stmt.order_by(
+                # Replace (not append to) the base descending ORDER BY, so the
+                # reverse scan direction actually takes effect
+                stmt = stmt.order_by(None).order_by(
                     CaseTableRow.created_at.asc(), CaseTableRow.id.asc()
                 )
             else:
@@ -120,11 +122,8 @@ class CaseTableRowsService(BaseWorkspaceService):
         items = links[:limit] if has_more else links
         has_previous = cursor is not None
 
-        if reverse:
-            items = list(reversed(items))
-
-        hydrated = await self._hydrate_links(items, include_row_data=include_row_data)
-
+        # Cursors are computed from scan order (before restoring display
+        # order), then swapped so they match the response direction.
         next_cursor = None
         prev_cursor = None
         if items and has_more:
@@ -141,8 +140,11 @@ class CaseTableRowsService(BaseWorkspaceService):
             )
 
         if reverse:
+            items = list(reversed(items))
             next_cursor, prev_cursor = prev_cursor, next_cursor
             has_more, has_previous = has_previous, has_more
+
+        hydrated = await self._hydrate_links(items, include_row_data=include_row_data)
 
         return CursorPaginatedResponse(
             items=hydrated,

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -548,15 +548,21 @@ class CasesService(BaseWorkspaceService):
 
         # Apply sorting: (sort_col, id) for stable pagination
         # Use id as tie-breaker unless we're already sorting by id
+        # Reverse pagination scans in the opposite direction so LIMIT keeps the
+        # rows adjacent to the cursor; items are restored to display order below.
+        if params.reverse:
+            scan_direction = "desc" if sort_direction == "asc" else "asc"
+        else:
+            scan_direction = sort_direction
         if sort_column == "id":
             # No tie-breaker needed when sorting by id (already unique)
-            if sort_direction == "asc":
+            if scan_direction == "asc":
                 stmt = stmt.order_by(sort_attr.asc())
             else:
                 stmt = stmt.order_by(sort_attr.desc())
         else:
             # Add id as tie-breaker for non-unique columns
-            if sort_direction == "asc":
+            if scan_direction == "asc":
                 stmt = stmt.order_by(sort_attr.asc(), Case.id.asc())
             else:
                 stmt = stmt.order_by(sort_attr.desc(), Case.id.desc())
@@ -600,19 +606,18 @@ class CasesService(BaseWorkspaceService):
         if params.cursor and cases:
             first_case = cases[0]
             sort_value = get_cursor_sort_value(first_case)
-            # For reverse pagination, swap the cursor meaning
-            if params.reverse:
-                next_cursor = paginator.encode_cursor(
-                    first_case.id,
-                    sort_column=sort_column,
-                    sort_value=sort_value,
-                )
-            else:
-                prev_cursor = paginator.encode_cursor(
-                    first_case.id,
-                    sort_column=sort_column,
-                    sort_value=sort_value,
-                )
+            prev_cursor = paginator.encode_cursor(
+                first_case.id,
+                sort_column=sort_column,
+                sort_value=sort_value,
+            )
+
+        # If we were doing reverse pagination, restore display order and swap
+        # the cursors/flags to match the response direction
+        if params.reverse:
+            cases = list(reversed(cases))
+            next_cursor, prev_cursor = prev_cursor, next_cursor
+            has_more, has_previous = has_previous, has_more
 
         # Convert to CaseReadMinimal objects with tags and dropdown values
         case_items = []

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -1506,15 +1506,21 @@ class BaseTablesService(BaseWorkspaceService):
 
         # Apply sorting: (sort_col, id) for stable pagination
         # Use id as tie-breaker unless we're already sorting by id
+        # Reverse pagination scans in the opposite direction so LIMIT keeps the
+        # rows adjacent to the cursor; items are restored to display order below.
+        if params.reverse:
+            scan_direction = "desc" if sort_direction == "asc" else "asc"
+        else:
+            scan_direction = sort_direction
         if sort_column == "id":
             # No tie-breaker needed when sorting by id (already unique)
-            if sort_direction == "asc":
+            if scan_direction == "asc":
                 stmt = stmt.order_by(sort_col.asc())
             else:
                 stmt = stmt.order_by(sort_col.desc())
         else:
             # Add id as tie-breaker for non-unique columns
-            if sort_direction == "asc":
+            if scan_direction == "asc":
                 stmt = stmt.order_by(sort_col.asc(), sa.column("id").asc())
             else:
                 stmt = stmt.order_by(sort_col.desc(), sa.column("id").desc())


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Fixes reverse (`reverse=true`, i.e. "previous page") cursor pagination in three list endpoints. The reference implementations already in the codebase (`TableEditorService.list_rows`, `WorkflowsManagementService.list_workflows`) do it in four steps: flip the scan direction, fetch `limit + 1`, compute cursors from scan order, then reverse the items and swap cursors/flags. Each of the fixed endpoints was missing a different piece:

- **`CasesService.search_cases`**: flipped the cursor comparison but not the `ORDER BY`, so `LIMIT` kept the first rows of the whole backward prefix — "previous page" returned page 1 from any page 3 or deeper. It also never swapped `has_more`/`has_previous` and its reverse branch overwrote `next_cursor` while leaving `prev_cursor` as `null`. Now uses the canonical scan-flip + reverse + swap.
- **`TablesService.list_rows`** (the search-style method behind `search_rows`): same missing `ORDER BY` flip; the post-fetch reversal/swap was already there, so it reversed the wrong window. Now flips the scan direction to match.
- **`CaseTableRowsService.list_rows`**: had two problems. Its reverse branch appended ascending sort keys to a statement already built with `.order_by(created_at.desc(), id.desc())` — SQLAlchemy keeps the first sort keys, so the intended flip never took effect and the same wrong window came back. It also computed cursors from the already-reversed items and then swapped them again, so "next" pointed backward and "prev" pointed forward. The reverse branch now replaces the ORDER BY (`order_by(None)` first), and cursors are computed from scan order before the reversal, like the siblings.

Forward pagination is untouched in all three (the reverse handling is a no-op when `reverse` is false).

## Related Issues

Fixes #3022

## Screenshots / Recordings

N/A (API behavior fix)

## Steps to QA

```
uv run pytest tests/unit/test_cases_service.py tests/unit/test_tables_service.py tests/unit/test_case_table_rows_service.py
```

The new regression tests page three deep and then walk back — the existing reverse tests only went back from page 2, where "previous page" and "page 1" coincide, which is why the bug never surfaced:

- `test_search_cases_reverse_pagination_returns_adjacent_page`: back from page 3 returns page 2 (previously page 1), flags are oriented in display direction, and the swapped cursors round-trip forward to page 3 and back to page 1.
- `test_list_rows_reverse_pagination_returns_adjacent_page` (tables): same walk over 7 rows with `limit=2`.
- `test_list_rows_reverse_pagination_cursors_point_forward_and_back` (case table rows): after going back a page, `next_cursor` returns to page 3 and `prev_cursor` continues to page 1 (previously each pointed the other way).

All pre-existing pagination tests in the three files pass unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reverse cursor pagination so “previous page” returns the adjacent page with correct cursors and flags across `CasesService.search_cases`, `TablesService.list_rows`, and `CaseTableRowsService.list_rows`. Forward pagination is unchanged.

- **Bug Fixes**
  - Implemented the canonical reverse flow: flip scan direction, fetch `limit + 1`, compute cursors from scan order, then reverse items and swap `next/prev` and `has_more/has_previous`. Added regression tests that walk back from page 3 to page 2.
  - `CasesService.search_cases` and `TablesService.list_rows`: now flip `ORDER BY` for reverse scans; case search also fixes swapped/overwritten cursors and flags.
  - `CaseTableRowsService.list_rows`: replaces (not appends) the base `ORDER BY` when reversing; computes cursors before reversal and swaps correctly so `next` points forward and `prev` points back.

<sup>Written for commit 8613676562ee8ce66a77613c99bee6952d4a2ec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

