### PR TITLE
refactor(agents): cut over resource head ownership

### DIFF
--- a/alembic/versions/d2e4f6a8b0c1_finalize_agent_preset_version_edges.py
+++ b/alembic/versions/d2e4f6a8b0c1_finalize_agent_preset_version_edges.py
@@ -1,0 +1,269 @@
+"""Cut over agent preset ResourceHead ownership.
+
+Revision ID: d2e4f6a8b0c1
+Revises: 44320bf05445
+Create Date: 2026-07-15 00:00:00.000000
+
+Reconcile rows written during the expand window, make normalized version edges
+authoritative, and keep expand and cutover writers compatible during rollout.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d2e4f6a8b0c1"
+down_revision: str | None = "44320bf05445"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SKILL_SLUG_INDEX = "uq_skill_workspace_slug_active"
+SUBAGENTS_NOT_NULL_CONSTRAINT = "ck_agent_preset_version_subagents_enabled_not_null"
+SUBAGENTS_SYNC_FUNCTION = "sync_agent_preset_version_subagents_enabled"
+SUBAGENTS_SYNC_TRIGGER = "trg_agent_preset_version_subagents_enabled"
+
+_SKILL = sa.table(
+    "skill",
+    sa.column("deleted_at", sa.TIMESTAMP(timezone=True)),
+    sa.column("archived_at", sa.TIMESTAMP(timezone=True)),
+)
+
+
+def _reconcile_version_subagents() -> None:
+    """Replace expand-window edges from their exact legacy JSON projection."""
+
+    # JSONB expansion and per-row LATERAL resolution are PostgreSQL-specific.
+    # The named CTEs document the resolution and validation stages directly.
+    op.execute(
+        sa.text(
+            """
+            CREATE TEMP TABLE _cutover_agent_preset_version_subagents
+            ON COMMIT DROP AS
+            WITH refs AS (
+                SELECT
+                    parent.id AS parent_version_id,
+                    parent.workspace_id,
+                    ref.value AS ref
+                FROM agent_preset_version AS parent
+                CROSS JOIN LATERAL jsonb_array_elements(
+                    CASE
+                        WHEN jsonb_typeof(parent.agents -> 'subagents') = 'array'
+                        THEN parent.agents -> 'subagents'
+                        ELSE '[]'::jsonb
+                    END
+                ) AS ref(value)
+            )
+            SELECT
+                refs.parent_version_id,
+                refs.workspace_id,
+                CASE
+                    WHEN refs.ref ->> 'preset_id' IS NOT NULL THEN child_by_id.id
+                    WHEN child_by_slug.active_count = 1 THEN child_by_slug.child_id
+                    WHEN child_by_slug.active_count = 0
+                        AND child_by_slug.total_count = 1
+                        THEN child_by_slug.child_id
+                    ELSE NULL
+                END AS child_id,
+                COALESCE(NULLIF(refs.ref ->> 'name', ''), refs.ref ->> 'preset')
+                    AS alias,
+                refs.ref ->> 'description' AS description,
+                CASE
+                    WHEN jsonb_typeof(refs.ref -> 'max_turns') = 'number'
+                    THEN (refs.ref ->> 'max_turns')::integer
+                    ELSE NULL
+                END AS max_turns
+            FROM refs
+            LEFT JOIN agent_preset AS child_by_id
+                ON child_by_id.workspace_id = refs.workspace_id
+                AND child_by_id.id = CASE
+                    WHEN refs.ref ->> 'preset_id' ~*
+                        '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+                    THEN (refs.ref ->> 'preset_id')::uuid
+                    ELSE NULL
+                END
+            LEFT JOIN LATERAL (
+                SELECT
+                    (
+                        array_agg(
+                            candidate.id
+                            ORDER BY
+                                (candidate.deleted_at IS NULL) DESC,
+                                candidate.id
+                        )
+                    )[1] AS child_id,
+                    count(*) FILTER (WHERE candidate.deleted_at IS NULL)
+                        AS active_count,
+                    count(*) AS total_count
+                FROM agent_preset AS candidate
+                WHERE candidate.workspace_id = refs.workspace_id
+                    AND candidate.slug = refs.ref ->> 'preset'
+            ) AS child_by_slug ON TRUE;
+
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM _cutover_agent_preset_version_subagents
+                    WHERE child_id IS NULL OR alias IS NULL
+                ) THEN
+                    RAISE EXCEPTION
+                        'Cannot cut over preset version subagents: unresolved or cross-workspace reference';
+                END IF;
+                IF EXISTS (
+                    SELECT 1
+                    FROM _cutover_agent_preset_version_subagents
+                    GROUP BY workspace_id, parent_version_id, alias
+                    HAVING count(*) > 1
+                ) THEN
+                    RAISE EXCEPTION
+                        'Cannot cut over preset version subagents: duplicate alias';
+                END IF;
+                IF EXISTS (
+                    SELECT 1
+                    FROM _cutover_agent_preset_version_subagents AS edge
+                    JOIN agent_preset_version AS version
+                        ON version.id = edge.parent_version_id
+                    WHERE version.agents -> 'enabled'
+                        IS DISTINCT FROM 'true'::jsonb
+                ) THEN
+                    RAISE EXCEPTION
+                        'Cannot cut over preset version subagents: disabled config has children';
+                END IF;
+            END $$;
+
+            DELETE FROM agent_preset_version_subagent;
+
+            INSERT INTO agent_preset_version_subagent (
+                parent_preset_version_id,
+                child_preset_id,
+                alias,
+                description,
+                max_turns,
+                workspace_id
+            )
+            SELECT
+                parent_version_id,
+                child_id,
+                alias,
+                description,
+                max_turns,
+                workspace_id
+            FROM _cutover_agent_preset_version_subagents
+            ORDER BY parent_version_id, alias;
+
+            UPDATE agent_preset_version
+            SET subagents_enabled = COALESCE(
+                (agents ->> 'enabled')::boolean,
+                false
+            );
+            """
+        )
+    )
+
+
+def _install_expand_writer_bridge() -> None:
+    """Populate the new ownership bit for expand writers during rollout."""
+
+    op.execute(
+        sa.text(
+            f"""
+            CREATE FUNCTION {SUBAGENTS_SYNC_FUNCTION}()
+            RETURNS trigger AS $$
+            BEGIN
+                IF TG_OP = 'INSERT' AND NEW.subagents_enabled IS NULL THEN
+                    NEW.subagents_enabled := COALESCE(
+                        (NEW.agents ->> 'enabled')::boolean,
+                        false
+                    );
+                ELSIF TG_OP = 'UPDATE'
+                    AND NEW.agents IS DISTINCT FROM OLD.agents
+                    AND NEW.subagents_enabled IS NOT DISTINCT FROM OLD.subagents_enabled
+                THEN
+                    NEW.subagents_enabled := COALESCE(
+                        (NEW.agents ->> 'enabled')::boolean,
+                        false
+                    );
+                END IF;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+
+            CREATE TRIGGER {SUBAGENTS_SYNC_TRIGGER}
+            BEFORE INSERT OR UPDATE OF agents
+            ON agent_preset_version
+            FOR EACH ROW
+            EXECUTE FUNCTION {SUBAGENTS_SYNC_FUNCTION}();
+            """
+        )
+    )
+
+
+def _drop_expand_writer_bridge() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            DROP TRIGGER IF EXISTS {SUBAGENTS_SYNC_TRIGGER}
+            ON agent_preset_version;
+            DROP FUNCTION IF EXISTS {SUBAGENTS_SYNC_FUNCTION}();
+            """
+        )
+    )
+
+
+def _replace_skill_slug_index(*, include_archived: bool) -> None:
+    op.drop_index(SKILL_SLUG_INDEX, table_name="skill")
+    predicate = (
+        "deleted_at IS NULL AND archived_at IS NULL"
+        if include_archived
+        else "deleted_at IS NULL"
+    )
+    op.create_index(
+        SKILL_SLUG_INDEX,
+        "skill",
+        ["workspace_id", "slug"],
+        unique=True,
+        postgresql_where=sa.text(predicate),
+    )
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_preset_version",
+        sa.Column("subagents_enabled", sa.Boolean(), nullable=True),
+    )
+    _reconcile_version_subagents()
+
+    op.execute(
+        _SKILL.update()
+        .where(_SKILL.c.deleted_at.is_(None), _SKILL.c.archived_at.is_not(None))
+        .values(deleted_at=_SKILL.c.archived_at)
+    )
+    _replace_skill_slug_index(include_archived=False)
+
+    op.execute(
+        sa.text(
+            "ALTER TABLE agent_preset_version ADD CONSTRAINT "
+            f"{SUBAGENTS_NOT_NULL_CONSTRAINT} "
+            "CHECK (subagents_enabled IS NOT NULL) NOT VALID"
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE agent_preset_version VALIDATE CONSTRAINT "
+            f"{SUBAGENTS_NOT_NULL_CONSTRAINT}"
+        )
+    )
+    _install_expand_writer_bridge()
+
+
+def downgrade() -> None:
+    _drop_expand_writer_bridge()
+    op.drop_constraint(
+        SUBAGENTS_NOT_NULL_CONSTRAINT,
+        "agent_preset_version",
+        type_="check",
+    )
+    op.drop_column("agent_preset_version", "subagents_enabled")
+    _replace_skill_slug_index(include_archived=True)

--- a/tests/migration/test_agent_preset_subagent_edges_migration.py
+++ b/tests/migration/test_agent_preset_subagent_edges_migration.py
@@ -19,6 +19,7 @@ from tests.database import TEST_DB_CONFIG
 
 PREVIOUS_REVISION: Final = "c6a8d4f3b2e1"
 EXPAND_REVISION: Final = "44320bf05445"
+CUTOVER_REVISION: Final = "d2e4f6a8b0c1"
 
 
 def _invoke_alembic(db_url: str, *args: str) -> subprocess.CompletedProcess[str]:
@@ -609,5 +610,203 @@ def test_expand_downgrade_roundtrip(migration_db_url: str) -> None:
                 ).scalar_one()
                 == child_id
             )
