### PR TITLE
chore(mcp): pin stdio catalog integrations

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -2487,51 +2487,11 @@
     {
       "slug": "terraform-mcp",
       "docs": "https://github.com/hashicorp/terraform-mcp-server",
-      "connection_spec": {
-        "server_type": "stdio",
-        "auth_type": "CUSTOM",
-        "stdio_command": null,
-        "stdio_args": [],
-        "stdio_env": [
-          "TFE_TOKEN",
-          "TFE_ADDRESS",
-          "TFE_SKIP_TLS_VERIFY",
-          "TRANSPORT_MODE",
-          "TRANSPORT_HOST",
-          "TRANSPORT_PORT",
-          "MCP_ENDPOINT",
-          "MCP_SESSION_MODE",
-          "ENABLE_TF_OPERATIONS"
-        ],
-        "packages": [],
-        "credentials": [
-          {
-            "key": "TFE_TOKEN",
-            "label": "HCP Terraform / Terraform Enterprise API Token",
-            "description": "API token used to authenticate against HCP Terraform or Terraform Enterprise for workspace, organization, and private registry operations. Optional for read-only public registry tools (provider docs, modules, policies) but required for any TFE/HCP workspace functionality and for approval-gated TF operations.",
-            "required": false,
-            "secret": true,
-            "target": "stdio_env"
-          },
-          {
-            "key": "TFE_ADDRESS",
-            "label": "Terraform Endpoint URL",
-            "description": "Base URL of the HCP Terraform / Terraform Enterprise instance. Defaults to https://app.terraform.io. Set this to your TFE host for self-managed/Enterprise deployments.",
-            "required": false,
-            "secret": false,
-            "type": "url",
-            "target": "stdio_env"
-          }
-        ],
-        "confidence": "high",
-        "docker_only": true,
-        "research_notes": "Official server: hashicorp/terraform-mcp-server. DOCKER_ONLY: the only official prebuilt distributions are a Docker image (hashicorp/terraform-mcp-server:0.5.2) and a Go binary (go install github.com/hashicorp/terraform-mcp-server/cmd/terraform-mcp-server@latest). There is NO npm, PyPI, npx, uvx, python, or node entrypoint, so packages[] is empty and stdio_* are null per the constraint. The canonical stdio launch is `docker run -i --rm hashicorp/terraform-mcp-server:0.5.2`; HTTP/streamable mode is `docker run -p 8080:8080 -e TRANSPORT_MODE=streamable-http -e TRANSPORT_HOST=0.0.0.0 hashicorp/terraform-mcp-server:0.5.2`.\\n\\nTransport: supports both STDIO (default) and streamable-HTTP. Chosen server_type=stdio to match intended transport. The HTTP mode is LOCAL ONLY (binds to 127.0.0.1:8080, endpoint path /mcp, health /health) — HashiCorp does NOT offer a hosted/remote managed MCP URL, so server_uri is null.\\n\\nAuth = CUSTOM (TFE_TOKEN bearer-style API token passed via env var; no OAuth flow). TFE_TOKEN and TFE_ADDRESS are technically OPTIONAL — the public Terraform Registry tools (provider docs, module search, Sentinel/policy lookup) work with no auth, and the token is only required for HCP Terraform / Terraform Enterprise workspace operations. Marked both credentials required=false accordingly; if a deployment needs TFE workspace features, TFE_TOKEN becomes required. Feature is currently labeled beta by HashiCorp. ENABLE_TF_OPERATIONS=true gates approval-required mutating tools.",
-        "sources": [
-          "https://github.com/hashicorp/terraform-mcp-server",
-          "https://github.com/hashicorp/terraform-mcp-server/blob/main/README.md",
-          "https://developer.hashicorp.com/terraform/mcp-server"
-        ]
-      }
+      "research_notes": "Coming soon: the official HashiCorp server is distributed as a Docker image or Go binary, but Tracecat's stdio runner does not currently permit Docker or Go executables.",
+      "sources": [
+        "https://github.com/hashicorp/terraform-mcp-server",
+        "https://developer.hashicorp.com/terraform/mcp-server"
+      ]
     },
     {
       "slug": "ansible-mcp",

--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -82,6 +82,8 @@
             "auth_type": "CUSTOM",
             "stdio_command": "uvx",
             "stdio_args": [
+              "--from",
+              "git+https://github.com/panther-labs/mcp-panther.git@7e6eca6f4f7f790057ed860bcfac669e13898d0c",
               "mcp-panther"
             ],
             "stdio_env": [
@@ -93,9 +95,11 @@
                 "manager": "uvx",
                 "command": "uvx",
                 "args": [
+                  "--from",
+                  "git+https://github.com/panther-labs/mcp-panther.git@7e6eca6f4f7f790057ed860bcfac669e13898d0c",
                   "mcp-panther"
                 ],
-                "package": "mcp-panther"
+                "package": "git+https://github.com/panther-labs/mcp-panther.git@7e6eca6f4f7f790057ed860bcfac669e13898d0c"
               }
             ],
             "credentials": [
@@ -285,7 +289,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "google-secops-mcp",
+          "git+https://github.com/google/mcp-security.git@fde561ff33fb69a1565780bd5f141f4750cfc770#subdirectory=server/secops",
           "secops_mcp"
         ],
         "stdio_env": [
@@ -300,19 +304,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "google-secops-mcp",
+              "git+https://github.com/google/mcp-security.git@fde561ff33fb69a1565780bd5f141f4750cfc770#subdirectory=server/secops",
               "secops_mcp"
             ],
-            "package": "google-secops-mcp"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "secops_mcp"
-            ],
-            "package": "google-secops-mcp"
+            "package": "git+https://github.com/google/mcp-security.git@fde561ff33fb69a1565780bd5f141f4750cfc770#subdirectory=server/secops"
           }
         ],
         "credentials": [
@@ -443,6 +438,8 @@
         "auth_type": "CUSTOM",
         "stdio_command": "uvx",
         "stdio_args": [
+          "--from",
+          "git+https://github.com/ClickHouse/mcp-clickhouse.git@5645bc9c2931ccba3314c29927b10e6cfafc7323",
           "mcp-clickhouse"
         ],
         "stdio_env": [
@@ -460,18 +457,11 @@
             "manager": "uvx",
             "command": "uvx",
             "args": [
+              "--from",
+              "git+https://github.com/ClickHouse/mcp-clickhouse.git@5645bc9c2931ccba3314c29927b10e6cfafc7323",
               "mcp-clickhouse"
             ],
-            "package": "mcp-clickhouse"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "mcp_clickhouse.main"
-            ],
-            "package": "mcp-clickhouse"
+            "package": "git+https://github.com/ClickHouse/mcp-clickhouse.git@5645bc9c2931ccba3314c29927b10e6cfafc7323"
           }
         ],
         "credentials": [
@@ -551,6 +541,8 @@
         "auth_type": "CUSTOM",
         "stdio_command": "uvx",
         "stdio_args": [
+          "--from",
+          "git+https://github.com/CrowdStrike/falcon-mcp.git@5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7",
           "falcon-mcp"
         ],
         "stdio_env": [
@@ -563,18 +555,11 @@
             "manager": "uvx",
             "command": "uvx",
             "args": [
+              "--from",
+              "git+https://github.com/CrowdStrike/falcon-mcp.git@5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7",
               "falcon-mcp"
             ],
-            "package": "falcon-mcp"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "falcon_mcp"
-            ],
-            "package": "falcon-mcp"
+            "package": "git+https://github.com/CrowdStrike/falcon-mcp.git@5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7"
           }
         ],
         "credentials": [
@@ -624,7 +609,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/Sentinel-One/purple-mcp.git",
+          "git+https://github.com/Sentinel-One/purple-mcp.git@07d4992089b10affff6163f296b1f6cb5734539f",
           "purple-mcp",
           "--mode",
           "stdio"
@@ -639,12 +624,12 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/Sentinel-One/purple-mcp.git",
+              "git+https://github.com/Sentinel-One/purple-mcp.git@07d4992089b10affff6163f296b1f6cb5734539f",
               "purple-mcp",
               "--mode",
               "stdio"
             ],
-            "package": "git+https://github.com/Sentinel-One/purple-mcp.git"
+            "package": "git+https://github.com/Sentinel-One/purple-mcp.git@07d4992089b10affff6163f296b1f6cb5734539f"
           }
         ],
         "credentials": [
@@ -703,16 +688,15 @@
         {
           "id": "local-stdio",
           "label": "Local stdio",
-          "description": "Run Jamf's open-source mcp-hub server locally to manage Apple devices across Jamf Pro, Protect, and Security Cloud. Requires a local clone of the repo plus API credentials.",
+          "description": "Run Jamf's open-source mcp-hub server locally from a QA-verified commit with API credentials.",
           "docs": "https://github.com/Jamf-Concepts/mcp-hub",
           "connection_spec": {
             "server_type": "stdio",
             "auth_type": "CUSTOM",
-            "stdio_command": null,
+            "stdio_command": "uvx",
             "stdio_args": [
-              "run",
-              "--directory",
-              "/path/to/mcp-hub",
+              "--from",
+              "git+https://github.com/Jamf-Concepts/mcp-hub.git@53843c4da3ef666b70de1ee793fa9e8c432b9972",
               "jamf-mcp"
             ],
             "stdio_env": [
@@ -726,7 +710,18 @@
               "JAMF_SECURITY_APP_ID",
               "JAMF_SECURITY_APP_SECRET"
             ],
-            "packages": [],
+            "packages": [
+              {
+                "manager": "uvx",
+                "command": "uvx",
+                "args": [
+                  "--from",
+                  "git+https://github.com/Jamf-Concepts/mcp-hub.git@53843c4da3ef666b70de1ee793fa9e8c432b9972",
+                  "jamf-mcp"
+                ],
+                "package": "git+https://github.com/Jamf-Concepts/mcp-hub.git@53843c4da3ef666b70de1ee793fa9e8c432b9972"
+              }
+            ],
             "credentials": [
               {
                 "key": "JAMF_PRO_URL",
@@ -806,7 +801,7 @@
             ],
             "confidence": "high",
             "docker_only": false,
-            "research_notes": "Official server is the first-party Jamf open-source repo Jamf-Concepts/mcp-hub (\"Jamf's open source mcp for Jamf Pro, Jamf Protect and Jamf Security\"), matching the catalog description. Transport is stdio. Python project (hatchling) with console script `jamf-mcp` (entry jamf_mcp.server:main); project version 0.1.0.\n\nIMPORTANT: NOT published to any package index. `pip install jamf-mcp` and `uvx jamf-mcp` will fail (PyPI returns 404, no npm package). The ONLY documented install is to git-clone the repo and run it from the local directory: `uv run --directory /path/to/mcp-hub jamf-mcp` (or `pip install -e .` inside the clone, then `jamf-mcp`). Because the canonical launcher is `uv run --directory <local-clone>` and our allowlisted commands (npx/uvx/python/python3/node) cannot pull this from a registry, I set stdio_command=null and packages=[] rather than fabricate a registry install. stdio_args/stdio_package reflect the documented `uv run` invocation against a local clone, with package name \"jamf-mcp\". This server requires git-clone setup — not docker (so docker_only=false) and not a registry package; it likely needs a follow-up decision on how to support local-clone-only servers.\n\nAuth (auth_type=CUSTOM): user supplies static API credentials via env vars. Jamf Pro uses a client-credentials API Role/Client (JAMF_PRO_CLIENT_ID/SECRET) — this is OAuth2 client_credentials internally, but from the user's perspective it is API-key-style credential entry (no browser sign-in, no DCR), so classified CUSTOM rather than OAUTH2. Required: JAMF_PRO_URL, JAMF_PRO_CLIENT_ID, JAMF_PRO_CLIENT_SECRET. Optional product modules: Jamf Protect (JAMF_PROTECT_URL/CLIENT_ID/PASSWORD) and Jamf Security Cloud (JAMF_SECURITY_URL/APP_ID/APP_SECRET) — only needed to enable those toolsets; README notes the server starts in \"onboarding mode\" with no credentials.\n\nThe separate official Jamf remote MCP at https://developer.jamf.com/mcp only serves Jamf developer DOCUMENTATION search, not device management — it is covered by the remote-http connection option on this entry.",
+            "research_notes": "QA PIN (2026-07-15): direct uvx installation and CLI launch were verified at commit 53843c4da3ef666b70de1ee793fa9e8c432b9972. Official first-party server is Jamf-Concepts/mcp-hub, with console script jamf-mcp. The catalog installs it reproducibly from the public Git repository via uvx --from git+https://github.com/Jamf-Concepts/mcp-hub.git@53843c4da3ef666b70de1ee793fa9e8c432b9972 jamf-mcp. Auth is CUSTOM: Jamf Pro requires JAMF_PRO_URL plus client ID and client secret; Jamf Protect and Jamf Security Cloud credentials are optional product-specific additions.",
             "sources": [
               "https://github.com/Jamf-Concepts/mcp-hub",
               "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/docs/INSTALLATION.md",
@@ -1040,7 +1035,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "gti-mcp",
+          "git+https://github.com/google/mcp-security.git@2552eeb5d0056317e352579a666c746a659e0b49#subdirectory=server/gti",
           "gti_mcp"
         ],
         "stdio_env": [
@@ -1053,19 +1048,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "gti-mcp",
+              "git+https://github.com/google/mcp-security.git@2552eeb5d0056317e352579a666c746a659e0b49#subdirectory=server/gti",
               "gti_mcp"
             ],
-            "package": "gti-mcp"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "gti_mcp.server"
-            ],
-            "package": "gti-mcp"
+            "package": "git+https://github.com/google/mcp-security.git@2552eeb5d0056317e352579a666c746a659e0b49#subdirectory=server/gti"
           }
         ],
         "credentials": [
@@ -1148,7 +1134,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/okta/okta-mcp-server.git@5cda0b8eb580b31c61572116343dd8cf083950c5",
+          "git+https://github.com/okta/okta-mcp-server.git@f9f6157f62d3d436bfbfce84ac20f198fcb94dde",
           "okta-mcp-server"
         ],
         "stdio_env": [
@@ -1164,10 +1150,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/okta/okta-mcp-server.git@5cda0b8eb580b31c61572116343dd8cf083950c5",
+              "git+https://github.com/okta/okta-mcp-server.git@f9f6157f62d3d436bfbfce84ac20f198fcb94dde",
               "okta-mcp-server"
             ],
-            "package": "git+https://github.com/okta/okta-mcp-server.git@5cda0b8eb580b31c61572116343dd8cf083950c5"
+            "package": "git+https://github.com/okta/okta-mcp-server.git@f9f6157f62d3d436bfbfce84ac20f198fcb94dde"
           }
         ],
         "credentials": [
@@ -1220,7 +1206,7 @@
         ],
         "confidence": "high",
         "docker_only": false,
-        "research_notes": "Official server is okta/okta-mcp-server (Python, built on Okta Python SDK), STDIO transport, console script `okta-mcp-server` (entry point okta_mcp_server:main). Launched via `uvx --from git+https://github.com/okta/okta-mcp-server.git@<sha> okta-mcp-server` (not published to PyPI/npm, so uvx installs from the git+ spec). PINNED to commit 5cda0b8eb580b31c61572116343dd8cf083950c5 (pyproject version 1.1.1, the GA-release merge on main dated 2026-06-24). The repo publishes NO git tags and NO GitHub releases, so a tag ref like @v1.1.1 does not resolve; the commit SHA is the only reproducible pin. To bump, find the new GA commit on main and replace the SHA in stdio_args + packages. We support ONLY the browserless Private Key JWT flow (the interactive Device Authorization browser flow is intentionally not offered: it requires a human to approve a device code and cannot complete in a headless server). So OKTA_ORG_URL, OKTA_CLIENT_ID, OKTA_PRIVATE_KEY, OKTA_KEY_ID, and OKTA_SCOPES are ALL required. The server enables browserless auth only when BOTH OKTA_PRIVATE_KEY and OKTA_KEY_ID are set (auth_manager.py: `if self.private_key and self.key_id`); if either is missing it silently falls back to device flow. VERIFIED against a real org: (1) OKTA_ORG_URL must be the org/OIDC-issuer host (e.g. https://your-org.okta.com), NOT the admin console host (https://your-org-admin.okta.com), which 302-redirects /oauth2/v1/* to /error/404. (2) Each requested scope must be GRANTED to the API Services app (Okta API Scopes tab) or the token endpoint returns 400 consent_required ('not allowed any of the requested scopes'); the app also needs an admin role for the scopes to return data. (3) Blank OKTA_SCOPES is NOT valid: the server then requests 'openid', which the client-credentials grant rejects with 400 invalid_scope — hence OKTA_SCOPES carries a default and is required. (4) The PEM private key should be stored as a workspace secret and referenced via ${{ SECRETS.okta.OKTA_PRIVATE_KEY }}; stdio_env resolves SECRETS/VARS template expressions at launch (preset/service.py _resolve_stdio_env). This avoids two problems with inline paste: the stdio_env JSON field cannot hold raw newlines, and a pasted PEM with leading indentation corrupts the base64. The secret editor's textarea accepts a multi-line PEM cleanly. We intentionally do NOT normalize PEMs inline in the MCP path (no precedent there); the secret-reference path is the supported convention. PYTHON_KEYRING_BACKEND is NOT included: it is Docker-only in Okta's README (containers lack a system keyring) and browserless Private Key JWT does not use the keyring. OAuth2 runs against the user's own Okta org domain, not a remote-MCP DCR sign-in. Third-party servers exist (fctr-id, kapilduraphe) but okta/okta-mcp-server is the first-party official one.",
+        "research_notes": "QA PIN (2026-07-15): direct uvx installation and CLI launch were verified for Okta release v1.1.3 at commit f9f6157f62d3d436bfbfce84ac20f198fcb94dde. The catalog installs okta-mcp-server reproducibly from that public Git commit. Only the browserless Private Key JWT flow is supported: OKTA_ORG_URL, OKTA_CLIENT_ID, OKTA_PRIVATE_KEY, OKTA_KEY_ID, and OKTA_SCOPES are required. Store the PEM private key as a workspace secret and reference it from stdio_env.",
         "sources": [
         "https://github.com/okta/okta-mcp-server",
         "https://raw.githubusercontent.com/okta/okta-mcp-server/main/README.md",
@@ -1290,7 +1276,9 @@
         "auth_type": "CUSTOM",
         "stdio_command": "uvx",
         "stdio_args": [
-          "mcp-proxy-for-aws@latest",
+          "--from",
+          "git+https://github.com/aws/mcp-proxy-for-aws.git@9a3022410f88cf6a6800bf411504615dad1adf12",
+          "mcp-proxy-for-aws",
           "https://aws-mcp.us-east-1.api.aws/mcp",
           "--metadata",
           "AWS_REGION=us-east-1"
@@ -1307,24 +1295,14 @@
             "manager": "uvx",
             "command": "uvx",
             "args": [
-              "mcp-proxy-for-aws@latest",
+              "--from",
+              "git+https://github.com/aws/mcp-proxy-for-aws.git@9a3022410f88cf6a6800bf411504615dad1adf12",
+              "mcp-proxy-for-aws",
               "https://aws-mcp.us-east-1.api.aws/mcp",
               "--metadata",
               "AWS_REGION=us-east-1"
             ],
-            "package": "mcp-proxy-for-aws"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "mcp_proxy_for_aws",
-              "https://aws-mcp.us-east-1.api.aws/mcp",
-              "--metadata",
-              "AWS_REGION=us-east-1"
-            ],
-            "package": "mcp-proxy-for-aws"
+            "package": "git+https://github.com/aws/mcp-proxy-for-aws.git@9a3022410f88cf6a6800bf411504615dad1adf12"
           }
         ],
         "credentials": [
@@ -1411,6 +1389,8 @@
         "auth_type": "CUSTOM",
         "stdio_command": "uvx",
         "stdio_args": [
+          "--from",
+          "git+https://github.com/zscaler/zscaler-mcp-server.git@23912913f8588c650b104d3bd30c0c755d6962cd",
           "zscaler-mcp"
         ],
         "stdio_env": [
@@ -1426,18 +1406,11 @@
             "manager": "uvx",
             "command": "uvx",
             "args": [
+              "--from",
+              "git+https://github.com/zscaler/zscaler-mcp-server.git@23912913f8588c650b104d3bd30c0c755d6962cd",
               "zscaler-mcp"
             ],
-            "package": "zscaler-mcp"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "zscaler_mcp"
-            ],
-            "package": "zscaler-mcp"
+            "package": "git+https://github.com/zscaler/zscaler-mcp-server.git@23912913f8588c650b104d3bd30c0c755d6962cd"
           }
         ],
         "credentials": [
@@ -1701,6 +1674,8 @@
         "auth_type": "CUSTOM",
         "stdio_command": "uvx",
         "stdio_args": [
+          "--from",
+          "git+https://github.com/osomai/servicenow-mcp.git@06250607bdfc814f9bb56551bba16c3a7fb5a8c9",
           "servicenow-mcp"
         ],
         "stdio_env": [
@@ -1719,18 +1694,11 @@
             "manager": "uvx",
             "command": "uvx",
             "args": [
+              "--from",
+              "git+https://github.com/osomai/servicenow-mcp.git@06250607bdfc814f9bb56551bba16c3a7fb5a8c9",
               "servicenow-mcp"
             ],
-            "package": "servicenow-mcp"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "servicenow_mcp.cli"
-            ],
-            "package": "servicenow-mcp"
+            "package": "git+https://github.com/osomai/servicenow-mcp.git@06250607bdfc814f9bb56551bba16c3a7fb5a8c9"
           }
         ],
         "credentials": [
@@ -1859,6 +1827,8 @@
         "auth_type": "CUSTOM",
         "stdio_command": "uvx",
         "stdio_args": [
+          "--from",
+          "git+https://github.com/PagerDuty/pagerduty-mcp-server.git@62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4",
           "pagerduty-mcp"
         ],
         "stdio_env": [
@@ -1870,18 +1840,11 @@
             "manager": "uvx",
             "command": "uvx",
             "args": [
+              "--from",
+              "git+https://github.com/PagerDuty/pagerduty-mcp-server.git@62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4",
               "pagerduty-mcp"
             ],
-            "package": "pagerduty-mcp"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "pagerduty_mcp"
-            ],
-            "package": "pagerduty-mcp"
+            "package": "git+https://github.com/PagerDuty/pagerduty-mcp-server.git@62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4"
           }
         ],
         "credentials": [
@@ -1922,7 +1885,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "rootly-mcp-server",
+          "git+https://github.com/Rootly-AI-Labs/Rootly-MCP-server.git@f4f55a049dbee11c8321daf52e4d6d5e2ab4f806",
           "rootly-mcp-server"
         ],
         "stdio_env": [
@@ -1936,19 +1899,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "rootly-mcp-server",
+              "git+https://github.com/Rootly-AI-Labs/Rootly-MCP-server.git@f4f55a049dbee11c8321daf52e4d6d5e2ab4f806",
               "rootly-mcp-server"
             ],
-            "package": "rootly-mcp-server"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "rootly_mcp_server"
-            ],
-            "package": "rootly-mcp-server"
+            "package": "git+https://github.com/Rootly-AI-Labs/Rootly-MCP-server.git@f4f55a049dbee11c8321daf52e4d6d5e2ab4f806"
           }
         ],
         "credentials": [
@@ -2148,6 +2102,8 @@
         "auth_type": "CUSTOM",
         "stdio_command": "uvx",
         "stdio_args": [
+          "--from",
+          "git+https://github.com/semgrep/mcp.git@6e340f843bf82a2f42de77125ae75cfd020abf9b",
           "semgrep-mcp"
         ],
         "stdio_env": [
@@ -2158,18 +2114,11 @@
             "manager": "uvx",
             "command": "uvx",
             "args": [
+              "--from",
+              "git+https://github.com/semgrep/mcp.git@6e340f843bf82a2f42de77125ae75cfd020abf9b",
               "semgrep-mcp"
             ],
-            "package": "semgrep-mcp"
-          },
-          {
-            "manager": "pip",
-            "command": "python",
-            "args": [
-              "-m",
-              "semgrep_mcp"
-            ],
-            "package": "semgrep-mcp"
+            "package": "git+https://github.com/semgrep/mcp.git@6e340f843bf82a2f42de77125ae75cfd020abf9b"
           }
         ],
         "credentials": [

--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -26,15 +26,17 @@
             "target": "http_header"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Elastic has two distinct MCP offerings. (1) The CURRENT, non-deprecated server is the Elastic Agent Builder MCP server, a native streamable-HTTP endpoint at {KIBANA_URL}/api/agent_builder/mcp (or {KIBANA_URL}/s/{SPACE_NAME}/api/agent_builder/mcp for custom spaces), available in Elastic 9.2.0+ and Elasticsearch Serverless. It uses an API-key custom header: 'Authorization: ApiKey <key>'. No OAuth/DCR/discovery — auth is a user-supplied API key, so auth_type=CUSTOM, not OAUTH2. There is no single fixed vendor host; KIBANA_URL is the user's own Kibana/Elastic Cloud deployment URL, hence server_uri is templated. Elastic's docs show clients that lack native HTTP-MCP support connecting via the third-party 'npx mcp-remote {url} --header Authorization:ApiKey <key>' proxy, but the real transport is HTTP, which matches the intended transport, so I selected server_type=http rather than stdio. (2) The OLDER repo elastic/mcp-server-elasticsearch (npm @elastic/mcp-server-elasticsearch, also Docker docker.elastic.co/mcp/elasticsearch) is now explicitly DEPRECATED ('will only receive critical security updates') and superseded by Agent Builder; it talks directly to Elasticsearch (ES_URL + ES_API_KEY or ES_USERNAME/ES_PASSWORD) and supports stdio/SSE/streamable-HTTP. I did not select it because it is deprecated. No uvx/pip distribution exists for either. packages[] left empty because the chosen offering is a remote HTTP endpoint (not a locally installed npx/uvx/pip package); the only local launcher is the generic mcp-remote proxy which is not an Elastic package.",
-        "sources": [
-          "https://www.elastic.co/docs/solutions/search/agent-builder/mcp-server",
-          "https://github.com/elastic/mcp-server-elasticsearch",
-          "https://github.com/elastic/mcp-server-elasticsearch/blob/main/README.md",
-          "https://www.elastic.co/search-labs/blog/model-context-protocol-elasticsearch"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Elastic has two distinct MCP offerings. (1) The CURRENT, non-deprecated server is the Elastic Agent Builder MCP server, a native streamable-HTTP endpoint at {KIBANA_URL}/api/agent_builder/mcp (or {KIBANA_URL}/s/{SPACE_NAME}/api/agent_builder/mcp for custom spaces), available in Elastic 9.2.0+ and Elasticsearch Serverless. It uses an API-key custom header: 'Authorization: ApiKey <key>'. No OAuth/DCR/discovery — auth is a user-supplied API key, so auth_type=CUSTOM, not OAUTH2. There is no single fixed vendor host; KIBANA_URL is the user's own Kibana/Elastic Cloud deployment URL, hence server_uri is templated. Elastic's docs show clients that lack native HTTP-MCP support connecting via the third-party 'npx mcp-remote {url} --header Authorization:ApiKey <key>' proxy, but the real transport is HTTP, which matches the intended transport, so I selected server_type=http rather than stdio. (2) The OLDER repo elastic/mcp-server-elasticsearch (npm @elastic/mcp-server-elasticsearch, also Docker docker.elastic.co/mcp/elasticsearch) is now explicitly DEPRECATED ('will only receive critical security updates') and superseded by Agent Builder; it talks directly to Elasticsearch (ES_URL + ES_API_KEY or ES_USERNAME/ES_PASSWORD) and supports stdio/SSE/streamable-HTTP. I did not select it because it is deprecated. No uvx/pip distribution exists for either. packages[] left empty because the chosen offering is a remote HTTP endpoint (not a locally installed npx/uvx/pip package); the only local launcher is the generic mcp-remote proxy which is not an Elastic package.",
+          "sources": [
+            "https://www.elastic.co/docs/solutions/search/agent-builder/mcp-server",
+            "https://github.com/elastic/mcp-server-elasticsearch",
+            "https://github.com/elastic/mcp-server-elasticsearch/blob/main/README.md",
+            "https://www.elastic.co/search-labs/blog/model-context-protocol-elasticsearch"
+          ]
+        }
       }
     },
     {
@@ -64,12 +66,14 @@
                 "secret": false
               }
             ],
-            "confidence": "high",
-            "docker_only": false,
-            "research_notes": "Panther Remote MCP is a hosted HTTPS endpoint at https://api.<your-panther-host>/mcp. It uses OAuth 2.1 + PKCE and dynamic client registration as a public client; Panther's docs explicitly state no client_secret is issued and API tokens are not supported for Remote MCP. The api. subdomain must be configured for the Panther deployment.",
-            "sources": [
-              "https://docs.panther.com/ai/mcp/panther-remote-mcp"
-            ]
+            "_research": {
+              "confidence": "high",
+              "docker_only": false,
+              "notes": "Panther Remote MCP is a hosted HTTPS endpoint at https://api.<your-panther-host>/mcp. It uses OAuth 2.1 + PKCE and dynamic client registration as a public client; Panther's docs explicitly state no client_secret is issued and API tokens are not supported for Remote MCP. The api. subdomain must be configured for the Panther deployment.",
+              "sources": [
+                "https://docs.panther.com/ai/mcp/panther-remote-mcp"
+              ]
+            }
           }
         },
         {
@@ -121,14 +125,16 @@
                 "target": "stdio_env"
               }
             ],
-            "confidence": "high",
-            "docker_only": false,
-            "research_notes": "Official first-party local MCP server is panther-labs/mcp-panther. Auth is a user-supplied Panther API token (PANTHER_API_TOKEN) plus Panther instance URL (PANTHER_INSTANCE_URL), not OAuth. Distribution: PyPI package mcp-panther runnable via uvx and Docker image ghcr.io/panther-labs/mcp-panther.",
-            "sources": [
-              "https://github.com/panther-labs/mcp-panther",
-              "https://docs.panther.com/ai/mcp/mcp-server",
-              "https://pypi.org/project/mcp-panther/"
-            ]
+            "_research": {
+              "confidence": "high",
+              "docker_only": false,
+              "notes": "Official first-party local MCP server is panther-labs/mcp-panther. Auth is a user-supplied Panther API token (PANTHER_API_TOKEN) plus Panther instance URL (PANTHER_INSTANCE_URL), not OAuth. Distribution: PyPI package mcp-panther runnable via uvx and Docker image ghcr.io/panther-labs/mcp-panther.",
+              "sources": [
+                "https://github.com/panther-labs/mcp-panther",
+                "https://docs.panther.com/ai/mcp/mcp-server",
+                "https://pypi.org/project/mcp-panther/"
+              ]
+            }
           }
         }
       ]
