### PR TITLE
feat(registry): add Scanner YAML templates

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/http.py
+++ b/packages/tracecat-registry/tracecat_registry/core/http.py
@@ -134,6 +134,13 @@ Payload = Annotated[
     JSONObjectOrArray | None,
     Doc("JSON serializable data in request body (POST, PUT, and PATCH)"),
 ]
+Content = Annotated[
+    str | None,
+    Doc(
+        "Raw string content to send as the request body (POST, PUT, and PATCH). "
+        "Cannot be combined with payload, form_data, or files."
+    ),
+]
 FormData = Annotated[
     dict[str, Any] | None,
     Doc("Form encoded data in request body (POST, PUT, and PATCH)"),
@@ -587,6 +594,7 @@ async def http_request(
     headers: Headers = None,
     params: Params = None,
     payload: Payload = None,
+    content: Content = None,
     form_data: FormData = None,
     files: Files = None,
     auth: Auth = None,
@@ -608,6 +616,13 @@ async def http_request(
     verify_ssl: VerifySSL = True,
 ) -> HTTPResponse:
     """Perform a HTTP request to a given URL."""
+
+    if content is not None and any(
+        body is not None for body in (payload, form_data, files)
+    ):
+        raise ValueError(
+            "Raw content cannot be combined with payload, form_data, or files."
+        )
 
     ignore_status_codes = ignore_status_codes or []
     basic_auth = httpx.BasicAuth(**auth) if auth else None
@@ -646,6 +661,7 @@ async def http_request(
                     url=url,
                     headers=headers,
                     params=params,
+                    content=content,
                     json=payload,
                     data=form_data,
                     files=httpx_files_param,

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/cancel_query.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/cancel_query.yml
@@ -1,0 +1,29 @@
+type: action
+definition:
+  title: Cancel Scanner query
+  description: Cancel a previously started asynchronous Scanner query.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/ad-hoc-queries
+  namespace: tools.scanner
+  name: cancel_query
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    query_run_id:
+      type: str
+      description: Query run ID (`qr_id`) returned by `tools.scanner.start_query`.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: cancel_query
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/cancel_query/${{ FN.url_encode(inputs.query_run_id) }}
+        method: POST
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+  returns: ${{ steps.cancel_query.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/create_detection_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/create_detection_rule.yml
@@ -1,0 +1,106 @@
+type: action
+definition:
+  title: Create Scanner detection rule
+  description: Create a detection rule in Scanner.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/detection-rules
+  namespace: tools.scanner
+  name: create_detection_rule
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    tenant_id:
+      type: str
+      description: Unique identifier for the Scanner tenant.
+    name:
+      type: str
+      description: Name of the detection rule.
+    description:
+      type: str
+      description: Description of the detection rule.
+    time_range_s:
+      type: int
+      description: Lookback period in seconds. Scanner requires minute granularity.
+    run_frequency_s:
+      type: int
+      description: Run frequency in seconds. Scanner requires minute granularity and a value no greater than `time_range_s`.
+    enabled_state_override:
+      type: str
+      description: Scanner enabled state, such as Active, Staging, or Paused.
+    severity:
+      type: str
+      description: Detection severity accepted by Scanner, such as Information, Low, Medium, High, Critical, Fatal, or Other.
+    query_text:
+      type: str
+      description: Scanner query text for the detection rule.
+    event_sink_ids:
+      type: list[str]
+      description: Event sink IDs that receive alerts from this detection rule.
+    tags:
+      type: list[str] | None
+      description: Tags to associate with the detection rule.
+      default: null
+    sync_key:
+      type: str | None
+      description: Sync key used by automatic detection rule syncers.
+      default: null
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: build_detection_rule
+      action: core.script.run_python
+      args:
+        inputs:
+          tenant_id: ${{ inputs.tenant_id }}
+          name: ${{ inputs.name }}
+          description: ${{ inputs.description }}
+          time_range_s: ${{ inputs.time_range_s }}
+          run_frequency_s: ${{ inputs.run_frequency_s }}
+          enabled_state_override: ${{ inputs.enabled_state_override }}
+          severity: ${{ inputs.severity }}
+          query_text: ${{ inputs.query_text }}
+          event_sink_ids: ${{ inputs.event_sink_ids }}
+          tags: ${{ inputs.tags }}
+          sync_key: ${{ inputs.sync_key }}
+        script: |
+          def main(
+              tenant_id,
+              name,
+              description,
+              time_range_s,
+              run_frequency_s,
+              enabled_state_override,
+              severity,
+              query_text,
+              event_sink_ids,
+              tags,
+              sync_key,
+          ):
+              payload = {
+                  "tenant_id": tenant_id,
+                  "name": name,
+                  "description": description,
+                  "time_range_s": time_range_s,
+                  "run_frequency_s": run_frequency_s,
+                  "enabled_state_override": enabled_state_override,
+                  "severity": severity,
+                  "query_text": query_text,
+                  "event_sink_ids": event_sink_ids,
+                  "tags": tags,
+                  "sync_key": sync_key,
+              }
+              return {key: value for key, value in payload.items() if value is not None}
+    - ref: create_detection_rule
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/detection_rule
+        method: POST
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+          Content-Type: application/json
+        payload: ${{ steps.build_detection_rule.result }}
+  returns: ${{ steps.create_detection_rule.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/create_event_sink.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/create_event_sink.yml
@@ -1,0 +1,44 @@
+type: action
+definition:
+  title: Create Scanner event sink
+  description: Create a Slack, webhook, or PagerDuty event sink in Scanner.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/event-sinks
+  namespace: tools.scanner
+  name: create_event_sink
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    tenant_id:
+      type: str
+      description: Unique identifier for the Scanner tenant.
+    name:
+      type: str
+      description: Name of the event sink.
+    description:
+      type: str
+      description: Description of the event sink.
+    event_sink_args:
+      type: dict[str, Any]
+      description: 'API-native event sink configuration, such as {"Webhook": {"url": "https://example.com/webhook"}}.'
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: create_event_sink
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/event_sink
+        method: POST
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+          Content-Type: application/json
+        payload:
+          tenant_id: ${{ inputs.tenant_id }}
+          name: ${{ inputs.name }}
+          description: ${{ inputs.description }}
+          event_sink_args: ${{ inputs.event_sink_args }}
+  returns: ${{ steps.create_event_sink.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/delete_detection_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/delete_detection_rule.yml
@@ -1,0 +1,29 @@
+type: action
+definition:
+  title: Delete Scanner detection rule
+  description: Delete a Scanner detection rule by ID.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/detection-rules
+  namespace: tools.scanner
+  name: delete_detection_rule
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    detection_rule_id:
+      type: str
+      description: Unique Scanner detection rule ID.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: delete_detection_rule
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/detection_rule/${{ FN.url_encode(inputs.detection_rule_id) }}
+        method: DELETE
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+  returns: ${{ steps.delete_detection_rule.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/delete_event_sink.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/delete_event_sink.yml
@@ -1,0 +1,29 @@
+type: action
+definition:
+  title: Delete Scanner event sink
+  description: Delete a Scanner event sink by ID.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/event-sinks
+  namespace: tools.scanner
+  name: delete_event_sink
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    event_sink_id:
+      type: str
+      description: Unique Scanner event sink ID.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: delete_event_sink
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/event_sink/${{ FN.url_encode(inputs.event_sink_id) }}
+        method: DELETE
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+  returns: ${{ steps.delete_event_sink.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/get_detection_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/get_detection_rule.yml
@@ -1,0 +1,29 @@
+type: action
+definition:
+  title: Get Scanner detection rule
+  description: Get a Scanner detection rule by ID.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/detection-rules
+  namespace: tools.scanner
+  name: get_detection_rule
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    detection_rule_id:
+      type: str
+      description: Unique Scanner detection rule ID.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: get_detection_rule
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/detection_rule/${{ FN.url_encode(inputs.detection_rule_id) }}
+        method: GET
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+  returns: ${{ steps.get_detection_rule.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/get_event_sink.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/get_event_sink.yml
@@ -1,0 +1,29 @@
+type: action
+definition:
+  title: Get Scanner event sink
+  description: Get a Scanner event sink by ID.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/event-sinks
+  namespace: tools.scanner
+  name: get_event_sink
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    event_sink_id:
+      type: str
+      description: Unique Scanner event sink ID.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: get_event_sink
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/event_sink/${{ FN.url_encode(inputs.event_sink_id) }}
+        method: GET
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+  returns: ${{ steps.get_event_sink.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/get_query_progress.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/get_query_progress.yml
@@ -1,0 +1,35 @@
+type: action
+definition:
+  title: Get Scanner query progress
+  description: Poll an asynchronous Scanner query for progress and results.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/ad-hoc-queries
+  namespace: tools.scanner
+  name: get_query_progress
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    query_run_id:
+      type: str
+      description: Query run ID (`qr_id`) returned by `tools.scanner.start_query`.
+    show_intermediate_results:
+      type: bool
+      description: Whether to return intermediate results while the query is running.
+      default: true
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: get_query_progress
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/query_progress/${{ FN.url_encode(inputs.query_run_id) }}
+        method: GET
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+        params:
+          show_intermediate_results: ${{ inputs.show_intermediate_results }}
+  returns: ${{ steps.get_query_progress.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/list_detection_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/list_detection_rules.yml
@@ -1,0 +1,53 @@
+type: action
+definition:
+  title: List Scanner detection rules
+  description: List detection rules for a Scanner tenant.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/detection-rules
+  namespace: tools.scanner
+  name: list_detection_rules
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    tenant_id:
+      type: str
+      description: Unique identifier for the Scanner tenant.
+    page_size:
+      type: int | None
+      description: Maximum detection rules to return in a page. Scanner defaults to 50.
+      default: null
+    page_token:
+      type: str | None
+      description: Pagination cursor returned as `next_page_token` by a previous request.
+      default: null
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: build_pagination_params
+      action: core.script.run_python
+      args:
+        inputs:
+          tenant_id: ${{ inputs.tenant_id }}
+          page_size: ${{ inputs.page_size }}
+          page_token: ${{ inputs.page_token }}
+        script: |
+          def main(tenant_id, page_size, page_token):
+              params = {
+                  "tenant_id": tenant_id,
+                  "pagination[page_size]": page_size,
+                  "pagination[page_token]": page_token,
+              }
+              return {key: value for key, value in params.items() if value is not None}
+    - ref: list_detection_rules
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/detection_rule
+        method: GET
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+        params: ${{ steps.build_pagination_params.result }}
+  returns: ${{ steps.list_detection_rules.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/list_event_sinks.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/list_event_sinks.yml
@@ -1,0 +1,31 @@
+type: action
+definition:
+  title: List Scanner event sinks
+  description: List event sinks for a Scanner tenant.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/event-sinks
+  namespace: tools.scanner
+  name: list_event_sinks
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    tenant_id:
+      type: str
+      description: Unique identifier for the Scanner tenant.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: list_event_sinks
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/event_sink
+        method: GET
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+        params:
+          tenant_id: ${{ inputs.tenant_id }}
+  returns: ${{ steps.list_event_sinks.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/run_detection_rule_yaml_tests.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/run_detection_rule_yaml_tests.yml
@@ -1,0 +1,31 @@
+type: action
+definition:
+  title: Run Scanner detection YAML tests
+  description: Run tests declared in a Scanner detection rule YAML document.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/validating-yaml-files
+  namespace: tools.scanner
+  name: run_detection_rule_yaml_tests
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    yaml_text:
+      type: str
+      description: Detection rule YAML content whose tests should be run.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: run_detection_rule_yaml_tests
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/detection_rule_yaml/run_tests
+        method: POST
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+          Content-Type: application/x-yaml
+        content: ${{ inputs.yaml_text }}
+  returns: ${{ steps.run_detection_rule_yaml_tests.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/run_query.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/run_query.yml
@@ -1,0 +1,75 @@
+type: action
+definition:
+  title: Run Scanner query
+  description: Execute a blocking ad hoc query and return its results.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/ad-hoc-queries
+  namespace: tools.scanner
+  name: run_query
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    query:
+      type: str
+      description: Scanner query text to execute.
+    start_time:
+      type: str
+      description: Inclusive query start timestamp in RFC 3339 format.
+    end_time:
+      type: str
+      description: Exclusive query end timestamp in RFC 3339 format.
+    max_rows:
+      type: int | None
+      description: Maximum rows to return. Scanner defaults to 1,000 and allows up to 100,000.
+      default: null
+    max_bytes:
+      type: int | None
+      description: Maximum bytes for the result table. Scanner defaults to 134,217,728 bytes.
+      default: null
+    scan_back_to_front:
+      type: bool | None
+      description: Scan from the latest events toward the earliest events.
+      default: null
+    timeout_seconds:
+      type: int
+      description: HTTP timeout in seconds. Scanner may hold blocking queries open for up to 300 seconds.
+      default: 310
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: build_query_payload
+      action: core.script.run_python
+      args:
+        inputs:
+          query: ${{ inputs.query }}
+          start_time: ${{ inputs.start_time }}
+          end_time: ${{ inputs.end_time }}
+          max_rows: ${{ inputs.max_rows }}
+          max_bytes: ${{ inputs.max_bytes }}
+          scan_back_to_front: ${{ inputs.scan_back_to_front }}
+        script: |
+          def main(query, start_time, end_time, max_rows, max_bytes, scan_back_to_front):
+              payload = {
+                  "query": query,
+                  "start_time": start_time,
+                  "end_time": end_time,
+                  "max_rows": max_rows,
+                  "max_bytes": max_bytes,
+                  "scan_back_to_front": scan_back_to_front,
+              }
+              return {key: value for key, value in payload.items() if value is not None}
+    - ref: run_query
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/blocking_query
+        method: POST
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+          Content-Type: application/json
+        payload: ${{ steps.build_query_payload.result }}
+        timeout: ${{ inputs.timeout_seconds }}
+  returns: ${{ steps.run_query.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/start_query.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/start_query.yml
@@ -1,0 +1,70 @@
+type: action
+definition:
+  title: Start Scanner query
+  description: Start an asynchronous ad hoc query and return its query run ID.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/ad-hoc-queries
+  namespace: tools.scanner
+  name: start_query
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    query:
+      type: str
+      description: Scanner query text to execute.
+    start_time:
+      type: str
+      description: Inclusive query start timestamp in RFC 3339 format.
+    end_time:
+      type: str
+      description: Exclusive query end timestamp in RFC 3339 format.
+    max_rows:
+      type: int | None
+      description: Maximum rows to return. Scanner defaults to 1,000 and allows up to 100,000.
+      default: null
+    max_bytes:
+      type: int | None
+      description: Maximum bytes for the result table. Scanner defaults to 134,217,728 bytes.
+      default: null
+    scan_back_to_front:
+      type: bool | None
+      description: Scan from the latest events toward the earliest events.
+      default: null
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: build_query_payload
+      action: core.script.run_python
+      args:
+        inputs:
+          query: ${{ inputs.query }}
+          start_time: ${{ inputs.start_time }}
+          end_time: ${{ inputs.end_time }}
+          max_rows: ${{ inputs.max_rows }}
+          max_bytes: ${{ inputs.max_bytes }}
+          scan_back_to_front: ${{ inputs.scan_back_to_front }}
+        script: |
+          def main(query, start_time, end_time, max_rows, max_bytes, scan_back_to_front):
+              payload = {
+                  "query": query,
+                  "start_time": start_time,
+                  "end_time": end_time,
+                  "max_rows": max_rows,
+                  "max_bytes": max_bytes,
+                  "scan_back_to_front": scan_back_to_front,
+              }
+              return {key: value for key, value in payload.items() if value is not None}
+    - ref: start_query
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/start_query
+        method: POST
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+          Content-Type: application/json
+        payload: ${{ steps.build_query_payload.result }}
+  returns: ${{ steps.start_query.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/update_detection_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/update_detection_rule.yml
@@ -1,0 +1,43 @@
+type: action
+definition:
+  title: Update Scanner detection rule
+  description: Update a Scanner detection rule with API-native fields.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/detection-rules
+  namespace: tools.scanner
+  name: update_detection_rule
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    detection_rule_id:
+      type: str
+      description: Unique Scanner detection rule ID.
+    updates:
+      type: dict[str, Any]
+      description: Detection rule fields to update. The rule ID is added to the request body.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: build_detection_rule_update
+      action: core.script.run_python
+      args:
+        inputs:
+          detection_rule_id: ${{ inputs.detection_rule_id }}
+          updates: ${{ inputs.updates }}
+        script: |
+          def main(detection_rule_id, updates):
+              return {**updates, "id": detection_rule_id}
+    - ref: update_detection_rule
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/detection_rule/${{ FN.url_encode(inputs.detection_rule_id) }}
+        method: PUT
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+          Content-Type: application/json
+        payload: ${{ steps.build_detection_rule_update.result }}
+  returns: ${{ steps.update_detection_rule.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/update_event_sink.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/update_event_sink.yml
@@ -1,0 +1,43 @@
+type: action
+definition:
+  title: Update Scanner event sink
+  description: Update a Scanner event sink with API-native fields.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/event-sinks
+  namespace: tools.scanner
+  name: update_event_sink
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    event_sink_id:
+      type: str
+      description: Unique Scanner event sink ID.
+    updates:
+      type: dict[str, Any]
+      description: Event sink fields to update. The event sink ID is added to the request body.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: build_event_sink_update
+      action: core.script.run_python
+      args:
+        inputs:
+          event_sink_id: ${{ inputs.event_sink_id }}
+          updates: ${{ inputs.updates }}
+        script: |
+          def main(event_sink_id, updates):
+              return {**updates, "id": event_sink_id}
+    - ref: update_event_sink
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/event_sink/${{ FN.url_encode(inputs.event_sink_id) }}
+        method: PUT
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+          Content-Type: application/json
+        payload: ${{ steps.build_event_sink_update.result }}
+  returns: ${{ steps.update_event_sink.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/validate_detection_rule_yaml.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/scanner/validate_detection_rule_yaml.yml
@@ -1,0 +1,31 @@
+type: action
+definition:
+  title: Validate Scanner detection YAML
+  description: Validate a Scanner detection rule YAML document.
+  display_group: Scanner
+  doc_url: https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/developer-tools/api/validating-yaml-files
+  namespace: tools.scanner
+  name: validate_detection_rule_yaml
+  secrets:
+    - name: scanner
+      keys: ["SCANNER_API_KEY"]
+  expects:
+    yaml_text:
+      type: str
+      description: Detection rule YAML content to validate.
+    base_url:
+      type: str | None
+      description: Scanner team API URL. Falls back to `VARS.scanner.base_url`.
+      default: null
+  steps:
+    - ref: validate_detection_rule_yaml
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.scanner.base_url }}/v1/detection_rule_yaml/validate
+        method: POST
+        headers:
+          Accept: application/json
+          Authorization: Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}
+          Content-Type: application/x-yaml
+        content: ${{ inputs.yaml_text }}
+  returns: ${{ steps.validate_detection_rule_yaml.result.data }}

--- a/tests/registry/test_core_http.py
+++ b/tests/registry/test_core_http.py
@@ -227,6 +227,53 @@ async def test_http_request_with_json_payload() -> None:
 
 @pytest.mark.anyio
 @respx.mock
+async def test_http_request_with_raw_content() -> None:
+    """Test sending a raw string as the complete request body."""
+    route = respx.post("https://api.example.com").mock(
+        return_value=httpx.Response(status_code=200)
+    )
+
+    content = "name: Example detection\n"
+    result = await http_request(
+        url="https://api.example.com",
+        method="POST",
+        headers={"Content-Type": "application/x-yaml"},
+        content=content,
+    )
+
+    assert route.called
+    request = route.calls.last.request
+    assert request.content == content.encode()
+    assert request.headers["Content-Type"] == "application/x-yaml"
+    assert result["status_code"] == 200
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "conflicting_body",
+    [
+        {"payload": {"data": "value"}},
+        {"form_data": {"field": "value"}},
+        {"files": {"file": "ZmlsZQ=="}},
+    ],
+)
+async def test_http_request_rejects_raw_content_with_other_body_modes(
+    conflicting_body: dict[str, object],
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="Raw content cannot be combined with payload, form_data, or files",
+    ):
+        await http_request(
+            url="https://api.example.com",
+            method="POST",
+            content="raw body",
+            **conflicting_body,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.anyio
+@respx.mock
 async def test_http_request_failure() -> None:
     """Test HTTP request with server error response."""
     route = respx.get("https://api.example.com").mock(

--- a/tests/registry/test_scanner_templates.py
+++ b/tests/registry/test_scanner_templates.py
@@ -1,0 +1,220 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tracecat_registry import RegistrySecret
+
+from tracecat.registry.actions.schemas import ActionStep, TemplateAction
+
+TEMPLATE_ROOT = Path(
+    "packages/tracecat-registry/tracecat_registry/templates/tools/scanner"
+)
+
+EXPECTED_ACTIONS = {
+    "tools.scanner.cancel_query",
+    "tools.scanner.create_detection_rule",
+    "tools.scanner.create_event_sink",
+    "tools.scanner.delete_detection_rule",
+    "tools.scanner.delete_event_sink",
+    "tools.scanner.get_detection_rule",
+    "tools.scanner.get_event_sink",
+    "tools.scanner.get_query_progress",
+    "tools.scanner.list_detection_rules",
+    "tools.scanner.list_event_sinks",
+    "tools.scanner.run_detection_rule_yaml_tests",
+    "tools.scanner.run_query",
+    "tools.scanner.start_query",
+    "tools.scanner.update_detection_rule",
+    "tools.scanner.update_event_sink",
+    "tools.scanner.validate_detection_rule_yaml",
+}
+
+
+def _load_template(filename: str) -> TemplateAction:
+    return TemplateAction.from_yaml(TEMPLATE_ROOT / filename)
+
+
+def _step(action: TemplateAction, ref: str) -> ActionStep:
+    return next(step for step in action.definition.steps if step.ref == ref)
+
+
+def _run_python_step(step: ActionStep, **inputs: Any) -> Any:
+    namespace: dict[str, Any] = {}
+    exec(step.args["script"], namespace)  # noqa: S102
+    return namespace["main"](**inputs)
+
+
+@pytest.fixture(scope="module")
+def templates() -> list[TemplateAction]:
+    return [
+        TemplateAction.from_yaml(path) for path in sorted(TEMPLATE_ROOT.glob("*.yml"))
+    ]
+
+
+def test_scanner_template_inventory(templates: list[TemplateAction]) -> None:
+    assert {template.definition.action for template in templates} == EXPECTED_ACTIONS
+
+
+def test_scanner_templates_share_auth_and_base_url_contract(
+    templates: list[TemplateAction],
+) -> None:
+    for template in templates:
+        assert template.definition.secrets is not None
+        secret = template.definition.secrets[0]
+        assert isinstance(secret, RegistrySecret)
+        assert secret.name == "scanner"
+        assert secret.keys == ["SCANNER_API_KEY"]
+
+        base_url = template.definition.expects["base_url"]
+        assert base_url.type == "str | None"
+        assert base_url.default is None
+
+        http_step = next(
+            step
+            for step in template.definition.steps
+            if step.action == "core.http_request"
+        )
+        assert http_step.args["url"].startswith(
+            "${{ inputs.base_url || VARS.scanner.base_url }}"
+        )
+        assert http_step.args["headers"]["Authorization"] == (
+            "Bearer ${{ SECRETS.scanner.SCANNER_API_KEY }}"
+        )
+
+
+def test_query_payload_omits_none_and_preserves_false() -> None:
+    template = _load_template("run_query.yml")
+    payload = _run_python_step(
+        _step(template, "build_query_payload"),
+        query="error | count",
+        start_time="2026-07-13T00:00:00Z",
+        end_time="2026-07-13T01:00:00Z",
+        max_rows=None,
+        max_bytes=None,
+        scan_back_to_front=False,
+    )
+
+    assert payload == {
+        "query": "error | count",
+        "start_time": "2026-07-13T00:00:00Z",
+        "end_time": "2026-07-13T01:00:00Z",
+        "scan_back_to_front": False,
+    }
+
+
+def test_detection_rule_pagination_uses_documented_parameter_names() -> None:
+    template = _load_template("list_detection_rules.yml")
+    params = _run_python_step(
+        _step(template, "build_pagination_params"),
+        tenant_id="00000000-0000-0000-0000-000000000001",
+        page_size=25,
+        page_token="next-page",
+    )
+
+    assert params == {
+        "tenant_id": "00000000-0000-0000-0000-000000000001",
+        "pagination[page_size]": 25,
+        "pagination[page_token]": "next-page",
+    }
+
+
+def test_create_detection_rule_matches_documented_contract() -> None:
+    template = _load_template("create_detection_rule.yml")
+    assert set(template.definition.expects) == {
+        "tenant_id",
+        "name",
+        "description",
+        "time_range_s",
+        "run_frequency_s",
+        "enabled_state_override",
+        "severity",
+        "query_text",
+        "event_sink_ids",
+        "tags",
+        "sync_key",
+        "base_url",
+    }
+
+    payload = _run_python_step(
+        _step(template, "build_detection_rule"),
+        tenant_id="00000000-0000-0000-0000-000000000001",
+        name="Example detection",
+        description="Detect an example event",
+        time_range_s=300,
+        run_frequency_s=300,
+        enabled_state_override="Active",
+        severity="Information",
+        query_text="error | count",
+        event_sink_ids=[],
+        tags=None,
+        sync_key=None,
+    )
+
+    assert payload["event_sink_ids"] == []
+    assert "tags" not in payload
+    assert "sync_key" not in payload
+
+
+@pytest.mark.parametrize(
+    ("filename", "step_ref", "resource_id_name"),
+    [
+        (
+            "update_detection_rule.yml",
+            "build_detection_rule_update",
+            "detection_rule_id",
+        ),
+        ("update_event_sink.yml", "build_event_sink_update", "event_sink_id"),
+    ],
+)
+def test_update_payload_uses_explicit_resource_id(
+    filename: str,
+    step_ref: str,
+    resource_id_name: str,
+) -> None:
+    template = _load_template(filename)
+    payload = _run_python_step(
+        _step(template, step_ref),
+        **{resource_id_name: "resource-id", "updates": {"id": "wrong-id"}},
+    )
+
+    assert payload == {"id": "resource-id"}
+
+
+def test_list_event_sinks_uses_only_documented_tenant_parameter() -> None:
+    template = _load_template("list_event_sinks.yml")
+    assert set(template.definition.expects) == {"tenant_id", "base_url"}
+    assert _step(template, "list_event_sinks").args["params"] == {
+        "tenant_id": "${{ inputs.tenant_id }}"
+    }
+
+
+@pytest.mark.parametrize(
+    ("filename", "step_ref", "path"),
+    [
+        (
+            "validate_detection_rule_yaml.yml",
+            "validate_detection_rule_yaml",
+            "/v1/detection_rule_yaml/validate",
+        ),
+        (
+            "run_detection_rule_yaml_tests.yml",
+            "run_detection_rule_yaml_tests",
+            "/v1/detection_rule_yaml/run_tests",
+        ),
+    ],
+)
+def test_detection_yaml_templates_send_raw_content(
+    filename: str,
+    step_ref: str,
+    path: str,
+) -> None:
+    template = _load_template(filename)
+    args = _step(template, step_ref).args
+
+    assert args["url"].endswith(path)
+    assert args["method"] == "POST"
+    assert args["content"] == "${{ inputs.yaml_text }}"
+    assert args["headers"]["Content-Type"] == "application/x-yaml"
+    assert "payload" not in args
+    assert "form_data" not in args
+    assert "files" not in args


### PR DESCRIPTION
## Summary

- Add 16 Scanner API actions as YAML templates for ad hoc queries, detection rules, event sinks, and detection-rule YAML validation.
- Add raw string body support to `core.http_request` so templates can send Scanner detection YAML without multipart encoding.
- Follow Scanner's current official API documentation, omitting the undocumented index endpoints from the earlier Python implementation.

## Implementation notes

- Scanner actions use the `scanner` secret with `SCANNER_API_KEY` and accept an optional `base_url` that falls back to `VARS.scanner.base_url`.
- Optional request fields are omitted while explicit false values and empty lists are preserved.
- Raw HTTP content is mutually exclusive with JSON payloads, form data, and files.

## Testing

- `uv run pytest --confcutdir=tests/registry tests/registry/test_core_http.py tests/registry/test_scanner_templates.py -q` (71 passed, 1 skipped)
- `uv run pytest --confcutdir=tests/registry tests/registry/test_templates.py -q` (421 passed)
- `uv run ruff check packages/tracecat-registry/tracecat_registry/core/http.py tests/registry/test_core_http.py tests/registry/test_scanner_templates.py`
- `uv run ruff format --check packages/tracecat-registry/tracecat_registry/core/http.py tests/registry/test_core_http.py tests/registry/test_scanner_templates.py`
- `uv run basedpyright packages/tracecat-registry/tracecat_registry/core/http.py tests/registry/test_core_http.py tests/registry/test_scanner_templates.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 16 Scanner API YAML templates for ad hoc queries, detection rules, event sinks, and YAML validation/tests. Also adds raw string body support to `core.http_request` to send Scanner detection YAML without multipart.

- **New Features**
  - 16 new `tools.scanner.*` templates for blocking/async queries, progress/cancel, CRUD for detection rules and event sinks, and YAML validate/run-tests.
  - `core.http_request` accepts `content` for raw bodies; it is exclusive with `payload`, `form_data`, and `files`.
  - Templates use the `scanner` secret (`SCANNER_API_KEY`) and an optional `base_url` that falls back to `VARS.scanner.base_url`.
  - Aligns with Scanner’s official API docs; undocumented index endpoints are not included.

- **Migration**
  - Configure `SCANNER_API_KEY` in the `scanner` secret and set `VARS.scanner.base_url`.
  - If using `core.http_request` directly for YAML, pass `content` and do not also pass `payload`, `form_data`, or `files`.

<sup>Written for commit 6c4206e35cadd8ada5a0b7a526ada4e2e88a48c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