+    finally:
+        engine.dispose()
+
+
+def test_cutover_reconciles_expand_writes_and_bridges_old_writers(
+    migration_db_url: str,
+) -> None:
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+    try:
+        parent_id = uuid.uuid4()
+        child_id = uuid.uuid4()
+        stale_child_id = uuid.uuid4()
+        parent_version_id = uuid.uuid4()
+        empty_enabled_version_id = uuid.uuid4()
+        archived_skill_id = uuid.uuid4()
+        with engine.begin() as conn:
+            workspace_id = _setup_workspace(conn, label="cutover")
+            _insert_preset(
+                conn, workspace_id=workspace_id, preset_id=child_id, slug="child"
+            )
+            _insert_preset(
+                conn,
+                workspace_id=workspace_id,
+                preset_id=stale_child_id,
+                slug="stale-child",
+            )
+            _insert_preset(
+                conn, workspace_id=workspace_id, preset_id=parent_id, slug="parent"
+            )
+            _insert_version(
+                conn,
+                workspace_id=workspace_id,
+                preset_id=parent_id,
+                version_id=parent_version_id,
+                version=1,
+                agents={
+                    "enabled": True,
+                    "subagents": [{"preset": "child", "name": "helper"}],
+                },
+            )
+
+        _run_alembic(migration_db_url, "upgrade", EXPAND_REVISION)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "DELETE FROM agent_preset_version_subagent "
+                    "WHERE parent_preset_version_id = :version_id"
+                ),
+                {"version_id": parent_version_id},
+            )
+            _insert_version_edge(
+                conn,
+                workspace_id=workspace_id,
+                version_id=parent_version_id,
+                child_id=stale_child_id,
+                alias="stale",
+            )
+            _insert_version(
+                conn,
+                workspace_id=workspace_id,
+                preset_id=parent_id,
+                version_id=empty_enabled_version_id,
+                version=2,
+                agents={"enabled": True, "subagents": []},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO skill (
+                        id, workspace_id, name, slug, draft_revision,
+                        archived_at, deleted_at
+                    )
+                    VALUES (
+                        :id, :workspace_id, 'archived', 'archived', 0,
+                        now(), NULL
+                    )
+                    """
+                ),
+                {"id": archived_skill_id, "workspace_id": workspace_id},
+            )
+
+        _run_alembic(migration_db_url, "upgrade", CUTOVER_REVISION)
+        with engine.begin() as conn:
+            assert conn.execute(
+                text(
+                    """
+                    SELECT child_preset_id, alias
+                    FROM agent_preset_version_subagent
+                    WHERE parent_preset_version_id = :version_id
+                    """
+                ),
+                {"version_id": parent_version_id},
+            ).one() == (child_id, "helper")
+            assert dict(
+                conn.execute(
+                    text(
+                        """
+                        SELECT id, subagents_enabled
+                        FROM agent_preset_version
+                        WHERE id IN (:parent_version_id, :empty_version_id)
+                        """
+                    ),
+                    {
+                        "parent_version_id": parent_version_id,
+                        "empty_version_id": empty_enabled_version_id,
+                    },
+                )
+                .tuples()
+                .all()
+            ) == {
+                parent_version_id: True,
+                empty_enabled_version_id: True,
+            }
+            archived_at, deleted_at = conn.execute(
+                text("SELECT archived_at, deleted_at FROM skill WHERE id = :id"),
+                {"id": archived_skill_id},
+            ).one()
+            assert deleted_at == archived_at
+            index_definition = conn.execute(
+                text(
+                    """
+                    SELECT pg_get_indexdef(indexrelid)
+                    FROM pg_index
+                    WHERE indexrelid = 'uq_skill_workspace_slug_active'::regclass
+                    """
+                )
+            ).scalar_one()
+            assert "deleted_at IS NULL" in index_definition
+            assert "archived_at IS NULL" not in index_definition
+            assert _column(conn, "agent_preset_version", "subagents_enabled") == {
+                "is_nullable": "YES",
+                "column_default": None,
+            }
+            assert _column(conn, "agent_preset_version", "agents") is not None
+            assert _table_exists(conn, "agent_preset_skill")
+
+            late_version_id = uuid.uuid4()
+            _insert_version(
+                conn,
+                workspace_id=workspace_id,
+                preset_id=parent_id,
+                version_id=late_version_id,
+                version=3,
+                agents={"enabled": False},
+            )
+            assert (
+                conn.execute(
+                    text(
+                        "SELECT subagents_enabled FROM agent_preset_version "
+                        "WHERE id = :id"
+                    ),
+                    {"id": late_version_id},
+                ).scalar_one()
+                is False
+            )
+    finally:
+        engine.dispose()
+
+
+def test_cutover_rejects_invalid_late_expand_write_atomically(
+    migration_db_url: str,
+) -> None:
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            workspace_id = _setup_workspace(conn, label="invalid-cutover")
+            child_id = uuid.uuid4()
+            parent_id = uuid.uuid4()
+            _insert_preset(
+                conn, workspace_id=workspace_id, preset_id=child_id, slug="child"
+            )
+            _insert_preset(
+                conn, workspace_id=workspace_id, preset_id=parent_id, slug="parent"
+            )
+
+        _run_alembic(migration_db_url, "upgrade", EXPAND_REVISION)
+        with engine.begin() as conn:
+            _insert_version(
+                conn,
+                workspace_id=workspace_id,
+                preset_id=parent_id,
+                version_id=uuid.uuid4(),
+                version=1,
+                agents={"enabled": False, "subagents": [{"preset": "child"}]},
+            )
+
+        result = _invoke_alembic(migration_db_url, "upgrade", CUTOVER_REVISION)
+
+        assert result.returncode != 0
+        assert "disabled config has children" in result.stdout + result.stderr
+        with engine.begin() as conn:
+            assert (
+                conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).scalar_one()
+                == EXPAND_REVISION
+            )
+            assert _column(conn, "agent_preset_version", "subagents_enabled") is None
     finally:
         engine.dispose()

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -36,7 +36,6 @@ from tracecat.agent.skill.schemas import (
 from tracecat.agent.skill.service import SkillService
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
-    AttachedSubagentRef,
     HeadAttachedSubagentRef,
     ResolvedAgentsConfig,
 )
@@ -47,7 +46,6 @@ from tracecat.db.models import (
     AgentChannelToken,
     AgentModelAccess,
     AgentPreset,
-    AgentPresetSkill,
     AgentPresetVersion,
     AgentPresetVersionSkill,
     AgentPresetVersionSubagent,
@@ -1199,57 +1197,6 @@ class TestAgentPresetService:
             for change in diff.tool_approval_changes
         )
 
-    async def test_compare_versions_keeps_legacy_slug_only_subagents(
-        self,
-        agent_preset_service: AgentPresetService,
-        agent_preset_create_params: AgentPresetCreate,
-    ) -> None:
-        """Version diffs retain old-writer refs that predate ResourceHead IDs."""
-
-        preset = await agent_preset_service.create_preset(agent_preset_create_params)
-        legacy_version = await agent_preset_service.get_current_version_for_preset(
-            preset
-        )
-
-        await agent_preset_service.update_preset(
-            preset,
-            AgentPresetUpdate(instructions="Create a comparison version"),
-        )
-        current_version = await agent_preset_service.get_current_version_for_preset(
-            preset
-        )
-
-        legacy_version.agents = AgentSubagentsConfig(
-            enabled=True,
-            subagents=[
-                AttachedSubagentRef(
-                    preset="legacy-child",
-                    name="legacy-alias",
-                    description="Old-writer child",
-                    max_turns=2,
-                )
-            ],
-        ).model_dump(mode="json")
-
-        diff = await agent_preset_service.compare_versions(
-            legacy_version,
-            current_version,
-        )
-
-        subagent_change = next(
-            change for change in diff.scalar_changes if change.field == "subagents"
-        )
-        assert subagent_change.old_value == [
-            {
-                "preset_id": None,
-                "preset": "legacy-child",
-                "alias": "legacy-alias",
-                "description": "Old-writer child",
-                "max_turns": 2,
-            }
-        ]
-        assert subagent_change.new_value == []
-
     async def test_compare_versions_reports_skill_head_attachment_changes(
         self,
         configure_minio_for_skills,
@@ -1259,7 +1206,7 @@ class TestAgentPresetService:
     ) -> None:
         skill_service = SkillService(session=session, role=svc_role)
         skill = await skill_service.create_skill(SkillCreate(name="diff-skill"))
-        published_skill = await skill_service.publish_skill(skill.id)
+        await skill_service.publish_skill(skill.id)
         preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
                 name="Skill diff preset",
@@ -1286,16 +1233,7 @@ class TestAgentPresetService:
                 AgentPresetVersionSkill.skill_id == skill.id,
             )
         )
-        head_edge = await session.scalar(
-            select(AgentPresetSkill).where(
-                AgentPresetSkill.preset_id == preset.id,
-                AgentPresetSkill.skill_id == skill.id,
-            )
-        )
         assert version_edge is not None
-        assert head_edge is not None
-        assert version_edge.skill_version_id == published_skill.id
-        assert head_edge.skill_version_id == published_skill.id
 
         draft = await skill_service.get_draft(skill.id)
         assert draft is not None
@@ -1353,7 +1291,7 @@ class TestAgentPresetService:
         created_skill = await skill_service.create_skill(
             SkillCreate(name="skill-only-current")
         )
-        published_skill = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -1381,64 +1319,10 @@ class TestAgentPresetService:
                 AgentPresetVersionSkill.skill_id == created_skill.id,
             )
         )
-        head_edge = await session.scalar(
-            select(AgentPresetSkill).where(
-                AgentPresetSkill.preset_id == created_preset.id,
-                AgentPresetSkill.skill_id == created_skill.id,
-            )
-        )
         assert version_edge is not None
-        assert head_edge is not None
-        assert version_edge.skill_version_id == published_skill.id
-        assert head_edge.skill_version_id == published_skill.id
-        assert created_preset.instructions == "Use the selected skill"
-        assert created_preset.model_name == "gpt-4o-mini"
-        assert created_preset.model_provider == "openai"
-
-    async def test_version_agents_falls_back_to_legacy_json_without_edges(
-        self,
-        session: AsyncSession,
-        agent_preset_service: AgentPresetService,
-        agent_preset_create_params: AgentPresetCreate,
-    ) -> None:
-        child = await agent_preset_service.create_preset(
-            agent_preset_create_params.model_copy(
-                update={"name": "Epoch child", "slug": "epoch-child"}
-            )
-        )
-        parent = await agent_preset_service.create_preset(
-            agent_preset_create_params.model_copy(
-                update={
-                    "name": "Epoch parent",
-                    "slug": "epoch-parent",
-                    "agents": AgentSubagentsConfig.model_validate(
-                        {
-                            "enabled": True,
-                            "subagents": [{"preset": child.slug}],
-                        }
-                    ),
-                }
-            )
-        )
-        version = await agent_preset_service.get_current_version_for_preset(parent)
-        await session.execute(
-            sa.delete(AgentPresetVersionSubagent).where(
-                AgentPresetVersionSubagent.parent_preset_version_id == version.id
-            )
-        )
-        session.add(version)
-        await session.commit()
-
-        legacy = await agent_preset_service._get_version_agents_config(version)
-        assert legacy.enabled is True
-        assert len(legacy.subagents) == 1
-        assert legacy.subagents[0].preset == child.slug
-
-        version.agents = AgentSubagentsConfig().model_dump(mode="json")
-        session.add(version)
-        await session.commit()
-        authoritative = await agent_preset_service._get_version_agents_config(version)
-        assert authoritative == AgentSubagentsConfig()
+        assert current_version.instructions == "Use the selected skill"
+        assert current_version.model_name == "gpt-4o-mini"
+        assert current_version.model_provider == "openai"
 
     async def test_client_supplied_stale_skill_version_is_ignored(
         self,
@@ -2801,121 +2685,6 @@ class TestAgentPresetService:
         }
         assert await agent_preset_service.get_preset(child.id) is not None
 
-    @pytest.mark.parametrize(
-        ("legacy_subagents", "blocks_delete"),
-        [
-            pytest.param("child-ref", True, id="child-ref"),
-            pytest.param(None, False, id="json-null"),
-            pytest.param("invalid-scalar", False, id="non-array"),
-        ],
-    )
-    async def test_delete_preset_handles_late_legacy_current_version(
-        self,
-        session: AsyncSession,
-        agent_preset_service: AgentPresetService,
-        agent_preset_create_params: AgentPresetCreate,
-        legacy_subagents: str | None,
-        blocks_delete: bool,
-    ) -> None:
-        """Legacy JSON protects real refs and tolerates non-array values."""
-
-        child = await agent_preset_service.create_preset(
-            agent_preset_create_params.model_copy(
-                update={"name": "Legacy child", "slug": "legacy-child"}
-            )
-        )
-        parent = await agent_preset_service.create_preset(
-            agent_preset_create_params.model_copy(
-                update={
-                    "name": "Legacy parent",
-                    "slug": "legacy-parent",
-                    "agents": AgentSubagentsConfig.model_validate(
-                        {
-                            "enabled": True,
-                            "subagents": [{"preset": child.slug}],
-                        }
-                    ),
-                }
-            )
-        )
-        version = await agent_preset_service.get_current_version_for_preset(parent)
-        await session.execute(
-            sa.delete(AgentPresetVersionSubagent).where(
-                AgentPresetVersionSubagent.parent_preset_version_id == version.id
-            )
-        )
-        version.agents = {
-            "enabled": True,
-            "subagents": (
-                [{"preset": child.slug}]
-                if legacy_subagents == "child-ref"
-                else legacy_subagents
-            ),
-        }
-        session.add(version)
-        await session.commit()
-
-        if blocks_delete:
-            with pytest.raises(TracecatValidationError, match="still referenced"):
-                await agent_preset_service.delete_preset(child)
-            return
-
-        await agent_preset_service.delete_preset(child)
-        assert await agent_preset_service.get_preset(child.id) is None
-
-    async def test_create_version_normalizes_late_legacy_subagent_refs(
-        self,
-        session: AsyncSession,
-        agent_preset_service: AgentPresetService,
-        agent_preset_create_params: AgentPresetCreate,
-    ) -> None:
-        """New writers turn a late old-writer JSON ref into a head edge."""
-
-        child = await agent_preset_service.create_preset(
-            agent_preset_create_params.model_copy(
-                update={"name": "Legacy child", "slug": "legacy-child"}
-            )
-        )
-        parent = await agent_preset_service.create_preset(
-            agent_preset_create_params.model_copy(
-                update={"name": "Legacy parent", "slug": "legacy-parent"}
-            )
-        )
-        current = await agent_preset_service.get_current_version_for_preset(parent)
-        await session.execute(
-            sa.delete(AgentPresetVersionSubagent).where(
-                AgentPresetVersionSubagent.parent_preset_version_id == current.id
-            )
-        )
-        current.agents = {
-            "enabled": True,
-            "subagents": [{"preset": child.slug}],
-        }
-        session.add(current)
-        await session.commit()
-
-        created = await agent_preset_service.create_version_from_current(parent)
-
-        edge = await session.scalar(
-            select(AgentPresetVersionSubagent).where(
-                AgentPresetVersionSubagent.parent_preset_version_id == created.id
-            )
-        )
-        assert edge is not None
-        assert edge.child_preset_id == child.id
-        assert edge.alias == child.slug
-
-        child.deleted_at = datetime.now(UTC)
-        await session.flush()
-        with pytest.raises(
-            TracecatValidationError,
-            match="Cannot create version.*unavailable subagent presets",
-        ):
-            await agent_preset_service.create_version_from_current(
-                parent,
-                current=current,
-            )
-
     async def test_delete_preset_soft_deletes_when_only_referenced_as_subagent_in_history(
         self,
         agent_preset_service: AgentPresetService,
@@ -3401,6 +3170,7 @@ class TestAgentPresetService:
             )
         )
         child_version = await agent_preset_service.get_current_version_for_preset(child)
+        child_version.subagents_enabled = True
         session.add(child_version)
         await session.execute(
             sa.insert(AgentPresetVersionSubagent).values(

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -860,22 +860,6 @@ class TestSkillService:
         assert by_slug is not None
         assert by_slug.id == created.id
 
-    async def test_legacy_archived_at_alone_is_not_live(
-        self,
-        skill_service: SkillService,
-    ) -> None:
-        """Old writers that only set archived_at hide the row during Expand."""
-
-        created = await skill_service.create_skill(SkillCreate(name="legacy-archived"))
-        legacy = await skill_service.get_skill(created.id)
-        assert legacy is not None
-        legacy.archived_at = datetime.now(UTC)
-        skill_service.session.add(legacy)
-        await skill_service.session.commit()
-
-        assert await skill_service.get_skill(created.id) is None
-        assert await skill_service.get_skill_by_slug(created.slug) is None
-
     async def test_get_skill_by_identifier_falls_back_to_uuid_like_slug(
         self,
         skill_service: SkillService,
@@ -2465,13 +2449,13 @@ class TestSkillService:
         assert archived is not None
         assert archived.deleted_at is not None
 
-    async def test_archive_blocks_when_unpublished_preset_retains_legacy_binding(
+    async def test_archive_blocks_when_unpublished_preset_retains_latest_binding(
         self,
         session: AsyncSession,
         svc_role: Role,
         skill_service: SkillService,
     ) -> None:
-        """Expand rollback bindings remain live while the preset is unpublished."""
+        """The unpublished builder baseline keeps its bound skills protected."""
 
         created = await skill_service.create_skill(
             SkillCreate(name="unpublished-preset-binding")

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -21,7 +21,7 @@ import pytest
 import yaml
 from pydantic import SecretStr, ValidationError
 from pydantic_core import PydanticSerializationError
-from sqlalchemy import delete, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.support.fake_vcs import FakeVcsServer
@@ -39,7 +39,6 @@ from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import (
     AgentCatalog,
     AgentPreset,
-    AgentPresetSkill,
     AgentPresetVersion,
     AgentPresetVersionSkill,
     AgentPresetVersionSubagent,
@@ -91,7 +90,6 @@ from tracecat.workspace_sync.schemas import (
     TABLE_ROOT,
     VARIABLE_ROOT,
     WORKFLOW_ROOT,
-    AgentPresetResourceSpec,
     AgentPresetSubagentRef,
     AgentPresetVersionResourceSpec,
     ResourceRef,
@@ -751,7 +749,7 @@ async def test_import_selected_fixture_reconciles_supported_non_workflow_resourc
         )
     )
     assert parent_version is not None
-    assert parent_version.agents["enabled"] is True
+    assert parent_version.subagents_enabled is True
     assert parent_version.base_url == "https://models.example.test/v1"
     assert parent_version.output_type == {
         "type": "json_schema",
@@ -1185,7 +1183,7 @@ async def test_agent_preset_import_resolves_subagent_to_active_preset(
 
 
 @pytest.mark.anyio
-async def test_agent_preset_subagent_configs_skip_invalid_heads(
+async def test_agent_preset_subagent_config_skips_invalid_heads(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
@@ -1213,7 +1211,7 @@ async def test_agent_preset_subagent_configs_skip_invalid_heads(
     await session.flush()
     importer = WorkspaceResourceImportService(session=session, role=svc_role)
 
-    configs = await AGENT_PRESET_RESOURCE_ADAPTER._resolved_subagent_configs(
+    config = await AGENT_PRESET_RESOURCE_ADAPTER._resolved_subagents_config(
         importer,
         AgentPresetVersionResourceSpec(
             version_number=1,
@@ -1221,7 +1219,7 @@ async def test_agent_preset_subagent_configs_skip_invalid_heads(
         ),
     )
 
-    assert all(not config.enabled and not config.subagents for config in configs)
+    assert not config.enabled and not config.subagents
 
     foreign_owner = AgentPreset(
         workspace_id=workspace_id,
@@ -1234,7 +1232,7 @@ async def test_agent_preset_subagent_configs_skip_invalid_heads(
     soft_deleted_version.preset_id = foreign_owner.id
     await session.flush()
 
-    configs = await AGENT_PRESET_RESOURCE_ADAPTER._resolved_subagent_configs(
+    config = await AGENT_PRESET_RESOURCE_ADAPTER._resolved_subagents_config(
         importer,
         AgentPresetVersionResourceSpec(
             version_number=1,
@@ -1242,7 +1240,7 @@ async def test_agent_preset_subagent_configs_skip_invalid_heads(
         ),
     )
 
-    assert all(not config.enabled and not config.subagents for config in configs)
+    assert not config.enabled and not config.subagents
 
 
 @pytest.mark.anyio
@@ -1796,7 +1794,6 @@ async def test_round_trip_preserves_preset_version_skill_edges(
         select(
             AgentPreset.slug,
             AgentPresetVersionSkill.skill_id,
-            AgentPresetVersionSkill.skill_version_id,
         )
         .select_from(AgentPreset)
         .join(
@@ -1808,20 +1805,9 @@ async def test_round_trip_preserves_preset_version_skill_edges(
     )
     version_bindings = version_binding_rows.tuples().all()
     assert version_bindings == [
-        ("agent-x", skill.id, skill.current_version_id),
-        ("agent-y", skill.id, skill.current_version_id),
+        ("agent-x", skill.id),
+        ("agent-y", skill.id),
     ]
-    head_binding_rows = await session.execute(
-        select(
-            AgentPreset.slug,
-            AgentPresetSkill.skill_id,
-            AgentPresetSkill.skill_version_id,
-        )
-        .join(AgentPresetSkill, AgentPresetSkill.preset_id == AgentPreset.id)
-        .where(AgentPreset.workspace_id == target_workspace_id)
-        .order_by(AgentPreset.slug.asc())
-    )
-    assert head_binding_rows.tuples().all() == version_bindings
 
 
 @pytest.mark.anyio
@@ -3272,7 +3258,7 @@ async def test_pull_agent_preset_slug_rename_reuses_source_id_mapping(
 
 
 @pytest.mark.anyio
-async def test_pull_unpublished_agent_preset_retains_rollback_projection(
+async def test_pull_unpublished_agent_preset_retains_latest_builder_baseline(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
@@ -3299,6 +3285,7 @@ async def test_pull_unpublished_agent_preset_retains_rollback_projection(
                 source_id="qa-draft",
                 slug="qa-draft",
                 name="QA draft",
+                instructions="Retained builder instructions",
             ),
         ),
         VcsTreeSnapshot(
@@ -3316,35 +3303,6 @@ async def test_pull_unpublished_agent_preset_retains_rollback_projection(
         return_value=transport,
     ):
         first_result = await service.pull(options=PullOptions(commit_sha="d" * 40))
-        preset = await session.scalar(
-            select(AgentPreset).where(
-                AgentPreset.workspace_id == svc_role.workspace_id,
-                AgentPreset.slug == "qa-draft",
-            )
-        )
-        assert preset is not None
-        rollback_projection = {
-            "instructions": preset.instructions,
-            "model_name": preset.model_name,
-            "model_provider": preset.model_provider,
-            "catalog_id": preset.catalog_id,
-            "base_url": preset.base_url,
-            "output_type": preset.output_type,
-            "actions": preset.actions,
-            "namespaces": preset.namespaces,
-            "tool_approvals": preset.tool_approvals,
-            "mcp_integrations": preset.mcp_integrations,
-            "retries": preset.retries,
-            "enable_thinking": preset.enable_thinking,
-            "enable_internet_access": preset.enable_internet_access,
-            "agents": preset.agents,
-        }
-        rollback_skill_count = await session.scalar(
-            select(func.count())
-            .select_from(AgentPresetSkill)
-            .where(AgentPresetSkill.preset_id == preset.id)
-        )
-
         second_result = await service.pull(options=PullOptions(commit_sha="e" * 40))
 
     assert first_result.success is True
@@ -3357,89 +3315,25 @@ async def test_pull_unpublished_agent_preset_retains_rollback_projection(
     )
     assert preset is not None
     assert preset.current_version_id is None
-    for field, expected in rollback_projection.items():
-        assert getattr(preset, field) == expected
-    preset_read = await AgentPresetService(session, svc_role).build_preset_read(preset)
-    assert preset_read.current_version_id is None
-    assert preset_read.model_name == preset.model_name
-    assert preset_read.model_provider == preset.model_provider
-    assert (
-        await session.scalar(
-            select(func.count())
-            .select_from(AgentPresetSkill)
-            .where(AgentPresetSkill.preset_id == preset.id)
-        )
-        == rollback_skill_count
-    )
-
     preset_service = AgentPresetService(session, svc_role)
+    preset_read = await preset_service.build_preset_read(preset)
+    assert preset_read.current_version_id is None
+    assert preset_read.instructions == "Retained builder instructions"
+
     metadata_only = await preset_service.update_preset(
         preset,
         AgentPresetUpdate(description="Imported draft metadata"),
     )
     assert metadata_only.current_version_id is None
-    assert metadata_only.description == "Imported draft metadata"
-
-    # Historical parent snapshots may still name the now-unpublished child.
-    # Import the usable parent and omit only that edge.
-    await WorkspaceResourceImportService(
-        session=session,
-        role=svc_role,
-    ).import_non_workflow_resources(
-        WorkspaceSpec(
-            agent_presets={
-                "parent": AgentPresetResourceSpec(
-                    id="parent",
-                    slug="parent",
-                    name="Parent",
-                    current_version=1,
-                    versions={
-                        1: AgentPresetVersionResourceSpec(
-                            version_number=1,
-                            subagents=[AgentPresetSubagentRef(slug="qa-draft")],
-                        )
-                    },
-                ),
-            }
-        )
-    )
-
-    parent_version = await session.scalar(
-        select(AgentPresetVersion)
-        .join(AgentPreset, AgentPresetVersion.preset_id == AgentPreset.id)
-        .where(
-            AgentPreset.workspace_id == svc_role.workspace_id,
-            AgentPreset.slug == "parent",
-            AgentPresetVersion.version == 1,
-        )
-    )
-    assert parent_version is not None
-    assert parent_version.agents["enabled"] is False
-    assert (
-        await session.scalar(
-            select(func.count())
-            .select_from(AgentPresetVersionSubagent)
-            .where(
-                AgentPresetVersionSubagent.parent_preset_version_id == parent_version.id
-            )
-        )
-        == 0
-    )
 
     published = await preset_service.update_preset(
         preset,
-        AgentPresetUpdate(
-            instructions="Publish the imported draft",
-            model_name="gpt-4o-mini",
-            model_provider="openai",
-        ),
+        AgentPresetUpdate(instructions="Republished builder instructions"),
     )
     assert published.current_version_id is not None
     current = await preset_service.get_current_version_for_preset(published)
     assert current.version == 2
-    assert published.instructions == "Publish the imported draft"
-    assert published.model_name == "gpt-4o-mini"
-    assert published.model_provider == "openai"
+    assert current.instructions == "Republished builder instructions"
 
 
 @pytest.mark.anyio
@@ -4757,14 +4651,7 @@ async def test_agent_preset_sync_preserves_subagent_options(
         )
     )
     assert parent_version is not None
-    assert parent.agents["enabled"] is True
-    assert parent.agents["subagents"][0]["preset_id"] == str(child.id)
-    assert parent.agents["subagents"][0]["preset_version_id"] == str(
-        child.current_version_id
-    )
-    assert parent_version.agents == parent.agents
-    assert parent.model_name == parent_version.model_name
-    assert parent.model_provider == parent_version.model_provider
+    assert parent_version.subagents_enabled is True
     version_subagent = await session.scalar(
         select(AgentPresetVersionSubagent).where(
             AgentPresetVersionSubagent.parent_preset_version_id == parent_version.id
@@ -4784,19 +4671,6 @@ async def test_agent_preset_sync_preserves_subagent_options(
     assert resolved_binding["subagents"][0]["preset_version_id"] == str(
         child.current_version_id
     )
-
-    await session.execute(
-        delete(AgentPresetVersionSubagent).where(
-            AgentPresetVersionSubagent.parent_preset_version_id == parent_version.id
-        )
-    )
-    await session.flush()
-    await WorkspaceResourceImportService(
-        session=session,
-        role=svc_role,
-    ).import_non_workflow_resources(snapshot.spec)
-    await session.refresh(parent_version)
-    assert parent_version.agents["subagents"][0]["preset_id"] == str(child.id)
 
     # Version-owned ResourceHead edges follow the child after a slug change.
     child.slug = "z-child-renamed"
@@ -4819,55 +4693,6 @@ async def test_agent_preset_sync_preserves_subagent_options(
             "max_turns": 3,
         }
     ]
-
-
-@pytest.mark.anyio
-async def test_agent_preset_projection_tolerates_invalid_legacy_agents_json(
-    session: AsyncSession,
-    svc_role: Role,
-) -> None:
-    """An old-writer payload must not block projection of the whole workspace."""
-
-    service = WorkspaceSyncService(session=session, role=svc_role)
-    files = _agent_preset_git_tree(
-        source_id="legacy-parent",
-        slug="legacy-parent",
-        name="Legacy parent",
-    )
-    snapshot, diagnostics = await service.parse_files(files, commit_sha="l" * 40)
-    assert diagnostics == []
-    await WorkspaceResourceImportService(
-        session=session,
-        role=svc_role,
-    ).import_non_workflow_resources(snapshot.spec)
-
-    version = await session.scalar(
-        select(AgentPresetVersion)
-        .join(AgentPreset, AgentPreset.id == AgentPresetVersion.preset_id)
-        .where(
-            AgentPresetVersion.workspace_id == svc_role.workspace_id,
-            AgentPreset.slug == "legacy-parent",
-            AgentPresetVersion.version == 1,
-        )
-    )
-    assert version is not None
-    version.agents = {
-        "enabled": True,
-        "subagents": [
-            {
-                "preset": "legacy-child",
-                "unsupported_legacy_field": True,
-            }
-        ],
-    }
-    await session.flush()
-
-    projection = await service.project_workspace(create_missing_mappings=False)
-
-    version_spec = yaml.safe_load(
-        projection.files[f"{AGENT_PRESET_ROOT}/legacy-parent/versions/1.yml"]
-    )
-    assert version_spec["subagents"] == []
 
 
 @pytest.mark.anyio
@@ -5046,9 +4871,8 @@ async def test_agent_preset_import_creates_new_version_without_mutating_history(
         )
         assert first_version is not None
         local_mcp_integrations = [str(uuid.uuid4())]
-        first_preset.mcp_integrations = local_mcp_integrations
         first_version.mcp_integrations = local_mcp_integrations
-        session.add_all([first_preset, first_version])
+        session.add(first_version)
         await session.commit()
         second_result = await service.pull(options=PullOptions(commit_sha="j" * 40))
 
@@ -5078,7 +4902,6 @@ async def test_agent_preset_import_creates_new_version_without_mutating_history(
         "Updated instructions",
     ]
     assert preset.current_version_id == versions[-1].id
-    assert preset.mcp_integrations == local_mcp_integrations
     assert [version.mcp_integrations for version in versions] == [
         local_mcp_integrations,
         local_mcp_integrations,

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -179,12 +179,9 @@ def build_agent_preset_read_minimal(
 ) -> AgentPresetReadMinimal:
     """Build a minimal preset response without exposing approval rule details."""
     version = preset.current_version
-    subagents_enabled = (
-        AgentSubagentsConfig.model_validate(version.agents).enabled
-        if version is not None
-        else False
+    agents_config = AgentSubagentsConfig(
+        enabled=version.subagents_enabled if version is not None else False
     )
-    agents_config = AgentSubagentsConfig(enabled=subagents_enabled)
     tool_approvals = version.tool_approvals if version is not None else None
     enable_internet_access = (
         version.enable_internet_access if version is not None else False

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 import sqlalchemy as sa
 from slugify import slugify
 from sqlalchemy import func, select
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import selectinload
 
 from tracecat.agent.access.service import AgentModelAccessService
@@ -61,7 +60,6 @@ from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentCatalog,
     AgentPreset,
-    AgentPresetSkill,
     AgentPresetVersion,
     AgentPresetVersionSkill,
     AgentPresetVersionSubagent,
@@ -93,6 +91,9 @@ from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets import secrets_manager
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
+
+DEFAULT_AGENT_MODEL_NAME = "gpt-5.5"
+DEFAULT_AGENT_MODEL_PROVIDER = "openai"
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -185,13 +186,8 @@ class AgentPresetService(BaseWorkspaceService):
             .order_by(AgentPresetVersionSubagent.alias)
         )
         rows = (await self.session.execute(with_deleted(stmt))).tuples().all()
-        if not rows:
-            # Old writers create JSON-only versions. New writers dual-write the
-            # exact JSON shape, which also disambiguates disabled from
-            # enabled-with-no-children when no normalized rows exist.
-            return AgentSubagentsConfig.model_validate(version.agents)
         return AgentSubagentsConfig(
-            enabled=True,
+            enabled=version.subagents_enabled,
             subagents=[
                 HeadAttachedSubagentRef(
                     preset=child_slug,
@@ -256,18 +252,22 @@ class AgentPresetService(BaseWorkspaceService):
             "created_at": preset.created_at,
             "updated_at": preset.updated_at,
         }
-        if preset.current_version_id is None:
+        version = (
+            await self.get_current_version_for_preset(preset)
+            if preset.current_version_id is not None
+            else await self._get_latest_version_for_preset(preset)
+        )
+        if version is None:
             return AgentPresetRead(
                 **metadata,
                 current_version_id=None,
-                model_name=preset.model_name,
-                model_provider=preset.model_provider,
+                model_name=DEFAULT_AGENT_MODEL_NAME,
+                model_provider=DEFAULT_AGENT_MODEL_PROVIDER,
             )
-        version = await self.get_current_version_for_preset(preset)
         agents = await self._get_version_agents_config(version)
         return AgentPresetRead(
             **metadata,
-            current_version_id=version.id,
+            current_version_id=preset.current_version_id,
             **self._execution_fields_from_version(version, agents=agents),
             skills=await self._list_version_skill_bindings(version.id),
         )
@@ -328,8 +328,6 @@ class AgentPresetService(BaseWorkspaceService):
             slug=slug,
             name=params.name,
             description=params.description,
-            model_name=execution.model_name,
-            model_provider=execution.model_provider,
         )
         self.session.add(preset)
         await self.session.flush()
@@ -402,19 +400,19 @@ class AgentPresetService(BaseWorkspaceService):
         """Update an existing preset."""
 
         preset = await self._lock_preset_row(preset.id)
-        current_version = (
+        base_version = (
             await self.get_current_version_for_preset(preset)
             if preset.current_version_id is not None
-            else None
+            else await self._get_latest_version_for_preset(preset)
         )
         current_agents = (
-            await self._get_version_agents_config(current_version)
-            if current_version is not None
+            await self._get_version_agents_config(base_version)
+            if base_version is not None
             else AgentSubagentsConfig()
         )
         current_skill_ids = (
-            await self._get_version_skill_binding_ids(current_version.id)
-            if current_version is not None
+            await self._get_version_skill_binding_ids(base_version.id)
+            if base_version is not None
             else []
         )
 
@@ -443,12 +441,12 @@ class AgentPresetService(BaseWorkspaceService):
             )
         else:
             requires_internet_access = False
-            if current_version is not None and (
+            if base_version is not None and (
                 execution_updates.get("enable_internet_access") is False
-                or not current_version.enable_internet_access
+                or not base_version.enable_internet_access
             ):
                 requires_internet_access = await self._has_stdio_mcp_integration(
-                    current_version.mcp_integrations,
+                    base_version.mcp_integrations,
                     raise_on_missing=False,
                 )
 
@@ -457,10 +455,10 @@ class AgentPresetService(BaseWorkspaceService):
 
         if "catalog_id" in execution_updates:
             effective_catalog_id = execution_updates["catalog_id"]
-        elif current_version is not None and (
+        elif base_version is not None and (
             "model_name" in execution_updates or "model_provider" in execution_updates
         ):
-            effective_catalog_id = current_version.catalog_id
+            effective_catalog_id = base_version.catalog_id
         else:
             effective_catalog_id = None
         if effective_catalog_id is not None:
@@ -470,10 +468,10 @@ class AgentPresetService(BaseWorkspaceService):
 
         current_execution = (
             self._execution_config_from_version(
-                current_version,
+                base_version,
                 agents=current_agents,
             )
-            if current_version is not None
+            if base_version is not None
             else None
         )
         agents: AgentSubagentsConfig | ResolvedAgentsConfig = current_agents
@@ -555,16 +553,9 @@ class AgentPresetService(BaseWorkspaceService):
     async def _count_head_subagent_references(self, preset: AgentPreset) -> int:
         """Count live heads whose current version references ``preset``."""
 
-        edge_stmt = (
+        stmt = (
             select(func.count())
             .select_from(AgentPreset)
-            .join(
-                AgentPresetVersion,
-                sa.and_(
-                    AgentPresetVersion.workspace_id == AgentPreset.workspace_id,
-                    AgentPresetVersion.id == AgentPreset.current_version_id,
-                ),
-            )
             .join(
                 AgentPresetVersionSubagent,
                 sa.and_(
@@ -580,61 +571,7 @@ class AgentPresetService(BaseWorkspaceService):
                 AgentPresetVersionSubagent.child_preset_id == preset.id,
             )
         )
-        edge_count = (await self.session.execute(edge_stmt)).scalar_one()
-
-        legacy_subagents = AgentPresetVersion.agents["subagents"]
-        legacy_subagent_array = sa.case(
-            (
-                sa.func.jsonb_typeof(legacy_subagents) == "array",
-                legacy_subagents,
-            ),
-            else_=sa.literal([], type_=JSONB),
-        )
-        legacy_refs = sa.func.jsonb_array_elements(legacy_subagent_array).table_valued(
-            "value"
-        )
-        legacy_ref = sa.cast(legacy_refs.c.value, JSONB)
-        legacy_stmt = (
-            select(func.count())
-            .select_from(AgentPresetVersion)
-            .join(
-                AgentPreset,
-                sa.and_(
-                    AgentPreset.workspace_id == AgentPresetVersion.workspace_id,
-                    AgentPreset.current_version_id == AgentPresetVersion.id,
-                ),
-            )
-            .where(
-                AgentPreset.workspace_id == self.workspace_id,
-                AgentPreset.id != preset.id,
-                AgentPreset.deleted_at.is_(None),
-                ~sa.exists(
-                    select(1)
-                    .select_from(AgentPresetVersionSubagent)
-                    .where(
-                        AgentPresetVersionSubagent.workspace_id
-                        == AgentPresetVersion.workspace_id,
-                        AgentPresetVersionSubagent.parent_preset_version_id
-                        == AgentPresetVersion.id,
-                    )
-                ),
-                sa.exists(
-                    select(1)
-                    .select_from(legacy_refs)
-                    .where(
-                        sa.or_(
-                            legacy_ref["preset_id"].as_string() == str(preset.id),
-                            sa.and_(
-                                legacy_ref["preset_id"].as_string().is_(None),
-                                legacy_ref["preset"].as_string() == preset.slug,
-                            ),
-                        )
-                    )
-                ),
-            )
-        )
-        legacy_count = (await self.session.execute(legacy_stmt)).scalar_one()
-        return edge_count + legacy_count
+        return (await self.session.execute(stmt)).scalar_one()
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def resolve_agent_preset_config(
@@ -1500,7 +1437,7 @@ class AgentPresetService(BaseWorkspaceService):
             AgentPresetVersion.preset_id,
             AgentPresetVersion.workspace_id,
             AgentPresetVersion.version,
-            AgentPresetVersion.agents,
+            AgentPresetVersion.subagents_enabled,
             AgentPresetVersion.tool_approvals,
             AgentPresetVersion.enable_internet_access,
             AgentPresetVersion.created_at,
@@ -1558,16 +1495,12 @@ class AgentPresetService(BaseWorkspaceService):
                 workspace_id=workspace_id,
                 version=version_number,
                 capabilities=_agent_preset_capabilities(
-                    agents_config=AgentSubagentsConfig(
-                        enabled=AgentSubagentsConfig.model_validate(agents_json).enabled
-                    ),
+                    agents_config=AgentSubagentsConfig(enabled=subagents_enabled),
                     tool_approvals=tool_approvals,
                     enable_internet_access=enable_internet_access,
                 ),
                 subagent_eligibility=build_subagent_eligibility(
-                    agents_config=AgentSubagentsConfig(
-                        enabled=AgentSubagentsConfig.model_validate(agents_json).enabled
-                    ),
+                    agents_config=AgentSubagentsConfig(enabled=subagents_enabled),
                     tool_approvals=tool_approvals,
                 ),
                 created_at=created_at,
@@ -1578,7 +1511,7 @@ class AgentPresetService(BaseWorkspaceService):
                 row_preset_id,
                 workspace_id,
                 version_number,
-                agents_json,
+                subagents_enabled,
                 tool_approvals,
                 enable_internet_access,
                 created_at,
@@ -1705,7 +1638,6 @@ class AgentPresetService(BaseWorkspaceService):
             Skill.workspace_id == self.workspace_id,
             Skill.id.in_(normalized_ids),
             Skill.deleted_at.is_(None),
-            Skill.archived_at.is_(None),
         )
         if for_update:
             stmt = stmt.order_by(Skill.id).with_for_update()
@@ -1819,6 +1751,21 @@ class AgentPresetService(BaseWorkspaceService):
                 return version
         raise TracecatNotFoundError(
             f"Agent preset '{preset.id}' has no current published version"
+        )
+
+    async def _get_latest_version_for_preset(
+        self, preset: AgentPreset
+    ) -> AgentPresetVersion | None:
+        """Return the latest immutable version as an unpublished builder baseline."""
+
+        return await self.session.scalar(
+            select(AgentPresetVersion)
+            .where(
+                AgentPresetVersion.workspace_id == self.workspace_id,
+                AgentPresetVersion.preset_id == preset.id,
+            )
+            .order_by(AgentPresetVersion.version.desc())
+            .limit(1)
         )
 
     @require_scope("agent:update")
@@ -2081,7 +2028,7 @@ class AgentPresetService(BaseWorkspaceService):
         agents: AgentSubagentsConfig | ResolvedAgentsConfig,
         preset_locked: bool = False,
     ) -> AgentPresetVersion:
-        """Create one immutable version and both rollout representations."""
+        """Create one immutable version and its ResourceHead edges."""
 
         if not preset_locked:
             preset = await self._lock_preset_row(preset.id)
@@ -2098,18 +2045,12 @@ class AgentPresetService(BaseWorkspaceService):
         current_version = result.scalar_one_or_none()
         next_version = (current_version or 0) + 1
 
-        legacy_agents = await self._legacy_agents_projection(
-            preset=preset,
-            agents=agents,
-        )
-        skill_version_ids = await self._current_skill_version_ids(skill_ids)
-
         version = AgentPresetVersion(
             workspace_id=self.workspace_id,
             preset_id=preset.id,
             version=next_version,
             **config.model_dump(exclude={"agents"}),
-            agents=legacy_agents.model_dump(mode="json"),
+            subagents_enabled=agents.enabled,
         )
         self.session.add(version)
         await self.session.flush()
@@ -2119,10 +2060,11 @@ class AgentPresetService(BaseWorkspaceService):
                     workspace_id=self.workspace_id,
                     preset_version_id=version.id,
                     skill_id=skill_id,
-                    skill_version_id=skill_version_ids[skill_id],
                 )
             )
-        for subagent in legacy_agents.subagents:
+        for subagent in agents.subagents:
+            if not isinstance(subagent, HeadAttachedSubagentRef):
+                raise ValueError("Persisted subagent edges require a preset_id")
             self.session.add(
                 AgentPresetVersionSubagent(
                     workspace_id=self.workspace_id,
@@ -2133,102 +2075,5 @@ class AgentPresetService(BaseWorkspaceService):
                     max_turns=subagent.max_turns,
                 )
             )
-        await self._sync_legacy_preset_head(
-            preset=preset,
-            config=config,
-            agents=legacy_agents,
-            skill_version_ids=skill_version_ids,
-        )
         await self.session.flush()
         return version
-
-    async def _legacy_agents_projection(
-        self,
-        *,
-        preset: AgentPreset,
-        agents: AgentSubagentsConfig | ResolvedAgentsConfig,
-    ) -> ResolvedAgentsConfig:
-        """Return the exact legacy JSON shape understood by the old app."""
-
-        if all(
-            isinstance(subagent, ResolvedAttachedSubagentRef)
-            for subagent in agents.subagents
-        ):
-            return ResolvedAgentsConfig.model_validate(agents.model_dump(mode="python"))
-        resolved = await resolve_agents_config(
-            self,
-            agents=agents.model_dump(mode="python"),
-            parent_preset_id=preset.id,
-            parent_slug=preset.slug,
-            include_runtime_config=False,
-        )
-        binding = self._require_available_subagents(
-            resolved,
-            operation="create version",
-        )
-        await self._lock_active_subagent_presets(binding)
-        return binding
-
-    async def _current_skill_version_ids(
-        self, skill_ids: Sequence[uuid.UUID]
-    ) -> dict[uuid.UUID, uuid.UUID]:
-        """Resolve ResourceHead skill edges to the legacy pinned projection."""
-
-        if not skill_ids:
-            return {}
-        rows = (
-            await self.session.execute(
-                select(Skill.id, Skill.current_version_id).where(
-                    Skill.workspace_id == self.workspace_id,
-                    Skill.id.in_(skill_ids),
-                    Skill.deleted_at.is_(None),
-                    Skill.archived_at.is_(None),
-                )
-            )
-        ).tuples()
-        resolved = {
-            skill_id: version_id
-            for skill_id, version_id in rows
-            if version_id is not None
-        }
-        if missing := set(skill_ids) - resolved.keys():
-            raise TracecatValidationError(
-                "Preset skills must have a current published version",
-                detail={
-                    "code": "skill_not_published",
-                    "skill_ids": sorted(str(skill_id) for skill_id in missing),
-                },
-            )
-        return resolved
-
-    async def _sync_legacy_preset_head(
-        self,
-        *,
-        preset: AgentPreset,
-        config: AgentPresetExecutionConfigWrite,
-        agents: ResolvedAgentsConfig,
-        skill_version_ids: Mapping[uuid.UUID, uuid.UUID],
-    ) -> None:
-        """Dual-write the mutable projection consumed by the old application."""
-
-        for field in self.EXECUTION_FIELDS:
-            if field == "agents":
-                preset.agents = agents.model_dump(mode="json")
-            else:
-                setattr(preset, field, getattr(config, field))
-        await self.session.execute(
-            sa.delete(AgentPresetSkill).where(
-                AgentPresetSkill.workspace_id == self.workspace_id,
-                AgentPresetSkill.preset_id == preset.id,
-            )
-        )
-        for skill_id, skill_version_id in skill_version_ids.items():
-            self.session.add(
-                AgentPresetSkill(
-                    workspace_id=self.workspace_id,
-                    preset_id=preset.id,
-                    skill_id=skill_id,
-                    skill_version_id=skill_version_id,
-                )
-            )
-        self.session.add(preset)

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -53,7 +53,7 @@ from tracecat.agent.skill.types import ResolvedSkillRef
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentPreset,
-    AgentPresetSkill,
+    AgentPresetVersion,
     AgentPresetVersionSkill,
     Skill,
     SkillBlob,
@@ -1171,8 +1171,7 @@ class SkillService(BaseWorkspaceService):
             draft_revision=skill.draft_revision,
             created_at=skill.created_at,
             updated_at=skill.updated_at,
-            # Expand compatibility: legacy writers archive through archived_at.
-            deleted_at=skill.deleted_at or skill.archived_at,
+            deleted_at=skill.deleted_at,
             current_version=current_version_summary,
             is_draft_publishable=draft.is_publishable,
             draft_validation_errors=draft.validation_errors,
@@ -1192,7 +1191,7 @@ class SkillService(BaseWorkspaceService):
             current_version_id=skill.current_version_id,
             created_at=skill.created_at,
             updated_at=skill.updated_at,
-            deleted_at=skill.deleted_at or skill.archived_at,
+            deleted_at=skill.deleted_at,
         )
 
     async def _validate_skill_slug_available(
@@ -1243,7 +1242,6 @@ class SkillService(BaseWorkspaceService):
             Skill.workspace_id == self.workspace_id,
             Skill.slug == slug,
             Skill.deleted_at.is_(None),
-            Skill.archived_at.is_(None),
         ]
         if excluding_skill_id is not None:
             predicates.append(Skill.id != excluding_skill_id)
@@ -1336,7 +1334,7 @@ class SkillService(BaseWorkspaceService):
             Skill.id == skill_id,
         ]
         if not include_archived:
-            predicates.extend((Skill.deleted_at.is_(None), Skill.archived_at.is_(None)))
+            predicates.append(Skill.deleted_at.is_(None))
         stmt = (
             select(Skill)
             .options(selectinload(Skill.current_version))
@@ -1384,7 +1382,6 @@ class SkillService(BaseWorkspaceService):
                 Skill.workspace_id == self.workspace_id,
                 Skill.slug == slug,
                 Skill.deleted_at.is_(None),
-                Skill.archived_at.is_(None),
             )
         )
         return (await self.session.execute(stmt)).scalar_one_or_none()
@@ -1408,7 +1405,6 @@ class SkillService(BaseWorkspaceService):
                 SkillVersion.id == version_id,
                 SkillVersion.skill_id == skill_id,
                 Skill.deleted_at.is_(None),
-                Skill.archived_at.is_(None),
             )
         )
         return (await self.session.execute(stmt)).scalar_one_or_none()
@@ -1423,7 +1419,7 @@ class SkillService(BaseWorkspaceService):
             Skill.id == skill_id,
         ]
         if not include_archived:
-            predicates.extend((Skill.deleted_at.is_(None), Skill.archived_at.is_(None)))
+            predicates.append(Skill.deleted_at.is_(None))
         stmt = select(Skill).where(*predicates).with_for_update()
         if include_archived:
             stmt = with_deleted(stmt)
@@ -1546,7 +1542,6 @@ class SkillService(BaseWorkspaceService):
         stmt = select(Skill).where(
             Skill.workspace_id == self.workspace_id,
             Skill.deleted_at.is_(None),
-            Skill.archived_at.is_(None),
         )
         if params.cursor:
             try:
@@ -2333,11 +2328,25 @@ class SkillService(BaseWorkspaceService):
         skill = await self._get_skill_for_update(skill_id)
         if skill is None:
             raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
-        current_version_binding = (
+        latest_version_id = (
+            select(AgentPresetVersion.id)
+            .where(
+                AgentPresetVersion.workspace_id == AgentPreset.workspace_id,
+                AgentPresetVersion.preset_id == AgentPreset.id,
+            )
+            .order_by(AgentPresetVersion.version.desc())
+            .limit(1)
+            .correlate(AgentPreset)
+            .scalar_subquery()
+        )
+        active_builder_binding = (
             select(AgentPresetVersionSkill)
             .join(
                 AgentPreset,
-                AgentPreset.current_version_id
+                sa.func.coalesce(
+                    AgentPreset.current_version_id,
+                    latest_version_id,
+                )
                 == AgentPresetVersionSkill.preset_version_id,
             )
             .where(
@@ -2348,35 +2357,13 @@ class SkillService(BaseWorkspaceService):
             )
             .exists()
         )
-        rollback_binding = (
-            select(AgentPresetSkill)
-            .join(
-                AgentPreset,
-                sa.and_(
-                    AgentPreset.workspace_id == AgentPresetSkill.workspace_id,
-                    AgentPreset.id == AgentPresetSkill.preset_id,
-                ),
-            )
-            .where(
-                AgentPresetSkill.workspace_id == self.workspace_id,
-                AgentPresetSkill.skill_id == skill.id,
-                AgentPreset.workspace_id == self.workspace_id,
-                AgentPreset.current_version_id.is_(None),
-                AgentPreset.deleted_at.is_(None),
-            )
-            .exists()
-        )
-        binding_exists = await self.session.scalar(
-            select(sa.or_(current_version_binding, rollback_binding))
-        )
+        binding_exists = await self.session.scalar(select(active_builder_binding))
         if binding_exists:
             raise TracecatValidationError(
                 "Cannot delete a skill that is still referenced by a preset",
                 detail={"code": "skill_in_use"},
             )
-        deleted_at = datetime.now(UTC)
-        skill.archived_at = deleted_at
-        skill.deleted_at = deleted_at
+        skill.deleted_at = datetime.now(UTC)
         self.session.add(skill)
         await self.session.commit()
 
@@ -2393,7 +2380,6 @@ class SkillService(BaseWorkspaceService):
                 Skill.name,
                 Skill.slug,
                 Skill.deleted_at,
-                Skill.archived_at,
                 Skill.current_version_id,
                 SkillVersion.name,
                 SkillVersion.manifest_sha256,
@@ -2430,12 +2416,11 @@ class SkillService(BaseWorkspaceService):
             current_skill_name,
             skill_slug,
             deleted_at,
-            archived_at,
             skill_version_id,
             skill_name,
             manifest_sha256,
         ) in rows:
-            if deleted_at is not None or archived_at is not None:
+            if deleted_at is not None:
                 reason = "deleted"
             elif skill_version_id is None or skill_name is None:
                 reason = "unpublished"

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3547,90 +3547,6 @@ class AgentPreset(SoftDeleteMixin, WorkspaceModel):
         nullable=True,
         doc="Current immutable version for this preset.",
     )
-    # Legacy execution projection retained only by the expand application.
-    # Cutover reads the immutable current version; these columns are dual-written
-    # so the immediately previous application can still be rolled back safely.
-    instructions: Mapped[str | None] = mapped_column(
-        Text,
-        nullable=True,
-        doc="System instructions used for legacy execution",
-    )
-    model_name: Mapped[str] = mapped_column(
-        String(120),
-        default="gpt-5.5",
-        nullable=False,
-        doc="Model name used for legacy execution",
-    )
-    model_provider: Mapped[str] = mapped_column(
-        String(120),
-        default="openai",
-        nullable=False,
-        doc="LLM provider used for legacy execution",
-    )
-    catalog_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID,
-        ForeignKey("agent_catalog.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
-        doc="Canonical catalog row backing the legacy model selection",
-    )
-    base_url: Mapped[str | None] = mapped_column(
-        String(500),
-        nullable=True,
-        doc="Optional model base URL override for legacy execution",
-    )
-    output_type: Mapped[dict[str, Any] | str | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="Optional structured output type definition for legacy execution",
-    )
-    actions: Mapped[list[str] | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="Tool identifiers available to legacy execution",
-    )
-    namespaces: Mapped[list[str] | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="Tool namespaces available to legacy execution",
-    )
-    tool_approvals: Mapped[dict[str, bool] | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="Tool approval requirements by tool name for legacy execution",
-    )
-    mcp_integrations: Mapped[list[str] | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="MCP integrations used for legacy execution",
-    )
-    agents: Mapped[dict[str, Any]] = mapped_column(
-        JSONB,
-        default=lambda: {"enabled": False},
-        server_default=text("'{\"enabled\": false}'::jsonb"),
-        nullable=False,
-        doc="Subagent configuration used for legacy execution",
-    )
-    retries: Mapped[int] = mapped_column(
-        Integer,
-        default=3,
-        nullable=False,
-        doc="Maximum retry attempts per legacy run",
-    )
-    enable_thinking: Mapped[bool] = mapped_column(
-        Boolean,
-        default=True,
-        server_default=text("true"),
-        nullable=False,
-        doc="Whether to enable high thinking for legacy agent runs",
-    )
-    enable_internet_access: Mapped[bool] = mapped_column(
-        Boolean,
-        default=False,
-        server_default=text("false"),
-        nullable=False,
-        doc="Whether legacy agent runs have direct internet access",
-    )
     folder_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID,
         ForeignKey("agent_folder.id", ondelete="SET NULL"),
@@ -3649,11 +3565,6 @@ class AgentPreset(SoftDeleteMixin, WorkspaceModel):
         back_populates="preset",
         cascade="all, delete",
         foreign_keys="[AgentPresetVersion.preset_id]",
-    )
-    skill_bindings: Mapped[list[AgentPresetSkill]] = relationship(
-        "AgentPresetSkill",
-        back_populates="preset",
-        cascade="all, delete-orphan",
     )
     current_version: Mapped[AgentPresetVersion | None] = relationship(
         "AgentPresetVersion",
@@ -3749,12 +3660,11 @@ class AgentPresetVersion(WorkspaceModel):
         nullable=True,
         doc="MCP integrations to use",
     )
-    agents: Mapped[dict[str, Any]] = mapped_column(
-        JSONB,
-        default=lambda: {"enabled": False},
-        server_default=text("'{\"enabled\": false}'::jsonb"),
+    subagents_enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
         nullable=False,
-        doc="Legacy subagent projection for mixed-version rollback",
+        doc="Whether the Agent tool was enabled for this preset version",
     )
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"
@@ -3852,7 +3762,7 @@ class Skill(SoftDeleteMixin, WorkspaceModel):
             "workspace_id",
             "slug",
             unique=True,
-            postgresql_where=text("deleted_at IS NULL AND archived_at IS NULL"),
+            postgresql_where=text("deleted_at IS NULL"),
         ),
     )
 
@@ -3894,11 +3804,6 @@ class Skill(SoftDeleteMixin, WorkspaceModel):
         nullable=True,
         doc="Cached description parsed from root SKILL.md frontmatter",
     )
-    archived_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True),
-        nullable=True,
-        doc="Legacy archive timestamp dual-written until contract",
-    )
     workspace: Mapped[Workspace] = relationship(back_populates="skills")
     current_version: Mapped[SkillVersion | None] = relationship(
         "SkillVersion",
@@ -3921,11 +3826,6 @@ class Skill(SoftDeleteMixin, WorkspaceModel):
         "SkillUpload",
         back_populates="skill",
         cascade="all, delete-orphan",
-    )
-    preset_bindings: Mapped[list[AgentPresetSkill]] = relationship(
-        "AgentPresetSkill",
-        back_populates="skill",
-        cascade="save-update",
     )
 
 
@@ -4174,16 +4074,6 @@ class SkillVersion(WorkspaceModel):
         back_populates="skill_version",
         cascade="all, delete-orphan",
     )
-    preset_bindings: Mapped[list[AgentPresetSkill]] = relationship(
-        "AgentPresetSkill",
-        back_populates="skill_version",
-        cascade="save-update",
-    )
-    preset_version_refs: Mapped[list[AgentPresetVersionSkill]] = relationship(
-        "AgentPresetVersionSkill",
-        back_populates="skill_version",
-        cascade="save-update",
-    )
 
 
 class SkillVersionFile(WorkspaceModel):
@@ -4233,49 +4123,6 @@ class SkillVersionFile(WorkspaceModel):
     blob: Mapped[SkillBlob] = relationship(back_populates="version_files")
 
 
-class AgentPresetSkill(WorkspaceModel):
-    """Legacy mutable skill projection retained for application rollback."""
-
-    __tablename__ = "agent_preset_skill"
-    __table_args__ = (
-        UniqueConstraint(
-            "workspace_id",
-            "preset_id",
-            "skill_id",
-            name="uq_agent_preset_skill_workspace_preset_skill",
-        ),
-    )
-
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID, default=uuid.uuid4, nullable=False, unique=True, index=True
-    )
-    preset_id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        ForeignKey("agent_preset.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    skill_id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        ForeignKey("skill.id", ondelete="RESTRICT"),
-        nullable=False,
-        index=True,
-    )
-    skill_version_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID,
-        ForeignKey("skill_version.id", ondelete="RESTRICT"),
-        nullable=True,
-        index=True,
-    )
-
-    preset: Mapped[AgentPreset] = relationship(back_populates="skill_bindings")
-    skill: Mapped[Skill] = relationship(back_populates="preset_bindings")
-    skill_version: Mapped[SkillVersion | None] = relationship(
-        back_populates="preset_bindings",
-        foreign_keys=[skill_version_id],
-    )
-
-
 class AgentPresetVersionSkill(WorkspaceModel):
     """Skill ResourceHead edge recorded by an immutable preset version."""
 
@@ -4308,20 +4155,10 @@ class AgentPresetVersionSkill(WorkspaceModel):
         nullable=False,
         index=True,
     )
-    skill_version_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID,
-        ForeignKey("skill_version.id", ondelete="RESTRICT"),
-        nullable=True,
-        index=True,
-    )
     preset_version: Mapped[AgentPresetVersion] = relationship(
         back_populates="skill_refs"
     )
     skill: Mapped[Skill] = relationship()
-    skill_version: Mapped[SkillVersion | None] = relationship(
-        back_populates="preset_version_refs",
-        foreign_keys=[skill_version_id],
-    )
 
 
 class AgentTag(WorkspaceModel):

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -82,7 +82,6 @@ POST_RLS_WORKSPACE_SCOPED_TABLES = (
     "skill_draft_file",
     "skill_version",
     "skill_version_file",
-    "agent_preset_skill",
     "agent_preset_version_skill",
     "agent_preset_version_subagent",
     "workspace_sync_resource_mapping",

--- a/tracecat/workspace_sync/adapters/agent_preset.py
+++ b/tracecat/workspace_sync/adapters/agent_preset.py
@@ -13,19 +13,15 @@ from slugify import slugify
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from tracecat.agent.preset.schemas import AGENT_PRESET_EXECUTION_FIELDS
 from tracecat.agent.skill.service import SkillService
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
     AnyAttachedSubagentRef,
     HeadAttachedSubagentRef,
-    ResolvedAgentsConfig,
-    ResolvedAttachedSubagentRef,
 )
 from tracecat.db.models import (
     AgentFolder,
     AgentPreset,
-    AgentPresetSkill,
     AgentPresetVersion,
     AgentPresetVersionSkill,
     AgentPresetVersionSubagent,
@@ -62,15 +58,6 @@ AGENT_PRESET_FILENAME = "preset.yml"
 AGENT_PRESET_VERSIONS_DIR = "versions"
 DEFAULT_AGENT_MODEL_NAME = "gpt-5.5"
 DEFAULT_AGENT_MODEL_PROVIDER = "openai"
-
-
-def _legacy_agents_config(agents: Mapping[str, object] | None) -> AgentSubagentsConfig:
-    """Parse old-writer subagent JSON without blocking workspace projection."""
-
-    try:
-        return AgentSubagentsConfig.model_validate(agents or {})
-    except ValidationError:
-        return AgentSubagentsConfig()
 
 
 class AgentPresetAdapter(DirectoryManifestAdapter):
@@ -319,7 +306,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         )
         subagent_bindings_by_version_id = await self._subagent_bindings_for_versions(
             workspace_service,
-            version_rows,
+            [version.id for version in version_rows],
         )
         versions: dict[int, AgentPresetVersionResourceSpec] = {}
         for version in version_rows:
@@ -378,12 +365,11 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
     async def _subagent_bindings_for_versions(
         self,
         workspace_service: SyncMappingService,
-        versions: list[AgentPresetVersion],
+        version_ids: list[uuid.UUID],
     ) -> dict[uuid.UUID, list[AgentPresetSubagentRef]]:
-        """Return subagent bindings from the representation epoch of each row."""
-        if not versions:
+        """Return current child slugs from normalized version head edges."""
+        if not version_ids:
             return {}
-        version_ids = [version.id for version in versions]
         stmt = (
             select(
                 AgentPresetVersionSubagent.parent_preset_version_id,
@@ -423,20 +409,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                     max_turns=max_turns,
                 )
             )
-        for version in versions:
-            if bindings.get(version.id):
-                continue
-            legacy_agents = _legacy_agents_config(version.agents)
-            bindings[version.id] = [
-                AgentPresetSubagentRef(
-                    slug=ref.preset,
-                    version=getattr(ref, "preset_version", None),
-                    name=ref.name,
-                    description=ref.description,
-                    max_turns=ref.max_turns,
-                )
-                for ref in legacy_agents.subagents
-            ]
         return bindings
 
     async def import_specs(
@@ -481,8 +453,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                     workspace_id=workspace_service.workspace_id,
                     slug=spec.slug,
                     name=spec.name,
-                    model_name=DEFAULT_AGENT_MODEL_NAME,
-                    model_provider=DEFAULT_AGENT_MODEL_PROVIDER,
                 )
             else:
                 preset.slug = spec.slug
@@ -502,11 +472,9 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         for source_id in import_order:
             spec = presets[source_id]
             preset = preset_by_source_id[source_id]
-            current_import: (
-                tuple[AgentPresetVersion, ResolvedAgentsConfig, list[Skill]] | None
-            ) = None
+            imported_versions: dict[int, AgentPresetVersion] = {}
             for version_number, version_spec in sorted(spec.versions.items()):
-                agents, legacy_agents = await self._resolved_subagent_configs(
+                agents = await self._resolved_subagents_config(
                     workspace_service,
                     version_spec,
                 )
@@ -519,29 +487,20 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                     preset=preset,
                     version=version_spec,
                     agents=agents,
-                    legacy_agents=legacy_agents,
                     skill_targets=skill_targets,
                 )
-                if version_number == spec.current_version:
-                    current_import = version, legacy_agents, skill_targets
+                imported_versions[version_number] = version
 
             if spec.current_version is None:
                 preset.current_version_id = None
             else:
-                if current_import is None:
+                if current_version := imported_versions.get(spec.current_version):
+                    preset.current_version_id = current_version.id
+                else:
                     raise TracecatValidationError(
                         f"Agent preset {spec.slug!r} current version "
                         f"{spec.current_version} is missing from the version snapshots."
                     )
-                current_version, legacy_agents, skill_targets = current_import
-                preset.current_version_id = current_version.id
-                await self._sync_legacy_preset_head(
-                    workspace_service,
-                    preset=preset,
-                    version=current_version,
-                    agents=legacy_agents,
-                    skill_targets=skill_targets,
-                )
             workspace_service.session.add(preset)
             await workspace_service.session.flush()
             imported.append(self.imported_resource(source_id, preset.id))
@@ -737,22 +696,21 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             )
         await workspace_service.session.flush()
 
-    async def _resolved_subagent_configs(
+    async def _resolved_subagents_config(
         self,
         workspace_service: SyncMappingService,
         spec: AgentPresetVersionResourceSpec,
-    ) -> tuple[AgentSubagentsConfig, ResolvedAgentsConfig]:
-        """Resolve normalized and rollback subagent configs in one pass.
+    ) -> AgentSubagentsConfig:
+        """Resolve subagent references to their ResourceHeads.
 
-        Resolves each subagent reference to its ResourceHead, skipping any that
-        are missing or unpublished. Version selectors in older manifests are
-        compatibility-only input and do not create version-to-version edges.
+        Missing or unpublished presets are skipped. Version selectors in older
+        manifests are compatibility-only input and do not create
+        version-to-version edges.
         """