@@ -136,12 +142,14 @@
     {
       "slug": "splunk-mcp",
       "docs": "https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.1/about-mcp-server-for-splunk-platform",
-      "research_notes": "Coming soon. QA (2026-07-15): the public splunk/splunk-mcp-server2 source at commit fac6cbb37be057a68607642d8d60d9c19ba5a060 is not runnable through Tracecat. The catalog's former `python server.py` recipe had no cloned source file at runtime. Direct uvx installation from that Git commit builds, but startup fails because server.py imports guardrails.py while pyproject.toml omits guardrails from setuptools py-modules. Splunk's official GA server is instead installed into a customer's Splunk deployment and exposes a self-hosted HTTP endpoint; there is no canonical vendor-hosted URL or supported public npx/uvx package for this stdio catalog entry.",
-      "sources": [
-        "https://github.com/splunk/splunk-mcp-server2",
-        "https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.1/about-mcp-server-for-splunk-platform",
-        "https://splunkbase.splunk.com/app/7931"
-      ]
+      "_research": {
+        "notes": "Coming soon. QA (2026-07-15): the public splunk/splunk-mcp-server2 source at commit fac6cbb37be057a68607642d8d60d9c19ba5a060 is not runnable through Tracecat. The catalog's former `python server.py` recipe had no cloned source file at runtime. Direct uvx installation from that Git commit builds, but startup fails because server.py imports guardrails.py while pyproject.toml omits guardrails from setuptools py-modules. Splunk's official GA server is instead installed into a customer's Splunk deployment and exposes a self-hosted HTTP endpoint; there is no canonical vendor-hosted URL or supported public npx/uvx package for this stdio catalog entry.",
+        "sources": [
+          "https://github.com/splunk/splunk-mcp-server2",
+          "https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.1/about-mcp-server-for-splunk-platform",
+          "https://splunkbase.splunk.com/app/7931"
+        ]
+      }
     },
     {
       "slug": "scanner-mcp",
@@ -160,12 +168,14 @@
             "target": "http_header"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Scanner's first-party MCP server is a hosted HTTP endpoint. The docs instruct users to configure `https://mcp.your-env-here.scanner.dev/v1/mcp` and pass `Authorization: Bearer API_KEY_HERE`; there is no OAuth flow or local stdio package. The API key is created in Scanner Settings > API Keys and must have Read and Query permissions on target indexes, or team-level IndexReadAny and IndexQueryAny permissions. The environment slug comes from the user's Scanner API URL / API key settings, so the catalog URI uses the documented placeholder host for users to edit.",
-        "sources": [
-          "https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/mcp-and-ai-secops/getting-started"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Scanner's first-party MCP server is a hosted HTTP endpoint. The docs instruct users to configure `https://mcp.your-env-here.scanner.dev/v1/mcp` and pass `Authorization: Bearer API_KEY_HERE`; there is no OAuth flow or local stdio package. The API key is created in Scanner Settings > API Keys and must have Read and Query permissions on target indexes, or team-level IndexReadAny and IndexQueryAny permissions. The environment slug comes from the user's Scanner API URL / API key settings, so the catalog URI uses the documented placeholder host for users to edit.",
+          "sources": [
+            "https://docs.scanner.dev/scanner/using-scanner-complete-feature-reference/mcp-and-ai-secops/getting-started"
+          ]
+        }
       }
     },
     {
@@ -179,15 +189,17 @@
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official, fully Microsoft-hosted remote MCP server (no infrastructure to deploy, no local process). Confirmed via Microsoft Learn docs. There are THREE separate remote HTTP endpoints, each a distinct tool collection: data-exploration (https://sentinel.microsoft.com/mcp/data-exploration), Security Copilot agent creation (https://sentinel.microsoft.com/mcp/security-copilot-agent-creation), and triage (https://sentinel.microsoft.com/mcp/triage). I selected data-exploration as server_uri because it best matches our catalog description (\"query Sentinel's data lake and triage incidents\"); the triage endpoint covers incident/threat-hunting across Defender XDR + Sentinel. Consider adding the other two as separate catalog entries if needed.\n\nTransport: VS Code setup instructs choosing \"HTTP (HTTP or Server-Sent Events)\" - it is streamable HTTP (SSE is deprecated upstream per MCP). Auth: uses Microsoft Entra for identity. The VS Code flow is a browser \"Allow\" sign-in (interactive authorization-code OAuth2 / Entra), NOT a user-supplied API key or bearer token - so no manual credentials. The server advertises its OAuth authorization/token endpoints via MCP auth discovery (protected-resource metadata pointing at Microsoft Entra / login.microsoftonline.com), which is why oauth_authorization_endpoint and oauth_token_endpoint are left null. OAuth endpoints are discovered from the MCP metadata chain. No explicit OAuth scopes are documented; access is governed by Entra roles (minimum \"Security reader\" role required to list/invoke tools). Prerequisite: tenant must be onboarded to the Microsoft Sentinel data lake (and optionally Defender XDR / Security Copilot for some tools).",
-        "sources": [
-          "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-tools-overview",
-          "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-overview",
-          "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-get-started",
-          "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-use-tool-visual-studio-code"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official, fully Microsoft-hosted remote MCP server (no infrastructure to deploy, no local process). Confirmed via Microsoft Learn docs. There are THREE separate remote HTTP endpoints, each a distinct tool collection: data-exploration (https://sentinel.microsoft.com/mcp/data-exploration), Security Copilot agent creation (https://sentinel.microsoft.com/mcp/security-copilot-agent-creation), and triage (https://sentinel.microsoft.com/mcp/triage). I selected data-exploration as server_uri because it best matches our catalog description (\"query Sentinel's data lake and triage incidents\"); the triage endpoint covers incident/threat-hunting across Defender XDR + Sentinel. Consider adding the other two as separate catalog entries if needed.\n\nTransport: VS Code setup instructs choosing \"HTTP (HTTP or Server-Sent Events)\" - it is streamable HTTP (SSE is deprecated upstream per MCP). Auth: uses Microsoft Entra for identity. The VS Code flow is a browser \"Allow\" sign-in (interactive authorization-code OAuth2 / Entra), NOT a user-supplied API key or bearer token - so no manual credentials. The server advertises its OAuth authorization/token endpoints via MCP auth discovery (protected-resource metadata pointing at Microsoft Entra / login.microsoftonline.com), which is why oauth_authorization_endpoint and oauth_token_endpoint are left null. OAuth endpoints are discovered from the MCP metadata chain. No explicit OAuth scopes are documented; access is governed by Entra roles (minimum \"Security reader\" role required to list/invoke tools). Prerequisite: tenant must be onboarded to the Microsoft Sentinel data lake (and optionally Defender XDR / Security Copilot for some tools).",
+          "sources": [
+            "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-tools-overview",
+            "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-overview",
+            "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-get-started",
+            "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-use-tool-visual-studio-code"
+          ]
+        }
       }
     },
     {
@@ -268,16 +280,18 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official Google repo: github.com/google/mcp-security (the SecOps/Chronicle server lives under server/secops). Distributed on PyPI as `google-secops-mcp` v0.7.0 with console entry point `secops_mcp`. Canonical STDIO launch per official README: `uvx --from google-secops-mcp secops_mcp`. Also installable via `uv tool install google-secops-mcp` or `pip install google-secops-mcp` (then run module `secops_mcp`).\n\nAuth classified as CUSTOM: the user does NOT pass a bearer token to the server. Instead the server authenticates to Google Cloud via Application Default Credentials (set up out-of-band with `gcloud auth application-default login`) OR via a service account JSON key file referenced by SECOPS_SA_PATH (optional, secret). The user must always supply non-secret identifiers CHRONICLE_PROJECT_ID, CHRONICLE_CUSTOMER_ID, and CHRONICLE_REGION. Underlying ADC is technically a Google OAuth2 credential, but from the connection-spec perspective there is no in-band OAuth flow the MCP server performs, so OAUTH2 fields are left null.\n\nGoogle ALSO offers a separate fully-managed REMOTE/HTTP MCP server for SecOps with a regional streamable-HTTP endpoint pattern like https://chronicle.<region>.rep.googleapis.com/mcp (region-specific). That remote variant is a different deployment than the STDIO package requested here; since the intended transport is STDIO, the STDIO local package is specified. If the HTTP remote variant is later wanted, server_uri would be the regional .../mcp endpoint and auth would be Google Cloud IAM/OAuth.",
-        "sources": [
-          "https://github.com/google/mcp-security",
-          "https://github.com/google/mcp-security/blob/main/README.md",
-          "https://google.github.io/mcp-security/servers/secops_mcp.html",
-          "https://pypi.org/project/google-secops-mcp/",
-          "https://docs.cloud.google.com/chronicle/docs/secops/use-google-secops-mcp"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official Google repo: github.com/google/mcp-security (the SecOps/Chronicle server lives under server/secops). Distributed on PyPI as `google-secops-mcp` v0.7.0 with console entry point `secops_mcp`. Canonical STDIO launch per official README: `uvx --from google-secops-mcp secops_mcp`. Also installable via `uv tool install google-secops-mcp` or `pip install google-secops-mcp` (then run module `secops_mcp`).\n\nAuth classified as CUSTOM: the user does NOT pass a bearer token to the server. Instead the server authenticates to Google Cloud via Application Default Credentials (set up out-of-band with `gcloud auth application-default login`) OR via a service account JSON key file referenced by SECOPS_SA_PATH (optional, secret). The user must always supply non-secret identifiers CHRONICLE_PROJECT_ID, CHRONICLE_CUSTOMER_ID, and CHRONICLE_REGION. Underlying ADC is technically a Google OAuth2 credential, but from the connection-spec perspective there is no in-band OAuth flow the MCP server performs, so OAUTH2 fields are left null.\n\nGoogle ALSO offers a separate fully-managed REMOTE/HTTP MCP server for SecOps with a regional streamable-HTTP endpoint pattern like https://chronicle.<region>.rep.googleapis.com/mcp (region-specific). That remote variant is a different deployment than the STDIO package requested here; since the intended transport is STDIO, the STDIO local package is specified. If the HTTP remote variant is later wanted, server_uri would be the regional .../mcp endpoint and auth would be Google Cloud IAM/OAuth.",
+          "sources": [
+            "https://github.com/google/mcp-security",
+            "https://github.com/google/mcp-security/blob/main/README.md",
+            "https://google.github.io/mcp-security/servers/secops_mcp.html",
+            "https://pypi.org/project/google-secops-mcp/",
+            "https://docs.cloud.google.com/chronicle/docs/secops/use-google-secops-mcp"
+          ]
+        }
       }
     },
     {
@@ -305,17 +319,19 @@
             "target": "http_header"
           }
         ],
-        "confidence": "low",
-        "docker_only": false,
-        "research_notes": "The official Sumo Logic MCP Server exists but is in LIMITED BETA with select customers; Sumo Logic states wider availability is \"coming in early 2026.\" As of this research, there is NO publicly documented connection spec: no endpoint URL, no transport type, no auth scheme, and no published package or repository.\n\nWhat is verifiable from first-party sources: Sumo Logic markets the MCP Server as a way to make their \"Dojo AI\" the hub of the customer's AI ecosystem (connecting Dojo AI agents with external copilots, models, and tools). The framing strongly implies a hosted/remote (HTTP) offering tied to the Sumo Logic platform / Dojo AI, but the exact streamable-HTTP/SSE endpoint URL is NOT published. I therefore left server_type=unknown rather than guessing \"http\".\n\nThere is NO official MCP repo in the github.com/SumoLogic org (verified via `gh api /orgs/SumoLogic/repos` and org repo search for \"mcp\" -> 0 results), and no official npm/PyPI package found.\n\nIMPORTANT distinction: Multiple THIRD-PARTY community MCP servers exist (e.g. github.com/samwang0723/mcp-sumologic, github.com/vinit-devops/sumologic_mcp, github.com/greyaperez/mcp-sumologic). These are STDIO Python servers that authenticate with a Sumo Logic API Access ID + Access Key and an endpoint URL (env vars SUMOLOGIC_ACCESS_ID, SUMOLOGIC_ACCESS_KEY, SUMOLOGIC_ENDPOINT, e.g. https://api.<deployment>.sumologic.com). They are NOT first-party and were not used to populate the spec. If the catalog wants a working integration today, one of these community servers could be evaluated, but it would be community-maintained.\n\nRecommendation: Re-research once the official server reaches general availability (expected early 2026) to obtain the real endpoint URL and auth flow. Confidence kept low because no official technical spec is published yet.",
-        "sources": [
-          "https://www.sumologic.com/glossary/model-context-protocol-mcp",
-          "https://www.sumologic.com/blog/agents-dojo-ai-soc-analyst-mcp",
-          "https://www.sumologic.com/demo/mcp-server",
-          "https://www.sumologic.com/solutions/dojo-ai",
-          "https://github.com/SumoLogic",
-          "https://github.com/orgs/SumoLogic/repositories?q=mcp"
-        ]
+        "_research": {
+          "confidence": "low",
+          "docker_only": false,
+          "notes": "The official Sumo Logic MCP Server exists but is in LIMITED BETA with select customers; Sumo Logic states wider availability is \"coming in early 2026.\" As of this research, there is NO publicly documented connection spec: no endpoint URL, no transport type, no auth scheme, and no published package or repository.\n\nWhat is verifiable from first-party sources: Sumo Logic markets the MCP Server as a way to make their \"Dojo AI\" the hub of the customer's AI ecosystem (connecting Dojo AI agents with external copilots, models, and tools). The framing strongly implies a hosted/remote (HTTP) offering tied to the Sumo Logic platform / Dojo AI, but the exact streamable-HTTP/SSE endpoint URL is NOT published. I therefore left server_type=unknown rather than guessing \"http\".\n\nThere is NO official MCP repo in the github.com/SumoLogic org (verified via `gh api /orgs/SumoLogic/repos` and org repo search for \"mcp\" -> 0 results), and no official npm/PyPI package found.\n\nIMPORTANT distinction: Multiple THIRD-PARTY community MCP servers exist (e.g. github.com/samwang0723/mcp-sumologic, github.com/vinit-devops/sumologic_mcp, github.com/greyaperez/mcp-sumologic). These are STDIO Python servers that authenticate with a Sumo Logic API Access ID + Access Key and an endpoint URL (env vars SUMOLOGIC_ACCESS_ID, SUMOLOGIC_ACCESS_KEY, SUMOLOGIC_ENDPOINT, e.g. https://api.<deployment>.sumologic.com). They are NOT first-party and were not used to populate the spec. If the catalog wants a working integration today, one of these community servers could be evaluated, but it would be community-maintained.\n\nRecommendation: Re-research once the official server reaches general availability (expected early 2026) to obtain the real endpoint URL and auth flow. Confidence kept low because no official technical spec is published yet.",
+          "sources": [
+            "https://www.sumologic.com/glossary/model-context-protocol-mcp",
+            "https://www.sumologic.com/blog/agents-dojo-ai-soc-analyst-mcp",
+            "https://www.sumologic.com/demo/mcp-server",
+            "https://www.sumologic.com/solutions/dojo-ai",
+            "https://github.com/SumoLogic",
+            "https://github.com/orgs/SumoLogic/repositories?q=mcp"
+          ]
+        }
       }
     },
     {
@@ -329,15 +345,17 @@
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official Datadog MCP Server (Bits AI). Verified first-party from docs.datadoghq.com. Transport: Streamable HTTP (remote). Endpoint path is /api/unstable/mcp-server/mcp; hostname is site-specific. US1 host is mcp.datadoghq.com (full URL: https://mcp.datadoghq.com/api/unstable/mcp-server/mcp). Other sites replace the host: EU=mcp.datadoghq.eu, US3=mcp.us3.datadoghq.com, US5=mcp.us5.datadoghq.com, AP1/AP2 analogous; same path. app.ddog-gov.com (GovCloud) is NOT supported. Primary auth is OAuth 2.0 with a browser-based sign-in/redirect (\"You are prompted to login through OAuth\"). The docs do not state whether DCR or discovery metadata is used; as a modern remote MCP server it almost certainly advertises authorization/token endpoints via OAuth discovery (.well-known), so oauth_authorization_endpoint/token_endpoint are left null and OAuth endpoints are discovered from the MCP metadata chain. No specific OAuth scopes are documented. ALTERNATIVE auth (not chosen here, since intended transport is HTTP+OAuth) for headless/server environments: pass two HTTP headers DD_API_KEY and DD_APPLICATION_KEY (Datadog recommends a scoped service-account API key + application key). If the catalog instead wants the API-key path, switch auth_type to CUSTOM with two required secret credentials keyed DD_API_KEY and DD_APPLICATION_KEY plus an optional non-secret site/host field for region selection. A toolsets query param controls available tools (?toolsets=all, default core, or comma-separated e.g. apm,llmobs,monitors,logs). No npx/uvx/pip package — it is a hosted remote server, so packages[] is empty.",
-        "sources": [
-          "https://docs.datadoghq.com/bits_ai/mcp_server/",
-          "https://docs.datadoghq.com/bits_ai/mcp_server/setup/",
-          "https://www.datadoghq.com/blog/datadog-remote-mcp-server/",
-          "https://www.datadoghq.com/knowledge-center/mcp-server/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official Datadog MCP Server (Bits AI). Verified first-party from docs.datadoghq.com. Transport: Streamable HTTP (remote). Endpoint path is /api/unstable/mcp-server/mcp; hostname is site-specific. US1 host is mcp.datadoghq.com (full URL: https://mcp.datadoghq.com/api/unstable/mcp-server/mcp). Other sites replace the host: EU=mcp.datadoghq.eu, US3=mcp.us3.datadoghq.com, US5=mcp.us5.datadoghq.com, AP1/AP2 analogous; same path. app.ddog-gov.com (GovCloud) is NOT supported. Primary auth is OAuth 2.0 with a browser-based sign-in/redirect (\"You are prompted to login through OAuth\"). The docs do not state whether DCR or discovery metadata is used; as a modern remote MCP server it almost certainly advertises authorization/token endpoints via OAuth discovery (.well-known), so oauth_authorization_endpoint/token_endpoint are left null and OAuth endpoints are discovered from the MCP metadata chain. No specific OAuth scopes are documented. ALTERNATIVE auth (not chosen here, since intended transport is HTTP+OAuth) for headless/server environments: pass two HTTP headers DD_API_KEY and DD_APPLICATION_KEY (Datadog recommends a scoped service-account API key + application key). If the catalog instead wants the API-key path, switch auth_type to CUSTOM with two required secret credentials keyed DD_API_KEY and DD_APPLICATION_KEY plus an optional non-secret site/host field for region selection. A toolsets query param controls available tools (?toolsets=all, default core, or comma-separated e.g. apm,llmobs,monitors,logs). No npx/uvx/pip package — it is a hosted remote server, so packages[] is empty.",
+          "sources": [
+            "https://docs.datadoghq.com/bits_ai/mcp_server/",
+            "https://docs.datadoghq.com/bits_ai/mcp_server/setup/",
+            "https://www.datadoghq.com/blog/datadog-remote-mcp-server/",
+            "https://www.datadoghq.com/knowledge-center/mcp-server/"
+          ]
+        }
       }
     },
     {
@@ -446,15 +464,17 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official first-party server: ClickHouse/mcp-clickhouse (PyPI package mcp-clickhouse). Default transport is STDIO with NO auth at the MCP layer (stdio communicates only over stdin/stdout). The \"auth\" here is the ClickHouse database connection itself, supplied via env vars — hence auth_type=CUSTOM (host/user/password). The README's canonical launch is `uv run --with mcp-clickhouse --python 3.10 mcp-clickhouse`, which pins Python 3.10 and isolates the dependency; the equivalent within our allowlist is `uvx mcp-clickhouse` (uvx runs the mcp-clickhouse console script). The pip option runs `python -m mcp_clickhouse.main` after `pip install mcp-clickhouse`. Optional chDB support is available via the `mcp-clickhouse[chdb]` extra plus CHDB_ENABLED/CHDB_DATA_PATH env vars (not included as required). The server ALSO supports HTTP/SSE transport (endpoint http://<host>:<port>/mcp) which then requires auth — either a static bearer token (CLICKHOUSE_MCP_AUTH_TOKEN) or a FastMCP OAuth/OIDC provider (FASTMCP_SERVER_AUTH). That HTTP mode is not the intended STDIO transport and there is no vendor-hosted remote URL, so STDIO is reported. CLICKHOUSE_PASSWORD may be an empty string for passwordless servers but is still expected to be set.",
-        "sources": [
-          "https://github.com/ClickHouse/mcp-clickhouse",
-          "https://raw.githubusercontent.com/ClickHouse/mcp-clickhouse/main/README.md",
-          "https://pypi.org/project/mcp-clickhouse/",
-          "https://clickhouse.com/docs/use-cases/AI/MCP"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official first-party server: ClickHouse/mcp-clickhouse (PyPI package mcp-clickhouse). Default transport is STDIO with NO auth at the MCP layer (stdio communicates only over stdin/stdout). The \"auth\" here is the ClickHouse database connection itself, supplied via env vars — hence auth_type=CUSTOM (host/user/password). The README's canonical launch is `uv run --with mcp-clickhouse --python 3.10 mcp-clickhouse`, which pins Python 3.10 and isolates the dependency; the equivalent within our allowlist is `uvx mcp-clickhouse` (uvx runs the mcp-clickhouse console script). The pip option runs `python -m mcp_clickhouse.main` after `pip install mcp-clickhouse`. Optional chDB support is available via the `mcp-clickhouse[chdb]` extra plus CHDB_ENABLED/CHDB_DATA_PATH env vars (not included as required). The server ALSO supports HTTP/SSE transport (endpoint http://<host>:<port>/mcp) which then requires auth — either a static bearer token (CLICKHOUSE_MCP_AUTH_TOKEN) or a FastMCP OAuth/OIDC provider (FASTMCP_SERVER_AUTH). That HTTP mode is not the intended STDIO transport and there is no vendor-hosted remote URL, so STDIO is reported. CLICKHOUSE_PASSWORD may be an empty string for passwordless servers but is still expected to be set.",
+          "sources": [
+            "https://github.com/ClickHouse/mcp-clickhouse",
+            "https://raw.githubusercontent.com/ClickHouse/mcp-clickhouse/main/README.md",
+            "https://pypi.org/project/mcp-clickhouse/",
+            "https://clickhouse.com/docs/use-cases/AI/MCP"
+          ]
+        }
       }
     },
     {
@@ -513,15 +533,17 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official CrowdStrike repo: github.com/CrowdStrike/falcon-mcp (maintained by CrowdStrike, currently public preview / pre-1.0). Published to PyPI as `falcon-mcp` with console entrypoint `falcon-mcp` (also runnable as `python -m falcon_mcp`). Default transport is stdio; it also supports streamable-http via `--transport streamable-http --host 0.0.0.0` (default port 8000), so it is NOT a remote-only hosted endpoint — there is no vendor-hosted MCP URL, hence server_uri is null. Auth is CUSTOM: the server uses CrowdStrike Falcon OAuth2 API client credentials (client ID + secret) under the hood via falconpy, but from the user's perspective they supply a static API key pair plus regional base URL as env vars — not an interactive OAuth browser flow, so auth_type=CUSTOM not OAUTH2. The official README's primary container example uses Docker (quay.io/crowdstrike/falcon-mcp), but Docker is NOT the only distribution — `uvx falcon-mcp` and `pip install falcon-mcp` are first-party supported, so docker_only=false. Optional CLI flag `--modules detections,hosts,intel,...` selects which tool modules load (not a credential). FALCON_BASE_URL marked required because EU/US-2/GovCloud tenants must override the US-1 default.",
-        "sources": [
-          "https://github.com/CrowdStrike/falcon-mcp",
-          "https://github.com/CrowdStrike/falcon-mcp/blob/main/README.md",
-          "https://pypi.org/project/falcon-mcp/",
-          "https://crowdstrike.github.io/falcon-mcp/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official CrowdStrike repo: github.com/CrowdStrike/falcon-mcp (maintained by CrowdStrike, currently public preview / pre-1.0). Published to PyPI as `falcon-mcp` with console entrypoint `falcon-mcp` (also runnable as `python -m falcon_mcp`). Default transport is stdio; it also supports streamable-http via `--transport streamable-http --host 0.0.0.0` (default port 8000), so it is NOT a remote-only hosted endpoint — there is no vendor-hosted MCP URL, hence server_uri is null. Auth is CUSTOM: the server uses CrowdStrike Falcon OAuth2 API client credentials (client ID + secret) under the hood via falconpy, but from the user's perspective they supply a static API key pair plus regional base URL as env vars — not an interactive OAuth browser flow, so auth_type=CUSTOM not OAUTH2. The official README's primary container example uses Docker (quay.io/crowdstrike/falcon-mcp), but Docker is NOT the only distribution — `uvx falcon-mcp` and `pip install falcon-mcp` are first-party supported, so docker_only=false. Optional CLI flag `--modules detections,hosts,intel,...` selects which tool modules load (not a credential). FALCON_BASE_URL marked required because EU/US-2/GovCloud tenants must override the US-1 default.",
+          "sources": [
+            "https://github.com/CrowdStrike/falcon-mcp",
+            "https://github.com/CrowdStrike/falcon-mcp/blob/main/README.md",
+            "https://pypi.org/project/falcon-mcp/",
+            "https://crowdstrike.github.io/falcon-mcp/"
+          ]
+        }
       }
     },
     {
@@ -576,14 +598,16 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official open-source server: github.com/Sentinel-One/purple-mcp. Read-only access to Purple AI, Alerts, Vulnerabilities, Misconfigurations, Events (PowerQuery), and Asset Inventory. Supports three transports: stdio (default, matches intended transport), sse, and streamable-http (selected via --mode flag). For the local STDIO use case the canonical install is `uvx --from git+https://github.com/Sentinel-One/purple-mcp.git purple-mcp --mode=stdio`. NOT published to PyPI or npm as a named package; it is distributed as a git source repo, so uvx installs it directly from the git URL (uvx supports git+ specs). A Dockerfile is also provided but Docker is not the only distribution, so docker_only=false. Auth is CUSTOM: a SentinelOne service-user token plus the console base URL, both passed as env vars; the token must have Account or Site-level (not Global) permissions. No OAuth flow.\"",
-        "sources": [
-          "https://github.com/Sentinel-One/purple-mcp",
-          "https://raw.githubusercontent.com/Sentinel-One/purple-mcp/main/README.md",
-          "https://aws.amazon.com/marketplace/pp/prodview-v3jszvcu3fdzk"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official open-source server: github.com/Sentinel-One/purple-mcp. Read-only access to Purple AI, Alerts, Vulnerabilities, Misconfigurations, Events (PowerQuery), and Asset Inventory. Supports three transports: stdio (default, matches intended transport), sse, and streamable-http (selected via --mode flag). For the local STDIO use case the canonical install is `uvx --from git+https://github.com/Sentinel-One/purple-mcp.git purple-mcp --mode=stdio`. NOT published to PyPI or npm as a named package; it is distributed as a git source repo, so uvx installs it directly from the git URL (uvx supports git+ specs). A Dockerfile is also provided but Docker is not the only distribution, so docker_only=false. Auth is CUSTOM: a SentinelOne service-user token plus the console base URL, both passed as env vars; the token must have Account or Site-level (not Global) permissions. No OAuth flow.\"",
+          "sources": [
+            "https://github.com/Sentinel-One/purple-mcp",
+            "https://raw.githubusercontent.com/Sentinel-One/purple-mcp/main/README.md",
+            "https://aws.amazon.com/marketplace/pp/prodview-v3jszvcu3fdzk"
+          ]
+        }
       }
     },
     {
@@ -601,12 +625,14 @@
             "auth_type": "NONE",
             "server_uri": "https://developer.jamf.com/mcp",
             "credentials": [],
-            "confidence": "high",
-            "docker_only": false,
-            "research_notes": "Official Jamf-hosted remote MCP server at https://developer.jamf.com/mcp, documented at developer.jamf.com/developer-guide/docs/mcp. Transport is streamable HTTP; first-party client configs (Cursor, Windsurf, Claude Desktop) are just {\"url\": \"https://developer.jamf.com/mcp\"} with no OAuth flow or API key, so auth_type=NONE. Scope is Jamf DEVELOPER DOCUMENTATION search and API code-generation assistance only — it does NOT manage devices or query Jamf Pro/Protect/Security Cloud tenant data. Device management requires the local-stdio mcp-hub option. Jamf also publishes an AI-agent index at https://developer.jamf.com/llms.txt.",
-            "sources": [
-              "https://developer.jamf.com/developer-guide/docs/mcp"
-            ]
+            "_research": {
+              "confidence": "high",
+              "docker_only": false,
+              "notes": "Official Jamf-hosted remote MCP server at https://developer.jamf.com/mcp, documented at developer.jamf.com/developer-guide/docs/mcp. Transport is streamable HTTP; first-party client configs (Cursor, Windsurf, Claude Desktop) are just {\"url\": \"https://developer.jamf.com/mcp\"} with no OAuth flow or API key, so auth_type=NONE. Scope is Jamf DEVELOPER DOCUMENTATION search and API code-generation assistance only — it does NOT manage devices or query Jamf Pro/Protect/Security Cloud tenant data. Device management requires the local-stdio mcp-hub option. Jamf also publishes an AI-agent index at https://developer.jamf.com/llms.txt.",
+              "sources": [
+                "https://developer.jamf.com/developer-guide/docs/mcp"
+              ]
+            }
           }
         },
         {
@@ -723,17 +749,19 @@
                 "target": "stdio_env"
               }
             ],
-            "confidence": "high",
-            "docker_only": false,
-            "research_notes": "QA PIN (2026-07-15): direct uvx installation and CLI launch were verified at commit 53843c4da3ef666b70de1ee793fa9e8c432b9972. Official first-party server is Jamf-Concepts/mcp-hub, with console script jamf-mcp. The catalog installs it reproducibly from the public Git repository via uvx --from git+https://github.com/Jamf-Concepts/mcp-hub.git@53843c4da3ef666b70de1ee793fa9e8c432b9972 jamf-mcp. Auth is CUSTOM: Jamf Pro requires JAMF_PRO_URL plus client ID and client secret; Jamf Protect and Jamf Security Cloud credentials are optional product-specific additions.",
-            "sources": [
-              "https://github.com/Jamf-Concepts/mcp-hub",
-              "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/docs/INSTALLATION.md",
-              "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/README.md",
-              "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/pyproject.toml",
-              "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/.env.example",
-              "https://pypi.org/pypi/jamf-mcp/json"
-            ]
+            "_research": {
+              "confidence": "high",
+              "docker_only": false,
+              "notes": "QA PIN (2026-07-15): direct uvx installation and CLI launch were verified at commit 53843c4da3ef666b70de1ee793fa9e8c432b9972. Official first-party server is Jamf-Concepts/mcp-hub, with console script jamf-mcp. The catalog installs it reproducibly from the public Git repository via uvx --from git+https://github.com/Jamf-Concepts/mcp-hub.git@53843c4da3ef666b70de1ee793fa9e8c432b9972 jamf-mcp. Auth is CUSTOM: Jamf Pro requires JAMF_PRO_URL plus client ID and client secret; Jamf Protect and Jamf Security Cloud credentials are optional product-specific additions.",
+              "sources": [
+                "https://github.com/Jamf-Concepts/mcp-hub",
+                "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/docs/INSTALLATION.md",
+                "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/README.md",
+                "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/pyproject.toml",
+                "https://raw.githubusercontent.com/Jamf-Concepts/mcp-hub/main/.env.example",
+                "https://pypi.org/pypi/jamf-mcp/json"
+              ]
+            }
           }
         }
       ]
