### PR TITLE
chore(sync): add workspace export diagnostics

### DIFF
--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -19,12 +19,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import yaml
+from cryptography.fernet import Fernet
 from pydantic import SecretStr, ValidationError
 from pydantic_core import PydanticSerializationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.support.fake_vcs import FakeVcsServer
+from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import (
@@ -832,6 +834,73 @@ async def test_project_workspace_exports_supported_non_workflow_resources(
     assert parent_version["instructions"] == (
         "Use the enrichment skill and escalate high severity."
     )
+
+
+@pytest.mark.anyio
+async def test_large_agent_preset_workspace_preview_matches_export(
+    session: AsyncSession,
+    svc_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__DB_ENCRYPTION_KEY",
+        Fernet.generate_key().decode(),
+    )
+    repo_url = "git+ssh://git@github.com/TracecatHQ/large-workspace-sync-test.git"
+    git_url = GitUrl(
+        host="github.com",
+        org="TracecatHQ",
+        repo="large-workspace-sync-test",
+    )
+    fake_vcs = FakeVcsServer()
+    assert svc_role.workspace_id is not None
+    await _set_workspace_git_repo_url(
+        session,
+        workspace_id=svc_role.workspace_id,
+        repo_url=repo_url,
+    )
+    service = WorkspaceSyncService(
+        session=session,
+        role=svc_role,
+        transport_factory=fake_vcs.transport_factory,
+    )
+    source_files = _large_agent_preset_git_tree()
+    snapshot, diagnostics = await service.parse_files(
+        source_files,
+        commit_sha="7" * 40,
+    )
+    assert diagnostics == []
+    imported = await WorkspaceResourceImportService(
+        session=session,
+        role=svc_role,
+    ).import_non_workflow_resources(snapshot.spec)
+    assert (
+        sum(
+            resource.resource_type is SyncResourceType.AGENT_PRESET
+            for resource in imported
+        )
+        == 37
+    )
+
+    preview = await service.preview_export_workspace(
+        WorkspaceSyncExportPreviewRequest()
+    )
+    export = await service.export_workspace(
+        WorkspaceSyncExportRequest(
+            message="Export generated large workspace",
+            branch="sync/large-workspace",
+            create_pr=False,
+        )
+    )
+
+    expected_paths = set(source_files)
+    assert preview.resource_counts[SyncResourceType.AGENT_PRESET.value] == 37
+    assert len(expected_paths) == 75
+    assert set(preview.files) == expected_paths
+    assert set(export.files) == expected_paths
+    assert export.commit.sha is not None
+    assert set(fake_vcs.repo_files(git_url, ref=export.commit.sha)) == expected_paths
 
 
 @pytest.mark.anyio
@@ -6684,6 +6753,35 @@ def _expanded_full_git_tree(*, include_schedules: bool) -> dict[str, str]:
             }
         ),
     }
