### PR TITLE
refactor(agents): contract legacy resource ownership

### DIFF
--- a/alembic/versions/c7d9e1f3a5b2_drop_skill_versions_from_preset_edges.py
+++ b/alembic/versions/c7d9e1f3a5b2_drop_skill_versions_from_preset_edges.py
@@ -1,0 +1,109 @@
+"""Contract legacy agent preset and skill representations.
+
+Revision ID: c7d9e1f3a5b2
+Revises: d2e4f6a8b0c1
+Create Date: 2026-07-15 00:00:00.000000
+
+The cutover application reads and writes only immutable preset versions and
+ResourceHead edges. This revision removes the rollout bridge and legacy copies
+without changing the authoritative representation.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from tracecat.db.tenant_rls import disable_workspace_table_rls
+
+revision: str = "c7d9e1f3a5b2"
+down_revision: str | None = "d2e4f6a8b0c1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SUBAGENTS_NOT_NULL_CONSTRAINT = "ck_agent_preset_version_subagents_enabled_not_null"
+SUBAGENTS_SYNC_FUNCTION = "sync_agent_preset_version_subagents_enabled"
+SUBAGENTS_SYNC_TRIGGER = "trg_agent_preset_version_subagents_enabled"
+
+
+def _drop_expand_writer_bridge() -> None:
+    """Remove compatibility DDL before dropping its legacy source column."""
+    op.execute(
+        sa.text(
+            f"DROP TRIGGER IF EXISTS {SUBAGENTS_SYNC_TRIGGER} ON agent_preset_version"
+        )
+    )
+    op.execute(sa.text(f"DROP FUNCTION IF EXISTS {SUBAGENTS_SYNC_FUNCTION}()"))
+
+
+def _drop_legacy_preset_head() -> None:
+    """Keep only mutable ResourceHead metadata on agent_preset."""
+    op.execute(disable_workspace_table_rls("agent_preset_skill"))
+    op.drop_table("agent_preset_skill")
+
+    op.drop_constraint(
+        op.f("fk_agent_preset_catalog_id_agent_catalog"),
+        "agent_preset",
+        type_="foreignkey",
+    )
+    op.drop_index(op.f("ix_agent_preset_catalog_id"), table_name="agent_preset")
+    for column in (
+        "instructions",
+        "model_name",
+        "model_provider",
+        "catalog_id",
+        "base_url",
+        "output_type",
+        "actions",
+        "namespaces",
+        "tool_approvals",
+        "mcp_integrations",
+        "agents",
+        "retries",
+        "enable_thinking",
+        "enable_internet_access",
+    ):
+        op.drop_column("agent_preset", column)
+
+
+def _drop_legacy_version_fields() -> None:
+    """Remove version fields superseded by ResourceHead edges."""
+    op.drop_index(
+        op.f("ix_agent_preset_version_skill_skill_version_id"),
+        table_name="agent_preset_version_skill",
+    )
+    op.drop_constraint(
+        op.f("fk_agent_preset_version_skill_skill_version_id_skill_version"),
+        "agent_preset_version_skill",
+        type_="foreignkey",
+    )
+    op.drop_column("agent_preset_version_skill", "skill_version_id")
+    op.drop_column("agent_preset_version", "agents")
+
+
+def upgrade() -> None:
+    _drop_expand_writer_bridge()
+
+    op.execute(sa.text("SET LOCAL lock_timeout = '1s'"))
+    op.alter_column(
+        "agent_preset_version",
+        "subagents_enabled",
+        existing_type=sa.Boolean(),
+        nullable=False,
+    )
+    op.drop_constraint(
+        op.f(SUBAGENTS_NOT_NULL_CONSTRAINT),
+        "agent_preset_version",
+        type_="check",
+    )
+
+    _drop_legacy_preset_head()
+    _drop_legacy_version_fields()
+    op.drop_column("skill", "archived_at")
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Contracted preset snapshots cannot be reconstructed without inventing "
+        "historical data; roll back the application to the cutover release instead."
+    )

--- a/tests/migration/test_agent_preset_subagent_edges_migration.py
+++ b/tests/migration/test_agent_preset_subagent_edges_migration.py
@@ -20,6 +20,7 @@ from tests.database import TEST_DB_CONFIG
 PREVIOUS_REVISION: Final = "c6a8d4f3b2e1"
 EXPAND_REVISION: Final = "44320bf05445"
 CUTOVER_REVISION: Final = "d2e4f6a8b0c1"
+CONTRACT_REVISION: Final = "c7d9e1f3a5b2"
 
 
 def _invoke_alembic(db_url: str, *args: str) -> subprocess.CompletedProcess[str]:
@@ -808,5 +809,215 @@ def test_cutover_rejects_invalid_late_expand_write_atomically(
                 == EXPAND_REVISION
             )
             assert _column(conn, "agent_preset_version", "subagents_enabled") is None
+    finally:
+        engine.dispose()
+
+
+def test_contract_drops_legacy_copies_and_preserves_resource_head_edges(
+    migration_db_url: str,
+) -> None:
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+    try:
+        parent_id = uuid.uuid4()
+        child_id = uuid.uuid4()
+        version_id = uuid.uuid4()
+        skill_id = uuid.uuid4()
+        skill_version_id = uuid.uuid4()
+        with engine.begin() as conn:
+            workspace_id = _setup_workspace(conn, label="contract")
+            _insert_preset(
+                conn, workspace_id=workspace_id, preset_id=child_id, slug="child"
+            )
+            _insert_preset(
+                conn, workspace_id=workspace_id, preset_id=parent_id, slug="parent"
+            )
+            _insert_version(
+                conn,
+                workspace_id=workspace_id,
+                preset_id=parent_id,
+                version_id=version_id,
+                version=1,
+                agents={
+                    "enabled": True,
+                    "subagents": [{"preset": "child", "name": "helper"}],
+                },
+            )
+            conn.execute(
+                text(
+                    "UPDATE agent_preset SET current_version_id = :version_id "
+                    "WHERE id = :preset_id"
+                ),
+                {"version_id": version_id, "preset_id": parent_id},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO skill (
+                        id, workspace_id, name, slug, draft_revision,
+                        archived_at, deleted_at
+                    )
+                    VALUES (:id, :workspace_id, 'skill', 'skill', 0, NULL, NULL)
+                    """
+                ),
+                {"id": skill_id, "workspace_id": workspace_id},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO skill_version (
+                        id, skill_id, version, manifest_sha256, file_count,
+                        total_size_bytes, name, workspace_id
+                    )
+                    VALUES (
+                        :id, :skill_id, 1, :digest, 0, 0, 'skill', :workspace_id
+                    )
+                    """
+                ),
+                {
+                    "id": skill_version_id,
+                    "skill_id": skill_id,
+                    "digest": "a" * 64,
+                    "workspace_id": workspace_id,
+                },
+            )
+            conn.execute(
+                text(
+                    "UPDATE skill SET current_version_id = :version_id WHERE id = :id"
+                ),
+                {"version_id": skill_version_id, "id": skill_id},
+            )
+            for table, owner_column, owner_id in (
+                ("agent_preset_skill", "preset_id", parent_id),
+                ("agent_preset_version_skill", "preset_version_id", version_id),
+            ):
+                conn.execute(
+                    text(
+                        f"""
+                        INSERT INTO {table} (
+                            id, {owner_column}, skill_id, skill_version_id,
+                            workspace_id
+                        )
+                        VALUES (
+                            :id, :owner_id, :skill_id, :skill_version_id,
+                            :workspace_id
+                        )
+                        """
+                    ),
+                    {
+                        "id": uuid.uuid4(),
+                        "owner_id": owner_id,
+                        "skill_id": skill_id,
+                        "skill_version_id": skill_version_id,
+                        "workspace_id": workspace_id,
+                    },
+                )
+
+        _run_alembic(migration_db_url, "upgrade", CONTRACT_REVISION)
+
+        with engine.begin() as conn:
+            assert not _table_exists(conn, "agent_preset_skill")
+            for column_name in (
+                "instructions",
+                "model_name",
+                "model_provider",
+                "catalog_id",
+                "base_url",
+                "output_type",
+                "actions",
+                "namespaces",
+                "tool_approvals",
+                "mcp_integrations",
+                "agents",
+                "retries",
+                "enable_thinking",
+                "enable_internet_access",
+            ):
+                assert _column(conn, "agent_preset", column_name) is None
+            assert _column(conn, "agent_preset_version", "agents") is None
+            assert (
+                _column(conn, "agent_preset_version_skill", "skill_version_id") is None
+            )
+            assert _column(conn, "skill", "archived_at") is None
+            assert _column(conn, "skill", "slug") == {
+                "is_nullable": "NO",
+                "column_default": None,
+            }
+            assert _column(conn, "agent_preset_version", "subagents_enabled") == {
+                "is_nullable": "NO",
+                "column_default": None,
+            }
+            assert (
+                conn.execute(
+                    text(
+                        """
+                    SELECT count(*) FROM pg_constraint
+                    WHERE conname =
+                        'ck_agent_preset_version_subagents_enabled_not_null'
+                    """
+                    )
+                ).scalar_one()
+                == 0
+            )
+            assert (
+                conn.execute(
+                    text(
+                        """
+                    SELECT count(*) FROM pg_trigger
+                    WHERE tgname =
+                        'trg_agent_preset_version_subagents_enabled'
+                    """
+                    )
+                ).scalar_one()
+                == 0
+            )
+            assert (
+                conn.execute(
+                    text(
+                        """
+                        SELECT to_regprocedure(
+                            'sync_agent_preset_version_subagents_enabled()'
+                        )
+                        """
+                    )
+                ).scalar_one()
+                is None
+            )
+            assert conn.execute(
+                text(
+                    """
+                    SELECT child_preset_id, alias
+                    FROM agent_preset_version_subagent
+                    WHERE parent_preset_version_id = :version_id
+                    """
+                ),
+                {"version_id": version_id},
+            ).one() == (child_id, "helper")
+            assert (
+                conn.execute(
+                    text(
+                        """
+                    SELECT skill_id FROM agent_preset_version_skill
+                    WHERE preset_version_id = :version_id
+                    """
+                    ),
+                    {"version_id": version_id},
+                ).scalar_one()
+                == skill_id
+            )
+            assert conn.execute(
+                text(
+                    """
+                    SELECT name, slug, current_version_id FROM agent_preset
+                    WHERE id = :id
+                    """
+                ),
+                {"id": parent_id},
+            ).one() == ("parent", "parent", version_id)
+            assert conn.execute(
+                text(
+                    "SELECT subagents_enabled FROM agent_preset_version WHERE id = :id"
+                ),
+                {"id": version_id},
+            ).scalar_one()
     finally:
         engine.dispose()


### PR DESCRIPTION
## Outcome

This is the Contract layer of the ENG-1530 Expand / Cutover / Contract stack. Once Cutover is fully deployed, it removes the temporary rollout bridge and the physical legacy representations that the application no longer reads or writes.

This PR was rebuilt directly on the fresh Cutover PR #3059. It supersedes #3024.

## Contract boundary

- Remove the temporary trigger and function that populated `subagents_enabled` for Expand writers.
- Make `agent_preset_version.subagents_enabled` physically `NOT NULL` and remove its rollout check constraint.
- Drop legacy execution configuration columns from `agent_preset`.
- Drop legacy subagent JSON from `agent_preset_version`.
- Drop the legacy `agent_preset_skill` table and pinned `skill_version_id` from version-owned skill edges.
- Drop `skill.archived_at`; `deleted_at` remains the sole deletion marker.

The migration is intentionally forward-only because the removed historical copies cannot be reconstructed without inventing data. Operational rollback should return to the Cutover application release before applying this contract migration.

## Release gate

1. Merge and fully deploy Cutover #3059.
2. Confirm no Expand application tasks remain.
3. Apply this Contract migration and deploy the Contract application release.

## Validation

- Full Expand → Cutover → Contract migration suite: 11 passed
- Contract assertions cover preserved subagent and skill ResourceHead edges, current preset pointers, physical nullability, and removal of every bridge and legacy field
- Ruff check and format on changed Python files
- BasedPyright on changed Python files
- Pre-commit hooks, including the repository Python type check

## Related issue

- [ENG-1530](https://linear.app/tracecat/issue/ENG-1530)
