### PR TITLE
perf(agent): move first-prompt auto-title off the request path

### DIFF
--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -633,6 +633,16 @@ export function useVercelChat({
       queryClient.invalidateQueries({
         queryKey: ["pending-approvals-count", workspaceId],
       })
+      // First-prompt auto-titling runs as a detached backend task that can
+      // commit after the invalidation above on fast turns, leaving the
+      // placeholder title ("Chat 1", ...) in the sidebar until the next
+      // mutation. Re-check on a delay — the second point covers the titling
+      // LLM call's 15s timeout. No-op when nothing is stale or mounted.
+      for (const delayMs of [4_000, 16_000]) {
+        setTimeout(() => {
+          queryClient.invalidateQueries({ queryKey: ["chats", workspaceId] })
+        }, delayMs)
+      }
     },
     onData,
   })

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -62,6 +62,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.agent.schemas import AgentOutput, RunAgentArgs, RunUsage, ToolFilters
     from tracecat.agent.session.activities import (
+        AutoTitleSessionInput,
         CreateSessionInput,
         FinalizeTurnInput,
         LoadSessionInput,
@@ -69,6 +70,7 @@ with workflow.unsafe.imports_passed_through():
         LoadSessionResult,
         PendingToolResult,
         ReconcileToolResultsInput,
+        auto_title_session_activity,
         create_session_activity,
         finalize_turn_activity,
         load_session_activity,
@@ -460,6 +462,7 @@ LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-histo
 PRESERVE_RESUMED_AGENT_BINDINGS_PATCH = (
     "durable-agent-preserve-resumed-agent-bindings-v1"
 )
+PARALLEL_AUTO_TITLE_PATCH = "durable-agent-parallel-auto-title-v1"
 
 
 def _agents_config_from_binding(
@@ -880,6 +883,19 @@ class DurableAgentWorkflow:
         else:
             logger.debug("Starting agent", prompt=args.agent_args.user_prompt)
 
+        auto_title_handle: workflow.ActivityHandle[None] | None = None
+        if workflow.patched(PARALLEL_AUTO_TITLE_PATCH):
+            auto_title_handle = workflow.start_activity(
+                auto_title_session_activity,
+                AutoTitleSessionInput(
+                    role=self.role,
+                    session_id=self.session_id,
+                    user_prompt=args.agent_args.user_prompt,
+                ),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+
         try:
             cfg = await self._build_config(args)
             # Success needs no write: last_error was already cleared at turn
@@ -903,6 +919,18 @@ class DurableAgentWorkflow:
             await self._finalize_session_error(e.message, should_stream=should_stream)
             raise
         finally:
+            # Detached activity handles are cancelled when the workflow returns.
+            # Await at the terminal boundary so titling completes without gating
+            # config resolution, agent execution, or streaming startup.
+            if auto_title_handle is not None:
+                try:
+                    await auto_title_handle
+                except ActivityError as exc:
+                    logger.warning(
+                        "Failed to auto-title agent session",
+                        session_id=str(self.session_id),
+                        error=str(exc),
+                    )
             # Terminal boundary only: approval-pause awaits inside the executor
             # loop and never reaches here. Clear the active-turn pointers so the
             # mid-turn DB filter releases the final rows and reconnect -> 204.

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -62,7 +62,6 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.agent.schemas import AgentOutput, RunAgentArgs, RunUsage, ToolFilters
     from tracecat.agent.session.activities import (
-        AutoTitleSessionInput,
         CreateSessionInput,
         FinalizeTurnInput,
         LoadSessionInput,
@@ -70,7 +69,6 @@ with workflow.unsafe.imports_passed_through():
         LoadSessionResult,
         PendingToolResult,
         ReconcileToolResultsInput,
-        auto_title_session_activity,
         create_session_activity,
         finalize_turn_activity,
         load_session_activity,
@@ -462,7 +460,6 @@ LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-histo
 PRESERVE_RESUMED_AGENT_BINDINGS_PATCH = (
     "durable-agent-preserve-resumed-agent-bindings-v1"
 )
-PARALLEL_AUTO_TITLE_PATCH = "durable-agent-parallel-auto-title-v1"
 
 
 def _agents_config_from_binding(
@@ -883,19 +880,6 @@ class DurableAgentWorkflow:
         else:
             logger.debug("Starting agent", prompt=args.agent_args.user_prompt)
 
-        auto_title_handle: workflow.ActivityHandle[None] | None = None
-        if workflow.patched(PARALLEL_AUTO_TITLE_PATCH):
-            auto_title_handle = workflow.start_activity(
-                auto_title_session_activity,
-                AutoTitleSessionInput(
-                    role=self.role,
-                    session_id=self.session_id,
-                    user_prompt=args.agent_args.user_prompt,
-                ),
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=RETRY_POLICIES["activity:fail_fast"],
-            )
-
         try:
             cfg = await self._build_config(args)
             # Success needs no write: last_error was already cleared at turn
@@ -919,18 +903,6 @@ class DurableAgentWorkflow:
             await self._finalize_session_error(e.message, should_stream=should_stream)
             raise
         finally:
-            # Detached activity handles are cancelled when the workflow returns.
-            # Await at the terminal boundary so titling completes without gating
-            # config resolution, agent execution, or streaming startup.
-            if auto_title_handle is not None:
-                try:
-                    await auto_title_handle
-                except ActivityError as exc:
-                    logger.warning(
-                        "Failed to auto-title agent session",
-                        session_id=str(self.session_id),
-                        error=str(exc),
-                    )
             # Terminal boundary only: approval-pause awaits inside the executor
             # loop and never reaches here. Clear the active-turn pointers so the
             # mid-turn DB filter releases the final rows and reconnect -> 204.

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -104,7 +104,7 @@ class TestSessionActivities:
         """Test that get_session_activities returns a list of activity functions."""
         activities = get_session_activities()
         assert isinstance(activities, list)
-        assert len(activities) == 5
+        assert len(activities) == 6
 
         # All returned items should have the temporal activity definition
         for activity in activities:
@@ -117,6 +117,7 @@ class TestSessionActivities:
             getattr(a, "__temporal_activity_definition").name for a in activities
         ]
         assert "create_session_activity" in activity_names
+        assert "auto_title_session_activity" in activity_names
         assert "load_session_activity" in activity_names
         assert "load_session_messages_activity" in activity_names
         assert "reconcile_tool_results_activity" in activity_names

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -104,7 +104,7 @@ class TestSessionActivities:
         """Test that get_session_activities returns a list of activity functions."""
         activities = get_session_activities()
         assert isinstance(activities, list)
-        assert len(activities) == 6
+        assert len(activities) == 5
 
         # All returned items should have the temporal activity definition
         for activity in activities:
@@ -117,7 +117,6 @@ class TestSessionActivities:
             getattr(a, "__temporal_activity_definition").name for a in activities
         ]
         assert "create_session_activity" in activity_names
-        assert "auto_title_session_activity" in activity_names
         assert "load_session_activity" in activity_names
         assert "load_session_messages_activity" in activity_names
         assert "reconcile_tool_results_activity" in activity_names

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -960,6 +960,7 @@ class TestCreateSessionActivity:
         mock_service.auto_title_session_on_first_prompt.assert_awaited_once_with(
             mock_agent_session,
             "Investigate login failures",
+            expected_title=mock_agent_session.title,
         )
 
     @pytest.mark.anyio

--- a/tests/unit/test_agent_session_auto_title.py
+++ b/tests/unit/test_agent_session_auto_title.py
@@ -116,7 +116,7 @@ async def test_auto_title_does_not_skip_when_history_exists(role: Role) -> None:
     )
     agent_session.id = uuid.uuid4()
 
-    service._is_first_prompt_for_session = AsyncMock(return_value=False)
+    service.is_first_prompt_for_session = AsyncMock(return_value=False)
 
     with patch(
         "tracecat.agent.session.service.generate_session_title",
@@ -125,7 +125,7 @@ async def test_auto_title_does_not_skip_when_history_exists(role: Role) -> None:
         await service.auto_title_session_on_first_prompt(agent_session, "Do something")
 
     assert agent_session.title == "Do something useful"
-    service._is_first_prompt_for_session.assert_not_awaited()
+    service.is_first_prompt_for_session.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_auto_title.py
+++ b/tests/unit/test_agent_session_auto_title.py
@@ -52,8 +52,6 @@ async def test_auto_title_updates_session_on_first_prompt(role: Role) -> None:
     )
     agent_session.id = uuid.uuid4()
 
-    service._is_first_prompt_for_session = AsyncMock(return_value=True)
-
     with patch(
         "tracecat.agent.session.service.generate_session_title",
         AsyncMock(return_value="Investigate login failures"),
@@ -82,8 +80,6 @@ async def test_auto_title_uses_service_role_for_generation(user_role: Role) -> N
         entity_id=uuid.uuid4(),
     )
     agent_session.id = uuid.uuid4()
-    service._is_first_prompt_for_session = AsyncMock(return_value=True)
-
     generate_title = AsyncMock(return_value="Investigate login failures")
     with patch(
         "tracecat.agent.session.service.generate_session_title",
@@ -106,12 +102,15 @@ async def test_auto_title_uses_service_role_for_generation(user_role: Role) -> N
 
 
 @pytest.mark.anyio
-async def test_auto_title_skips_when_not_first_prompt(role: Role) -> None:
+async def test_auto_title_does_not_skip_when_history_exists(role: Role) -> None:
     session = AsyncMock()
+    session.execute.return_value = SimpleNamespace(
+        scalar_one_or_none=lambda: uuid.uuid4()
+    )
     service = AgentSessionService(session, role)
     agent_session = AgentSession(
         workspace_id=role.workspace_id,
-        title="Existing title",
+        title="New Chat",
         entity_type="copilot",
         entity_id=uuid.uuid4(),
     )
@@ -119,9 +118,14 @@ async def test_auto_title_skips_when_not_first_prompt(role: Role) -> None:
 
     service._is_first_prompt_for_session = AsyncMock(return_value=False)
 
-    await service.auto_title_session_on_first_prompt(agent_session, "Do something")
+    with patch(
+        "tracecat.agent.session.service.generate_session_title",
+        AsyncMock(return_value="Do something useful"),
+    ):
+        await service.auto_title_session_on_first_prompt(agent_session, "Do something")
 
-    session.execute.assert_not_awaited()
+    assert agent_session.title == "Do something useful"
+    service._is_first_prompt_for_session.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -137,8 +141,6 @@ async def test_auto_title_does_not_raise_on_expected_generation_error(
         entity_id=uuid.uuid4(),
     )
     agent_session.id = uuid.uuid4()
-
-    service._is_first_prompt_for_session = AsyncMock(return_value=True)
 
     with patch(
         "tracecat.agent.session.service.generate_session_title",
@@ -167,8 +169,6 @@ async def test_auto_title_does_not_raise_on_llm_completion_error(
     )
     agent_session.id = uuid.uuid4()
 
-    service._is_first_prompt_for_session = AsyncMock(return_value=True)
-
     with patch(
         "tracecat.agent.session.service.generate_session_title",
         AsyncMock(side_effect=LLMCompletionError("provider down")),
@@ -196,8 +196,6 @@ async def test_auto_title_does_not_raise_on_validation_error(
     )
     agent_session.id = uuid.uuid4()
 
-    service._is_first_prompt_for_session = AsyncMock(return_value=True)
-
     with patch(
         "tracecat.agent.session.service.generate_session_title",
         AsyncMock(side_effect=TracecatValidationError("invalid model config")),
@@ -222,8 +220,6 @@ async def test_auto_title_raises_on_unexpected_generation_error(role: Role) -> N
         entity_id=uuid.uuid4(),
     )
     agent_session.id = uuid.uuid4()
-
-    service._is_first_prompt_for_session = AsyncMock(return_value=True)
 
     with (
         patch(
@@ -268,8 +264,6 @@ async def test_auto_title_skips_when_compare_and_set_guard_fails(role: Role) -> 
         entity_id=uuid.uuid4(),
     )
     agent_session.id = uuid.uuid4()
-
-    service._is_first_prompt_for_session = AsyncMock(return_value=True)
 
     with patch(
         "tracecat.agent.session.service.generate_session_title",

--- a/tests/unit/test_agent_session_auto_title.py
+++ b/tests/unit/test_agent_session_auto_title.py
@@ -59,6 +59,7 @@ async def test_auto_title_updates_session_on_first_prompt(role: Role) -> None:
         await service.auto_title_session_on_first_prompt(
             agent_session,
             "Users cannot sign in",
+            expected_title=agent_session.title,
         )
 
     assert agent_session.title == "Investigate login failures"
@@ -88,6 +89,7 @@ async def test_auto_title_uses_service_role_for_generation(user_role: Role) -> N
         await service.auto_title_session_on_first_prompt(
             agent_session,
             "Users cannot sign in",
+            expected_title=agent_session.title,
         )
 
     generate_title.assert_awaited_once()
@@ -122,7 +124,11 @@ async def test_auto_title_does_not_skip_when_history_exists(role: Role) -> None:
         "tracecat.agent.session.service.generate_session_title",
         AsyncMock(return_value="Do something useful"),
     ):
-        await service.auto_title_session_on_first_prompt(agent_session, "Do something")
+        await service.auto_title_session_on_first_prompt(
+            agent_session,
+            "Do something",
+            expected_title=agent_session.title,
+        )
 
     assert agent_session.title == "Do something useful"
     service.is_first_prompt_for_session.assert_not_awaited()
@@ -149,6 +155,7 @@ async def test_auto_title_does_not_raise_on_expected_generation_error(
         await service.auto_title_session_on_first_prompt(
             agent_session,
             "Find issue",
+            expected_title=agent_session.title,
         )
 
     session.execute.assert_not_awaited()
@@ -176,6 +183,7 @@ async def test_auto_title_does_not_raise_on_llm_completion_error(
         await service.auto_title_session_on_first_prompt(
             agent_session,
             "Find issue",
+            expected_title=agent_session.title,
         )
 
     session.execute.assert_not_awaited()
@@ -203,6 +211,7 @@ async def test_auto_title_does_not_raise_on_validation_error(
         await service.auto_title_session_on_first_prompt(
             agent_session,
             "Find issue",
+            expected_title=agent_session.title,
         )
 
     session.execute.assert_not_awaited()
@@ -231,6 +240,7 @@ async def test_auto_title_raises_on_unexpected_generation_error(role: Role) -> N
         await service.auto_title_session_on_first_prompt(
             agent_session,
             "Find issue",
+            expected_title=agent_session.title,
         )
 
 
@@ -246,7 +256,11 @@ async def test_auto_title_skips_empty_prompt(role: Role) -> None:
     )
     agent_session.id = uuid.uuid4()
 
-    await service.auto_title_session_on_first_prompt(agent_session, "   ")
+    await service.auto_title_session_on_first_prompt(
+        agent_session,
+        "   ",
+        expected_title=agent_session.title,
+    )
 
     session.execute.assert_not_awaited()
     session.commit.assert_not_awaited()
@@ -272,6 +286,42 @@ async def test_auto_title_skips_when_compare_and_set_guard_fails(role: Role) -> 
         await service.auto_title_session_on_first_prompt(
             agent_session,
             "Investigate this approval request",
+            expected_title=agent_session.title,
         )
 
     session.refresh.assert_awaited_once_with(agent_session)
+
+
+@pytest.mark.anyio
+async def test_auto_title_preserves_manual_rename_after_scheduling(
+    role: Role,
+) -> None:
+    session = AsyncMock()
+    service = AgentSessionService(session, role)
+    agent_session = AgentSession(
+        workspace_id=role.workspace_id,
+        title="New Chat",
+        entity_type="approval",
+        entity_id=uuid.uuid4(),
+    )
+    agent_session.id = uuid.uuid4()
+    expected_title = agent_session.title
+
+    agent_session.title = "Manually renamed session"
+    await session.commit()
+
+    generate_title = AsyncMock(return_value="Approval follow-up investigation")
+    with patch(
+        "tracecat.agent.session.service.generate_session_title",
+        generate_title,
+    ):
+        await service.auto_title_session_on_first_prompt(
+            agent_session,
+            "Investigate this approval request",
+            expected_title=expected_title,
+        )
+
+    assert agent_session.title == "Manually renamed session"
+    generate_title.assert_not_awaited()
+    session.execute.assert_not_awaited()
+    session.commit.assert_awaited_once()

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -466,6 +466,7 @@ async def test_send_message_continue_uses_path_session_id_for_stream_key() -> No
         session_id=session_id,
         request=request,
         active_stream_id=agent_session.active_stream_id,
+        is_first_prompt=None,
     )
 
 
@@ -497,7 +498,7 @@ async def test_send_message_new_turn_uses_fresh_per_turn_stream() -> None:
         validate_turn_request=AsyncMock(return_value=agent_session),
         get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(return_value=None),
-        should_seed_initial_artifact=AsyncMock(return_value=False),
+        is_first_prompt_for_session=AsyncMock(return_value=False),
         build_initial_artifact=AsyncMock(return_value=None),
     )
     fake_stream = SimpleNamespace(
@@ -529,7 +530,7 @@ async def test_send_message_new_turn_uses_fresh_per_turn_stream() -> None:
 
     assert isinstance(response, StreamingResponse)
     with_session_mock.assert_called_once_with(role=role)
-    fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
+    fake_svc.is_first_prompt_for_session.assert_awaited_once_with(session_id)
     fake_svc.build_initial_artifact.assert_not_awaited()
     fake_stream.sse.assert_called_once()
     assert fake_stream.sse.call_args.kwargs["last_id"] == "0-0"
@@ -546,6 +547,7 @@ async def test_send_message_new_turn_uses_fresh_per_turn_stream() -> None:
         session_id=session_id,
         request=request,
         active_stream_id=minted_stream_id,
+        is_first_prompt=False,
     )
 
 
@@ -589,7 +591,7 @@ async def test_send_message_new_turn_bubble_id_survives_fast_finalize() -> None:
                 stream_url="/stream", chat_id=session_id, curr_run_id=run_id
             )
         ),
-        should_seed_initial_artifact=AsyncMock(return_value=False),
+        is_first_prompt_for_session=AsyncMock(return_value=False),
         build_initial_artifact=AsyncMock(return_value=None),
     )
     fake_stream = SimpleNamespace(
@@ -658,7 +660,7 @@ async def test_send_message_new_turn_appends_initial_artifact() -> None:
         validate_turn_request=AsyncMock(return_value=agent_session),
         get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(return_value=None),
-        should_seed_initial_artifact=AsyncMock(return_value=True),
+        is_first_prompt_for_session=AsyncMock(return_value=True),
         build_initial_artifact=AsyncMock(return_value=artifact),
         apply_artifact_side_effects=AsyncMock(return_value=[artifact]),
     )
@@ -691,7 +693,7 @@ async def test_send_message_new_turn_appends_initial_artifact() -> None:
         )
 
     assert isinstance(response, StreamingResponse)
-    fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
+    fake_svc.is_first_prompt_for_session.assert_awaited_once_with(session_id)
     fake_svc.build_initial_artifact.assert_awaited_once_with(agent_session)
     fake_stream.append.assert_awaited_once()
     artifact_event = fake_stream.append.await_args.args[0]
@@ -717,6 +719,7 @@ async def test_send_message_new_turn_appends_initial_artifact() -> None:
     assert run_turn_kwargs["session_id"] == session_id
     assert run_turn_kwargs["request"] == request
     assert isinstance(run_turn_kwargs["active_stream_id"], uuid.UUID)
+    assert run_turn_kwargs["is_first_prompt"] is True
 
 
 @pytest.mark.anyio
@@ -755,7 +758,7 @@ async def test_send_message_new_turn_skips_initial_artifact_after_first_prompt()
         validate_turn_request=AsyncMock(return_value=agent_session),
         get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(return_value=None),
-        should_seed_initial_artifact=AsyncMock(return_value=False),
+        is_first_prompt_for_session=AsyncMock(return_value=False),
         build_initial_artifact=AsyncMock(return_value=artifact),
         apply_artifact_side_effects=AsyncMock(return_value=[artifact]),
     )
@@ -788,7 +791,7 @@ async def test_send_message_new_turn_skips_initial_artifact_after_first_prompt()
         )
 
     assert isinstance(response, StreamingResponse)
