### PR TITLE
fix(agent): preserve caller scopes in MCP execution

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -21213,6 +21213,21 @@ export const $Role = {
       ],
       title: "Scopes",
     },
+    delegated_scopes: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+          uniqueItems: true,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Delegated Scopes",
+    },
   },
   additionalProperties: true,
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6426,6 +6426,7 @@ export type Role = {
     | "tracecat-ui"
   is_platform_superuser?: boolean
   scopes?: Array<string> | null
+  delegated_scopes?: Array<string> | null
   [key: string]: unknown | string | boolean
 }
 

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -668,15 +668,12 @@ class DurableAgentWorkflow:
         internal_tool_context: InternalToolContext | None = None,
     ) -> str:
         info = workflow.info()
-        delegated_scopes = None
-        if workflow.patched(DELEGATE_MCP_SCOPES_PATCH):
-            delegated_scopes = self.role.scopes or frozenset()
         return mint_mcp_token(
             workspace_id=self.workspace_id,
             organization_id=self.organization_id,
             user_id=self.role.user_id,
             allowed_actions=list(build_result.tool_definitions.keys()),
-            delegated_scopes=delegated_scopes,
+            delegated_scopes=self._delegated_mcp_scopes(),
             session_id=self.session_id,
             parent_agent_workflow_id=info.workflow_id,
             parent_agent_run_id=info.run_id,
@@ -685,6 +682,11 @@ class DurableAgentWorkflow:
             internal_tool_context=internal_tool_context,
             registry_lock=build_result.registry_lock,
         )
+
+    def _delegated_mcp_scopes(self) -> frozenset[str] | None:
+        if workflow.patched(DELEGATE_MCP_SCOPES_PATCH):
+            return self.role.scopes or frozenset()
+        return None
 
     def _remint_scope_tokens(
         self,
@@ -1678,6 +1680,7 @@ class DurableAgentWorkflow:
             workspace_id=self.role.workspace_id,
             organization_id=self.role.organization_id,
             user_id=self.role.user_id,
+            delegated_scopes=self._delegated_mcp_scopes(),
         )
         pending_results: list[PendingToolResult] = []
         cancelled_tool_call_ids: list[str] = []

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -482,6 +482,7 @@ def _preserved_agents_binding(
 
 FINALIZE_TURN_PATCH = "durable-agent-finalize-turn-v1"
 REMINT_SCOPE_TOKENS_PATCH = "durable-agent-remint-scope-tokens-v1"
+DELEGATE_MCP_SCOPES_PATCH = "durable-agent-delegate-mcp-scopes-v1"
 
 
 @workflow.defn
@@ -667,11 +668,15 @@ class DurableAgentWorkflow:
         internal_tool_context: InternalToolContext | None = None,
     ) -> str:
         info = workflow.info()
