### PR TITLE
fix(agent): remove duplicate token remint

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -1381,25 +1381,6 @@ class DurableAgentWorkflow:
                         routes=compiled_run.llm_routes,
                     )
 
-                # Approval waits are unbounded. Tokens are turn-scoped, so resumed
-                # user-MCP tool execution and the continuation need fresh tokens.
-                if workflow.patched(REMINT_SCOPE_TOKENS_PATCH):
-                    compiled_run = self._remint_scope_tokens(
-                        compiled_run,
-                        internal_tool_context=internal_tool_context,
-                    )
-                    llm_gateway_auth_token = mint_llm_token(
-                        workspace_id=self.workspace_id,
-                        organization_id=self.organization_id,
-                        session_id=self.session_id,
-                        model=cfg.model_name,
-                        provider=cfg.model_provider,
-                        catalog_id=cfg.catalog_id,
-                        base_url=cfg.base_url,
-                        model_settings=cfg.model_settings,
-                        routes=compiled_run.llm_routes,
-                    )
-
                 # Execute approved tools and reconcile the SDK transcript.
                 approved_tools, denied_tools = self._build_tool_lists_from_approvals(
                     result.approval_items or []


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a duplicate token remint in the agent resume path so tokens are minted only once after approval waits. This stops redundant `mint_llm_token` calls and avoids inconsistent auth state during tool execution.

- **Bug Fixes**
  - Deleted the second `_remint_scope_tokens(...)` and `mint_llm_token(...)` block in `_run_with_agent_executor` (`tracecat_ee/agent/workflows/durable.py`).
  - Kept the single remint path when `REMINT_SCOPE_TOKENS_PATCH` is applied.

<sup>Written for commit 52abb2abce01b77d6208294a9fe7d94c6209e2a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