-        head_refs: list[AnyAttachedSubagentRef] = []
-        resolved_refs: list[ResolvedAttachedSubagentRef] = []
+        refs: list[AnyAttachedSubagentRef] = []
         for subagent in spec.subagents:
-            result = await workspace_service.session.execute(
-                select(AgentPreset, AgentPresetVersion)
+            child = await workspace_service.session.scalar(
+                select(AgentPreset)
                 .join(
                     AgentPresetVersion,
                     sa.and_(
@@ -767,30 +725,18 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                     AgentPreset.deleted_at.is_(None),
                 )
             )
-            row = result.tuples().one_or_none()
-            if row is None:
+            if child is None:
                 continue
-            child, child_version = row
-            ref_fields = {
-                "preset": child.slug,
-                "preset_id": child.id,
-                "name": subagent.name,
-                "description": subagent.description,
-                "max_turns": subagent.max_turns,
-            }
-            head_refs.append(HeadAttachedSubagentRef(**ref_fields))
-            resolved_refs.append(
-                ResolvedAttachedSubagentRef(
-                    **ref_fields,
-                    preset_version_id=child_version.id,
-                    preset_version=child_version.version,
+            refs.append(
+                HeadAttachedSubagentRef(
+                    preset=child.slug,
+                    preset_id=child.id,
+                    name=subagent.name,
+                    description=subagent.description,
+                    max_turns=subagent.max_turns,
                 )
             )
-        enabled = bool(head_refs)
-        return (
-            AgentSubagentsConfig(enabled=enabled, subagents=head_refs),
-            ResolvedAgentsConfig(enabled=enabled, subagents=resolved_refs),
-        )
+        return AgentSubagentsConfig(enabled=bool(refs), subagents=refs)
 
     async def _version_matches_import(
         self,
@@ -854,26 +800,10 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                 )
             ).tuples()
         )
-        if not existing_subagents:
-            legacy_agents = _legacy_agents_config(version.agents)
-            if legacy_agents.enabled != agents.enabled:
-                return False
-            desired_by_slug = {
-                (
-                    subagent.preset,
-                    subagent.alias,
-                    subagent.description,
-                    subagent.max_turns,
-                )
-                for subagent in agents.subagents
-                if isinstance(subagent, HeadAttachedSubagentRef)
-            }
-            legacy_by_slug = {
-                (ref.preset, ref.alias, ref.description, ref.max_turns)
-                for ref in legacy_agents.subagents
-            }
-            return legacy_by_slug == desired_by_slug
-        return existing_subagents == desired_subagents
+        return (
+            version.subagents_enabled == agents.enabled
+            and existing_subagents == desired_subagents
+        )
 
     async def _upsert_agent_preset_version(
         self,
@@ -882,7 +812,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         preset: AgentPreset,
         version: AgentPresetVersionResourceSpec,
         agents: AgentSubagentsConfig,
-        legacy_agents: ResolvedAgentsConfig,
         skill_targets: list[Skill],
     ) -> AgentPresetVersion:
         """Create an exact-number version or verify an identical existing one."""
@@ -894,16 +823,24 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             )
         )
         attrs = self._version_attrs_from_spec(version)