+        delegated_scopes = None
+        if workflow.patched(DELEGATE_MCP_SCOPES_PATCH):
+            delegated_scopes = self.role.scopes or frozenset()
         return mint_mcp_token(
             workspace_id=self.workspace_id,
             organization_id=self.organization_id,
             user_id=self.role.user_id,
             allowed_actions=list(build_result.tool_definitions.keys()),
+            delegated_scopes=delegated_scopes,
             session_id=self.session_id,
             parent_agent_workflow_id=info.workflow_id,
             parent_agent_run_id=info.run_id,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -685,7 +685,7 @@ class DurableAgentWorkflow:
 
     def _delegated_mcp_scopes(self) -> frozenset[str] | None:
         if workflow.patched(DELEGATE_MCP_SCOPES_PATCH):
-            return self.role.scopes or frozenset()
+            return self.role.scopes
         return None
 
     def _remint_scope_tokens(

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -92,7 +92,6 @@ from tracecat.agent.tokens import UserMCPServerClaim
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.auth.types import Role
-from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.chat.schemas import ChatMessage
 from tracecat.db.models import AgentSessionHistory, User
 from tracecat.dsl.common import RETRY_POLICIES
@@ -1252,7 +1251,8 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
     assert captured_executor_roles[0].workspace_id == svc_role.workspace_id
     assert captured_executor_roles[0].organization_id == svc_role.organization_id
     assert captured_executor_roles[0].user_id == svc_role.user_id
-    assert captured_executor_roles[0].scopes == SERVICE_PRINCIPAL_SCOPES["tracecat-mcp"]
+    assert captured_executor_roles[0].scopes == svc_role.scopes
+    assert captured_executor_roles[0].delegated_scopes == svc_role.scopes
 
     async with AgentSessionService.with_session(role=svc_role) as service:
         history = await service.get_session_history(mock_session_id)

--- a/tests/unit/test_agent_mcp_executor.py
+++ b/tests/unit/test_agent_mcp_executor.py
@@ -15,7 +15,11 @@ from tracecat.workflow.executions.correlation import build_agent_session_correla
 from tracecat.workflow.executions.enums import TemporalSearchAttr
 
 
-def _build_claims() -> MCPTokenClaims:
+def _build_claims(
+    *,
+    allowed_actions: list[str] | None = None,
+    delegated_scopes: frozenset[str] | None = None,
+) -> MCPTokenClaims:
     session_id = uuid.UUID("00000000-0000-0000-0000-000000000003")
     return MCPTokenClaims(
         workspace_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
@@ -23,14 +27,17 @@ def _build_claims() -> MCPTokenClaims:
         session_id=session_id,
         parent_agent_workflow_id=f"agent/{session_id}",
         parent_agent_run_id="run-123",
-        allowed_actions=["core.http_request"],
+        allowed_actions=allowed_actions or ["core.http_request"],
+        delegated_scopes=delegated_scopes,
     )
 
 
-def _build_registry_lock() -> RegistryLock:
+def _build_registry_lock(
+    action_name: str = "core.http_request",
+) -> RegistryLock:
     return RegistryLock(
         origins={"tracecat_registry": "test-version"},
-        actions={"core.http_request": "tracecat_registry"},
+        actions={action_name: "tracecat_registry"},
     )
 
 
@@ -82,6 +89,36 @@ async def test_execute_action_starts_registry_tool_workflow_with_alias_correlati
     assert pairs[TemporalSearchAttr.WORKSPACE_ID.value] == str(claims.workspace_id)
     retrieve_stored_object.assert_awaited_once_with({"uri": "s3://stored"})
     assert result == {"ok": True}
+
+
+@pytest.mark.anyio
+async def test_execute_action_preserves_delegated_scope_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delegated_scopes = frozenset({"action:core.script.run_python:execute"})
+    claims = _build_claims(
+        allowed_actions=["core.script.run_python"],
+        delegated_scopes=delegated_scopes,
+    )
+    execute_workflow = AsyncMock(return_value={"uri": "s3://stored"})
+    monkeypatch.setattr(executor, "_execute_action_workflow", execute_workflow)
+    monkeypatch.setattr(
+        executor,
+        "retrieve_stored_object",
+        AsyncMock(return_value={"ok": True}),
+    )
+
+    await executor.execute_action(
+        "core.script.run_python",
+        {"script": "def main():\n    return True"},
+        claims,
+        _build_registry_lock("core.script.run_python"),
+    )
+
+    assert execute_workflow.await_args is not None
+    workflow_input = execute_workflow.await_args.args[0]
+    assert workflow_input.role.scopes == delegated_scopes
+    assert "case:read" not in workflow_input.role.scopes
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_tokens.py
+++ b/tests/unit/test_agent_tokens.py
@@ -32,12 +32,14 @@ def test_mcp_token_round_trips_parent_agent_workflow_metadata(
     organization_id = uuid.uuid4()
     session_id = uuid.uuid4()
     user_id = uuid.uuid4()
+    delegated_scopes = frozenset({"action:core.http_request:execute"})
 
     token = mint_mcp_token(
         workspace_id=workspace_id,
         organization_id=organization_id,
         user_id=user_id,
         allowed_actions=["core.http_request"],
+        delegated_scopes=delegated_scopes,
         session_id=session_id,
         parent_agent_workflow_id=f"agent/{session_id}",
         parent_agent_run_id="run-123",
@@ -49,6 +51,7 @@ def test_mcp_token_round_trips_parent_agent_workflow_metadata(
     assert claims.organization_id == organization_id
     assert claims.session_id == session_id
     assert claims.user_id == user_id
+    assert claims.delegated_scopes == delegated_scopes
     assert claims.parent_agent_workflow_id == f"agent/{session_id}"
     assert claims.parent_agent_run_id == "run-123"
     assert claims.registry_lock == _registry_lock()

--- a/tests/unit/test_auth_scope_resolution.py
+++ b/tests/unit/test_auth_scope_resolution.py
@@ -77,6 +77,20 @@ async def test_compute_effective_scopes_service_with_user_id_uses_allowlist() ->
 
 
 @pytest.mark.anyio
+async def test_compute_effective_scopes_uses_delegated_service_scope_ceiling() -> None:
+    delegated_scopes = frozenset({"action:core.script.run_python:execute"})
+    role = Role(
+        type="service",
+        service_id="tracecat-mcp",
+        delegated_scopes=delegated_scopes,
+    )
+
+    scopes = await credentials.compute_effective_scopes(role)
+
+    assert scopes == delegated_scopes
+
+
+@pytest.mark.anyio
 async def test_compute_effective_scopes_unknown_service_principal_gets_empty_scopes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_authoring_context.py
+++ b/tests/unit/test_authoring_context.py
@@ -302,6 +302,37 @@ class TestComputeAttributedUserScopes:
         scopes = await credentials.compute_attributed_user_scopes(role)
         assert scopes == frozenset({"workflow:read"})
 
+    async def test_intersects_user_scopes_with_delegated_ceiling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tracecat.auth import credentials
+        from tracecat.auth.types import Role
+
+        user_id = uuid.uuid4()
+        org_id = uuid.uuid4()
+        ws_id = uuid.uuid4()
+        role = Role(
+            type="service",
+            service_id="tracecat-executor",
+            user_id=user_id,
+            organization_id=org_id,
+            workspace_id=ws_id,
+            delegated_scopes=frozenset({"workflow:read"}),
+        )
+
+        async def _fake_scopes(
+            uid: uuid.UUID, oid: uuid.UUID, wid: uuid.UUID | None
+        ) -> frozenset[str]:
+            assert (uid, oid, wid) == (user_id, org_id, ws_id)
+            return frozenset({"workflow:read", "secret:read"})
+
+        monkeypatch.setattr(
+            credentials, "_compute_effective_scopes_cached", _fake_scopes
+        )
+
+        scopes = await credentials.compute_attributed_user_scopes(role)
+        assert scopes == frozenset({"workflow:read"})
+
 
 class TestAuthoringContextRouteCallerScoping:
     """The internal authoring-context route gates inventory by the real caller.

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -136,6 +136,42 @@ def test_mcp_token_delegates_scopes_behind_replay_patch(
     patched_mock.assert_called_once_with(DELEGATE_MCP_SCOPES_PATCH)
 
 
+def test_mcp_token_preserves_unresolved_legacy_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=None,
+    )
+    workflow_instance = DurableAgentWorkflow(_build_workflow_args(role))
+    build_result = BuildToolDefsResult(
+        tool_definitions={},
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test-version"},
+            actions={},
+        ),
+    )
+
+    with (
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.patched",
+            return_value=True,
+        ),
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.info",
+            return_value=SimpleNamespace(workflow_id="agent/test", run_id="run-1"),
+        ),
+    ):
+        token = workflow_instance._mint_scope_mcp_token(build_result=build_result)
+
+    assert verify_mcp_token(token).delegated_scopes is None
+
+
 @pytest.mark.anyio
 async def test_upsert_tracecat_search_attributes_fills_missing_keys() -> None:
     role = Role(

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -14,6 +14,7 @@ from temporalio.exceptions import ActivityError
 from tracecat_ee.agent.activities import BuildToolDefsArgs, BuildToolDefsResult
 from tracecat_ee.agent.workflows.durable import (
     BUILD_AGENT_TOOL_DEFINITIONS_PATCH,
+    DELEGATE_MCP_SCOPES_PATCH,
     EMIT_PRE_STREAM_SESSION_ERRORS_PATCH,
     FINALIZE_TURN_PATCH,
     LOAD_TERMINAL_MESSAGE_HISTORY_PATCH,
@@ -25,12 +26,14 @@ from tracecat_ee.agent.workflows.durable import (
     _build_approved_tool_run_input,
 )
 
+from tracecat import config
 from tracecat.agent.common.types import MCPToolDefinition
 from tracecat.agent.executor.activity import AgentExecutorResult
 from tracecat.agent.executor.schemas import ApprovedToolCall
 from tracecat.agent.preset.activities import ResolveAgentPresetConfigActivityInput
 from tracecat.agent.schemas import AgentOutput, RunAgentArgs
 from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.tokens import verify_mcp_token
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.auth.types import Role
@@ -85,6 +88,52 @@ def test_agent_workflow_args_ignores_legacy_workspace_credentials() -> None:
     assert workflow_args.agent_args.session_id == payload["agent_args"]["session_id"]
     assert not hasattr(workflow_args, "use_workspace_credentials")
     assert not hasattr(workflow_args.agent_args, "use_workspace_credentials")
+
+
+@pytest.mark.parametrize(
+    ("patch_enabled", "expected_scopes"),
+    [
+        (False, None),
+        (True, frozenset({"agent:execute", "secret:read"})),
+    ],
+)
+def test_mcp_token_delegates_scopes_behind_replay_patch(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_enabled: bool,
+    expected_scopes: frozenset[str] | None,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute", "secret:read"}),
+    )
+    workflow_instance = DurableAgentWorkflow(_build_workflow_args(role))
+    build_result = BuildToolDefsResult(
+        tool_definitions={},
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test-version"},
+            actions={},
+        ),
+    )
+
+    with (
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.patched",
+            return_value=patch_enabled,
+        ) as patched_mock,
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.info",
+            return_value=SimpleNamespace(workflow_id="agent/test", run_id="run-1"),
+        ),
+    ):
+        token = workflow_instance._mint_scope_mcp_token(build_result=build_result)
+
+    assert verify_mcp_token(token).delegated_scopes == expected_scopes
+    patched_mock.assert_called_once_with(DELEGATE_MCP_SCOPES_PATCH)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_executor_token_service_id.py
+++ b/tests/unit/test_executor_token_service_id.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
 
 import jwt
 import pytest
@@ -16,6 +17,8 @@ from tracecat.auth.executor_tokens import (
     mint_executor_token,
     verify_executor_token,
 )
+from tracecat.authz.controls import check_scopes
+from tracecat.exceptions import ScopeDeniedError
 
 
 def _make_request(token: str) -> Request:
@@ -143,3 +146,44 @@ async def test_authenticate_executor_uses_service_id_claim_when_present(
     )
 
     assert role.service_id == "tracecat-schedule-runner"
+
+
+@pytest.mark.anyio
+async def test_executor_token_preserves_delegated_scope_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service_key = "test-service-key"
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", service_key)
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    delegated_scopes = frozenset({"action:core.script.run_python:execute"})
+
+    async def mock_get_workspace_org_id(ws_id: uuid.UUID) -> uuid.UUID | None:
+        return organization_id if ws_id == workspace_id else None
+
+    monkeypatch.setattr(credentials, "_get_workspace_org_id", mock_get_workspace_org_id)
+    token = mint_executor_token(
+        workspace_id=workspace_id,
+        user_id=uuid.uuid4(),
+        service_id="tracecat-mcp",
+        delegated_scopes=delegated_scopes,
+        wf_id="wf-1",
+        wf_exec_id="run-1",
+    )
+
+    role = await credentials._role_dependency(
+        request=_make_request(token),
+        session=AsyncMock(),
+        workspace_id=workspace_id,
+        user=None,
+        api_key=None,
+        allow_user=False,
+        allow_service=False,
+        allow_executor=True,
+        require_workspace="yes",
+    )
+
+    assert role.scopes == delegated_scopes
+    check_scopes(role, "action:core.script.run_python:execute")
+    with pytest.raises(ScopeDeniedError):
+        check_scopes(role, "case:read")

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -25,6 +25,7 @@ from tracecat.authz.scopes import (
     SERVICE_PRINCIPAL_SCOPES,
     VIEWER_SCOPES,
     WORKSPACE_OPERATIONAL_SCOPES,
+    backfill_legacy_role_scopes,
 )
 from tracecat.contexts import ctx_role
 from tracecat.exceptions import ScopeDeniedError
@@ -528,3 +529,14 @@ class TestServicePrincipalScopes:
     def test_llm_gateway_has_secret_read(self):
         """LLM gateway needs secret:read for workspace credential lookup (case chat path)."""
         assert "secret:read" in SERVICE_PRINCIPAL_SCOPES["tracecat-llm-gateway"]
+
+    def test_backfill_preserves_empty_delegated_scope_ceiling(self):
+        role = Role(
+            type="service",
+            service_id="tracecat-mcp",
+            delegated_scopes=frozenset(),
+        )
+
+        backfilled_role = backfill_legacy_role_scopes(role)
+
+        assert backfilled_role.scopes == frozenset()

--- a/tests/unit/test_role_headers.py
+++ b/tests/unit/test_role_headers.py
@@ -148,6 +148,7 @@ class TestAuthenticateServiceRoundtrip:
             organization_id=organization_id,
             user_id=user_id,
             scopes=frozenset({"workflow:read"}),
+            delegated_scopes=frozenset({"workflow:read"}),
         )
 
         headers = MockHeaders(original_role.to_headers())
@@ -163,6 +164,31 @@ class TestAuthenticateServiceRoundtrip:
         assert reconstructed.workspace_id == workspace_id
         assert reconstructed.organization_id == organization_id
         assert reconstructed.scopes == frozenset({"workflow:read"})
+        assert reconstructed.delegated_scopes == frozenset({"workflow:read"})
+
+    async def test_roundtrip_preserves_empty_delegated_scope_ceiling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "tracecat.auth.credentials.config.TRACECAT__SERVICE_KEY", "test-key"
+        )
+        monkeypatch.setattr(
+            "tracecat.auth.credentials.config.TRACECAT__SERVICE_ROLES_WHITELIST",
+            ["tracecat-runner"],
+        )
+        original_role = Role(
+            type="service",
+            service_id="tracecat-runner",
+            delegated_scopes=frozenset(),
+        )
+
+        request = MagicMock()
+        request.headers = MockHeaders(original_role.to_headers())
+
+        reconstructed = await _authenticate_service(request, api_key="test-key")
+
+        assert reconstructed is not None
+        assert reconstructed.delegated_scopes == frozenset()
 
     async def test_authenticate_service_reads_scopes(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tracecat/agent/mcp/executor.py
+++ b/tracecat/agent/mcp/executor.py
@@ -55,15 +55,22 @@ def build_tracecat_mcp_role(
     workspace_id: UUID | None,
     organization_id: UUID | None,
     user_id: UUID | None,
+    delegated_scopes: frozenset[str] | None = None,
 ) -> Role:
     """Build the trusted MCP service role for action execution."""
+    scopes = (
+        delegated_scopes
+        if delegated_scopes is not None
+        else SERVICE_PRINCIPAL_SCOPES["tracecat-mcp"]
+    )
     return Role(
         type="service",
         service_id="tracecat-mcp",
         workspace_id=workspace_id,
         organization_id=organization_id,
         user_id=user_id,
-        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-mcp"],
+        scopes=scopes,
+        delegated_scopes=delegated_scopes,
     )
 
 
@@ -73,6 +80,7 @@ def build_role_from_claims(claims: MCPTokenClaims) -> Role:
         workspace_id=claims.workspace_id,
         organization_id=claims.organization_id,
         user_id=claims.user_id,
+        delegated_scopes=claims.delegated_scopes,
     )
 
 

--- a/tracecat/agent/mcp/internal_tools.py
+++ b/tracecat/agent/mcp/internal_tools.py
@@ -21,6 +21,7 @@ from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
 from tracecat import config
 from tracecat.agent.common.types import MCPToolDefinition
+from tracecat.agent.mcp.executor import build_role_from_claims
 from tracecat.agent.preset.schemas import AgentPresetUpdate
 from tracecat.agent.session.schemas import (
     AgentSessionRead,
@@ -30,7 +31,6 @@ from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.agent.tokens import InternalToolContext, MCPTokenClaims
 from tracecat.auth.types import Role
-from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.contexts import ctx_role
 from tracecat.exceptions import (
     TracecatValidationError,
@@ -215,14 +215,7 @@ def _get_preset_id(context: InternalToolContext | None) -> uuid.UUID:
 
 def _build_role(claims: MCPTokenClaims) -> Role:
     """Build a Role from MCP token claims."""
-    return Role(
-        type="service",
-        service_id="tracecat-mcp",
-        workspace_id=claims.workspace_id,
-        organization_id=claims.organization_id,
-        user_id=claims.user_id,
-        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-mcp"],
-    )
+    return build_role_from_claims(claims)
 
 
 async def _get_action_configuration(

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -38,6 +38,7 @@ from tracecat.agent.common.types import (
 from tracecat.agent.mcp.executor import (
     ActionExecutionError,
     ActionNotAllowedError,
+    build_role_from_claims,
     execute_action,
 )
 from tracecat.agent.mcp.internal_tools import (
@@ -62,7 +63,6 @@ from tracecat.agent.mcp.utils import (
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.tokens import MCPTokenClaims, UserMCPServerClaim, verify_mcp_token
 from tracecat.auth.types import Role
-from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.contexts import ctx_role
 from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
@@ -170,14 +170,7 @@ def _set_role_context(claims: MCPTokenClaims) -> Role:
 
     This must be called before any service that requires organization context.
     """
-    role = Role(
-        type="service",
-        service_id="tracecat-mcp",
-        workspace_id=claims.workspace_id,
-        organization_id=claims.organization_id,
-        user_id=claims.user_id,
-        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-mcp"],
-    )
+    role = build_role_from_claims(claims)
     ctx_role.set(role)
     return role
 

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -114,6 +114,12 @@ class MCPTokenClaims(BaseModel):
     """Organization UUID for authorization context."""
     allowed_actions: list[str]
     """Set of allowed action names (e.g., {"tools.slack.post_message", "core.http_request"})."""
+    delegated_scopes: frozenset[str] | None = None
+    """Caller scopes delegated to trusted tool and nested SDK execution.
+
+    Optional only for compatibility with tokens minted before delegated scope
+    propagation was introduced.
+    """
     user_mcp_servers: list[UserMCPServerClaim] = Field(default_factory=list)
     """User-defined MCP server configurations for proxying tool calls."""
     allowed_internal_tools: list[str] = Field(default_factory=list)
@@ -137,6 +143,7 @@ def mint_mcp_token(
     allowed_actions: list[str],
     session_id: uuid.UUID,
     registry_lock: RegistryLock,
+    delegated_scopes: frozenset[str] | None = None,
     user_id: UserID | None = None,
     parent_agent_workflow_id: str | None = None,
     parent_agent_run_id: str | None = None,
@@ -160,6 +167,7 @@ def mint_mcp_token(
         allowed_actions: Set of allowed action names
         session_id: Agent session ID for traceability
         registry_lock: Registry lock resolved for this token's registry actions
+        delegated_scopes: Caller scopes delegated to tool and SDK execution
         user_id: Optional user ID for audit/traceability
         user_mcp_servers: User-defined MCP server configs for proxying
         allowed_internal_tools: Set of allowed internal tool names
@@ -191,6 +199,7 @@ def mint_mcp_token(
             parent_agent_workflow_id=parent_agent_workflow_id,
             parent_agent_run_id=parent_agent_run_id,
             allowed_actions=allowed_actions,
+            delegated_scopes=delegated_scopes,
             user_mcp_servers=user_mcp_servers or [],
             allowed_internal_tools=allowed_internal_tools or [],
             internal_tool_context=internal_tool_context,

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -128,9 +128,9 @@ async def compute_effective_scopes(role: Role) -> frozenset[str]:
 
     Scope computation follows this hierarchy:
     1. Roles explicitly executing with platform-superuser privileges get "*"
-    2. Service principals (non-user flows) use static allowlist scopes
-    3. Direct user role assignments (org-wide and workspace-specific)
-    4. Group role assignments (org-wide and workspace-specific)
+    2. Delegated service executions use their signed scope ceiling
+    3. Other service principals use static allowlist scopes
+    4. Direct and group user role assignments
     """
     if role.is_platform_superuser:
         return frozenset({"*"})
@@ -139,6 +139,14 @@ async def compute_effective_scopes(role: Role) -> frozenset[str]:
         return role.scopes or frozenset()
 
     if role.type == "service":
+        if role.delegated_scopes is not None:
+            logger.debug(
+                "Resolved effective scopes from delegated executor token",
+                service_id=role.service_id,
+                scope_count=len(role.delegated_scopes),
+                source="delegated_executor_token",
+            )
+            return role.delegated_scopes
         service_scopes = SERVICE_PRINCIPAL_SCOPES.get(role.service_id)
         if service_scopes is None:
             logger.warning(
@@ -823,6 +831,7 @@ async def _authenticate_executor(
         workspace_id=token_payload.workspace_id,
         organization_id=organization_id,
         user_id=token_payload.user_id,
+        delegated_scopes=token_payload.delegated_scopes,
     )
 
     # Validate workspace requirements for executor

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -194,9 +194,12 @@ async def compute_attributed_user_scopes(role: Role) -> frozenset[str] | None:
     """
     if role.type != "service" or role.user_id is None or role.organization_id is None:
         return None
-    return await _compute_effective_scopes_cached(
+    user_scopes = await _compute_effective_scopes_cached(
         role.user_id, role.organization_id, role.workspace_id
     )
+    if role.delegated_scopes is not None:
+        return user_scopes & role.delegated_scopes
+    return user_scopes
 
 
 @alru_cache(maxsize=10000, ttl=30)
@@ -354,6 +357,17 @@ async def _authenticate_service(
         scopes = frozenset(
             stripped for s in scopes_header.split(",") if (stripped := s.strip())
         )
+    delegated_scopes: frozenset[str] | None = None
+    if (
+        delegated_scopes_header := request.headers.get(
+            "x-tracecat-role-delegated-scopes"
+        )
+    ) is not None:
+        delegated_scopes = frozenset(
+            stripped
+            for scope in delegated_scopes_header.split(",")
+            if (stripped := scope.strip())
+        )
     service_account_id = (
         uuid.UUID(raw_service_account_id)
         if (
@@ -383,6 +397,7 @@ async def _authenticate_service(
         organization_id=organization_id,
         service_account_id=service_account_id,
         scopes=scopes,
+        delegated_scopes=delegated_scopes,
     )
 
 

--- a/tracecat/auth/executor_tokens.py
+++ b/tracecat/auth/executor_tokens.py
@@ -32,6 +32,7 @@ class ExecutorTokenPayload(BaseModel):
     workspace_id: WorkspaceID
     user_id: UserID | None
     service_id: InternalServiceID | None = None
+    delegated_scopes: frozenset[str] | None = None
     wf_id: str
     wf_exec_id: str
 
@@ -41,6 +42,7 @@ def mint_executor_token(
     workspace_id: WorkspaceID,
     user_id: UserID | None,
     service_id: InternalServiceID = "tracecat-executor",
+    delegated_scopes: frozenset[str] | None = None,
     wf_id: str,
     wf_exec_id: str,
     ttl_seconds: int | None = None,
@@ -60,6 +62,8 @@ def mint_executor_token(
         "wf_id": wf_id,
         "wf_exec_id": wf_exec_id,
     }
+    if delegated_scopes is not None:
+        payload["delegated_scopes"] = sorted(delegated_scopes)
 
     return jwt.encode(payload, get_service_key(), algorithm="HS256")
 
@@ -68,7 +72,7 @@ def verify_executor_token(token: str) -> ExecutorTokenPayload:
     """Verify executor JWT and return the token payload.
 
     Returns the ExecutorTokenPayload containing workspace_id, user_id, service_id,
-    wf_id, and wf_exec_id.
+    delegated_scopes, wf_id, and wf_exec_id.
     """
     try:
         payload = jwt.decode(
@@ -92,6 +96,7 @@ def verify_executor_token(token: str) -> ExecutorTokenPayload:
             workspace_id=payload["workspace_id"],
             user_id=payload.get("user_id"),
             service_id=payload.get("service_id"),
+            delegated_scopes=payload.get("delegated_scopes"),
             wf_id=payload["wf_id"],
             wf_exec_id=payload["wf_exec_id"],
         )

--- a/tracecat/auth/types.py
+++ b/tracecat/auth/types.py
@@ -106,6 +106,10 @@ class Role(BaseModel):
             headers["x-tracecat-role-organization-id"] = str(self.organization_id)
         if self.scopes:
             headers["x-tracecat-role-scopes"] = ",".join(sorted(self.scopes))
+        if self.delegated_scopes is not None:
+            headers["x-tracecat-role-delegated-scopes"] = ",".join(
+                sorted(self.delegated_scopes)
+            )
         if self.service_account_id is not None:
             headers["x-tracecat-role-service-account-id"] = str(self.service_account_id)
         return headers

--- a/tracecat/auth/types.py
+++ b/tracecat/auth/types.py
@@ -42,6 +42,10 @@ class Role(BaseModel):
     """Whether this role is currently executing platform-superuser privileges."""
     scopes: frozenset[str] | None = Field(default=None, frozen=True, repr=False)
     """Effective scopes for this role. None means unresolved/unset."""
+    delegated_scopes: frozenset[str] | None = Field(
+        default=None, frozen=True, repr=False
+    )
+    """Signed scope ceiling delegated across a service execution boundary."""
 
     @model_validator(mode="after")
     def validate_service_account_shape(self) -> Self:

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -440,6 +440,9 @@ def backfill_legacy_role_scopes(role: Role) -> Role:
 
     Returns the role unchanged if it already has scopes populated.
     """
+    if role.delegated_scopes is not None:
+        return role.model_copy(update={"scopes": role.delegated_scopes})
+
     if role.scopes:
         # Already has scopes — nothing to backfill
         return role

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -328,6 +328,7 @@ class ActionRunner:
                 workspace_id=role.workspace_id,
                 user_id=role.user_id,
                 service_id=role.service_id,
+                delegated_scopes=role.delegated_scopes,
                 wf_id=str(input.run_context.wf_id),
                 wf_exec_id=str(input.run_context.wf_run_id),
             )

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -405,6 +405,7 @@ async def _prepare_step_context(
         workspace_id=role.workspace_id,
         user_id=role.user_id,
         service_id=role.service_id,
+        delegated_scopes=role.delegated_scopes,
         wf_id=str(input.run_context.wf_id),
         wf_exec_id=str(input.run_context.wf_run_id),
     )
@@ -735,6 +736,7 @@ async def prepare_resolved_context(
         workspace_id=role.workspace_id,
         user_id=role.user_id,
         service_id=role.service_id,
+        delegated_scopes=role.delegated_scopes,
         wf_id=str(input.run_context.wf_id),
         wf_exec_id=str(input.run_context.wf_run_id),
     )


### PR DESCRIPTION
## Summary

- preserve the originating caller's scopes when a trusted MCP tool starts an executor workflow
- carry the signed delegated scope ceiling into executor SDK tokens instead of re-expanding the `tracecat-mcp` service allowlist
- retain compatibility for legacy tokens and gate the new MCP claim behind a Temporal patch marker for replay safety

## Root cause

The trusted MCP server reconstructed a `tracecat-mcp` service role using `SERVICE_PRINCIPAL_SCOPES`. When `core.script.run_python` received its executor SDK token, API authentication expanded the same service identity back to that broad allowlist. As a result, nested SDK calls such as case listing could receive scopes the original caller did not hold.

## Red/green proof

Before the fix, these regressions failed because both reconstructed roles included `case:read`:

```text
tests/unit/test_agent_mcp_executor.py::test_execute_action_preserves_delegated_scope_ceiling
tests/unit/test_executor_token_service_id.py::test_executor_token_preserves_delegated_scope_ceiling
```

After the fix, both pass and the executor-authenticated role permits only `action:core.script.run_python:execute`; `case:read` is denied.

## Validation

- 120 affected MCP, token, auth, and RBAC tests passed
- 14 action-runner and executor-context tests passed
- 13 durable-agent workflow tests passed, including replay patch coverage
- `uv run ruff check` passed for all changed Python files
- `uv run ruff format --check` passed for all changed Python files
- targeted `uv run basedpyright --warnings --threads 4` passed with 0 errors and 0 warnings
- all pre-commit hooks passed, including OpenAPI generation and frontend typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the caller’s scope ceiling across MCP tool and approved-tool execution to prevent scope escalation in nested executor SDK calls. Delegated scopes are signed into MCP and executor tokens, propagated end-to-end, and enforced during auth and role resolution, gated by a Temporal patch.

- **Bug Fixes**
  - Added `delegated_scopes` to MCP and executor tokens; propagate through role headers, role context, action runner, and approved-tool workflows.
  - Compute service role scopes from `delegated_scopes` first; intersect with attributed user scopes when present; fall back to static allowlists otherwise.
  - Build MCP service roles from token claims across executor, trusted server, and internal tools; preserve empty delegated ceilings and avoid re-expanding the broad `tracecat-mcp` allowlist.
  - Backfill `Role.scopes` from `delegated_scopes` when available; delegation is gated behind `durable-agent-delegate-mcp-scopes-v1` so legacy tokens continue to work.
  - Frontend `Role` schema/types now expose `delegated_scopes`.

- **Migration**
  - No action needed. Legacy tokens continue to work; enable the patch to start delegating scopes.

<sup>Written for commit 8acb86d6ad633240738003f3f9064f9491971f49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