@@ -771,13 +799,15 @@
             "target": "http_header"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official first-party Iru (formerly Kandji) MCP server, documented at docs.iru.com. Transport is streamable HTTP (config uses \"type\": \"http\"). Auth is CUSTOM via two HTTP headers: X-API-Key (the API key, must include the sk_live: prefix exactly as shown) and X-MCP-Profile (a profile ID). No OAuth. The endpoint URL is tenant- and connector-specific (https://<tenant>.connect.iru.dev/mcp-server/connector/<connector-slug>/tools), so the user must paste the exact URL Iru generates rather than a fixed global endpoint; hence the URL itself is treated as a user-supplied (non-secret) credential. Token must be created with MCP enabled under Access -> API tokens -> Add Token, then copy the provided MCP configuration JSON (url + headers). A separate third-party stdio implementation exists (github.com/mangopudding/mcp-server-iru-api, KANDJI_API_TOKEN/KANDJI_SUBDOMAIN/KANDJI_REGION, not published to npm), but it is community-built and not the official server; the official HTTP server matches the intended transport.",
-        "sources": [
-          "https://docs.iru.com/en/endpoint/api/model-context-protocol/iru-mcp",
-          "https://www.iru.com/blog/iru-mcp"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official first-party Iru (formerly Kandji) MCP server, documented at docs.iru.com. Transport is streamable HTTP (config uses \"type\": \"http\"). Auth is CUSTOM via two HTTP headers: X-API-Key (the API key, must include the sk_live: prefix exactly as shown) and X-MCP-Profile (a profile ID). No OAuth. The endpoint URL is tenant- and connector-specific (https://<tenant>.connect.iru.dev/mcp-server/connector/<connector-slug>/tools), so the user must paste the exact URL Iru generates rather than a fixed global endpoint; hence the URL itself is treated as a user-supplied (non-secret) credential. Token must be created with MCP enabled under Access -> API tokens -> Add Token, then copy the provided MCP configuration JSON (url + headers). A separate third-party stdio implementation exists (github.com/mangopudding/mcp-server-iru-api, KANDJI_API_TOKEN/KANDJI_SUBDOMAIN/KANDJI_REGION, not published to npm), but it is community-built and not the official server; the official HTTP server matches the intended transport.",
+          "sources": [
+            "https://docs.iru.com/en/endpoint/api/model-context-protocol/iru-mcp",
+            "https://www.iru.com/blog/iru-mcp"
+          ]
+        }
       }
     },
     {
@@ -805,16 +835,18 @@
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "There is NO standalone official \"Microsoft Defender XDR MCP server\". The first-party Microsoft offering that triages Defender XDR detections across endpoints (devices), identity (users), and email (incidents/alerts/evidence) is the Microsoft Sentinel MCP server, specifically its TRIAGE tool collection, hosted at https://sentinel.microsoft.com/mcp/triage. This matches the catalog intent (HTTP transport; triage Defender XDR detections). The triage collection's documented prerequisite is \"Microsoft Defender XDR, Microsoft Defender for Endpoint, or Microsoft Sentinel onboarded to the Defender portal\", and its tools (ListIncidents, GetIncidentById, ListAlerts, GetDefenderMachine, ListUserRelatedAlerts, RunAdvancedHuntingQuery, etc.) operate over Defender data.\n\nTransport: remote HTTP. In VS Code you add it via \"MCP: Add Server\" -> \"HTTP (HTTP or Server-Sent Events)\" and paste the URL. Streaming is HTTP with a 120-second streaming limit. So server_type=http.\n\nAuth: Microsoft Entra ID. Docs state \"Microsoft Sentinel MCP server implements the latest authorization specifications from MCP\" and the client prompts the user to \"Allow\" an interactive sign-in (browser/Entra). This is OAuth2 authorization-code; the server advertises its authorization/token endpoints via MCP OAuth discovery (.well-known/oauth-authorization-server + protected-resource), so oauth_authorization_endpoint and oauth_token_endpoint are intentionally left null — clients discover them. The underlying Entra token endpoint is login.microsoftonline.com; the resource/discovery host is sentinel.microsoft.com. No static OAuth scopes are documented; access is governed by Entra RBAC (minimum \"Security reader\" role; triage collection enforces the user's existing permissions). No user-supplied API key/token is needed (sign-in flow), so credentials[] is empty.\n\nOther endpoints in the same Sentinel MCP server: data-exploration is at https://sentinel.microsoft.com/mcp/data-exploration (per the official microsoft/mcp catalog). The triage endpoint is the correct one for \"triage Defender XDR detections\". Triage is in PREVIEW per the application card.\n\nConstraints/limits: home-tenant only (no guest/delegated access), English-only, optimized for specific regions (AU, CA, EU, IN, JP, NO, SEA, CH, UK, US). Requires onboarding to the Defender portal / Sentinel data lake.\n\nNon-first-party alternatives exist but were NOT used as the spec basis: github.com/MenkW/Defender-MCP (local Node, dual Entra app-registration tokens) and github.com/markolauren/ResponseMCP (Azure Container Apps). These are community projects requiring a self-registered Entra app + client secret; ignore unless a self-hosted CUSTOM-auth variant is desired.",
-        "sources": [
-          "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-get-started",
-          "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-triage-tool",
-          "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-use-tool-visual-studio-code",
-          "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-application-card",
-          "https://github.com/microsoft/mcp"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "There is NO standalone official \"Microsoft Defender XDR MCP server\". The first-party Microsoft offering that triages Defender XDR detections across endpoints (devices), identity (users), and email (incidents/alerts/evidence) is the Microsoft Sentinel MCP server, specifically its TRIAGE tool collection, hosted at https://sentinel.microsoft.com/mcp/triage. This matches the catalog intent (HTTP transport; triage Defender XDR detections). The triage collection's documented prerequisite is \"Microsoft Defender XDR, Microsoft Defender for Endpoint, or Microsoft Sentinel onboarded to the Defender portal\", and its tools (ListIncidents, GetIncidentById, ListAlerts, GetDefenderMachine, ListUserRelatedAlerts, RunAdvancedHuntingQuery, etc.) operate over Defender data.\n\nTransport: remote HTTP. In VS Code you add it via \"MCP: Add Server\" -> \"HTTP (HTTP or Server-Sent Events)\" and paste the URL. Streaming is HTTP with a 120-second streaming limit. So server_type=http.\n\nAuth: Microsoft Entra ID. Docs state \"Microsoft Sentinel MCP server implements the latest authorization specifications from MCP\" and the client prompts the user to \"Allow\" an interactive sign-in (browser/Entra). This is OAuth2 authorization-code; the server advertises its authorization/token endpoints via MCP OAuth discovery (.well-known/oauth-authorization-server + protected-resource), so oauth_authorization_endpoint and oauth_token_endpoint are intentionally left null — clients discover them. The underlying Entra token endpoint is login.microsoftonline.com; the resource/discovery host is sentinel.microsoft.com. No static OAuth scopes are documented; access is governed by Entra RBAC (minimum \"Security reader\" role; triage collection enforces the user's existing permissions). No user-supplied API key/token is needed (sign-in flow), so credentials[] is empty.\n\nOther endpoints in the same Sentinel MCP server: data-exploration is at https://sentinel.microsoft.com/mcp/data-exploration (per the official microsoft/mcp catalog). The triage endpoint is the correct one for \"triage Defender XDR detections\". Triage is in PREVIEW per the application card.\n\nConstraints/limits: home-tenant only (no guest/delegated access), English-only, optimized for specific regions (AU, CA, EU, IN, JP, NO, SEA, CH, UK, US). Requires onboarding to the Defender portal / Sentinel data lake.\n\nNon-first-party alternatives exist but were NOT used as the spec basis: github.com/MenkW/Defender-MCP (local Node, dual Entra app-registration tokens) and github.com/markolauren/ResponseMCP (Azure Container Apps). These are community projects requiring a self-registered Entra app + client secret; ignore unless a self-hosted CUSTOM-auth variant is desired.",
+          "sources": [
+            "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-get-started",
+            "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-triage-tool",
+            "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-use-tool-visual-studio-code",
+            "https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-mcp-application-card",
+            "https://github.com/microsoft/mcp"
+          ]
+        }
       }
     },
     {
@@ -919,14 +951,16 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "QA PIN (2026-07-15): npm package @greynoise/greynoise-mcp-server@0.4.0 is associated through npm gitHead with public release commit 017bc228439be1672da60b3f49ef902d6311ea51. Its registry integrity hash was verified, the packaged build/index.js entrypoint launched, and an MCP initialize/list-tools probe returned 18 tools. Version 0.4.1 was not selected because its advertised gitHead is not publicly reachable. Default transport is stdio and authentication uses GREYNOISE_API_KEY.",
-        "sources": [
-          "https://github.com/GreyNoise-Intelligence/greynoise-mcp-server",
-          "https://docs.greynoise.io/docs/mcp-server",
-          "https://registry.npmjs.org/@greynoise/greynoise-mcp-server"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "QA PIN (2026-07-15): npm package @greynoise/greynoise-mcp-server@0.4.0 is associated through npm gitHead with public release commit 017bc228439be1672da60b3f49ef902d6311ea51. Its registry integrity hash was verified, the packaged build/index.js entrypoint launched, and an MCP initialize/list-tools probe returned 18 tools. Version 0.4.1 was not selected because its advertised gitHead is not publicly reachable. Default transport is stdio and authentication uses GREYNOISE_API_KEY.",
+          "sources": [
+            "https://github.com/GreyNoise-Intelligence/greynoise-mcp-server",
+            "https://docs.greynoise.io/docs/mcp-server",
+            "https://registry.npmjs.org/@greynoise/greynoise-mcp-server"
+          ]
+        }
       }
     },
     {
@@ -940,14 +974,16 @@
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official Feedly \"Threat Graph\" MCP server is a remote/hosted HTTP server at https://mcp.feedly.com/mcp. Endpoints ending in /mcp are streamable-HTTP transport (not SSE). Setup per official docs: in Claude, Connectors > \"Add custom connector\", Name \"Feedly Threat Graph\", Server URL https://mcp.feedly.com/mcp, then \"Connect\" and authenticate with a Feedly Enterprise or Advanced account. This Connect + browser sign-in flow is the standard remote-MCP OAuth2 authorization-code flow; modern remote MCP servers advertise authorization/token endpoints via OAuth protected-resource / authorization-server discovery, so the explicit authorization_endpoint and token_endpoint are left null (resolved at runtime via .well-known discovery against mcp.feedly.com / feedly.com). No documented scopes. Requires a paid Feedly Enterprise or Advanced (CTI) account; there is no user-supplied API key/token in the documented Claude connector flow (auth is the OAuth sign-in). No npx/uvx/pip package and no Docker image — it is a vendor-hosted remote server only, so packages[] is empty and docker_only=false. NOTE: several third-party community Feedly MCP servers exist on GitHub (c0ffee0wl/feedly-mcp-server, hafnium49/mcp_server_feedly, shaojiejiang/feedly-mcp) that use a Feedly API token via stdio, but those are NOT first-party; the catalog slug describes curated threat-intel feeds which matches the official Feedly Threat Graph remote server.",
-        "sources": [
-          "https://docs.feedly.com/article/822-setting-up-the-feedly-mcp-server-in-claude",
-          "https://docs.feedly.com/category/819-mcp-server",
-          "https://feedly.com/new-features/posts/feedly-mcp-server-automate-cti-workflows-with-claude-and-the-feedly-threat-graph"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official Feedly \"Threat Graph\" MCP server is a remote/hosted HTTP server at https://mcp.feedly.com/mcp. Endpoints ending in /mcp are streamable-HTTP transport (not SSE). Setup per official docs: in Claude, Connectors > \"Add custom connector\", Name \"Feedly Threat Graph\", Server URL https://mcp.feedly.com/mcp, then \"Connect\" and authenticate with a Feedly Enterprise or Advanced account. This Connect + browser sign-in flow is the standard remote-MCP OAuth2 authorization-code flow; modern remote MCP servers advertise authorization/token endpoints via OAuth protected-resource / authorization-server discovery, so the explicit authorization_endpoint and token_endpoint are left null (resolved at runtime via .well-known discovery against mcp.feedly.com / feedly.com). No documented scopes. Requires a paid Feedly Enterprise or Advanced (CTI) account; there is no user-supplied API key/token in the documented Claude connector flow (auth is the OAuth sign-in). No npx/uvx/pip package and no Docker image — it is a vendor-hosted remote server only, so packages[] is empty and docker_only=false. NOTE: several third-party community Feedly MCP servers exist on GitHub (c0ffee0wl/feedly-mcp-server, hafnium49/mcp_server_feedly, shaojiejiang/feedly-mcp) that use a Feedly API token via stdio, but those are NOT first-party; the catalog slug describes curated threat-intel feeds which matches the official Feedly Threat Graph remote server.",
+          "sources": [
+            "https://docs.feedly.com/article/822-setting-up-the-feedly-mcp-server-in-claude",
+            "https://docs.feedly.com/category/819-mcp-server",
+            "https://feedly.com/new-features/posts/feedly-mcp-server-automate-cti-workflows-with-claude-and-the-feedly-threat-graph"
+          ]
+        }
       }
     },
     {
@@ -996,17 +1032,19 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "The official VirusTotal/Google Threat Intelligence MCP server is the \"gti\" server in Google's first-party monorepo google/mcp-security (maintained by the Google SecOps Team, chronicle@google.com). It matches our catalog description and intended STDIO transport: server.py runs with transport='stdio'.\n\nDistribution: published to PyPI as `gti-mcp` (v0.1.2, 2025-09-05). pyproject.toml defines a console script entry point `gti_mcp = \"gti_mcp.server:main\"` (also aliased as `gti-mcp`), so `uvx --from gti-mcp gti_mcp` is the canonical zero-install runner. pip install + `python -m gti_mcp.server` also works (module is gti_mcp, entry main()). The official README documents running from cloned source (`uv --directory server/gti/gti_mcp run server.py`), but the PyPI package is the cleaner supported path and uses the same entry point.\n\nAuth: CUSTOM. Requires VT_APIKEY (VirusTotal API key, 64-char hex) passed as an environment variable; server raises if missing. No OAuth. Optional STATELESS=1 env toggles per-request transport. No proxy/base-url env vars are read.\n\nNote: several third-party/unofficial VirusTotal MCP servers exist (e.g. npm @burtthecoder/mcp-virustotal, BurtTheCoder/mcp-virustotal; Python barvhaim/virustotal-mcp-server). These are NOT first-party; the catalog description specifically references Google Threat Intelligence, which is the google/mcp-security `gti` server selected here.",
-        "sources": [
-          "https://github.com/google/mcp-security",
-          "https://google.github.io/mcp-security/servers/gti_mcp.html",
-          "https://pypi.org/project/gti-mcp/",
-          "https://raw.githubusercontent.com/google/mcp-security/main/server/gti/README.md",
-          "https://raw.githubusercontent.com/google/mcp-security/main/server/gti/pyproject.toml",
-          "https://raw.githubusercontent.com/google/mcp-security/main/server/gti/gti_mcp/server.py"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "The official VirusTotal/Google Threat Intelligence MCP server is the \"gti\" server in Google's first-party monorepo google/mcp-security (maintained by the Google SecOps Team, chronicle@google.com). It matches our catalog description and intended STDIO transport: server.py runs with transport='stdio'.\n\nDistribution: published to PyPI as `gti-mcp` (v0.1.2, 2025-09-05). pyproject.toml defines a console script entry point `gti_mcp = \"gti_mcp.server:main\"` (also aliased as `gti-mcp`), so `uvx --from gti-mcp gti_mcp` is the canonical zero-install runner. pip install + `python -m gti_mcp.server` also works (module is gti_mcp, entry main()). The official README documents running from cloned source (`uv --directory server/gti/gti_mcp run server.py`), but the PyPI package is the cleaner supported path and uses the same entry point.\n\nAuth: CUSTOM. Requires VT_APIKEY (VirusTotal API key, 64-char hex) passed as an environment variable; server raises if missing. No OAuth. Optional STATELESS=1 env toggles per-request transport. No proxy/base-url env vars are read.\n\nNote: several third-party/unofficial VirusTotal MCP servers exist (e.g. npm @burtthecoder/mcp-virustotal, BurtTheCoder/mcp-virustotal; Python barvhaim/virustotal-mcp-server). These are NOT first-party; the catalog description specifically references Google Threat Intelligence, which is the google/mcp-security `gti` server selected here.",
+          "sources": [
+            "https://github.com/google/mcp-security",
+            "https://google.github.io/mcp-security/servers/gti_mcp.html",
+            "https://pypi.org/project/gti-mcp/",
+            "https://raw.githubusercontent.com/google/mcp-security/main/server/gti/README.md",
+            "https://raw.githubusercontent.com/google/mcp-security/main/server/gti/pyproject.toml",
+            "https://raw.githubusercontent.com/google/mcp-security/main/server/gti/gti_mcp/server.py"
+          ]
+        }
       }
     },
     {
@@ -1039,14 +1077,16 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official first-party server is the \"Microsoft MCP Server for Enterprise\" (microsoft/EnterpriseMCP), a Microsoft-hosted remote streamable-HTTP MCP server. VS Code install config from Microsoft Learn explicitly states type=http and url=https://mcp.svc.cloud.microsoft/enterprise. It exposes microsoft_graph_suggest_queries, microsoft_graph_get, and microsoft_graph_list_properties to read users, groups, applications, devices, and policies in the Entra tenant via Microsoft Graph — matching the catalog description. Currently public PREVIEW.\n\nAuth: delegated OAuth2 (authorization-code / interactive sign-in) against Microsoft Entra ID (login.microsoftonline.com). The MCP server is a Microsoft-owned service identity (appId e8c77dc2-69b3-43f4-bc51-3213c9d915b4). IMPORTANT: Entra's authorization server does NOT support DCR (dynamic client registration) or CIMD, so a remote MCP client cannot auto-register. Instead, an Entra admin must (a) provision the server once per tenant via PowerShell (Grant-EntraBetaMCPServerPermission), and (b) register an Entra app as the OAuth client. Microsoft Copilot Studio docs list fixed organizations endpoints for this server: authorize https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize and token https://login.microsoftonline.com/organizations/oauth2/v2.0/token, with scope api://e8c77dc2-69b3-43f4-bc51-3213c9d915b4/.default. App-only/client-credentials flows are NOT supported — delegated only.\n\nNo npm/PyPI package and no local/stdio distribution — it is a hosted remote endpoint only, so packages[] and stdio_* are empty/null and docker_only=false. The user supplies an Entra Application (client) ID for the OAuth client; the actual access token is obtained interactively via browser sign-in. Several third-party community Entra/Graph MCP servers exist (e.g. hieuttmmo/entraid-mcp-server, ry-ops/microsoft-graph-mcp-server) but are not first-party and were not used.",
-        "sources": [
-          "https://learn.microsoft.com/en-us/graph/mcp-server/overview",
-          "https://learn.microsoft.com/en-us/graph/mcp-server/get-started",
-          "https://github.com/microsoft/EnterpriseMCP"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official first-party server is the \"Microsoft MCP Server for Enterprise\" (microsoft/EnterpriseMCP), a Microsoft-hosted remote streamable-HTTP MCP server. VS Code install config from Microsoft Learn explicitly states type=http and url=https://mcp.svc.cloud.microsoft/enterprise. It exposes microsoft_graph_suggest_queries, microsoft_graph_get, and microsoft_graph_list_properties to read users, groups, applications, devices, and policies in the Entra tenant via Microsoft Graph — matching the catalog description. Currently public PREVIEW.\n\nAuth: delegated OAuth2 (authorization-code / interactive sign-in) against Microsoft Entra ID (login.microsoftonline.com). The MCP server is a Microsoft-owned service identity (appId e8c77dc2-69b3-43f4-bc51-3213c9d915b4). IMPORTANT: Entra's authorization server does NOT support DCR (dynamic client registration) or CIMD, so a remote MCP client cannot auto-register. Instead, an Entra admin must (a) provision the server once per tenant via PowerShell (Grant-EntraBetaMCPServerPermission), and (b) register an Entra app as the OAuth client. Microsoft Copilot Studio docs list fixed organizations endpoints for this server: authorize https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize and token https://login.microsoftonline.com/organizations/oauth2/v2.0/token, with scope api://e8c77dc2-69b3-43f4-bc51-3213c9d915b4/.default. App-only/client-credentials flows are NOT supported — delegated only.\n\nNo npm/PyPI package and no local/stdio distribution — it is a hosted remote endpoint only, so packages[] and stdio_* are empty/null and docker_only=false. The user supplies an Entra Application (client) ID for the OAuth client; the actual access token is obtained interactively via browser sign-in. Several third-party community Entra/Graph MCP servers exist (e.g. hieuttmmo/entraid-mcp-server, ry-ops/microsoft-graph-mcp-server) but are not first-party and were not used.",
+          "sources": [
+            "https://learn.microsoft.com/en-us/graph/mcp-server/overview",
+            "https://learn.microsoft.com/en-us/graph/mcp-server/get-started",
+            "https://github.com/microsoft/EnterpriseMCP"
+          ]
+        }
       }
     },
     {
@@ -1128,28 +1168,32 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "QA PIN (2026-07-15): direct uvx installation and CLI launch were verified for Okta release v1.1.3 at commit f9f6157f62d3d436bfbfce84ac20f198fcb94dde. The catalog installs the exact official PyPI package okta-mcp-server==1.1.3. Only the browserless Private Key JWT flow is supported: OKTA_ORG_URL, OKTA_CLIENT_ID, OKTA_PRIVATE_KEY, OKTA_KEY_ID, and OKTA_SCOPES are required. Store the PEM private key as a workspace secret and reference it from stdio_env.",
-        "sources": [
-        "https://github.com/okta/okta-mcp-server",
-        "https://raw.githubusercontent.com/okta/okta-mcp-server/main/README.md",
-        "https://developer.okta.com/docs/guides/start-mcp-server/main/",
-        "https://developer.okta.com/blog/2025/09/22/okta-mcp-server",
-        "https://developer.okta.com/docs/concepts/mcp-server/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "QA PIN (2026-07-15): direct uvx installation and CLI launch were verified for Okta release v1.1.3 at commit f9f6157f62d3d436bfbfce84ac20f198fcb94dde. The catalog installs the exact official PyPI package okta-mcp-server==1.1.3. Only the browserless Private Key JWT flow is supported: OKTA_ORG_URL, OKTA_CLIENT_ID, OKTA_PRIVATE_KEY, OKTA_KEY_ID, and OKTA_SCOPES are required. Store the PEM private key as a workspace secret and reference it from stdio_env.",
+          "sources": [
+            "https://github.com/okta/okta-mcp-server",
+            "https://raw.githubusercontent.com/okta/okta-mcp-server/main/README.md",
+            "https://developer.okta.com/docs/guides/start-mcp-server/main/",
+            "https://developer.okta.com/blog/2025/09/22/okta-mcp-server",
+            "https://developer.okta.com/docs/concepts/mcp-server/"
+          ]
+        }
       }
     },
     {
       "slug": "hashicorp-vault-mcp",
       "docs": "https://github.com/hashicorp/vault-mcp-server",
-      "research_notes": "Coming soon. QA (2026-07-15): HashiCorp Vault MCP Server v0.2.0 at commit c67575dc4f98db37f187d62400bd70fe0211a60c was verified using HashiCorp's checksum-published Darwin arm64 binary. It completed MCP initialization and exposed 16 tools. The server works, but its official distributions are precompiled binaries, Docker, and `go install`; Tracecat's stdio catalog only permits npx, uvx, python, python3, or node launchers. HashiCorp also supports self-hosted streamable HTTP, but explicitly recommends local/internal deployment and provides no vendor-hosted endpoint.",
-      "sources": [
-        "https://github.com/hashicorp/vault-mcp-server",
-        "https://releases.hashicorp.com/vault-mcp-server/0.2.0/",
-        "https://developer.hashicorp.com/vault/docs/mcp-server/deploy",
-        "https://developer.hashicorp.com/vault/docs/mcp-server/overview"
-      ]
+      "_research": {
+        "notes": "Coming soon. QA (2026-07-15): HashiCorp Vault MCP Server v0.2.0 at commit c67575dc4f98db37f187d62400bd70fe0211a60c was verified using HashiCorp's checksum-published Darwin arm64 binary. It completed MCP initialization and exposed 16 tools. The server works, but its official distributions are precompiled binaries, Docker, and `go install`; Tracecat's stdio catalog only permits npx, uvx, python, python3, or node launchers. HashiCorp also supports self-hosted streamable HTTP, but explicitly recommends local/internal deployment and provides no vendor-hosted endpoint.",
+        "sources": [
+          "https://github.com/hashicorp/vault-mcp-server",
+          "https://releases.hashicorp.com/vault-mcp-server/0.2.0/",
+          "https://developer.hashicorp.com/vault/docs/mcp-server/deploy",
+          "https://developer.hashicorp.com/vault/docs/mcp-server/overview"
+        ]
+      }
     },
     {
       "slug": "aws-mcp",
@@ -1230,16 +1274,18 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "The catalog description (\"Call any of 15,000+ AWS APIs via the official AWS MCP server\") and \"HTTP\" intended transport map to the managed remote AWS MCP Server (GA May 2026), exposing tools like aws___call_aws. The remote endpoint is a SigV4-authenticated streamable-HTTP service at https://aws-mcp.us-east-1.api.aws/mcp (also https://aws-mcp.eu-central-1.api.aws/mcp). However, the endpoint uses AWS IAM SigV4, NOT OAuth, so it is NOT directly connectable as a plain remote MCP URL by an OAuth/header-token client. AWS's official and only documented connection method is the local stdio proxy 'mcp-proxy-for-aws' (run via uvx), which translates MCP traffic into SigV4-signed requests using the standard boto3 credential chain. Hence server_type is reported as stdio with the canonical uvx command; the remote URL is recorded in server_uri and the proxy args. auth_type=CUSTOM because the user supplies AWS IAM credentials (access key/secret/session token or a named profile, or 'aws login' SSO) — there is no user-facing OAuth flow. Optional proxy flags: --read-only (disable write tools), --profile, --region, --skip-auth. pip install option exists (pip install mcp-proxy-for-aws); a public ECR Docker image also exists but is not used since uvx/pip cover it. The endpoint Region (in the URL) is independent of the AWS_REGION metadata (default region for operations). Requires AWS CLI v2.32.0+ for the 'aws login' flow.",
-        "sources": [
-          "https://aws.amazon.com/blogs/aws/the-aws-mcp-server-is-now-generally-available/",
-          "https://docs.aws.amazon.com/aws-mcp/latest/userguide/getting-started-aws-mcp-server.html",
-          "https://docs.aws.amazon.com/aws-mcp/latest/userguide/understanding-mcp-server-tools.html",
-          "https://github.com/aws/mcp-proxy-for-aws",
-          "https://pypi.org/project/mcp-proxy-for-aws/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "The catalog description (\"Call any of 15,000+ AWS APIs via the official AWS MCP server\") and \"HTTP\" intended transport map to the managed remote AWS MCP Server (GA May 2026), exposing tools like aws___call_aws. The remote endpoint is a SigV4-authenticated streamable-HTTP service at https://aws-mcp.us-east-1.api.aws/mcp (also https://aws-mcp.eu-central-1.api.aws/mcp). However, the endpoint uses AWS IAM SigV4, NOT OAuth, so it is NOT directly connectable as a plain remote MCP URL by an OAuth/header-token client. AWS's official and only documented connection method is the local stdio proxy 'mcp-proxy-for-aws' (run via uvx), which translates MCP traffic into SigV4-signed requests using the standard boto3 credential chain. Hence server_type is reported as stdio with the canonical uvx command; the remote URL is recorded in server_uri and the proxy args. auth_type=CUSTOM because the user supplies AWS IAM credentials (access key/secret/session token or a named profile, or 'aws login' SSO) — there is no user-facing OAuth flow. Optional proxy flags: --read-only (disable write tools), --profile, --region, --skip-auth. pip install option exists (pip install mcp-proxy-for-aws); a public ECR Docker image also exists but is not used since uvx/pip cover it. The endpoint Region (in the URL) is independent of the AWS_REGION metadata (default region for operations). Requires AWS CLI v2.32.0+ for the 'aws login' flow.",
+          "sources": [
+            "https://aws.amazon.com/blogs/aws/the-aws-mcp-server-is-now-generally-available/",
+            "https://docs.aws.amazon.com/aws-mcp/latest/userguide/getting-started-aws-mcp-server.html",
+            "https://docs.aws.amazon.com/aws-mcp/latest/userguide/understanding-mcp-server-tools.html",
+            "https://github.com/aws/mcp-proxy-for-aws",
+            "https://pypi.org/project/mcp-proxy-for-aws/"
+          ]
+        }
       }
     },
     {
@@ -1253,15 +1299,17 @@
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Cloudflare's primary general-purpose remote MCP server is https://mcp.cloudflare.com/mcp (the \"Code Mode\" server in the cloudflare/mcp repo), exposing ~2,500 Cloudflare API endpoints (DNS, Workers, R2, WAF, Zero Trust, etc.) via two tools (search/execute). This matches the catalog's intended HTTP transport and \"edge, DNS, WAF, Zero Trust\" description. Transport is streamable-http at the /mcp path (an /sse path also exists but is deprecated).\n\nAuth: recommended path is OAuth 2.1 sign-in — connecting to the URL redirects the user to Cloudflare (dash.cloudflare.com) to authorize and select permissions. Built on Cloudflare's workers-oauth-provider, which exposes /authorize, /token, and /register endpoints — i.e. supports Dynamic Client Registration (DCR) and advertises endpoints via standard remote-MCP /.well-known discovery, so oauth_authorization_endpoint/token_endpoint are left null (client discovers them). Grant type is authorization_code. Scopes are user-selected interactively during the consent/permission step and are not a fixed documented list, so scopes is left empty.\n\nAlternative auth (not the primary catalog transport): for CI/CD the server also accepts a Cloudflare API token passed as a Bearer token (Authorization: Bearer <token>). If we wanted to model the API-token path instead, auth_type would be CUSTOM with a single secret credential \"Authorization\" (Cloudflare API token). Given the intended transport is the hosted HTTP/OAuth experience, OAUTH2 is the correct primary spec.\n\nCloudflare also runs many product-specific remote servers (docs.mcp.cloudflare.com, bindings.mcp.cloudflare.com, observability.mcp.cloudflare.com, radar.mcp.cloudflare.com, logs.mcp.cloudflare.com, casb.mcp.cloudflare.com, dex.mcp.cloudflare.com, graphql.mcp.cloudflare.com, etc.), all same OAuth pattern; mcp.cloudflare.com/mcp is the all-in-one. No official local stdio/npx/uvx/pip distribution of the hosted server — it is remote-hosted only, so packages[] is empty and docker_only is false.",
-        "sources": [
-          "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
-          "https://github.com/cloudflare/mcp",
-          "https://developers.cloudflare.com/agents/model-context-protocol/authorization/",
-          "https://developers.cloudflare.com/agents/model-context-protocol/transport/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Cloudflare's primary general-purpose remote MCP server is https://mcp.cloudflare.com/mcp (the \"Code Mode\" server in the cloudflare/mcp repo), exposing ~2,500 Cloudflare API endpoints (DNS, Workers, R2, WAF, Zero Trust, etc.) via two tools (search/execute). This matches the catalog's intended HTTP transport and \"edge, DNS, WAF, Zero Trust\" description. Transport is streamable-http at the /mcp path (an /sse path also exists but is deprecated).\n\nAuth: recommended path is OAuth 2.1 sign-in — connecting to the URL redirects the user to Cloudflare (dash.cloudflare.com) to authorize and select permissions. Built on Cloudflare's workers-oauth-provider, which exposes /authorize, /token, and /register endpoints — i.e. supports Dynamic Client Registration (DCR) and advertises endpoints via standard remote-MCP /.well-known discovery, so oauth_authorization_endpoint/token_endpoint are left null (client discovers them). Grant type is authorization_code. Scopes are user-selected interactively during the consent/permission step and are not a fixed documented list, so scopes is left empty.\n\nAlternative auth (not the primary catalog transport): for CI/CD the server also accepts a Cloudflare API token passed as a Bearer token (Authorization: Bearer <token>). If we wanted to model the API-token path instead, auth_type would be CUSTOM with a single secret credential \"Authorization\" (Cloudflare API token). Given the intended transport is the hosted HTTP/OAuth experience, OAUTH2 is the correct primary spec.\n\nCloudflare also runs many product-specific remote servers (docs.mcp.cloudflare.com, bindings.mcp.cloudflare.com, observability.mcp.cloudflare.com, radar.mcp.cloudflare.com, logs.mcp.cloudflare.com, casb.mcp.cloudflare.com, dex.mcp.cloudflare.com, graphql.mcp.cloudflare.com, etc.), all same OAuth pattern; mcp.cloudflare.com/mcp is the all-in-one. No official local stdio/npx/uvx/pip distribution of the hosted server — it is remote-hosted only, so packages[] is empty and docker_only is false.",
+          "sources": [
+            "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/",
+            "https://github.com/cloudflare/mcp",
+            "https://developers.cloudflare.com/agents/model-context-protocol/authorization/",
+            "https://developers.cloudflare.com/agents/model-context-protocol/transport/"
+          ]
+        }
       }
     },
     {
@@ -1346,26 +1394,30 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official server: github.com/zscaler/zscaler-mcp-server; PyPI package `zscaler-mcp` (v0.13.1, MIT, alpha), console script `zscaler-mcp`, Python 3.11+. Canonical/recommended install is `uvx zscaler-mcp`; the docs MCP client config uses `command: uvx, args: [\"--env-file\", \"/path/.env\", \"zscaler-mcp\"]`. STDIO is the default transport (matches intended); the server can ALSO run as a remote HTTP server via `--transport streamable-http`/`sse` (default host 127.0.0.1:8000, path /mcp), but that is a self-hosted deployment with no fixed public URL, so server_uri is null.\n\nAuth: classified CUSTOM because the user supplies OneAPI credentials (client_id + client_secret, or a PEM private key for JWT, plus vanity domain and ZPA customer_id) as env vars. Under the hood the server performs a OneAPI OAuth2 client-credentials grant against the Zscaler ZIdentity token endpoint, but there is no interactive authorization-code/DCR browser flow for the MCP connection itself, so this is not OAUTH2 from a connection-spec perspective. (Separately, the HTTP transport offers optional Layer-2 MCP client auth modes — api-key/JWT/zscaler/OAuth 2.1 via ZSCALER_MCP_AUTH_* — but those gate the HTTP listener, not the STDIO upstream auth.)\n\npip package import module is `zscaler_mcp` (underscore); pip run shown as `python -m zscaler_mcp` though the primary entry point is the `zscaler-mcp` console script. Either ZSCALER_CLIENT_SECRET or ZSCALER_PRIVATE_KEY is required (one of the two). Docker image `zscaler/zscaler-mcp-server:latest` also exists but is not the only distribution, so docker_only=false.",
-        "sources": [
-          "https://github.com/zscaler/zscaler-mcp-server",
-          "https://github.com/zscaler/zscaler-mcp-server/blob/master/README.md",
-          "https://zscaler-mcp-server.readthedocs.io/en/latest/getting-started.html",
-          "https://pypi.org/project/zscaler-mcp/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official server: github.com/zscaler/zscaler-mcp-server; PyPI package `zscaler-mcp` (v0.13.1, MIT, alpha), console script `zscaler-mcp`, Python 3.11+. Canonical/recommended install is `uvx zscaler-mcp`; the docs MCP client config uses `command: uvx, args: [\"--env-file\", \"/path/.env\", \"zscaler-mcp\"]`. STDIO is the default transport (matches intended); the server can ALSO run as a remote HTTP server via `--transport streamable-http`/`sse` (default host 127.0.0.1:8000, path /mcp), but that is a self-hosted deployment with no fixed public URL, so server_uri is null.\n\nAuth: classified CUSTOM because the user supplies OneAPI credentials (client_id + client_secret, or a PEM private key for JWT, plus vanity domain and ZPA customer_id) as env vars. Under the hood the server performs a OneAPI OAuth2 client-credentials grant against the Zscaler ZIdentity token endpoint, but there is no interactive authorization-code/DCR browser flow for the MCP connection itself, so this is not OAUTH2 from a connection-spec perspective. (Separately, the HTTP transport offers optional Layer-2 MCP client auth modes — api-key/JWT/zscaler/OAuth 2.1 via ZSCALER_MCP_AUTH_* — but those gate the HTTP listener, not the STDIO upstream auth.)\n\npip package import module is `zscaler_mcp` (underscore); pip run shown as `python -m zscaler_mcp` though the primary entry point is the `zscaler-mcp` console script. Either ZSCALER_CLIENT_SECRET or ZSCALER_PRIVATE_KEY is required (one of the two). Docker image `zscaler/zscaler-mcp-server:latest` also exists but is not the only distribution, so docker_only=false.",
+          "sources": [
+            "https://github.com/zscaler/zscaler-mcp-server",
+            "https://github.com/zscaler/zscaler-mcp-server/blob/master/README.md",
+            "https://zscaler-mcp-server.readthedocs.io/en/latest/getting-started.html",
+            "https://pypi.org/project/zscaler-mcp/"
+          ]
+        }
       }
     },
     {
       "slug": "palo-alto-mcp",
       "docs": "https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Enterprise-Documentation/Cortex-MCP-server",
-      "research_notes": "Coming soon. QA (2026-07-15): Palo Alto's official Cortex MCP server is obtainable only by downloading a tenant-specific archive from the Cortex console. The archive supports local Poetry/Python or Docker execution and stdio or streamable HTTP, but Palo Alto does not publish the Cortex server as public source, an npx package, or a PyPI package that Tracecat can install. The public PaloAltoNetworks/pan-mcp-relay project is a Prisma AIRS security proxy and is not the Cortex XSIAM/XDR operations server represented by this catalog entry.",
-      "sources": [
-        "https://docs-cortex.paloaltonetworks.com/r/Cortex/Cortex-MCP-server/Install-the-Cortex-MCP-server",
-        "https://docs-cortex.paloaltonetworks.com/r/Cortex/Cortex-MCP-server/Configure-the-MCP-client",
-        "https://github.com/PaloAltoNetworks/pan-mcp-relay"
-      ]
+      "_research": {
+        "notes": "Coming soon. QA (2026-07-15): Palo Alto's official Cortex MCP server is obtainable only by downloading a tenant-specific archive from the Cortex console. The archive supports local Poetry/Python or Docker execution and stdio or streamable HTTP, but Palo Alto does not publish the Cortex server as public source, an npx package, or a PyPI package that Tracecat can install. The public PaloAltoNetworks/pan-mcp-relay project is a Prisma AIRS security proxy and is not the Cortex XSIAM/XDR operations server represented by this catalog entry.",
+        "sources": [
+          "https://docs-cortex.paloaltonetworks.com/r/Cortex/Cortex-MCP-server/Install-the-Cortex-MCP-server",
+          "https://docs-cortex.paloaltonetworks.com/r/Cortex/Cortex-MCP-server/Configure-the-MCP-client",
+          "https://github.com/PaloAltoNetworks/pan-mcp-relay"
+        ]
+      }
     },
     {
       "slug": "sixtyfour-mcp",
@@ -1384,15 +1436,17 @@
             "target": "http_header"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Our catalog assumed STDIO, but Sixtyfour's official MCP offering is HTTP (streamable HTTP), per their official docs at docs.sixtyfour.ai/developer-tools/mcp-setup. There is NO STDIO/npx/uvx/pip/docker package distribution.\n\nSixtyfour actually publishes TWO remote MCP servers:\n1. Documentation MCP - https://docs.sixtyfour.ai/mcp - NO auth required (answers questions about the API/docs).\n2. Filter Search MCP - https://mcp.sixtyfour.ai/mcp?api_key=YOUR_API_KEY - requires an API key, used for company filter searches that chain into enrichment (enrich_company / enrich_lead). This is the functional server matching the catalog description 'enrich people and companies', so it is the one specified here as server_uri.\n\nAuth note: The API key is passed as a QUERY-STRING parameter (?api_key=...) on the endpoint URL, not as a header. This is unusual; if our connector model only supports headers, the key may need to be appended to the URL instead. It is the same API key used as the x-api-key header on the Sixtyfour REST API (https://docs.sixtyfour.ai). No OAuth flow is involved.\n\nOfficial Claude Code install commands from the docs:\n  claude mcp add --transport http sixtyfour-docs \"https://docs.sixtyfour.ai/mcp\"\n  claude mcp add --transport http sixtyfour-filter-search \"https://mcp.sixtyfour.ai/mcp?api_key=YOUR_API_KEY\"\n\nConfidence high: values taken directly from Sixtyfour's first-party documentation page that I read.",
-        "sources": [
-          "https://docs.sixtyfour.ai/developer-tools/mcp-setup.md",
-          "https://docs.sixtyfour.ai/llms.txt",
-          "https://www.sixtyfour.ai/blog/build-smarter-gtm-pipelines-with-sixtyfour-s-mcp-integration",
-          "https://docs.sixtyfour.ai/introduction"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Our catalog assumed STDIO, but Sixtyfour's official MCP offering is HTTP (streamable HTTP), per their official docs at docs.sixtyfour.ai/developer-tools/mcp-setup. There is NO STDIO/npx/uvx/pip/docker package distribution.\n\nSixtyfour actually publishes TWO remote MCP servers:\n1. Documentation MCP - https://docs.sixtyfour.ai/mcp - NO auth required (answers questions about the API/docs).\n2. Filter Search MCP - https://mcp.sixtyfour.ai/mcp?api_key=YOUR_API_KEY - requires an API key, used for company filter searches that chain into enrichment (enrich_company / enrich_lead). This is the functional server matching the catalog description 'enrich people and companies', so it is the one specified here as server_uri.\n\nAuth note: The API key is passed as a QUERY-STRING parameter (?api_key=...) on the endpoint URL, not as a header. This is unusual; if our connector model only supports headers, the key may need to be appended to the URL instead. It is the same API key used as the x-api-key header on the Sixtyfour REST API (https://docs.sixtyfour.ai). No OAuth flow is involved.\n\nOfficial Claude Code install commands from the docs:\n  claude mcp add --transport http sixtyfour-docs \"https://docs.sixtyfour.ai/mcp\"\n  claude mcp add --transport http sixtyfour-filter-search \"https://mcp.sixtyfour.ai/mcp?api_key=YOUR_API_KEY\"\n\nConfidence high: values taken directly from Sixtyfour's first-party documentation page that I read.",
+          "sources": [
+            "https://docs.sixtyfour.ai/developer-tools/mcp-setup.md",
+            "https://docs.sixtyfour.ai/llms.txt",
+            "https://www.sixtyfour.ai/blog/build-smarter-gtm-pipelines-with-sixtyfour-s-mcp-integration",
+            "https://docs.sixtyfour.ai/introduction"
+          ]
+        }
       }
     },
     {
@@ -1421,15 +1475,17 @@
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official Atlassian Rovo (Remote) MCP Server. Intended transport HTTP confirmed: it is a cloud-hosted remote streamable-HTTP MCP server, no local install required. Canonical endpoint per Atlassian IDE setup docs is https://mcp.atlassian.com/v1/mcp/authv2 (the modern authv2 path). The bare https://mcp.atlassian.com/v1/mcp also works; the legacy SSE endpoint https://mcp.atlassian.com/v1/sse is deprecated after 2026-06-30. Auth is OAuth 2.1 with a browser sign-in flow; if the client supports dynamic client registration (DCR) no OAuth app needs to be created (the server handles authorization). Authorization/token endpoints are advertised via OAuth discovery (well-known metadata), so they are left null here. OAuth flow touches mcp.atlassian.com and Atlassian's identity host auth.atlassian.com (browser redirect). Scopes are granted/managed by Atlassian per site permissions and are not enumerated as explicit user-supplied scope strings in the docs, so left empty. No user-supplied credential needed for the OAuth path (browser sign-in). Atlassian also offers an API-token path for headless clients (admin must enable it), but the primary documented flow is OAuth 2.1, matching auth_type=OAUTH2. For non-OAuth-native clients, Atlassian documents using the mcp-remote bridge: npx -y mcp-remote@latest https://mcp.atlassian.com/v1/mcp/authv2 — but this is a client-side adapter, not the MCP server itself, so the server remains http and no stdio package is recorded.",
-        "sources": [
-          "https://github.com/atlassian/atlassian-mcp-server",
-          "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/setting-up-ides/",
-          "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/",
-          "https://www.atlassian.com/platform/remote-mcp-server"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official Atlassian Rovo (Remote) MCP Server. Intended transport HTTP confirmed: it is a cloud-hosted remote streamable-HTTP MCP server, no local install required. Canonical endpoint per Atlassian IDE setup docs is https://mcp.atlassian.com/v1/mcp/authv2 (the modern authv2 path). The bare https://mcp.atlassian.com/v1/mcp also works; the legacy SSE endpoint https://mcp.atlassian.com/v1/sse is deprecated after 2026-06-30. Auth is OAuth 2.1 with a browser sign-in flow; if the client supports dynamic client registration (DCR) no OAuth app needs to be created (the server handles authorization). Authorization/token endpoints are advertised via OAuth discovery (well-known metadata), so they are left null here. OAuth flow touches mcp.atlassian.com and Atlassian's identity host auth.atlassian.com (browser redirect). Scopes are granted/managed by Atlassian per site permissions and are not enumerated as explicit user-supplied scope strings in the docs, so left empty. No user-supplied credential needed for the OAuth path (browser sign-in). Atlassian also offers an API-token path for headless clients (admin must enable it), but the primary documented flow is OAuth 2.1, matching auth_type=OAUTH2. For non-OAuth-native clients, Atlassian documents using the mcp-remote bridge: npx -y mcp-remote@latest https://mcp.atlassian.com/v1/mcp/authv2 — but this is a client-side adapter, not the MCP server itself, so the server remains http and no stdio package is recorded.",
+          "sources": [
+            "https://github.com/atlassian/atlassian-mcp-server",
+            "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/setting-up-ides/",
+            "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/",
+            "https://www.atlassian.com/platform/remote-mcp-server"
+          ]
+        }
       }
     },
     {
@@ -1459,12 +1515,14 @@
                 "target": "server_uri"
               }
             ],