+        attrs["subagents_enabled"] = agents.enabled
         if existing is None:
-            # MCP selections are workspace-local rather than portable Git state.
-            # Carry the destination preset's local selection into a newly imported
-            # version so advancing the imported head does not silently clear it.
-            attrs["mcp_integrations"] = preset.mcp_integrations
+            attrs["mcp_integrations"] = await workspace_service.session.scalar(
+                select(AgentPresetVersion.mcp_integrations)
+                .where(
+                    AgentPresetVersion.workspace_id == workspace_service.workspace_id,
+                    AgentPresetVersion.preset_id == preset.id,
+                )
+                .order_by(
+                    (AgentPresetVersion.id == preset.current_version_id).desc(),
+                    AgentPresetVersion.version.desc(),
+                )
+                .limit(1)
+            )
             existing = AgentPresetVersion(
                 workspace_id=workspace_service.workspace_id,
                 preset_id=preset.id,
                 version=version.version_number,
-                agents=legacy_agents.model_dump(mode="json"),
                 **attrs,
             )
         else:
@@ -923,13 +860,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                         "version": version.version_number,
                     },
                 )
-            await self._sync_legacy_version_projection(
-                workspace_service,
-                version=existing,
-                agents=agents,
-                legacy_agents=legacy_agents,
-                skill_targets=skill_targets,
-            )
             return existing
         workspace_service.session.add(existing)
         await workspace_service.session.flush()
