### PR TITLE
perf(agent): instrument TTFT segments and prioritize interactive turns

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -399,6 +399,10 @@ class AgentWorkflowArgs(BaseModel):
 
     role: Role
     agent_args: RunAgentArgs
+    trigger_ts: datetime | None = Field(
+        default=None,
+        description="API wall-clock timestamp recorded before workflow dispatch.",
+    )
     # Session metadata
     title: str = Field(default="New Chat", description="Session title")
     entity_type: AgentSessionEntity = Field(
@@ -510,6 +514,35 @@ class DurableAgentWorkflow:
         self.max_tool_calls = args.agent_args.max_tool_calls
         self._cancel_requested: bool = False
         self._cancel_reason: str | None = None
+        self._pre_executor_started_at: datetime | None = None
+
+    def _ttft_log_fields(self) -> dict[str, str]:
+        info = workflow.info()
+        return {
+            "session_id": str(self.session_id),
+            "workflow_id": info.workflow_id,
+            "workflow_run_id": info.run_id,
+            "run_id": str(
+                AgentWorkflowID.from_workflow_id(info.workflow_id).session_id
+            ),
+        }
+
+    @staticmethod
+    def _ttft_now() -> datetime | None:
+        if not workflow.in_workflow():
+            return None
+        return workflow.now()
+
+    def _log_ttft_duration(self, event: str, started_at: datetime | None) -> None:
+        if started_at is None:
+            return
+        workflow.logger.info(
+            event,
+            extra={
+                **self._ttft_log_fields(),
+                "duration_ms": (workflow.now() - started_at).total_seconds() * 1000,
+            },
+        )
 
     def _upsert_tracecat_search_attributes(self) -> None:
         """Ensure direct agent runs have core Tracecat search attributes.
@@ -567,11 +600,16 @@ class DurableAgentWorkflow:
     ) -> None:
         if cfg.model_provider != "custom-model-provider":
             return
+        started_at = self._ttft_now()
         result = await workflow.execute_activity(
             resolve_custom_model_provider_config_activity,
             args=(self.role, cfg.catalog_id),
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
+        )
+        self._log_ttft_duration(
+            "ttft.pre_executor.resolve_custom_model_provider_config_activity",
+            started_at,
         )
         cfg.base_url = result.base_url
         cfg.passthrough = result.passthrough
@@ -598,11 +636,16 @@ class DurableAgentWorkflow:
                     preset_version=args.agent_args.preset_version,
                 )
             )
+            started_at = self._ttft_now()
             preset_config_payload = await workflow.execute_activity(
                 resolve_agent_preset_config_activity,
                 activity_input,
                 start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+            self._log_ttft_duration(
+                "ttft.pre_executor.resolve_agent_preset_config_activity",
+                started_at,
             )
             preset_config = agent_config_from_payload(preset_config_payload)
             # Apply overrides from the provided config (if any)
@@ -647,7 +690,8 @@ class DurableAgentWorkflow:
             return ResolvedAgentsRuntimeConfig()
         if not agents_config.subagents:
             return ResolvedAgentsRuntimeConfig(enabled=True)
-        return await workflow.execute_activity(
+        started_at = self._ttft_now()
+        result = await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(
                 role=self.role,
@@ -659,6 +703,10 @@ class DurableAgentWorkflow:
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
         )
+        self._log_ttft_duration(
+            "ttft.pre_executor.resolve_agents_config_activity", started_at
+        )
+        return result
 
     def _mint_scope_mcp_token(
         self,
@@ -725,6 +773,7 @@ class DurableAgentWorkflow:
         )
         if not workflow.patched(BUILD_AGENT_TOOL_DEFINITIONS_PATCH):
             try:
+                started_at = self._ttft_now()
                 legacy_build_result = await workflow.execute_activity_method(
                     AgentActivities.build_tool_definitions,
                     arg=BuildToolDefsArgs(
@@ -739,6 +788,9 @@ class DurableAgentWorkflow:
                     ),
                     start_to_close_timeout=timedelta(seconds=120),
                     retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                )
+                self._log_ttft_duration(
+                    "ttft.pre_executor.build_tool_definitions", started_at
                 )
             except ActivityError as e:
                 if isinstance(e.cause, ApplicationError):
@@ -786,6 +838,7 @@ class DurableAgentWorkflow:
             scope_specs.append(scope_spec)
 
         try:
+            started_at = self._ttft_now()
             build_result = await workflow.execute_activity_method(
                 AgentActivities.build_agent_tool_definitions,
                 arg=BuildAgentToolDefsArgs(
@@ -796,6 +849,9 @@ class DurableAgentWorkflow:
                     seconds=120 * max(1, len(scope_specs))
                 ),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+            self._log_ttft_duration(
+                "ttft.pre_executor.build_agent_tool_definitions", started_at
             )
         except ActivityError as e:
             if isinstance(e.cause, ApplicationError):
@@ -869,6 +925,18 @@ class DurableAgentWorkflow:
     @workflow.run
     async def run(self, args: AgentWorkflowArgs) -> AgentOutput:
         """Run the agent until completion. The agent will call tools until it needs human approval."""
+        if args.trigger_ts is not None:
+            workflow.logger.info(
+                "ttft.temporal_scheduling",
+                extra={
+                    **self._ttft_log_fields(),
+                    "approx_wall_delta_ms": (
+                        workflow.now() - args.trigger_ts
+                    ).total_seconds()
+                    * 1000,
+                },
+            )
+        self._pre_executor_started_at = self._ttft_now()
         if workflow.patched(UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH):
             self._upsert_tracecat_search_attributes()
         logger.debug(
@@ -1098,11 +1166,15 @@ class DurableAgentWorkflow:
             # Load session topology before resolving agents. A resumed session's
             # stored binding is the stable runtime contract, even if the preset
             # now follows a newer child version.
+            started_at = self._ttft_now()
             load_result = await workflow.execute_activity(
                 load_session_activity,
                 LoadSessionInput(role=self.role, session_id=self.session_id),
                 start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+            self._log_ttft_duration(
+                "ttft.pre_executor.load_session_activity", started_at
             )
             if preserved_binding := _preserved_agents_binding(load_result):
                 agents_result = await self._resolve_agents_config(
@@ -1118,6 +1190,7 @@ class DurableAgentWorkflow:
 
         # Create or get the AgentSession - idempotent, safe to call on resume
         # Persist the active workflow token as curr_run_id for approval lookups.
+        started_at = self._ttft_now()
         create_result = await workflow.execute_activity(
             create_session_activity,
             CreateSessionInput(
@@ -1139,6 +1212,7 @@ class DurableAgentWorkflow:
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
         )
+        self._log_ttft_duration("ttft.pre_executor.create_session_activity", started_at)
         if not create_result.success:
             raise ApplicationError(
                 f"Failed to create agent session: {create_result.error}",
@@ -1174,11 +1248,15 @@ class DurableAgentWorkflow:
             # Legacy command order for histories without the binding-preservation
             # patch marker. sdk_session_data is replay compatibility only; new
             # activity executions leave it unset.
+            started_at = self._ttft_now()
             load_result = await workflow.execute_activity(
                 load_session_activity,
                 LoadSessionInput(role=self.role, session_id=self.session_id),
                 start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+            self._log_ttft_duration(
+                "ttft.pre_executor.load_session_activity", started_at
             )
 
         if load_result.found and load_result.sdk_session_id:
@@ -1209,6 +1287,8 @@ class DurableAgentWorkflow:
             workspace_id=self.workspace_id,
             active_stream_id=args.agent_args.active_stream_id,
             curr_run_id=curr_run_id,
+            workflow_id=info.workflow_id,
+            workflow_run_id=info.run_id,
             user_prompt=args.agent_args.user_prompt,
             config=cfg,
             role=self.role,
@@ -1220,6 +1300,10 @@ class DurableAgentWorkflow:
             sdk_session_data=load_result.sdk_session_data,
             is_fork=load_result.is_fork,
         )
+
+        if self._pre_executor_started_at is not None:
+            self._log_ttft_duration("ttft.pre_executor", self._pre_executor_started_at)
+            self._pre_executor_started_at = None
 
         # Run the executor activity
         while True:
@@ -1452,6 +1536,8 @@ class DurableAgentWorkflow:
                     workspace_id=self.workspace_id,
                     active_stream_id=args.agent_args.active_stream_id,
                     curr_run_id=curr_run_id,
+                    workflow_id=info.workflow_id,
+                    workflow_run_id=info.run_id,
                     user_prompt=args.agent_args.user_prompt,
                     config=cfg,
                     role=self.role,

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -49,6 +49,7 @@ class RuntimeInitPayload:
     sdk_session_data: str | None = None  # JSONL content for resume
     is_approval_continuation: bool = False  # True when resuming after approval decision
     is_fork: bool = False
+    ttft_activity_started_at: float | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RuntimeInitPayload:
@@ -85,6 +86,7 @@ class RuntimeInitPayload:
             sdk_session_data=data.get("sdk_session_data"),
             is_approval_continuation=data.get("is_approval_continuation", False),
             is_fork=data.get("is_fork", False),
+            ttft_activity_started_at=data.get("ttft_activity_started_at"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -112,6 +114,8 @@ class RuntimeInitPayload:
             result["sdk_session_id"] = self.sdk_session_id
         if self.sdk_session_data is not None:
             result["sdk_session_data"] = self.sdk_session_data
+        if self.ttft_activity_started_at is not None:
+            result["ttft_activity_started_at"] = self.ttft_activity_started_at
         return result
 
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -117,6 +117,8 @@ class AgentExecutorInput(BaseModel):
     # Workflow run id for this turn. Pinned so the producer tags persisted
     # history rows, letting mid-turn loads hide the active run's partial rows.
     curr_run_id: uuid.UUID | None = None
+    workflow_id: str | None = None
+    workflow_run_id: str | None = None
     user_prompt: str
     config: AgentConfig
     # Role for context
@@ -240,6 +242,7 @@ class SandboxedAgentExecutor:
     """
 
     input: AgentExecutorInput
+    activity_started_at: float = field(default_factory=perf_counter)
     timeout_seconds: int = field(
         default_factory=lambda: TRACECAT__AGENT_SANDBOX_TIMEOUT
     )
@@ -417,6 +420,7 @@ class SandboxedAgentExecutor:
             sdk_session_data=self.input.sdk_session_data,
             is_approval_continuation=self.input.is_approval_continuation,
             is_fork=self.input.is_fork,
+            ttft_activity_started_at=self.activity_started_at,
         )
 
     async def run(self) -> AgentExecutorResult:
@@ -448,6 +452,8 @@ class SandboxedAgentExecutor:
                 workspace_id=self.input.workspace_id,
                 active_stream_id=self.input.active_stream_id,
                 curr_run_id=self.input.curr_run_id,
+                workflow_id=self.input.workflow_id,
+                workflow_run_id=self.input.workflow_run_id,
             )
             handler = LoopbackHandler(input=loopback_input)
 
@@ -1177,6 +1183,7 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
     Returns:
         AgentExecutorResult with execution status and terminal output.
     """
+    activity_started_at = perf_counter()
     sandbox_mode = "direct" if TRACECAT__DISABLE_NSJAIL else "nsjail"
     activity.heartbeat(
         f"Starting agent execution ({sandbox_mode} mode): {input.session_id}"
@@ -1197,6 +1204,7 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
         )
 
     executor = SandboxedAgentExecutor(input=input)
+    executor.activity_started_at = activity_started_at
     result = await executor.run()
 
     if result.success:

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -97,6 +97,8 @@ class LoopbackInput:
     workspace_id: uuid.UUID
     active_stream_id: uuid.UUID | None = None
     curr_run_id: uuid.UUID | None = None
+    workflow_id: str | None = None
+    workflow_run_id: str | None = None
 
 
 @dataclass(kw_only=True, slots=True)
@@ -849,12 +851,17 @@ class LoopbackHandler:
     async def send_log(self, level: str, message: str, **extra: object) -> None:
         """Emit a structured runtime log."""
         log_fn = getattr(logger, level, logger.info)
-        log_fn(
-            "[runtime] {}",
-            message,
-            session_id=self.input.session_id,
+        fields = {
+            "session_id": self.input.session_id,
+            "workflow_id": self.input.workflow_id,
+            "workflow_run_id": self.input.workflow_run_id,
+            "run_id": str(self.input.curr_run_id) if self.input.curr_run_id else None,
             **extra,
-        )
+        }
+        if message.startswith("ttft."):
+            log_fn(message, **fields)
+        else:
+            log_fn("[runtime] {}", message, **fields)
 
     async def _initialize_stream_sink(self) -> LoopbackEventSink:
         """Build stream sink for this session."""

--- a/tracecat/agent/priority.py
+++ b/tracecat/agent/priority.py
@@ -1,0 +1,9 @@
+"""Temporal priorities for work scheduled on the shared agent queue."""
+
+from temporalio.common import Priority
+
+INTERACTIVE_AGENT_WORKFLOW_PRIORITY = Priority(priority_key=1)
+"""Priority for latency-sensitive interactive agent turns."""
+
+BACKGROUND_AGENT_WORKFLOW_PRIORITY = Priority(priority_key=3)
+"""Priority for headless agent turns started by DSL workflows."""

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -1633,6 +1633,13 @@ class ClaudeAgentRuntime:
                 self.client = client
                 self._client_connected_event.set()
                 log_benchmark_phase("runtime_client_connected")
+                if payload.ttft_activity_started_at is not None:
+                    await self._event_writer.send_log(
+                        "info",
+                        "ttft.sandbox_startup",
+                        duration_ms=(perf_counter() - payload.ttft_activity_started_at)
+                        * 1000,
+                    )
                 stderr_task = asyncio.create_task(drain_stderr())
                 session_flush_task = asyncio.create_task(
                     self._flush_session_lines_when_signaled(
@@ -1652,6 +1659,7 @@ class ClaudeAgentRuntime:
                         await self._event_writer.send_stream_event(
                             self._build_compaction_status_event(phase="started")
                         )
+                    prompt_dispatched_at = perf_counter()
                     await client.query(query_input)
                     log_benchmark_phase("runtime_query_sent")
                     self._query_sent_event.set()
@@ -1678,13 +1686,23 @@ class ClaudeAgentRuntime:
                             fork_session=fork_session,
                         )
                         if isinstance(message, StreamEvent):
+                            first_token_duration_ms: float | None = None
                             if not first_stream_event_logged:
                                 first_stream_event_logged = True
                                 log_benchmark_phase("runtime_first_stream_event")
+                                first_token_duration_ms = (
+                                    perf_counter() - prompt_dispatched_at
+                                ) * 1000
 
                             # Partial streaming delta - forward to UI
                             unified = self._stream_adapter.to_unified_event(message)
                             await self._event_writer.send_stream_event(unified)
+                            if first_token_duration_ms is not None:
+                                await self._event_writer.send_log(
+                                    "info",
+                                    "ttft.first_token",
+                                    duration_ms=first_token_duration_ms,
+                                )
                             self._session_flush_event.set()
 
                         elif isinstance(message, ResultMessage):

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -9,6 +9,7 @@ import uuid
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, Literal
 
 import orjson
@@ -47,6 +48,7 @@ from tracecat.agent.llm import LLMCompletionError
 from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.preset.prompts import AgentPresetBuilderPrompt
 from tracecat.agent.preset.service import AgentPresetService
+from tracecat.agent.priority import INTERACTIVE_AGENT_WORKFLOW_PRIORITY
 from tracecat.agent.runtime.claude_code.session_lines import (
     APPROVAL_INTERRUPT_CONTENT_EXACT,
     APPROVAL_INTERRUPT_CONTENT_MARKERS,
@@ -1362,6 +1364,7 @@ class AgentSessionService(BaseWorkspaceService):
             TracecatNotFoundError: If the session is not found.
             ValueError: If the request/entity type is unsupported.
         """