-            "confidence": "high",
-            "docker_only": false,
-            "research_notes": "Freshservice's official EAP documentation describes a hosted MCP server at https://<your-freshservice-domain>/mcp. The integration is currently Beta/EAP for selected Freshservice Enterprise customers and requires administrator or agent privileges. OAuth is the recommended configuration path: clients connect over HTTP/streamable HTTP to the tenant MCP URL, then complete the browser authorization flow. Freshservice's docs show OAuth examples for Claude Connector, Cursor, Microsoft Copilot Studio, and VS Code; for clients that need a local stdio bridge, they recommend npx mcp-remote against the same remote URL. Because the actual MCP server is hosted by Freshservice, the catalog entry is modeled as HTTP, not stdio, and no npx/uvx/pip package is recorded. Authorization/token endpoints are discovered dynamically from the tenant MCP server, so explicit OAuth endpoints are left null. No OAuth scopes are documented.",
-            "sources": [
-              "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-"
-            ]
+            "_research": {
+              "confidence": "high",
+              "docker_only": false,
+              "notes": "Freshservice's official EAP documentation describes a hosted MCP server at https://<your-freshservice-domain>/mcp. The integration is currently Beta/EAP for selected Freshservice Enterprise customers and requires administrator or agent privileges. OAuth is the recommended configuration path: clients connect over HTTP/streamable HTTP to the tenant MCP URL, then complete the browser authorization flow. Freshservice's docs show OAuth examples for Claude Connector, Cursor, Microsoft Copilot Studio, and VS Code; for clients that need a local stdio bridge, they recommend npx mcp-remote against the same remote URL. Because the actual MCP server is hosted by Freshservice, the catalog entry is modeled as HTTP, not stdio, and no npx/uvx/pip package is recorded. Authorization/token endpoints are discovered dynamically from the tenant MCP server, so explicit OAuth endpoints are left null. No OAuth scopes are documented.",
+              "sources": [
+                "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-"
+              ]
+            }
           }
         },
         {
@@ -1495,13 +1553,15 @@
                 "target": "http_header"
               }
             ],
-            "confidence": "high",
-            "docker_only": false,
-            "research_notes": "Freshservice documents API-key authentication as the OAuth alternative for MCP clients. The examples use HTTP transport to https://<your-freshservice-domain>/mcp with a custom Authorization header containing the API key. Freshservice explicitly recommends OAuth 2.0 as the best practice; this option exists for environments that cannot complete OAuth.",
-            "sources": [
-              "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-",
-              "https://api.freshservice.com/#authentication"
-            ]
+            "_research": {
+              "confidence": "high",
+              "docker_only": false,
+              "notes": "Freshservice documents API-key authentication as the OAuth alternative for MCP clients. The examples use HTTP transport to https://<your-freshservice-domain>/mcp with a custom Authorization header containing the API key. Freshservice explicitly recommends OAuth 2.0 as the best practice; this option exists for environments that cannot complete OAuth.",
+              "sources": [
+                "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-",
+                "https://api.freshservice.com/#authentication"
+              ]
+            }
           }
         }
       ]
