### PR TITLE
fix(integrations): FOR UPDATE lock during oauth refresh flow

### DIFF
--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -7,6 +7,7 @@ import pytest
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.oauth2.rfc7636 import create_s256_code_challenge
 from pydantic import BaseModel, SecretStr, ValidationError
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
@@ -864,6 +865,71 @@ class TestIntegrationService:
                 assert refreshed.expires_at >= integration.expires_at, (
                     "New expiry should be greater than or equal to old expiry"
                 )
+
+    async def test_refresh_token_if_needed_skips_when_concurrently_refreshed(
+        self,
+        integration_service: IntegrationService,
+        mock_provider: MockOAuthProvider,
+        mock_token_response: TokenResponse,
+    ) -> None:
+        """A refresher that loses the row-lock race must not replay the refresh.
+
+        Simulates a concurrent process having already refreshed the row: the
+        in-memory instance still looks stale, but the locked re-read inside
+        refresh_token_if_needed sees the fresh row and must skip the provider
+        call, since replaying an already-rotated refresh token trips
+        server-side reuse detection and revokes the grant.
+        """
+        provider_key = ProviderKey(
+            id=mock_provider.id,
+            grant_type=mock_provider.grant_type,
+        )
+
+        with patch(
+            "tracecat.integrations.service.get_provider_class"
+        ) as mock_get_provider:
+            mock_get_provider.return_value = MockOAuthProvider
+
+            with patch.object(
+                MockOAuthProvider, "refresh_access_token", new_callable=AsyncMock
+            ) as mock_refresh:
+                await integration_service.store_provider_config(
+                    provider_key=provider_key,
+                    client_id="mock_client_id",
+                    client_secret=SecretStr("mock_client_secret"),
+                )
+                integration = await integration_service.store_integration(
+                    provider_key=provider_key,
+                    access_token=mock_token_response.access_token,
+                    refresh_token=mock_token_response.refresh_token,
+                    expires_in=60,  # Within the refresh window
+                )
+                assert integration.needs_refresh
+
+                # Simulate the concurrent winner: update the row directly so
+                # the DB is fresh while this instance still looks stale.
+                await integration_service.session.execute(
+                    update(OAuthIntegration)
+                    .where(OAuthIntegration.id == integration.id)
+                    .values(
+                        encrypted_access_token=integration_service._encrypt_token(
+                            "concurrently_refreshed_token"
+                        ),
+                        expires_at=datetime.now(UTC) + timedelta(hours=2),
+                    )
+                )
+                await integration_service.session.commit()
+
+                refreshed = await integration_service.refresh_token_if_needed(
+                    integration
+                )
+
+                # The locked re-read saw the fresh row: no provider call, and
+                # the concurrent refresher's token is what callers get.
+                mock_refresh.assert_not_called()
+                assert not refreshed.needs_refresh
+                access_token, _ = integration_service.get_decrypted_tokens(refreshed)
+                assert access_token == "concurrently_refreshed_token"
 
     async def test_refresh_token_if_needed_no_refresh_token(
         self,

--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, ClassVar
@@ -7,13 +8,18 @@ import pytest
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.oauth2.rfc7636 import create_s256_code_challenge
 from pydantic import BaseModel, SecretStr, ValidationError
-from sqlalchemy import update
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
+from tests.database import TEST_DB_CONFIG
 from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
-from tracecat.db.models import OAuthIntegration
+from tracecat.db.models import OAuthIntegration, Workspace
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.integrations.enums import OAuthGrantType
 from tracecat.integrations.providers.base import (
@@ -866,70 +872,281 @@ class TestIntegrationService:
                     "New expiry should be greater than or equal to old expiry"
                 )
 
-    async def test_refresh_token_if_needed_skips_when_concurrently_refreshed(
+    async def test_refresh_token_if_needed_serializes_concurrent_refreshes(
+        self,
+        mock_provider: MockOAuthProvider,
+        mock_token_response: TokenResponse,
+        svc_role: Role,
+        encryption_key: str,
+    ) -> None:
+        """Concurrent stale readers must present the refresh token only once."""
+        del encryption_key
+        provider_key = ProviderKey(
+            id=mock_provider.id,
+            grant_type=mock_provider.grant_type,
+        )
+        role = svc_role.model_copy(
+            update={"workspace_id": uuid.uuid4()},
+            deep=True,
+        )
+        concurrent_engine = create_async_engine(TEST_DB_CONFIG.test_url)
+        session_factory = async_sessionmaker(
+            bind=concurrent_engine,
+            expire_on_commit=False,
+        )
+        first_refresh_started = asyncio.Event()
+        release_first_refresh = asyncio.Event()
+        first_task: asyncio.Task[OAuthIntegration] | None = None
+        second_task: asyncio.Task[OAuthIntegration] | None = None
+        expected_refresh_token = mock_token_response.refresh_token
+        assert expected_refresh_token is not None
+
+        async def refresh_access_token(refresh_token: str) -> TokenResponse:
+            assert refresh_token == expected_refresh_token.get_secret_value()
+            first_refresh_started.set()
+            await release_first_refresh.wait()
+            return TokenResponse(
+                access_token=SecretStr("refreshed_token"),
+                refresh_token=SecretStr("rotated_refresh_token"),
+                expires_in=7200,
+                scope="read write",
+                token_type="Bearer",
+            )
+
+        async def wait_until_second_refresh_is_blocked() -> None:
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + 5
+            async with concurrent_engine.connect() as observer:
+                while loop.time() < deadline:
+                    # PostgreSQL caches statistics within a transaction unless
+                    # the snapshot is explicitly cleared between polls.
+                    await observer.execute(text("SELECT pg_stat_clear_snapshot()"))
+                    is_blocked = await observer.scalar(
+                        text(
+                            """
+                            SELECT EXISTS (
+                                SELECT 1
+                                FROM pg_stat_activity
+                                WHERE datname = current_database()
+                                  AND cardinality(pg_blocking_pids(pid)) > 0
+                                  AND query ILIKE '%oauth_integration%'
+                            )
+                            """
+                        )
+                    )
+                    if is_blocked:
+                        return
+                    await asyncio.sleep(0.01)
+            raise AssertionError("Second refresh did not block on the row lock")
+
+        try:
+            with (
+                patch(
+                    "tracecat.integrations.service.get_provider_class",
+                    return_value=MockOAuthProvider,
+                ),
+                patch.object(
+                    MockOAuthProvider,
+                    "refresh_access_token",
+                    new_callable=AsyncMock,
+                    side_effect=refresh_access_token,
+                ) as mock_refresh,
+            ):
+                async with session_factory() as seed_session:
+                    seed_session.add(
+                        Workspace(
+                            id=role.workspace_id,
+                            name=f"refresh-race-{role.workspace_id}",
+                            organization_id=role.organization_id,
+                        )
+                    )
+                    await seed_session.commit()
+                    seed_service = IntegrationService(
+                        session=seed_session,
+                        role=role.model_copy(deep=True),
+                    )
+                    await seed_service.store_provider_config(
+                        provider_key=provider_key,
+                        client_id="mock_client_id",
+                        client_secret=SecretStr("mock_client_secret"),
+                    )
+                    integration = await seed_service.store_integration(
+                        provider_key=provider_key,
+                        access_token=mock_token_response.access_token,
+                        refresh_token=mock_token_response.refresh_token,
+                        expires_in=60,
+                    )
+                    integration_id = integration.id
+
+                async with (
+                    session_factory() as first_session,
+                    session_factory() as second_session,
+                ):
+                    first_integration = await first_session.get(
+                        OAuthIntegration, integration_id
+                    )
+                    second_integration = await second_session.get(
+                        OAuthIntegration, integration_id
+                    )
+                    assert first_integration is not None
+                    assert second_integration is not None
+                    assert first_integration is not second_integration
+                    assert first_integration.needs_refresh
+                    assert second_integration.needs_refresh
+
+                    first_service = IntegrationService(
+                        session=first_session,
+                        role=role.model_copy(deep=True),
+                    )
+                    second_service = IntegrationService(
+                        session=second_session,
+                        role=role.model_copy(deep=True),
+                    )
+
+                    first_task = asyncio.create_task(
+                        first_service.refresh_token_if_needed(first_integration)
+                    )
+                    await asyncio.wait_for(first_refresh_started.wait(), timeout=5)
+
+                    second_task = asyncio.create_task(
+                        second_service.refresh_token_if_needed(second_integration)
+                    )
+                    await wait_until_second_refresh_is_blocked()
+
+                    assert mock_refresh.await_count == 1
+                    assert not second_task.done()
+
+                    release_first_refresh.set()
+                    first_result, second_result = await asyncio.gather(
+                        first_task,
+                        second_task,
+                    )
+
+                    mock_refresh.assert_awaited_once()
+                    for service, refreshed in (
+                        (first_service, first_result),
+                        (second_service, second_result),
+                    ):
+                        access_token, refresh_token = service.get_decrypted_tokens(
+                            refreshed
+                        )
+                        assert access_token == "refreshed_token"
+                        assert refresh_token == "rotated_refresh_token"
+                        assert not refreshed.needs_refresh
+        finally:
+            release_first_refresh.set()
+            tasks = [task for task in (first_task, second_task) if task is not None]
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            await concurrent_engine.dispose()
+
+    async def test_successful_refresh_does_not_commit_caller_session(
         self,
         integration_service: IntegrationService,
         mock_provider: MockOAuthProvider,
         mock_token_response: TokenResponse,
+        svc_workspace: Workspace,
     ) -> None:
-        """A refresher that loses the row-lock race must not replay the refresh.
-
-        Simulates a concurrent process having already refreshed the row: the
-        in-memory instance still looks stale, but the locked re-read inside
-        refresh_token_if_needed sees the fresh row and must skip the provider
-        call, since replaying an already-rotated refresh token trips
-        server-side reuse detection and revokes the grant.
-        """
+        """A successful refresh must leave unrelated caller changes uncommitted."""
         provider_key = ProviderKey(
             id=mock_provider.id,
             grant_type=mock_provider.grant_type,
         )
 
-        with patch(
-            "tracecat.integrations.service.get_provider_class"
-        ) as mock_get_provider:
-            mock_get_provider.return_value = MockOAuthProvider
+        with (
+            patch(
+                "tracecat.integrations.service.get_provider_class",
+                return_value=MockOAuthProvider,
+            ),
+            patch.object(
+                MockOAuthProvider,
+                "refresh_access_token",
+                new_callable=AsyncMock,
+                return_value=TokenResponse(
+                    access_token=SecretStr("refreshed_token"),
+                    refresh_token=SecretStr("new_refresh_token"),
+                    expires_in=7200,
+                    scope="read write",
+                    token_type="Bearer",
+                ),
+            ) as mock_refresh,
+        ):
+            await integration_service.store_provider_config(
+                provider_key=provider_key,
+                client_id="mock_client_id",
+                client_secret=SecretStr("mock_client_secret"),
+            )
+            integration = await integration_service.store_integration(
+                provider_key=provider_key,
+                access_token=mock_token_response.access_token,
+                refresh_token=mock_token_response.refresh_token,
+                expires_in=60,
+            )
+            pending_workspace_name = f"{svc_workspace.name}-pending"
+            svc_workspace.name = pending_workspace_name
+            assert svc_workspace in integration_service.session.dirty
 
-            with patch.object(
-                MockOAuthProvider, "refresh_access_token", new_callable=AsyncMock
-            ) as mock_refresh:
-                await integration_service.store_provider_config(
-                    provider_key=provider_key,
-                    client_id="mock_client_id",
-                    client_secret=SecretStr("mock_client_secret"),
-                )
-                integration = await integration_service.store_integration(
-                    provider_key=provider_key,
-                    access_token=mock_token_response.access_token,
-                    refresh_token=mock_token_response.refresh_token,
-                    expires_in=60,  # Within the refresh window
-                )
-                assert integration.needs_refresh
+            refreshed = await integration_service.refresh_token_if_needed(integration)
 
-                # Simulate the concurrent winner: update the row directly so
-                # the DB is fresh while this instance still looks stale.
-                await integration_service.session.execute(
-                    update(OAuthIntegration)
-                    .where(OAuthIntegration.id == integration.id)
-                    .values(
-                        encrypted_access_token=integration_service._encrypt_token(
-                            "concurrently_refreshed_token"
-                        ),
-                        expires_at=datetime.now(UTC) + timedelta(hours=2),
-                    )
-                )
-                await integration_service.session.commit()
+            mock_refresh.assert_awaited_once()
+            access_token, refresh_token = integration_service.get_decrypted_tokens(
+                refreshed
+            )
+            assert access_token == "refreshed_token"
+            assert refresh_token == "new_refresh_token"
+            assert svc_workspace.name == pending_workspace_name
+            assert svc_workspace in integration_service.session.dirty
 
-                refreshed = await integration_service.refresh_token_if_needed(
-                    integration
-                )
+    async def test_refresh_failure_does_not_commit_caller_session(
+        self,
+        integration_service: IntegrationService,
+        mock_provider: MockOAuthProvider,
+        mock_token_response: TokenResponse,
+        svc_workspace: Workspace,
+    ) -> None:
+        """A failed refresh must leave unrelated caller changes uncommitted."""
+        provider_key = ProviderKey(
+            id=mock_provider.id,
+            grant_type=mock_provider.grant_type,
+        )
 
-                # The locked re-read saw the fresh row: no provider call, and
-                # the concurrent refresher's token is what callers get.
-                mock_refresh.assert_not_called()
-                assert not refreshed.needs_refresh
-                access_token, _ = integration_service.get_decrypted_tokens(refreshed)
-                assert access_token == "concurrently_refreshed_token"
+        with (
+            patch(
+                "tracecat.integrations.service.get_provider_class",
+                return_value=MockOAuthProvider,
+            ),
+            patch.object(
+                MockOAuthProvider,
+                "refresh_access_token",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("refresh failed"),
+            ) as mock_refresh,
+        ):
+            await integration_service.store_provider_config(
+                provider_key=provider_key,
+                client_id="mock_client_id",
+                client_secret=SecretStr("mock_client_secret"),
+            )
+            integration = await integration_service.store_integration(
+                provider_key=provider_key,
+                access_token=mock_token_response.access_token,
+                refresh_token=mock_token_response.refresh_token,
+                expires_in=60,
+            )
+            pending_workspace_name = f"{svc_workspace.name}-pending"
+            svc_workspace.name = pending_workspace_name
+            assert svc_workspace in integration_service.session.dirty
+
+            refreshed = await integration_service.refresh_token_if_needed(integration)
+
+            mock_refresh.assert_awaited_once()
+            access_token, _ = integration_service.get_decrypted_tokens(refreshed)
+            assert access_token == mock_token_response.access_token.get_secret_value()
+            assert svc_workspace.name == pending_workspace_name
+            assert svc_workspace in integration_service.session.dirty
 
     async def test_refresh_token_if_needed_no_refresh_token(
         self,

--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, ClassVar
@@ -8,13 +9,15 @@ import pytest
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.oauth2.rfc7636 import create_s256_code_challenge
 from pydantic import BaseModel, SecretStr, ValidationError
-from sqlalchemy import text
+from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
 
+import tracecat.integrations.service as integration_service_module
 from tests.database import TEST_DB_CONFIG
 from tracecat import config
 from tracecat.auth.types import Role
@@ -36,6 +39,7 @@ from tracecat.integrations.schemas import (
 from tracecat.integrations.service import (
     InsecureOAuthEndpointError,
     IntegrationService,
+    OAuthRefreshBusyError,
 )
 from tracecat.integrations.types import TokenResponse
 
@@ -125,9 +129,27 @@ def encryption_key(monkeypatch: pytest.MonkeyPatch) -> str:
 
 @pytest.fixture
 async def integration_service(
-    session: AsyncSession, svc_role: Role, encryption_key: str
+    session: AsyncSession,
+    svc_role: Role,
+    encryption_key: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> IntegrationService:
     """Create an integration service instance for testing."""
+
+    @contextlib.asynccontextmanager
+    async def get_refresh_session():
+        async with AsyncSession(
+            session.bind,
+            expire_on_commit=False,
+            join_transaction_mode="create_savepoint",
+        ) as refresh_session:
+            yield refresh_session
+
+    monkeypatch.setattr(
+        integration_service_module,
+        "get_async_session_context_manager",
+        get_refresh_session,
+    )
     return IntegrationService(session=session, role=svc_role)
 
 
@@ -787,10 +809,15 @@ class TestIntegrationService:
         # Integration should not need refresh
         assert not integration.needs_refresh
 
-        # Mock the provider registry (should not be called)
-        with patch(
-            "tracecat.integrations.service.get_provider_class"
-        ) as mock_get_provider:
+        # Neither the provider nor an isolated refresh session should be needed.
+        with (
+            patch(
+                "tracecat.integrations.service.get_provider_class"
+            ) as mock_get_provider,
+            patch(
+                "tracecat.integrations.service.get_async_session_context_manager"
+            ) as mock_refresh_session,
+        ):
             # This should not be called since refresh is not needed
             mock_get_provider.return_value = MockOAuthProvider
 
@@ -798,10 +825,11 @@ class TestIntegrationService:
             refreshed = await integration_service.refresh_token_if_needed(integration)
 
             # Should be the same instance, unchanged
-            assert refreshed.id == integration.id
+            assert refreshed is integration
             assert refreshed.expires_at == integration.expires_at
 
-            # Registry should not have been accessed
+            # Fast path should not consume another connection or load a provider.
+            mock_refresh_session.assert_not_called()
             mock_get_provider.assert_not_called()
 
     async def test_refresh_token_if_needed(
@@ -896,6 +924,8 @@ class TestIntegrationService:
         )
         first_refresh_started = asyncio.Event()
         release_first_refresh = asyncio.Event()
+        retry_sleep_started = asyncio.Event()
+        allow_retry = asyncio.Event()
         first_task: asyncio.Task[OAuthIntegration] | None = None
         second_task: asyncio.Task[OAuthIntegration] | None = None
         expected_refresh_token = mock_token_response.refresh_token
@@ -913,31 +943,14 @@ class TestIntegrationService:
                 token_type="Bearer",
             )
 
-        async def wait_until_second_refresh_is_blocked() -> None:
-            loop = asyncio.get_running_loop()
-            deadline = loop.time() + 5
-            async with concurrent_engine.connect() as observer:
-                while loop.time() < deadline:
-                    # PostgreSQL caches statistics within a transaction unless
-                    # the snapshot is explicitly cleared between polls.
-                    await observer.execute(text("SELECT pg_stat_clear_snapshot()"))
-                    is_blocked = await observer.scalar(
-                        text(
-                            """
-                            SELECT EXISTS (
-                                SELECT 1
-                                FROM pg_stat_activity
-                                WHERE datname = current_database()
-                                  AND cardinality(pg_blocking_pids(pid)) > 0
-                                  AND query ILIKE '%oauth_integration%'
-                            )
-                            """
-                        )
-                    )
-                    if is_blocked:
-                        return
-                    await asyncio.sleep(0.01)
-            raise AssertionError("Second refresh did not block on the row lock")
+        async def retry_sleep(_: float) -> None:
+            retry_sleep_started.set()
+            await allow_retry.wait()
+
+        @contextlib.asynccontextmanager
+        async def get_concurrent_session():
+            async with session_factory() as refresh_session:
+                yield refresh_session
 
         try:
             with (
@@ -951,6 +964,15 @@ class TestIntegrationService:
                     new_callable=AsyncMock,
                     side_effect=refresh_access_token,
                 ) as mock_refresh,
+                patch(
+                    "tracecat.integrations.service.asyncio.sleep",
+                    new_callable=AsyncMock,
+                    side_effect=retry_sleep,
+                ) as mock_sleep,
+                patch(
+                    "tracecat.integrations.service.get_async_session_context_manager",
+                    side_effect=get_concurrent_session,
+                ),
             ):
                 async with session_factory() as seed_session:
                     seed_session.add(
@@ -978,14 +1000,16 @@ class TestIntegrationService:
                     )
                     integration_id = integration.id
 
+                # Prove both independent readers can observe stale state before
+                # either refresh transaction starts.
                 async with (
-                    session_factory() as first_session,
-                    session_factory() as second_session,
+                    session_factory() as first_reader,
+                    session_factory() as second_reader,
                 ):
-                    first_integration = await first_session.get(
+                    first_integration = await first_reader.get(
                         OAuthIntegration, integration_id
                     )
-                    second_integration = await second_session.get(
+                    second_integration = await second_reader.get(
                         OAuthIntegration, integration_id
                     )
                     assert first_integration is not None
@@ -994,6 +1018,10 @@ class TestIntegrationService:
                     assert first_integration.needs_refresh
                     assert second_integration.needs_refresh
 
+                async with (
+                    session_factory() as first_session,
+                    session_factory() as second_session,
+                ):
                     first_service = IntegrationService(
                         session=first_session,
                         role=role.model_copy(deep=True),
@@ -1002,6 +1030,10 @@ class TestIntegrationService:
                         session=second_session,
                         role=role.model_copy(deep=True),
                     )
+                    refresh_pool = concurrent_engine.sync_engine.pool
+                    checkedout = getattr(refresh_pool, "checkedout", None)
+                    assert checkedout is not None
+                    baseline_checked_out = checkedout()
 
                     first_task = asyncio.create_task(
                         first_service.refresh_token_if_needed(first_integration)
@@ -1011,16 +1043,19 @@ class TestIntegrationService:
                     second_task = asyncio.create_task(
                         second_service.refresh_token_if_needed(second_integration)
                     )
-                    await wait_until_second_refresh_is_blocked()
+                    await asyncio.wait_for(retry_sleep_started.wait(), timeout=5)
 
                     assert mock_refresh.await_count == 1
                     assert not second_task.done()
+                    assert mock_sleep.await_count == 1
+                    # Winner owns one connection. Loser closed its failed
+                    # NOWAIT attempt before entering retry sleep.
+                    assert checkedout() == baseline_checked_out + 1
 
                     release_first_refresh.set()
-                    first_result, second_result = await asyncio.gather(
-                        first_task,
-                        second_task,
-                    )
+                    first_result = await first_task
+                    allow_retry.set()
+                    second_result = await second_task
 
                     mock_refresh.assert_awaited_once()
                     for service, refreshed in (
@@ -1042,6 +1077,44 @@ class TestIntegrationService:
             if tasks:
                 await asyncio.gather(*tasks, return_exceptions=True)
             await concurrent_engine.dispose()
+
+    async def test_refresh_token_if_needed_times_out_when_lock_stays_busy(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """A busy row raises after the bounded retry deadline."""
+
+        class LockNotAvailableError(Exception):
+            sqlstate = "55P03"
+
+        lock_error = OperationalError(
+            "SELECT ... FOR UPDATE NOWAIT",
+            {},
+            LockNotAvailableError(),
+        )
+        integration = OAuthIntegration(
+            id=uuid.uuid4(),
+            workspace_id=integration_service.workspace_id,
+            provider_id="busy_provider",
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+            encrypted_access_token=b"",
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+
+        with (
+            patch.object(
+                AsyncSession,
+                "scalar",
+                new_callable=AsyncMock,
+                side_effect=lock_error,
+            ),
+            patch(
+                "tracecat.integrations.service.OAUTH_REFRESH_RETRY_TIMEOUT_SECONDS",
+                0.0,
+            ),
+        ):
+            with pytest.raises(OAuthRefreshBusyError):
+                await integration_service.refresh_token_if_needed(integration)
 
     async def test_successful_refresh_does_not_commit_caller_session(
         self,
@@ -1147,6 +1220,105 @@ class TestIntegrationService:
             assert access_token == mock_token_response.access_token.get_secret_value()
             assert svc_workspace.name == pending_workspace_name
             assert svc_workspace in integration_service.session.dirty
+
+    async def test_successful_refresh_does_not_commit_flushed_caller_change(
+        self,
+        mock_provider: MockOAuthProvider,
+        mock_token_response: TokenResponse,
+        svc_role: Role,
+        encryption_key: str,
+    ) -> None:
+        """Refresh isolation preserves already-flushed caller writes."""
+        del encryption_key
+        role = svc_role.model_copy(
+            update={"workspace_id": uuid.uuid4()},
+            deep=True,
+        )
+        engine = create_async_engine(TEST_DB_CONFIG.test_url)
+        session_factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+        original_name = f"refresh-isolation-{role.workspace_id}"
+        pending_name = f"{original_name}-pending"
+        provider_key = ProviderKey(
+            id=mock_provider.id,
+            grant_type=mock_provider.grant_type,
+        )
+
+        @contextlib.asynccontextmanager
+        async def get_refresh_session():
+            async with session_factory() as refresh_session:
+                yield refresh_session
+
+        try:
+            async with session_factory() as seed_session:
+                seed_session.add(
+                    Workspace(
+                        id=role.workspace_id,
+                        name=original_name,
+                        organization_id=role.organization_id,
+                    )
+                )
+                await seed_session.commit()
+                seed_service = IntegrationService(session=seed_session, role=role)
+                await seed_service.store_provider_config(
+                    provider_key=provider_key,
+                    client_id="mock_client_id",
+                    client_secret=SecretStr("mock_client_secret"),
+                )
+                integration = await seed_service.store_integration(
+                    provider_key=provider_key,
+                    access_token=mock_token_response.access_token,
+                    refresh_token=mock_token_response.refresh_token,
+                    expires_in=60,
+                )
+
+            with (
+                patch(
+                    "tracecat.integrations.service.get_provider_class",
+                    return_value=MockOAuthProvider,
+                ),
+                patch.object(
+                    MockOAuthProvider,
+                    "refresh_access_token",
+                    new_callable=AsyncMock,
+                    return_value=TokenResponse(
+                        access_token=SecretStr("refreshed_token"),
+                        refresh_token=SecretStr("rotated_refresh_token"),
+                        expires_in=7200,
+                        scope="read write",
+                        token_type="Bearer",
+                    ),
+                ) as mock_refresh,
+                patch(
+                    "tracecat.integrations.service.get_async_session_context_manager",
+                    side_effect=get_refresh_session,
+                ),
+            ):
+                async with session_factory() as caller_session:
+                    workspace = await caller_session.scalar(
+                        select(Workspace).where(Workspace.id == role.workspace_id)
+                    )
+                    assert workspace is not None
+                    workspace.name = pending_name
+                    await caller_session.flush()
+                    assert workspace not in caller_session.dirty
+
+                    caller_service = IntegrationService(
+                        session=caller_session,
+                        role=role,
+                    )
+                    await caller_service.refresh_token_if_needed(integration)
+
+                    mock_refresh.assert_awaited_once()
+                    async with session_factory() as observer_session:
+                        observed = await observer_session.scalar(
+                            select(Workspace).where(Workspace.id == role.workspace_id)
+                        )
+                        assert observed is not None
+                        assert observed.name == original_name
+                    assert workspace.name == pending_name
+                    await caller_session.rollback()
+        finally:
+            await engine.dispose()
 
     async def test_refresh_token_if_needed_no_refresh_token(
         self,

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -8,6 +8,7 @@ This test suite covers MCP integration functionality including:
 - MCP provider OAuth discovery behavior
 """
 
+import contextlib
 import socket
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -181,9 +182,26 @@ def _install_catalog_entry(
 
 @pytest.fixture
 async def integration_service(
-    session: AsyncSession, svc_role: Role
+    session: AsyncSession,
+    svc_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> IntegrationService:
     """Create an integration service instance for testing."""
+
+    @contextlib.asynccontextmanager
+    async def get_refresh_session():
+        async with AsyncSession(
+            session.bind,
+            expire_on_commit=False,
+            join_transaction_mode="create_savepoint",
+        ) as refresh_session:
+            yield refresh_session
+
+    monkeypatch.setattr(
+        integration_service_module,
+        "get_async_session_context_manager",
+        get_refresh_session,
+    )
     return IntegrationService(session=session, role=svc_role)
 
 

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -55,6 +55,7 @@ from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
 from tracecat.integrations.mcp_validation import (
     MCPConfigurationError,
     MCPConnectionVerificationError,
+    MCPSecretResolutionError,
 )
 from tracecat.integrations.providers.base import (
     DynamicRegistrationResult,
@@ -84,7 +85,10 @@ from tracecat.integrations.schemas import (
     ProviderMetadata,
     ProviderScopes,
 )
-from tracecat.integrations.service import IntegrationService
+from tracecat.integrations.service import (
+    IntegrationService,
+    OAuthRefreshBusyError,
+)
 from tracecat.integrations.types import OAuthServerMetadata
 from tracecat.tiers import defaults as tier_defaults
 
@@ -4560,6 +4564,65 @@ class TestMCPConnectionVerification:
         assert headers["Authorization"] == "Bearer test_access_token"
         assert "authorization" not in headers
         assert headers["X-Tenant"] == "t1"
+
+    async def test_resolve_http_config_translates_busy_oauth_refresh(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A contended OAuth refresh remains an MCP configuration error."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Busy OAuth MCP",
+                server_uri="https://oauth.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+        busy_error = OAuthRefreshBusyError("OAuth integration is busy refreshing")
+        monkeypatch.setattr(
+            IntegrationService,
+            "refresh_token_if_needed",
+            AsyncMock(side_effect=busy_error),
+        )
+
+        with pytest.raises(MCPConfigurationError) as exc_info:
+            await integration_service.resolve_mcp_http_server_config(mcp_integration)
+
+        assert exc_info.value.__cause__ is busy_error
+
+    async def test_resolve_mcp_secrets_translates_busy_oauth_refresh(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Secret resolution exposes its documented credential error."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Busy OAuth Secrets MCP",
+                server_uri="https://oauth.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+        busy_error = OAuthRefreshBusyError("OAuth integration is busy refreshing")
+        monkeypatch.setattr(
+            IntegrationService,
+            "refresh_token_if_needed",
+            AsyncMock(side_effect=busy_error),
+        )
+        preset_service = AgentPresetService(
+            session=integration_service.session,
+            role=integration_service.role,
+        )
+
+        with pytest.raises(MCPSecretResolutionError) as exc_info:
+            await preset_service.resolve_mcp_integration_secrets(mcp_integration.id)
+
+        assert isinstance(exc_info.value.__cause__, MCPConfigurationError)
+        assert exc_info.value.__cause__.__cause__ is busy_error
 
     async def test_resolve_http_config_errors(
         self,

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1651,6 +1651,12 @@ class IntegrationService(BaseWorkspaceService):
             return integration
 
         try:
+            # Lock the row and re-check staleness so concurrent refreshers
+            # never present the same (single-use) refresh token twice.
+            await self.session.refresh(integration, with_for_update=True)
+            if not integration.needs_refresh:
+                # Another process already refreshed; use its result.
+                return integration
             if integration.grant_type == OAuthGrantType.AUTHORIZATION_CODE:
                 integration = await self._refresh_ac_integration(integration)
             elif integration.grant_type == OAuthGrantType.CLIENT_CREDENTIALS:
@@ -1661,18 +1667,29 @@ class IntegrationService(BaseWorkspaceService):
                     grant_type=integration.grant_type,
                     provider=integration.provider_id,
                 )
-                return integration
         except Exception as e:
             self.logger.error(
                 "Failed to refresh token, continuing with current token",
                 error=str(e),
                 provider=integration.provider_id,
-                expires_at=integration.expires_at,
             )
-            # Return unchanged - let it fail naturally when token expires
-            return integration
-
-        await self.session.refresh(integration)
+            # Fall through - let it fail naturally when token expires
+        finally:
+            # Always end the transaction so the row lock is released even on
+            # bail-out paths. Commit, not rollback: rollback would expire
+            # every object in the caller's session (expire_on_commit=False).
+            try:
+                await self.session.commit()
+            except Exception:
+                await self.session.rollback()
+                try:
+                    # Rollback expires ORM state; reload for the caller.
+                    await self.session.refresh(integration)
+                except Exception:
+                    self.logger.warning(
+                        "Could not reload integration after refresh attempt",
+                        provider=integration.provider_id,
+                    )
         return integration
 
     async def _provider_from_integration(

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1,6 +1,7 @@
 """Service for managing user integrations with external services."""
 
 import asyncio
+import random
 import re
 import secrets
 import uuid
@@ -19,7 +20,7 @@ from authlib.oauth2.rfc7636 import create_s256_code_challenge
 from pydantic import SecretStr
 from slugify import slugify
 from sqlalchemy import and_, delete, or_, select, update
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import DBAPIError
 from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
 from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 from temporalio.exceptions import TerminatedError
@@ -39,8 +40,8 @@ from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.authz.controls import has_scope, require_scope
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import (
-    _initialize_session_rls_context,
     get_async_session_bypass_rls_context_manager,
+    get_async_session_context_manager,
 )
 from tracecat.db.models import (
     AgentPreset,
@@ -116,6 +117,11 @@ from tracecat.tiers.enums import Entitlement
 MCP_TEST_CONNECTION_TIMEOUT_CAP = 15
 """Maximum seconds an MCP connection verification may take."""
 
+OAUTH_REFRESH_LOCK_NOT_AVAILABLE = "55P03"
+OAUTH_REFRESH_RETRY_TIMEOUT_SECONDS = 10.0
+OAUTH_REFRESH_RETRY_MIN_SECONDS = 0.025
+OAUTH_REFRESH_RETRY_MAX_SECONDS = 0.1
+
 
 @dataclass(frozen=True)
 class PlatformMCPCatalogConnectResult:
@@ -143,6 +149,10 @@ class InsecureOAuthEndpointError(ValueError):
 
 class ProviderConfigurationRequiredError(ValueError):
     """Raised when an OAuth provider must be configured before connection."""
+
+
+class OAuthRefreshBusyError(RuntimeError):
+    """Raised when an OAuth integration stays locked past the retry deadline."""
 
 
 @dataclass(frozen=True)
@@ -1435,13 +1445,11 @@ class IntegrationService(BaseWorkspaceService):
                 token.refresh_token.get_secret_value()
             )
         if token.expires_in is not None:
-            integration.expires_at = datetime.now() + timedelta(
+            integration.expires_at = datetime.now(UTC) + timedelta(
                 seconds=token.expires_in
             )
         if token.scope:
             integration.scope = token.scope
-        await self.session.commit()
-        await self.session.refresh(integration)
         return integration
 
     @staticmethod
@@ -1649,9 +1657,18 @@ class IntegrationService(BaseWorkspaceService):
             await self.delete_custom_provider(provider_key=provider_key)
 
     async def refresh_token_if_needed(
-        self, integration: OAuthIntegration
+        self,
+        integration: OAuthIntegration,
     ) -> OAuthIntegration:
         """Refresh the access token if it's expired or about to expire.
+
+        Fresh caller state returns without opening another database session.
+        Stale caller state is reloaded under the refresh transaction's row lock
+        before deciding whether to call the OAuth provider.
+
+        Each attempt owns a separate transaction. A contending refresher uses
+        NOWAIT, rolls back and closes its session before sleeping, then retries
+        with jitter. The caller's session is never committed or rolled back.
 
         The row lock prevents concurrent database readers from presenting the
         same refresh token. It cannot make refresh-token rotation atomic with
@@ -1661,53 +1678,83 @@ class IntegrationService(BaseWorkspaceService):
         if not integration.needs_refresh:
             return integration
 
-        # Keep the lock and token update in a separate session so committing
-        # them never commits the caller's unit of work.
+        integration_id = integration.id
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + OAUTH_REFRESH_RETRY_TIMEOUT_SECONDS
         role_token = ctx_role.set(self.role)
         try:
-            async with AsyncSession(
-                self.session.bind,
-                expire_on_commit=False,
-                join_transaction_mode="create_savepoint",
-            ) as refresh_session:
-                await _initialize_session_rls_context(refresh_session)
-                # Lock the row and re-check staleness so concurrent refreshers
-                # never present the same (single-use) refresh token twice.
-                locked = await refresh_session.get(
-                    OAuthIntegration, integration.id, with_for_update=True
-                )
-                if locked is not None and locked.needs_refresh:
-                    svc = IntegrationService(session=refresh_session, role=self.role)
-                    if locked.grant_type == OAuthGrantType.AUTHORIZATION_CODE:
-                        await svc._refresh_ac_integration(locked)
-                    elif locked.grant_type == OAuthGrantType.CLIENT_CREDENTIALS:
-                        await svc._refresh_cc_integration(locked)
-                    else:
-                        self.logger.warning(
-                            "Unsupported grant type for refresh",
-                            grant_type=locked.grant_type,
-                            provider=locked.provider_id,
+            while True:
+                try:
+                    async with get_async_session_context_manager() as refresh_session:
+                        refresh_service = IntegrationService(
+                            session=refresh_session,
+                            role=self.role,
                         )
-        except Exception as e:
-            self.logger.error(
-                "Failed to refresh token, continuing with current token",
-                error=str(e),
-                provider=integration.provider_id,
-            )
-            # Fall through - let it fail naturally when token expires
+                        locked = await refresh_session.scalar(
+                            select(OAuthIntegration)
+                            .where(
+                                OAuthIntegration.id == integration_id,
+                                OAuthIntegration.workspace_id == self.workspace_id,
+                            )
+                            .with_for_update(nowait=True)
+                        )
+                        if locked is None:
+                            raise ValueError("OAuth integration not found")
+
+                        if locked.needs_refresh:
+                            refresh_error: Exception | None = None
+                            try:
+                                async with refresh_session.begin_nested():
+                                    if (
+                                        locked.grant_type
+                                        == OAuthGrantType.AUTHORIZATION_CODE
+                                    ):
+                                        await refresh_service._refresh_ac_integration(
+                                            locked
+                                        )
+                                    elif (
+                                        locked.grant_type
+                                        == OAuthGrantType.CLIENT_CREDENTIALS
+                                    ):
+                                        await refresh_service._refresh_cc_integration(
+                                            locked
+                                        )
+                                    else:
+                                        refresh_service.logger.warning(
+                                            "Unsupported grant type for refresh",
+                                            grant_type=locked.grant_type,
+                                            provider=locked.provider_id,
+                                        )
+                            except Exception as e:
+                                refresh_error = e
+                                await refresh_session.refresh(locked)
+
+                            await refresh_session.commit()
+                            if refresh_error is not None:
+                                refresh_service.logger.error(
+                                    "Failed to refresh token, continuing with current token",
+                                    error=str(refresh_error),
+                                    provider=locked.provider_id,
+                                )
+                        else:
+                            await refresh_session.commit()
+                        return locked
+                except DBAPIError as e:
+                    sqlstate = getattr(e.orig, "sqlstate", None)
+                    if sqlstate != OAUTH_REFRESH_LOCK_NOT_AVAILABLE:
+                        raise
+                    if loop.time() >= deadline:
+                        raise OAuthRefreshBusyError(
+                            f"OAuth integration {integration_id} is busy refreshing"
+                        ) from e
+                    await asyncio.sleep(
+                        random.uniform(
+                            OAUTH_REFRESH_RETRY_MIN_SECONDS,
+                            OAUTH_REFRESH_RETRY_MAX_SECONDS,
+                        )
+                    )
         finally:
             ctx_role.reset(role_token)
-        try:
-            # refresh() normally flushes every pending change in the caller's
-            # session. Avoid writing that unrelated work just to reload this row.
-            with self.session.no_autoflush:
-                await self.session.refresh(integration)
-        except Exception:
-            self.logger.warning(
-                "Could not reload integration after refresh attempt",
-                provider=integration.provider_id,
-            )
-        return integration
 
     async def _provider_from_integration(
         self, integration: OAuthIntegration
@@ -1798,7 +1845,7 @@ class IntegrationService(BaseWorkspaceService):
 
         # Update expiry time
         integration.expires_at = (
-            datetime.now() + timedelta(seconds=token_response.expires_in)
+            datetime.now(UTC) + timedelta(seconds=token_response.expires_in)
             if token_response.expires_in is not None
             else None
         )
@@ -1806,29 +1853,17 @@ class IntegrationService(BaseWorkspaceService):
         # Update scope if changed
         integration.scope = token_response.scope
 
-        await self.session.commit()
-        await self.session.refresh(integration)
         return integration
 
     async def _refresh_ac_integration(
         self, integration: OAuthIntegration
     ) -> OAuthIntegration:
-        """Refresh an integration using the refresh token for authorization code grant type."""
-        # Check if refresh token exists by attempting to decrypt
-        try:
-            refresh_token = (
-                self._decrypt_token(integration.encrypted_refresh_token)
-                if integration.encrypted_refresh_token
-                else None
-            )
-        except Exception as e:
-            self.logger.error(
-                "Failed to decrypt refresh token",
-                user_id=integration.user_id,
-                provider=integration.provider_id,
-                error=str(e),
-            )
-            return integration
+        """Apply an authorization-code refresh without ending the transaction."""
+        refresh_token = (
+            self._decrypt_token(integration.encrypted_refresh_token)
+            if integration.encrypted_refresh_token
+            else None
+        )
 
         if not refresh_token:
             self.logger.warning(
@@ -1839,19 +1874,10 @@ class IntegrationService(BaseWorkspaceService):
             return integration
 
         if self._is_custom_mcp_oauth_provider(integration.provider_id):
-            try:
-                return await self._refresh_custom_mcp_integration(
-                    integration=integration,
-                    refresh_token=refresh_token,
-                )
-            except Exception as e:
-                self.logger.error(
-                    "Failed to refresh generic MCP OAuth token",
-                    user_id=integration.user_id,
-                    provider=integration.provider_id,
-                    error=str(e),
-                )
-                return integration
+            return await self._refresh_custom_mcp_integration(
+                integration=integration,
+                refresh_token=refresh_token,
+            )
 
         provider = await self._provider_from_integration(integration)
         if not provider:
@@ -1870,48 +1896,26 @@ class IntegrationService(BaseWorkspaceService):
             )
             return integration
 
-        # Refresh the access token
-        try:
-            token_response = await provider.refresh_access_token(refresh_token)
+        token_response = await provider.refresh_access_token(refresh_token)
 
-            # Update integration with new tokens
-            integration.encrypted_access_token = self._encrypt_token(
-                token_response.access_token.get_secret_value()
+        integration.encrypted_access_token = self._encrypt_token(
+            token_response.access_token.get_secret_value()
+        )
+        if token_response.refresh_token:
+            integration.encrypted_refresh_token = self._encrypt_token(
+                token_response.refresh_token.get_secret_value()
             )
-
-            # Update refresh token if provider rotated it
-            if token_response.refresh_token:
-                integration.encrypted_refresh_token = self._encrypt_token(
-                    token_response.refresh_token.get_secret_value()
-                )
-
-            # Update expiry time
-            if token_response.expires_in is not None:
-                integration.expires_at = datetime.now() + timedelta(
-                    seconds=token_response.expires_in
-                )
-
-            # Update scope if changed
-            integration.scope = token_response.scope
-
-            await self.session.commit()
-            await self.session.refresh(integration)
-
-            self.logger.info(
-                "Successfully updated integration with refreshed tokens",
-                user_id=integration.user_id,
-                provider=integration.provider_id,
+        if token_response.expires_in is not None:
+            integration.expires_at = datetime.now(UTC) + timedelta(
+                seconds=token_response.expires_in
             )
+        integration.scope = token_response.scope
 
-        except Exception as e:
-            self.logger.error(
-                "Failed to refresh access token",
-                user_id=integration.user_id,
-                provider=integration.provider_id,
-                error=str(e),
-            )
-            # Return unchanged integration instead of raising
-            return integration
+        self.logger.info(
+            "Successfully updated integration with refreshed tokens",
+            user_id=integration.user_id,
+            provider=integration.provider_id,
+        )
 
         return integration
 
@@ -3733,7 +3737,7 @@ class IntegrationService(BaseWorkspaceService):
             oauth_integration = result.scalars().first()
             if not oauth_integration:
                 raise MCPConfigurationError("Linked OAuth integration not found")
-            await self.refresh_token_if_needed(oauth_integration)
+            oauth_integration = await self.refresh_token_if_needed(oauth_integration)
             access_token = await self.get_access_token(oauth_integration)
             if not access_token:
                 raise MCPConfigurationError(

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -19,6 +19,7 @@ from authlib.oauth2.rfc7636 import create_s256_code_challenge
 from pydantic import SecretStr
 from slugify import slugify
 from sqlalchemy import and_, delete, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
 from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 from temporalio.exceptions import TerminatedError
@@ -36,7 +37,11 @@ from tracecat.agent.mcp.stdio_probe_types import (
 from tracecat.agent.workflows.mcp_probe import StdioMCPProbeWorkflow
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.authz.controls import has_scope, require_scope
-from tracecat.db.engine import get_async_session_bypass_rls_context_manager
+from tracecat.contexts import ctx_role
+from tracecat.db.engine import (
+    _initialize_session_rls_context,
+    get_async_session_bypass_rls_context_manager,
+)
 from tracecat.db.models import (
     AgentPreset,
     AgentSession,
@@ -1646,27 +1651,43 @@ class IntegrationService(BaseWorkspaceService):
     async def refresh_token_if_needed(
         self, integration: OAuthIntegration
     ) -> OAuthIntegration:
-        """Refresh the access token if it's expired or about to expire."""
+        """Refresh the access token if it's expired or about to expire.
+
+        The row lock prevents concurrent database readers from presenting the
+        same refresh token. It cannot make refresh-token rotation atomic with
+        persisting the OAuth response, so a lost response or failed commit
+        after server-side rotation remains unrecoverable here.
+        """
         if not integration.needs_refresh:
             return integration
 
+        # Keep the lock and token update in a separate session so committing
+        # them never commits the caller's unit of work.
+        role_token = ctx_role.set(self.role)
         try:
-            # Lock the row and re-check staleness so concurrent refreshers
-            # never present the same (single-use) refresh token twice.
-            await self.session.refresh(integration, with_for_update=True)
-            if not integration.needs_refresh:
-                # Another process already refreshed; use its result.
-                return integration
-            if integration.grant_type == OAuthGrantType.AUTHORIZATION_CODE:
-                integration = await self._refresh_ac_integration(integration)
-            elif integration.grant_type == OAuthGrantType.CLIENT_CREDENTIALS:
-                integration = await self._refresh_cc_integration(integration)
-            else:
-                self.logger.warning(
-                    "Unsupported grant type for refresh",
-                    grant_type=integration.grant_type,
-                    provider=integration.provider_id,
+            async with AsyncSession(
+                self.session.bind,
+                expire_on_commit=False,
+                join_transaction_mode="create_savepoint",
+            ) as refresh_session:
+                await _initialize_session_rls_context(refresh_session)
+                # Lock the row and re-check staleness so concurrent refreshers
+                # never present the same (single-use) refresh token twice.
+                locked = await refresh_session.get(
+                    OAuthIntegration, integration.id, with_for_update=True
                 )
+                if locked is not None and locked.needs_refresh:
+                    svc = IntegrationService(session=refresh_session, role=self.role)
+                    if locked.grant_type == OAuthGrantType.AUTHORIZATION_CODE:
+                        await svc._refresh_ac_integration(locked)
+                    elif locked.grant_type == OAuthGrantType.CLIENT_CREDENTIALS:
+                        await svc._refresh_cc_integration(locked)
+                    else:
+                        self.logger.warning(
+                            "Unsupported grant type for refresh",
+                            grant_type=locked.grant_type,
+                            provider=locked.provider_id,
+                        )
         except Exception as e:
             self.logger.error(
                 "Failed to refresh token, continuing with current token",
@@ -1675,21 +1696,17 @@ class IntegrationService(BaseWorkspaceService):
             )
             # Fall through - let it fail naturally when token expires
         finally:
-            # Always end the transaction so the row lock is released even on
-            # bail-out paths. Commit, not rollback: rollback would expire
-            # every object in the caller's session (expire_on_commit=False).
-            try:
-                await self.session.commit()
-            except Exception:
-                await self.session.rollback()
-                try:
-                    # Rollback expires ORM state; reload for the caller.
-                    await self.session.refresh(integration)
-                except Exception:
-                    self.logger.warning(
-                        "Could not reload integration after refresh attempt",
-                        provider=integration.provider_id,
-                    )
+            ctx_role.reset(role_token)
+        try:
+            # refresh() normally flushes every pending change in the caller's
+            # session. Avoid writing that unrelated work just to reload this row.
+            with self.session.no_autoflush:
+                await self.session.refresh(integration)
+        except Exception:
+            self.logger.warning(
+                "Could not reload integration after refresh attempt",
+                provider=integration.provider_id,
+            )
         return integration
 
     async def _provider_from_integration(

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -3737,7 +3737,14 @@ class IntegrationService(BaseWorkspaceService):
             oauth_integration = result.scalars().first()
             if not oauth_integration:
                 raise MCPConfigurationError("Linked OAuth integration not found")
-            oauth_integration = await self.refresh_token_if_needed(oauth_integration)
+            try:
+                oauth_integration = await self.refresh_token_if_needed(
+                    oauth_integration
+                )
+            except OAuthRefreshBusyError as e:
+                raise MCPConfigurationError(
+                    "OAuth integration is busy refreshing"
+                ) from e
             access_token = await self.get_access_token(oauth_integration)
             if not access_token:
                 raise MCPConfigurationError(

--- a/tracecat/secrets/secrets_manager.py
+++ b/tracecat/secrets/secrets_manager.py
@@ -221,7 +221,7 @@ async def get_action_secrets(
                         grant_type=integration.grant_type,
                     )
                     fetched_keys.add(provider_key)
-                    await service.refresh_token_if_needed(integration)
+                    integration = await service.refresh_token_if_needed(integration)
                     try:
                         if access_token := await service.get_access_token(integration):
                             # SECRETS.<provider_id>_oauth.[<prefix>_[SERVICE|USER]_TOKEN]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents duplicate OAuth refreshes under concurrency by locking the integration row with FOR UPDATE NOWAIT and running the refresh in an isolated transaction with jittered retries and a timeout. Single-use refresh tokens aren’t replayed, and caller transactions are never committed or rolled back.

- **Bug Fixes**
  - Lock `oauth_integration` with `with_for_update(nowait=True)`; on lock-not-available, close the refresh session and retry with random backoff until `OAUTH_REFRESH_RETRY_TIMEOUT_SECONDS`, else raise `OAuthRefreshBusyError`.
  - Use a dedicated, RLS-aware session via `get_async_session_context_manager`, set `ctx_role`, and wrap the refresh in a savepoint; `_refresh_*` helpers no longer commit and set expiries with `datetime.now(UTC)`.
  - Fast path: if not stale, return the same `OAuthIntegration` without opening a refresh session or loading a provider.
  - API: `refresh_token_if_needed(integration)` returns the updated integration; callers (e.g., secrets manager, MCP) assign the result.
  - MCP: translate `OAuthRefreshBusyError` to `MCPConfigurationError` for HTTP config and to `MCPSecretResolutionError` during secret resolution.
  - Tests cover: serialized concurrent refresh (provider called once), timeout on busy lock, isolation that preserves caller changes (including already-flushed writes), and MCP error translation.

<sup>Written for commit 3af08b002bec5232e78eebe0349e3596285539f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