-    fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
+    fake_svc.is_first_prompt_for_session.assert_awaited_once_with(session_id)
     fake_svc.build_initial_artifact.assert_not_awaited()
     fake_svc.apply_artifact_side_effects.assert_not_awaited()
     fake_stream.append.assert_not_awaited()
@@ -823,7 +826,7 @@ async def test_send_message_new_turn_clears_stream_when_startup_fails() -> None:
         validate_turn_request=AsyncMock(return_value=agent_session),
         get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(side_effect=RuntimeError("temporal unavailable")),
-        should_seed_initial_artifact=AsyncMock(return_value=False),
+        is_first_prompt_for_session=AsyncMock(return_value=False),
         build_initial_artifact=AsyncMock(return_value=None),
         clear_active_turn=AsyncMock(return_value=None),
     )
@@ -856,7 +859,7 @@ async def test_send_message_new_turn_clears_stream_when_startup_fails() -> None:
             )
 
     assert exc_info.value.status_code == 500
-    fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
+    fake_svc.is_first_prompt_for_session.assert_awaited_once_with(session_id)
     fake_svc.build_initial_artifact.assert_not_awaited()
     fake_svc.run_turn.assert_awaited_once()
     # Startup failure surfaces a terminal frame + clears the active-turn pointers.

--- a/tests/unit/test_agent_session_search_attributes.py
+++ b/tests/unit/test_agent_session_search_attributes.py
@@ -93,10 +93,16 @@ async def test_run_turn_stamps_tracecat_search_attributes(
     agent_session = _build_session(role_with_user, session_id=session_id)
 
     temporal_client = AsyncMock()
+    first_prompt_check = AsyncMock()
 
     with (
         patch.object(service, "get_session", AsyncMock(return_value=agent_session)),
         patch.object(service, "has_pending_approvals", AsyncMock(return_value=False)),
+        patch.object(
+            service,
+            "is_first_prompt_for_session",
+            first_prompt_check,
+        ),
         patch.object(service, "auto_title_session_on_first_prompt", AsyncMock()),
         patch.object(service, "_build_agent_config", _mock_agent_config_context),
         patch(
@@ -107,9 +113,11 @@ async def test_run_turn_stamps_tracecat_search_attributes(
         response = await service.run_turn(
             session_id=session_id,
             request=cast(ChatRequest, BasicChatRequest(message="hello world")),
+            is_first_prompt=False,
         )
 
     assert response is not None
+    first_prompt_check.assert_not_awaited()
     temporal_client.start_workflow.assert_awaited_once()
     kwargs = temporal_client.start_workflow.await_args.kwargs
     search_attributes = kwargs["search_attributes"]
@@ -153,6 +161,7 @@ async def test_run_turn_omits_triggered_by_when_role_has_no_user_id(
         _ = await service.run_turn(
             session_id=session_id,
             request=cast(ChatRequest, BasicChatRequest(message="hello world")),
+            is_first_prompt=False,
         )
 
     kwargs = temporal_client.start_workflow.await_args.kwargs

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -62,14 +62,6 @@ class CreateSessionResult(BaseModel):
     error: str | None = None
 
 
-class AutoTitleSessionInput(BaseModel):
-    """Input for auto_title_session_activity."""
-
-    role: Role
-    session_id: uuid.UUID
-    user_prompt: str
-
-
 class PendingToolResult(BaseModel):
     """Pending tool execution result that preserves approval ordering."""
 
@@ -224,9 +216,8 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                 service.session.add(agent_session)
                 await service.session.commit()
 
-            # Workflow-created sessions do not exist when the detached auto-title
-            # activity starts, so title them here after creation. The service's
-            # compare-and-set guard makes this safe if the activities overlap.
+            # Avoid duplicate title generation when run_turn already attempted
+            # first-prompt auto-title before spawning this workflow.
             if created and input.initial_user_prompt is not None:
                 await service.auto_title_session_on_first_prompt(
                     agent_session,
@@ -268,36 +259,6 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
         logger.error("Failed to create agent session", error=str(e))
         return CreateSessionResult(
             session_id=input.session_id, success=False, error=str(e)
-        )
-
-
-@activity.defn
-async def auto_title_session_activity(input: AutoTitleSessionInput) -> None:
-    """Best-effort auto-title for an existing session's first prompt."""
-    ctx_role.set(input.role)
-
-    try:
-        async with AgentSessionService.with_session(role=input.role) as service:
-            agent_session = await service.get_session(input.session_id)
-            if agent_session is None:
-                logger.info(
-                    "session_auto_title_skip",
-                    session_id=str(input.session_id),
-                    prompt_length=len(input.user_prompt.strip()),
-                    reason="session_not_found",
-                )
-                return
-            await service.auto_title_session_on_first_prompt(
-                agent_session,
-                input.user_prompt,
-            )
-    except Exception as e:
-        logger.warning(
-            "session_auto_title_failure",
-            session_id=str(input.session_id),
-            prompt_length=len(input.user_prompt.strip()),
-            error=str(e),
-            error_type=type(e).__name__,
         )
 
 
@@ -517,7 +478,6 @@ def get_session_activities() -> list:
     """Get all session-related activities for worker registration."""
     return [
         create_session_activity,
-        auto_title_session_activity,
         load_session_activity,
         load_session_messages_activity,
         reconcile_tool_results_activity,

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -222,6 +222,7 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                 await service.auto_title_session_on_first_prompt(
                     agent_session,
                     input.initial_user_prompt,
+                    expected_title=agent_session.title,
                 )
 
         if created:

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -62,6 +62,14 @@ class CreateSessionResult(BaseModel):
     error: str | None = None
 
 
+class AutoTitleSessionInput(BaseModel):
+    """Input for auto_title_session_activity."""
+
+    role: Role
+    session_id: uuid.UUID
+    user_prompt: str
+
+
 class PendingToolResult(BaseModel):
     """Pending tool execution result that preserves approval ordering."""
 
@@ -216,8 +224,9 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                 service.session.add(agent_session)
                 await service.session.commit()
 
-            # Avoid duplicate title generation when run_turn already attempted
-            # first-prompt auto-title before spawning this workflow.
+            # Workflow-created sessions do not exist when the detached auto-title
+            # activity starts, so title them here after creation. The service's
+            # compare-and-set guard makes this safe if the activities overlap.
             if created and input.initial_user_prompt is not None:
                 await service.auto_title_session_on_first_prompt(
                     agent_session,
@@ -259,6 +268,36 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
         logger.error("Failed to create agent session", error=str(e))
         return CreateSessionResult(
             session_id=input.session_id, success=False, error=str(e)
+        )
+
+
+@activity.defn
+async def auto_title_session_activity(input: AutoTitleSessionInput) -> None:
+    """Best-effort auto-title for an existing session's first prompt."""
+    ctx_role.set(input.role)
+
+    try:
+        async with AgentSessionService.with_session(role=input.role) as service:
+            agent_session = await service.get_session(input.session_id)
+            if agent_session is None:
+                logger.info(
+                    "session_auto_title_skip",
+                    session_id=str(input.session_id),
+                    prompt_length=len(input.user_prompt.strip()),
+                    reason="session_not_found",
+                )
+                return
+            await service.auto_title_session_on_first_prompt(
+                agent_session,
+                input.user_prompt,
+            )
+    except Exception as e:
+        logger.warning(
+            "session_auto_title_failure",
+            session_id=str(input.session_id),
+            prompt_length=len(input.user_prompt.strip()),
+            error=str(e),
+            error_type=type(e).__name__,
         )
 
 
@@ -478,6 +517,7 @@ def get_session_activities() -> list:
     """Get all session-related activities for worker registration."""
     return [
         create_session_activity,
+        auto_title_session_activity,
         load_session_activity,
         load_session_messages_activity,
         reconcile_tool_results_activity,

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -476,6 +476,7 @@ async def send_message(
                 agent_session=agent_session,
             )
 
+            is_first_prompt: bool | None = None
             if isinstance(request, ContinueRunRequest):
                 # Continuations resume the same workflow + per-turn stream. Reuse
                 # the existing stream id and follow only newly appended events;
@@ -499,7 +500,8 @@ async def send_message(
                     stream_id=stream_id,
                 )
                 start_id = "0-0"
-                if await svc.should_seed_initial_artifact(agent_session) and (
+                is_first_prompt = await svc.is_first_prompt_for_session(session_id)
+                if is_first_prompt and (
                     artifact := await svc.build_initial_artifact(agent_session)
                 ):
                     await svc.apply_artifact_side_effects(
@@ -514,6 +516,7 @@ async def send_message(
                     session_id=session_id,
                     request=request,
                     active_stream_id=stream_id,
+                    is_first_prompt=is_first_prompt,
                 )
             except Exception as turn_exc:
                 if not isinstance(request, ContinueRunRequest):

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1411,9 +1411,6 @@ class AgentSessionService(BaseWorkspaceService):
         if is_continuation and isinstance(request, ContinueRunRequest):
             return await self._continue_with_approvals(session_id, request)
 
-        if user_prompt is not None:
-            await self.auto_title_session_on_first_prompt(agent_session, user_prompt)
-
         # Build agent config and spawn workflow for new turn
         async with self._build_agent_config(agent_session) as agent_config:
             if request_instructions:

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import copy
 import hashlib
@@ -75,6 +76,7 @@ from tracecat.agent.types import AgentConfig, ClaudeSDKMessageTA, StreamKey
 from tracecat.artifacts.bindings import ArtifactSideEffect
 from tracecat.artifacts.schemas import Artifact, ArtifactAdapter, ArtifactType
 from tracecat.audit.logger import audit_log
+from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.cases.prompts import CaseCopilotPrompts
 from tracecat.cases.service import CasesService
@@ -129,7 +131,41 @@ if TYPE_CHECKING:
     from tracecat.agent.executor.activity import ToolExecutionResult
 
 AUTO_TITLE_SERVICE_ID = "tracecat-api"
+DEFAULT_SESSION_TITLE = "New Chat"
 APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
+_background_tasks: set[asyncio.Task[None]] = set()
+
+
+async def _auto_title_session(
+    *,
+    session_id: uuid.UUID,
+    user_prompt: str,
+    role: Role,
+) -> None:
+    """Best-effort auto-title using a fresh database session."""
+    try:
+        async with AgentSessionService.with_session(role=role) as service:
+            agent_session = await service.get_session(session_id)
+            if agent_session is None:
+                logger.info(
+                    "session_auto_title_skip",
+                    session_id=str(session_id),
+                    prompt_length=len(user_prompt.strip()),
+                    reason="session_not_found",
+                )
+                return
+            await service.auto_title_session_on_first_prompt(
+                agent_session,
+                user_prompt,
+            )
+    except Exception as e:
+        logger.warning(
+            "session_auto_title_failure",
+            session_id=str(session_id),
+            prompt_length=len(user_prompt.strip()),
+            error=str(e),
+            error_type=type(e).__name__,
+        )
 
 
 @dataclass
@@ -1192,18 +1228,6 @@ class AgentSessionService(BaseWorkspaceService):
             )
             return
 
-        if not await self._is_first_prompt_for_session(agent_session.id):
-            logger.info(
-                "session_auto_title_skip",
-                session_id=str(agent_session.id),
-                entity_type=entity_type,
-                prompt_length=len(prompt),
-                old_title_length=len(old_title),
-                new_title_length=0,
-                reason="not_first_prompt",
-            )
-            return
-
         logger.info(
             "session_auto_title_attempt",
             session_id=str(agent_session.id),
@@ -1270,16 +1294,6 @@ class AgentSessionService(BaseWorkspaceService):
             )
             return
 
-        history_exists = (
-            select(AgentSessionHistory.id)
-            .where(
-                AgentSessionHistory.workspace_id == self.workspace_id,
-                AgentSessionHistory.session_id == agent_session.id,
-            )
-            .limit(1)
-            .exists()
-        )
-
         try:
             result = await self.session.execute(
                 update(AgentSession)
@@ -1287,7 +1301,6 @@ class AgentSessionService(BaseWorkspaceService):
                     AgentSession.id == agent_session.id,
                     AgentSession.workspace_id == self.workspace_id,
                     AgentSession.title == old_title,
-                    ~history_exists,
                 )
                 .values(title=new_title)
                 .returning(AgentSession.id)
@@ -1410,6 +1423,19 @@ class AgentSessionService(BaseWorkspaceService):
         # Handle continuation (approval submission) vs new turn
         if is_continuation and isinstance(request, ContinueRunRequest):
             return await self._continue_with_approvals(session_id, request)
+
+        if user_prompt is not None and (
+            not agent_session.title or agent_session.title == DEFAULT_SESSION_TITLE
+        ):
+            task = asyncio.create_task(
+                _auto_title_session(
+                    session_id=session_id,
+                    user_prompt=user_prompt,
+                    role=self.role,
+                )
+            )
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
 
         # Build agent config and spawn workflow for new turn
         async with self._build_agent_config(agent_session) as agent_config:

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -140,6 +140,7 @@ async def _auto_title_session(
     *,
     session_id: uuid.UUID,
     user_prompt: str,
+    expected_title: str,
     role: Role,
 ) -> None:
     """Best-effort auto-title using a fresh database session.
@@ -161,6 +162,7 @@ async def _auto_title_session(
         await service.auto_title_session_on_first_prompt(
             agent_session,
             user_prompt,
+            expected_title=expected_title,
         )
 
 
@@ -1217,11 +1219,25 @@ class AgentSessionService(BaseWorkspaceService):
         self,
         agent_session: AgentSession,
         user_prompt: str,
+        *,
+        expected_title: str,
     ) -> None:
         """Best-effort auto-title on first prompt via direct PydanticAI call."""
         prompt = user_prompt.strip()
         entity_type = agent_session.entity_type
-        old_title = agent_session.title
+        old_title = expected_title
+
+        if agent_session.title != expected_title:
+            logger.info(
+                "session_auto_title_skip",
+                session_id=str(agent_session.id),
+                entity_type=entity_type,
+                prompt_length=len(prompt),
+                old_title_length=len(old_title),
+                new_title_length=len(agent_session.title),
+                reason="title_changed_since_scheduling",
+            )
+            return
 
         if not prompt:
             logger.info(
@@ -1441,6 +1457,8 @@ class AgentSessionService(BaseWorkspaceService):
         if is_first_prompt is None:
             is_first_prompt = await self.is_first_prompt_for_session(session_id)
         should_auto_title = user_prompt is not None and is_first_prompt
+        # Snapshot here so the detached task cannot overwrite a mid-flight rename.
+        expected_title = agent_session.title
 
         # Build agent config and spawn workflow for new turn
         async with self._build_agent_config(agent_session) as agent_config:
@@ -1529,6 +1547,7 @@ class AgentSessionService(BaseWorkspaceService):
                     _auto_title_session(
                         session_id=session_id,
                         user_prompt=user_prompt,
+                        expected_title=expected_title,
                         role=self.role,
                     )
                 )

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1119,7 +1119,7 @@ class AgentSessionService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
-    async def _is_first_prompt_for_session(self, session_id: uuid.UUID) -> bool:
+    async def is_first_prompt_for_session(self, session_id: uuid.UUID) -> bool:
         """Check whether this session has any persisted local history yet."""
         stmt = (
             select(AgentSessionHistory.id)
@@ -1131,10 +1131,6 @@ class AgentSessionService(BaseWorkspaceService):
         )
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none() is None
-
-    async def should_seed_initial_artifact(self, agent_session: AgentSession) -> bool:
-        """Return whether the session should receive its initial artifact seed."""
-        return await self._is_first_prompt_for_session(agent_session.id)
 
     async def has_pending_approvals(self, session_id: uuid.UUID) -> bool:
         """Return whether the session has pending approval decisions."""
@@ -1365,6 +1361,7 @@ class AgentSessionService(BaseWorkspaceService):
         request: ChatRequest | ContinueRunRequest | BasicChatRequest,
         *,
         active_stream_id: uuid.UUID | None = None,
+        is_first_prompt: bool | None = None,
     ) -> ChatResponse | None:
         """Run a session turn by spawning a DurableAgentWorkflow.
 
@@ -1377,6 +1374,8 @@ class AgentSessionService(BaseWorkspaceService):
                 into the workflow input and onto the session row so the producer
                 and reader share the same per-turn Redis key. Defaults to a freshly
                 minted id for callers that don't manage their own stream.
+            is_first_prompt: Whether the session had no history before this turn.
+                When omitted, the service queries history for direct callers.
             request: Either a ChatRequest (start) or ContinueRunRequest (continue).
 
         Returns:
@@ -1439,9 +1438,9 @@ class AgentSessionService(BaseWorkspaceService):
         # executor streams history rows mid-turn, so checking afterwards would
         # race. Placeholder titles ("Chat 1", "Slack thread", ...) vary by
         # surface, so first-prompt history is the signal, not the title text.
-        should_auto_title = user_prompt is not None and (
-            await self._is_first_prompt_for_session(session_id)
-        )
+        if is_first_prompt is None:
+            is_first_prompt = await self.is_first_prompt_for_session(session_id)
+        should_auto_title = user_prompt is not None and is_first_prompt
 
         # Build agent config and spawn workflow for new turn
         async with self._build_agent_config(agent_session) as agent_config:

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -10,6 +10,7 @@ import uuid
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
+from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
 import orjson
@@ -131,7 +132,6 @@ if TYPE_CHECKING:
     from tracecat.agent.executor.activity import ToolExecutionResult
 
 AUTO_TITLE_SERVICE_ID = "tracecat-api"
-DEFAULT_SESSION_TITLE = "New Chat"
 APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
 _background_tasks: set[asyncio.Task[None]] = set()
 
@@ -142,29 +142,40 @@ async def _auto_title_session(
     user_prompt: str,
     role: Role,
 ) -> None:
-    """Best-effort auto-title using a fresh database session."""
-    try:
-        async with AgentSessionService.with_session(role=role) as service:
-            agent_session = await service.get_session(session_id)
-            if agent_session is None:
-                logger.info(
-                    "session_auto_title_skip",
-                    session_id=str(session_id),
-                    prompt_length=len(user_prompt.strip()),
-                    reason="session_not_found",
-                )
-                return
-            await service.auto_title_session_on_first_prompt(
-                agent_session,
-                user_prompt,
+    """Best-effort auto-title using a fresh database session.
+
+    Expected generation errors are handled inside
+    ``auto_title_session_on_first_prompt``; anything else propagates to the
+    task's done callback so programming/database faults surface in logs.
+    """
+    async with AgentSessionService.with_session(role=role) as service:
+        agent_session = await service.get_session(session_id)
+        if agent_session is None:
+            logger.info(
+                "session_auto_title_skip",
+                session_id=str(session_id),
+                prompt_length=len(user_prompt.strip()),
+                reason="session_not_found",
             )
-    except Exception as e:
-        logger.warning(
+            return
+        await service.auto_title_session_on_first_prompt(
+            agent_session,
+            user_prompt,
+        )
+
+
+def _finalize_auto_title_task(
+    task: asyncio.Task[None], *, session_id: uuid.UUID
+) -> None:
+    _background_tasks.discard(task)
+    if task.cancelled():
+        return
+    if (exc := task.exception()) is not None:
+        logger.error(
             "session_auto_title_failure",
             session_id=str(session_id),
-            prompt_length=len(user_prompt.strip()),
-            error=str(e),
-            error_type=type(e).__name__,
+            error=str(exc),
+            error_type=type(exc).__name__,
         )
 
 
@@ -1424,18 +1435,13 @@ class AgentSessionService(BaseWorkspaceService):
         if is_continuation and isinstance(request, ContinueRunRequest):
             return await self._continue_with_approvals(session_id, request)
 
-        if user_prompt is not None and (
-            not agent_session.title or agent_session.title == DEFAULT_SESSION_TITLE
-        ):
-            task = asyncio.create_task(
-                _auto_title_session(
-                    session_id=session_id,
-                    user_prompt=user_prompt,
-                    role=self.role,
-                )
-            )
-            _background_tasks.add(task)
-            task.add_done_callback(_background_tasks.discard)
+        # Titling eligibility must be decided before the workflow spawns: the
+        # executor streams history rows mid-turn, so checking afterwards would
+        # race. Placeholder titles ("Chat 1", "Slack thread", ...) vary by
+        # surface, so first-prompt history is the signal, not the title text.
+        should_auto_title = user_prompt is not None and (
+            await self._is_first_prompt_for_session(session_id)
+        )
 
         # Build agent config and spawn workflow for new turn
         async with self._build_agent_config(agent_session) as agent_config:
@@ -1516,6 +1522,21 @@ class AgentSessionService(BaseWorkspaceService):
                     session_id
                 ),
             )
+
+            # Spawn after the workflow starts so a rejected/failed turn never
+            # renames the session.
+            if should_auto_title and user_prompt is not None:
+                task = asyncio.create_task(
+                    _auto_title_session(
+                        session_id=session_id,
+                        user_prompt=user_prompt,
+                        role=self.role,
+                    )
+                )
+                _background_tasks.add(task)
+                task.add_done_callback(
+                    partial(_finalize_auto_title_task, session_id=session_id)
+                )
 
         # Return ChatResponse with session_id for streaming. Surface run_id so the
         # HTTP layer builds the stable bubble id from the value we just minted


### PR DESCRIPTION
Closes [ENG-1535](https://linear.app/tracecat/issue/ENG-1535/perfagent-first-prompt-auto-title-llm-call-blocks-ttft)

## Problem

On a session's first prompt, `AgentSessionService.run_turn` awaited `auto_title_session_on_first_prompt` — a full `llm_complete` roundtrip with a 15s timeout — **before** spawning `DurableAgentWorkflow`. Since the combined `send_message` endpoint only constructs its SSE `StreamingResponse` after `run_turn` returns, every first message paid an entire extra LLM roundtrip of TTFT before the workflow even started.

## Fix

Titling moves off the request path as a **service-layer fire-and-forget task, gated to interactive first prompts**:

- Eligibility is decided in `run_turn` with the existing first-prompt history check (`_is_first_prompt_for_session`), evaluated **before** the workflow spawns so it cannot race the executor's mid-turn history writes. Placeholder titles vary by surface (`"Chat N"`, `"New Chat - <ts>"`, `"Slack thread"`), so history — not title text — is the signal.
- The detached task is spawned only **after** `start_workflow` succeeds, so a rejected/failed turn never renames the session. Headless/DSL lineages never hit this path — `DurableAgentWorkflow` is untouched, and no extra Temporal activity roundtrip is forced on non-interactive turns.
- The task holds a strong reference via a module-level task set (GC guard) and builds its own DB session with `AgentSessionService.with_session(...)` (the request-scoped session is gone by the time it runs). Expected generation errors stay best-effort inside `auto_title_session_on_first_prompt`; unexpected failures propagate to the task's done callback and are logged at error level.
- Workflow-created sessions keep their existing titling in `create_session_activity` (`created` + initial-prompt gate, unchanged).

### Guard fix

Detaching titling exposed a race in the compare-and-set: `tracecat/agent/executor/loopback.py` inserts `AgentSessionHistory` rows mid-turn as the executor streams, so the `~history_exists` condition (and the in-method first-prompt pre-check) would lose to the first streamed line and silently drop the title. Both are removed; the `AgentSession.title == old_title` condition remains as the dedup/race guard (concurrent turns: one wins; user rename mid-flight: preserved). Call sites now own eligibility, checked race-free before the workflow starts.

`old_title` is the title **snapshotted in `run_turn` at that same race-free point** and passed into the detached task as `expected_title` — not the title refetched when the task runs, which would capture (and then clobber) a manual rename that landed before the refetch. The task early-skips without an LLM call when the refetched title already differs from the snapshot; renames landing after the refetch fail the CAS instead.

## Verification

- `ruff check` / `ruff format --check` clean; `basedpyright --warnings` on `tracecat/agent/session/`, `packages/tracecat-ee/tracecat_ee/agent/`, and the changed test files — 0 errors/warnings.
- `pytest tests/unit -k "session or title"`: 341 passed, 1 skipped. The 2 failures (`test_soft_delete_filter.py`) fail identically on unmodified `main` (matched by `-k session` on their names only; unrelated, environmental).
- `tests/unit/test_agent_session_auto_title.py` updated to pin the new guard semantics (titles no longer dropped when history rows exist), including `test_auto_title_preserves_manual_rename_after_scheduling` for the `expected_title` snapshot guard.