@@ -1617,17 +1677,19 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "medium",
-        "docker_only": false,
-        "research_notes": "PROVENANCE/DISCREPANCY: The catalog slug `servicenow-mcp` exactly matches the community Python package `servicenow-mcp` (repo github.com/osomai/servicenow-mcp, aka echelon-ai-labs/servicenow-mcp), published to PyPI as `servicenow-mcp` v0.1.1 (\"MCP for ServiceNow\", requires Python >=3.12). This is a THIRD-PARTY server, not first-party ServiceNow. It talks to a ServiceNow instance via the REST API and supports three user-supplied auth modes (basic username/password [default], oauth client-credentials-style with client id/secret/token URL, api_key) — hence auth_type=CUSTOM, not the platform's OAuth 2.1 browser flow.\n\nThe catalog DESCRIPTION (\"via the Zurich MCP server\", HTTP) instead refers to ServiceNow's NATIVE Zurich-release MCP feature (MCP Server Console / AI Agent Studio), which uses Streamable HTTP + OAuth 2.1 with PKCE. That native feature is NOT a downloadable/installable package — it is a per-instance, governed endpoint configured inside the customer's ServiceNow tenant (no fixed public MCP URL; the docs are JS-rendered and could not be fully read). If Tracecat actually wants the first-party Zurich endpoint, this spec is the wrong artifact and should be revisited: it would be server_type=http, auth_type=OAUTH2 (authorization_code + PKCE, likely DCR/discovery), with a per-instance server_uri the user provides — not the community package below.\n\nTRANSPORT: The osomai package ships as stdio (entry point `servicenow-mcp` -> servicenow_mcp.cli:main) and self-hosted SSE (entry point `servicenow-mcp-sse` -> servicenow_mcp.server_sse:main, binds 0.0.0.0:8080 /sse). There is no vendor-hosted HTTP endpoint, so I selected stdio as the real transport (server_uri left null). For SSE you would self-host `uvx --from servicenow-mcp servicenow-mcp-sse`. uvx works because the PyPI dist defines console_scripts; `python -m servicenow_mcp.cli` is the documented from-source alternative. Confidence MEDIUM: package name/version/entry points/env vars verified on PyPI and the repo README, but the stdio-vs-Zurich-HTTP intent conflict and the per-instance OAuth specifics for the native option are unresolved.",
-        "sources": [
-          "https://github.com/osomai/servicenow-mcp",
-          "https://raw.githubusercontent.com/osomai/servicenow-mcp/main/README.md",
-          "https://github.com/osomai/servicenow-mcp/blob/main/pyproject.toml",
-          "https://pypi.org/pypi/servicenow-mcp/json",
-          "https://www.servicenow.com/docs/bundle/zurich-intelligent-experiences/page/administer/model-context-protocol-client/task/add-an-oauth-2-1-mcp-server.html",
-          "https://mcpservers.org/servers/osomai/servicenow-mcp"
-        ]
+        "_research": {
+          "confidence": "medium",
+          "docker_only": false,
+          "notes": "PROVENANCE/DISCREPANCY: The catalog slug `servicenow-mcp` exactly matches the community Python package `servicenow-mcp` (repo github.com/osomai/servicenow-mcp, aka echelon-ai-labs/servicenow-mcp), published to PyPI as `servicenow-mcp` v0.1.1 (\"MCP for ServiceNow\", requires Python >=3.12). This is a THIRD-PARTY server, not first-party ServiceNow. It talks to a ServiceNow instance via the REST API and supports three user-supplied auth modes (basic username/password [default], oauth client-credentials-style with client id/secret/token URL, api_key) — hence auth_type=CUSTOM, not the platform's OAuth 2.1 browser flow.\n\nThe catalog DESCRIPTION (\"via the Zurich MCP server\", HTTP) instead refers to ServiceNow's NATIVE Zurich-release MCP feature (MCP Server Console / AI Agent Studio), which uses Streamable HTTP + OAuth 2.1 with PKCE. That native feature is NOT a downloadable/installable package — it is a per-instance, governed endpoint configured inside the customer's ServiceNow tenant (no fixed public MCP URL; the docs are JS-rendered and could not be fully read). If Tracecat actually wants the first-party Zurich endpoint, this spec is the wrong artifact and should be revisited: it would be server_type=http, auth_type=OAUTH2 (authorization_code + PKCE, likely DCR/discovery), with a per-instance server_uri the user provides — not the community package below.\n\nTRANSPORT: The osomai package ships as stdio (entry point `servicenow-mcp` -> servicenow_mcp.cli:main) and self-hosted SSE (entry point `servicenow-mcp-sse` -> servicenow_mcp.server_sse:main, binds 0.0.0.0:8080 /sse). There is no vendor-hosted HTTP endpoint, so I selected stdio as the real transport (server_uri left null). For SSE you would self-host `uvx --from servicenow-mcp servicenow-mcp-sse`. uvx works because the PyPI dist defines console_scripts; `python -m servicenow_mcp.cli` is the documented from-source alternative. Confidence MEDIUM: package name/version/entry points/env vars verified on PyPI and the repo README, but the stdio-vs-Zurich-HTTP intent conflict and the per-instance OAuth specifics for the native option are unresolved.",
+          "sources": [
+            "https://github.com/osomai/servicenow-mcp",
+            "https://raw.githubusercontent.com/osomai/servicenow-mcp/main/README.md",
+            "https://github.com/osomai/servicenow-mcp/blob/main/pyproject.toml",
+            "https://pypi.org/pypi/servicenow-mcp/json",
+            "https://www.servicenow.com/docs/bundle/zurich-intelligent-experiences/page/administer/model-context-protocol-client/task/add-an-oauth-2-1-mcp-server.html",
+            "https://mcpservers.org/servers/osomai/servicenow-mcp"
+          ]
+        }
       }
     },
     {
@@ -1650,13 +1712,15 @@
             "target": "http_header"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official, hosted remote MCP server by incident.io (Public Beta), confirmed via official docs at docs.incident.io/ai/remote-mcp. Transport is HTTP (streamable) at https://mcp.incident.io/mcp; example: `claude mcp add incident-io --transport http https://mcp.incident.io/mcp`. Two auth modes: (1) OAuth2 authorization-code browser flow for human/interactive clients (Claude, ChatGPT, Cursor) — the MCP client handles the flow and users approve in browser. Discovery metadata on mcp.incident.io advertises authorization/token endpoints on the sibling host app.incident.io (verified live), so those endpoints are pinned here to mark app.incident.io trusted during discovery; the live discovered endpoints are still what gets used. (2) API key passed as `Authorization: Bearer <key>` for programmatic agents/automation. I set auth_type=OAUTH2 as the primary mode matching the interactive intended use, and captured the API-key option as an optional credential. No OAuth scopes are documented for the OAuth flow (API-key scopes are configured per-key in the dashboard but are not MCP OAuth scopes). OAuth endpoints are discovered from the MCP metadata chain; exact auth hostname beyond 'redirected to incident.io' is not enumerated verbatim in docs. A separate unofficial Golang local/stdio prototype exists (github.com/incident-io/incidentio-mcp-golang) but it is explicitly an early prototype and not the official transport, so it is excluded.",
-        "sources": [
-          "https://docs.incident.io/ai/remote-mcp",
-          "https://incident.io/changelog/introducing-incident-io-mcp"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official, hosted remote MCP server by incident.io (Public Beta), confirmed via official docs at docs.incident.io/ai/remote-mcp. Transport is HTTP (streamable) at https://mcp.incident.io/mcp; example: `claude mcp add incident-io --transport http https://mcp.incident.io/mcp`. Two auth modes: (1) OAuth2 authorization-code browser flow for human/interactive clients (Claude, ChatGPT, Cursor) — the MCP client handles the flow and users approve in browser. Discovery metadata on mcp.incident.io advertises authorization/token endpoints on the sibling host app.incident.io (verified live), so those endpoints are pinned here to mark app.incident.io trusted during discovery; the live discovered endpoints are still what gets used. (2) API key passed as `Authorization: Bearer <key>` for programmatic agents/automation. I set auth_type=OAUTH2 as the primary mode matching the interactive intended use, and captured the API-key option as an optional credential. No OAuth scopes are documented for the OAuth flow (API-key scopes are configured per-key in the dashboard but are not MCP OAuth scopes). OAuth endpoints are discovered from the MCP metadata chain; exact auth hostname beyond 'redirected to incident.io' is not enumerated verbatim in docs. A separate unofficial Golang local/stdio prototype exists (github.com/incident-io/incidentio-mcp-golang) but it is explicitly an early prototype and not the official transport, so it is excluded.",
+          "sources": [
+            "https://docs.incident.io/ai/remote-mcp",
+            "https://incident.io/changelog/introducing-incident-io-mcp"
+          ]
+        }
       }
     },
     {
@@ -1706,14 +1770,16 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official server is PagerDuty/pagerduty-mcp-server (GitHub), distributed on PyPI as package name `pagerduty-mcp` (NOT `pagerduty-mcp-server`; that PyPI name is a separate third-party project by wpfleger96 and should not be used). Transport is STDIO only — no HTTP/remote endpoint and no OAuth flow; matches intended STDIO transport. Auth = PagerDuty User API Token via PAGERDUTY_USER_API_KEY env var (CUSTOM). Canonical launch is `uvx pagerduty-mcp`. The server defaults to read-only tools; write tools require an explicit `--enable-write-tools` flag which I omitted from args to keep the read-only scope described in the catalog (read incidents, schedules, services, on-call). pip-install path runs via `python -m pagerduty_mcp` (module name uses underscore). Official Docker image also exists but is not the only distribution, so docker_only=false. Module entry point name (pagerduty_mcp) confirmed from README local-dev command `python -m pagerduty_mcp`.",
-        "sources": [
-          "https://github.com/PagerDuty/pagerduty-mcp-server",
-          "https://raw.githubusercontent.com/PagerDuty/pagerduty-mcp-server/main/README.md",
-          "https://pypi.org/project/pagerduty-mcp/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official server is PagerDuty/pagerduty-mcp-server (GitHub), distributed on PyPI as package name `pagerduty-mcp` (NOT `pagerduty-mcp-server`; that PyPI name is a separate third-party project by wpfleger96 and should not be used). Transport is STDIO only — no HTTP/remote endpoint and no OAuth flow; matches intended STDIO transport. Auth = PagerDuty User API Token via PAGERDUTY_USER_API_KEY env var (CUSTOM). Canonical launch is `uvx pagerduty-mcp`. The server defaults to read-only tools; write tools require an explicit `--enable-write-tools` flag which I omitted from args to keep the read-only scope described in the catalog (read incidents, schedules, services, on-call). pip-install path runs via `python -m pagerduty_mcp` (module name uses underscore). Official Docker image also exists but is not the only distribution, so docker_only=false. Module entry point name (pagerduty_mcp) confirmed from README local-dev command `python -m pagerduty_mcp`.",
+          "sources": [
+            "https://github.com/PagerDuty/pagerduty-mcp-server",
+            "https://raw.githubusercontent.com/PagerDuty/pagerduty-mcp-server/main/README.md",
+            "https://pypi.org/project/pagerduty-mcp/"
+          ]
+        }
       }
     },
     {
@@ -1755,15 +1821,17 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official MCP server is from Rootly AI Labs (Apache 2.0). Rootly offers BOTH transports: (1) STDIO local process via the rootly-mcp-server PyPI package, run with `uvx --from rootly-mcp-server rootly-mcp-server`, authenticated with the ROOTLY_API_TOKEN env var (CUSTOM auth, personal/team/global API key). This matches the intended STDIO transport, so it is the selected spec. (2) A hosted remote HTTP server at https://mcp.rootly.com/mcp (streamable HTTP), with SSE at https://mcp.rootly.com/sse and a code-mode variant at https://mcp.rootly.com/mcp-codemode. The hosted endpoint supports OAuth2 browser sign-in (automatic for Claude Desktop/Code/Cursor) OR a Bearer API token header. If you instead want the HTTP variant, server_type=http, server_uri=https://mcp.rootly.com/mcp, auth_type=OAUTH2 (grant=authorization_code, allowed host mcp.rootly.com, endpoints advertised via discovery) or CUSTOM with Authorization: Bearer <ROOTLY_API_TOKEN>. Requires Python 3.12+. The pip-based package entrypoint (python -m rootly_mcp_server) is inferred from the PyPI module name and was not explicitly documented; the canonical/documented install is uvx. ROOTLY_MCP_ENABLE_WRITE_TOOLS (toggle write ops) and ROOTLY_MCP_ENABLED_TOOLS (comma-separated allowlist) are optional env vars; ~150+ tools available.",
-        "sources": [
-          "https://github.com/Rootly-AI-Labs/Rootly-MCP-server",
-          "https://docs.rootly.com/integrations/mcp-server",
-          "https://pypi.org/project/rootly-mcp-server/",
-          "https://rootly.com/blog/introducing-the-rootly-mcp-server"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official MCP server is from Rootly AI Labs (Apache 2.0). Rootly offers BOTH transports: (1) STDIO local process via the rootly-mcp-server PyPI package, run with `uvx --from rootly-mcp-server rootly-mcp-server`, authenticated with the ROOTLY_API_TOKEN env var (CUSTOM auth, personal/team/global API key). This matches the intended STDIO transport, so it is the selected spec. (2) A hosted remote HTTP server at https://mcp.rootly.com/mcp (streamable HTTP), with SSE at https://mcp.rootly.com/sse and a code-mode variant at https://mcp.rootly.com/mcp-codemode. The hosted endpoint supports OAuth2 browser sign-in (automatic for Claude Desktop/Code/Cursor) OR a Bearer API token header. If you instead want the HTTP variant, server_type=http, server_uri=https://mcp.rootly.com/mcp, auth_type=OAUTH2 (grant=authorization_code, allowed host mcp.rootly.com, endpoints advertised via discovery) or CUSTOM with Authorization: Bearer <ROOTLY_API_TOKEN>. Requires Python 3.12+. The pip-based package entrypoint (python -m rootly_mcp_server) is inferred from the PyPI module name and was not explicitly documented; the canonical/documented install is uvx. ROOTLY_MCP_ENABLE_WRITE_TOOLS (toggle write ops) and ROOTLY_MCP_ENABLED_TOOLS (comma-separated allowlist) are optional env vars; ~150+ tools available.",
+          "sources": [
+            "https://github.com/Rootly-AI-Labs/Rootly-MCP-server",
+            "https://docs.rootly.com/integrations/mcp-server",
+            "https://pypi.org/project/rootly-mcp-server/",
+            "https://rootly.com/blog/introducing-the-rootly-mcp-server"
+          ]
+        }
       }
     },
     {
@@ -1802,15 +1870,17 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official first-party Slack MCP server, hosted remote HTTP (Streamable HTTP / JSON-RPC 2.0) at https://mcp.slack.com/mcp. This is the correct server matching the catalog description (search, post, canvases) and the intended HTTP transport.\n\nAuth: OAuth 2.0 \"confidential OAuth\" (authorization_code grant) using a registered Slack app's client_id + client_secret. Dynamic Client Registration (DCR) is NOT supported and SSE transport is NOT supported. The server advertises OAuth metadata via RFC 8414 discovery: https://mcp.slack.com/.well-known/oauth-protected-resource and https://mcp.slack.com/.well-known/oauth-authorization-server (so clients can auto-discover endpoints). Slack also documents explicit endpoints: authorize https://slack.com/oauth/v2_user/authorize and token https://slack.com/api/oauth.v2.user.access — I included these explicitly since they are documented, but a compliant client can rely on discovery. PKCE is supported for desktop clients.\n\nScopes are per-tool and the list above is a representative/documented subset (e.g. search:read.public, chat:write, channels:history, canvases:write); the exact required set depends on which tools are enabled.\n\nNo stdio/npx/pip distribution: the slackapi/slack-mcp-plugin repo is config-only (a Claude Code plugin pointing at the remote URL); there is no local server package. The unrelated @modelcontextprotocol/server-slack npm package is a separate, older community/reference stdio server using bot tokens — NOT this official hosted server, so it was not used for the spec.\n\nOAuth flow hosts: mcp.slack.com (resource + metadata discovery) and slack.com (authorize + token).",
-        "sources": [
-          "https://docs.slack.dev/ai/slack-mcp-server/",
-          "https://github.com/slackapi/slack-mcp-plugin",
-          "https://slack.com/blog/news/mcp-real-time-search-api-now-available",
-          "https://slack.com/help/articles/48855576908307-Guide-to-the-Slack-MCP-server"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official first-party Slack MCP server, hosted remote HTTP (Streamable HTTP / JSON-RPC 2.0) at https://mcp.slack.com/mcp. This is the correct server matching the catalog description (search, post, canvases) and the intended HTTP transport.\n\nAuth: OAuth 2.0 \"confidential OAuth\" (authorization_code grant) using a registered Slack app's client_id + client_secret. Dynamic Client Registration (DCR) is NOT supported and SSE transport is NOT supported. The server advertises OAuth metadata via RFC 8414 discovery: https://mcp.slack.com/.well-known/oauth-protected-resource and https://mcp.slack.com/.well-known/oauth-authorization-server (so clients can auto-discover endpoints). Slack also documents explicit endpoints: authorize https://slack.com/oauth/v2_user/authorize and token https://slack.com/api/oauth.v2.user.access — I included these explicitly since they are documented, but a compliant client can rely on discovery. PKCE is supported for desktop clients.\n\nScopes are per-tool and the list above is a representative/documented subset (e.g. search:read.public, chat:write, channels:history, canvases:write); the exact required set depends on which tools are enabled.\n\nNo stdio/npx/pip distribution: the slackapi/slack-mcp-plugin repo is config-only (a Claude Code plugin pointing at the remote URL); there is no local server package. The unrelated @modelcontextprotocol/server-slack npm package is a separate, older community/reference stdio server using bot tokens — NOT this official hosted server, so it was not used for the spec.\n\nOAuth flow hosts: mcp.slack.com (resource + metadata discovery) and slack.com (authorize + token).",
+          "sources": [
+            "https://docs.slack.dev/ai/slack-mcp-server/",
+            "https://github.com/slackapi/slack-mcp-plugin",
+            "https://slack.com/blog/news/mcp-real-time-search-api-now-available",
+            "https://slack.com/help/articles/48855576908307-Guide-to-the-Slack-MCP-server"
+          ]
+        }
       }
     },
     {
@@ -1843,14 +1913,16 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official server is Microsoft \"Work IQ Teams\" (server ID mcp_TeamsServer) under Microsoft Agent 365, a remote streamable-HTTP MCP server (config uses \"type\": \"http\"). It manages Teams chats, channels, teams, members, and messages via Microsoft Graph. The endpoint is tenant-scoped: tenantId must be substituted into the URL path. Feature is in PREVIEW as of May 2026 and REQUIRES a Microsoft 365 Copilot license.\n\nAuth is Microsoft Entra ID OAuth2 authorization-code with PKCE (the desktop/CLI public-client pattern documented for Claude Code / GitHub Copilot CLI / VS Code). The user registers their own Entra enterprise application (clientId) granted the WorkIQ-TeamsServer permission (scope McpServers.Teams.All) with a localhost redirect URI (e.g. http://localhost:8080/callback). The MCP client config only supplies clientId + callbackPort; the authorization and token endpoints are not hard-coded by the user — they are resolved against Microsoft Entra (login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize and /token), advertised/negotiated via the OAuth flow, hence oauth_authorization_endpoint/token_endpoint left null. One known caveat from MS docs: Entra ID rejects the \"resource\" parameter sent by some MCP SDKs, which can break the flow.\n\nNeither tenantId nor clientId is a secret. There is no static API key or bearer token the user pastes in — sign-in is interactive (browser). This is NOT a stdio/npx/pip package; there is no published npm/PyPI distribution, so packages[] is empty and stdio_* are null (not docker-only — it is a hosted remote HTTP service). Note: Microsoft also has an OLDER, still-supported \"Microsoft Teams MCP server\" predecessor; for new connections MS recommends Work IQ Teams (documented here). Numerous unofficial community Teams MCP servers exist (InditexTech/mcp-teams-server [PyPI/uvx], floriscornel/teams-mcp, softeria/ms-365-mcp-server) but those are third-party, not first-party Microsoft, so they were not selected given the \"official\" + \"HTTP\" intent.",
-        "sources": [
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/teams",
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview",
-          "https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official server is Microsoft \"Work IQ Teams\" (server ID mcp_TeamsServer) under Microsoft Agent 365, a remote streamable-HTTP MCP server (config uses \"type\": \"http\"). It manages Teams chats, channels, teams, members, and messages via Microsoft Graph. The endpoint is tenant-scoped: tenantId must be substituted into the URL path. Feature is in PREVIEW as of May 2026 and REQUIRES a Microsoft 365 Copilot license.\n\nAuth is Microsoft Entra ID OAuth2 authorization-code with PKCE (the desktop/CLI public-client pattern documented for Claude Code / GitHub Copilot CLI / VS Code). The user registers their own Entra enterprise application (clientId) granted the WorkIQ-TeamsServer permission (scope McpServers.Teams.All) with a localhost redirect URI (e.g. http://localhost:8080/callback). The MCP client config only supplies clientId + callbackPort; the authorization and token endpoints are not hard-coded by the user — they are resolved against Microsoft Entra (login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize and /token), advertised/negotiated via the OAuth flow, hence oauth_authorization_endpoint/token_endpoint left null. One known caveat from MS docs: Entra ID rejects the \"resource\" parameter sent by some MCP SDKs, which can break the flow.\n\nNeither tenantId nor clientId is a secret. There is no static API key or bearer token the user pastes in — sign-in is interactive (browser). This is NOT a stdio/npx/pip package; there is no published npm/PyPI distribution, so packages[] is empty and stdio_* are null (not docker-only — it is a hosted remote HTTP service). Note: Microsoft also has an OLDER, still-supported \"Microsoft Teams MCP server\" predecessor; for new connections MS recommends Work IQ Teams (documented here). Numerous unofficial community Teams MCP servers exist (InditexTech/mcp-teams-server [PyPI/uvx], floriscornel/teams-mcp, softeria/ms-365-mcp-server) but those are third-party, not first-party Microsoft, so they were not selected given the \"official\" + \"HTTP\" intent.",
+          "sources": [
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/teams",
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview",
+            "https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow"
+          ]
+        }
       }
     },
     {
@@ -1884,14 +1956,16 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "First-party Google-hosted remote MCP server (gmailmcp.googleapis.com), matching the intended HTTP transport. Official Google docs confirm: transport = HTTP (streamable httpUrl https://gmailmcp.googleapis.com/mcp/v1), auth = OAuth 2.0. CRITICAL: Google does NOT support dynamic client registration for these MCP servers — the user must manually create an OAuth client ID + secret in the Google Cloud console and add the platform's redirect URI (Google docs example uses https://claude.ai/api/mcp/auth_callback for Claude; select 'Web application' app type). Grant type is the standard Google OAuth 2.0 authorization_code flow; authorization endpoint = accounts.google.com/o/oauth2/v2/auth and token endpoint = oauth2.googleapis.com/token (Google's well-known OAuth 2.0 endpoints, not enumerated on the MCP page itself but standard for all Google OAuth). Documented Gmail scopes: gmail.readonly and gmail.compose (read/search/list-labels + create-draft/label tools). Sibling Google servers exist at drivemcp.googleapis.com/mcp/v1 and calendarmcp.googleapis.com/mcp/v1. Many third-party Gmail MCP servers also exist on GitHub (e.g. GongRzhe/Gmail-MCP-Server, taylorwilsdon/google_workspace_mcp) but those are STDIO/self-hosted; the official first-party HTTP server is the Google-hosted one selected here.",
-        "sources": [
-          "https://developers.google.com/workspace/gmail/api/guides/configure-mcp-server",
-          "https://developers.google.com/workspace/guides/configure-mcp-servers",
-          "https://developers.google.com/workspace/gmail/api/reference/mcp"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "First-party Google-hosted remote MCP server (gmailmcp.googleapis.com), matching the intended HTTP transport. Official Google docs confirm: transport = HTTP (streamable httpUrl https://gmailmcp.googleapis.com/mcp/v1), auth = OAuth 2.0. CRITICAL: Google does NOT support dynamic client registration for these MCP servers — the user must manually create an OAuth client ID + secret in the Google Cloud console and add the platform's redirect URI (Google docs example uses https://claude.ai/api/mcp/auth_callback for Claude; select 'Web application' app type). Grant type is the standard Google OAuth 2.0 authorization_code flow; authorization endpoint = accounts.google.com/o/oauth2/v2/auth and token endpoint = oauth2.googleapis.com/token (Google's well-known OAuth 2.0 endpoints, not enumerated on the MCP page itself but standard for all Google OAuth). Documented Gmail scopes: gmail.readonly and gmail.compose (read/search/list-labels + create-draft/label tools). Sibling Google servers exist at drivemcp.googleapis.com/mcp/v1 and calendarmcp.googleapis.com/mcp/v1. Many third-party Gmail MCP servers also exist on GitHub (e.g. GongRzhe/Gmail-MCP-Server, taylorwilsdon/google_workspace_mcp) but those are STDIO/self-hosted; the official first-party HTTP server is the Google-hosted one selected here.",
+          "sources": [
+            "https://developers.google.com/workspace/gmail/api/guides/configure-mcp-server",
+            "https://developers.google.com/workspace/guides/configure-mcp-servers",
+            "https://developers.google.com/workspace/gmail/api/reference/mcp"
+          ]
+        }
       }
     },
     {
@@ -1924,14 +1998,16 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "This is Microsoft's official first-party \"Work IQ Mail\" MCP server, part of Microsoft Agent 365 (currently in public preview). Verified from Microsoft Learn docs I read directly.\n\nTransport: remote streamable HTTP. The official config uses \"type\": \"http\" with URL https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_MailTools (server ID mcp_MailTools). There is no stdio / npx / uvx / pip distribution — it is a hosted remote server only, so packages[] is empty and stdio_* are null. NOT docker_only (it's a remote URL, not a Docker image).\n\nAuth: OAuth2 authorization-code \"sign in\" browser flow against Microsoft Entra. The user must (1) register an Entra enterprise/public-client app, (2) grant it the WorkIQ-MailServer API permission (the \"scope\"), and (3) add a redirect URI such as http://localhost:8080/callback. The MCP client config then provides clientId + a callbackPort (default 8080); tenantId goes in the URL path. The server advertises its OAuth authorization/token endpoints via discovery, so oauth_authorization_endpoint/token_endpoint are left null (they resolve to Microsoft Entra login.microsoftonline.com under the hood). Backed by Microsoft Graph Mail APIs.\n\nNote clientId/tenantId are configuration identifiers (not secrets) the user supplies; secret=false for both. There is no static API key/bearer token to store — the access token is obtained interactively via the OAuth flow.\n\nPrerequisite: a Microsoft 365 Copilot license is required to use Work IQ MCP servers. Confirmed working with Claude Code, GitHub Copilot CLI, and VS Code per the docs.\n\nDistinct from the third-party Softeria/ms-365-mcp-server (npx @softeria/ms-365-mcp-server), which is NOT first-party; given the intended HTTP transport and \"Microsoft 365 mail\" description, the official Agent 365 Work IQ Mail server is the correct match.",
-        "sources": [
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/mail",
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview",
-          "https://github.com/microsoft/mcp"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "This is Microsoft's official first-party \"Work IQ Mail\" MCP server, part of Microsoft Agent 365 (currently in public preview). Verified from Microsoft Learn docs I read directly.\n\nTransport: remote streamable HTTP. The official config uses \"type\": \"http\" with URL https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_MailTools (server ID mcp_MailTools). There is no stdio / npx / uvx / pip distribution — it is a hosted remote server only, so packages[] is empty and stdio_* are null. NOT docker_only (it's a remote URL, not a Docker image).\n\nAuth: OAuth2 authorization-code \"sign in\" browser flow against Microsoft Entra. The user must (1) register an Entra enterprise/public-client app, (2) grant it the WorkIQ-MailServer API permission (the \"scope\"), and (3) add a redirect URI such as http://localhost:8080/callback. The MCP client config then provides clientId + a callbackPort (default 8080); tenantId goes in the URL path. The server advertises its OAuth authorization/token endpoints via discovery, so oauth_authorization_endpoint/token_endpoint are left null (they resolve to Microsoft Entra login.microsoftonline.com under the hood). Backed by Microsoft Graph Mail APIs.\n\nNote clientId/tenantId are configuration identifiers (not secrets) the user supplies; secret=false for both. There is no static API key/bearer token to store — the access token is obtained interactively via the OAuth flow.\n\nPrerequisite: a Microsoft 365 Copilot license is required to use Work IQ MCP servers. Confirmed working with Claude Code, GitHub Copilot CLI, and VS Code per the docs.\n\nDistinct from the third-party Softeria/ms-365-mcp-server (npx @softeria/ms-365-mcp-server), which is NOT first-party; given the intended HTTP transport and \"Microsoft 365 mail\" description, the official Agent 365 Work IQ Mail server is the correct match.",
+          "sources": [
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/mail",
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview",
+            "https://github.com/microsoft/mcp"
+          ]
+        }
       }
     },
     {
@@ -1971,16 +2047,18 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official server is semgrep/mcp (PyPI package `semgrep-mcp`). Default transport is STDIO, matching the intended transport. Canonical install is `uvx semgrep-mcp`; also installable via `pip install semgrep-mcp` (exposes the `semgrep-mcp` console script; the `python -m semgrep_mcp` module form is the standard module path but not explicitly documented). Auth is CUSTOM via SEMGREP_APP_TOKEN, which is OPTIONAL — passed as an env var. The server also supports streamable-http (`-t streamable-http` on 127.0.0.1:8000/mcp) and SSE (`-t sse` on 127.0.0.1:8000/sse), and there is an experimental hosted endpoint at https://mcp.semgrep.ai/sse (documented as experimental and may break), but these are not the intended STDIO transport. DEPRECATION: the standalone semgrep/mcp repo has been moved into the main semgrep repo (cli/src/semgrep/mcp); future updates ship via the `semgrep` binary using `semgrep mcp`. However `uvx semgrep-mcp` remains the documented, currently-working install in the README, so it is used here.",
-        "sources": [
-          "https://github.com/semgrep/mcp",
-          "https://github.com/semgrep/mcp/blob/main/README.md",
-          "https://raw.githubusercontent.com/semgrep/mcp/main/README.md",
-          "https://pypi.org/project/semgrep-mcp/",
-          "https://semgrep.dev/docs/mcp"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official server is semgrep/mcp (PyPI package `semgrep-mcp`). Default transport is STDIO, matching the intended transport. Canonical install is `uvx semgrep-mcp`; also installable via `pip install semgrep-mcp` (exposes the `semgrep-mcp` console script; the `python -m semgrep_mcp` module form is the standard module path but not explicitly documented). Auth is CUSTOM via SEMGREP_APP_TOKEN, which is OPTIONAL — passed as an env var. The server also supports streamable-http (`-t streamable-http` on 127.0.0.1:8000/mcp) and SSE (`-t sse` on 127.0.0.1:8000/sse), and there is an experimental hosted endpoint at https://mcp.semgrep.ai/sse (documented as experimental and may break), but these are not the intended STDIO transport. DEPRECATION: the standalone semgrep/mcp repo has been moved into the main semgrep repo (cli/src/semgrep/mcp); future updates ship via the `semgrep` binary using `semgrep mcp`. However `uvx semgrep-mcp` remains the documented, currently-working install in the README, so it is used here.",
+          "sources": [
+            "https://github.com/semgrep/mcp",
+            "https://github.com/semgrep/mcp/blob/main/README.md",
+            "https://raw.githubusercontent.com/semgrep/mcp/main/README.md",
+            "https://pypi.org/project/semgrep-mcp/",
+            "https://semgrep.dev/docs/mcp"
+          ]
+        }
       }
     },
     {
@@ -2033,15 +2111,17 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "QA PIN (2026-07-15): npm package snyk@1.1306.0 corresponds by release version to public tag commit d4e9a98123a364a47b91770df8d86e2d31dcbc45. Its registry integrity hash was verified, the tarball contains bin/snyk and dist/cli/index.js, and an MCP initialize/list-tools probe returned 13 tools. Direct installation from the Git commit is not usable because the repository omits the built dist/cli/index.js artifact. The stdio server uses SNYK_TOKEN for headless authentication and optionally SNYK_CFG_ORG.",
-        "sources": [
-          "https://snyk.io/articles/secure-ai-coding-with-snyk-now-supporting-model-context-protocol-mcp/",
-          "https://snyk.io/articles/snyk-mcp-cheat-sheet/",
-          "https://docs.snyk.io/cli-ide-and-ci-cd-integrations/snyk-cli/developer-guardrails-for-agentic-workflows/snyk-mcp-early-access/snyk-mcp-installation-configuration-and-startup",
-          "https://docs.snyk.io/integrations/developer-guardrails-for-agentic-workflows/quickstart-guides-for-mcp"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "QA PIN (2026-07-15): npm package snyk@1.1306.0 corresponds by release version to public tag commit d4e9a98123a364a47b91770df8d86e2d31dcbc45. Its registry integrity hash was verified, the tarball contains bin/snyk and dist/cli/index.js, and an MCP initialize/list-tools probe returned 13 tools. Direct installation from the Git commit is not usable because the repository omits the built dist/cli/index.js artifact. The stdio server uses SNYK_TOKEN for headless authentication and optionally SNYK_CFG_ORG.",
+          "sources": [
+            "https://snyk.io/articles/secure-ai-coding-with-snyk-now-supporting-model-context-protocol-mcp/",
+            "https://snyk.io/articles/snyk-mcp-cheat-sheet/",
+            "https://docs.snyk.io/cli-ide-and-ci-cd-integrations/snyk-cli/developer-guardrails-for-agentic-workflows/snyk-mcp-early-access/snyk-mcp-installation-configuration-and-startup",
+            "https://docs.snyk.io/integrations/developer-guardrails-for-agentic-workflows/quickstart-guides-for-mcp"
+          ]
+        }
       }
     },
     {
@@ -2055,16 +2135,18 @@
         "oauth_authorization_endpoint": "https://app.vanta.com/oauth/authorize",
         "oauth_token_endpoint": "https://api.vanta.com/oauth/token",
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Vanta ships two official MCP options. The preferred catalog default is the remote HTTP MCP server documented by Vanta's Help Center: US https://mcp.vanta.com/mcp, EU https://mcp.eu.vanta.com/mcp, and AUS https://mcp.aus.vanta.com/mcp. The remote server uses interactive OAuth in the user's Vanta app; Vanta Admin role is required. OAuth endpoints are discovered by the MCP client, so explicit authorization/token endpoint overrides are null. US endpoint is used as the default; users in EU/AUS can configure the URI to the regional endpoint. Discovery metadata on mcp.vanta.com advertises endpoints on sibling hosts (authorize on app.vanta.com, token/register on api.vanta.com), so the US endpoints are pinned here to mark those hosts trusted; regional EU/AUS servers likely use their own sibling hosts and may need their own pins if connected. Vanta also ships an npm STDIO package @vantasdk/vanta-mcp-server, but it requires VANTA_ENV_FILE to point at a JSON credential file containing client_id/client_secret. Tracecat currently stores stdio env as encrypted key/value pairs, not materialized files, so the HTTP variant is the better platform default.",
-        "sources": [
-          "https://help.vanta.com/en/articles/14094979-connecting-to-vanta-mcp",
-          "https://github.com/VantaInc/vanta-mcp-server/",
-          "https://raw.githubusercontent.com/VantaInc/vanta-mcp-server/main/README.md",
-          "https://www.npmjs.com/package/@vantasdk/vanta-mcp-server",
-          "https://developer.vanta.com/docs/api-access-setup"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Vanta ships two official MCP options. The preferred catalog default is the remote HTTP MCP server documented by Vanta's Help Center: US https://mcp.vanta.com/mcp, EU https://mcp.eu.vanta.com/mcp, and AUS https://mcp.aus.vanta.com/mcp. The remote server uses interactive OAuth in the user's Vanta app; Vanta Admin role is required. OAuth endpoints are discovered by the MCP client, so explicit authorization/token endpoint overrides are null. US endpoint is used as the default; users in EU/AUS can configure the URI to the regional endpoint. Discovery metadata on mcp.vanta.com advertises endpoints on sibling hosts (authorize on app.vanta.com, token/register on api.vanta.com), so the US endpoints are pinned here to mark those hosts trusted; regional EU/AUS servers likely use their own sibling hosts and may need their own pins if connected. Vanta also ships an npm STDIO package @vantasdk/vanta-mcp-server, but it requires VANTA_ENV_FILE to point at a JSON credential file containing client_id/client_secret. Tracecat currently stores stdio env as encrypted key/value pairs, not materialized files, so the HTTP variant is the better platform default.",
+          "sources": [
+            "https://help.vanta.com/en/articles/14094979-connecting-to-vanta-mcp",
+            "https://github.com/VantaInc/vanta-mcp-server/",
+            "https://raw.githubusercontent.com/VantaInc/vanta-mcp-server/main/README.md",
+            "https://www.npmjs.com/package/@vantasdk/vanta-mcp-server",
+            "https://developer.vanta.com/docs/api-access-setup"
+          ]
+        }
       }
     },
     {
@@ -2096,14 +2178,16 @@
             "target": "server_uri"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official Drata-hosted remote MCP server (Beta). Transport is HTTP (streamable HTTP at the /mcp/ path); no SSE path documented. Authentication is OAuth 2.0 via browser sign-in — Drata explicitly states \"your credentials are never shared with the AI client,\" so the user supplies no API token, only completes the OAuth flow. Admins create an OAuth configuration in Drata Settings > MCP Configuration (name, expiration date, selected read scopes) before connecting a client. Three regional endpoints exist: US https://mcp.drata.com/mcp/, EU https://mcp-euc1.drata.com/mcp/, APAC https://mcp-apse2.drata.com/mcp/ — default/US is used as server_uri. Discovery metadata on mcp.drata.com advertises the token/registration endpoints on Drata's Auth0 tenant drata-prod.us.auth0.com (verified live), so the authorization/token endpoints are pinned here to mark that host trusted during discovery; the live discovered endpoints are still what gets used. Regional EU/APAC servers may advertise different hosts and would need their own pins if connected. Eight read scopes are documented. Note: there are unofficial third-party Drata MCP servers (e.g. github.com/sderosiaux/drata-mcp, StackOne) — those are NOT first-party and were not used for this spec.",
-        "sources": [
-          "https://developers.drata.com/developer-portal/v2/recipes/mcp-oauth-setup/",
-          "https://help.drata.com/en/articles/13379899-mcp-configuration-new-experience",
-          "https://drata.com/blog/drata-mcp-built-for-ai-native-trust-management"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official Drata-hosted remote MCP server (Beta). Transport is HTTP (streamable HTTP at the /mcp/ path); no SSE path documented. Authentication is OAuth 2.0 via browser sign-in — Drata explicitly states \"your credentials are never shared with the AI client,\" so the user supplies no API token, only completes the OAuth flow. Admins create an OAuth configuration in Drata Settings > MCP Configuration (name, expiration date, selected read scopes) before connecting a client. Three regional endpoints exist: US https://mcp.drata.com/mcp/, EU https://mcp-euc1.drata.com/mcp/, APAC https://mcp-apse2.drata.com/mcp/ — default/US is used as server_uri. Discovery metadata on mcp.drata.com advertises the token/registration endpoints on Drata's Auth0 tenant drata-prod.us.auth0.com (verified live), so the authorization/token endpoints are pinned here to mark that host trusted during discovery; the live discovered endpoints are still what gets used. Regional EU/APAC servers may advertise different hosts and would need their own pins if connected. Eight read scopes are documented. Note: there are unofficial third-party Drata MCP servers (e.g. github.com/sderosiaux/drata-mcp, StackOne) — those are NOT first-party and were not used for this spec.",
+          "sources": [
+            "https://developers.drata.com/developer-portal/v2/recipes/mcp-oauth-setup/",
+            "https://help.drata.com/en/articles/13379899-mcp-configuration-new-experience",
+            "https://drata.com/blog/drata-mcp-built-for-ai-native-trust-management"
+          ]
+        }
       }
     },
     {
@@ -2123,12 +2207,14 @@
             "target": "http_header"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Oneleet documents a first-party remote MCP server at https://api.oneleet.com/mcp using Streamable HTTP transport. OAuth-based user login is not available yet, so clients authenticate with a tenant-scoped API service key. The service key is shown once at creation, uses the service_<id>_<secret> format, and is passed to MCP clients as Authorization: Bearer <your-service-key>. Service keys can be scoped to read tenant details, controls, policies, frameworks, members, integrations, evidence, monitors, pentest findings, and write evidence, integrations, or monitor reruns. No stdio, npx, uvx, pip, Docker, or OAuth option is documented for this server.",
-        "sources": [
-          "https://docs.oneleet.com/api-and-mcp/service-keys-and-mcp/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Oneleet documents a first-party remote MCP server at https://api.oneleet.com/mcp using Streamable HTTP transport. OAuth-based user login is not available yet, so clients authenticate with a tenant-scoped API service key. The service key is shown once at creation, uses the service_<id>_<secret> format, and is passed to MCP clients as Authorization: Bearer <your-service-key>. Service keys can be scoped to read tenant details, controls, policies, frameworks, members, integrations, evidence, monitors, pentest findings, and write evidence, integrations, or monitor reruns. No stdio, npx, uvx, pip, Docker, or OAuth option is documented for this server.",
+          "sources": [
+            "https://docs.oneleet.com/api-and-mcp/service-keys-and-mcp/"
+          ]
+        }
       }
     },
     {
@@ -2178,15 +2264,17 @@
             "target": "stdio_env"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "QA PIN (2026-07-15): PyPI package mcp-grafana==0.17.2 is the official uvx wrapper for Grafana release v0.17.2 at public tag commit fac7c8a312c6f6aee8330de72182dcf45bf4ae26. The platform wheel SHA-256 was verified, the bundled Go binary reported v0.17.2, and an MCP initialize/list-tools probe returned 65 tools. The PyPI binary is built separately from the GitHub release archive, so the reproducible catalog control is the exact PyPI version rather than a direct Git SHA install. Authentication uses GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN.",
-        "sources": [
-          "https://github.com/grafana/mcp-grafana",
-          "https://grafana.com/docs/grafana/latest/developer-resources/mcp/set-up/install-with-uvx/",
-          "https://grafana.com/docs/grafana/latest/developer-resources/mcp/",
-          "https://pypi.org/project/mcp-grafana/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "QA PIN (2026-07-15): PyPI package mcp-grafana==0.17.2 is the official uvx wrapper for Grafana release v0.17.2 at public tag commit fac7c8a312c6f6aee8330de72182dcf45bf4ae26. The platform wheel SHA-256 was verified, the bundled Go binary reported v0.17.2, and an MCP initialize/list-tools probe returned 65 tools. The PyPI binary is built separately from the GitHub release archive, so the reproducible catalog control is the exact PyPI version rather than a direct Git SHA install. Authentication uses GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN.",
+          "sources": [
+            "https://github.com/grafana/mcp-grafana",
+            "https://grafana.com/docs/grafana/latest/developer-resources/mcp/set-up/install-with-uvx/",
+            "https://grafana.com/docs/grafana/latest/developer-resources/mcp/",
+            "https://pypi.org/project/mcp-grafana/"
+          ]
+        }
       }
     },
     {
@@ -2214,15 +2302,17 @@
             "target": "http_header"
           }
         ],
-        "confidence": "medium",
-        "docker_only": false,
-        "research_notes": "Two official Snowflake MCP options exist. (1) The Snowflake-MANAGED remote MCP server (matches the intended HTTP transport): no single fixed vendor URL — the endpoint is account/database/schema/server-name specific, formatted as https://<org>-<account>.snowflakecomputing.com/api/v2/databases/{database}/schemas/{schema}/mcp-servers/{name}. The user must create the MCP server object in their Snowflake account and supply the full URL, so server_uri is left null. Auth: the getting-started guide demonstrates Programmatic Access Token (PAT) Bearer auth ('Authorization: Bearer <PAT>'), which is why I modeled this as CUSTOM. The docs also state it supports OAuth 2.0 'aligned with the MCP protocol authorization recommendation' but explicitly does NOT support dynamic client registration — you must manually create an OAuth security integration to get client id/secret, so it's not a turnkey browser DCR flow. If modeled as OAuth instead, grant would be authorization_code over *.snowflakecomputing.com with discovery/.well-known metadata (not separately documented). (2) The self-hosted Snowflake-Labs/mcp (PyPI 'snowflake-labs-mcp', `uvx snowflake-labs-mcp --service-config-file config.yaml`, transports stdio/streamable-http, default endpoint /mcp port 9000, env SNOWFLAKE_ACCOUNT/USER/PASSWORD/ROLE/WAREHOUSE/PRIVATE_KEY) is now DEPRECATED — its PyPI page and README state it is no longer maintained and direct users to the managed server. I therefore did not populate packages[] with the deprecated project. Confidence medium because the precise OAuth grant type / discovery metadata is not explicitly documented and the per-account URL cannot be a fixed value.",
-        "sources": [
-          "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp",
-          "https://www.snowflake.com/en/developers/guides/getting-started-with-snowflake-mcp-server/",
-          "https://github.com/Snowflake-Labs/mcp",
-          "https://pypi.org/project/snowflake-labs-mcp/"
-        ]
+        "_research": {
+          "confidence": "medium",
+          "docker_only": false,
+          "notes": "Two official Snowflake MCP options exist. (1) The Snowflake-MANAGED remote MCP server (matches the intended HTTP transport): no single fixed vendor URL — the endpoint is account/database/schema/server-name specific, formatted as https://<org>-<account>.snowflakecomputing.com/api/v2/databases/{database}/schemas/{schema}/mcp-servers/{name}. The user must create the MCP server object in their Snowflake account and supply the full URL, so server_uri is left null. Auth: the getting-started guide demonstrates Programmatic Access Token (PAT) Bearer auth ('Authorization: Bearer <PAT>'), which is why I modeled this as CUSTOM. The docs also state it supports OAuth 2.0 'aligned with the MCP protocol authorization recommendation' but explicitly does NOT support dynamic client registration — you must manually create an OAuth security integration to get client id/secret, so it's not a turnkey browser DCR flow. If modeled as OAuth instead, grant would be authorization_code over *.snowflakecomputing.com with discovery/.well-known metadata (not separately documented). (2) The self-hosted Snowflake-Labs/mcp (PyPI 'snowflake-labs-mcp', `uvx snowflake-labs-mcp --service-config-file config.yaml`, transports stdio/streamable-http, default endpoint /mcp port 9000, env SNOWFLAKE_ACCOUNT/USER/PASSWORD/ROLE/WAREHOUSE/PRIVATE_KEY) is now DEPRECATED — its PyPI page and README state it is no longer maintained and direct users to the managed server. I therefore did not populate packages[] with the deprecated project. Confidence medium because the precise OAuth grant type / discovery metadata is not explicitly documented and the per-account URL cannot be a fixed value.",
+          "sources": [
+            "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp",
+            "https://www.snowflake.com/en/developers/guides/getting-started-with-snowflake-mcp-server/",
+            "https://github.com/Snowflake-Labs/mcp",
+            "https://pypi.org/project/snowflake-labs-mcp/"
+          ]
+        }
       }
     },
     {
@@ -2260,17 +2350,19 @@
             "target": "http_header"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Databricks ships first-party \"managed MCP servers\" (Public Preview) hosted per-workspace, governed by Unity Catalog / Unity AI Gateway. Transport is streamable HTTP (the docs show client config type \"http\"/\"streamable-http\"; the databricks-mcp Python SDK uses mcp's streamablehttp_client). There is NO single global MCP endpoint — the URL is workspace-specific and tool-family-specific. The five documented URL patterns are:\n- Databricks SQL: https://<workspace-hostname>/api/2.0/mcp/sql (scope: sql)\n- Genie (all spaces): https://<workspace-hostname>/api/2.0/mcp/genie (scope: genie)\n- Genie single space: https://<workspace-hostname>/api/2.0/mcp/genie/{genie_space_id} (scope: genie)\n- Vector Search: https://<workspace-hostname>/api/2.0/mcp/vector-search/{catalog}/{schema}/{index_name} (scope: vector-search)\n- Unity Catalog functions: https://<workspace-hostname>/api/2.0/mcp/functions/{catalog}/{schema}/{function_name} (scope: unity-catalog)\nI set server_uri to the SQL endpoint as a representative example since the catalog description leads with \"Query Databricks SQL\"; substitute the desired family/path. <workspace-hostname> must be replaced with the user's actual workspace host.\n\nAUTH: Two supported methods. (1) OAuth (recommended) — authorization-code flow with browser sign-in via `databricks auth login`; supports public (no secret) and confidential (with secret) clients; uses scoped permissions + automatic token refresh; granular scopes genie/vector-search/sql/unity-catalog plus all-apis (broad) and offline_access (refresh). The server advertises endpoints via discovery (the docs/SDK use mcp's OAuthClientProvider against the workspace host), so I left oauth_authorization_endpoint/token_endpoint null — both live on the workspace hostname. (2) PAT alternative — Databricks personal access token passed as `Authorization: Bearer <token>` header; supported for managed and external MCP servers. I reported auth_type=OAUTH2 since that's the recommended/primary flow and matches the HTTP intent; PAT is captured as an optional credential.\n\nPyPI package `databricks-mcp` (DatabricksMCPClient) exists but is a helper SDK for building/deploying agents that CALL these servers (resource discovery + auth helpers), NOT a standalone stdio MCP server to install — so no stdio/packages entries. Several unofficial third-party stdio Databricks MCP servers exist on GitHub/PyPI (e.g. RafaelCartenet/mcp-databricks-server, databricks-mcp-server, databrickslabs/mcp) but those are NOT the first-party managed offering matching the HTTP intent.",
-        "sources": [
-          "https://docs.databricks.com/aws/en/generative-ai/mcp/managed-mcp",
-          "https://learn.microsoft.com/en-us/azure/databricks/generative-ai/mcp/managed-mcp",
-          "https://docs.databricks.com/aws/en/generative-ai/mcp/connect-clients",
-          "https://docs.databricks.com/aws/en/generative-ai/mcp/",
-          "https://pypi.org/project/databricks-mcp/",
-          "https://www.databricks.com/blog/announcing-managed-mcp-servers-unity-catalog-and-mosaic-ai-integration"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Databricks ships first-party \"managed MCP servers\" (Public Preview) hosted per-workspace, governed by Unity Catalog / Unity AI Gateway. Transport is streamable HTTP (the docs show client config type \"http\"/\"streamable-http\"; the databricks-mcp Python SDK uses mcp's streamablehttp_client). There is NO single global MCP endpoint — the URL is workspace-specific and tool-family-specific. The five documented URL patterns are:\n- Databricks SQL: https://<workspace-hostname>/api/2.0/mcp/sql (scope: sql)\n- Genie (all spaces): https://<workspace-hostname>/api/2.0/mcp/genie (scope: genie)\n- Genie single space: https://<workspace-hostname>/api/2.0/mcp/genie/{genie_space_id} (scope: genie)\n- Vector Search: https://<workspace-hostname>/api/2.0/mcp/vector-search/{catalog}/{schema}/{index_name} (scope: vector-search)\n- Unity Catalog functions: https://<workspace-hostname>/api/2.0/mcp/functions/{catalog}/{schema}/{function_name} (scope: unity-catalog)\nI set server_uri to the SQL endpoint as a representative example since the catalog description leads with \"Query Databricks SQL\"; substitute the desired family/path. <workspace-hostname> must be replaced with the user's actual workspace host.\n\nAUTH: Two supported methods. (1) OAuth (recommended) — authorization-code flow with browser sign-in via `databricks auth login`; supports public (no secret) and confidential (with secret) clients; uses scoped permissions + automatic token refresh; granular scopes genie/vector-search/sql/unity-catalog plus all-apis (broad) and offline_access (refresh). The server advertises endpoints via discovery (the docs/SDK use mcp's OAuthClientProvider against the workspace host), so I left oauth_authorization_endpoint/token_endpoint null — both live on the workspace hostname. (2) PAT alternative — Databricks personal access token passed as `Authorization: Bearer <token>` header; supported for managed and external MCP servers. I reported auth_type=OAUTH2 since that's the recommended/primary flow and matches the HTTP intent; PAT is captured as an optional credential.\n\nPyPI package `databricks-mcp` (DatabricksMCPClient) exists but is a helper SDK for building/deploying agents that CALL these servers (resource discovery + auth helpers), NOT a standalone stdio MCP server to install — so no stdio/packages entries. Several unofficial third-party stdio Databricks MCP servers exist on GitHub/PyPI (e.g. RafaelCartenet/mcp-databricks-server, databricks-mcp-server, databrickslabs/mcp) but those are NOT the first-party managed offering matching the HTTP intent.",
+          "sources": [
+            "https://docs.databricks.com/aws/en/generative-ai/mcp/managed-mcp",
+            "https://learn.microsoft.com/en-us/azure/databricks/generative-ai/mcp/managed-mcp",
+            "https://docs.databricks.com/aws/en/generative-ai/mcp/connect-clients",
+            "https://docs.databricks.com/aws/en/generative-ai/mcp/",
+            "https://pypi.org/project/databricks-mcp/",
+            "https://www.databricks.com/blog/announcing-managed-mcp-servers-unity-catalog-and-mosaic-ai-integration"
+          ]
+        }
       }
     },
     {
@@ -2315,23 +2407,27 @@
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official first-party GitLab MCP server, introduced in GitLab 18.6. Recommended transport is HTTP (streamable) at the path /api/v4/mcp. For GitLab.com the endpoint is https://gitlab.com/api/v4/mcp; self-managed instances use https://<gitlab.example.com>/api/v4/mcp (server_uri should be templated per-instance for self-managed). Auth is OAuth 2.0 with Dynamic Client Registration (DCR) — the AI client auto-registers as an OAuth application, opens the browser for an authorization-code flow, and receives an access token. Authorization and token endpoints are advertised via OAuth discovery (protected-resource / authorization-server metadata at the gitlab.com host), so they are left null here. No explicit scopes are documented. The OAuth flow only touches the GitLab host (gitlab.com for SaaS). No user-supplied static credentials are required for the HTTP/OAuth path; the browser sign-in handles authorization. GitLab also documents an alternative stdio transport via the `mcp-remote` Node proxy, but the recommended and intended transport is HTTP, so HTTP is reported here. Several popular community servers exist (zereight/gitlab-mcp via npm @zereight/mcp-gitlab using a GitLab personal access token) but those are third-party, not the official server referenced by this catalog slug.",
-        "sources": [
-          "https://docs.gitlab.com/user/gitlab_duo/model_context_protocol/mcp_server/",
-          "https://about.gitlab.com/blog/duo-agent-platform-with-mcp/"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official first-party GitLab MCP server, introduced in GitLab 18.6. Recommended transport is HTTP (streamable) at the path /api/v4/mcp. For GitLab.com the endpoint is https://gitlab.com/api/v4/mcp; self-managed instances use https://<gitlab.example.com>/api/v4/mcp (server_uri should be templated per-instance for self-managed). Auth is OAuth 2.0 with Dynamic Client Registration (DCR) — the AI client auto-registers as an OAuth application, opens the browser for an authorization-code flow, and receives an access token. Authorization and token endpoints are advertised via OAuth discovery (protected-resource / authorization-server metadata at the gitlab.com host), so they are left null here. No explicit scopes are documented. The OAuth flow only touches the GitLab host (gitlab.com for SaaS). No user-supplied static credentials are required for the HTTP/OAuth path; the browser sign-in handles authorization. GitLab also documents an alternative stdio transport via the `mcp-remote` Node proxy, but the recommended and intended transport is HTTP, so HTTP is reported here. Several popular community servers exist (zereight/gitlab-mcp via npm @zereight/mcp-gitlab using a GitLab personal access token) but those are third-party, not the official server referenced by this catalog slug.",
+          "sources": [
+            "https://docs.gitlab.com/user/gitlab_duo/model_context_protocol/mcp_server/",
+            "https://about.gitlab.com/blog/duo-agent-platform-with-mcp/"
+          ]
+        }
       }
     },
     {
       "slug": "terraform-mcp",
       "docs": "https://github.com/hashicorp/terraform-mcp-server",
-      "research_notes": "Coming soon: the official HashiCorp server is distributed as a Docker image or Go binary, but Tracecat's stdio runner does not currently permit Docker or Go executables.",
-      "sources": [
-        "https://github.com/hashicorp/terraform-mcp-server",
-        "https://developer.hashicorp.com/terraform/mcp-server"
-      ]
+      "_research": {
+        "notes": "Coming soon: the official HashiCorp server is distributed as a Docker image or Go binary, but Tracecat's stdio runner does not currently permit Docker or Go executables.",
+        "sources": [
+          "https://github.com/hashicorp/terraform-mcp-server",
+          "https://developer.hashicorp.com/terraform/mcp-server"
+        ]
+      }
     },
     {
       "slug": "ansible-mcp",
@@ -2358,17 +2454,19 @@
             "target": "server_uri"
           }
         ],
