### PR TITLE
feat(ui): add sidebar organization switcher

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -494,6 +494,7 @@ import type {
   OrganizationGetInvitationTokenResponse,
   OrganizationGetOrganizationEntitlementsResponse,
   OrganizationGetOrganizationResponse,
+  OrganizationListCurrentUserOrganizationMembershipsResponse,
   OrganizationListInvitationsData,
   OrganizationListInvitationsResponse,
   OrganizationListMyPendingInvitationsResponse,
@@ -4129,6 +4130,20 @@ export const organizationDeleteOrganization = (
     },
   })
 }
+
+/**
+ * List Current User Organization Memberships
+ * List active organizations the current user belongs to.
+ * @returns tracecat__organization__schemas__OrgRead Successful Response
+ * @throws ApiError
+ */
+export const organizationListCurrentUserOrganizationMemberships =
+  (): CancelablePromise<OrganizationListCurrentUserOrganizationMembershipsResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/organization/memberships",
+    })
+  }
 
 /**
  * List Organization Domains

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -10826,6 +10826,9 @@ export type OrganizationDeleteOrganizationData = {
 
 export type OrganizationDeleteOrganizationResponse = void
 
+export type OrganizationListCurrentUserOrganizationMembershipsResponse =
+  Array<tracecat__organization__schemas__OrgRead>
+
 export type OrganizationListOrganizationDomainsResponse =
   Array<tracecat__organization__schemas__OrgDomainRead>
 
@@ -15317,6 +15320,16 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/memberships": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<tracecat__organization__schemas__OrgRead>
       }
     }
   }

--- a/frontend/src/components/sidebar/app-menu.tsx
+++ b/frontend/src/components/sidebar/app-menu.tsx
@@ -123,7 +123,9 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
       secure:
         typeof window !== "undefined" && window.location.protocol === "https:",
     })
-    router.push("/workspaces")
+    // Hard navigation: switching orgs invalidates all org-scoped client state
+    // (React Query caches, providers), so re-bootstrap instead of router.push.
+    window.location.assign("/workspaces")
   }
 
   return (

--- a/frontend/src/components/sidebar/app-menu.tsx
+++ b/frontend/src/components/sidebar/app-menu.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Cookies from "js-cookie"
 import {
   BuildingIcon,
   ChevronsUpDown,
@@ -37,6 +38,10 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import {
+  useOrganization,
+  useOrganizationMemberships,
+} from "@/hooks/use-organization"
 import { useWorkspaceManager } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import { getWorkspaceLandingPath } from "@/lib/workspace-navigation"
@@ -46,6 +51,8 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const { workspaces, createWorkspace } = useWorkspaceManager()
+  const { organization: activeOrganization } = useOrganization()
+  const { organizations } = useOrganizationMemberships()
   const canAdministerOrg = useScopeCheck("org:update")
   const canCreateWorkspace = useScopeCheck("workspace:create")
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -53,6 +60,7 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
   const [isCreating, setIsCreating] = useState(false)
 
   const activeWorkspace = workspaces?.find((ws) => ws.id === workspaceId)
+  const showOrganizationSelector = (organizations?.length ?? 0) > 1
 
   const buildWorkspaceHref = (
     targetWorkspaceId: string,
@@ -103,6 +111,19 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
       .map((word) => word[0])
       .join("")
       .toUpperCase()
+  }
+
+  const handleSelectOrganization = (organizationId: string) => {
+    if (organizationId === activeOrganization?.id) {
+      return
+    }
+
+    Cookies.set("tracecat:active-org-id", organizationId, {
+      sameSite: "lax",
+      secure:
+        typeof window !== "undefined" && window.location.protocol === "https:",
+    })
+    router.push("/workspaces")
   }
 
   return (
@@ -210,6 +231,34 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
                   </form>
                 </DialogContent>
               </Dialog>
+            )}
+
+            {showOrganizationSelector && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
+                  Organizations
+                </DropdownMenuLabel>
+                {organizations?.map((organization) => (
+                  <DropdownMenuItem
+                    key={organization.id}
+                    className={cn(
+                      "flex items-center gap-2 py-1 px-2",
+                      organization.id === activeOrganization?.id &&
+                        "bg-foreground/5 dark:bg-foreground/10"
+                    )}
+                    onSelect={() => handleSelectOrganization(organization.id)}
+                  >
+                    <div className="flex size-6 items-center justify-center rounded-md bg-muted text-[10px]">
+                      {getWorkspaceInitials(organization.name)}
+                    </div>
+                    <span className="flex-1">{organization.name}</span>
+                    {organization.id === activeOrganization?.id && (
+                      <CircleCheck className="ml-auto size-4" />
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </>
             )}
 
             <DropdownMenuSeparator />

--- a/frontend/src/hooks/use-organization.ts
+++ b/frontend/src/hooks/use-organization.ts
@@ -3,7 +3,9 @@
 import { useQuery } from "@tanstack/react-query"
 import {
   type OrganizationGetOrganizationResponse,
+  type OrganizationListCurrentUserOrganizationMembershipsResponse,
   organizationGetOrganization,
+  organizationListCurrentUserOrganizationMemberships,
 } from "@/client"
 
 /**
@@ -29,6 +31,34 @@ export function useOrganization({
 
   return {
     organization,
+    isLoading,
+    error,
+  }
+}
+
+/**
+ * Hook to fetch active organizations the current user belongs to.
+ *
+ * Used by the sidebar organization switcher to render only for multi-org users.
+ */
+export function useOrganizationMemberships({
+  enabled = true,
+}: {
+  enabled?: boolean
+} = {}) {
+  const {
+    data: organizations,
+    isLoading,
+    error,
+  } = useQuery<OrganizationListCurrentUserOrganizationMembershipsResponse>({
+    queryKey: ["organization-memberships"],
+    queryFn: organizationListCurrentUserOrganizationMemberships,
+    enabled,
+    retry: false,
+  })
+
+  return {
+    organizations,
     isLoading,
     error,
   }

--- a/tests/unit/api/test_api_organization_members.py
+++ b/tests/unit/api/test_api_organization_members.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 from tracecat.api.app import app
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
-from tracecat.db.engine import get_async_session
+from tracecat.db.engine import get_async_session, get_async_session_bypass_rls
 from tracecat.organization import router as organization_router
 
 
@@ -58,6 +58,30 @@ def _override_organization_role_dependencies(  # pyright: ignore[reportUnusedFun
         if metadata and hasattr(metadata[1], "dependency"):
             dependency = metadata[1].dependency
             app.dependency_overrides.pop(dependency, None)
+
+
+@pytest.mark.anyio
+async def test_list_current_user_organization_memberships(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    first_org_id = uuid.uuid4()
+    second_org_id = uuid.uuid4()
+    mock_session = await app.dependency_overrides[get_async_session_bypass_rls]()
+
+    memberships_result = Mock()
+    memberships_result.all.return_value = [
+        (first_org_id, "Alpha"),
+        (second_org_id, "Beta"),
+    ]
+    mock_session.execute = AsyncMock(return_value=memberships_result)
+
+    response = client.get("/organization/memberships")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == [
+        {"id": str(first_org_id), "name": "Alpha"},
+        {"id": str(second_org_id), "name": "Beta"},
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_organization_members.py
+++ b/tests/unit/api/test_api_organization_members.py
@@ -83,6 +83,20 @@ async def test_list_current_user_organization_memberships(
         {"id": str(second_org_id), "name": "Beta"},
     ]
 
+    # Tenant-isolation guard: the query must filter memberships by the
+    # authenticated user's id and only return active organizations. Compile
+    # the actual statement passed to execute so a regression that drops or
+    # broadens the user_id predicate fails here.
+    execute_await_args = mock_session.execute.await_args
+    assert execute_await_args is not None
+    stmt = execute_await_args.args[0]
+    compiled = stmt.compile()
+    sql = str(compiled)
+
+    assert "organization_membership.user_id = " in sql
+    assert "organization.is_active" in sql
+    assert test_admin_role.user_id in compiled.params.values()
+
 
 @pytest.mark.anyio
 async def test_list_org_members_omits_superuser_flag(

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -96,6 +96,36 @@ async def get_organization(
     return OrgRead(id=org.id, name=org.name)
 
 
+@router.get("/memberships", response_model=list[OrgRead])
+async def list_current_user_organization_memberships(
+    *,
+    role: AuthenticatedUserOnly,
+    session: AsyncDBSessionBypass,
+) -> list[OrgRead]:
+    """List active organizations the current user belongs to."""
+    # No org context exists yet when switching orgs, so this uses the
+    # RLS-bypass session like the invitation endpoints below. The user_id
+    # filter is the tenant-isolation control — keep it in any refactor.
+    # user_id is guaranteed to be set by AuthenticatedUserOnly
+    assert role.user_id is not None
+
+    stmt = (
+        select(Organization.id, Organization.name)
+        .join(
+            OrganizationMembership,
+            OrganizationMembership.organization_id == Organization.id,
+        )
+        .where(
+            OrganizationMembership.user_id == role.user_id,
+            Organization.is_active.is_(True),
+        )
+        .order_by(Organization.name.asc(), Organization.id.asc())
+    )
+    result = await session.execute(stmt)
+
+    return [OrgRead(id=org_id, name=name) for org_id, name in result.all()]
+
+
 @router.get("/domains", response_model=list[OrgDomainRead])
 @require_scope("org:read")
 async def list_organization_domains(


### PR DESCRIPTION
## Summary

Redo of #3026 (closed) with a passing `quality` check and a security-review pass.

- Add `GET /organization/memberships`: lists the active organizations the current user belongs to. Uses `AuthenticatedUserOnly` + the RLS-bypass session, matching the existing org-less invitation endpoints in the same router; the query is scoped to the authenticated user's own memberships.
- Add an `Organizations` section to the sidebar workspace dropdown, shown only when the user belongs to more than one organization. Selecting an org sets the `tracecat:active-org-id` cookie (an untrusted hint — membership is re-validated server-side on every request) and routes to `/workspaces`.
- Add a `useOrganizationMemberships` hook and a unit test for the endpoint.

### Changes from #3026

- Regenerated the frontend client with `just gen-client-ci` instead of hand-editing `services.gen.ts`/`types.gen.ts` — this is what broke the `quality` CI check on the original PR.
- Trimmed the endpoint docstring so auth-bypass internals are no longer published into the OpenAPI schema and generated client; the rationale lives in a code comment instead.
- Use `assert role.user_id is not None` like the sibling `AuthenticatedUserOnly` endpoints rather than an unreachable 401 branch.

## Tests

- `uv run ruff check` / `uv run ruff format --check` on touched Python files
- `uv run basedpyright --warnings tracecat/organization/router.py` — 0 errors, 0 warnings
- `uv run pytest tests/unit/api/test_api_organization_members.py` — 4 passed
- `pnpm -C frontend exec biome check` + `pnpm -C frontend run typecheck`
- Re-ran client generation and verified the diff is byte-identical (freshness check will pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sidebar organization switcher for multi-org users and a backend endpoint to list the user’s organizations. Also hardens org switching navigation and strengthens the membership test to enforce tenant isolation.

- New Features
  - Backend: `GET /organization/memberships` returns active orgs for the current user (`OrgRead[]`), gated by `AuthenticatedUserOnly` with an RLS-bypass session.
  - Frontend: Adds an “Organizations” section in the sidebar dropdown for users with >1 org; selecting an org sets the `tracecat:active-org-id` cookie and performs a hard navigation to `/workspaces` (secure on HTTPS, SameSite=Lax, ignores no-op when selecting the current org).
  - Client/Hook: Generated `organizationListCurrentUserOrganizationMemberships` and added `useOrganizationMemberships` for fetching memberships.
  - Tests: Added a unit test for the memberships endpoint and strengthened it to assert the SQL filters by `user_id` and `is_active`.

- Refactors
  - Regenerated frontend client with `just gen-client-ci` to satisfy quality checks.
  - Trimmed endpoint docstring to keep auth internals out of OpenAPI; added rationale in code comments.
  - Used `assert role.user_id is not None` to match sibling endpoints.

<sup>Written for commit 42d3beef9bfaa37ec19aad2e77497a6be0cdaa4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