@@ -939,7 +869,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                     workspace_id=workspace_service.workspace_id,
                     preset_version_id=existing.id,
                     skill_id=skill.id,
-                    skill_version_id=skill.current_version_id,
                 )
             )
         await workspace_service.session.flush()
@@ -970,78 +899,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             "enable_thinking": spec.enable_thinking,
             "enable_internet_access": spec.enable_internet_access,
         }
-
-    async def _sync_legacy_version_projection(
-        self,
-        workspace_service: SyncMappingService,
-        *,
-        version: AgentPresetVersion,
-        agents: AgentSubagentsConfig,
-        legacy_agents: ResolvedAgentsConfig,
-        skill_targets: list[Skill],
-    ) -> None:
-        """Heal rollback-only columns on an existing immutable version."""
-
-        version.agents = legacy_agents.model_dump(mode="json")
-        workspace_service.session.add(version)
-        await workspace_service.session.execute(
-            sa.delete(AgentPresetVersionSubagent).where(
-                AgentPresetVersionSubagent.workspace_id
-                == workspace_service.workspace_id,
-                AgentPresetVersionSubagent.parent_preset_version_id == version.id,
-            )
-        )
-        await self._add_version_subagent_bindings(
-            workspace_service,
-            version,
-            agents,
-        )
-        for skill in skill_targets:
-            if skill.current_version_id is None:
-                continue
-            await workspace_service.session.execute(
-                sa.update(AgentPresetVersionSkill)
-                .where(
-                    AgentPresetVersionSkill.workspace_id
-                    == workspace_service.workspace_id,
-                    AgentPresetVersionSkill.preset_version_id == version.id,
-                    AgentPresetVersionSkill.skill_id == skill.id,
-                )
-                .values(skill_version_id=skill.current_version_id)
-            )
-
-    async def _sync_legacy_preset_head(
-        self,
-        workspace_service: SyncMappingService,
-        *,
-        preset: AgentPreset,
-        version: AgentPresetVersion,
-        agents: ResolvedAgentsConfig,
-        skill_targets: list[Skill],
-    ) -> None:
-        """Dual-write the mutable preset projection consumed by the old app."""
-
-        for field in AGENT_PRESET_EXECUTION_FIELDS:
-            if field != "agents":
-                setattr(preset, field, getattr(version, field))
-        preset.agents = agents.model_dump(mode="json")
-        await workspace_service.session.execute(
-            sa.delete(AgentPresetSkill).where(
-                AgentPresetSkill.workspace_id == workspace_service.workspace_id,
-                AgentPresetSkill.preset_id == preset.id,
-            )
-        )
-        for skill in skill_targets:
-            if skill.current_version_id is None:
-                continue
-            workspace_service.session.add(
-                AgentPresetSkill(
-                    workspace_id=workspace_service.workspace_id,
-                    preset_id=preset.id,
-                    skill_id=skill.id,
-                    skill_version_id=skill.current_version_id,
-                )
-            )
 
     async def _add_version_subagent_bindings(
         self,

--- a/tracecat/workspace_sync/adapters/skill.py
+++ b/tracecat/workspace_sync/adapters/skill.py
@@ -370,7 +370,6 @@ class SkillAdapter(DirectoryManifestAdapter):
             .where(
                 Skill.workspace_id == workspace_service.workspace_id,
                 Skill.deleted_at.is_(None),
-                Skill.archived_at.is_(None),
             )
             .options(selectinload(Skill.current_version))
             .order_by(Skill.slug.asc(), Skill.id.asc())
@@ -508,14 +507,8 @@ class SkillAdapter(DirectoryManifestAdapter):
             owner_label="skill",
             error_cls=TracecatValidationError,
             temp_prefix="__tc_sync_tmp_",
-            row_predicates=(
-                Skill.deleted_at.is_(None),
-                Skill.archived_at.is_(None),
-            ),
-            availability_predicates=(
-                Skill.deleted_at.is_(None),
-                Skill.archived_at.is_(None),
-            ),
+            row_predicates=(Skill.deleted_at.is_(None),),
+            availability_predicates=(Skill.deleted_at.is_(None),),
         )
         imported: list[ImportedResource] = []
         skill_service = SkillService(
@@ -813,10 +806,7 @@ class SkillAdapter(DirectoryManifestAdapter):
                 workspace_service,
                 source_id=source_id,
                 model=Skill,
-                row_predicates=(
-                    Skill.deleted_at.is_(None),
-                    Skill.archived_at.is_(None),
-                ),
+                row_predicates=(Skill.deleted_at.is_(None),),
             )
         )
         if skill is not None:


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut over Agent Preset ResourceHead ownership to make version edges authoritative, remove legacy mutable projections, and keep expand writers compatible during rollout. Aligns with ENG-1530 cutover requirements.