+    return dict(sorted(files.items()))
+
+
+def _large_agent_preset_git_tree() -> dict[str, str]:
+    files = {MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())}
+    for index in range(37):
+        source_id = f"generated-agent-{index:02d}"
+        name = f"Generated agent {index:02d}"
+        files[f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml"] = _yaml(
+            {
+                "version": 1,
+                "type": "agent_preset",
+                "id": source_id,
+                "slug": source_id,
+                "name": name,
+                "current_version": 1,
+            }
+        )
+        files[f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml"] = _yaml(
+            {
+                "version": 1,
+                "type": "agent_preset_version",
+                "version_number": 1,
+                "name": name,
+                "instructions": f"Handle generated test workload {index:02d}.",
+                "skills": [],
+                "subagents": [],
+            }
+        )
     return dict(sorted(files.items()))
 
 

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -26,6 +26,7 @@ from tracecat.exceptions import (
 from tracecat.git.types import GitUrl
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.sync import CommitInfo, PullOptions, PushStatus
+from tracecat.vcs.github.app import GitHubAppError
 from tracecat.workflow.store.schemas import RemoteCaseTrigger, RemoteWorkflowSchedule
 from tracecat.workspace_sync.adapters import (
     SECRET_METADATA_RESOURCE_ADAPTER,
@@ -1705,6 +1706,48 @@ async def test_github_write_files_uses_tree_sha_for_stale_path_scan(
 
 
 @pytest.mark.anyio
+async def test_github_write_files_logs_rate_limit_response_headers(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    sync_logger = Mock()
+    repo = _FakeGitHubRepo(
+        files={},
+        branch_exists=True,
+        ahead_by=0,
+        contents_error=GithubException(
+            status=403,
+            data={"message": "Request blocked"},
+            headers={
+                "X-GitHub-Request-Id": "request-id",
+                "Retry-After": "60",
+                "X-RateLimit-Remaining": "4999",
+                "X-RateLimit-Resource": "core",
+            },
+        ),
+    )
+
+    with pytest.raises(GitHubAppError):
+        await _write_files_with_fake_repo(
+            repo,
+            service=workspace_sync_service,
+            files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+            logger=sync_logger,
+        )
+
+    error_log = sync_logger.error.call_args
+    assert error_log.args == ("GitHub workspace sync request failed",)
+    assert error_log.kwargs["stage"] == "compare_projected_files"
+    assert error_log.kwargs["github_endpoint"].endswith("/contents/{path}")
+    assert error_log.kwargs["github_status"] == 403
+    assert error_log.kwargs["github_request_id"] == "request-id"
+    assert error_log.kwargs["github_retry_after"] == "60"
+    assert error_log.kwargs["github_rate_limit_headers"] == {
+        "x-ratelimit-remaining": "4999",
+        "x-ratelimit-resource": "core",
+    }
+
+
+@pytest.mark.anyio
 async def test_github_read_files_uses_commit_tree_sha(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:
@@ -1799,6 +1842,7 @@ async def _write_files_with_fake_repo(
     branch: str = "sync/agents-1",
     create_pr: bool = True,
     delete_missing_paths_under: tuple[str, ...] = (),
+    logger: Mock | None = None,
 ):
     gh = Mock()
     gh.get_repo.return_value = repo
@@ -1810,6 +1854,8 @@ async def _write_files_with_fake_repo(
         session=service.session,
         role=service.role,
     )
+    if logger is not None:
+        transport.logger = logger
     with patch(
         "tracecat.workspace_sync.transport.GitHubAppService",
         return_value=gh_service,
@@ -1834,11 +1880,13 @@ class _FakeGitHubRepo:
         branch_exists: bool,
         ahead_by: int,
         existing_pr: object | None = None,
+        contents_error: GithubException | None = None,
     ) -> None:
         self._files = files
         self._branch_exists = branch_exists
         self._ahead_by = ahead_by
         self._existing_pr = existing_pr
+        self._contents_error = contents_error
         self.created_refs: list[tuple[str, str]] = []
         self.compare_calls: list[tuple[str, str]] = []
         self.create_pull = Mock(
@@ -1862,6 +1910,8 @@ class _FakeGitHubRepo:
         self._branch_exists = True
 
     def get_contents(self, path: str, *, ref: str):
+        if self._contents_error is not None:
+            raise self._contents_error
         if path not in self._files:
             raise GithubException(status=404, data={"message": "Not Found"})
         encoded = base64.b64encode(self._files[path].encode()).decode()
@@ -1887,7 +1937,11 @@ class _FakeGitHubRepo:
         return SimpleNamespace(sha=f"blob-{len(self.blobs)}")
 
     def create_git_tree(self, elements: list[object], *, base_tree: object):
-        tree = SimpleNamespace(elements=elements, base_tree=base_tree)
+        tree = SimpleNamespace(
+            sha=f"tree-{len(self.trees) + 1}",
+            elements=elements,
+            base_tree=base_tree,
+        )
         self.trees.append(tree)
         return tree
 

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -1706,6 +1706,51 @@ async def test_github_write_files_uses_tree_sha_for_stale_path_scan(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("unchanged_file_count", "expected_tree_entry_count"),
+    [
+        pytest.param(0, 807, id="all_files_changed"),
+        pytest.param(657, 150, id="only_150_files_changed"),
+    ],
+)
+async def test_github_write_files_builds_complete_tree_delta_for_large_projection(
+    workspace_sync_service: WorkspaceSyncService,
+    unchanged_file_count: int,
+    expected_tree_entry_count: int,
+) -> None:
+    files = {
+        f"workflows/generated-{index:04d}/definition.yml": (
+            f"version: 1\nid: generated-{index:04d}\n"
+        )
+        for index in range(806)
+    }
+    files[MANIFEST_FILENAME] = canonical_json_text(WorkspaceManifest())
+    unchanged_paths = set(sorted(files)[:unchanged_file_count])
+    repo = _FakeGitHubRepo(
+        files={path: files[path] for path in unchanged_paths},
+        branch_exists=True,
+        ahead_by=0,
+    )
+
+    result = await _write_files_with_fake_repo(
+        repo,
+        service=workspace_sync_service,
+        files=files,
+        create_pr=False,
+    )
+
+    expected_changed_paths = set(files) - unchanged_paths
+    assert result.status is PushStatus.COMMITTED
+    assert len(files) == 807
+    assert len(expected_changed_paths) == expected_tree_entry_count
+    assert len(repo.blobs) == expected_tree_entry_count
+    assert len(repo.trees) == 1
+    assert {
+        cast(Any, element)._identity["path"] for element in repo.trees[0].elements
+    } == expected_changed_paths
+
+
+@pytest.mark.anyio
 async def test_github_write_files_logs_rate_limit_response_headers(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:
@@ -1896,7 +1941,7 @@ class _FakeGitHubRepo:
             )
         )
         self.blobs: list[tuple[str, str]] = []
-        self.trees: list[object] = []
+        self.trees: list[SimpleNamespace] = []
         self.commits: list[object] = []
         self.get_git_tree_calls: list[str] = []
 

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -216,6 +216,13 @@ class WorkspaceSyncService(SyncMappingService):
             include_schedules=params.include_schedules,
             create_missing_mappings=True,
         )
+        self.logger.info(
+            "Projected workspace sync export",
+            operation="export",
+            full_workspace_export=resource_ids is None,
+            projected_file_count=len(projection.files),
+            projected_resource_counts=projection.spec.resource_count_map(),
+        )
         self._require_projected_export_scopes(projection.spec)
         self._validate_projected_workspace_dependencies(projection.spec)
         delete_missing_paths_under = await self._export_delete_roots(
@@ -256,6 +263,13 @@ class WorkspaceSyncService(SyncMappingService):
             resource_ids=resource_ids,
             include_schedules=params.include_schedules,
             create_missing_mappings=False,
+        )
+        self.logger.info(
+            "Projected workspace sync export",
+            operation="preview",
+            full_workspace_export=resource_ids is None,
+            projected_file_count=len(projection.files),
+            projected_resource_counts=projection.spec.resource_count_map(),
         )
         self._require_projected_export_scopes(projection.spec)
         self._validate_projected_workspace_dependencies(projection.spec)

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -12,6 +12,7 @@ from typing import Any, Protocol
 from urllib.parse import quote, urlparse
 
 import httpx
+import orjson
 from github.GithubException import GithubException
 from github.InputGitTreeElement import InputGitTreeElement
 from pydantic import BaseModel
@@ -161,6 +162,15 @@ def _path_is_under_roots(path: str, roots: Sequence[str]) -> bool:
 
 _GITHUB_BLOB_CONCURRENCY = 8
 """Maximum concurrent GitHub blob/content calls during sync reads and writes."""
+
+_GITHUB_RATE_LIMIT_HEADER_NAMES = (
+    "x-ratelimit-limit",
+    "x-ratelimit-remaining",
+    "x-ratelimit-used",
+    "x-ratelimit-reset",
+    "x-ratelimit-resource",
+)
+"""GitHub response headers retained in structured exporter error logs."""
 
 _GITLAB_PAGE_SIZE = 100
 """GitLab REST page size used for workspace sync reads."""
@@ -342,6 +352,8 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
 
         gh_svc = GitHubAppService(session=self.session, role=self.role)
         gh = await gh_svc.get_github_client_for_repo(url)
+        github_stage = "prepare_branch"
+        github_endpoint = "GET|POST /repos/{owner}/{repo}/branches|git/refs"
         try:
             repo = await asyncio.to_thread(gh.get_repo, f"{url.org}/{url.repo}")
             base_branch_name = pr_base_branch or url.ref or repo.default_branch
@@ -386,6 +398,8 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     return path, content
                 return None
 
+            github_stage = "compare_projected_files"
+            github_endpoint = "GET /repos/{owner}/{repo}/contents/{path}"
             changed_file_entries = await asyncio.gather(
                 *(
                     changed_file(path, content)
@@ -399,10 +413,14 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 for path, content in (entry,)
             }
 
+            github_stage = "resolve_target_commit"
+            github_endpoint = "GET /repos/{owner}/{repo}/git/commits/{sha}"
             target_commit = await asyncio.to_thread(
                 repo.get_git_commit,
                 target_branch.commit.sha,
             )
+            github_stage = "scan_stale_paths"
+            github_endpoint = "GET /repos/{owner}/{repo}/git/trees/{sha}"
             stale_paths = await self._stale_paths_under_roots(
                 repo=repo,
                 tree_sha=target_commit.tree.sha,
@@ -413,7 +431,14 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             pr_url: str | None = None
             pr_number: int | None = None
             pr_reused = False
+            self.logger.info(
+                "Prepared GitHub workspace sync changes",
+                changed_file_count=len(changed_files),
+                deleted_file_count=len(stale_paths),
+            )
             if not changed_files and not stale_paths:
+                github_stage = "reuse_pull_request"
+                github_endpoint = "GET|POST /repos/{owner}/{repo}/compare|pulls"
                 branch_has_commits = await self._branch_has_commits_between(
                     repo=repo,
                     base_branch_name=base_branch_name,
@@ -458,6 +483,8 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     sha=blob.sha,
                 )
 
+            github_stage = "create_blobs"
+            github_endpoint = "POST /repos/{owner}/{repo}/git/blobs"
             elements = list(
                 await asyncio.gather(
                     *(
@@ -466,21 +493,33 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     )
                 )
             )
-            for path in sorted(stale_paths):
-                elements.append(
-                    InputGitTreeElement(
-                        path=path,
-                        mode="100644",
-                        type="blob",
-                        sha=None,
-                    )
+            elements.extend(
+                InputGitTreeElement(path=path, mode="100644", type="blob", sha=None)
+                for path in sorted(stale_paths)
+            )
+            tree_payload_size_bytes = len(
+                orjson.dumps(
+                    {
+                        "base_tree": target_commit.tree.sha,
+                        "tree": [element._identity for element in elements],
+                    }
                 )
+            )
 
+            self.logger.info(
+                "Creating GitHub workspace sync tree",
+                tree_entry_count=len(elements),
+                tree_payload_size_bytes=tree_payload_size_bytes,
+            )
+            github_stage = "create_tree"
+            github_endpoint = "POST /repos/{owner}/{repo}/git/trees"
             tree = await asyncio.to_thread(
                 repo.create_git_tree,
                 elements,
                 base_tree=target_commit.tree,
             )
+            github_stage = "finalize_commit"
+            github_endpoint = "POST|PATCH /repos/{owner}/{repo}/git/commits|refs"
             commit = await asyncio.to_thread(
                 repo.create_git_commit,
                 message,
@@ -489,6 +528,12 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             )
             ref = await asyncio.to_thread(repo.get_git_ref, f"heads/{branch}")
             await asyncio.to_thread(ref.edit, sha=commit.sha)
+            self.logger.info(
+                "Updated GitHub workspace sync ref",
+                tree_sha=tree.sha,
+                commit_sha=commit.sha,
+                ref=branch,
+            )
 
             if create_pr:
                 pr_url, pr_number, pr_reused = await self._upsert_pull_request(
@@ -510,6 +555,20 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 message="Committed workspace sync changes.",
             )
         except GithubException as e:
+            headers = {key.lower(): value for key, value in (e.headers or {}).items()}
+            self.logger.error(
+                "GitHub workspace sync request failed",
+                stage=github_stage,
+                github_endpoint=github_endpoint,
+                github_status=e.status,
+                github_request_id=headers.get("x-github-request-id"),
+                github_retry_after=headers.get("retry-after"),
+                github_rate_limit_headers={
+                    name: headers[name]
+                    for name in _GITHUB_RATE_LIMIT_HEADER_NAMES
+                    if name in headers
+                },
+            )
             raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
         finally:
             gh.close()

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -352,10 +352,12 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
 
         gh_svc = GitHubAppService(session=self.session, role=self.role)
         gh = await gh_svc.get_github_client_for_repo(url)
-        github_stage = "prepare_branch"
-        github_endpoint = "GET|POST /repos/{owner}/{repo}/branches|git/refs"
+        github_stage = "resolve_repository"
+        github_endpoint = "GET /repos/{owner}/{repo}"
         try:
             repo = await asyncio.to_thread(gh.get_repo, f"{url.org}/{url.repo}")
+            github_stage = "prepare_branch"
+            github_endpoint = "GET|POST /repos/{owner}/{repo}/branches|git/refs"
             base_branch_name = pr_base_branch or url.ref or repo.default_branch
             if create_pr and branch == base_branch_name:
                 raise TracecatValidationError(
@@ -536,6 +538,8 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             )
 
             if create_pr:
+                github_stage = "upsert_pull_request"
+                github_endpoint = "GET|POST /repos/{owner}/{repo}/pulls"
                 pr_url, pr_number, pr_reused = await self._upsert_pull_request(
                     repo=repo,
                     url=url,


### PR DESCRIPTION
## Summary

- log preview and export projection counts without resource names or paths
- log changed/deleted counts, Git tree entry count, and tree payload size
- retain the failing GitHub stage, endpoint, request ID, retry guidance, and rate-limit headers
- log the resulting tree, commit, and branch ref after a successful update
- reproduce full-workspace projection with 37 generated presets
- verify 807 projected files produce either 807 or 150 complete tree entries depending on the target branch contents

## Why

Workspace export failures currently wrap GitHub errors without enough context to distinguish a projection discrepancy from a content-read, blob-write, or tree-creation failure. Large exports also lack the counts needed to evaluate GitHub timeout and secondary-rate-limit responses.

## Impact

Future workspace export investigations can correlate preview and export projections with the exact GitHub write stage while keeping customer resource names and paths out of logs. The regression coverage confirms that preview and export retain all 37 generated presets and that the GitHub transport does not drop entries from large tree deltas.

## Validation

- `uv run pytest tests/unit/test_workspace_sync_service.py tests/unit/test_workspace_sync_acceptance_contract.py -q` (132 passed)
- `uv run ruff check tests/unit/test_workspace_sync_service.py tests/unit/test_workspace_sync_acceptance_contract.py`
- `uv run ruff format --check tests/unit/test_workspace_sync_service.py tests/unit/test_workspace_sync_acceptance_contract.py`
- `uv run basedpyright tests/unit/test_workspace_sync_service.py tests/unit/test_workspace_sync_acceptance_contract.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured diagnostics for workspace export and GitHub write stages to improve debuggability during large syncs, without logging customer names or paths. Also labels repo lookup and PR upsert stages so failures are attributed correctly.

- **New Features**
  - Log projected export details: file count and per-resource counts.
  - Log changed and deleted file counts before writing.
  - Log tree creation metrics: entry count and payload size.
  - Log GitHub write stages with endpoint, status, request ID, retry-after, and rate-limit headers, with accurate stage labels (e.g., `resolve_repository`, `upsert_pull_request`).
  - Log resulting `tree_sha`, `commit_sha`, and updated branch ref on success.
  - Add tests for large exports: preview/export parity, complete tree deltas (807 vs 150 entries), and rate-limit header logging on errors.

<sup>Written for commit 3ae18788fc349f1bce823082b596705697a84b1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

