### PR TITLE
fix(agent): align subagent tool input with execution

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -274,6 +274,21 @@ class TestClaudeAgentRuntimeRun:
         assert "not a Tracecat action or MCP tool" in prompt
         assert prompt.endswith("Preset instructions.")
 
+    def test_system_prompt_prefers_attached_subagent_aliases(
+        self, mock_socket_writer: MagicMock
+    ) -> None:
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: MagicMock()
+        )
+        runtime._agents_enabled = True
+
+        prompt = runtime._build_system_prompt(None)
+
+        assert prompt.endswith(
+            "prefer the most specific attached alias; use `general-purpose` only "
+            "when none matches."
+        )
+
     @pytest.mark.anyio
     async def test_sends_done_on_completion(
         self,
@@ -2211,6 +2226,51 @@ class TestClaudeAgentRuntimePreToolUseHook:
         hook_output = get_hook_output(result)
         assert hook_output.get("permissionDecision") == "deny"
         assert "not available" in (hook_output.get("permissionDecisionReason") or "")
+
+    @pytest.mark.parametrize("tool_name", ["Agent", "Task"])
+    @pytest.mark.anyio
+    async def test_agent_tool_strips_model_and_isolation_overrides(
+        self,
+        mock_socket_writer: MagicMock,
+        tool_name: str,
+    ) -> None:
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: MagicMock()
+        )
+        runtime._agents_enabled = True
+        runtime._explicit_subagent_aliases = {"analyst"}
+        tool_input = {
+            "subagent_type": "analyst",
+            "prompt": "Investigate the issue.",
+            "description": "Investigate issue",
+            "model": "sonnet",
+            "isolation": "worktree",
+            "run_in_background": False,
+        }
+
+        result = await runtime._pre_tool_use_hook(
+            input_data=make_hook_input(
+                tool_name=tool_name,
+                tool_input=tool_input,
+                tool_use_id="call-agent",
+            ),
+            tool_use_id="call-agent",
+            context=make_hook_context(),
+        )
+
+        hook_output = get_hook_output(result)
+        assert hook_output == {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "updatedInput": {
+                "subagent_type": "analyst",
+                "prompt": "Investigate the issue.",
+                "description": "Investigate issue",
+                "run_in_background": False,
+            },
+        }
+        assert tool_input["model"] == "sonnet"
+        assert tool_input["isolation"] == "worktree"
 
     @pytest.mark.anyio
     async def test_explicit_subagents_do_not_use_root_approval_policy(

--- a/tests/unit/test_claude_adapter.py
+++ b/tests/unit/test_claude_adapter.py
@@ -389,6 +389,51 @@ def test_tool_use_block_stop_empty_args():
     assert unified.tool_input == {}
 
 
+@pytest.mark.parametrize("tool_name", ["Agent", "Task"])
+def test_agent_tool_stop_emits_effective_input(tool_name: str) -> None:
+    """Agent runtime controls are removed from the unified UI event."""
+    adapter = ClaudeSDKAdapter()
+    content_block: ToolUseContentBlock = {
+        "type": "tool_use",
+        "id": "toolu_agent",
+        "name": tool_name,
+        "input": {},
+    }
+    adapter.to_unified_event(
+        make_stream_event(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": content_block,
+            }
+        )
+    )
+    adapter.to_unified_event(
+        make_stream_event(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": (
+                        '{"subagent_type":"case-agent","prompt":"List cases",'
+                        '"model":"sonnet","isolation":"worktree"}'
+                    ),
+                },
+            }
+        )
+    )
+
+    unified = adapter.to_unified_event(
+        make_stream_event({"type": "content_block_stop", "index": 0})
+    )
+
+    assert unified.tool_input == {
+        "subagent_type": "case-agent",
+        "prompt": "List cases",
+    }
+
+
 def test_tool_use_block_stop_invalid_json():
     """Test tool_use stop with invalid JSON falls back to empty dict."""
     adapter = ClaudeSDKAdapter()

--- a/tests/unit/test_vercel_adapter.py
+++ b/tests/unit/test_vercel_adapter.py
@@ -3,10 +3,12 @@ from typing import cast
 from uuid import uuid4
 
 import pytest
+from claude_agent_sdk.types import AssistantMessage, ToolUseBlock
 
 from tracecat.agent.adapter.vercel import (
     DataEventPayload,
     DataUIPart,
+    ToolUIPartInputAvailable,
     VercelStreamContext,
     convert_chat_messages_to_ui,
 )
