### PR TITLE
fix(ui): prevent repeated MCP failure toast on refresh

### DIFF
--- a/frontend/src/hooks/use-stdio-mcp-verification-status.test.tsx
+++ b/frontend/src/hooks/use-stdio-mcp-verification-status.test.tsx
@@ -36,6 +36,40 @@ function createWrapper(queryClient: QueryClient) {
 }
 
 describe("useStdioMcpVerificationStatus", () => {
+  beforeEach(() => {
+    jest.mocked(toast).mockClear()
+  })
+
+  it("does not toast a saved failure loaded after a refresh", async () => {
+    const refreshedIntegrationId = "mcp-integration-refreshed"
+    const refreshedQueryKey = [
+      "mcp-verification-status",
+      workspaceId,
+      refreshedIntegrationId,
+    ] as const
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    queryClient.setQueryData<MCPVerificationStatusRead>(refreshedQueryKey, {
+      status: "failed",
+      error: "Invalid credentials",
+    })
+
+    const { result } = renderHook(
+      () =>
+        useStdioMcpVerificationStatus({
+          workspaceId,
+          pendingIntegrationIds: [refreshedIntegrationId],
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await waitFor(() =>
+      expect(result.current.get(refreshedIntegrationId)?.status).toBe("failed")
+    )
+    expect(toast).not.toHaveBeenCalled()
+  })
+
   it("exposes live status and re-arms a failed verification on reconnect", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },

--- a/frontend/src/hooks/use-stdio-mcp-verification-status.ts
+++ b/frontend/src/hooks/use-stdio-mcp-verification-status.ts
@@ -85,7 +85,10 @@ export function useStdioMcpVerificationStatus({
         continue
       }
 
-      if (statusRead.status === "failed" && previousStatus !== "failed") {
+      // A saved failure is also loaded when the page mounts. Only announce a
+      // failure that this client observed completing; the persistent failure
+      // badge remains responsible for failures loaded after a refresh.
+      if (statusRead.status === "failed" && previousStatus === "verifying") {
         toast({
           title: "MCP server verification failed",
           description: verificationFailureToastDescription(statusRead.error),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop showing duplicate “MCP server verification failed” toasts after a page refresh. The toast now only appears when this client sees a transition from “verifying” to “failed”; persisted failures are handled by the badge.

- **Bug Fixes**
  - Gate failure toast to cases where previous status was “verifying” (prevents announcing saved failures on mount).
  - Add test to ensure no toast is shown when a failed status is loaded from cache after refresh.

<sup>Written for commit 9efe66f4896fb9bc0223bd174f2117fb9503b2c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