+        turn_started_at = perf_counter()
         from tracecat_ee.agent.types import AgentWorkflowID
         from tracecat_ee.agent.workflows.durable import (
             AgentWorkflowArgs,
@@ -1483,15 +1486,25 @@ class AgentSessionService(BaseWorkspaceService):
                 task_queue=config.TRACECAT__AGENT_QUEUE,
             )
 
-            await client.start_workflow(
+            workflow_args.trigger_ts = datetime.now(UTC)
+            handle = await client.start_workflow(
                 DurableAgentWorkflow.run,
                 workflow_args,
                 id=str(workflow_id),
                 task_queue=config.TRACECAT__AGENT_QUEUE,
                 retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+                priority=INTERACTIVE_AGENT_WORKFLOW_PRIORITY,
                 search_attributes=self._build_direct_agent_search_attributes(
                     session_id
                 ),
+            )
+            logger.info(
+                "ttft.http_prelude",
+                session_id=str(session_id),
+                workflow_id=str(workflow_id),
+                workflow_run_id=getattr(handle, "first_execution_run_id", None),
+                run_id=str(run_id),
+                duration_ms=(perf_counter() - turn_started_at) * 1000,
             )
 
         # Return ChatResponse with session_id for streaming. Surface run_id so the

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from temporalio import workflow
 from temporalio.common import (
+    Priority,
     RetryPolicy,
     SearchAttributePair,
     TypedSearchAttributes,
@@ -40,6 +41,7 @@ with workflow.unsafe.imports_passed_through():
         ResolveAgentPresetVersionRefActivityInput,
         resolve_agent_preset_version_ref_activity,
     )
+    from tracecat.agent.priority import BACKGROUND_AGENT_WORKFLOW_PRIORITY
     from tracecat.agent.schemas import RunAgentArgs
     from tracecat.agent.session.types import AgentSessionEntity
     from tracecat.agent.types import AgentConfig
@@ -163,6 +165,13 @@ with workflow.unsafe.imports_passed_through():
 
 
 _CHILD_RUN_ARG_PREP_YIELD_EVERY = 8
+DURABLE_AGENT_PRIORITY_PATCH = "dsl-durable-agent-priority-v1"
+
+
+def _durable_agent_workflow_priority() -> Priority:
+    if workflow.patched(DURABLE_AGENT_PRIORITY_PATCH):
+        return BACKGROUND_AGENT_WORKFLOW_PRIORITY
+    return Priority()
 
 
 def _inherit_search_attributes_with_alias(
@@ -1005,6 +1014,7 @@ class DSLWorkflow:
                         retry_policy=RETRY_POLICIES["workflow:fail_fast"],
                         # Route to agent worker queue for session activities
                         task_queue=config.TRACECAT__AGENT_QUEUE,
+                        priority=_durable_agent_workflow_priority(),
                         execution_timeout=wf_info.execution_timeout,
                         task_timeout=wf_info.task_timeout,
                         search_attributes=child_search_attributes,
@@ -1072,6 +1082,7 @@ class DSLWorkflow:
                         retry_policy=RETRY_POLICIES["workflow:fail_fast"],
                         # Route to agent worker queue for session activities
                         task_queue=config.TRACECAT__AGENT_QUEUE,
+                        priority=_durable_agent_workflow_priority(),
                         execution_timeout=wf_info.execution_timeout,
                         task_timeout=wf_info.task_timeout,
                         search_attributes=child_search_attributes,
@@ -1152,6 +1163,7 @@ class DSLWorkflow:
                         retry_policy=RETRY_POLICIES["workflow:fail_fast"],
                         # Route to agent worker queue for session activities
                         task_queue=config.TRACECAT__AGENT_QUEUE,
+                        priority=_durable_agent_workflow_priority(),
                         execution_timeout=wf_info.execution_timeout,
                         task_timeout=wf_info.task_timeout,
                         search_attributes=child_search_attributes,


### PR DESCRIPTION
Part of [ENG-1537](https://linear.app/tracecat/issue/ENG-1537/perfagent-measure-ttft-breakdown-and-evaluate-temporal-priority-for) — this PR delivers the instrumentation and Priority plumbing; the measured breakdown from a live cluster run and the go/no-go on Priority follow as the spike's published result.

## What this adds

### TTFT span instrumentation (logging-only, behavior-neutral)

Structured `ttft.*` log events so one real turn yields a full per-segment breakdown. Every span carries `session_id`, `workflow_id`, `workflow_run_id`, and `run_id` for joining, plus `duration_ms`:

| Event | Where | Measures |
|---|---|---|
| `ttft.http_prelude` | `run_turn` | method entry → `start_workflow` returned |
| `ttft.temporal_scheduling` | top of `DurableAgentWorkflow.run` | API pre-dispatch wall clock → first workflow instruction (`approx_wall_delta_ms`: crosses API/worker clocks, deliberately not named `duration_ms`) |
| `ttft.pre_executor.<activity>` | `durable.py` | each pre-executor activity individually (config/preset/subagent resolution, tool definitions, load/create session) |
| `ttft.pre_executor` | `durable.py` | workflow entry → executor input ready (chain total) |
| `ttft.sandbox_startup` | `claude_code/runtime.py` | `run_agent_activity` entry → SDK client ready |
| `ttft.first_token` | `claude_code/runtime.py` | prompt dispatch → first `StreamEvent` |

Determinism: workflow-side spans use only `workflow.now()` + `workflow.logger` (replay-suppressed). The new `AgentWorkflowArgs.trigger_ts` field is optional/defaulted so in-flight histories replay unchanged. `ttft.sandbox_startup` compares `perf_counter()` across the activity→runtime process boundary, which is valid because the sandbox runs on the same kernel as the executor (CLOCK_MONOTONIC is system-wide); it is not valid across hosts.

Per-activity spans are kept individual (plus the chain total) so the instrumentation stays meaningful after the ENG-1536 pre-executor fusion lands.

### Temporal Priority on the shared agent queue

New `tracecat/agent/priority.py` constants, applied per callsite:

| Site | Priority |
|---|---|
| Interactive `run_turn` → `DurableAgentWorkflow` | `priority_key=1` |
| DSL `ai.agent` / `ai.action` / `ai.preset_agent` child workflows | explicit background `priority_key=3` (= server default), patch-gated (`dsl-durable-agent-priority-v1`) for replay safety |
| `agent/mcp/executor.py` registry-tool workflow | pre-existing `priority_key=2`, unchanged |
| MCP probe workflows | left default (background maintenance) |

Priority only reorders work under queue contention; with idle workers it is a no-op. Eager workflow execution was evaluated and deliberately not added — the API service runs no worker on the agent queue, so there is no local worker to eager-dispatch to.

## Reading a turn's breakdown

```bash
RID=<curr-run-uuid>; just cluster logs api agent-worker agent-executor 2>&1 | rg --pcre2 "(?=.*ttft\.)(?=.*${RID})"
```

## Verification

- `ruff check` / `ruff format --check` clean; `basedpyright --warnings` on `tracecat/agent/`, `packages/tracecat-ee/tracecat_ee/agent/`, `tracecat/dsl/` — 0 errors/warnings.
- `temporalio==1.20.0` signatures verified against the installed package: `priority` accepted on client workflow starts, child workflows, and activity execution.
- `pytest tests/unit -k "agent and (session or workflow)"`: 207 passed (existing suites unchanged — the change is behavior-neutral apart from logs and scheduling priority).
- No live cluster measurement in this PR; that run is the next step of the spike.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured TTFT logging across the agent path and sets `temporalio` priorities so interactive turns run ahead of background work under queue contention. Supports ENG-1537 by enabling a per-turn TTFT breakdown and evaluating priority impact.

- **New Features**
  - TTFT span logs (behavior-neutral): `ttft.http_prelude`, `ttft.temporal_scheduling`, `ttft.pre_executor.*` (per activity + chain), `ttft.sandbox_startup`, `ttft.first_token`.
  - Every event includes `session_id`, `workflow_id`, `workflow_run_id`, `run_id`, and `duration_ms` (`ttft.temporal_scheduling` uses `approx_wall_delta_ms`).
  - Workflow-side timing uses `workflow.now()` and `workflow.logger` for determinism; logs only, no behavior changes.
  - Priority routing on the shared agent queue:
    - Interactive `run_turn` → priority 1.
    - DSL-spawned agent child workflows → background priority 3 (patch-gated with `dsl-durable-agent-priority-v1` for replay safety).
    - Takes effect only under queue contention; idle workers behave the same.

<sup>Written for commit cbc0fac7686215bb543f570607b052345c143ba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