-        "confidence": "medium",
-        "docker_only": false,
-        "research_notes": "CATALOG/TRANSPORT MISMATCH — read carefully.\n\nThe catalog description (\"Run playbooks and manage automation jobs on Ansible Automation Platform\") maps to the OFFICIAL Red Hat \"MCP server for Ansible Automation Platform\" (Technology Preview, AAP 2.6.4+). That server is NOT a packaged local stdio process. It is deployed INSIDE an AAP installation (as a pod via the containerized RHEL installer, or via the AAP Operator on OpenShift) and exposed as a REMOTE HTTPS service on port 8448 (service base URL e.g. https://aap.example.com:8448). It connects directly to the AAP controller APIs and enforces dual-layer security: server-level config + the calling user's RBAC, derived from an AAP API token. So I classified it server_type=http, auth_type=CUSTOM (bearer API token). This contradicts the catalog's \"intended transport: STDIO\".\n\nserver_uri is left null because there is no vendor-hosted public endpoint — the URL is the customer's own AAP instance (host + :8448). The exact MCP path (e.g. /mcp vs SSE) was not confirmed; Red Hat's detailed docs pages return HTTP 403 to the fetcher. Auth is via AAP_TOKEN (create in AAP dashboard, Write scope) against AAP_URL; I could verify the token+base-URL model and port 8448/HTTPS from the Red Hat blog and forum, but not the literal header/path, hence medium confidence.\n\nNO official npx/uvx/pip distribution exists for the AAP MCP server — its only official distribution is the AAP containerized installer / OpenShift operator (container image ansible-automation-platform-26/mcp-tools-rhel9 in the Red Hat catalog). We cannot run that as a stdio subprocess, so packages[] is empty. I did NOT set docker_only=true because the real interaction model is HTTP-to-a-self-hosted-service, not \"run a docker image locally as the MCP server\".\n\nSEPARATE, DIFFERENT official server (do not conflate): @ansible/ansible-mcp-server (the \"Ansible Development Tools MCP Server\", repo github.com/ansible/vscode-ansible, latest 26.5.0). That one IS stdio and npx-runnable: `npx -y @ansible/ansible-mcp-server --stdio`, reads env WORKSPACE_ROOT/NODE_OPTIONS, requires Node 24+, and has NO auth. BUT its scope is local linting, workspace access, and authoring prompts — it does NOT run playbooks or manage jobs on AAP, so it does not match this catalog entry's description.\n\nThere are also numerous community AAP MCP servers (sibilleb/AAP-Enterprise-MCP-Server, rlopez133/mcp, mancubus77/mcp-server-aap) that wrap the AAP API as a local stdio process using AAP_TOKEN + AAP_URL/AAP_BASE_URL env vars — this is likely where the catalog's \"STDIO\" intent and the AAP_TOKEN/AAP_URL credential names originate. None are first-party Red Hat, so I did not adopt any as the canonical spec. RECOMMENDATION: confirm with stakeholders whether this catalog entry should represent (a) the official Red Hat AAP HTTP server [as specified here], (b) the official stdio dev-tools npm server, or (c) a community stdio AAP wrapper.",
-        "sources": [
-          "https://www.redhat.com/en/blog/it-automation-agentic-ai-introducing-mcp-server-red-hat-ansible-automation-platform",
-          "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/deploying-ansible-mcp-server",
-          "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/installing_on_openshift_container_platform/deploy-ansible-mcp-server-operator-install",
-          "https://forum.ansible.com/t/introducing-the-mcp-server-for-red-hat-ansible-automation-platform/45246",
-          "https://docs.ansible.com/projects/vscode-ansible/mcp/",
-          "https://www.npmjs.com/package/@ansible/ansible-mcp-server"
-        ]
+        "_research": {
+          "confidence": "medium",
+          "docker_only": false,
+          "notes": "CATALOG/TRANSPORT MISMATCH — read carefully.\n\nThe catalog description (\"Run playbooks and manage automation jobs on Ansible Automation Platform\") maps to the OFFICIAL Red Hat \"MCP server for Ansible Automation Platform\" (Technology Preview, AAP 2.6.4+). That server is NOT a packaged local stdio process. It is deployed INSIDE an AAP installation (as a pod via the containerized RHEL installer, or via the AAP Operator on OpenShift) and exposed as a REMOTE HTTPS service on port 8448 (service base URL e.g. https://aap.example.com:8448). It connects directly to the AAP controller APIs and enforces dual-layer security: server-level config + the calling user's RBAC, derived from an AAP API token. So I classified it server_type=http, auth_type=CUSTOM (bearer API token). This contradicts the catalog's \"intended transport: STDIO\".\n\nserver_uri is left null because there is no vendor-hosted public endpoint — the URL is the customer's own AAP instance (host + :8448). The exact MCP path (e.g. /mcp vs SSE) was not confirmed; Red Hat's detailed docs pages return HTTP 403 to the fetcher. Auth is via AAP_TOKEN (create in AAP dashboard, Write scope) against AAP_URL; I could verify the token+base-URL model and port 8448/HTTPS from the Red Hat blog and forum, but not the literal header/path, hence medium confidence.\n\nNO official npx/uvx/pip distribution exists for the AAP MCP server — its only official distribution is the AAP containerized installer / OpenShift operator (container image ansible-automation-platform-26/mcp-tools-rhel9 in the Red Hat catalog). We cannot run that as a stdio subprocess, so packages[] is empty. I did NOT set docker_only=true because the real interaction model is HTTP-to-a-self-hosted-service, not \"run a docker image locally as the MCP server\".\n\nSEPARATE, DIFFERENT official server (do not conflate): @ansible/ansible-mcp-server (the \"Ansible Development Tools MCP Server\", repo github.com/ansible/vscode-ansible, latest 26.5.0). That one IS stdio and npx-runnable: `npx -y @ansible/ansible-mcp-server --stdio`, reads env WORKSPACE_ROOT/NODE_OPTIONS, requires Node 24+, and has NO auth. BUT its scope is local linting, workspace access, and authoring prompts — it does NOT run playbooks or manage jobs on AAP, so it does not match this catalog entry's description.\n\nThere are also numerous community AAP MCP servers (sibilleb/AAP-Enterprise-MCP-Server, rlopez133/mcp, mancubus77/mcp-server-aap) that wrap the AAP API as a local stdio process using AAP_TOKEN + AAP_URL/AAP_BASE_URL env vars — this is likely where the catalog's \"STDIO\" intent and the AAP_TOKEN/AAP_URL credential names originate. None are first-party Red Hat, so I did not adopt any as the canonical spec. RECOMMENDATION: confirm with stakeholders whether this catalog entry should represent (a) the official Red Hat AAP HTTP server [as specified here], (b) the official stdio dev-tools npm server, or (c) a community stdio AAP wrapper.",
+          "sources": [
+            "https://www.redhat.com/en/blog/it-automation-agentic-ai-introducing-mcp-server-red-hat-ansible-automation-platform",
+            "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/deploying-ansible-mcp-server",
+            "https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/installing_on_openshift_container_platform/deploy-ansible-mcp-server-operator-install",
+            "https://forum.ansible.com/t/introducing-the-mcp-server-for-red-hat-ansible-automation-platform/45246",
+            "https://docs.ansible.com/projects/vscode-ansible/mcp/",
+            "https://www.npmjs.com/package/@ansible/ansible-mcp-server"
+          ]
+        }
       }
     },
     {
@@ -2399,14 +2497,16 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "This is the Microsoft Agent 365 \"Work IQ User\" MCP server (internal server ID mcp_MeServer, display name \"Work IQ User\"), which surfaces Microsoft Graph /me + directory data (getMyProfile, getMyManager, getUserProfile, getUsersManager, getDirectReports, listUsers). It is a Microsoft-hosted REMOTE HTTP/streamable MCP server, not an npm/pip/stdio package — confirmed by official .mcp.json examples that use \"type\": \"http\". There is no installable package, so packages[] and stdio_* are empty.\n\nServer URL is TENANT-SCOPED: https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_MeServer — the user must substitute their Entra tenant GUID. (The Microsoft Foundry/Copilot Studio low-code UIs fill this in automatically; pro-code/CLI clients require the explicit URL.)\n\nAuth is OAuth2 authorization-code via Microsoft Entra ID delegated (On-Behalf-Of / agentic user identity) auth. The official Claude Code / VS Code / Copilot CLI examples use an oauth block { \"clientId\": \"<app id>\", \"callbackPort\": 8080 } with a localhost redirect (http://localhost:8080/callback). The clientId is a Microsoft Entra public-client enterprise app the user/admin registers and grants the Work IQ User API permission to (permission naming follows the WorkIQ-*Server pattern, e.g. WorkIQ-MailServer for Mail; the User server permission follows the same convention). OAuth authorization/token endpoints are NOT hardcoded — they are obtained via Entra (login.microsoftonline.com) and MCP/OAuth discovery against the agent365 host, so they are left null. No plain OAuth scope strings are documented; access is gated by Entra API permissions + admin consent rather than scope strings, hence scopes[] is empty.\n\nRequires a Microsoft 365 Copilot license. Currently in PREVIEW (catalog status coming_soon is consistent). Both tenantId and clientId are non-secret identifiers (no static token/secret the user pastes; the secret is obtained interactively via browser sign-in).",
-        "sources": [
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/me",
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview",
-          "https://github.com/microsoft/work-iq"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "This is the Microsoft Agent 365 \"Work IQ User\" MCP server (internal server ID mcp_MeServer, display name \"Work IQ User\"), which surfaces Microsoft Graph /me + directory data (getMyProfile, getMyManager, getUserProfile, getUsersManager, getDirectReports, listUsers). It is a Microsoft-hosted REMOTE HTTP/streamable MCP server, not an npm/pip/stdio package — confirmed by official .mcp.json examples that use \"type\": \"http\". There is no installable package, so packages[] and stdio_* are empty.\n\nServer URL is TENANT-SCOPED: https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_MeServer — the user must substitute their Entra tenant GUID. (The Microsoft Foundry/Copilot Studio low-code UIs fill this in automatically; pro-code/CLI clients require the explicit URL.)\n\nAuth is OAuth2 authorization-code via Microsoft Entra ID delegated (On-Behalf-Of / agentic user identity) auth. The official Claude Code / VS Code / Copilot CLI examples use an oauth block { \"clientId\": \"<app id>\", \"callbackPort\": 8080 } with a localhost redirect (http://localhost:8080/callback). The clientId is a Microsoft Entra public-client enterprise app the user/admin registers and grants the Work IQ User API permission to (permission naming follows the WorkIQ-*Server pattern, e.g. WorkIQ-MailServer for Mail; the User server permission follows the same convention). OAuth authorization/token endpoints are NOT hardcoded — they are obtained via Entra (login.microsoftonline.com) and MCP/OAuth discovery against the agent365 host, so they are left null. No plain OAuth scope strings are documented; access is gated by Entra API permissions + admin consent rather than scope strings, hence scopes[] is empty.\n\nRequires a Microsoft 365 Copilot license. Currently in PREVIEW (catalog status coming_soon is consistent). Both tenantId and clientId are non-secret identifiers (no static token/secret the user pastes; the secret is obtained interactively via browser sign-in).",
+          "sources": [
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/me",
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview",
+            "https://github.com/microsoft/work-iq"
+          ]
+        }
       }
     },
     {
@@ -2437,13 +2537,15 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official server is Microsoft Agent 365 \"Work IQ Word\" (server ID mcp_WordServer), a remote HTTP MCP server. Verified from Microsoft Learn. Exact endpoint: https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_WordServer — {tenantId} is the user's Entra tenant GUID. Tools: WordCreateNewDocument, WordGetDocumentContent, WordCreateNewComment, WordReplyToComment (matches catalog \"create documents and comments\"). Transport is \"http\" (streamable HTTP) per official .mcp.json samples (\"type\":\"http\").\n\nAuth: OAuth2 authorization-code (browser sign-in) against Microsoft Entra. The official MCP client config supplies only url + oauth.clientId + callbackPort (localhost:8080), so the authorization/token endpoints are obtained via OAuth/protected-resource discovery from the resource server rather than hardcoded — hence oauth_authorization_endpoint/token_endpoint left null. Microsoft Entra OAuth touches login.microsoftonline.com. The clientId comes from an Entra app registration the user must create themselves (public client with redirect http://localhost:8080/callback); only tenant admins can fully provision. No client secret is used in the documented public-client flow, so clientId is marked non-secret. Scopes: the docs grant API permissions like WorkIQ-WordServer on the app registration rather than passing OAuth scope strings in the connection, so scopes left empty.\n\nPrerequisite: a Microsoft 365 Copilot license. Feature is in preview as of 2026-05. Note: there are many third-party \"Word MCP\" servers (e.g. GongRzhe/Office-Word-MCP-Server on PyPI/uvx, stdio), but those operate on local .docx files and are NOT the official Microsoft server; the catalog description (OneDrive/SharePoint documents + comments, HTTP transport) matches the official Agent 365 Work IQ Word server selected here.",
-        "sources": [
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/word",
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official server is Microsoft Agent 365 \"Work IQ Word\" (server ID mcp_WordServer), a remote HTTP MCP server. Verified from Microsoft Learn. Exact endpoint: https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_WordServer — {tenantId} is the user's Entra tenant GUID. Tools: WordCreateNewDocument, WordGetDocumentContent, WordCreateNewComment, WordReplyToComment (matches catalog \"create documents and comments\"). Transport is \"http\" (streamable HTTP) per official .mcp.json samples (\"type\":\"http\").\n\nAuth: OAuth2 authorization-code (browser sign-in) against Microsoft Entra. The official MCP client config supplies only url + oauth.clientId + callbackPort (localhost:8080), so the authorization/token endpoints are obtained via OAuth/protected-resource discovery from the resource server rather than hardcoded — hence oauth_authorization_endpoint/token_endpoint left null. Microsoft Entra OAuth touches login.microsoftonline.com. The clientId comes from an Entra app registration the user must create themselves (public client with redirect http://localhost:8080/callback); only tenant admins can fully provision. No client secret is used in the documented public-client flow, so clientId is marked non-secret. Scopes: the docs grant API permissions like WorkIQ-WordServer on the app registration rather than passing OAuth scope strings in the connection, so scopes left empty.\n\nPrerequisite: a Microsoft 365 Copilot license. Feature is in preview as of 2026-05. Note: there are many third-party \"Word MCP\" servers (e.g. GongRzhe/Office-Word-MCP-Server on PyPI/uvx, stdio), but those operate on local .docx files and are NOT the official Microsoft server; the catalog description (OneDrive/SharePoint documents + comments, HTTP transport) matches the official Agent 365 Work IQ Word server selected here.",
+          "sources": [
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/word",
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview"
+          ]
+        }
       }
     },
     {
@@ -2474,14 +2576,16 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Official server is Microsoft \"Work IQ OneDrive\" (server ID mcp_OneDriveRemoteServer), part of Microsoft Agent 365 / Work IQ MCP (currently preview). It is a remote HTTP (streamable, type \"http\") MCP server, NOT stdio. Endpoint is tenant-scoped: https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_OneDriveRemoteServer — the {tenantId} placeholder must be replaced with the user's Entra tenant ID.\n\nAuth is OAuth2 (authorization_code) via Microsoft Entra ID. Microsoft's documented client config uses {\"type\":\"http\",\"url\":\"...\",\"oauth\":{\"clientId\":\"<appId>\",\"callbackPort\":8080}} — i.e. the MCP client performs an OAuth authorization-code browser sign-in. The server advertises auth via discovery, so explicit authorization/token endpoints are not published in the docs (they resolve to login.microsoftonline.com / Entra). I left oauth_authorization_endpoint and oauth_token_endpoint null for that reason.\n\nPrerequisites per Microsoft docs: (1) a Microsoft 365 Copilot license, and (2) a registered Microsoft Entra enterprise application (public client) with the relevant Work IQ server API permission granted. The documented example uses WorkIQ-MailServer permission for the Mail server; the OneDrive server requires the analogous WorkIQ-OneDrive(Server) permission (exact permission display name for OneDrive not explicitly shown in the doc, so not asserted as a scope). Redirect URI http://localhost:8080/callback (or http://127.0.0.1, etc.) must be configured on the app registration.\n\nThe older combined server (mcp_ODSPRemoteServer, \"Microsoft SharePoint and OneDrive MCP server\") is deprecated as of 2026-03-13 and is replaced by separate Work IQ OneDrive and Work IQ SharePoint servers; this spec targets the current OneDrive server.\n\nNo npx/uvx/pip package distribution exists — it is a Microsoft-hosted remote endpoint, so packages[] is empty and stdio fields are null. docker_only is false (not a Docker image either).\n\nCredentials clientId/tenantId are connection identifiers, not secrets; the actual bearer token is acquired interactively via the OAuth flow rather than supplied by the user.",
-        "sources": [
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/onedrive",
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview",
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/odspremoteserver"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official server is Microsoft \"Work IQ OneDrive\" (server ID mcp_OneDriveRemoteServer), part of Microsoft Agent 365 / Work IQ MCP (currently preview). It is a remote HTTP (streamable, type \"http\") MCP server, NOT stdio. Endpoint is tenant-scoped: https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_OneDriveRemoteServer — the {tenantId} placeholder must be replaced with the user's Entra tenant ID.\n\nAuth is OAuth2 (authorization_code) via Microsoft Entra ID. Microsoft's documented client config uses {\"type\":\"http\",\"url\":\"...\",\"oauth\":{\"clientId\":\"<appId>\",\"callbackPort\":8080}} — i.e. the MCP client performs an OAuth authorization-code browser sign-in. The server advertises auth via discovery, so explicit authorization/token endpoints are not published in the docs (they resolve to login.microsoftonline.com / Entra). I left oauth_authorization_endpoint and oauth_token_endpoint null for that reason.\n\nPrerequisites per Microsoft docs: (1) a Microsoft 365 Copilot license, and (2) a registered Microsoft Entra enterprise application (public client) with the relevant Work IQ server API permission granted. The documented example uses WorkIQ-MailServer permission for the Mail server; the OneDrive server requires the analogous WorkIQ-OneDrive(Server) permission (exact permission display name for OneDrive not explicitly shown in the doc, so not asserted as a scope). Redirect URI http://localhost:8080/callback (or http://127.0.0.1, etc.) must be configured on the app registration.\n\nThe older combined server (mcp_ODSPRemoteServer, \"Microsoft SharePoint and OneDrive MCP server\") is deprecated as of 2026-03-13 and is replaced by separate Work IQ OneDrive and Work IQ SharePoint servers; this spec targets the current OneDrive server.\n\nNo npx/uvx/pip package distribution exists — it is a Microsoft-hosted remote endpoint, so packages[] is empty and stdio fields are null. docker_only is false (not a Docker image either).\n\nCredentials clientId/tenantId are connection identifiers, not secrets; the actual bearer token is acquired interactively via the OAuth flow rather than supplied by the user.",
+          "sources": [
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/onedrive",
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/tooling-servers-overview",
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/odspremoteserver"
+          ]
+        }
       }
     },
     {
@@ -2504,14 +2608,16 @@
             "target": "server_uri"
           }
         ],
-        "confidence": "medium",
-        "docker_only": false,
-        "research_notes": "The official first-party SharePoint MCP server is the \"Work IQ SharePoint\" server in Microsoft Agent 365 (server ID `mcp_SharePointRemoteServer`), currently in PREVIEW as of 2026-05. It supersedes the now-deprecated (since 2026-03-13) combined \"Microsoft SharePoint and OneDrive MCP server\" (`mcp_ODSPRemoteServer`). It covers sites, lists, list items, columns, document libraries (drives), files, folders, and sharing (file ops limited to <=5MB).\n\nTRANSPORT: Remote HTTP MCP server (streamable HTTP via the Agent 365 tooling gateway). The endpoint is tenant-specific and templated: https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_SharePointRemoteServer — the {tenantId} must be replaced with the caller's Entra tenant GUID. This is NOT a single static public URL.\n\nAUTH: Microsoft Entra ID OAuth2 (bearer token). The Agent 365 tooling model uses delegated/OBO (authorization_code-family) tokens or agentic auth. Auth is gated behind: (1) a one-time per-tenant service principal for \"Agent 365 Tools\" (app id ea9ffc3e-8a23-4a7d-836d-234d7c7565c1) created via a Microsoft PowerShell script, (2) an Entra app/agent blueprint with admin-consented API permissions, and (3) Global Administrator consent. So this is NOT a self-service \"sign in with browser and go\" DCR-style remote MCP server; it requires tenant admin onboarding and the Agent 365 CLI to provision permissions.\n\nSCOPE/AUDIENCE: The CLI auto-populates an OAuth `scope` and `audience` per server from the Agent 365 MCP catalog and writes them to ToolingManifest.json. The docs show the pattern using the MAIL server example: scope `McpServers.Mail.All`, audience `api://05879165-0320-489e-b644-f72b33f3edf0`. The SharePoint-specific scope (likely of the form `McpServers.SharePoint.All` or similar) and its audience GUID are NOT published on the pages reviewed, so scopes left empty and oauth endpoints left null. Confidence is MEDIUM because endpoint URL + transport + Entra-OAuth model are verified from official Microsoft Learn docs, but the exact SharePoint scope string/audience GUID and the precise OAuth discovery endpoints were not confirmed first-hand. Set required=true on tenantId because the URL is unusable without it.\n\nMany community/third-party SharePoint MCP servers exist (e.g. mcp-sharepoint on PyPI, DEmodoriGatsuO/sharepoint-mcp, sekops, ftaricano/mcp-onedrive-sharepoint via Graph + device-code). Those are NOT first-party and were not selected; the intended transport is HTTP and the official first-party offering is the Agent 365 remote HTTP server above.",
-        "sources": [
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/sharepoint",
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/odspremoteserver",
-          "https://learn.microsoft.com/en-us/microsoft-agent-365/developer/tooling"
-        ]
+        "_research": {
+          "confidence": "medium",
+          "docker_only": false,
+          "notes": "The official first-party SharePoint MCP server is the \"Work IQ SharePoint\" server in Microsoft Agent 365 (server ID `mcp_SharePointRemoteServer`), currently in PREVIEW as of 2026-05. It supersedes the now-deprecated (since 2026-03-13) combined \"Microsoft SharePoint and OneDrive MCP server\" (`mcp_ODSPRemoteServer`). It covers sites, lists, list items, columns, document libraries (drives), files, folders, and sharing (file ops limited to <=5MB).\n\nTRANSPORT: Remote HTTP MCP server (streamable HTTP via the Agent 365 tooling gateway). The endpoint is tenant-specific and templated: https://agent365.svc.cloud.microsoft/agents/tenants/{tenantId}/servers/mcp_SharePointRemoteServer — the {tenantId} must be replaced with the caller's Entra tenant GUID. This is NOT a single static public URL.\n\nAUTH: Microsoft Entra ID OAuth2 (bearer token). The Agent 365 tooling model uses delegated/OBO (authorization_code-family) tokens or agentic auth. Auth is gated behind: (1) a one-time per-tenant service principal for \"Agent 365 Tools\" (app id ea9ffc3e-8a23-4a7d-836d-234d7c7565c1) created via a Microsoft PowerShell script, (2) an Entra app/agent blueprint with admin-consented API permissions, and (3) Global Administrator consent. So this is NOT a self-service \"sign in with browser and go\" DCR-style remote MCP server; it requires tenant admin onboarding and the Agent 365 CLI to provision permissions.\n\nSCOPE/AUDIENCE: The CLI auto-populates an OAuth `scope` and `audience` per server from the Agent 365 MCP catalog and writes them to ToolingManifest.json. The docs show the pattern using the MAIL server example: scope `McpServers.Mail.All`, audience `api://05879165-0320-489e-b644-f72b33f3edf0`. The SharePoint-specific scope (likely of the form `McpServers.SharePoint.All` or similar) and its audience GUID are NOT published on the pages reviewed, so scopes left empty and oauth endpoints left null. Confidence is MEDIUM because endpoint URL + transport + Entra-OAuth model are verified from official Microsoft Learn docs, but the exact SharePoint scope string/audience GUID and the precise OAuth discovery endpoints were not confirmed first-hand. Set required=true on tenantId because the URL is unusable without it.\n\nMany community/third-party SharePoint MCP servers exist (e.g. mcp-sharepoint on PyPI, DEmodoriGatsuO/sharepoint-mcp, sekops, ftaricano/mcp-onedrive-sharepoint via Graph + device-code). Those are NOT first-party and were not selected; the intended transport is HTTP and the official first-party offering is the Agent 365 remote HTTP server above.",
+          "sources": [
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/sharepoint",
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/odspremoteserver",
+            "https://learn.microsoft.com/en-us/microsoft-agent-365/developer/tooling"
+          ]
+        }
       }
     },
     {
@@ -2545,14 +2651,16 @@
             "target": "oauth_client"
           }
         ],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Google publishes an official first-party REMOTE (HTTP/streamable) MCP server for Google Drive at https://drivemcp.googleapis.com/mcp/v1, which matches the intended HTTP transport. This is the canonical official server (Google for Developers docs), not a community STDIO reference server. Auth is OAuth 2.0 authorization-code flow: the user must create their own OAuth Client ID/Secret in Google Cloud Console (with the Drive API enabled) and configure scopes drive.readonly and drive.file. The client config example uses an \"oauth\" block with clientId/clientSecret/scopes (Gemini CLI desktop-app client; Claude uses a web-app client with redirect URI https://claude.ai/api/mcp/auth_callback). I set oauth_authorization_endpoint/token_endpoint to Google's standard well-known OAuth endpoints (accounts.google.com / oauth2.googleapis.com) since these are Google's documented OAuth 2.0 endpoints; the server may also advertise them via MCP discovery, but the configure-mcp-server doc shows credentials are supplied by the user rather than via dynamic client registration. Tools exposed: copy_file, create_file, download_file_content, get_file_metadata, get_file_permissions, list_recent_files, read_file_content, search_files. Note: numerous community STDIO servers exist (e.g. modelcontextprotocol reference gdrive npm package, isaacphi/mcp-gdrive) but the official Google remote HTTP server is the better match here.",