@@ -84,6 +86,45 @@ def test_convert_chat_messages_to_ui_cancelled_marker_carries_tool_call_ids() ->
     assert part["data"] == {
         "reason": "user_cancel",
         "tool_call_ids": ["toolu_aborted"],
+    }
+
+
+def test_convert_claude_agent_tool_history_uses_effective_input() -> None:
+    """Reloaded UI history matches the input Tracecat actually executed."""
+    requested_input = {
+        "subagent_type": "case-agent",
+        "prompt": "List cases",
+        "model": "sonnet",
+        "isolation": "worktree",
+    }
+    tool_use = ToolUseBlock(
+        id="toolu_agent",
+        name="Agent",
+        input=requested_input,
+    )
+    messages = convert_chat_messages_to_ui(
+        [
+            ChatMessage(
+                id=str(uuid4()),
+                message=AssistantMessage(
+                    content=[tool_use],
+                    model="custom-model",
+                ),
+            )
+        ]
+    )
+
+    assert len(messages) == 1
+    part = cast(ToolUIPartInputAvailable, messages[0].parts[0])
+    assert part["input"] == {
+        "subagent_type": "case-agent",
+        "prompt": "List cases",
+    }
+    assert tool_use.input == {
+        "subagent_type": "case-agent",
+        "prompt": "List cases",
+        "model": "sonnet",
+        "isolation": "worktree",
     }
 
 

--- a/tests/unit/test_vercel_stream_context.py
+++ b/tests/unit/test_vercel_stream_context.py
@@ -295,6 +295,49 @@ async def test_tool_call_input_delta():
 
 
 @pytest.mark.anyio
+async def test_agent_tool_buffers_and_sanitizes_input() -> None:
+    """Agent input is only published after runtime controls are removed."""
+    ctx = VercelStreamContext(message_id="msg_test")
+
+    events = [
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_CALL_START,
+            part_id=0,
+            tool_call_id="call_agent",
+            tool_name="Agent",
+            tool_input={},
+        ),
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_CALL_DELTA,
+            part_id=0,
+            text='{"model":"sonnet","isolation":"worktree"}',
+        ),
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_CALL_STOP,
+            part_id=0,
+            tool_call_id="call_agent",
+            tool_name="Agent",
+            tool_input={
+                "subagent_type": "case-agent",
+                "prompt": "List cases",
+                "model": "sonnet",
+                "isolation": "worktree",
+            },
+        ),
+    ]
+
+    frames = await collect_frames(ctx, events)
+
+    assert len(frames) == 2
+    assert isinstance(frames[0], ToolInputStartEventPayload)
+    assert isinstance(frames[1], ToolInputAvailableEventPayload)
+    assert frames[1].input == {
+        "subagent_type": "case-agent",
+        "prompt": "List cases",
+    }
+
+
+@pytest.mark.anyio
 async def test_tool_call_with_empty_args():
     """Test tool call with empty/null args."""
     ctx = VercelStreamContext(message_id="msg_test")

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -65,6 +65,10 @@ from tracecat.agent.common.stream_types import (
     UnifiedStreamEvent,
     parse_vercel_frame_cursor,
 )
