### PR TITLE
fix(mcp): point Google Cloud SecOps docs link at the SecOps server

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -278,7 +278,7 @@
     },
     {
       "slug": "google-cloud-secops-mcp",
-      "docs": "https://google.github.io/mcp-security/servers/scc_mcp.html",
+      "docs": "https://google.github.io/mcp-security/servers/secops_mcp.html",
       "connection_spec": {
         "server_type": "stdio",
         "auth_type": "CUSTOM",


### PR DESCRIPTION
## Summary

The `google-cloud-secops-mcp` catalog entry's `docs` link points at the **Security Command Center (SCC)** page instead of the **SecOps / Chronicle** page. The entry itself is the SecOps server — only the docs URL is wrong.

```diff
  "slug": "google-cloud-secops-mcp",
- "docs": "https://google.github.io/mcp-security/servers/scc_mcp.html",
+ "docs": "https://google.github.io/mcp-security/servers/secops_mcp.html",
```

## Why this is the SecOps server, not SCC

Three independent signals in the same entry all say **SecOps / Chronicle**:

1. **The package it runs** — `uvx --from google-secops-mcp secops_mcp`
2. **The env vars it requires** — `CHRONICLE_PROJECT_ID`, `CHRONICLE_CUSTOMER_ID`, `CHRONICLE_REGION`, `SECOPS_SA_PATH` (`CHRONICLE_CUSTOMER_ID` has no meaning for SCC)
3. **The entry's own `research_notes` and `sources`** — the notes state *"the SecOps/Chronicle server lives under `server/secops` … distributed on PyPI as `google-secops-mcp`"*, and `sources` already cites the correct `.../servers/secops_mcp.html`

So the entry is correct; only the user-facing `docs` link was copy-pasted from the wrong sibling page in Google's `mcp-security` docs, which host several servers side by side:

```
.../servers/scc_mcp.html          ← Security Command Center  (was linked, wrong)
.../servers/secops_mcp.html       ← SecOps / Chronicle       (correct, this PR)
.../servers/secops_soar_mcp.html
.../servers/gti_mcp.html
```

For reference, the `virustotal-mcp` entry pairs `gti_mcp.html` with the `gti-mcp` package correctly — this entry was the only mismatch.

## Impact

The `docs` field surfaces in the UI (`mcp-servers` page renders `docs_url`), so users clicking **Docs** on the *Google Cloud SecOps* integration currently land on the *Security Command Center* documentation. This is confusing, and can give the impression that SCC is already supported when it isn't.

## Verification

- `mcp_catalog_private.json` still parses as valid JSON.
- `https://google.github.io/mcp-security/servers/secops_mcp.html` resolves and documents the Chronicle SecOps MCP server, requiring exactly the `CHRONICLE_*` env vars this entry declares.

## Before

<img width="1505" height="861" alt="Screenshot 2026-07-13 at 9 00 03 AM" src="https://github.com/user-attachments/assets/00f5be5d-5f88-4979-8639-a6b568bef8ef" />

## After
<img width="1505" height="861" alt="Screenshot 2026-07-13 at 9 05 54 AM" src="https://github.com/user-attachments/assets/32c9deba-b71f-4fa6-a9cd-33276943a8a5" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs link for the `google-cloud-secops-mcp` catalog entry to point to `https://google.github.io/mcp-security/servers/secops_mcp.html` (SecOps/Chronicle) instead of SCC. This ensures the UI Docs button opens the correct guide.

<sup>Written for commit 86d873f74086c42b53763cc4290f96f24265f5ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