-        "sources": [
-          "https://developers.google.com/workspace/drive/api/guides/configure-mcp-server",
-          "https://developers.google.com/workspace/drive/api/reference/mcp",
-          "https://docs.cloud.google.com/mcp/supported-products"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Google publishes an official first-party REMOTE (HTTP/streamable) MCP server for Google Drive at https://drivemcp.googleapis.com/mcp/v1, which matches the intended HTTP transport. This is the canonical official server (Google for Developers docs), not a community STDIO reference server. Auth is OAuth 2.0 authorization-code flow: the user must create their own OAuth Client ID/Secret in Google Cloud Console (with the Drive API enabled) and configure scopes drive.readonly and drive.file. The client config example uses an \"oauth\" block with clientId/clientSecret/scopes (Gemini CLI desktop-app client; Claude uses a web-app client with redirect URI https://claude.ai/api/mcp/auth_callback). I set oauth_authorization_endpoint/token_endpoint to Google's standard well-known OAuth endpoints (accounts.google.com / oauth2.googleapis.com) since these are Google's documented OAuth 2.0 endpoints; the server may also advertise them via MCP discovery, but the configure-mcp-server doc shows credentials are supplied by the user rather than via dynamic client registration. Tools exposed: copy_file, create_file, download_file_content, get_file_metadata, get_file_permissions, list_recent_files, read_file_content, search_files. Note: numerous community STDIO servers exist (e.g. modelcontextprotocol reference gdrive npm package, isaacphi/mcp-gdrive) but the official Google remote HTTP server is the better match here.",
+          "sources": [
+            "https://developers.google.com/workspace/drive/api/guides/configure-mcp-server",
+            "https://developers.google.com/workspace/drive/api/reference/mcp",
+            "https://docs.cloud.google.com/mcp/supported-products"
+          ]
+        }
       }
     },
     {
@@ -2571,14 +2679,16 @@
         "oauth_authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
         "oauth_token_endpoint": "https://oauth2.googleapis.com/token",
         "credentials": [],
-        "confidence": "high",
-        "docker_only": false,
-        "research_notes": "Google ships a FIRST-PARTY remote (HTTP) Google Calendar MCP server at https://calendarmcp.googleapis.com/mcp/v1 — this matches the intended HTTP transport and is preferred over community stdio servers (e.g. nspady/@cocal/google-calendar-mcp on npm). Transport is described as a \"remote MCP server\" over HTTP (streamable HTTP); not SSE. Auth is OAuth 2.0 authorization-code. The server exposes 8 tools: list_events, get_event, list_calendars, suggest_time, create_event, update_event, delete_event, respond_to_event — i.e. it supports both reads and writes (creating/scheduling/updating/deleting events), so a write scope (calendar.events) is required in addition to the read-only scopes Google lists in the config guide.\n\nOAuth notes: the user must create their own OAuth 2.0 client in Google Cloud Console (https://console.cloud.google.com/auth/clients/create) and enable the Calendar API — this is standard Google OAuth, NOT RFC 7591 dynamic client registration. For Claude integration the documented redirect/callback URI is https://claude.ai/api/mcp/auth_callback. Google's OAuth uses well-known endpoints: authorization at accounts.google.com/o/oauth2/v2/auth and token exchange at oauth2.googleapis.com/token (these are Google's standard OAuth2 endpoints, not explicitly restated on the MCP config page but are the canonical Google OAuth endpoints). The client_id/client_secret from the user's own Google Cloud OAuth client are supplied by the OAuth platform configuration rather than as static per-user header credentials, so credentials[] is left empty (no user-supplied API key/token/host is passed directly to the MCP endpoint at request time). The read-only scopes explicitly listed in Google's guide are calendar.calendarlist.readonly, calendar.events.readonly, and calendar.events.freebusy; calendar.events (read/write) is required for the write tools.",
-        "sources": [
-          "https://developers.google.com/workspace/calendar/api/guides/configure-mcp-server",
-          "https://developers.google.com/workspace/calendar/api/v3/reference/mcp",
-          "https://developers.google.com/workspace/guides/configure-mcp-servers"
-        ]
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Google ships a FIRST-PARTY remote (HTTP) Google Calendar MCP server at https://calendarmcp.googleapis.com/mcp/v1 — this matches the intended HTTP transport and is preferred over community stdio servers (e.g. nspady/@cocal/google-calendar-mcp on npm). Transport is described as a \"remote MCP server\" over HTTP (streamable HTTP); not SSE. Auth is OAuth 2.0 authorization-code. The server exposes 8 tools: list_events, get_event, list_calendars, suggest_time, create_event, update_event, delete_event, respond_to_event — i.e. it supports both reads and writes (creating/scheduling/updating/deleting events), so a write scope (calendar.events) is required in addition to the read-only scopes Google lists in the config guide.\n\nOAuth notes: the user must create their own OAuth 2.0 client in Google Cloud Console (https://console.cloud.google.com/auth/clients/create) and enable the Calendar API — this is standard Google OAuth, NOT RFC 7591 dynamic client registration. For Claude integration the documented redirect/callback URI is https://claude.ai/api/mcp/auth_callback. Google's OAuth uses well-known endpoints: authorization at accounts.google.com/o/oauth2/v2/auth and token exchange at oauth2.googleapis.com/token (these are Google's standard OAuth2 endpoints, not explicitly restated on the MCP config page but are the canonical Google OAuth endpoints). The client_id/client_secret from the user's own Google Cloud OAuth client are supplied by the OAuth platform configuration rather than as static per-user header credentials, so credentials[] is left empty (no user-supplied API key/token/host is passed directly to the MCP endpoint at request time). The read-only scopes explicitly listed in Google's guide are calendar.calendarlist.readonly, calendar.events.readonly, and calendar.events.freebusy; calendar.events (read/write) is required for the write tools.",
+          "sources": [
+            "https://developers.google.com/workspace/calendar/api/guides/configure-mcp-server",
+            "https://developers.google.com/workspace/calendar/api/v3/reference/mcp",
+            "https://developers.google.com/workspace/guides/configure-mcp-servers"
+          ]
+        }
       }
     },
     {

--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -136,88 +136,12 @@
     {
       "slug": "splunk-mcp",
       "docs": "https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.1/about-mcp-server-for-splunk-platform",
-      "connection_spec": {
-        "server_type": "stdio",
-        "auth_type": "CUSTOM",
-        "stdio_command": "python",
-        "stdio_args": [
-          "server.py"
-        ],
-        "stdio_env": [
-          "TRANSPORT",
-          "SPLUNK_HOST",
-          "SPLUNK_PORT",
-          "SPLUNK_USERNAME",
-          "SPLUNK_PASSWORD",
-          "SPLUNK_TOKEN",
-          "VERIFY_SSL",
-          "SPL_MAX_EVENTS_COUNT",
-          "SPL_RISK_TOLERANCE",
-          "SPL_SAFE_TIMERANGE",
-          "SPL_SANITIZE_OUTPUT"
-        ],
-        "packages": [],
-        "credentials": [
-          {
-            "key": "SPLUNK_HOST",
-            "label": "Splunk Host",
-            "description": "Hostname of the Splunk Enterprise/Cloud management instance (e.g. splunk.example.com). Used for the Splunk REST API.",
-            "required": true,
-            "secret": false,
-            "target": "stdio_env"
-          },
-          {
-            "key": "SPLUNK_PORT",
-            "label": "Splunk Management Port",
-            "description": "Splunk management REST API port. Defaults to 8089.",
-            "required": false,
-            "secret": false,
-            "target": "stdio_env"
-          },
-          {
-            "key": "SPLUNK_TOKEN",
-            "label": "Splunk Auth Token",
-            "description": "Splunk authentication (bearer) token. Preferred over username/password. Provide this OR username+password.",
-            "required": false,
-            "secret": true,
-            "target": "stdio_env"
-          },
-          {
-            "key": "SPLUNK_USERNAME",
-            "label": "Splunk Username",
-            "description": "Splunk account username. Used with SPLUNK_PASSWORD if a token is not supplied.",
-            "required": false,
-            "secret": false,
-            "target": "stdio_env"
-          },
-          {
-            "key": "SPLUNK_PASSWORD",
-            "label": "Splunk Password",
-            "description": "Splunk account password. Used with SPLUNK_USERNAME if a token is not supplied.",
-            "required": false,
-            "secret": true,
-            "target": "stdio_env"
-          },
-          {
-            "key": "VERIFY_SSL",
-            "label": "Verify SSL",
-            "description": "Whether to verify the Splunk server's TLS certificate. Optional.",
-            "required": false,
-            "secret": false,
-            "target": "stdio_env"
-          }
-        ],
-        "confidence": "medium",
-        "docker_only": false,
-        "research_notes": "Two distinct Splunk MCP offerings exist, and neither cleanly matches our install constraints.\n\n1) OFFICIAL hosted server: Splunk markets a GA \"MCP Server for Splunk platform\" distributed as a Splunkbase app (app/7931) that you install INTO your own Splunk Enterprise/Cloud instance. It speaks streamable HTTP and uses Splunk token-based auth + RBAC (NOT OAuth2 sign-in). However it is self-hosted, so there is no canonical/public server_uri — the endpoint is your own Splunk host path, which the public docs do not pin down. So I did not set server_type=http with a URL.\n\n2) splunk/splunk-mcp-server2 (in the Splunk GitHub org) is EXPLICITLY self-described as \"Unofficial.\" It supports stdio/SSE and is what matches our intended STDIO transport. It runs via `python server.py` with TRANSPORT=stdio. Auth is CUSTOM: Splunk REST API on port 8089 using either SPLUNK_TOKEN (bearer) or SPLUNK_USERNAME+SPLUNK_PASSWORD.\n\nPACKAGE GAP (why packages[] is empty and stdio_package is null): there is NO published npx/uvx/pip package for any Splunk-org MCP server. Confirmed PyPI 404 for splunk-mcp-server2 and splunk-mcp-server, and npm 404 for splunk-mcp-server2. The repo only documents `pip install -e .` from a git clone (local editable install) plus a Docker option — neither is a package-manager install we support. The `python server.py` command also requires running from the cloned repo directory, so it is not runnable standalone via our allowlist. A third-party PyPI package `mcp-server-splunk` (200 on PyPI) exists but it is jkosik's Go implementation, not first-party Splunk.\n\nRecommendation: this catalog entry cannot be fulfilled with a supported npx/uvx/pip STDIO package today. Either (a) wait for Splunk to publish a packaged server, or (b) reclassify as HTTP and require the user to supply their self-hosted Splunk MCP endpoint URL + token. Confidence set to medium because env vars/auth/transport are sourced from first-party (Splunk-org) docs, but the canonical install path and official-vs-unofficial story are unresolved.",
-        "sources": [
-          "https://github.com/splunk/splunk-mcp-server2",
-          "https://github.com/splunk/splunk-mcp-server2/blob/main/python/README.md",
-          "https://raw.githubusercontent.com/splunk/splunk-mcp-server2/main/python/README.md",
-          "https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.1/about-mcp-server-for-splunk-platform",
-          "https://splunkbase.splunk.com/app/7931"
-        ]
-      }
+      "research_notes": "Coming soon. QA (2026-07-15): the public splunk/splunk-mcp-server2 source at commit fac6cbb37be057a68607642d8d60d9c19ba5a060 is not runnable through Tracecat. The catalog's former `python server.py` recipe had no cloned source file at runtime. Direct uvx installation from that Git commit builds, but startup fails because server.py imports guardrails.py while pyproject.toml omits guardrails from setuptools py-modules. Splunk's official GA server is instead installed into a customer's Splunk deployment and exposes a self-hosted HTTP endpoint; there is no canonical vendor-hosted URL or supported public npx/uvx package for this stdio catalog entry.",
+      "sources": [
+        "https://github.com/splunk/splunk-mcp-server2",
+        "https://help.splunk.com/en/splunk-cloud-platform/mcp-server-for-splunk-platform/1.1/about-mcp-server-for-splunk-platform",
+        "https://splunkbase.splunk.com/app/7931"
+      ]
     },
     {
       "slug": "scanner-mcp",
@@ -970,7 +894,7 @@
         "auth_type": "CUSTOM",
         "stdio_command": "npx",
         "stdio_args": [
-          "@greynoise/greynoise-mcp-server"
+          "@greynoise/greynoise-mcp-server@0.4.0"
         ],
         "stdio_env": [
           "GREYNOISE_API_KEY"
@@ -980,9 +904,9 @@
             "manager": "npx",
             "command": "npx",
             "args": [
-              "@greynoise/greynoise-mcp-server"
+              "@greynoise/greynoise-mcp-server@0.4.0"
             ],
-            "package": "@greynoise/greynoise-mcp-server"
+            "package": "@greynoise/greynoise-mcp-server@0.4.0"
           }
         ],
         "credentials": [
@@ -997,7 +921,7 @@
         ],
         "confidence": "high",
         "docker_only": false,
-        "research_notes": "Official first-party MCP server published by GreyNoise (GitHub org GreyNoise-Intelligence). Verified package on npm: @greynoise/greynoise-mcp-server v0.4.0, bin name \"gnapi\", build/index.js entrypoint. Default transport is stdio (matches intended STDIO); the server also supports an optional HTTP transport via --transport http but that requires installing Express separately and is not the canonical/default mode and exposes no hosted endpoint — there is NO vendor-hosted remote MCP URL. Auth is a single Enterprise API key passed via the GREYNOISE_API_KEY env var (the underlying API at api.greynoise.io uses key/header auth, not OAuth). Claude Desktop config uses command=npx, args=[\"@greynoise/greynoise-mcp-server\"], env GREYNOISE_API_KEY. Also distributed as an MCPB/DXT bundle for Claude Desktop (key stored in OS keychain), but npx is the canonical cross-client install. Not docker-only.",
+        "research_notes": "QA PIN (2026-07-15): npm package @greynoise/greynoise-mcp-server@0.4.0 is associated through npm gitHead with public release commit 017bc228439be1672da60b3f49ef902d6311ea51. Its registry integrity hash was verified, the packaged build/index.js entrypoint launched, and an MCP initialize/list-tools probe returned 18 tools. Version 0.4.1 was not selected because its advertised gitHead is not publicly reachable. Default transport is stdio and authentication uses GREYNOISE_API_KEY.",
         "sources": [
           "https://github.com/GreyNoise-Intelligence/greynoise-mcp-server",
           "https://docs.greynoise.io/docs/mcp-server",
@@ -1219,54 +1143,13 @@
     {
       "slug": "hashicorp-vault-mcp",
       "docs": "https://github.com/hashicorp/vault-mcp-server",
-      "connection_spec": {
-        "server_type": "stdio",
-        "auth_type": "CUSTOM",
-        "stdio_command": null,
-        "stdio_args": [],
-        "stdio_env": [
-          "VAULT_ADDR",
-          "VAULT_TOKEN",
-          "VAULT_NAMESPACE"
-        ],
-        "packages": [],
-        "credentials": [
-          {
-            "key": "VAULT_ADDR",
-            "label": "Vault Server Address",
-            "description": "Base URL of the HashiCorp Vault server, e.g. http://127.0.0.1:8200. Defaults to http://127.0.0.1:8200 if unset.",
-            "required": true,
-            "secret": false,
-            "type": "url",
-            "target": "stdio_env"
-          },
-          {
-            "key": "VAULT_TOKEN",
-            "label": "Vault Token",
-            "description": "Vault authentication token used to access mounts, KV secrets, and PKI. Passed via VAULT_TOKEN env var (or X-Vault-Token header in HTTP mode).",
-            "required": true,
-            "secret": true,
-            "target": "stdio_env"
-          },
-          {
-            "key": "VAULT_NAMESPACE",
-            "label": "Vault Namespace",
-            "description": "Optional Vault Enterprise/HCP namespace to scope operations.",
-            "required": false,
-            "secret": false,
-            "target": "stdio_env"
-          }
-        ],
-        "confidence": "high",
-        "docker_only": true,
-        "research_notes": "Official server is hashicorp/vault-mcp-server (HashiCorp GitHub org), written in Go and currently in beta. It supports BOTH stdio (default) and streamable-HTTP transports. However, the ONLY official distributions are a Docker image (hashicorp/vault-mcp-server), a precompiled Go binary from releases.hashicorp.com/vault-mcp-server, and `go install github.com/hashicorp/vault-mcp-server/cmd/vault-mcp-server@latest`. There is NO npm/npx, PyPI/pip, uvx, or Node package, so packages[] is empty and docker_only=true per the constraint (command must be npx/uvx/python/python3/node).\n\nAlthough the intended catalog transport is HTTP, the HTTP (\"streamable-http\") mode is NOT a vendor-hosted remote MCP endpoint — it is a self-hosted local process. Default HTTP bind is 127.0.0.1:8080 with MCP path /mcp (full URL http://127.0.0.1:8080/mcp), and HashiCorp explicitly recommends running it locally only and not exposing it to the network. Because there is no fixed public/remote URL to publish, server_uri is left null and server_type is set to stdio (local process) with docker_only=true.\n\nAuth is CUSTOM (Vault native token), not OAuth. In stdio/Docker mode credentials come from env vars: VAULT_ADDR (default http://127.0.0.1:8200), VAULT_TOKEN (required), VAULT_NAMESPACE (optional). In HTTP mode the token can alternatively be passed per-request via the X-Vault-Token header (and X-Vault-Namespace). HTTP-mode-only config env vars (TRANSPORT_MODE/host/port, MCP_ENDPOINT, MCP_ALLOWED_ORIGINS, MCP_CORS_MODE, MCP_TLS_*, MCP_RATE_LIMIT_*) are server tuning, not user secrets, so they are excluded from credentials.",
-        "sources": [
-          "https://github.com/hashicorp/vault-mcp-server",
-          "https://raw.githubusercontent.com/hashicorp/vault-mcp-server/main/README.md",
-          "https://developer.hashicorp.com/vault/docs/mcp-server/deploy",
-          "https://developer.hashicorp.com/vault/docs/mcp-server/overview"
-        ]
-      }
+      "research_notes": "Coming soon. QA (2026-07-15): HashiCorp Vault MCP Server v0.2.0 at commit c67575dc4f98db37f187d62400bd70fe0211a60c was verified using HashiCorp's checksum-published Darwin arm64 binary. It completed MCP initialization and exposed 16 tools. The server works, but its official distributions are precompiled binaries, Docker, and `go install`; Tracecat's stdio catalog only permits npx, uvx, python, python3, or node launchers. HashiCorp also supports self-hosted streamable HTTP, but explicitly recommends local/internal deployment and provides no vendor-hosted endpoint.",
+      "sources": [
+        "https://github.com/hashicorp/vault-mcp-server",
+        "https://releases.hashicorp.com/vault-mcp-server/0.2.0/",
+        "https://developer.hashicorp.com/vault/docs/mcp-server/deploy",
+        "https://developer.hashicorp.com/vault/docs/mcp-server/overview"
+      ]
     },
     {
       "slug": "aws-mcp",
@@ -1477,55 +1360,12 @@
     {
       "slug": "palo-alto-mcp",
       "docs": "https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Enterprise-Documentation/Cortex-MCP-server",
-      "connection_spec": {
-        "server_type": "stdio",
-        "auth_type": "CUSTOM",
-        "stdio_command": null,
-        "stdio_args": [],
-        "stdio_env": [
-          "CORTEX_MCP_PAPI_URL",
-          "CORTEX_MCP_PAPI_AUTH_HEADER",
-          "CORTEX_MCP_PAPI_AUTH_ID"
-        ],
-        "packages": [],
-        "credentials": [
-          {
-            "key": "CORTEX_MCP_PAPI_URL",
-            "label": "Cortex Tenant API URL",
-            "description": "The Cortex (XSIAM/XDR) tenant API base URL for your tenant, e.g. https://api-<tenant>.xdr.<region>.paloaltonetworks.com. Used as CORTEX_MCP_PAPI_URL.",
-            "required": true,
-            "secret": false,
-            "type": "url",
-            "target": "stdio_env"
-          },
-          {
-            "key": "CORTEX_MCP_PAPI_AUTH_HEADER",
-            "label": "Cortex API Key",
-            "description": "The Cortex API key secret generated under Settings > Configurations > API Keys. Passed as the Authorization header value via CORTEX_MCP_PAPI_AUTH_HEADER.",
-            "required": true,
-            "secret": true,
-            "target": "stdio_env"
-          },
-          {
-            "key": "CORTEX_MCP_PAPI_AUTH_ID",
-            "label": "Cortex API Key ID",
-            "description": "The numeric ID associated with the Cortex API key (the x-xdr-auth-id). Passed via CORTEX_MCP_PAPI_AUTH_ID.",
-            "required": true,
-            "secret": false,
-            "target": "stdio_env"
-          }
-        ],
-        "confidence": "medium",
-        "docker_only": true,
-        "research_notes": "The official Palo Alto Networks \"Cortex MCP server\" (open beta as of late 2025) covers Cortex XSIAM and Cortex XDR. It is distributed ONLY as a Docker image and runs locally, so the real transport is stdio, NOT the HTTP transport intended in our catalog. Our environment does not support docker/bunx/deno launchers, hence docker_only=true and stdio_command/args/package left null; there is no official npx/uvx/pip package from Palo Alto Networks.\n\nOfficial install per Palo Alto docs/LIVEcommunity runs: `docker run --env-file ./cortex-xdr.env -it cortex-mcp` (image built/pulled per Palo Alto's docs at docs-cortex.paloaltonetworks.com under \"Install the Cortex MCP server\" / \"Configure the MCP client\"). Auth is CUSTOM (Cortex API key + key ID), not OAuth. The three env vars are CORTEX_MCP_PAPI_URL (tenant API URL), CORTEX_MCP_PAPI_AUTH_HEADER (API key secret), and CORTEX_MCP_PAPI_AUTH_ID (numeric API key ID / x-xdr-auth-id).\n\nConfidence is medium, not high: the docs-cortex.paloaltonetworks.com pages are JavaScript-rendered and returned truncated content to the fetcher, so exact image registry path/tag and the precise env var semantics were corroborated from the official PANW blog + LIVEcommunity thread + search snippets of the official docs rather than a fully-read install page. The exact tenant-URL format for CORTEX_MCP_PAPI_URL should be verified against the user's tenant.\n\nCAUTION on confusable sources: search engines heavily conflate this with unrelated \"Cortex\" projects that are NOT Palo Alto — cortexapps/cortex-mcp and mcp.cortex.io (Cortex.io internal developer portal), Snowflake Cortex Agents MCP, and gbrigandi/mcp-server-cortex (TheHive Cortex analyzer). Those use CORTEX_API_TOKEN / mcp.cortex.io and must NOT be used for Palo Alto Networks. Values above are sourced only from paloaltonetworks.com / docs-cortex.paloaltonetworks.com.",
-        "sources": [
-          "https://www.paloaltonetworks.com/blog/security-operations/introducing-the-cortex-mcp-server/",
-          "https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR/Cortex-XDR-5.x-Documentation/Cortex-MCP-server-overview",
-          "https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Enterprise-Documentation/Install-the-Cortex-MCP-server",
-          "https://docs-cortex.paloaltonetworks.com/r/Cortex-CLOUD/Cortex-Cloud-Runtime-Security-Documentation/Cortex-MCP-server",
-          "https://live.paloaltonetworks.com/t5/cortex-xdr-discussions/try-to-install-the-cortex-mcp-server/td-p/1250623"
-        ]
-      }
+      "research_notes": "Coming soon. QA (2026-07-15): Palo Alto's official Cortex MCP server is obtainable only by downloading a tenant-specific archive from the Cortex console. The archive supports local Poetry/Python or Docker execution and stdio or streamable HTTP, but Palo Alto does not publish the Cortex server as public source, an npx package, or a PyPI package that Tracecat can install. The public PaloAltoNetworks/pan-mcp-relay project is a Prisma AIRS security proxy and is not the Cortex XSIAM/XDR operations server represented by this catalog entry.",
+      "sources": [
+        "https://docs-cortex.paloaltonetworks.com/r/Cortex/Cortex-MCP-server/Install-the-Cortex-MCP-server",
+        "https://docs-cortex.paloaltonetworks.com/r/Cortex/Cortex-MCP-server/Configure-the-MCP-client",
+        "https://github.com/PaloAltoNetworks/pan-mcp-relay"
+      ]
     },
     {
       "slug": "sixtyfour-mcp",
@@ -2152,7 +1992,7 @@
         "stdio_command": "npx",
         "stdio_args": [
           "-y",
-          "snyk@latest",
+          "snyk@1.1306.0",
           "mcp",
           "-t",
           "stdio"
@@ -2167,12 +2007,12 @@
             "command": "npx",
             "args": [
               "-y",
-              "snyk@latest",
+              "snyk@1.1306.0",
               "mcp",
               "-t",
               "stdio"
             ],
-            "package": "snyk"
+            "package": "snyk@1.1306.0"
           }
         ],
         "credentials": [
@@ -2195,7 +2035,7 @@
         ],
         "confidence": "high",
         "docker_only": false,
-        "research_notes": "The official Snyk MCP server is built into the Snyk CLI (the `snyk` npm package), invoked as `snyk mcp -t stdio`. Official recommended config uses `npx -y snyk@latest mcp -t stdio`, confirmed in Snyk's own blog and docs. Requires Snyk CLI >= 1.1296.2. Feature was launched as experimental (`--experimental` flag in earliest docs) and has since moved to early-access/GA-style docs where the flag is no longer required in the recommended config; the canonical command is `mcp -t stdio`.\n\nTransport: STDIO is the primary/intended transport. The CLI also supports `-t sse` (SSE) as a local-process transport, but that still runs the same local `snyk` binary, not a hosted remote endpoint, so there is no remote MCP server_uri.\n\nAuth (CUSTOM): The server uses two mechanisms. (1) Default interactive browser login via the `snyk_auth` tool (OAuth-style sign-in handled by the CLI, opens a browser). (2) For headless/automated/restricted environments, set the `SNYK_TOKEN` env var (Snyk API token). Because our use case is non-interactive, the practical required credential is the API token, hence auth_type=CUSTOM rather than OAUTH2. `SNYK_CFG_ORG` is an optional org selector. Other standard Snyk CLI env vars (proxy settings, SNYK_API for self-hosted/region endpoints) are also honored but not required for the default SaaS case.\n\nSeparately, Snyk also offers a newer hosted \"Snyk API & Web MCP Server\" (Snyk Studio) which is a remote/HTTP MCP. That is a distinct product from this CLI-based `snyk mcp` STDIO server; this spec covers the STDIO CLI server matching the intended transport.\n\nThe `pip`/`uvx` install path does not apply — the CLI is distributed via npm (and standalone binaries / Homebrew / Docker), not PyPI.",
+        "research_notes": "QA PIN (2026-07-15): npm package snyk@1.1306.0 corresponds by release version to public tag commit d4e9a98123a364a47b91770df8d86e2d31dcbc45. Its registry integrity hash was verified, the tarball contains bin/snyk and dist/cli/index.js, and an MCP initialize/list-tools probe returned 13 tools. Direct installation from the Git commit is not usable because the repository omits the built dist/cli/index.js artifact. The stdio server uses SNYK_TOKEN for headless authentication and optionally SNYK_CFG_ORG.",
         "sources": [
           "https://snyk.io/articles/secure-ai-coding-with-snyk-now-supporting-model-context-protocol-mcp/",
           "https://snyk.io/articles/snyk-mcp-cheat-sheet/",
@@ -2299,7 +2139,7 @@
         "auth_type": "CUSTOM",
         "stdio_command": "uvx",
         "stdio_args": [
-          "mcp-grafana",
+          "mcp-grafana==0.17.2",
           "-t",
           "stdio"
         ],
@@ -2312,11 +2152,11 @@
             "manager": "uvx",
             "command": "uvx",
             "args": [
-              "mcp-grafana",
+              "mcp-grafana==0.17.2",
               "-t",
               "stdio"
             ],
-            "package": "mcp-grafana"
+            "package": "mcp-grafana==0.17.2"
           }
         ],
         "credentials": [
@@ -2340,7 +2180,7 @@
         ],
         "confidence": "high",
         "docker_only": false,
-        "research_notes": "Official server is grafana/mcp-grafana (Go binary, Apache-2.0). It is also published to PyPI as `mcp-grafana` (publisher: grafana-machine-learning, latest v0.14.0, May 2026), which is the recommended way to run it via `uvx mcp-grafana`. The PyPI wrapper downloads/runs the Go binary, so no npm package exists (npx not supported). STDIO is fully supported and is the intended transport; pass `-t stdio` (the binary defaults to stdio for local use, but the Docker entrypoint defaults to SSE, so the explicit flag is safest). Auth is CUSTOM via a Grafana service account token (GRAFANA_SERVICE_ACCOUNT_TOKEN). Legacy/optional alternatives the binary also reads: GRAFANA_API_KEY (deprecated), GRAFANA_USERNAME/GRAFANA_PASSWORD (basic auth), GRAFANA_ORG_ID — not included as required credentials. The server can alternatively run as a remote HTTP/SSE/streamable-http server, and Grafana Cloud offers a hosted MCP endpoint, but the catalog intent is STDIO so the local uvx process is specified here.",
+        "research_notes": "QA PIN (2026-07-15): PyPI package mcp-grafana==0.17.2 is the official uvx wrapper for Grafana release v0.17.2 at public tag commit fac7c8a312c6f6aee8330de72182dcf45bf4ae26. The platform wheel SHA-256 was verified, the bundled Go binary reported v0.17.2, and an MCP initialize/list-tools probe returned 65 tools. The PyPI binary is built separately from the GitHub release archive, so the reproducible catalog control is the exact PyPI version rather than a direct Git SHA install. Authentication uses GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN.",
         "sources": [
           "https://github.com/grafana/mcp-grafana",
           "https://grafana.com/docs/grafana/latest/developer-resources/mcp/set-up/install-with-uvx/",

--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -83,7 +83,7 @@
             "stdio_command": "uvx",
             "stdio_args": [
               "--from",
-              "git+https://github.com/panther-labs/mcp-panther.git@7e6eca6f4f7f790057ed860bcfac669e13898d0c",
+              "mcp-panther==2.3.1",
               "mcp-panther"
             ],
             "stdio_env": [
@@ -96,10 +96,10 @@
                 "command": "uvx",
                 "args": [
                   "--from",
-                  "git+https://github.com/panther-labs/mcp-panther.git@7e6eca6f4f7f790057ed860bcfac669e13898d0c",
+                  "mcp-panther==2.3.1",
                   "mcp-panther"
                 ],
-                "package": "git+https://github.com/panther-labs/mcp-panther.git@7e6eca6f4f7f790057ed860bcfac669e13898d0c"
+                "package": "mcp-panther==2.3.1"
               }
             ],
             "credentials": [
@@ -213,7 +213,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/google/mcp-security.git@fde561ff33fb69a1565780bd5f141f4750cfc770#subdirectory=server/secops",
+          "google-secops-mcp==0.7.0",
           "secops_mcp"
         ],
         "stdio_env": [
@@ -228,10 +228,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/google/mcp-security.git@fde561ff33fb69a1565780bd5f141f4750cfc770#subdirectory=server/secops",
+              "google-secops-mcp==0.7.0",
               "secops_mcp"
             ],
-            "package": "git+https://github.com/google/mcp-security.git@fde561ff33fb69a1565780bd5f141f4750cfc770#subdirectory=server/secops"
+            "package": "google-secops-mcp==0.7.0"
           }
         ],
         "credentials": [
@@ -363,7 +363,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/ClickHouse/mcp-clickhouse.git@5645bc9c2931ccba3314c29927b10e6cfafc7323",
+          "mcp-clickhouse==0.4.0",
           "mcp-clickhouse"
         ],
         "stdio_env": [
@@ -382,10 +382,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/ClickHouse/mcp-clickhouse.git@5645bc9c2931ccba3314c29927b10e6cfafc7323",
+              "mcp-clickhouse==0.4.0",
               "mcp-clickhouse"
             ],
-            "package": "git+https://github.com/ClickHouse/mcp-clickhouse.git@5645bc9c2931ccba3314c29927b10e6cfafc7323"
+            "package": "mcp-clickhouse==0.4.0"
           }
         ],
         "credentials": [
@@ -466,7 +466,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/CrowdStrike/falcon-mcp.git@5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7",
+          "falcon-mcp==0.13.0",
           "falcon-mcp"
         ],
         "stdio_env": [
@@ -480,10 +480,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/CrowdStrike/falcon-mcp.git@5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7",
+              "falcon-mcp==0.13.0",
               "falcon-mcp"
             ],
-            "package": "git+https://github.com/CrowdStrike/falcon-mcp.git@5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7"
+            "package": "falcon-mcp==0.13.0"
           }
         ],
         "credentials": [
@@ -959,7 +959,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/google/mcp-security.git@2552eeb5d0056317e352579a666c746a659e0b49#subdirectory=server/gti",
+          "gti-mcp==0.1.2",
           "gti_mcp"
         ],
         "stdio_env": [
@@ -972,10 +972,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/google/mcp-security.git@2552eeb5d0056317e352579a666c746a659e0b49#subdirectory=server/gti",
+              "gti-mcp==0.1.2",
               "gti_mcp"
             ],
-            "package": "git+https://github.com/google/mcp-security.git@2552eeb5d0056317e352579a666c746a659e0b49#subdirectory=server/gti"
+            "package": "gti-mcp==0.1.2"
           }
         ],
         "credentials": [
@@ -1058,7 +1058,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/okta/okta-mcp-server.git@f9f6157f62d3d436bfbfce84ac20f198fcb94dde",
+          "okta-mcp-server==1.1.3",
           "okta-mcp-server"
         ],
         "stdio_env": [
@@ -1074,10 +1074,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/okta/okta-mcp-server.git@f9f6157f62d3d436bfbfce84ac20f198fcb94dde",
+              "okta-mcp-server==1.1.3",
               "okta-mcp-server"
             ],
