### PR TITLE
fix(mcp): resolve OIDC org from active-org context for multi-org users

### DIFF
--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -863,12 +863,12 @@ async def test_organization_id_populated_when_require_workspace_no(
     test_org_id = uuid.uuid4()
 
     # Mock session - need to properly mock execute() for org membership lookup
-    # The code does: org_ids = org_membership_result.scalars().all()
+    # The code does: org_membership_result.scalars().first()
     mock_session = AsyncMock()
 
     # First call: OrganizationMembership query returns the org_id
     org_result = MagicMock()
-    org_result.scalars.return_value.all.return_value = [test_org_id]
+    org_result.scalars.return_value.first.return_value = test_org_id
 
     # Second call: OrganizationMembership lookup for org_role returns None
     org_role_result = MagicMock()

--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -35,7 +35,6 @@ from tracecat.mcp.oidc.session import (
     OrgResolutionError,
     SessionNeedsAction,
     SessionResult,
-    resolve_authorize_session,
 )
 
 # ---------------------------------------------------------------------------
@@ -515,7 +514,7 @@ async def test_authorize_access_denied_when_no_org_membership(
         AsyncMock(
             side_effect=OrgResolutionError(
                 "User user@example.com cannot use MCP: "
-                "expected exactly 1 organization membership, found 0",
+                "no active organization membership",
                 membership_count=0,
             )
         ),
@@ -534,39 +533,6 @@ async def test_authorize_access_denied_when_no_org_membership(
     assert query["error"] == ["access_denied"]
     assert query["state"] == ["denied-state"]
     assert query["error_description"] == ["User has no organization membership"]
-
-
-@pytest.mark.anyio
-async def test_authorize_access_denied_when_multiple_org_memberships(
-    client: TestClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "tracecat.mcp.oidc.endpoints.resolve_authorize_session",
-        AsyncMock(
-            side_effect=OrgResolutionError(
-                "User user@example.com cannot use MCP: "
-                "expected exactly 1 organization membership, found 2",
-                membership_count=2,
-            )
-        ),
-    )
-
-    response = client.get(
-        "/authorize",
-        params=_authorize_params(state="denied-state"),
-        follow_redirects=False,
-    )
-
-    assert response.status_code == 302
-    location = response.headers["location"]
-    assert location.startswith(_ALLOWED_REDIRECT)
-    query = _location_query_params(location)
-    assert query["error"] == ["access_denied"]
-    assert query["state"] == ["denied-state"]
-    assert query["error_description"] == [
-        "User belongs to multiple organizations; MCP requires exactly one"
-    ]
 
 
 # ---------------------------------------------------------------------------
@@ -1497,8 +1463,8 @@ async def test_authorize_resume_redirects_access_denied_to_client_callback(
         AsyncMock(
             side_effect=OrgResolutionError(
                 "User user@example.com cannot use MCP: "
-                "expected exactly 1 organization membership, found 2",
-                membership_count=2,
+                "no active organization membership",
+                membership_count=0,
             )
         ),
     )
@@ -1515,9 +1481,7 @@ async def test_authorize_resume_redirects_access_denied_to_client_callback(
     query = _location_query_params(location)
     assert query["error"] == ["access_denied"]
     assert query["state"] == ["resume-denied-state"]
-    assert query["error_description"] == [
-        "User belongs to multiple organizations; MCP requires exactly one"
-    ]
+    assert query["error_description"] == ["User has no organization membership"]
 
 
 # ---------------------------------------------------------------------------
@@ -1552,59 +1516,3 @@ def test_get_internal_discovery_url_falls_back_when_empty(
     monkeypatch.setattr(oidc_config, "TRACECAT__PUBLIC_API_URL", _TEST_API_URL)
     url = oidc_config.get_internal_discovery_url()
     assert url == f"{_TEST_API_URL}/oauth/mcp/.well-known/openid-configuration"
-
-
-# ---------------------------------------------------------------------------
-# Session resolution — typed OrgResolutionError with membership_count
-# ---------------------------------------------------------------------------
-
-
-class _FakeOrgResult:
-    """Result stub returning fixed org-membership rows."""
-
-    def __init__(self, org_ids: list[uuid.UUID]) -> None:
-        self._org_ids = org_ids
-
-    def all(self) -> list[tuple[uuid.UUID]]:
-        return [(oid,) for oid in self._org_ids]
-
-
-class _FakeOrgSession:
-    """Session stub returning a fixed set of org memberships."""
-
-    def __init__(self, org_ids: list[uuid.UUID]) -> None:
-        self._org_ids = org_ids
-
-    async def execute(self, *_args, **_kwargs) -> _FakeOrgResult:
-        return _FakeOrgResult(self._org_ids)
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize(
-    ("org_ids", "expected_count"),
-    [
-        ([], 0),
-        ([uuid.uuid4(), uuid.uuid4()], 2),
-    ],
-)
-async def test_resolve_authorize_session_raises_typed_error_with_membership_count(
-    mock_user: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    org_ids: list[uuid.UUID],
-    expected_count: int,
-) -> None:
-    """Zero or multiple memberships raise OrgResolutionError carrying the count."""
-
-    @contextlib.asynccontextmanager
-    async def _fake_session_cm():
-        yield _FakeOrgSession(org_ids)
-
-    monkeypatch.setattr(
-        "tracecat.mcp.oidc.session.get_async_session_bypass_rls_context_manager",
-        _fake_session_cm,
-    )
-
-    with pytest.raises(OrgResolutionError) as exc_info:
-        await resolve_authorize_session(cast(User, mock_user))
-
-    assert exc_info.value.membership_count == expected_count

--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -532,7 +532,7 @@ async def test_authorize_access_denied_when_no_org_membership(
     query = _location_query_params(location)
     assert query["error"] == ["access_denied"]
     assert query["state"] == ["denied-state"]
-    assert query["error_description"] == ["User has no organization membership"]
+    assert query["error_description"] == ["User has no active organization membership"]
 
 
 # ---------------------------------------------------------------------------
@@ -1481,7 +1481,7 @@ async def test_authorize_resume_redirects_access_denied_to_client_callback(
     query = _location_query_params(location)
     assert query["error"] == ["access_denied"]
     assert query["state"] == ["resume-denied-state"]
-    assert query["error_description"] == ["User has no organization membership"]
+    assert query["error_description"] == ["User has no active organization membership"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_oidc_session.py
+++ b/tests/unit/test_mcp_oidc_session.py
@@ -1,77 +1,254 @@
+"""Tests for MCP OIDC session and active organization resolution."""
+
 import uuid
-from types import SimpleNamespace
-from typing import cast
+from datetime import UTC, datetime, timedelta
+from types import TracebackType
+from unittest.mock import MagicMock
 
 import pytest
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from tracecat.db.models import User
+from tracecat.auth.org_context import ACTIVE_ORG_COOKIE
+from tracecat.auth.schemas import UserRole
+from tracecat.db.models import Organization, OrganizationMembership, User
 from tracecat.mcp.oidc import session as oidc_session
 
 
-class _Result:
-    def __init__(self, org_ids: list[uuid.UUID]) -> None:
-        self._org_ids = org_ids
-
-    def all(self) -> list[tuple[uuid.UUID]]:
-        return [(org_id,) for org_id in self._org_ids]
-
-
-class _Session:
-    def __init__(self, org_ids: list[uuid.UUID]) -> None:
-        self._org_ids = org_ids
-
-    async def execute(self, _stmt) -> _Result:
-        return _Result(self._org_ids)
-
-
-class _AsyncContext:
-    def __init__(self, session: _Session) -> None:
+class _AsyncSessionContext:
+    def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def __aenter__(self) -> _Session:
+    async def __aenter__(self) -> AsyncSession:
         return self._session
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         return None
 
 
-@pytest.mark.anyio
-async def test_resolve_authorize_session_superuser_uses_membership_org(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    org_id = uuid.uuid4()
-    user = cast(
-        User,
-        SimpleNamespace(id=uuid.uuid4(), email="admin@example.com", is_superuser=True),
-    )
+def _request_with_cookie(value: str | None) -> Request:
+    request = MagicMock(spec=Request)
+    request.cookies = {ACTIVE_ORG_COOKIE: value} if value is not None else {}
+    return request
 
+
+async def _seed_user(session: AsyncSession, *, is_superuser: bool = False) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"mcp-oidc-session-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.BASIC,
+        is_active=True,
+        is_superuser=is_superuser,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _seed_org(
+    session: AsyncSession,
+    slug_prefix: str,
+    created_at: datetime | None = None,
+    is_active: bool = True,
+) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name=f"Org {slug_prefix}",
+        slug=f"{slug_prefix}-{uuid.uuid4().hex[:8]}",
+        is_active=is_active,
+    )
+    if created_at is not None:
+        org.created_at = created_at
+    session.add(org)
+    await session.flush()
+    return org
+
+
+async def _add_membership(
+    session: AsyncSession, *, user_id: uuid.UUID, organization_id: uuid.UUID
+) -> None:
+    session.add(
+        OrganizationMembership(user_id=user_id, organization_id=organization_id)
+    )
+    await session.flush()
+
+
+def _patch_session(monkeypatch: pytest.MonkeyPatch, session: AsyncSession) -> None:
     monkeypatch.setattr(
         oidc_session,
         "get_async_session_bypass_rls_context_manager",
-        lambda: _AsyncContext(_Session([org_id])),
+        lambda: _AsyncSessionContext(session),
     )
 
-    result = await oidc_session.resolve_authorize_session(user)
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_without_user_requires_login() -> None:
+    result = await oidc_session.resolve_authorize_session(
+        None, _request_with_cookie(None)
+    )
+
+    assert isinstance(result, oidc_session.SessionNeedsAction)
+    assert result.action == oidc_session.NeedsAction.LOGIN
+
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_honors_active_org_cookie(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await _seed_user(session)
+    org_a = await _seed_org(session, "cookie-a")
+    org_b = await _seed_org(session, "cookie-b")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+    await _add_membership(session, user_id=user.id, organization_id=org_b.id)
+    _patch_session(monkeypatch, session)
+
+    result = await oidc_session.resolve_authorize_session(
+        user, _request_with_cookie(str(org_b.id))
+    )
 
     assert isinstance(result, oidc_session.SessionResult)
-    assert result.user is user
-    assert result.organization_id == org_id
+    assert result.organization_id == org_b.id
+
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_ignores_nonmember_cookie(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await _seed_user(session)
+    member_org = await _seed_org(session, "member")
+    other_org = await _seed_org(session, "other")
+    await _add_membership(session, user_id=user.id, organization_id=member_org.id)
+    _patch_session(monkeypatch, session)
+
+    result = await oidc_session.resolve_authorize_session(
+        user, _request_with_cookie(str(other_org.id))
+    )
+
+    assert isinstance(result, oidc_session.SessionResult)
+    assert result.organization_id == member_org.id
+
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_ignores_malformed_cookie(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await _seed_user(session)
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    newer_org = await _seed_org(
+        session, "malformed-newer", created_at=base_time + timedelta(days=1)
+    )
+    oldest_org = await _seed_org(session, "malformed-oldest", created_at=base_time)
+    await _add_membership(session, user_id=user.id, organization_id=newer_org.id)
+    await _add_membership(session, user_id=user.id, organization_id=oldest_org.id)
+    _patch_session(monkeypatch, session)
+
+    result = await oidc_session.resolve_authorize_session(
+        user, _request_with_cookie("not-a-uuid")
+    )
+
+    assert isinstance(result, oidc_session.SessionResult)
+    assert result.organization_id == oldest_org.id
+
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_single_membership(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await _seed_user(session)
+    org = await _seed_org(session, "single")
+    await _add_membership(session, user_id=user.id, organization_id=org.id)
+    _patch_session(monkeypatch, session)
+
+    result = await oidc_session.resolve_authorize_session(
+        user, _request_with_cookie(None)
+    )
+
+    assert isinstance(result, oidc_session.SessionResult)
+    assert result.organization_id == org.id
+
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_multiple_memberships_returns_oldest(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await _seed_user(session)
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    newer_org = await _seed_org(
+        session, "multiple-newer", created_at=base_time + timedelta(days=1)
+    )
+    oldest_org = await _seed_org(session, "multiple-oldest", created_at=base_time)
+    await _add_membership(session, user_id=user.id, organization_id=newer_org.id)
+    await _add_membership(session, user_id=user.id, organization_id=oldest_org.id)
+    _patch_session(monkeypatch, session)
+
+    result = await oidc_session.resolve_authorize_session(
+        user, _request_with_cookie(None)
+    )
+
+    assert isinstance(result, oidc_session.SessionResult)
+    assert result.organization_id == oldest_org.id
+
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_without_memberships_errors(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await _seed_user(session)
+    _patch_session(monkeypatch, session)
+
+    with pytest.raises(
+        oidc_session.OrgResolutionError,
+        match="no active organization membership",
+    ) as exc_info:
+        await oidc_session.resolve_authorize_session(user, _request_with_cookie(None))
+
+    assert exc_info.value.membership_count == 0
+
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_with_only_inactive_membership_errors(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await _seed_user(session)
+    inactive_org = await _seed_org(session, "inactive", is_active=False)
+    await _add_membership(session, user_id=user.id, organization_id=inactive_org.id)
+    _patch_session(monkeypatch, session)
+
+    with pytest.raises(
+        oidc_session.OrgResolutionError,
+        match="no active organization membership",
+    ) as exc_info:
+        await oidc_session.resolve_authorize_session(user, _request_with_cookie(None))
+
+    assert exc_info.value.membership_count == 0
 
 
 @pytest.mark.anyio
 async def test_resolve_authorize_session_superuser_without_membership_errors(
+    session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    user = cast(
-        User,
-        SimpleNamespace(id=uuid.uuid4(), email="admin@example.com", is_superuser=True),
-    )
+    user = await _seed_user(session, is_superuser=True)
+    _patch_session(monkeypatch, session)
 
-    monkeypatch.setattr(
-        oidc_session,
-        "get_async_session_bypass_rls_context_manager",
-        lambda: _AsyncContext(_Session([])),
-    )
+    with pytest.raises(
+        oidc_session.OrgResolutionError,
+        match="no active organization membership",
+    ) as exc_info:
+        await oidc_session.resolve_authorize_session(user, _request_with_cookie(None))
 
-    with pytest.raises(ValueError, match="expected exactly 1 organization membership"):
-        await oidc_session.resolve_authorize_session(user)
+    assert exc_info.value.membership_count == 0

--- a/tests/unit/test_org_context.py
+++ b/tests/unit/test_org_context.py
@@ -1,0 +1,231 @@
+"""Tests for shared active organization resolution helpers."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.org_context import (
+    ACTIVE_ORG_COOKIE,
+    parse_active_org_cookie,
+    resolve_active_org_id,
+)
+from tracecat.auth.schemas import UserRole
+from tracecat.db.models import Organization, OrganizationMembership, User
+
+
+def _request_with_cookie(value: str | None) -> Request:
+    request = MagicMock(spec=Request)
+    request.cookies = {ACTIVE_ORG_COOKIE: value} if value is not None else {}
+    return request
+
+
+async def _seed_user(session: AsyncSession) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"org-context-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.BASIC,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _seed_org(
+    session: AsyncSession,
+    slug_prefix: str,
+    created_at: datetime | None = None,
+    org_id: uuid.UUID | None = None,
+    is_active: bool = True,
+) -> Organization:
+    org = Organization(
+        id=org_id or uuid.uuid4(),
+        name=f"Org {slug_prefix}",
+        slug=f"{slug_prefix}-{uuid.uuid4().hex[:8]}",
+        is_active=is_active,
+    )
+    if created_at is not None:
+        org.created_at = created_at
+    session.add(org)
+    await session.flush()
+    return org
+
+
+async def _add_membership(
+    session: AsyncSession, *, user_id: uuid.UUID, organization_id: uuid.UUID
+) -> None:
+    session.add(
+        OrganizationMembership(user_id=user_id, organization_id=organization_id)
+    )
+    await session.flush()
+
+
+@pytest.mark.anyio
+async def test_preferred_active_membership_is_honored(
+    session: AsyncSession,
+) -> None:
+    user = await _seed_user(session)
+    org_a = await _seed_org(session, "preferred-a")
+    org_b = await _seed_org(session, "preferred-b")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+    await _add_membership(session, user_id=user.id, organization_id=org_b.id)
+
+    resolved = await resolve_active_org_id(session, user.id, preferred_org_id=org_b.id)
+
+    assert resolved == org_b.id
+
+
+@pytest.mark.anyio
+async def test_nonmember_preference_falls_back_to_oldest_active_membership(
+    session: AsyncSession,
+) -> None:
+    user = await _seed_user(session)
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    newer_org = await _seed_org(
+        session, "nonmember-newer", created_at=base_time + timedelta(days=1)
+    )
+    oldest_org = await _seed_org(session, "nonmember-oldest", created_at=base_time)
+    other_org = await _seed_org(session, "nonmember-other")
+    await _add_membership(session, user_id=user.id, organization_id=newer_org.id)
+    await _add_membership(session, user_id=user.id, organization_id=oldest_org.id)
+
+    resolved = await resolve_active_org_id(
+        session, user.id, preferred_org_id=other_org.id
+    )
+
+    assert resolved == oldest_org.id
+
+
+@pytest.mark.anyio
+async def test_inactive_preference_falls_back_to_oldest_active_membership(
+    session: AsyncSession,
+) -> None:
+    user = await _seed_user(session)
+    active_org = await _seed_org(session, "inactive-preference-active")
+    inactive_org = await _seed_org(
+        session, "inactive-preference-inactive", is_active=False
+    )
+    await _add_membership(session, user_id=user.id, organization_id=active_org.id)
+    await _add_membership(session, user_id=user.id, organization_id=inactive_org.id)
+
+    resolved = await resolve_active_org_id(
+        session, user.id, preferred_org_id=inactive_org.id
+    )
+
+    assert resolved == active_org.id
+
+
+@pytest.mark.anyio
+async def test_no_preference_single_active_membership_returns_it(
+    session: AsyncSession,
+) -> None:
+    user = await _seed_user(session)
+    org = await _seed_org(session, "single")
+    await _add_membership(session, user_id=user.id, organization_id=org.id)
+
+    resolved = await resolve_active_org_id(session, user.id)
+
+    assert resolved == org.id
+
+
+@pytest.mark.anyio
+async def test_no_preference_multiple_active_memberships_returns_oldest(
+    session: AsyncSession,
+) -> None:
+    user = await _seed_user(session)
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    newer_org = await _seed_org(
+        session, "multiple-newer", created_at=base_time + timedelta(days=1)
+    )
+    oldest_org = await _seed_org(session, "multiple-oldest", created_at=base_time)
+    await _add_membership(session, user_id=user.id, organization_id=newer_org.id)
+    await _add_membership(session, user_id=user.id, organization_id=oldest_org.id)
+
+    resolved = await resolve_active_org_id(session, user.id)
+
+    assert resolved == oldest_org.id
+
+
+@pytest.mark.anyio
+async def test_no_preference_identical_creation_times_returns_lower_id(
+    session: AsyncSession,
+) -> None:
+    user = await _seed_user(session)
+    shared_time = datetime(2024, 1, 1, tzinfo=UTC)
+    higher_id_org = await _seed_org(
+        session,
+        "higher-id",
+        created_at=shared_time,
+        org_id=uuid.UUID("00000000-0000-4000-8000-000000000002"),
+    )
+    lower_id_org = await _seed_org(
+        session,
+        "lower-id",
+        created_at=shared_time,
+        org_id=uuid.UUID("00000000-0000-4000-8000-000000000001"),
+    )
+    await _add_membership(session, user_id=user.id, organization_id=higher_id_org.id)
+    await _add_membership(session, user_id=user.id, organization_id=lower_id_org.id)
+
+    resolved = await resolve_active_org_id(session, user.id)
+
+    assert resolved == lower_id_org.id
+
+
+@pytest.mark.anyio
+async def test_fallback_skips_older_inactive_org(session: AsyncSession) -> None:
+    user = await _seed_user(session)
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    inactive_org = await _seed_org(
+        session, "older-inactive", created_at=base_time, is_active=False
+    )
+    active_org = await _seed_org(
+        session, "newer-active", created_at=base_time + timedelta(days=1)
+    )
+    await _add_membership(session, user_id=user.id, organization_id=inactive_org.id)
+    await _add_membership(session, user_id=user.id, organization_id=active_org.id)
+
+    resolved = await resolve_active_org_id(session, user.id)
+
+    assert resolved == active_org.id
+
+
+@pytest.mark.anyio
+async def test_zero_memberships_returns_none(session: AsyncSession) -> None:
+    user = await _seed_user(session)
+
+    resolved = await resolve_active_org_id(session, user.id)
+
+    assert resolved is None
+
+
+@pytest.mark.anyio
+async def test_only_inactive_membership_returns_none(session: AsyncSession) -> None:
+    user = await _seed_user(session)
+    inactive_org = await _seed_org(session, "only-inactive", is_active=False)
+    await _add_membership(session, user_id=user.id, organization_id=inactive_org.id)
+
+    resolved = await resolve_active_org_id(session, user.id)
+
+    assert resolved is None
+
+
+def test_parse_active_org_cookie_returns_valid_uuid() -> None:
+    org_id = uuid.uuid4()
+
+    assert parse_active_org_cookie(_request_with_cookie(str(org_id))) == org_id
+
+
+def test_parse_active_org_cookie_returns_none_for_malformed_value() -> None:
+    assert parse_active_org_cookie(_request_with_cookie("not-a-uuid")) is None
+
+
+def test_parse_active_org_cookie_returns_none_when_missing() -> None:
+    assert parse_active_org_cookie(_request_with_cookie(None)) is None

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -37,6 +37,13 @@ from tracecat.auth.api_keys import (
     verify_api_key,
 )
 from tracecat.auth.executor_tokens import verify_executor_token
+from tracecat.auth.org_context import (
+    ACTIVE_ORG_COOKIE as ACTIVE_ORG_COOKIE,
+)
+from tracecat.auth.org_context import (
+    parse_active_org_cookie,
+    resolve_active_org_id,
+)
 from tracecat.auth.secrets import get_service_key
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.auth.users import (
@@ -52,8 +59,6 @@ from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import (
     GroupMember,
     GroupRoleAssignment,
-    Organization,
-    OrganizationMembership,
     RoleScope,
     Scope,
     ServiceAccount,
@@ -603,9 +608,6 @@ async def _get_membership_with_cache(
     return membership_with_org
 
 
-ACTIVE_ORG_COOKIE = "tracecat:active-org-id"
-
-
 async def _resolve_org_for_regular_user(
     request: Request,
     session: AsyncSession,
@@ -613,60 +615,22 @@ async def _resolve_org_for_regular_user(
 ) -> uuid.UUID:
     """Resolve organization context for a regular user from their memberships.
 
-    Honors the ``tracecat:active-org-id`` cookie when the user is a confirmed
-    member of the cookie's organization. The cookie is an untrusted hint —
-    membership is re-validated here on every request, so a tampered or stale
-    value cannot grant access to an org the user does not belong to.
+    Honors the ``tracecat:active-org-id`` cookie as an untrusted hint that is
+    re-validated against active memberships on every request. Without a valid
+    hint, falls back to the user's oldest active organization.
 
     Raises:
-        HTTPException(400): If user has no org memberships.
+        HTTPException(400): If user has no active org memberships.
     """
-    if cookie_value := request.cookies.get(ACTIVE_ORG_COOKIE):
-        try:
-            cookie_org_id = uuid.UUID(cookie_value)
-        except ValueError:
-            cookie_org_id = None
-        if cookie_org_id is not None:
-            membership_stmt = (
-                select(OrganizationMembership.organization_id)
-                .join(
-                    Organization,
-                    Organization.id == OrganizationMembership.organization_id,
-                )
-                .where(
-                    OrganizationMembership.user_id == user.id,
-                    OrganizationMembership.organization_id == cookie_org_id,
-                    Organization.is_active.is_(True),
-                )
-            )
-            membership_row = (
-                await session.execute(membership_stmt)
-            ).scalar_one_or_none()
-            if membership_row is not None:
-                return cookie_org_id
-
-    org_mem_stmt = (
-        select(OrganizationMembership.organization_id)
-        .join(Organization, Organization.id == OrganizationMembership.organization_id)
-        .where(
-            OrganizationMembership.user_id == user.id,
-            Organization.is_active.is_(True),
-        )
-        .order_by(Organization.created_at.asc(), Organization.id.asc())
+    org_id = await resolve_active_org_id(
+        session, user.id, preferred_org_id=parse_active_org_cookie(request)
     )
-    org_membership_result = await session.execute(org_mem_stmt)
-    org_ids = org_membership_result.scalars().all()
-
-    if len(org_ids) == 0:
+    if org_id is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="User has no organization memberships",
         )
-    # If no explicit active-org cookie/workspace context is available, choose a
-    # stable active membership instead of blocking login for multi-org users.
-    # Callers that need a specific org can still pass workspace_id or set the
-    # active-org cookie; both are re-validated above/before this fallback.
-    return org_ids[0]
+    return org_id
 
 
 def _invalidate_user_scope_cache(

--- a/tracecat/auth/org_context.py
+++ b/tracecat/auth/org_context.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 from fastapi import HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,8 +9,63 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat import config
 from tracecat.api.common import get_default_organization_id
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
-from tracecat.db.models import Organization
+from tracecat.db.models import Organization, OrganizationMembership
 from tracecat.identifiers import OrganizationID
+
+ACTIVE_ORG_COOKIE = "tracecat:active-org-id"
+
+
+def parse_active_org_cookie(request: Request) -> uuid.UUID | None:
+    """Parse the active organization cookie as a UUID when valid."""
+    cookie_value = request.cookies.get(ACTIVE_ORG_COOKIE)
+    if not cookie_value:
+        return None
+    try:
+        return uuid.UUID(cookie_value)
+    except ValueError:
+        return None
+
+
+async def resolve_active_org_id(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    preferred_org_id: uuid.UUID | None = None,
+) -> OrganizationID | None:
+    """Resolve an active organization membership for a user.
+
+    The preferred organization ID is an untrusted hint re-validated against
+    live memberships on every call. This helper performs pure SELECTs with no
+    side effects and is safe under both RLS-scoped and RLS-bypass sessions.
+    """
+    if preferred_org_id is not None:
+        membership_stmt = (
+            select(OrganizationMembership.organization_id)
+            .join(
+                Organization,
+                Organization.id == OrganizationMembership.organization_id,
+            )
+            .where(
+                OrganizationMembership.user_id == user_id,
+                OrganizationMembership.organization_id == preferred_org_id,
+                Organization.is_active.is_(True),
+            )
+        )
+        membership_row = (await session.execute(membership_stmt)).scalar_one_or_none()
+        if membership_row is not None:
+            return preferred_org_id
+
+    org_mem_stmt = (
+        select(OrganizationMembership.organization_id)
+        .join(Organization, Organization.id == OrganizationMembership.organization_id)
+        .where(
+            OrganizationMembership.user_id == user_id,
+            Organization.is_active.is_(True),
+        )
+        .order_by(Organization.created_at.asc(), Organization.id.asc())
+    )
+    org_membership_result = await session.execute(org_mem_stmt)
+    return org_membership_result.scalars().first()
 
 
 async def _resolve_by_slug(

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -311,7 +311,7 @@ async def _handle_authorize(
 
     # --- Session resolution ---
     try:
-        session_result = await resolve_authorize_session(user)
+        session_result = await resolve_authorize_session(user, request)
     except OrgResolutionError as exc:
         # The OAuth client callback has already been validated at this point.
         logger.warning(
@@ -319,12 +319,7 @@ async def _handle_authorize(
             error=str(exc),
             client_ip=_get_client_ip(request),
         )
-        if exc.membership_count == 0:
-            description = "User has no organization membership"
-        else:
-            description = (
-                "User belongs to multiple organizations; MCP requires exactly one"
-            )
+        description = "User has no organization membership"
         return _oauth_error_redirect_response(
             redirect_uri,
             "access_denied",

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -319,7 +319,7 @@ async def _handle_authorize(
             error=str(exc),
             client_ip=_get_client_ip(request),
         )
-        description = "User has no organization membership"
+        description = "User has no active organization membership"
         return _oauth_error_redirect_response(
             redirect_uri,
             "access_denied",

--- a/tracecat/mcp/oidc/session.py
+++ b/tracecat/mcp/oidc/session.py
@@ -1,7 +1,8 @@
 """Session and organization resolution for the internal OIDC issuer.
 
-Reuses the existing Tracecat session cookie and org resolution patterns
-without duplicating the underlying auth logic.
+Organization resolution mirrors the HTTP API path: the active-org cookie is a
+re-validated hint, with a stable oldest-active-org fallback. This scopes MCP
+tokens to one organization while allowing multi-org users to authorize.
 """
 
 from __future__ import annotations
@@ -9,11 +10,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum, auto
 
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import Request
 
+from tracecat.auth.org_context import parse_active_org_cookie, resolve_active_org_id
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
-from tracecat.db.models import OrganizationMembership, User
+from tracecat.db.models import User
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 
@@ -50,11 +51,16 @@ class OrgResolutionError(ValueError):
 
 async def resolve_authorize_session(
     user: User | None,
+    request: Request,
 ) -> SessionResult | SessionNeedsAction:
-    """Resolve a Tracecat user and their single organization from the session.
+    """Resolve a Tracecat user and one active organization from the session.
+
+    The active-org cookie is re-validated against live memberships. If it is
+    absent or invalid, the user's oldest active organization is selected.
 
     Args:
         user: The ``optional_current_active_user`` dependency result.
+        request: The request carrying the optional active-org cookie.
 
     Returns:
         ``SessionResult`` on success, or ``SessionNeedsAction`` indicating
@@ -64,45 +70,18 @@ async def resolve_authorize_session(
         return SessionNeedsAction(action=NeedsAction.LOGIN)
 
     async with get_async_session_bypass_rls_context_manager() as session:
-        return await _resolve_regular_user_org(session, user)
-
-
-async def _resolve_regular_user_org(
-    session: AsyncSession,
-    user: User,
-) -> SessionResult:
-    """Resolve org for a regular user from their memberships.
-
-    Exactly one org must exist. Zero or multiple orgs is an error (fail closed).
-
-    Raises:
-        OrgResolutionError: If the user does not have exactly one organization
-            membership.
-    """
-    result = await session.execute(
-        select(OrganizationMembership.organization_id).where(
-            OrganizationMembership.user_id == user.id
+        org_id = await resolve_active_org_id(
+            session,
+            user.id,
+            preferred_org_id=parse_active_org_cookie(request),
         )
-    )
-    org_ids = {row[0] for row in result.all()}
-
-    if len(org_ids) == 1:
-        org_id = next(iter(org_ids))
-        return SessionResult(user=user, organization_id=org_id)
-
-    if len(org_ids) == 0:
+    if org_id is None:
         logger.warning(
-            "MCP OIDC: user has no org memberships",
+            "MCP OIDC: user has no active org memberships",
             user_id=str(user.id),
         )
-    else:
-        logger.warning(
-            "MCP OIDC: user has multiple org memberships (unsupported in v1)",
-            user_id=str(user.id),
-            org_count=len(org_ids),
+        raise OrgResolutionError(
+            f"User {user.email} cannot use MCP: no active organization membership",
+            membership_count=0,
         )
-    raise OrgResolutionError(
-        f"User {user.email} cannot use MCP: "
-        f"expected exactly 1 organization membership, found {len(org_ids)}",
-        membership_count=len(org_ids),
-    )
+    return SessionResult(user=user, organization_id=org_id)


### PR DESCRIPTION
## Summary

Redo of #3009. Fixes `access_denied: "User cannot be resolved to a single organization"` when a multi-org user authorizes an MCP client.

- Extract the HTTP auth path's active-org resolution into a shared, transport-agnostic helper `resolve_active_org_id()` (+ `parse_active_org_cookie()`) in `tracecat/auth/org_context.py`, so `credentials.py` and the MCP OIDC issuer can no longer drift — the canonical `ACTIVE_ORG_COOKIE` definition moves there and is re-exported from `credentials.py`.
- MCP OIDC `resolve_authorize_session` now takes the request and resolves the org the same way the API does: honor the `tracecat:active-org-id` cookie when it points at an active membership, otherwise fall back to the user's oldest active organization. `request` is required (the only caller always has one); the fail-closed multi-org branch is gone.
- Org resolution at issuance now also requires `Organization.is_active` — previously a user whose only org was deactivated could still mint MCP tokens.
- `OrgResolutionError` now only fires for zero active memberships; the multi-org error branch in `endpoints.py` is removed accordingly.

### Why this is safe

- The cookie is an untrusted, unsigned hint set by frontend JS — it is re-validated against live memberships and `Organization.is_active` on every call (same as the existing API auth path), so it can only select among orgs the user actually belongs to.
- Only token issuance was blocked for multi-org users: request-time authorization (`resolve_org_role_for_request`) already intersects the token's `organization_id` claim with live active memberships. A stale claim cannot grant access beyond current membership.
- The no-cookie fallback (oldest active org) matches `_resolve_org_for_regular_user` exactly, so the MCP grant is always scoped to the same org the web app session would show the user. With the sidebar org switcher (#3027), users can explicitly pick the org before authorizing.

### Changes from #3009

- Shared helper instead of duplicating the cookie-validation + fallback queries in the MCP module.
- Dropped the dead `request: Request | None = None` dual-mode and the now-unreachable multi-org error description.
- Tests rewritten against the real-DB `session` fixture (pattern from `tests/unit/test_active_org_cookie.py`) instead of ordered fake-session stubs; added direct coverage for the shared helper in `tests/unit/test_org_context.py`.

## Testing

- `uv run pytest tests/unit/test_org_context.py tests/unit/test_active_org_cookie.py tests/unit/test_mcp_oidc_session.py tests/unit/test_mcp_oidc_endpoints.py tests/unit/test_auth_middleware.py` — 97 passed, 1 skipped
- `uv run pytest tests/integration/test_mcp_oidc_flow.py` — 7 passed
- `uv run ruff check .` / `uv run ruff format --check .` clean; `basedpyright --warnings` on touched files: 0 errors, 0 warnings
- Live E2E against a dev cluster with a seeded two-org user, exercising the real `/oauth/mcp/authorize` → `/token` flow (session login + PKCE):
  - cookie = org B → access token `organization_id` = org B
  - no cookie → oldest active org
  - cookie = org the user is not a member of → falls back to oldest active org

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix MCP OIDC auth for multi‑org users by resolving the org from the active‑org context, falling back to the oldest active org. The OAuth error now clearly states when a user has only inactive orgs.

- **Bug Fixes**
  - MCP OIDC now resolves org via `resolve_authorize_session(user, request)` using `parse_active_org_cookie` and `resolve_active_org_id`; honors the `tracecat:active-org-id` cookie when valid, else falls back to the oldest active org. Tokens are issued only for active orgs, and `access_denied` now returns “User has no active organization membership.”

- **Refactors**
  - Extracted shared helpers `resolve_active_org_id()` and `parse_active_org_cookie()` to `tracecat/auth/org_context.py`; moved the canonical `ACTIVE_ORG_COOKIE` there (re‑exported from `credentials.py`). Unified org resolution between API auth and MCP OIDC; updated and added tests for the shared helper and session flow.

<sup>Written for commit 3fcca8e5d3ff74af4699de942d0057d04e154cf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

