### PR TITLE
feat(audit): Audit Workflow Publish

### DIFF
--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -802,3 +802,46 @@ async def test_audit_log_failure_logging_failure_still_raises_original_exception
 
     assert len(create_event_calls) == 1
     assert create_event_calls[0][1]["status"] == AuditEventStatus.ATTEMPT
+
+
+@pytest.mark.anyio
+async def test_audit_log_semantic_failure_via_ok_attribute_logs_failure_event(
+    role: Role,
+) -> None:
+    """A result that returns normally but reports ``ok=False`` (e.g. workflow
+    publish validation errors) should be logged as a FAILURE, not a SUCCESS."""
+
+    class PublishResult:
+        def __init__(self, workflow_id: uuid.UUID, ok: bool):
+            self.workflow_id = workflow_id
+            self._ok = ok
+
+        @property
+        def ok(self) -> bool:
+            return self._ok
+
+    class MockService:
+        def __init__(self):
+            self.session = AsyncMock()
+
+        @audit_log(resource_type="workflow", action="update")
+        async def publish_workflow(self, workflow_id: uuid.UUID):
+            return PublishResult(workflow_id, ok=False)
+
+    service = MockService()
+    token = ctx_role.set(role)
+
+    create_event_calls = []
+
+    async def mock_create_event(*args, **kwargs):
+        create_event_calls.append(kwargs)
+
+    try:
+        with patch.object(AuditService, "create_event", side_effect=mock_create_event):
+            result = await service.publish_workflow(workflow_id=uuid.uuid4())
+    finally:
+        ctx_role.reset(token)
+
+    assert result.ok is False
+    statuses = [call["status"] for call in create_event_calls]
+    assert statuses == [AuditEventStatus.ATTEMPT, AuditEventStatus.FAILURE]

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -128,6 +128,7 @@ def audit_log(
                             status=(
                                 AuditEventStatus.FAILURE
                                 if getattr(result, "success", None) is False
+                                or getattr(result, "ok", None) is False
                                 else AuditEventStatus.SUCCESS
                             ),
                         )

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -928,6 +928,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
             raise e
 
     @require_scope("workflow:update")
+    @audit_log(resource_type="workflow", action="update")
     async def publish_workflow(self, workflow_id: WorkflowID) -> WorkflowPublishResult:
         """Publish (commit) a workflow's current draft as a new versioned definition.
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

- Add audit logging to `publish_workflow`
- The decorator treated publish's `ok=False` validation as SUCCESS since it only checked success, so also need to check `ok`


## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds audit logging to workflow publish and correctly logs validation failures as FAILURE instead of SUCCESS. Publish now emits ATTEMPT and a final SUCCESS/FAILURE event.

- **New Features**
  - Applied `@audit_log(resource_type="workflow", action="update")` to `publish_workflow` to record publish attempts and outcomes.

- **Bug Fixes**
  - Updated audit logger to treat `result.ok is False` as FAILURE; added a unit test to cover this case.

<sup>Written for commit adfe2a523de5437dbf7f2af92241574c8de94415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