-            "package": "git+https://github.com/okta/okta-mcp-server.git@f9f6157f62d3d436bfbfce84ac20f198fcb94dde"
+            "package": "okta-mcp-server==1.1.3"
           }
         ],
         "credentials": [
@@ -1130,7 +1130,7 @@
         ],
         "confidence": "high",
         "docker_only": false,
-        "research_notes": "QA PIN (2026-07-15): direct uvx installation and CLI launch were verified for Okta release v1.1.3 at commit f9f6157f62d3d436bfbfce84ac20f198fcb94dde. The catalog installs okta-mcp-server reproducibly from that public Git commit. Only the browserless Private Key JWT flow is supported: OKTA_ORG_URL, OKTA_CLIENT_ID, OKTA_PRIVATE_KEY, OKTA_KEY_ID, and OKTA_SCOPES are required. Store the PEM private key as a workspace secret and reference it from stdio_env.",
+        "research_notes": "QA PIN (2026-07-15): direct uvx installation and CLI launch were verified for Okta release v1.1.3 at commit f9f6157f62d3d436bfbfce84ac20f198fcb94dde. The catalog installs the exact official PyPI package okta-mcp-server==1.1.3. Only the browserless Private Key JWT flow is supported: OKTA_ORG_URL, OKTA_CLIENT_ID, OKTA_PRIVATE_KEY, OKTA_KEY_ID, and OKTA_SCOPES are required. Store the PEM private key as a workspace secret and reference it from stdio_env.",
         "sources": [
         "https://github.com/okta/okta-mcp-server",
         "https://raw.githubusercontent.com/okta/okta-mcp-server/main/README.md",
@@ -1160,7 +1160,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/aws/mcp-proxy-for-aws.git@9a3022410f88cf6a6800bf411504615dad1adf12",
+          "mcp-proxy-for-aws==1.6.3",
           "mcp-proxy-for-aws",
           "https://aws-mcp.us-east-1.api.aws/mcp",
           "--metadata",
@@ -1179,13 +1179,13 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/aws/mcp-proxy-for-aws.git@9a3022410f88cf6a6800bf411504615dad1adf12",
+              "mcp-proxy-for-aws==1.6.3",
               "mcp-proxy-for-aws",
               "https://aws-mcp.us-east-1.api.aws/mcp",
               "--metadata",
               "AWS_REGION=us-east-1"
             ],
-            "package": "git+https://github.com/aws/mcp-proxy-for-aws.git@9a3022410f88cf6a6800bf411504615dad1adf12"
+            "package": "mcp-proxy-for-aws==1.6.3"
           }
         ],
         "credentials": [
@@ -1273,7 +1273,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/zscaler/zscaler-mcp-server.git@23912913f8588c650b104d3bd30c0c755d6962cd",
+          "zscaler-mcp==0.13.1",
           "zscaler-mcp"
         ],
         "stdio_env": [
@@ -1290,10 +1290,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/zscaler/zscaler-mcp-server.git@23912913f8588c650b104d3bd30c0c755d6962cd",
+              "zscaler-mcp==0.13.1",
               "zscaler-mcp"
             ],
-            "package": "git+https://github.com/zscaler/zscaler-mcp-server.git@23912913f8588c650b104d3bd30c0c755d6962cd"
+            "package": "zscaler-mcp==0.13.1"
           }
         ],
         "credentials": [
@@ -1348,7 +1348,7 @@
         ],
         "confidence": "high",
         "docker_only": false,
-        "research_notes": "Official server: github.com/zscaler/zscaler-mcp-server; PyPI package `zscaler-mcp` (v0.12.3, MIT, alpha), console script `zscaler-mcp`, Python 3.11+. Canonical/recommended install is `uvx zscaler-mcp`; the docs MCP client config uses `command: uvx, args: [\"--env-file\", \"/path/.env\", \"zscaler-mcp\"]`. STDIO is the default transport (matches intended); the server can ALSO run as a remote HTTP server via `--transport streamable-http`/`sse` (default host 127.0.0.1:8000, path /mcp), but that is a self-hosted deployment with no fixed public URL, so server_uri is null.\n\nAuth: classified CUSTOM because the user supplies OneAPI credentials (client_id + client_secret, or a PEM private key for JWT, plus vanity domain and ZPA customer_id) as env vars. Under the hood the server performs a OneAPI OAuth2 client-credentials grant against the Zscaler ZIdentity token endpoint, but there is no interactive authorization-code/DCR browser flow for the MCP connection itself, so this is not OAUTH2 from a connection-spec perspective. (Separately, the HTTP transport offers optional Layer-2 MCP client auth modes — api-key/JWT/zscaler/OAuth 2.1 via ZSCALER_MCP_AUTH_* — but those gate the HTTP listener, not the STDIO upstream auth.)\n\npip package import module is `zscaler_mcp` (underscore); pip run shown as `python -m zscaler_mcp` though the primary entry point is the `zscaler-mcp` console script. Either ZSCALER_CLIENT_SECRET or ZSCALER_PRIVATE_KEY is required (one of the two). Docker image `zscaler/zscaler-mcp-server:latest` also exists but is not the only distribution, so docker_only=false.",
+        "research_notes": "Official server: github.com/zscaler/zscaler-mcp-server; PyPI package `zscaler-mcp` (v0.13.1, MIT, alpha), console script `zscaler-mcp`, Python 3.11+. Canonical/recommended install is `uvx zscaler-mcp`; the docs MCP client config uses `command: uvx, args: [\"--env-file\", \"/path/.env\", \"zscaler-mcp\"]`. STDIO is the default transport (matches intended); the server can ALSO run as a remote HTTP server via `--transport streamable-http`/`sse` (default host 127.0.0.1:8000, path /mcp), but that is a self-hosted deployment with no fixed public URL, so server_uri is null.\n\nAuth: classified CUSTOM because the user supplies OneAPI credentials (client_id + client_secret, or a PEM private key for JWT, plus vanity domain and ZPA customer_id) as env vars. Under the hood the server performs a OneAPI OAuth2 client-credentials grant against the Zscaler ZIdentity token endpoint, but there is no interactive authorization-code/DCR browser flow for the MCP connection itself, so this is not OAUTH2 from a connection-spec perspective. (Separately, the HTTP transport offers optional Layer-2 MCP client auth modes — api-key/JWT/zscaler/OAuth 2.1 via ZSCALER_MCP_AUTH_* — but those gate the HTTP listener, not the STDIO upstream auth.)\n\npip package import module is `zscaler_mcp` (underscore); pip run shown as `python -m zscaler_mcp` though the primary entry point is the `zscaler-mcp` console script. Either ZSCALER_CLIENT_SECRET or ZSCALER_PRIVATE_KEY is required (one of the two). Docker image `zscaler/zscaler-mcp-server:latest` also exists but is not the only distribution, so docker_only=false.",
         "sources": [
           "https://github.com/zscaler/zscaler-mcp-server",
           "https://github.com/zscaler/zscaler-mcp-server/blob/master/README.md",
@@ -1515,7 +1515,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/osomai/servicenow-mcp.git@06250607bdfc814f9bb56551bba16c3a7fb5a8c9",
+          "servicenow-mcp==0.1.1",
           "servicenow-mcp"
         ],
         "stdio_env": [
@@ -1535,10 +1535,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/osomai/servicenow-mcp.git@06250607bdfc814f9bb56551bba16c3a7fb5a8c9",
+              "servicenow-mcp==0.1.1",
               "servicenow-mcp"
             ],
-            "package": "git+https://github.com/osomai/servicenow-mcp.git@06250607bdfc814f9bb56551bba16c3a7fb5a8c9"
+            "package": "servicenow-mcp==0.1.1"
           }
         ],
         "credentials": [
@@ -1668,7 +1668,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/PagerDuty/pagerduty-mcp-server.git@62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4",
+          "pagerduty-mcp==1.1.0",
           "pagerduty-mcp"
         ],
         "stdio_env": [
@@ -1681,10 +1681,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/PagerDuty/pagerduty-mcp-server.git@62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4",
+              "pagerduty-mcp==1.1.0",
               "pagerduty-mcp"
             ],
-            "package": "git+https://github.com/PagerDuty/pagerduty-mcp-server.git@62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4"
+            "package": "pagerduty-mcp==1.1.0"
           }
         ],
         "credentials": [
@@ -1725,7 +1725,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/Rootly-AI-Labs/Rootly-MCP-server.git@f4f55a049dbee11c8321daf52e4d6d5e2ab4f806",
+          "rootly-mcp-server==2.3.9",
           "rootly-mcp-server"
         ],
         "stdio_env": [
@@ -1739,10 +1739,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/Rootly-AI-Labs/Rootly-MCP-server.git@f4f55a049dbee11c8321daf52e4d6d5e2ab4f806",
+              "rootly-mcp-server==2.3.9",
               "rootly-mcp-server"
             ],
-            "package": "git+https://github.com/Rootly-AI-Labs/Rootly-MCP-server.git@f4f55a049dbee11c8321daf52e4d6d5e2ab4f806"
+            "package": "rootly-mcp-server==2.3.9"
           }
         ],
         "credentials": [
@@ -1943,7 +1943,7 @@
         "stdio_command": "uvx",
         "stdio_args": [
           "--from",
-          "git+https://github.com/semgrep/mcp.git@6e340f843bf82a2f42de77125ae75cfd020abf9b",
+          "semgrep-mcp==0.9.0",
           "semgrep-mcp"
         ],
         "stdio_env": [
@@ -1955,10 +1955,10 @@
             "command": "uvx",
             "args": [
               "--from",
-              "git+https://github.com/semgrep/mcp.git@6e340f843bf82a2f42de77125ae75cfd020abf9b",
+              "semgrep-mcp==0.9.0",
               "semgrep-mcp"
             ],
-            "package": "git+https://github.com/semgrep/mcp.git@6e340f843bf82a2f42de77125ae75cfd020abf9b"
+            "package": "semgrep-mcp==0.9.0"
           }
         ],
         "credentials": [

--- a/tests/unit/test_mcp_catalog_loader.py
+++ b/tests/unit/test_mcp_catalog_loader.py
@@ -588,10 +588,9 @@ def test_private_catalog_overlay_does_not_drop_public_rows() -> None:
     for entry in public_entries:
         assert entry.slug in private_by_slug
 
-    terraform_spec = private_by_slug["terraform-mcp"].connection_spec
-    if terraform_spec is not None:
-        assert terraform_spec.server_type == "stdio"
-        assert terraform_spec.requires_config is True
+    terraform = private_by_slug["terraform-mcp"]
+    assert terraform.status == "coming_soon"
+    assert terraform.connection_spec is None
 
     # jamf-mcp defaults to Jamf's hosted no-auth HTTP server; the local
     # stdio (device management) option survives alongside it.

--- a/tests/unit/test_mcp_catalog_loader.py
+++ b/tests/unit/test_mcp_catalog_loader.py
@@ -588,9 +588,15 @@ def test_private_catalog_overlay_does_not_drop_public_rows() -> None:
     for entry in public_entries:
         assert entry.slug in private_by_slug
 
-    terraform = private_by_slug["terraform-mcp"]
-    assert terraform.status == "coming_soon"
-    assert terraform.connection_spec is None
+    for slug in (
+        "splunk-mcp",
+        "hashicorp-vault-mcp",
+        "palo-alto-mcp",
+        "terraform-mcp",
+    ):
+        coming_soon = private_by_slug[slug]
+        assert coming_soon.status == "coming_soon"
+        assert coming_soon.connection_spec is None
 
     # jamf-mcp defaults to Jamf's hosted no-auth HTTP server; the local
     # stdio (device management) option survives alongside it.

--- a/tests/unit/test_mcp_catalog_pins.py
+++ b/tests/unit/test_mcp_catalog_pins.py
@@ -24,11 +24,37 @@ QA_VERIFIED_STDIO_PINS = {
     "semgrep-mcp": "6e340f843bf82a2f42de77125ae75cfd020abf9b",
 }
 
+QA_VERIFIED_STDIO_PACKAGE_PINS = {
+    "greynoise-mcp": {
+        "manager": "npx",
+        "package": "@greynoise/greynoise-mcp-server@0.4.0",
+        "source_sha": "017bc228439be1672da60b3f49ef902d6311ea51",
+    },
+    "snyk-mcp": {
+        "manager": "npx",
+        "package": "snyk@1.1306.0",
+        "source_sha": "d4e9a98123a364a47b91770df8d86e2d31dcbc45",
+    },
+    "grafana-mcp": {
+        "manager": "uvx",
+        "package": "mcp-grafana==0.17.2",
+        "source_sha": "fac7c8a312c6f6aee8330de72182dcf45bf4ae26",
+    },
+}
+
 
 def _catalog_servers() -> dict[str, dict[str, Any]]:
     catalog_path = (
         Path(__file__).parents[2]
         / "packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json"
+    )
+    payload = orjson.loads(catalog_path.read_bytes())
+    return {server["slug"]: server for server in payload["servers"]}
+
+
+def _public_catalog_servers() -> dict[str, dict[str, Any]]:
+    catalog_path = (
+        Path(__file__).parents[2] / "tracecat/integrations/catalog/mcp_catalog.json"
     )
     payload = orjson.loads(catalog_path.read_bytes())
     return {server["slug"]: server for server in payload["servers"]}
@@ -58,3 +84,30 @@ def test_qa_verified_stdio_mcp_recipes_are_pinned_to_source_shas() -> None:
         assert all(package["manager"] == "uvx" for package in packages)
         assert all(sha in " ".join(package["args"]) for package in packages)
         assert all(sha in package["package"] for package in packages)
+
+
+def test_qa_verified_registry_mcp_recipes_are_pinned_to_exact_versions() -> None:
+    servers = _catalog_servers()
+
+    for slug, expected in QA_VERIFIED_STDIO_PACKAGE_PINS.items():
+        spec = _stdio_spec(servers[slug])
+        packages = spec["packages"]
+
+        assert len(packages) == 1
+        assert spec["stdio_command"] == expected["manager"]
+        assert expected["package"] in spec["stdio_args"]
+        assert packages[0]["manager"] == expected["manager"]
+        assert packages[0]["command"] == expected["manager"]
+        assert packages[0]["args"] == spec["stdio_args"]
+        assert packages[0]["package"] == expected["package"]
+        assert expected["source_sha"] in spec["research_notes"]
+
+
+def test_unavailable_qa_integrations_are_coming_soon_without_specs() -> None:
+    private_servers = _catalog_servers()
+    public_servers = _public_catalog_servers()
+
+    for slug in ("splunk-mcp", "hashicorp-vault-mcp", "palo-alto-mcp"):
+        assert public_servers[slug]["status"] == "coming_soon"
+        assert "connection_spec" not in private_servers[slug]
+        assert private_servers[slug]["research_notes"].startswith("Coming soon.")

--- a/tests/unit/test_mcp_catalog_pins.py
+++ b/tests/unit/test_mcp_catalog_pins.py
@@ -165,4 +165,4 @@ def test_unavailable_qa_integrations_are_coming_soon_without_specs() -> None:
     ):
         assert public_servers[slug]["status"] == "coming_soon"
         assert "connection_spec" not in private_servers[slug]
-        assert private_servers[slug]["research_notes"].startswith("Coming soon")
+        assert private_servers[slug]["_research"]["notes"].startswith("Coming soon")

--- a/tests/unit/test_mcp_catalog_pins.py
+++ b/tests/unit/test_mcp_catalog_pins.py
@@ -1,4 +1,4 @@
-"""Regression tests for QA-verified stdio MCP source pins."""
+"""Regression tests for QA-verified stdio MCP package pins."""
 
 from __future__ import annotations
 
@@ -7,24 +7,73 @@ from typing import Any
 
 import orjson
 
-QA_VERIFIED_STDIO_PINS = {
-    "panther-mcp": "7e6eca6f4f7f790057ed860bcfac669e13898d0c",
-    "google-cloud-secops-mcp": "fde561ff33fb69a1565780bd5f141f4750cfc770",
-    "clickhouse-mcp": "5645bc9c2931ccba3314c29927b10e6cfafc7323",
-    "crowdstrike-falcon-mcp": "5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7",
+QA_VERIFIED_STDIO_SOURCE_PINS = {
     "sentinelone-mcp": "07d4992089b10affff6163f296b1f6cb5734539f",
     "jamf-mcp": "53843c4da3ef666b70de1ee793fa9e8c432b9972",
-    "virustotal-mcp": "2552eeb5d0056317e352579a666c746a659e0b49",
-    "okta-mcp": "f9f6157f62d3d436bfbfce84ac20f198fcb94dde",
-    "aws-mcp": "9a3022410f88cf6a6800bf411504615dad1adf12",
-    "zscaler-mcp": "23912913f8588c650b104d3bd30c0c755d6962cd",
-    "servicenow-mcp": "06250607bdfc814f9bb56551bba16c3a7fb5a8c9",
-    "pagerduty-mcp": "62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4",
-    "rootly-mcp": "f4f55a049dbee11c8321daf52e4d6d5e2ab4f806",
-    "semgrep-mcp": "6e340f843bf82a2f42de77125ae75cfd020abf9b",
 }
 
+# Source SHAs retain the QA provenance; exact registry versions are the runtime pins.
 QA_VERIFIED_STDIO_PACKAGE_PINS = {
+    "panther-mcp": {
+        "manager": "uvx",
+        "package": "mcp-panther==2.3.1",
+        "source_sha": "7e6eca6f4f7f790057ed860bcfac669e13898d0c",
+    },
+    "google-cloud-secops-mcp": {
+        "manager": "uvx",
+        "package": "google-secops-mcp==0.7.0",
+        "source_sha": "fde561ff33fb69a1565780bd5f141f4750cfc770",
+    },
+    "clickhouse-mcp": {
+        "manager": "uvx",
+        "package": "mcp-clickhouse==0.4.0",
+        "source_sha": "5645bc9c2931ccba3314c29927b10e6cfafc7323",
+    },
+    "crowdstrike-falcon-mcp": {
+        "manager": "uvx",
+        "package": "falcon-mcp==0.13.0",
+        "source_sha": "5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7",
+    },
+    "virustotal-mcp": {
+        "manager": "uvx",
+        "package": "gti-mcp==0.1.2",
+        "source_sha": "2552eeb5d0056317e352579a666c746a659e0b49",
+    },
+    "okta-mcp": {
+        "manager": "uvx",
+        "package": "okta-mcp-server==1.1.3",
+        "source_sha": "f9f6157f62d3d436bfbfce84ac20f198fcb94dde",
+    },
+    "aws-mcp": {
+        "manager": "uvx",
+        "package": "mcp-proxy-for-aws==1.6.3",
+        "source_sha": "9a3022410f88cf6a6800bf411504615dad1adf12",
+    },
+    "zscaler-mcp": {
+        "manager": "uvx",
+        "package": "zscaler-mcp==0.13.1",
+        "source_sha": "23912913f8588c650b104d3bd30c0c755d6962cd",
+    },
+    "servicenow-mcp": {
+        "manager": "uvx",
+        "package": "servicenow-mcp==0.1.1",
+        "source_sha": "06250607bdfc814f9bb56551bba16c3a7fb5a8c9",
+    },
+    "pagerduty-mcp": {
+        "manager": "uvx",
+        "package": "pagerduty-mcp==1.1.0",
+        "source_sha": "62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4",
+    },
+    "rootly-mcp": {
+        "manager": "uvx",
+        "package": "rootly-mcp-server==2.3.9",
+        "source_sha": "f4f55a049dbee11c8321daf52e4d6d5e2ab4f806",
+    },
+    "semgrep-mcp": {
+        "manager": "uvx",
+        "package": "semgrep-mcp==0.9.0",
+        "source_sha": "6e340f843bf82a2f42de77125ae75cfd020abf9b",
+    },
     "greynoise-mcp": {
         "manager": "npx",
         "package": "@greynoise/greynoise-mcp-server@0.4.0",
@@ -74,7 +123,7 @@ def _stdio_spec(server: dict[str, Any]) -> dict[str, Any]:
 def test_qa_verified_stdio_mcp_recipes_are_pinned_to_source_shas() -> None:
     servers = _catalog_servers()
 
-    for slug, sha in QA_VERIFIED_STDIO_PINS.items():
+    for slug, sha in QA_VERIFIED_STDIO_SOURCE_PINS.items():
         spec = _stdio_spec(servers[slug])
         packages = spec["packages"]
 
@@ -100,14 +149,20 @@ def test_qa_verified_registry_mcp_recipes_are_pinned_to_exact_versions() -> None
         assert packages[0]["command"] == expected["manager"]
         assert packages[0]["args"] == spec["stdio_args"]
         assert packages[0]["package"] == expected["package"]
-        assert expected["source_sha"] in spec["research_notes"]
+        assert len(expected["source_sha"]) == 40
+        assert set(expected["source_sha"]) <= set("0123456789abcdef")
 
 
 def test_unavailable_qa_integrations_are_coming_soon_without_specs() -> None:
     private_servers = _catalog_servers()
     public_servers = _public_catalog_servers()
 
-    for slug in ("splunk-mcp", "hashicorp-vault-mcp", "palo-alto-mcp"):
+    for slug in (
+        "splunk-mcp",
+        "hashicorp-vault-mcp",
+        "palo-alto-mcp",
+        "terraform-mcp",
+    ):
         assert public_servers[slug]["status"] == "coming_soon"
         assert "connection_spec" not in private_servers[slug]
-        assert private_servers[slug]["research_notes"].startswith("Coming soon.")
+        assert private_servers[slug]["research_notes"].startswith("Coming soon")

--- a/tests/unit/test_mcp_catalog_pins.py
+++ b/tests/unit/test_mcp_catalog_pins.py
@@ -1,0 +1,60 @@
+"""Regression tests for QA-verified stdio MCP source pins."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import orjson
+
+QA_VERIFIED_STDIO_PINS = {
+    "panther-mcp": "7e6eca6f4f7f790057ed860bcfac669e13898d0c",
+    "google-cloud-secops-mcp": "fde561ff33fb69a1565780bd5f141f4750cfc770",
+    "clickhouse-mcp": "5645bc9c2931ccba3314c29927b10e6cfafc7323",
+    "crowdstrike-falcon-mcp": "5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7",
+    "sentinelone-mcp": "07d4992089b10affff6163f296b1f6cb5734539f",
+    "jamf-mcp": "53843c4da3ef666b70de1ee793fa9e8c432b9972",
+    "virustotal-mcp": "2552eeb5d0056317e352579a666c746a659e0b49",
+    "okta-mcp": "f9f6157f62d3d436bfbfce84ac20f198fcb94dde",
+    "aws-mcp": "9a3022410f88cf6a6800bf411504615dad1adf12",
+    "zscaler-mcp": "23912913f8588c650b104d3bd30c0c755d6962cd",
+    "servicenow-mcp": "06250607bdfc814f9bb56551bba16c3a7fb5a8c9",
+    "pagerduty-mcp": "62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4",
+    "rootly-mcp": "f4f55a049dbee11c8321daf52e4d6d5e2ab4f806",
+    "semgrep-mcp": "6e340f843bf82a2f42de77125ae75cfd020abf9b",
+}
+
+
+def _catalog_servers() -> dict[str, dict[str, Any]]:
+    catalog_path = (
+        Path(__file__).parents[2]
+        / "packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json"
+    )
+    payload = orjson.loads(catalog_path.read_bytes())
+    return {server["slug"]: server for server in payload["servers"]}
+
+
+def _stdio_spec(server: dict[str, Any]) -> dict[str, Any]:
+    if (spec := server.get("connection_spec")) and spec.get("server_type") == "stdio":
+        return spec
+    for option in server.get("connection_options", []):
+        if (spec := option.get("connection_spec")) and spec.get(
+            "server_type"
+        ) == "stdio":
+            return spec
+    raise AssertionError(f"No stdio connection spec found for {server['slug']}")
+
+
+def test_qa_verified_stdio_mcp_recipes_are_pinned_to_source_shas() -> None:
+    servers = _catalog_servers()
+
+    for slug, sha in QA_VERIFIED_STDIO_PINS.items():
+        spec = _stdio_spec(servers[slug])
+        packages = spec["packages"]
+
+        assert spec["stdio_command"] == "uvx"
+        assert sha in " ".join(spec["stdio_args"])
+        assert packages
+        assert all(package["manager"] == "uvx" for package in packages)
+        assert all(sha in " ".join(package["args"]) for package in packages)
+        assert all(sha in package["package"] for package in packages)

--- a/tracecat/integrations/catalog/mcp_catalog.json
+++ b/tracecat/integrations/catalog/mcp_catalog.json
@@ -356,6 +356,7 @@
       "name": "Terraform",
       "description": "Plan and apply infrastructure changes with Terraform",
       "category": "IaC",
+      "status": "coming_soon",
       "icon": "https://cdn.simpleicons.org/terraform"
     },
     {

--- a/tracecat/integrations/catalog/mcp_catalog.json
+++ b/tracecat/integrations/catalog/mcp_catalog.json
@@ -19,6 +19,7 @@
       "name": "Splunk",
       "description": "Search indexes and triage events on Splunk (Cloud or on-prem)",
       "category": "SIEM / Datalake",
+      "status": "coming_soon",
       "icon": "https://www.google.com/s2/favicons?domain=help.splunk.com&sz=128"
     },
     {
@@ -167,6 +168,7 @@
       "name": "HashiCorp Vault",
       "description": "Read mounts, KV secrets, and PKI from HashiCorp Vault",
       "category": "Identity",
+      "status": "coming_soon",
       "icon": "https://cdn.simpleicons.org/vault"
     },
     {
@@ -195,6 +197,7 @@
       "name": "Palo Alto Networks",
       "description": "Investigate incidents and assets on Cortex XSIAM and XDR",
       "category": "Network",
+      "status": "coming_soon",
       "icon": "https://cdn.simpleicons.org/paloaltonetworks"
     },
     {


### PR DESCRIPTION
## Summary

- prefer exact official PyPI/npm versions for QA-verified stdio MCP integrations
- retain immutable Git SHA installs only for SentinelOne and Jamf, which have no valid registry package
- mark Terraform, Splunk, HashiCorp Vault, and Palo Alto as coming soon because no supported catalog launcher currently produces a working integration
- add regression coverage for the approved registry-version and source-SHA pins

## Pin policy

Exact registry versions are preferred when the official published artifact is runnable. PyPI and npm validate the downloaded artifact's integrity, while the published wheel or tarball is usually smaller and more directly executable than a Git checkout. The exact version is also easier for operators to recognize and audit.

Git SHAs remain the fallback when no trustworthy registry artifact exists and the public source tree can be launched directly. The catalog never uses `latest` or another floating version.

## QA-verified integrations

The source commit records the public release or source revision used during QA. The runtime pin is what the catalog installs.

| Integration | Catalog runtime pin | QA source commit |
| --- | --- | --- |
| Panther (`panther-mcp`) | `mcp-panther==2.3.1` | `7e6eca6f4f7f790057ed860bcfac669e13898d0c` |
| Google Cloud SecOps (`google-cloud-secops-mcp`) | `google-secops-mcp==0.7.0` | `fde561ff33fb69a1565780bd5f141f4750cfc770` |
| ClickHouse (`clickhouse-mcp`) | `mcp-clickhouse==0.4.0` | `5645bc9c2931ccba3314c29927b10e6cfafc7323` |
| CrowdStrike Falcon (`crowdstrike-falcon-mcp`) | `falcon-mcp==0.13.0` | `5f6c0581e8f941a3a05ad884c4ae667b85b8f6b7` |
| SentinelOne Purple (`sentinelone-mcp`) | Git SHA `07d4992089b10affff6163f296b1f6cb5734539f` | `07d4992089b10affff6163f296b1f6cb5734539f` |
| Jamf (`jamf-mcp`) | Git SHA `53843c4da3ef666b70de1ee793fa9e8c432b9972` | `53843c4da3ef666b70de1ee793fa9e8c432b9972` |
| GreyNoise (`greynoise-mcp`) | `@greynoise/greynoise-mcp-server@0.4.0` | `017bc228439be1672da60b3f49ef902d6311ea51` |
| VirusTotal / GTI (`virustotal-mcp`) | `gti-mcp==0.1.2` | `2552eeb5d0056317e352579a666c746a659e0b49` |
| Okta (`okta-mcp`) | `okta-mcp-server==1.1.3` | `f9f6157f62d3d436bfbfce84ac20f198fcb94dde` |
| AWS MCP proxy (`aws-mcp`) | `mcp-proxy-for-aws==1.6.3` | `9a3022410f88cf6a6800bf411504615dad1adf12` |
| Zscaler (`zscaler-mcp`) | `zscaler-mcp==0.13.1` | `23912913f8588c650b104d3bd30c0c755d6962cd` |
| Snyk (`snyk-mcp`) | `snyk@1.1306.0` | `d4e9a98123a364a47b91770df8d86e2d31dcbc45` |
| ServiceNow community server (`servicenow-mcp`) | `servicenow-mcp==0.1.1` | `06250607bdfc814f9bb56551bba16c3a7fb5a8c9` |
| PagerDuty (`pagerduty-mcp`) | `pagerduty-mcp==1.1.0` | `62c806c98c90ac13de92d8b1ad7b4aa3ecc366c4` |
| Rootly (`rootly-mcp`) | `rootly-mcp-server==2.3.9` | `f4f55a049dbee11c8321daf52e4d6d5e2ab4f806` |
| Semgrep (`semgrep-mcp`) | `semgrep-mcp==0.9.0` | `6e340f843bf82a2f42de77125ae75cfd020abf9b` |
| Grafana (`grafana-mcp`) | `mcp-grafana==0.17.2` | `fac7c8a312c6f6aee8330de72182dcf45bf4ae26` |

## Coming soon

| Integration | Reason |
| --- | --- |
| Terraform | The public implementation is Go; `go` and Docker are not permitted catalog launchers. |
| Splunk | The public Python distribution omits `guardrails.py` and fails during import. |
| HashiCorp Vault | The public implementation is Go; `go` and Docker are not permitted catalog launchers. |
| Palo Alto | No publicly installable source or registry package is available. |

## Impact

Catalog-created integrations now resolve to human-readable, immutable registry releases where possible. Published build output is used directly, avoiding Git-source failures where generated files are absent. SentinelOne and Jamf remain reproducible through full source commit pins.

## Validation

- installed and launched all 12 newly selected exact PyPI artifacts through their packaged entrypoints
- Okta and ServiceNow reached their expected missing-credential checks during credential-free smoke testing
- `uv run pytest tests/unit/test_mcp_catalog_pins.py tests/unit/test_mcp_catalog_loader.py` — 17 passed
- `uv run ruff check tests/unit/test_mcp_catalog_pins.py`
- `uv run ruff format --check tests/unit/test_mcp_catalog_pins.py`
- `jq empty packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json`
- `git diff --check`
- repository pre-commit suite — passed
- removed temporary uv/npx QA artifacts after testing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned stdio MCP catalog installs to exact, reproducible versions and marked unsupported vendors as coming soon. Also grouped catalog research notes under `_research` and added tests to enforce pins, gating, and metadata.

- **Refactors**
  - Use exact PyPI/npm pins via `uvx`/`npx`; only `sentinelone-mcp` and `jamf-mcp` use Git SHAs.
  - Switch Okta to `okta-mcp-server==1.1.3`; launch Jamf via `uvx --from git+…@<sha> jamf-mcp`.
  - Drop all `pip`/`python` fallbacks; each server has a single pinned package/command.
  - Gate `splunk-mcp`, `hashicorp-vault-mcp`, `palo-alto-mcp`, and `terraform-mcp` as `coming_soon` in public, and remove their `connection_spec` from private.
  - Group catalog research metadata under `_research`; add regression tests for exact pins, Git SHAs, `coming_soon` gating, and `_research` structure.
  - Notable pins: `mcp-panther==2.3.1`, `mcp-clickhouse==0.4.0`, `falcon-mcp==0.13.0`, `google-secops-mcp==0.7.0`, `gti-mcp==0.1.2`, `servicenow-mcp==0.1.1`, `pagerduty-mcp==1.1.0`, `rootly-mcp-server==2.3.9`, `semgrep-mcp==0.9.0`, `zscaler-mcp==0.13.1`, `@greynoise/greynoise-mcp-server@0.4.0`, `snyk@1.1306.0`, `mcp-proxy-for-aws==1.6.3`, `mcp-grafana==0.17.2`.

<sup>Written for commit 8f365028bfc8465574f070fad07a7f210f2c7031. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