- **Migration**
  - Added `subagents_enabled` to `agent_preset_version`; backfilled from legacy `agents.enabled`, validated not-null, and installed a trigger to keep it in sync during rollout.
  - Reconciled subagent edges by expanding legacy JSON, resolving by ID or slug, enforcing unique aliases, and rejecting disabled configs with children; replaced rows in `agent_preset_version_subagent`.
  - Converted `skill.archived_at` to `deleted_at` and updated `uq_skill_workspace_slug_active` to only consider `deleted_at IS NULL`.
  - Downgrade removes the trigger, column, and restores the index. Invalid late expand writes fail atomically during upgrade.

- **Refactors**
  - Removed legacy preset head execution columns and `agent_preset_skill`; dropped `Skill.archived_at`. `AgentPresetVersion.agents` replaced by `subagents_enabled`.
  - Persisted subagents via normalized version edges only; stopped dual-writing to the mutable preset head. Reads come from immutable versions; unpublished presets use the latest version as the builder baseline.
  - Skill archival now checks bindings against a preset’s current or latest builder baseline and sets `deleted_at` only.
  - Workspace sync resolves subagents to heads, compares/imports via `subagents_enabled` and edges, and carries forward `mcp_integrations` from the destination’s latest/current version.
  - Default read values for model fields use `gpt-5.5` and `openai`. Tests updated to reflect new ownership and behaviors.

<sup>Written for commit 5799c6083767e1ee32aae51de83e8652b9cacd5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

