### PR TITLE
feat(registry): add SentinelOne alert lifecycle actions

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/update_alert_analyst_verdict.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/update_alert_analyst_verdict.yml
@@ -1,0 +1,37 @@
+type: action
+definition:
+  title: Update alert analyst verdict
+  description: Update the analyst verdict for one or more SentinelOne alerts.
+  display_group: SentinelOne
+  doc_url: https://github.com/Sentinel-One/purple-mcp
+  namespace: tools.sentinel_one
+  name: update_alert_analyst_verdict
+  secrets:
+    - name: sentinel_one
+      keys: ["SENTINEL_ONE_API_TOKEN"]
+  expects:
+    alert_ids:
+      type: list[str]
+      description: IDs of the alerts to update.
+    analyst_verdict:
+      type: str
+      description: Analyst verdict to apply to the alerts.
+    base_url:
+      type: str | None
+      description: SentinelOne tenant URL.
+      default: null
+  steps:
+    - ref: update_alert_analyst_verdict
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.sentinel_one.base_url }}/web/api/v2.1/cloud-detection/alerts/analyst-verdict
+        method: POST
+        headers:
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
+          Content-Type: "application/json"
+        payload:
+          filter:
+            ids: ${{ inputs.alert_ids }}
+          data:
+            analystVerdict: ${{ inputs.analyst_verdict }}
+  returns: ${{ steps.update_alert_analyst_verdict.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/update_alert_incident_status.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/update_alert_incident_status.yml
@@ -1,0 +1,37 @@
+type: action
+definition:
+  title: Update alert incident status
+  description: Update the incident status for one or more SentinelOne alerts.
+  display_group: SentinelOne
+  doc_url: https://github.com/Sentinel-One/purple-mcp
+  namespace: tools.sentinel_one
+  name: update_alert_incident_status
+  secrets:
+    - name: sentinel_one
+      keys: ["SENTINEL_ONE_API_TOKEN"]
+  expects:
+    alert_ids:
+      type: list[str]
+      description: IDs of the alerts to update.
+    incident_status:
+      type: str
+      description: Incident status to apply to the alerts.
+    base_url:
+      type: str | None
+      description: SentinelOne tenant URL.
+      default: null
+  steps:
+    - ref: update_alert_incident_status
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.sentinel_one.base_url }}/web/api/v2.1/cloud-detection/alerts/incident
+        method: POST
+        headers:
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
+          Content-Type: "application/json"
+        payload:
+          filter:
+            ids: ${{ inputs.alert_ids }}
+          data:
+            incidentStatus: ${{ inputs.incident_status }}
+  returns: ${{ steps.update_alert_incident_status.result.data }}

--- a/tests/registry/test_sentinel_one_templates.py
+++ b/tests/registry/test_sentinel_one_templates.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import pytest
+
+from tracecat.registry.actions.schemas import TemplateAction
+
+TEMPLATE_ROOT = Path(
+    "packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one"
+)
+
+
+@pytest.mark.parametrize(
+    ("filename", "action_name", "endpoint", "data_key", "data_input"),
+    [
+        (
+            "update_alert_analyst_verdict.yml",
+            "tools.sentinel_one.update_alert_analyst_verdict",
+            "/web/api/v2.1/cloud-detection/alerts/analyst-verdict",
+            "analystVerdict",
+            "${{ inputs.analyst_verdict }}",
+        ),
+        (
+            "update_alert_incident_status.yml",
+            "tools.sentinel_one.update_alert_incident_status",
+            "/web/api/v2.1/cloud-detection/alerts/incident",
+            "incidentStatus",
+            "${{ inputs.incident_status }}",
+        ),
+    ],
+)
+def test_alert_lifecycle_template_contract(
+    filename: str,
+    action_name: str,
+    endpoint: str,
+    data_key: str,
+    data_input: str,
+) -> None:
+    template = TemplateAction.from_yaml(TEMPLATE_ROOT / filename)
+    definition = template.definition
+
+    assert definition.action == action_name
+    assert definition.expects["alert_ids"].type == "list[str]"
+    assert definition.expects["base_url"].default is None
+
+    step = definition.steps[0]
+    assert step.action == "core.http_request"
+    assert step.args["method"] == "POST"
+    assert step.args["url"] == (
+        "${{ inputs.base_url || VARS.sentinel_one.base_url }}" + endpoint
+    )
+    assert step.args["payload"] == {
+        "filter": {"ids": "${{ inputs.alert_ids }}"},
+        "data": {data_key: data_input},
+    }


### PR DESCRIPTION
## Summary

- add a SentinelOne action for updating alert analyst verdicts
- add a SentinelOne action for updating alert incident statuses
- support single or batch lifecycle updates through alert ID lists
- add regression coverage for the endpoint and payload contracts

## Validation

- endpoint paths and HTTP methods checked against the public SentinelOne Postman collection
- request envelopes cross-checked against established SentinelOne client implementations
- focused lifecycle template tests pass
- full registry template validation passes
- scoped pre-commit hooks pass


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SentinelOne alert lifecycle actions to update analyst verdicts and incident statuses, with single or batch support. Includes contract tests to lock endpoint paths and payload shapes.

- New Features
  - `tools.sentinel_one.update_alert_analyst_verdict`: POST to `/web/api/v2.1/cloud-detection/alerts/analyst-verdict` with `analyst_verdict`.
  - `tools.sentinel_one.update_alert_incident_status`: POST to `/web/api/v2.1/cloud-detection/alerts/incident` with `incident_status`.
  - Shared inputs: `alert_ids` (list), optional `base_url`; auth via `SENTINEL_ONE_API_TOKEN`.

<sup>Written for commit 3ba3b433eb4361fd52b600780c786713dae2e4a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