+from tracecat.agent.common.tool_inputs import (
+    AGENT_TOOL_NAMES,
+    sanitize_agent_tool_input,
+)
 from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
 from tracecat.agent.mcp.utils import normalize_mcp_tool_name
 from tracecat.agent.stream.events import (
@@ -963,10 +967,11 @@ class VercelStreamContext:
                 if event.part_id is not None:
                     state = self.part_states.get(event.part_id)
                     if state and state.tool_call and event.text:
-                        yield ToolInputDeltaEventPayload(
-                            toolCallId=state.tool_call.tool_call_id,
-                            inputTextDelta=event.text,
-                        )
+                        if state.tool_call.tool_name not in AGENT_TOOL_NAMES:
+                            yield ToolInputDeltaEventPayload(
+                                toolCallId=state.tool_call.tool_call_id,
+                                inputTextDelta=event.text,
+                            )
 
             case StreamEventType.TOOL_CALL_STOP:
                 if event.part_id is not None:
@@ -975,11 +980,15 @@ class VercelStreamContext:
                         tool_call_id = state.tool_call.tool_call_id
                         if not self.tool_input_emitted.get(tool_call_id, False):
                             # Emit final tool input
+                            tool_name = event.tool_name or state.tool_call.tool_name
+                            tool_input = sanitize_agent_tool_input(
+                                tool_name,
+                                event.tool_input or state.tool_call.args_as_dict(),
+                            )
                             yield ToolInputAvailableEventPayload(
                                 toolCallId=tool_call_id,
-                                toolName=event.tool_name or state.tool_call.tool_name,
-                                input=event.tool_input
-                                or state.tool_call.args_as_dict(),
+                                toolName=tool_name,
+                                input=tool_input,
                             )
                             self.tool_input_emitted[tool_call_id] = True
                     for message in self._finalize_part(event.part_id):
@@ -1732,6 +1741,7 @@ def convert_chat_messages_to_ui(
                         tool_input = tool_input.get("args", tool_input)
                     # Normalize MCP registry prefix
                     tool_name = normalize_mcp_tool_name(tool_name)
+                    tool_input = sanitize_agent_tool_input(tool_name, tool_input)
                     tool_part = MutableToolPart(
                         type=f"tool-{tool_name}",
                         tool_call_id=part.id,

--- a/tracecat/agent/common/tool_inputs.py
+++ b/tracecat/agent/common/tool_inputs.py
@@ -1,0 +1,28 @@
+"""Shared normalization for agent harness tool inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+AGENT_TOOL_NAMES = frozenset({"Agent", "Task"})
+AGENT_RUNTIME_CONTROL_FIELDS = frozenset({"model", "isolation"})
+
+
+def sanitize_agent_tool_input(
+    tool_name: str,
+    tool_input: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Return the effective input for an Agent or Task tool call.
+
+    Tracecat owns subagent model selection and runtime isolation, so model-proposed
+    values for those fields must not affect execution or appear as effective input
+    in user-facing tool-call representations.
+    """
+    sanitized = dict(tool_input or {})
+    if tool_name not in AGENT_TOOL_NAMES:
+        return sanitized
+
+    for field in AGENT_RUNTIME_CONTROL_FIELDS:
+        sanitized.pop(field, None)
+    return sanitized

--- a/tracecat/agent/runtime/claude_code/adapter.py
+++ b/tracecat/agent/runtime/claude_code/adapter.py
@@ -20,6 +20,7 @@ from tracecat.agent.common.stream_types import (
     StreamEventType,
     UnifiedStreamEvent,
 )
+from tracecat.agent.common.tool_inputs import sanitize_agent_tool_input
 from tracecat.agent.mcp.utils import normalize_mcp_tool_name
 
 
@@ -269,6 +270,7 @@ class ClaudeSDKAdapter(BaseHarnessAdapter):
             # Normalize tool name for display
             raw_tool_name = (state.tool_name if state else None) or "unknown"
             normalized_tool_name = normalize_mcp_tool_name(raw_tool_name)
+            args = sanitize_agent_tool_input(normalized_tool_name, args)
             return UnifiedStreamEvent(
                 type=StreamEventType.TOOL_CALL_STOP,
                 part_id=index,

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -59,6 +59,10 @@ from tracecat.agent.common.stream_types import (
     ToolCallContent,
     UnifiedStreamEvent,
 )
+from tracecat.agent.common.tool_inputs import (
+    AGENT_TOOL_NAMES,
+    sanitize_agent_tool_input,
+)
 from tracecat.agent.common.types import (
     MCPServerConfig,
     MCPStdioServerConfig,
@@ -190,7 +194,6 @@ DISALLOWED_TOOLS = [
     "SlashCommand",
 ]
 
-AGENT_TOOL_NAMES = frozenset({"Agent", "Task"})
 CHILD_AGENT_DISALLOWED_TOOLS = [
     "Agent",
     "Task",
@@ -985,7 +988,11 @@ class ClaudeAgentRuntime:
             "hookEventName": "PreToolUse",
             "permissionDecision": "allow",
         }
-        if self._should_inject_tool_metadata(tool_name, action_name):
+        if tool_name in AGENT_TOOL_NAMES:
+            sanitized_input = sanitize_agent_tool_input(tool_name, tool_input)
+            if sanitized_input != tool_input:
+                hook_output["updatedInput"] = sanitized_input
+        elif self._should_inject_tool_metadata(tool_name, action_name):
             if tool_use_id:
                 hook_output["updatedInput"] = self._with_tool_call_metadata(
                     tool_input,
@@ -1059,6 +1066,11 @@ class ClaudeAgentRuntime:
         if instructions:
             prompt_parts.append(instructions)
         prompt_parts.extend(self._system_prompt_fragments)
+        if self._agents_enabled:
+            prompt_parts.append(
+                "prefer the most specific attached alias; use `general-purpose` only "
+                "when none matches."
+            )
         return "\n\n".join(prompt_parts)
 
     def _build_agent_definitions(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align Agent/Task tool inputs with actual execution by stripping runtime-only fields (`model`, `isolation`) and emitting the sanitized input in streams and chat history. Also defers agent input deltas until stop and adds guidance to prefer specific attached aliases.

- **Bug Fixes**
  - Remove `model` and `isolation` from Agent/Task inputs before execution; publish only the effective input in unified events, Vercel frames, and reloaded history.
  - Suppress `ToolInputDelta` for Agent/Task and emit the sanitized input on `TOOL_CALL_STOP`.
  - Update system prompt to prefer the most specific attached alias over `general-purpose`.

- **Refactors**
  - Add `tracecat.agent.common.tool_inputs` with `sanitize_agent_tool_input` and `AGENT_TOOL_NAMES`, applied in the Claude adapter/runtime and `tracecat/agent/adapter/vercel.py`.

<sup>Written for commit 50cd8bab32ca2dff9172f60dd12d69595d94b40e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

