### PR TITLE
perf(agents): fuse turn-prepare activity chain into one activity

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -504,9 +504,8 @@ class AgentActivities:
             # Scope compilation (MCP discovery included) is the slow part of
             # both this activity and the fused prepare activity that calls it
             # in-process; heartbeat per scope so heartbeat timeouts can catch
-            # a hang. No-op when invoked outside an activity context (tests).
-            if activity.in_activity():
-                activity.heartbeat(f"compiling tool scope '{scope.scope}'")
+            # a hang.
+            activity.heartbeat(f"compiling tool scope '{scope.scope}'")
             results[scope.scope] = await self._build_scope_tool_definitions(
                 scope,
                 role=args.role,

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -501,6 +501,12 @@ class AgentActivities:
                     f"Duplicate agent compile scope '{scope.scope}'",
                     non_retryable=True,
                 )
+            # Scope compilation (MCP discovery included) is the slow part of
+            # both this activity and the fused prepare activity that calls it
+            # in-process; heartbeat per scope so heartbeat timeouts can catch
+            # a hang. No-op when invoked outside an activity context (tests).
+            if activity.in_activity():
+                activity.heartbeat(f"compiling tool scope '{scope.scope}'")
             results[scope.scope] = await self._build_scope_tool_definitions(
                 scope,
                 role=args.role,

--- a/packages/tracecat-ee/tracecat_ee/agent/prepare.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/prepare.py
@@ -1,0 +1,371 @@
+"""Fused pre-executor prepare phase for the durable agent workflow.
+
+Before dispatching the executor activity, a durable-agent turn must:
+
+1. Resolve the effective agent config (preset + caller overrides + custom
+   model provider runtime config).
+2. Load session resume metadata (SDK session id, fork state, stored binding).
+3. Resolve the subagent topology (a resumed session's stored binding wins).
+4. Create or update the session row (curr_run_id, stream buffer, auto-title).
+5. Compile tool definitions for the root scope and every subagent scope.
+
+Historically the workflow scheduled each step as its own activity — up to six
+sequential task-queue round-trips per turn. ``prepare_agent_turn_activity``
+runs the same steps, in the same order, in one activity. The workflow gates it
+behind a patch marker so pre-fuse histories keep replaying the old chain (see
+``DurableAgentWorkflow._prepare_turn``).
+
+Token minting stays in the workflow: MCP/LLM gateway tokens embed workflow
+identity (``workflow.info()``) and are re-minted after approval waits.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+
+from tracecat.agent.common.stream_types import HarnessType
+from tracecat.agent.preset.activities import (
+    ResolveAgentPresetConfigActivityInput,
+    ResolveAgentsConfigActivityInput,
+    resolve_agent_preset_config_activity,
+    resolve_agents_config_activity,
+    resolve_custom_model_provider_config_activity,
+)
+from tracecat.agent.preset.resolver import (
+    ResolvedAgentsRuntimeConfig,
+    ResolvedSubagentConfig,
+)
+from tracecat.agent.schemas import ToolFilters
+from tracecat.agent.session.activities import (
+    CreateSessionInput,
+    LoadSessionInput,
+    LoadSessionResult,
+    create_session_activity,
+    load_session_activity,
+)
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.subagents import (
+    AgentSubagentsConfig,
+    ResolvedAgentsConfig,
+    has_manual_tool_approvals,
+)
+from tracecat.agent.tokens import InternalToolContext
+from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_config import agent_config_from_payload
+from tracecat.auth.types import Role
+from tracecat.contexts import ctx_role
+from tracecat_ee.agent.activities import (
+    AgentActivities,
+    BuildAgentScopeToolDefsArgs,
+    BuildAgentToolDefsArgs,
+    BuildToolDefsResult,
+)
+
+ROOT_AGENT_SCOPE = "root"
+
+
+class PrepareAgentTurnInput(BaseModel):
+    """Inputs for the fused pre-executor prepare phase."""
+
+    role: Role
+    session_id: uuid.UUID
+    curr_run_id: uuid.UUID
+    user_prompt: str
+    # Agent config source: explicit config, or a preset (with optional overrides).
+    config: AgentConfig | None = None
+    preset_slug: str | None = None
+    preset_version: int | None = None
+    agent_preset_id: uuid.UUID | None = None
+    agent_preset_version_id: uuid.UUID | None = None
+    # Session row fields.
+    title: str = "New Chat"
+    entity_type: AgentSessionEntity
+    entity_id: uuid.UUID
+    tools: list[str] | None = None
+    harness_type: HarnessType = HarnessType.CLAUDE_CODE
+    continue_existing_session: bool = False
+
+
+class PreparedSubagent(BaseModel):
+    """One resolved subagent and its compiled tool scope."""
+
+    resolved: ResolvedSubagentConfig
+    config: AgentConfig
+    build_result: BuildToolDefsResult
+
+
+class PrepareAgentTurnResult(BaseModel):
+    """Everything the workflow needs to compile and dispatch the executor."""
+
+    config: AgentConfig
+    sdk_session_id: str | None = None
+    is_fork: bool = False
+    root_build_result: BuildToolDefsResult
+    subagents: list[PreparedSubagent]
+
+
+def internal_tool_context_for(
+    entity_type: AgentSessionEntity, entity_id: uuid.UUID
+) -> InternalToolContext | None:
+    """Internal-tool context for builder assistant sessions, else None."""
+    if entity_type != AgentSessionEntity.AGENT_PRESET_BUILDER:
+        return None
+    return InternalToolContext(
+        preset_id=entity_id,
+        entity_type="agent_preset_builder",
+    )
+
+
+async def _resolve_turn_config(input: PrepareAgentTurnInput) -> AgentConfig:
+    """Resolve the effective root agent config.
+
+    Preset runs pin an exact version when the workflow recorded one, otherwise
+    resolve by slug (+ optional version number). The caller-provided config
+    then acts as an override layer for actions and appended instructions.
+    """
+    if input.preset_slug:
+        if input.agent_preset_version_id is not None:
+            resolve_input = ResolveAgentPresetConfigActivityInput(
+                role=input.role,
+                preset_version_id=input.agent_preset_version_id,
+            )
+        else:
+            resolve_input = ResolveAgentPresetConfigActivityInput(
+                role=input.role,
+                preset_slug=input.preset_slug,
+                preset_version=input.preset_version,
+            )
+        payload = await resolve_agent_preset_config_activity(resolve_input)
+        config = agent_config_from_payload(payload)
+        if override := input.config:
+            if override.actions:
+                config.actions = override.actions
+            if override.instructions:
+                config.instructions = (
+                    "\n".join([config.instructions, override.instructions])
+                    if config.instructions
+                    else override.instructions
+                )
+    else:
+        if input.config is None:
+            raise ApplicationError(
+                "Config must be provided if preset_slug is not set",
+                non_retryable=True,
+            )
+        config = input.config
+
+    await _apply_custom_model_provider_config(input.role, config)
+    return config
+
+
+async def _apply_custom_model_provider_config(role: Role, config: AgentConfig) -> None:
+    if config.model_provider != "custom-model-provider":
+        return
+    result = await resolve_custom_model_provider_config_activity(
+        role, config.catalog_id
+    )
+    config.base_url = result.base_url
+    config.passthrough = result.passthrough
+    if result.model_name:
+        config.model_name = result.model_name
+
+
+def _preserved_agents_binding(
+    load_result: LoadSessionResult,
+) -> ResolvedAgentsConfig | None:
+    """Return the resumed session's stored subagent binding, if any.
+
+    A resumed session's stored binding is the stable runtime contract, even if
+    the preset now follows a newer child version. A session with resume state
+    but no binding predates bindings and is pinned to no subagents.
+    """
+    if not load_result.found:
+        return None
+    if load_result.agents_binding is not None:
+        return load_result.agents_binding
+    if load_result.has_resume_state:
+        return ResolvedAgentsConfig()
+    return None
+
+
+async def _resolve_subagents(
+    input: PrepareAgentTurnInput,
+    config: AgentConfig,
+    load_result: LoadSessionResult,
+) -> ResolvedAgentsRuntimeConfig:
+    if binding := _preserved_agents_binding(load_result):
+        agents = AgentSubagentsConfig.model_validate(binding.model_dump(mode="json"))
+        follow_latest_versions: bool | None = False
+    else:
+        agents = config.agents
+        follow_latest_versions = None
+
+    if not agents.enabled:
+        return ResolvedAgentsRuntimeConfig()
+    if not agents.subagents:
+        return ResolvedAgentsRuntimeConfig(enabled=True)
+    return await resolve_agents_config_activity(
+        ResolveAgentsConfigActivityInput(
+            role=input.role,
+            agents=agents,
+            parent_preset_id=input.agent_preset_id,
+            parent_slug=input.preset_slug,
+            follow_latest_versions=follow_latest_versions,
+        )
+    )
+
+
+def _scope_args(
+    scope: str,
+    config: AgentConfig,
+    *,
+    internal_tool_context: InternalToolContext | None = None,
+    fail_on_mcp_discovery_error: bool = False,
+) -> BuildAgentScopeToolDefsArgs:
+    return BuildAgentScopeToolDefsArgs(
+        scope=scope,
+        tool_filters=ToolFilters(
+            namespaces=config.namespaces,
+            actions=config.actions,
+        ),
+        tool_approvals=config.tool_approvals,
+        mcp_servers=config.mcp_servers,
+        internal_tool_context=internal_tool_context,
+        fail_on_mcp_discovery_error=fail_on_mcp_discovery_error,
+    )
+
+
+def _unsupported_subagent_approvals_error(preset: str) -> ApplicationError:
+    return ApplicationError(
+        f"Subagent preset '{preset}' uses manual approvals, "
+        "which are not supported for subagents yet.",
+        non_retryable=True,
+    )
+
+
+@activity.defn
+async def prepare_agent_turn_activity(
+    input: PrepareAgentTurnInput,
+) -> PrepareAgentTurnResult:
+    """Run the whole pre-executor prepare phase in one activity.
+
+    Performs the same steps the legacy activity chain scheduled individually,
+    in the same order, by calling the same underlying activity functions
+    in-process (they are plain async functions and this activity provides the
+    activity context they expect).
+    """
+    ctx_role.set(input.role)
+
+    # 1. Effective agent config (preset + overrides + custom provider).
+    config = await _resolve_turn_config(input)
+
+    # 2. Session resume metadata.
+    load_result = await load_session_activity(
+        LoadSessionInput(role=input.role, session_id=input.session_id)
+    )
+
+    # 3. Subagent topology (a resumed session's stored binding wins).
+    agents_result = await _resolve_subagents(input, config, load_result)
+
+    # 4. Session row: create or update, pin curr_run_id, init stream buffer.
+    create_result = await create_session_activity(
+        CreateSessionInput(
+            role=input.role,
+            session_id=input.session_id,
+            require_existing=input.continue_existing_session,
+            title=input.title,
+            created_by=input.role.user_id,
+            entity_type=input.entity_type,
+            entity_id=input.entity_id,
+            tools=input.tools,
+            agent_preset_id=input.agent_preset_id,
+            agent_preset_version_id=input.agent_preset_version_id,
+            agents_binding=agents_result.to_agents_binding(),
+            harness_type=input.harness_type,
+            curr_run_id=input.curr_run_id,
+            initial_user_prompt=input.user_prompt,
+        )
+    )
+    if not create_result.success:
+        raise ApplicationError(
+            f"Failed to create agent session: {create_result.error}",
+            non_retryable=True,
+        )
+
+    # 5. Compile tool definitions for the root and every subagent scope.
+    internal_tool_context = internal_tool_context_for(
+        input.entity_type, input.entity_id
+    )
+    scopes = [
+        _scope_args(
+            ROOT_AGENT_SCOPE,
+            config,
+            internal_tool_context=internal_tool_context,
+        )
+    ]
+    subagent_configs: list[tuple[ResolvedSubagentConfig, AgentConfig]] = []
+    for resolved_subagent in agents_result.subagents:
+        child_config = agent_config_from_payload(resolved_subagent.config)
+        if has_manual_tool_approvals(child_config.tool_approvals):
+            raise _unsupported_subagent_approvals_error(
+                resolved_subagent.binding.preset
+            )
+        await _apply_custom_model_provider_config(input.role, child_config)
+        subagent_configs.append((resolved_subagent, child_config))
+        scopes.append(
+            _scope_args(
+                resolved_subagent.alias,
+                child_config,
+                fail_on_mcp_discovery_error=True,
+            )
+        )
+
+    build_result = await AgentActivities().build_agent_tool_definitions(
+        BuildAgentToolDefsArgs(role=input.role, scopes=scopes)
+    )
+
+    root_build_result = build_result.scopes.get(ROOT_AGENT_SCOPE)
+    if root_build_result is None:
+        raise ApplicationError(
+            "Batched agent tool compilation did not return the root scope",
+            non_retryable=True,
+        )
+    # Adopt the effective approval policy computed during tool compilation.
+    if root_build_result.tool_approvals is not None:
+        config.tool_approvals = root_build_result.tool_approvals
+
+    subagents: list[PreparedSubagent] = []
+    for resolved_subagent, child_config in subagent_configs:
+        child_build_result = build_result.scopes.get(resolved_subagent.alias)
+        if child_build_result is None:
+            raise ApplicationError(
+                "Batched agent tool compilation did not return scope "
+                f"'{resolved_subagent.alias}'",
+                non_retryable=True,
+            )
+        # Compilation may add approval-gated tools (e.g. user MCP policies).
+        if has_manual_tool_approvals(child_build_result.tool_approvals):
+            raise _unsupported_subagent_approvals_error(
+                resolved_subagent.binding.preset
+            )
+        if child_build_result.tool_approvals is not None:
+            child_config.tool_approvals = child_build_result.tool_approvals
+        subagents.append(
+            PreparedSubagent(
+                resolved=resolved_subagent,
+                config=child_config,
+                build_result=child_build_result,
+            )
+        )
+
+    return PrepareAgentTurnResult(
+        config=config,
+        sdk_session_id=load_result.sdk_session_id,
+        is_fork=load_result.is_fork,
+        root_build_result=root_build_result,
+        subagents=subagents,
+    )

--- a/packages/tracecat-ee/tracecat_ee/agent/prepare.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/prepare.py
@@ -262,14 +262,17 @@ async def prepare_agent_turn_activity(
 
     # 1. Effective agent config (preset + overrides + custom provider).
     config = await _resolve_turn_config(input)
+    activity.heartbeat("resolved config")
 
     # 2. Session resume metadata.
     load_result = await load_session_activity(
         LoadSessionInput(role=input.role, session_id=input.session_id)
     )
+    activity.heartbeat("loaded session")
 
     # 3. Subagent topology (a resumed session's stored binding wins).
     agents_result = await _resolve_subagents(input, config, load_result)
+    activity.heartbeat("resolved subagents")
 
     # 4. Session row: create or update, pin curr_run_id, init stream buffer.
     create_result = await create_session_activity(
@@ -295,6 +298,7 @@ async def prepare_agent_turn_activity(
             f"Failed to create agent session: {create_result.error}",
             non_retryable=True,
         )
+    activity.heartbeat("session ready")
 
     # 5. Compile tool definitions for the root and every subagent scope.
     internal_tool_context = internal_tool_context_for(

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from temporalio import workflow
-from temporalio.common import TypedSearchAttributes
+from temporalio.common import RetryPolicy, TypedSearchAttributes
 from temporalio.exceptions import (
     ActivityError,
     ApplicationError,
@@ -92,7 +92,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.auth.types import Role
     from tracecat.chat.schemas import ChatMessage
     from tracecat.contexts import ctx_role
-    from tracecat.dsl.common import RETRY_POLICIES
+    from tracecat.dsl.common import NON_RETRYABLE_ERROR_TYPES, RETRY_POLICIES
     from tracecat.executor.activities import ExecutorActivities
     from tracecat.logger import logger
     from tracecat.registry.lock.types import RegistryLock
@@ -1143,11 +1143,24 @@ class DurableAgentWorkflow:
                     harness_type=HarnessType(self.harness_type),
                     continue_existing_session=args.continue_existing_session,
                 ),
-                # One ceiling for the whole phase. Tool compilation dominates
-                # (the legacy chain allowed 120s per scope) and MCP discovery
-                # carries its own internal timeouts.
-                start_to_close_timeout=timedelta(seconds=300),
-                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                # One generous ceiling for the whole phase; hang detection
+                # comes from heartbeats instead (the activity heartbeats
+                # between steps and per compiled scope, and the legacy chain
+                # allowed 120s per scope, so 180s of silence means stuck).
+                start_to_close_timeout=timedelta(seconds=900),
+                heartbeat_timeout=timedelta(seconds=180),
+                # Not fail_fast: every genuine prepare failure raises
+                # ApplicationError(non_retryable=True) and still stops on the
+                # first attempt. Leaving retries on covers transient infra
+                # errors (the whole phase is idempotent) and, critically,
+                # mixed-version rollouts: a not-yet-updated worker fails this
+                # activity with a retryable NotFoundError, and the retry lands
+                # on an updated worker instead of terminally failing the turn.
+                retry_policy=RetryPolicy(
+                    maximum_attempts=5,
+                    initial_interval=timedelta(seconds=2),
+                    non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
+                ),
             )
         except ActivityError as e:
             # Unwrap typed pre-stream failures (e.g. AgentToolDefinitionError)

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -116,10 +116,16 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat_ee.agent.approvals.service import ApprovalManager, ApprovalMap
     from tracecat_ee.agent.context import AgentContext
+    from tracecat_ee.agent.prepare import (
+        ROOT_AGENT_SCOPE,
+        PrepareAgentTurnInput,
+        PrepareAgentTurnResult,
+        internal_tool_context_for,
+        prepare_agent_turn_activity,
+    )
     from tracecat_ee.agent.types import AgentWorkflowID
 
 
-ROOT_AGENT_SCOPE = "root"
 AGENT_TOOL_DEFINITION_ERROR = "AgentToolDefinitionError"
 AGENT_EXECUTOR_PRE_STREAM_ERROR = "AgentExecutorPreStreamError"
 AGENT_RUNTIME_EXECUTION_ERROR = "AgentRuntimeExecutionError"
@@ -138,6 +144,7 @@ PERSIST_SESSION_ERROR_PATCH = (
 # marker have aged out, then use workflow.deprecate_patch(...) before removing
 # the marker entirely in a later cleanup.
 AGENT_REQUEST_CANCEL_PATCH = "durable-agent-request-cancel-v1"
+FUSED_PREPARE_TURN_PATCH = "durable-agent-fused-prepare-turn-v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -387,6 +394,25 @@ class CompiledAgentRun(BaseModel):
     @property
     def sandbox_subagents(self) -> list[SandboxSubagentConfig]:
         return [subagent.to_sandbox_subagent() for subagent in self.subagents]
+
+
+class PreparedTurn(BaseModel):
+    """Workflow-local output of the pre-executor prepare phase.
+
+    Everything ``_execute_agent_turns`` needs to dispatch the executor,
+    produced either by the fused prepare activity or, for pre-fuse histories,
+    by the legacy activity chain.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    config: AgentConfig
+    compiled_run: CompiledAgentRun
+    internal_tool_context: InternalToolContext | None = None
+    sdk_session_id: str | None = None
+    # Legacy replay compatibility only; new executions never populate SDK JSONL.
+    sdk_session_data: str | None = None
+    is_fork: bool = False
 
 
 class AgentWorkflowArgs(BaseModel):
@@ -881,10 +907,10 @@ class DurableAgentWorkflow:
             logger.debug("Starting agent", prompt=args.agent_args.user_prompt)
 
         try:
-            cfg = await self._build_config(args)
+            prepared = await self._prepare_turn(args)
             # Success needs no write: last_error was already cleared at turn
             # start, and last_error is the only persisted run-outcome signal.
-            return await self._run_with_agent_executor(args, cfg)
+            return await self._execute_agent_turns(args, prepared)
         except ActivityError as e:
             # Pre-stream failure: persist last_error and stream it (the loopback
             # was not yet wired up to surface it inline).
@@ -1073,20 +1099,149 @@ class DurableAgentWorkflow:
     def validate_request_cancel(self, request: WorkflowCancelRequest) -> None:
         WorkflowCancelRequest.model_validate(request)
 
-    async def _run_with_agent_executor(
-        self, args: AgentWorkflowArgs, cfg: AgentConfig
-    ) -> AgentOutput:
-        """Run the agent through the executor activity.
+    async def _prepare_turn(self, args: AgentWorkflowArgs) -> PreparedTurn:
+        """Prepare everything the executor needs for this turn.
 
-        This path:
-        1. Resolves tool definitions from registry
-        2. Loads session history from DB (for resume)
-        3. Mints JWT/LLM gateway tokens
-        4. Calls run_agent_activity, which dispatches one runtime turn
-        5. Persists session history after execution
-        6. Handles approval requests
+        Covers agent config resolution, the session row, subagent topology,
+        tool compilation, and per-scope tokens. New executions run the whole
+        phase as one fused activity; histories recorded before the patch
+        marker replay the original activity chain.
         """
-        logger.info("Running agent executor", session_id=self.session_id)
+        if workflow.patched(FUSED_PREPARE_TURN_PATCH):
+            return await self._prepare_turn_fused(args)
+        return await self._prepare_turn_legacy(args)
+
+    async def _prepare_turn_fused(self, args: AgentWorkflowArgs) -> PreparedTurn:
+        """Run the pre-executor phase as a single activity round-trip.
+
+        The activity resolves the config, loads session resume metadata,
+        resolves subagents, upserts the session row, and compiles tool
+        definitions for every scope (see ``tracecat_ee.agent.prepare``).
+        Tokens are minted afterwards in the workflow because they embed
+        workflow identity.
+        """
+        # Persist the workflow-id UUID token used to start this execution so
+        # approval continuation can target the exact live workflow later.
+        curr_run_id = AgentWorkflowID.from_workflow_id(
+            workflow.info().workflow_id
+        ).session_id
+        try:
+            prepare_result = await workflow.execute_activity(
+                prepare_agent_turn_activity,
+                PrepareAgentTurnInput(
+                    role=self.role,
+                    session_id=self.session_id,
+                    curr_run_id=curr_run_id,
+                    user_prompt=args.agent_args.user_prompt,
+                    config=args.agent_args.config,
+                    preset_slug=args.agent_args.preset_slug,
+                    preset_version=args.agent_args.preset_version,
+                    agent_preset_id=args.agent_preset_id,
+                    agent_preset_version_id=args.agent_preset_version_id,
+                    title=args.title,
+                    entity_type=args.entity_type,
+                    entity_id=args.entity_id,
+                    tools=args.tools,
+                    harness_type=HarnessType(self.harness_type),
+                    continue_existing_session=args.continue_existing_session,
+                ),
+                # One ceiling for the whole phase. Tool compilation dominates
+                # (the legacy chain allowed 120s per scope) and MCP discovery
+                # carries its own internal timeouts.
+                start_to_close_timeout=timedelta(seconds=300),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+        except ActivityError as e:
+            # Unwrap typed pre-stream failures (e.g. AgentToolDefinitionError)
+            # so run()'s error handling streams them like the legacy chain did.
+            if isinstance(e.cause, ApplicationError):
+                raise e.cause from e
+            raise
+
+        if prepare_result.sdk_session_id:
+            logger.info(
+                "Resuming from existing session",
+                sdk_session_id=prepare_result.sdk_session_id,
+                is_fork=prepare_result.is_fork,
+            )
+
+        internal_tool_context = internal_tool_context_for(
+            args.entity_type, args.entity_id
+        )
+        return PreparedTurn(
+            config=prepare_result.config,
+            compiled_run=self._compile_prepared_agent_run(
+                prepare_result, internal_tool_context=internal_tool_context
+            ),
+            internal_tool_context=internal_tool_context,
+            sdk_session_id=prepare_result.sdk_session_id,
+            is_fork=prepare_result.is_fork,
+        )
+
+    def _compile_prepared_agent_run(
+        self,
+        prepare_result: PrepareAgentTurnResult,
+        *,
+        internal_tool_context: InternalToolContext | None,
+    ) -> CompiledAgentRun:
+        """Mint per-scope MCP tokens and LLM routes for a prepared turn."""
+        root_spec = AgentScopeSpec(
+            name=ROOT_AGENT_SCOPE,
+            config=prepare_result.config,
+            internal_tool_context=internal_tool_context,
+        )
+        root_scope = CompiledAgentScope(
+            spec=root_spec,
+            build_result=prepare_result.root_build_result,
+            mcp_auth_token=self._mint_scope_mcp_token(
+                build_result=prepare_result.root_build_result,
+                internal_tool_context=internal_tool_context,
+            ),
+        )
+
+        compiled_subagents: list[CompiledSubagentScope] = []
+        llm_routes: dict[str, LLMRouteClaim] = {}
+        for subagent in prepare_result.subagents:
+            route_resolution = _llm_route_for_config(subagent.config)
+            scoped_route_model = _subagent_litellm_route_model(
+                subagent.resolved.alias, route_resolution.route_model
+            )
+            llm_routes[scoped_route_model] = route_resolution.claim
+            scope_spec = AgentScopeSpec(
+                name=subagent.resolved.alias,
+                config=subagent.config,
+                fail_on_mcp_discovery_error=True,
+            )
+            compiled_subagents.append(
+                CompiledSubagentScope(
+                    scope=CompiledAgentScope(
+                        spec=scope_spec,
+                        build_result=subagent.build_result,
+                        mcp_auth_token=self._mint_scope_mcp_token(
+                            build_result=subagent.build_result,
+                        ),
+                        model_route=scoped_route_model,
+                    ),
+                    resolved=subagent.resolved,
+                )
+            )
+
+        return CompiledAgentRun(
+            root=root_scope,
+            subagents=compiled_subagents,
+            registry_lock=prepare_result.root_build_result.registry_lock,
+            llm_routes=llm_routes,
+        )
+
+    async def _prepare_turn_legacy(self, args: AgentWorkflowArgs) -> PreparedTurn:
+        """Replay-only prepare phase for histories without FUSED_PREPARE_TURN_PATCH.
+
+        Pre-fuse executions recorded the prepare phase as a chain of individual
+        activities; this preserves that command sequence — including its older
+        nested patch markers — exactly. Do not extend this path: new behavior
+        belongs in _prepare_turn_fused / prepare_agent_turn_activity.
+        """
+        cfg = await self._build_config(args)
 
         # Persist the workflow-id UUID token used to start this execution so
         # approval continuation can target the exact live workflow later.
@@ -1188,6 +1343,37 @@ class DurableAgentWorkflow:
                 is_fork=load_result.is_fork,
             )
 
+        return PreparedTurn(
+            config=cfg,
+            compiled_run=compiled_run,
+            internal_tool_context=internal_tool_context,
+            sdk_session_id=load_result.sdk_session_id,
+            sdk_session_data=load_result.sdk_session_data,
+            is_fork=load_result.is_fork,
+        )
+
+    async def _execute_agent_turns(
+        self, args: AgentWorkflowArgs, prepared: PreparedTurn
+    ) -> AgentOutput:
+        """Dispatch executor turns until the agent completes.
+
+        Each iteration runs one run_agent_activity turn. Approval requests
+        pause the loop, execute the approved/denied tools, reconcile the SDK
+        transcript, and resume the executor with a continuation turn.
+        """
+        logger.info("Running agent executor", session_id=self.session_id)
+
+        cfg = prepared.config
+        compiled_run = prepared.compiled_run
+        internal_tool_context = prepared.internal_tool_context
+        root_registry_lock = compiled_run.registry_lock
+        allowed_actions = compiled_run.root.tool_definitions
+        # The workflow-id UUID token for this execution (same value the prepare
+        # phase persisted as curr_run_id). workflow.info() is replay-safe.
+        curr_run_id = AgentWorkflowID.from_workflow_id(
+            workflow.info().workflow_id
+        ).session_id
+
         info = workflow.info()
         # Mint the LLM gateway token after compiling subagent routes. MCP tokens
         # are scoped and minted as part of the compiled agent run.
@@ -1216,9 +1402,9 @@ class DurableAgentWorkflow:
             llm_gateway_auth_token=llm_gateway_auth_token,
             allowed_actions=allowed_actions,
             subagents=compiled_run.sandbox_subagents,
-            sdk_session_id=load_result.sdk_session_id,
-            sdk_session_data=load_result.sdk_session_data,
-            is_fork=load_result.is_fork,
+            sdk_session_id=prepared.sdk_session_id,
+            sdk_session_data=prepared.sdk_session_data,
+            is_fork=prepared.is_fork,
         )
 
         # Run the executor activity

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -89,6 +89,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.agent.types import AgentConfig
     from tracecat.agent.workflow_config import agent_config_from_payload
+    from tracecat.agent.workflow_schemas import AgentTurnRequest
     from tracecat.auth.types import Role
     from tracecat.chat.schemas import ChatMessage
     from tracecat.contexts import ctx_role
@@ -423,6 +424,13 @@ class AgentWorkflowArgs(BaseModel):
 
     role: Role
     agent_args: RunAgentArgs
+    request: AgentTurnRequest | None = Field(
+        default=None,
+        description=(
+            "Reader-only next-generation turn contract. Legacy fields remain the "
+            "active workflow input until all workers can decode this shape."
+        ),
+    )
     # Session metadata
     title: str = Field(default="New Chat", description="Session title")
     entity_type: AgentSessionEntity = Field(

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -410,8 +410,6 @@ class PreparedTurn(BaseModel):
     compiled_run: CompiledAgentRun
     internal_tool_context: InternalToolContext | None = None
     sdk_session_id: str | None = None
-    # Legacy replay compatibility only; new executions never populate SDK JSONL.
-    sdk_session_data: str | None = None
     is_fork: bool = False
 
 
@@ -1327,8 +1325,7 @@ class DurableAgentWorkflow:
 
         if load_result is None:
             # Legacy command order for histories without the binding-preservation
-            # patch marker. sdk_session_data is replay compatibility only; new
-            # activity executions leave it unset.
+            # patch marker.
             load_result = await workflow.execute_activity(
                 load_session_activity,
                 LoadSessionInput(role=self.role, session_id=self.session_id),
@@ -1348,7 +1345,6 @@ class DurableAgentWorkflow:
             compiled_run=compiled_run,
             internal_tool_context=internal_tool_context,
             sdk_session_id=load_result.sdk_session_id,
-            sdk_session_data=load_result.sdk_session_data,
             is_fork=load_result.is_fork,
         )
 
@@ -1403,7 +1399,6 @@ class DurableAgentWorkflow:
             allowed_actions=allowed_actions,
             subagents=compiled_run.sandbox_subagents,
             sdk_session_id=prepared.sdk_session_id,
-            sdk_session_data=prepared.sdk_session_data,
             is_fork=prepared.is_fork,
         )
 
@@ -1646,7 +1641,6 @@ class DurableAgentWorkflow:
                     allowed_actions=allowed_actions,
                     subagents=compiled_run.sandbox_subagents,
                     sdk_session_id=reload_result.sdk_session_id,
-                    sdk_session_data=reload_result.sdk_session_data,
                     is_fork=reload_result.is_fork,
                     is_approval_continuation=True,
                 )

--- a/tests/integration/test_agent_worker.py
+++ b/tests/integration/test_agent_worker.py
@@ -25,8 +25,13 @@ import pytest
 from temporalio import activity
 from temporalio.client import Client, WorkflowFailureError
 from temporalio.worker import Worker
-from tracecat_ee.agent.activities import AgentActivities
+from tracecat_ee.agent.activities import AgentActivities, BuildToolDefsResult
 from tracecat_ee.agent.approvals.service import ApprovalManager
+from tracecat_ee.agent.prepare import (
+    PrepareAgentTurnInput,
+    PrepareAgentTurnResult,
+    prepare_agent_turn_activity,
+)
 from tracecat_ee.agent.types import AgentWorkflowID
 from tracecat_ee.agent.workflows.durable import (
     AgentWorkflowArgs,
@@ -37,6 +42,7 @@ from tracecat_ee.agent.workflows.durable import (
 from tests.conftest import AGENT_TASK_QUEUE
 from tracecat import config
 from tracecat.agent.common.stream_types import ToolCallContent
+from tracecat.agent.common.types import MCPToolDefinition
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
@@ -60,6 +66,7 @@ from tracecat.auth.types import Role
 from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.redis.client import get_redis_client
+from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.object import InlineObject
 
 # Use worker-specific queue from conftest for pytest-xdist isolation
@@ -115,6 +122,47 @@ def create_mock_load_session_messages_activity() -> Callable[..., Any]:
     return mock_load_session_messages_activity
 
 
+def create_mock_prepare_turn_activity(
+    *,
+    sdk_session_id: str | None = None,
+) -> Callable[..., Any]:
+    """Create deterministic fused prepare data without session DB dependencies."""
+    tool_definitions = {
+        "core.http_request": MCPToolDefinition(
+            name="core__http_request",
+            description="Make HTTP requests",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string"},
+                    "method": {"type": "string"},
+                },
+                "required": ["url", "method"],
+            },
+        )
+    }
+
+    @activity.defn(name="prepare_agent_turn_activity")
+    async def mock_prepare_agent_turn_activity(
+        input: PrepareAgentTurnInput,
+    ) -> PrepareAgentTurnResult:
+        assert input.config is not None
+        return PrepareAgentTurnResult(
+            config=input.config,
+            sdk_session_id=sdk_session_id,
+            root_build_result=BuildToolDefsResult(
+                tool_definitions=tool_definitions,
+                registry_lock=RegistryLock(
+                    origins={"tracecat_registry": "test-version"},
+                    actions={"core.http_request": "tracecat_registry"},
+                ),
+            ),
+            subagents=[],
+        )
+
+    return mock_prepare_agent_turn_activity
+
+
 def create_mock_run_agent_activity(
     response_callback: Callable[[AgentExecutorInput], AgentExecutorResult],
 ) -> Callable[..., Any]:
@@ -156,6 +204,7 @@ def create_activities_with_mock_executor(
     activities.append(create_mock_create_session_activity())
     activities.append(create_mock_load_session_activity())
     activities.append(create_mock_load_session_messages_activity())
+    activities.append(create_mock_prepare_turn_activity())
 
     # Add mocked runtime activity
     activities.append(create_mock_run_agent_activity(response_callback))
@@ -190,6 +239,7 @@ def agent_worker_factory(
             activities = [
                 *agent_activities.get_activities(),
                 *get_session_activities(),
+                prepare_agent_turn_activity,
                 *ApprovalManager.get_activities(),
             ]
 
@@ -247,6 +297,7 @@ class TestAgentWorkerLifecycle:
             "load_session_activity",
             "load_session_messages_activity",
             "reconcile_tool_results_activity",
+            "finalize_turn_activity",
         }
 
 
@@ -435,17 +486,11 @@ class TestAgentWorkerSingleTenant:
         ) -> CreateSessionResult:
             return CreateSessionResult(session_id=input.session_id, success=True)
 
-        load_session_call_count = 0
-
         @activity.defn(name="load_session_activity")
         async def mock_load_session_activity(
             input: LoadSessionInput,
         ) -> LoadSessionResult:
             del input
-            nonlocal load_session_call_count
-            load_session_call_count += 1
-            if load_session_call_count == 1:
-                return LoadSessionResult(found=False)
             return LoadSessionResult(
                 found=True,
                 sdk_session_id="sdk-session",
@@ -514,6 +559,9 @@ class TestAgentWorkerSingleTenant:
             mock_create_session_activity,
             mock_load_session_activity,
             create_mock_load_session_messages_activity(),
+            # First turn starts without an SDK session; the continuation's
+            # "sdk-session" must come from the mid-loop reload, not prepare.
+            create_mock_prepare_turn_activity(),
             mock_record_approval_requests,
             mock_apply_approval_decisions,
             mock_execute_action_activity,

--- a/tests/integration/test_dsl_agent_wiring.py
+++ b/tests/integration/test_dsl_agent_wiring.py
@@ -14,6 +14,10 @@ from tracecat_ee.agent.activities import (
     BuildAgentToolDefsResult,
     BuildToolDefsResult,
 )
+from tracecat_ee.agent.prepare import (
+    PrepareAgentTurnInput,
+    PrepareAgentTurnResult,
+)
 from tracecat_ee.agent.workflows.durable import DurableAgentWorkflow
 
 from tests.shared import to_data
@@ -146,6 +150,33 @@ def create_mock_build_tool_definitions_activity() -> Callable[..., Any]:
     return mock_build_tool_definitions
 
 
+def create_mock_prepare_turn_activity(
+    captured_inputs: list[PrepareAgentTurnInput] | None = None,
+) -> Callable[..., Any]:
+    @activity.defn(name="prepare_agent_turn_activity")
+    async def mock_prepare_agent_turn_activity(
+        input: PrepareAgentTurnInput,
+    ) -> PrepareAgentTurnResult:
+        if captured_inputs is not None:
+            captured_inputs.append(input)
+        assert input.config is not None
+        return PrepareAgentTurnResult(
+            config=input.config,
+            root_build_result=BuildToolDefsResult(
+                tool_definitions={},
+                registry_lock=RegistryLock(
+                    origins={"tracecat_registry": "test-version"},
+                    actions={},
+                ),
+                user_mcp_claims=None,
+                allowed_internal_tools=None,
+            ),
+            subagents=[],
+        )
+
+    return mock_prepare_agent_turn_activity
+
+
 def create_mock_run_agent_activity(*, output: str) -> Callable[..., Any]:
     @activity.defn(name="run_agent_activity")
     async def mock_run_agent_activity(
@@ -199,6 +230,7 @@ class TestDSLAgentWiring:
             create_mock_load_session_activity(),
             create_mock_load_session_messages_activity(),
             create_mock_build_tool_definitions_activity(),
+            create_mock_prepare_turn_activity(),
         ):
             agent_activities = _replace_activity(agent_activities, replacement)
         agent_activities.append(
@@ -259,14 +291,17 @@ class TestDSLAgentWiring:
         agent_worker_factory: Callable[..., Worker],
     ) -> None:
         session_id = uuid.uuid4()
-        captured_inputs: list[CreateSessionInput] = []
+        # Session creation happens inside the fused prepare activity, so the
+        # session-reuse contract is asserted on the prepare input.
+        captured_inputs: list[PrepareAgentTurnInput] = []
 
         agent_activities = list(get_agent_worker_activities())
         for replacement in (
-            create_mock_create_session_activity(captured_inputs),
+            create_mock_create_session_activity(),
             create_mock_load_session_activity(),
             create_mock_load_session_messages_activity(),
             create_mock_build_tool_definitions_activity(),
+            create_mock_prepare_turn_activity(captured_inputs),
         ):
             agent_activities = _replace_activity(agent_activities, replacement)
         agent_activities.append(
@@ -319,4 +354,4 @@ class TestDSLAgentWiring:
         assert data["output"] == "dsl-agent-existing-session"
         assert len(captured_inputs) == 1
         assert captured_inputs[0].session_id == session_id
-        assert captured_inputs[0].require_existing is True
+        assert captured_inputs[0].continue_existing_session is True

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -44,6 +44,11 @@ from tracecat_ee.agent.approvals.service import (
     ApprovalMap,
     ApprovalService,
 )
+from tracecat_ee.agent.prepare import (
+    PrepareAgentTurnInput,
+    PrepareAgentTurnResult,
+    PreparedSubagent,
+)
 from tracecat_ee.agent.types import AgentWorkflowID
 from tracecat_ee.agent.workflows.durable import (
     AgentWorkflowArgs,
@@ -60,11 +65,7 @@ from tracecat.agent.executor.activity import (
     AgentExecutorResult,
     ToolExecutionResult,
 )
-from tracecat.agent.preset.activities import ResolveAgentsConfigActivityInput
-from tracecat.agent.preset.resolver import (
-    ResolvedAgentsRuntimeConfig,
-    ResolvedSubagentConfig,
-)
+from tracecat.agent.preset.resolver import ResolvedSubagentConfig
 from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.session.activities import (
     CreateSessionInput,
@@ -85,7 +86,6 @@ from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
-    ResolvedAgentsConfig,
     ResolvedAttachedSubagentRef,
 )
 from tracecat.agent.tokens import UserMCPServerClaim
@@ -172,6 +172,25 @@ def create_mock_build_tool_definitions_activity(
     tool_definitions: dict[str, MCPToolDefinition] | None = None,
 ) -> Callable[..., Any]:
     """Create a mock build_agent_tool_definitions activity."""
+
+    @activity.defn(name="build_agent_tool_definitions")
+    async def mock_build_agent_tool_definitions(
+        args: BuildAgentToolDefsArgs,
+    ) -> BuildAgentToolDefsResult:
+        return BuildAgentToolDefsResult(
+            scopes={
+                scope.scope: create_mock_build_tool_defs_result(tool_definitions)
+                for scope in args.scopes
+            }
+        )
+
+    return mock_build_agent_tool_definitions
+
+
+def create_mock_build_tool_defs_result(
+    tool_definitions: dict[str, MCPToolDefinition] | None = None,
+) -> BuildToolDefsResult:
+    """Create deterministic compiled tool data shared by prepare/build mocks."""
     if tool_definitions is None:
         tool_definitions = {
             "core.http_request": MCPToolDefinition(
@@ -188,27 +207,67 @@ def create_mock_build_tool_definitions_activity(
             )
         }
 
-    # Create a mock registry lock for the tools
     registry_lock = RegistryLock(
         origins={"tracecat_registry": "test-version"},
         actions=dict.fromkeys(tool_definitions.keys(), "tracecat_registry"),
     )
+    return BuildToolDefsResult(
+        tool_definitions=tool_definitions,
+        registry_lock=registry_lock,
+    )
 
-    @activity.defn(name="build_agent_tool_definitions")
-    async def mock_build_agent_tool_definitions(
-        args: BuildAgentToolDefsArgs,
-    ) -> BuildAgentToolDefsResult:
-        return BuildAgentToolDefsResult(
-            scopes={
-                scope.scope: BuildToolDefsResult(
-                    tool_definitions=tool_definitions,
-                    registry_lock=registry_lock,
+
+def create_mock_prepare_turn_activity(
+    tool_definitions: dict[str, MCPToolDefinition] | None = None,
+    *,
+    sdk_session_id: str | None = None,
+    is_fork: bool = False,
+    captured_inputs: list[PrepareAgentTurnInput] | None = None,
+    error: Exception | None = None,
+    root_build_result: BuildToolDefsResult | None = None,
+    subagents: list[PreparedSubagent] | None = None,
+    persist_session: bool = False,
+) -> Callable[..., Any]:
+    """Create a mock fused prepare activity for new workflow executions."""
+
+    @activity.defn(name="prepare_agent_turn_activity")
+    async def mock_prepare_agent_turn_activity(
+        input: PrepareAgentTurnInput,
+    ) -> PrepareAgentTurnResult:
+        if captured_inputs is not None:
+            captured_inputs.append(input)
+        if error is not None:
+            raise error
+        assert input.config is not None
+        if persist_session:
+            create_result = await create_session_activity(
+                CreateSessionInput(
+                    role=input.role,
+                    session_id=input.session_id,
+                    require_existing=input.continue_existing_session,
+                    title=input.title,
+                    created_by=input.role.user_id,
+                    entity_type=input.entity_type,
+                    entity_id=input.entity_id,
+                    tools=input.tools,
+                    agent_preset_id=input.agent_preset_id,
+                    agent_preset_version_id=input.agent_preset_version_id,
+                    harness_type=input.harness_type,
+                    curr_run_id=input.curr_run_id,
+                    initial_user_prompt=input.user_prompt,
                 )
-                for scope in args.scopes
-            }
+            )
+            assert create_result.success
+        return PrepareAgentTurnResult(
+            config=input.config,
+            sdk_session_id=sdk_session_id,
+            is_fork=is_fork,
+            root_build_result=root_build_result
+            or create_mock_build_tool_defs_result(tool_definitions),
+            subagents=subagents or [],
         )
 
-    return mock_build_agent_tool_definitions
+    return mock_prepare_agent_turn_activity
 
 
 def create_mock_run_agent_activity(
@@ -284,6 +343,9 @@ def create_activities_with_mock_executor(
     tool_definitions: dict[str, MCPToolDefinition] | None = None,
     message_load_inputs: list[LoadSessionMessagesInput] | None = None,
     session_messages: list[ChatMessage] | None = None,
+    sdk_session_id: str | None = None,
+    is_fork: bool = False,
+    prepare_inputs: list[PrepareAgentTurnInput] | None = None,
 ) -> Sequence[Callable[..., Any]]:
     """Create a full activity list with mocked agent executor.
 
@@ -301,6 +363,12 @@ def create_activities_with_mock_executor(
         create_mock_load_session_messages_activity(
             captured_inputs=message_load_inputs,
             messages=session_messages,
+        ),
+        create_mock_prepare_turn_activity(
+            tool_definitions,
+            sdk_session_id=sdk_session_id,
+            is_fork=is_fork,
+            captured_inputs=prepare_inputs,
         ),
         create_mock_build_tool_definitions_activity(tool_definitions),
         create_mock_run_agent_activity(response_callback),
@@ -497,17 +565,6 @@ async def test_agent_workflow_streams_tool_definition_error(
     queue = f"test-agent-queue-{mock_session_id}"
     emitted_errors: list[EmitSessionErrorInputs] = []
 
-    @activity.defn(name="build_agent_tool_definitions")
-    async def mock_build_tool_definitions(
-        args: BuildAgentToolDefsArgs,
-    ) -> BuildAgentToolDefsResult:
-        del args
-        raise ApplicationError(
-            "Cannot request more than 100 tools",
-            type="AgentToolDefinitionError",
-            non_retryable=True,
-        )
-
     @activity.defn(name="emit_session_error")
     async def mock_emit_session_error(args: EmitSessionErrorInputs) -> None:
         emitted_errors.append(args)
@@ -515,7 +572,14 @@ async def test_agent_workflow_streams_tool_definition_error(
     activities = [
         create_mock_create_session_activity(),
         create_mock_load_session_activity(),
-        mock_build_tool_definitions,
+        create_mock_prepare_turn_activity(
+            error=ApplicationError(
+                "Cannot request more than 100 tools",
+                type="AgentToolDefinitionError",
+                non_retryable=True,
+            )
+        ),
+        create_mock_build_tool_definitions_activity(),
         mock_emit_session_error,
     ]
 
@@ -723,60 +787,24 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
         preset_id=child_preset_id,
         preset_version_id=latest_version_id,
     )
-    stored_binding = ResolvedAgentsConfig(enabled=True, subagents=[stored_ref])
     latest_agents_config = AgentSubagentsConfig(enabled=True, subagents=[latest_ref])
-    resolve_inputs: list[ResolveAgentsConfigActivityInput] = []
-    create_inputs: list[CreateSessionInput] = []
+    prepare_inputs: list[PrepareAgentTurnInput] = []
     agent_inputs: list[AgentExecutorInput] = []
-
-    @activity.defn(name="load_session_activity")
-    async def mock_load_session_activity(
-        input: LoadSessionInput,
-    ) -> LoadSessionResult:
-        assert input.session_id == mock_session_id
-        return LoadSessionResult(
-            found=True,
-            sdk_session_id="sdk-session",
-            agents_binding=stored_binding,
-            has_resume_state=True,
-        )
-
-    @activity.defn(name="resolve_agents_config_activity")
-    async def mock_resolve_agents_config_activity(
-        input: ResolveAgentsConfigActivityInput,
-    ) -> ResolvedAgentsRuntimeConfig:
-        resolve_inputs.append(input)
-        assert input.follow_latest_versions is False
-        assert len(input.agents.subagents) == 1
-        resolved_ref = input.agents.subagents[0]
-        assert isinstance(resolved_ref, ResolvedAttachedSubagentRef)
-        assert resolved_ref.preset_version_id == stored_version_id
-
-        return ResolvedAgentsRuntimeConfig(
-            enabled=True,
-            subagents=[
-                ResolvedSubagentConfig(
-                    binding=stored_ref,
-                    description="Stored analyst",
-                    prompt="Complete the delegated analysis.",
-                    config=agent_config_to_payload(
-                        AgentConfig(
-                            model_name="claude-3-5-sonnet-20241022",
-                            model_provider="anthropic",
-                            actions=[],
-                        )
-                    ),
-                )
-            ],
-        )
-
-    @activity.defn(name="create_session_activity")
-    async def mock_create_session_activity(
-        input: CreateSessionInput,
-    ) -> CreateSessionResult:
-        create_inputs.append(input)
-        assert input.agents_binding == stored_binding
-        return CreateSessionResult(session_id=input.session_id, success=True)
+    child_config = AgentConfig(
+        model_name="claude-3-5-sonnet-20241022",
+        model_provider="anthropic",
+        actions=[],
+    )
+    prepared_subagent = PreparedSubagent(
+        resolved=ResolvedSubagentConfig(
+            binding=stored_ref,
+            description="Stored analyst",
+            prompt="Complete the delegated analysis.",
+            config=agent_config_to_payload(child_config),
+        ),
+        config=child_config,
+        build_result=create_mock_build_tool_defs_result({}),
+    )
 
     @activity.defn(name="run_agent_activity")
     async def mock_run_agent_activity(
@@ -799,13 +827,18 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
         ),
         entity_type=AgentSessionEntity.WORKFLOW,
         entity_id=uuid.uuid4(),
+        continue_existing_session=True,
     )
 
     activities = [
-        mock_load_session_activity,
-        mock_resolve_agents_config_activity,
-        mock_create_session_activity,
+        create_mock_load_session_activity(),
+        create_mock_create_session_activity(),
         create_mock_load_session_messages_activity(),
+        create_mock_prepare_turn_activity(
+            sdk_session_id="sdk-session",
+            captured_inputs=prepare_inputs,
+            subagents=[prepared_subagent],
+        ),
         create_mock_build_tool_definitions_activity(),
         mock_run_agent_activity,
         create_mock_execute_action_activity(),
@@ -827,13 +860,22 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
 
     assert result.session_id == mock_session_id
     assert result.output == {"status": "ok"}
-    assert len(resolve_inputs) == 1
-    assert resolve_inputs[0].agents.subagents == [stored_ref]
-    assert len(create_inputs) == 1
-    assert create_inputs[0].agents_binding == stored_binding
+    assert len(prepare_inputs) == 1
+    prepare_input = prepare_inputs[0]
+    assert prepare_input.session_id == mock_session_id
+    assert prepare_input.curr_run_id == mock_session_id
+    assert prepare_input.user_prompt == "Continue the existing session"
+    assert prepare_input.continue_existing_session is True
+    assert prepare_input.preset_slug is None
+    assert prepare_input.preset_version is None
+    assert prepare_input.agent_preset_id is None
+    assert prepare_input.agent_preset_version_id is None
+    assert prepare_input.config is not None
+    assert prepare_input.config.agents.subagents == [latest_ref]
     assert len(agent_inputs) == 1
     assert agent_inputs[0].sdk_session_id == "sdk-session"
     assert [subagent.alias for subagent in agent_inputs[0].subagents] == ["analyst"]
+    assert agent_inputs[0].subagents[0].description == "Stored analyst"
 
 
 @pytest.mark.anyio
@@ -994,31 +1036,32 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         fake_agent_stream_new,
     )
 
+    tool_result = BuildToolDefsResult(
+        tool_definitions={
+            "core.http_request": MCPToolDefinition(
+                name="core__http_request",
+                description="HTTP request",
+                parameters_json_schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                        "method": {"type": "string"},
+                    },
+                    "required": ["url", "method"],
+                    "additionalProperties": False,
+                },
+            )
+        },
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test-version"},
+            actions={"core.http_request": "tracecat_registry"},
+        ),
+    )
+
     @activity.defn(name="build_agent_tool_definitions")
     async def mock_build_tool_definitions(
         args: BuildAgentToolDefsArgs,
     ) -> BuildAgentToolDefsResult:
-        tool_result = BuildToolDefsResult(
-            tool_definitions={
-                "core.http_request": MCPToolDefinition(
-                    name="core__http_request",
-                    description="HTTP request",
-                    parameters_json_schema={
-                        "type": "object",
-                        "properties": {
-                            "url": {"type": "string"},
-                            "method": {"type": "string"},
-                        },
-                        "required": ["url", "method"],
-                        "additionalProperties": False,
-                    },
-                )
-            },
-            registry_lock=RegistryLock(
-                origins={"tracecat_registry": "test-version"},
-                actions={"core.http_request": "tracecat_registry"},
-            ),
-        )
         return BuildAgentToolDefsResult(
             scopes={scope.scope: tool_result for scope in args.scopes}
         )
@@ -1177,6 +1220,10 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
             load_session_messages_activity,
             reconcile_tool_results_activity,
             finalize_turn_activity,
+            create_mock_prepare_turn_activity(
+                root_build_result=tool_result,
+                persist_session=True,
+            ),
             mock_build_tool_definitions,
             mock_record_approval_requests,
             mock_apply_approval_decisions,
@@ -1305,11 +1352,8 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
     captured_run_inputs: list[RunActionInput] = []
     captured_pending_result_batches: list[list[Any]] = []
     captured_approval_decisions: list[Any] = []
+    prepare_inputs: list[PrepareAgentTurnInput] = []
 
-    parent_sdk_session_data = (
-        '{"type":"user","message":{"content":"parent prompt"}}\n'
-        '{"type":"assistant","message":{"content":[{"type":"text","text":"parent answer"}]}}\n'
-    )
     continuation_sdk_session_data = (
         '{"type":"user","message":{"content":"parent prompt"}}\n'
         '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"call_safe",'
@@ -1330,22 +1374,11 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
         assert input.session_id == mock_session_id
         return CreateSessionResult(session_id=input.session_id, success=True)
 
-    load_session_call_count = 0
-
     @activity.defn(name="load_session_activity")
     async def mock_load_session_activity(
         input: LoadSessionInput,
     ) -> LoadSessionResult:
-        nonlocal load_session_call_count
         assert input.session_id == mock_session_id
-        load_session_call_count += 1
-        if load_session_call_count == 1:
-            return LoadSessionResult(
-                found=True,
-                sdk_session_id="parent-sdk-session",
-                sdk_session_data=parent_sdk_session_data,
-                is_fork=True,
-            )
         return LoadSessionResult(
             found=True,
             sdk_session_id="child-sdk-session",
@@ -1353,33 +1386,35 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
             is_fork=False,
         )
 
+    tool_result = BuildToolDefsResult(
+        tool_definitions={
+            "core.http_request": MCPToolDefinition(
+                name="core__http_request",
+                description="HTTP request",
+                parameters_json_schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                        "method": {"type": "string"},
+                    },
+                    "required": ["url", "method"],
+                    "additionalProperties": False,
+                },
+            )
+        },
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test-version"},
+            actions={"core.http_request": "tracecat_registry"},
+        ),
+        tool_approvals={"core.http_request": True},
+    )
+
     @activity.defn(name="build_agent_tool_definitions")
     async def mock_build_tool_definitions(
         args: BuildAgentToolDefsArgs,
     ) -> BuildAgentToolDefsResult:
         root_scope = next(scope for scope in args.scopes if scope.scope == "root")
         assert root_scope.tool_approvals == {"core.http_request": True}
-        tool_result = BuildToolDefsResult(
-            tool_definitions={
-                "core.http_request": MCPToolDefinition(
-                    name="core__http_request",
-                    description="HTTP request",
-                    parameters_json_schema={
-                        "type": "object",
-                        "properties": {
-                            "url": {"type": "string"},
-                            "method": {"type": "string"},
-                        },
-                        "required": ["url", "method"],
-                        "additionalProperties": False,
-                    },
-                )
-            },
-            registry_lock=RegistryLock(
-                origins={"tracecat_registry": "test-version"},
-                actions={"core.http_request": "tracecat_registry"},
-            ),
-        )
         return BuildAgentToolDefsResult(
             scopes={scope.scope: tool_result for scope in args.scopes}
         )
@@ -1396,7 +1431,7 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
         if run_agent_call_count == 0:
             run_agent_call_count += 1
             assert input.sdk_session_id == "parent-sdk-session"
-            assert input.sdk_session_data == parent_sdk_session_data
+            assert input.sdk_session_data is None
             assert input.is_fork is True
             assert input.is_approval_continuation is False
             return AgentExecutorResult(
@@ -1491,6 +1526,12 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
             mock_create_session_activity,
             mock_load_session_activity,
             create_mock_load_session_messages_activity(),
+            create_mock_prepare_turn_activity(
+                sdk_session_id="parent-sdk-session",
+                is_fork=True,
+                captured_inputs=prepare_inputs,
+                root_build_result=tool_result,
+            ),
             mock_build_tool_definitions,
             mock_record_approval_requests,
             mock_apply_approval_decisions,
@@ -1545,6 +1586,10 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
     assert result.session_id == mock_session_id
     assert result.output == {"status": "continued"}
     assert continuation_seen.is_set()
+    assert len(prepare_inputs) == 1
+    assert prepare_inputs[0].session_id == mock_session_id
+    assert prepare_inputs[0].config is not None
+    assert prepare_inputs[0].config.tool_approvals == {"core.http_request": True}
     assert [agent_input.is_fork for agent_input in captured_agent_inputs] == [
         True,
         False,
@@ -1617,27 +1662,28 @@ async def test_agent_workflow_routes_approved_user_mcp_tool_to_remote_activity(
             is_fork=False,
         )
 
+    tool_result = BuildToolDefsResult(
+        tool_definitions={
+            "mcp__Jira__getIssue": MCPToolDefinition(
+                name="mcp__Jira__getIssue",
+                description="Get an issue",
+                parameters_json_schema={
+                    "type": "object",
+                    "properties": {"issue_key": {"type": "string"}},
+                    "required": ["issue_key"],
+                    "additionalProperties": False,
+                },
+            )
+        },
+        registry_lock=RegistryLock(origins={}, actions={}),
+        user_mcp_claims=[UserMCPServerClaim(name="Jira", id=integration_id)],
+        tool_approvals={"mcp.Jira.getIssue": True},
+    )
+
     @activity.defn(name="build_agent_tool_definitions")
     async def mock_build_tool_definitions(
         args: BuildAgentToolDefsArgs,
     ) -> BuildAgentToolDefsResult:
-        tool_result = BuildToolDefsResult(
-            tool_definitions={
-                "mcp__Jira__getIssue": MCPToolDefinition(
-                    name="mcp__Jira__getIssue",
-                    description="Get an issue",
-                    parameters_json_schema={
-                        "type": "object",
-                        "properties": {"issue_key": {"type": "string"}},
-                        "required": ["issue_key"],
-                        "additionalProperties": False,
-                    },
-                )
-            },
-            registry_lock=RegistryLock(origins={}, actions={}),
-            user_mcp_claims=[UserMCPServerClaim(name="Jira", id=integration_id)],
-            tool_approvals={"mcp.Jira.getIssue": True},
-        )
         return BuildAgentToolDefsResult(
             scopes={scope.scope: tool_result for scope in args.scopes}
         )
@@ -1740,6 +1786,7 @@ async def test_agent_workflow_routes_approved_user_mcp_tool_to_remote_activity(
         create_mock_create_session_activity(),
         mock_load_session_activity,
         create_mock_load_session_messages_activity(),
+        create_mock_prepare_turn_activity(root_build_result=tool_result),
         mock_build_tool_definitions,
         mock_run_agent_activity,
         mock_record_approval_requests,
@@ -1791,34 +1838,23 @@ async def test_agent_workflow_routes_approved_user_mcp_tool_to_remote_activity(
 
 @pytest.mark.anyio
 @pytest.mark.integration
-async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
+async def test_agent_workflow_replays_suspended_fused_prepare_history(
     svc_role: Role,
     temporal_client: Client,
     agent_worker_factory,
     mock_session_id: uuid.UUID,
     agent_config_with_approvals: AgentConfig,
 ) -> None:
-    """A suspended workflow with legacy SDK JSONL payloads should replay."""
+    """A suspended fused-prepare workflow should replay before and after resume."""
     queue = f"test-agent-queue-{mock_session_id}"
     approval_request_recorded = asyncio.Event()
     captured_agent_inputs: list[AgentExecutorInput] = []
-    legacy_sdk_session_data = (
-        '{"type":"user","message":{"content":"legacy prompt"}}\n'
-        '{"type":"assistant","message":{"content":[{"type":"text","text":"legacy"}]}}\n'
-    )
 
     @activity.defn(name="load_session_activity")
     async def mock_load_session_activity(
         input: LoadSessionInput,
     ) -> LoadSessionResult:
         assert input.session_id == mock_session_id
-        if len(captured_agent_inputs) == 0:
-            return LoadSessionResult(
-                found=True,
-                sdk_session_id="legacy-sdk-session",
-                sdk_session_data=legacy_sdk_session_data,
-                is_fork=False,
-            )
         return LoadSessionResult(
             found=True,
             sdk_session_id="legacy-sdk-session",
@@ -1833,7 +1869,7 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         captured_agent_inputs.append(input)
         if len(captured_agent_inputs) == 1:
             assert input.sdk_session_id == "legacy-sdk-session"
-            assert input.sdk_session_data == legacy_sdk_session_data
+            assert input.sdk_session_data is None
             assert input.is_approval_continuation is False
             return AgentExecutorResult(
                 success=True,
@@ -1884,6 +1920,7 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         create_mock_create_session_activity(),
         mock_load_session_activity,
         create_mock_load_session_messages_activity(),
+        create_mock_prepare_turn_activity(sdk_session_id="legacy-sdk-session"),
         create_mock_build_tool_definitions_activity(),
         mock_run_agent_activity,
         create_mock_execute_action_activity(),
@@ -1922,10 +1959,7 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
 
     assert result.session_id == mock_session_id
     assert result.output == {"status": "continued"}
-    assert [input.sdk_session_data for input in captured_agent_inputs] == [
-        legacy_sdk_session_data,
-        None,
-    ]
+    assert [input.sdk_session_data for input in captured_agent_inputs] == [None, None]
 
 
 @pytest.mark.anyio
@@ -1974,31 +2008,32 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         fake_agent_stream_new,
     )
 
+    tool_result = BuildToolDefsResult(
+        tool_definitions={
+            "core.http_request": MCPToolDefinition(
+                name="core__http_request",
+                description="HTTP request",
+                parameters_json_schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"},
+                        "method": {"type": "string"},
+                    },
+                    "required": ["url", "method"],
+                    "additionalProperties": False,
+                },
+            )
+        },
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test-version"},
+            actions={"core.http_request": "tracecat_registry"},
+        ),
+    )
+
     @activity.defn(name="build_agent_tool_definitions")
     async def mock_build_tool_definitions(
         args: BuildAgentToolDefsArgs,
     ) -> BuildAgentToolDefsResult:
-        tool_result = BuildToolDefsResult(
-            tool_definitions={
-                "core.http_request": MCPToolDefinition(
-                    name="core__http_request",
-                    description="HTTP request",
-                    parameters_json_schema={
-                        "type": "object",
-                        "properties": {
-                            "url": {"type": "string"},
-                            "method": {"type": "string"},
-                        },
-                        "required": ["url", "method"],
-                        "additionalProperties": False,
-                    },
-                )
-            },
-            registry_lock=RegistryLock(
-                origins={"tracecat_registry": "test-version"},
-                actions={"core.http_request": "tracecat_registry"},
-            ),
-        )
         return BuildAgentToolDefsResult(
             scopes={scope.scope: tool_result for scope in args.scopes}
         )
@@ -2143,6 +2178,10 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
             load_session_activity,
             load_session_messages_activity,
             reconcile_tool_results_activity,
+            create_mock_prepare_turn_activity(
+                root_build_result=tool_result,
+                persist_session=True,
+            ),
             mock_build_tool_definitions,
             mock_record_approval_requests,
             mock_apply_approval_decisions,

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -1453,10 +1453,11 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
 
         run_agent_call_count += 1
         assert input.sdk_session_id == "child-sdk-session"
-        assert input.sdk_session_data == continuation_sdk_session_data
+        # Even if a stale load result carries legacy SDK JSONL, the workflow
+        # must not forward it: the executor loads SDK history from the DB.
+        assert input.sdk_session_data is None
         assert input.is_fork is False
         assert input.is_approval_continuation is True
-        assert '"type":"tool_result"' in input.sdk_session_data
         continuation_seen.set()
         return AgentExecutorResult(
             success=True,

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from temporalio.exceptions import ApplicationError
+from temporalio.testing import ActivityEnvironment
 from tracecat_ee.agent import activities as agent_activities
 from tracecat_ee.agent.activities import (
     AgentActivities,
@@ -585,7 +586,10 @@ class TestBuildToolDefinitionsActivity:
             lambda: _AsyncContext(),
         )
 
-        result = await AgentActivities().build_agent_tool_definitions(
+        # The activity heartbeats per scope, so run it inside a fake activity
+        # context where heartbeat() is a no-op.
+        result = await ActivityEnvironment().run(
+            AgentActivities().build_agent_tool_definitions,
             BuildAgentToolDefsArgs(
                 role=mock_role,
                 scopes=[
@@ -598,7 +602,7 @@ class TestBuildToolDefinitionsActivity:
                         tool_filters=ToolFilters(actions=["core.child"]),
                     ),
                 ],
-            )
+            ),
         )
 
         assert set(result.scopes) == {"root", "analyst"}

--- a/tests/unit/test_agent_prepare.py
+++ b/tests/unit/test_agent_prepare.py
@@ -1,0 +1,251 @@
+"""Unit tests for the fused durable-agent prepare activity helpers.
+
+Covers the config/binding resolution logic that previously ran as workflow
+code (and was exercised through mocked per-step activities in the temporal
+tests) and now lives inside ``prepare_agent_turn_activity``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio.exceptions import ApplicationError
+from tracecat_ee.agent.prepare import (
+    PrepareAgentTurnInput,
+    _preserved_agents_binding,
+    _resolve_subagents,
+    _resolve_turn_config,
+    internal_tool_context_for,
+)
+
+from tracecat.agent.preset.resolver import ResolvedAgentsRuntimeConfig
+from tracecat.agent.session.activities import LoadSessionResult
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.subagents import (
+    ResolvedAgentsConfig,
+    ResolvedAttachedSubagentRef,
+)
+from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_config import agent_config_to_payload
+from tracecat.auth.types import Role
+
+
+def _role() -> Role:
+    return Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute", "secret:read"}),
+    )
+
+
+def _prepare_input(
+    role: Role,
+    *,
+    config: AgentConfig | None = None,
+    preset_slug: str | None = None,
+    preset_version: int | None = None,
+    agent_preset_version_id: uuid.UUID | None = None,
+) -> PrepareAgentTurnInput:
+    return PrepareAgentTurnInput(
+        role=role,
+        session_id=uuid.uuid4(),
+        curr_run_id=uuid.uuid4(),
+        user_prompt="hello",
+        config=config,
+        preset_slug=preset_slug,
+        preset_version=preset_version,
+        agent_preset_version_id=agent_preset_version_id,
+        entity_type=AgentSessionEntity.WORKSPACE_CHAT,
+        entity_id=uuid.uuid4(),
+    )
+
+
+def _stored_binding() -> ResolvedAgentsConfig:
+    return ResolvedAgentsConfig(
+        enabled=True,
+        subagents=[
+            ResolvedAttachedSubagentRef(
+                preset="analyst-preset",
+                name="analyst",
+                preset_id=uuid.uuid4(),
+                preset_version_id=uuid.uuid4(),
+            )
+        ],
+    )
+
+
+class TestPreservedAgentsBinding:
+    def test_session_not_found_returns_none(self) -> None:
+        assert _preserved_agents_binding(LoadSessionResult(found=False)) is None
+
+    def test_stored_binding_wins(self) -> None:
+        binding = _stored_binding()
+        load_result = LoadSessionResult(
+            found=True, agents_binding=binding, has_resume_state=True
+        )
+        assert _preserved_agents_binding(load_result) == binding
+
+    def test_resume_state_without_binding_pins_disabled_subagents(self) -> None:
+        load_result = LoadSessionResult(found=True, has_resume_state=True)
+        assert _preserved_agents_binding(load_result) == ResolvedAgentsConfig()
+
+    def test_fresh_session_returns_none(self) -> None:
+        load_result = LoadSessionResult(found=True, has_resume_state=False)
+        assert _preserved_agents_binding(load_result) is None
+
+
+class TestResolveSubagents:
+    @pytest.mark.anyio
+    async def test_agents_disabled_skips_resolution(self) -> None:
+        role = _role()
+        config = AgentConfig(model_name="gpt-4o-mini", model_provider="openai")
+        with patch(
+            "tracecat_ee.agent.prepare.resolve_agents_config_activity",
+            AsyncMock(),
+        ) as resolve_mock:
+            result = await _resolve_subagents(
+                _prepare_input(role, config=config),
+                config,
+                LoadSessionResult(found=False),
+            )
+        resolve_mock.assert_not_awaited()
+        assert result == ResolvedAgentsRuntimeConfig()
+
+    @pytest.mark.anyio
+    async def test_resumed_session_pins_stored_binding(self) -> None:
+        """A resumed session resolves the stored binding, not the live preset."""
+        role = _role()
+        binding = _stored_binding()
+        stored_ref = binding.subagents[0]
+        # The live config points at a different (newer) subagent set; the
+        # stored binding must win and pin exact versions.
+        config = AgentConfig(model_name="gpt-4o-mini", model_provider="openai")
+        resolved = ResolvedAgentsRuntimeConfig(enabled=True)
+        with patch(
+            "tracecat_ee.agent.prepare.resolve_agents_config_activity",
+            AsyncMock(return_value=resolved),
+        ) as resolve_mock:
+            result = await _resolve_subagents(
+                _prepare_input(role, config=config),
+                config,
+                LoadSessionResult(
+                    found=True, agents_binding=binding, has_resume_state=True
+                ),
+            )
+        resolve_mock.assert_awaited_once()
+        resolve_input = resolve_mock.await_args.args[0]  # type: ignore[union-attr]
+        assert resolve_input.follow_latest_versions is False
+        assert resolve_input.agents.enabled is True
+        [ref] = resolve_input.agents.subagents
+        assert isinstance(ref, ResolvedAttachedSubagentRef)
+        assert ref.preset_version_id == stored_ref.preset_version_id
+        assert result == resolved
+
+    @pytest.mark.anyio
+    async def test_resume_state_without_binding_disables_subagents(self) -> None:
+        role = _role()
+        agent_config_ctor = cast(Any, AgentConfig)
+        config = agent_config_ctor(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            agents={"enabled": True},
+        )
+        with patch(
+            "tracecat_ee.agent.prepare.resolve_agents_config_activity",
+            AsyncMock(),
+        ) as resolve_mock:
+            result = await _resolve_subagents(
+                _prepare_input(role, config=config),
+                config,
+                LoadSessionResult(found=True, has_resume_state=True),
+            )
+        resolve_mock.assert_not_awaited()
+        assert result == ResolvedAgentsRuntimeConfig()
+
+    @pytest.mark.anyio
+    async def test_enabled_without_subagents_short_circuits(self) -> None:
+        role = _role()
+        agent_config_ctor = cast(Any, AgentConfig)
+        config = agent_config_ctor(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            agents={"enabled": True},
+        )
+        with patch(
+            "tracecat_ee.agent.prepare.resolve_agents_config_activity",
+            AsyncMock(),
+        ) as resolve_mock:
+            result = await _resolve_subagents(
+                _prepare_input(role, config=config),
+                config,
+                LoadSessionResult(found=False),
+            )
+        resolve_mock.assert_not_awaited()
+        assert result == ResolvedAgentsRuntimeConfig(enabled=True)
+
+
+class TestResolveTurnConfig:
+    @pytest.mark.anyio
+    async def test_missing_config_without_preset_raises(self) -> None:
+        with pytest.raises(ApplicationError, match="Config must be provided"):
+            await _resolve_turn_config(_prepare_input(_role()))
+
+    @pytest.mark.anyio
+    async def test_preset_overrides_layer_actions_and_instructions(self) -> None:
+        role = _role()
+        preset_config = AgentConfig(
+            model_name="claude-3-5-sonnet-20241022",
+            model_provider="anthropic",
+            instructions="base instructions",
+            actions=["core.http_request"],
+        )
+        override = AgentConfig(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            instructions="append this",
+            actions=["core.cases.list_cases"],
+        )
+        pinned_version_id = uuid.uuid4()
+        with patch(
+            "tracecat_ee.agent.prepare.resolve_agent_preset_config_activity",
+            AsyncMock(return_value=agent_config_to_payload(preset_config)),
+        ) as resolve_mock:
+            config = await _resolve_turn_config(
+                _prepare_input(
+                    role,
+                    config=override,
+                    preset_slug="triage-agent",
+                    agent_preset_version_id=pinned_version_id,
+                )
+            )
+        # A recorded preset version id wins over slug + version resolution.
+        resolve_input = resolve_mock.await_args.args[0]  # type: ignore[union-attr]
+        assert resolve_input.preset_version_id == pinned_version_id
+        assert resolve_input.preset_slug is None
+        # Preset is the base; overrides replace actions and append instructions.
+        assert config.model_name == "claude-3-5-sonnet-20241022"
+        assert config.actions == ["core.cases.list_cases"]
+        assert config.instructions == "base instructions\nappend this"
+
+
+class TestInternalToolContext:
+    def test_builder_sessions_get_context(self) -> None:
+        entity_id = uuid.uuid4()
+        context = internal_tool_context_for(
+            AgentSessionEntity.AGENT_PRESET_BUILDER, entity_id
+        )
+        assert context is not None
+        assert context.preset_id == entity_id
+        assert context.entity_type == "agent_preset_builder"
+
+    def test_other_sessions_get_none(self) -> None:
+        assert (
+            internal_tool_context_for(AgentSessionEntity.WORKSPACE_CHAT, uuid.uuid4())
+            is None
+        )

--- a/tests/unit/test_agent_turn_request.py
+++ b/tests/unit/test_agent_turn_request.py
@@ -1,0 +1,117 @@
+"""Tests for the additive durable-agent turn request contract."""
+
+from __future__ import annotations
+
+import uuid
+
+from tracecat_ee.agent.workflows.durable import AgentWorkflowArgs
+
+from tracecat.agent.common.stream_types import HarnessType
+from tracecat.agent.schemas import RunAgentArgs
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_schemas import (
+    AgentConfigPayload,
+    AgentTurnRequest,
+    InlineAgentSource,
+    PresetAgentSource,
+)
+from tracecat.auth.types import Role
+
+
+def _role() -> Role:
+    return Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+
+
+def _legacy_workflow_args(role: Role) -> AgentWorkflowArgs:
+    return AgentWorkflowArgs(
+        role=role,
+        agent_args=RunAgentArgs(
+            user_prompt="Investigate this alert",
+            session_id=uuid.uuid4(),
+            config=AgentConfig(
+                model_name="test-model",
+                model_provider="test-provider",
+            ),
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+    )
+
+
+def test_legacy_workflow_args_decode_without_request() -> None:
+    """Workflow inputs recorded before the expansion retain the legacy shape."""
+    legacy_args = _legacy_workflow_args(_role())
+    legacy_payload = legacy_args.model_dump(mode="python", exclude={"request"})
+
+    decoded = AgentWorkflowArgs.model_validate(legacy_payload)
+
+    assert decoded.request is None
+    assert decoded.agent_args == legacy_args.agent_args
+
+
+def test_workflow_args_round_trip_with_turn_request() -> None:
+    """The expanded envelope preserves and discriminates the new request."""
+    role = _role()
+    legacy_args = _legacy_workflow_args(role)
+    request = AgentTurnRequest(
+        role=role,
+        session_id=legacy_args.agent_args.session_id,
+        active_stream_id=uuid.uuid4(),
+        user_prompt=legacy_args.agent_args.user_prompt,
+        source=PresetAgentSource(
+            slug="investigation-agent",
+            version=3,
+            preset_id=uuid.uuid4(),
+            preset_version_id=uuid.uuid4(),
+            actions=["core.http_request"],
+            instructions="Focus on the highest-confidence evidence.",
+        ),
+        title="Alert investigation",
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=legacy_args.entity_id,
+        tools=["core.http_request"],
+        harness_type=HarnessType.CLAUDE_CODE,
+        max_requests=10,
+        max_tool_calls=20,
+    )
+    expanded_args = legacy_args.model_copy(update={"request": request})
+
+    decoded = AgentWorkflowArgs.model_validate_json(expanded_args.model_dump_json())
+    decoded_request = decoded.request
+
+    assert decoded_request is not None
+    assert decoded_request == request
+    assert isinstance(decoded_request.source, PresetAgentSource)
+    assert decoded_request.source.slug == "investigation-agent"
+    assert decoded.agent_args == legacy_args.agent_args
+
+
+def test_inline_agent_source_round_trip() -> None:
+    """Inline requests retain their workflow-safe configuration payload."""
+    request = AgentTurnRequest(
+        role=_role(),
+        session_id=uuid.uuid4(),
+        user_prompt="Summarize the evidence",
+        source=InlineAgentSource(
+            config=AgentConfigPayload(
+                model_name="test-model",
+                model_provider="test-provider",
+                retries=3,
+            )
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+    )
+
+    decoded = AgentTurnRequest.model_validate_json(request.model_dump_json())
+
+    assert isinstance(decoded.source, InlineAgentSource)
+    assert decoded.source.config.model_name == "test-model"

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -12,15 +12,23 @@ import pytest
 from temporalio.common import TypedSearchAttributes
 from temporalio.exceptions import ActivityError
 from tracecat_ee.agent.activities import BuildToolDefsArgs, BuildToolDefsResult
+from tracecat_ee.agent.prepare import (
+    PrepareAgentTurnInput,
+    PrepareAgentTurnResult,
+    prepare_agent_turn_activity,
+)
+from tracecat_ee.agent.types import AgentWorkflowID
 from tracecat_ee.agent.workflows.durable import (
     BUILD_AGENT_TOOL_DEFINITIONS_PATCH,
     EMIT_PRE_STREAM_SESSION_ERRORS_PATCH,
     FINALIZE_TURN_PATCH,
+    FUSED_PREPARE_TURN_PATCH,
     LOAD_TERMINAL_MESSAGE_HISTORY_PATCH,
     PERSIST_SESSION_ERROR_PATCH,
     UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,
     AgentWorkflowArgs,
     DurableAgentWorkflow,
+    PreparedTurn,
     _approved_user_mcp_tool_name,
     _build_approved_tool_run_input,
 )
@@ -175,7 +183,7 @@ async def test_run_skips_search_attribute_upsert_without_patch_marker() -> None:
     )
     workflow_args = _build_workflow_args(role)
     workflow_instance = DurableAgentWorkflow(workflow_args)
-    cfg = cast(Any, workflow_args.agent_args.config)
+    prepared = cast(Any, object())
     expected_output = AgentOutput(
         output="ok",
         duration=0.1,
@@ -194,23 +202,126 @@ async def test_run_skips_search_attribute_upsert_without_patch_marker() -> None:
         patch.object(
             workflow_instance, "_upsert_tracecat_search_attributes"
         ) as upsert_mock,
-        patch.object(workflow_instance, "_build_config", AsyncMock(return_value=cfg)),
         patch.object(
             workflow_instance,
-            "_run_with_agent_executor",
+            "_prepare_turn_legacy",
+            AsyncMock(return_value=prepared),
+        ) as prepare_legacy_mock,
+        patch.object(
+            workflow_instance,
+            "_execute_agent_turns",
             AsyncMock(return_value=expected_output),
         ) as run_mock,
     ):
         result = await workflow_instance.run(workflow_args)
 
-    # run() gates the search-attribute upsert (entry) and finalize_turn (finally)
-    # behind patch markers; legacy histories see False for both.
+    # run() gates the search-attribute upsert (entry), the fused prepare phase,
+    # and finalize_turn (finally) behind patch markers; legacy histories see
+    # False for all three and take the legacy prepare chain.
     assert patched_mock.call_args_list == [
         ((UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,),),
+        ((FUSED_PREPARE_TURN_PATCH,),),
         ((FINALIZE_TURN_PATCH,),),
     ]
     upsert_mock.assert_not_called()
-    run_mock.assert_awaited_once_with(workflow_args, cfg)
+    prepare_legacy_mock.assert_awaited_once_with(workflow_args)
+    run_mock.assert_awaited_once_with(workflow_args, prepared)
+    assert result == expected_output
+
+
+@pytest.mark.anyio
+async def test_run_uses_fused_prepare_activity_with_patch_marker() -> None:
+    """New executions run the whole prepare phase as one activity."""
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute", "secret:read"}),
+    )
+    workflow_args = _build_workflow_args(role)
+    workflow_instance = DurableAgentWorkflow(workflow_args)
+    cfg = cast(Any, workflow_args.agent_args.config)
+    root_build_result = BuildToolDefsResult(
+        tool_definitions={},
+        registry_lock=RegistryLock(origins={}, actions={}),
+    )
+    prepare_result = PrepareAgentTurnResult(
+        config=cfg,
+        sdk_session_id="sdk-session",
+        is_fork=True,
+        root_build_result=root_build_result,
+        subagents=[],
+    )
+    expected_output = AgentOutput(
+        output="ok",
+        duration=0.1,
+        session_id=workflow_args.agent_args.session_id,
+    )
+    expected_curr_run_id = workflow_args.agent_args.session_id
+
+    with (
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.patched",
+            side_effect=[False, True, False],
+        ) as patched_mock,
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.unsafe.is_replaying",
+            return_value=False,
+        ),
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.info",
+            return_value=SimpleNamespace(
+                workflow_id=str(AgentWorkflowID(expected_curr_run_id))
+            ),
+        ),
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.execute_activity",
+            AsyncMock(return_value=prepare_result),
+        ) as execute_activity_mock,
+        patch.object(
+            workflow_instance,
+            "_mint_scope_mcp_token",
+            return_value="mcp-token",
+        ),
+        patch.object(
+            workflow_instance,
+            "_execute_agent_turns",
+            AsyncMock(return_value=expected_output),
+        ) as run_mock,
+    ):
+        result = await workflow_instance.run(workflow_args)
+
+    assert patched_mock.call_args_list == [
+        ((UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,),),
+        ((FUSED_PREPARE_TURN_PATCH,),),
+        ((FINALIZE_TURN_PATCH,),),
+    ]
+
+    execute_activity_mock.assert_awaited_once()
+    assert execute_activity_mock.await_args is not None
+    activity_fn, activity_input = execute_activity_mock.await_args.args
+    assert activity_fn is prepare_agent_turn_activity
+    assert isinstance(activity_input, PrepareAgentTurnInput)
+    assert activity_input.session_id == workflow_args.agent_args.session_id
+    assert activity_input.curr_run_id == expected_curr_run_id
+    assert activity_input.user_prompt == "hello"
+    timeout = execute_activity_mock.await_args.kwargs["start_to_close_timeout"]
+    assert timeout.total_seconds() == 300
+
+    run_mock.assert_awaited_once()
+    assert run_mock.await_args is not None
+    _, prepared = run_mock.await_args.args
+    assert isinstance(prepared, PreparedTurn)
+    assert prepared.config == cfg
+    assert prepared.sdk_session_id == "sdk-session"
+    assert prepared.is_fork is True
+    assert prepared.internal_tool_context is None
+    assert prepared.compiled_run.root.build_result == root_build_result
+    assert prepared.compiled_run.root.mcp_auth_token == "mcp-token"
+    assert prepared.compiled_run.subagents == []
+    assert prepared.compiled_run.llm_routes == {}
     assert result == expected_output
 
 
@@ -227,7 +338,6 @@ async def test_run_skips_activity_error_emission_without_patch_marker() -> None:
     )
     workflow_args = _build_workflow_args(role)
     workflow_instance = DurableAgentWorkflow(workflow_args)
-    cfg = cast(Any, workflow_args.agent_args.config)
     activity_error = ActivityError(
         "activity failed",
         scheduled_event_id=1,
@@ -241,16 +351,15 @@ async def test_run_skips_activity_error_emission_without_patch_marker() -> None:
     with (
         patch(
             "tracecat_ee.agent.workflows.durable.workflow.patched",
-            side_effect=[False, False, False, False],
+            side_effect=[False, False, False, False, False],
         ) as patched_mock,
         patch(
             "tracecat_ee.agent.workflows.durable.workflow.unsafe.is_replaying",
             return_value=False,
         ),
-        patch.object(workflow_instance, "_build_config", AsyncMock(return_value=cfg)),
         patch.object(
             workflow_instance,
-            "_run_with_agent_executor",
+            "_prepare_turn_legacy",
             AsyncMock(side_effect=activity_error),
         ),
         # Let the real _finalize_session_error run so its patch-gated
@@ -268,6 +377,7 @@ async def test_run_skips_activity_error_emission_without_patch_marker() -> None:
     # emit_session_error, preserving the legacy command shape.
     assert patched_mock.call_args_list == [
         ((UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,),),
+        ((FUSED_PREPARE_TURN_PATCH,),),
         ((EMIT_PRE_STREAM_SESSION_ERRORS_PATCH,),),
         ((PERSIST_SESSION_ERROR_PATCH,),),
         ((FINALIZE_TURN_PATCH,),),

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -308,7 +308,11 @@ async def test_run_uses_fused_prepare_activity_with_patch_marker() -> None:
     assert activity_input.curr_run_id == expected_curr_run_id
     assert activity_input.user_prompt == "hello"
     timeout = execute_activity_mock.await_args.kwargs["start_to_close_timeout"]
-    assert timeout.total_seconds() == 300
+    assert timeout.total_seconds() == 900
+    retry_policy = execute_activity_mock.await_args.kwargs["retry_policy"]
+    # Retries stay on so a mixed-version rollout (NotFoundError from an old
+    # worker) or a transient infra error retries the idempotent prepare phase.
+    assert retry_policy.maximum_attempts == 5
 
     run_mock.assert_awaited_once()
     assert run_mock.await_args is not None

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -23,6 +23,7 @@ with workflow.unsafe.imports_passed_through():
     import uvloop
     from tracecat_ee.agent.activities import AgentActivities
     from tracecat_ee.agent.approvals.service import ApprovalManager
+    from tracecat_ee.agent.prepare import prepare_agent_turn_activity
     from tracecat_ee.agent.workflows.durable import DurableAgentWorkflow
     from tracecat_ee.agent.workflows.registry_tool import ExecuteRegistryToolWorkflow
 
@@ -86,6 +87,7 @@ def get_activities() -> list[Callable[..., object]]:
     activities.append(resolve_agents_config_activity)
     activities.append(resolve_custom_model_provider_config_activity)
     activities.append(persist_stdio_mcp_connection_activity)
+    activities.append(prepare_agent_turn_activity)
     activities.extend(get_session_activities())
     return activities
 

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -11,7 +11,10 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, model_validator
 
+from tracecat.agent.common.stream_types import HarnessType
+from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.subagents import AgentSubagentsConfig
+from tracecat.auth.types import Role
 from tracecat.integrations.schemas import MCPToolStatus
 
 _LEGACY_AGENT_CONFIG_KEYS = frozenset({"deps_type", "custom_tools"})
@@ -141,3 +144,56 @@ class AgentConfigPayload(BaseModel):
     enable_internet_access: bool = Field(default=False)
     resolved_skills: list[ResolvedSkillRefPayload] | None = Field(default=None)
     builtin_skills: list[str] | None = Field(default=None)
+
+
+class InlineAgentSource(BaseModel):
+    """Inline configuration to resolve for one durable agent turn."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    kind: Literal["inline"] = Field(default="inline")
+    config: AgentConfigPayload
+
+
+class PresetAgentSource(BaseModel):
+    """Preset reference and supported overrides for one durable agent turn."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    kind: Literal["preset"] = Field(default="preset")
+    slug: str
+    version: int | None = Field(default=None)
+    preset_id: uuid.UUID | None = Field(default=None)
+    preset_version_id: uuid.UUID | None = Field(default=None)
+    actions: list[str] | None = Field(default=None)
+    instructions: str | None = Field(default=None)
+
+
+type AgentSource = Annotated[
+    InlineAgentSource | PresetAgentSource,
+    Discriminator("kind"),
+]
+
+
+class AgentTurnRequest(BaseModel):
+    """Unresolved, immutable request for one durable agent turn."""
+
+    # This payload is stored in Temporal history. Ignore stale keys so future
+    # contract cleanup does not make earlier executions undecodable.
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    role: Role
+    session_id: uuid.UUID
+    active_stream_id: uuid.UUID | None = Field(default=None)
+    user_prompt: str
+    source: AgentSource
+
+    title: str = Field(default="New Chat")
+    entity_type: AgentSessionEntity
+    entity_id: uuid.UUID
+    tools: list[str] | None = Field(default=None)
+    harness_type: HarnessType = Field(default=HarnessType.CLAUDE_CODE)
+    continue_existing_session: bool = Field(default=False)
+
+    max_requests: int | None = Field(default=None)
+    max_tool_calls: int | None = Field(default=None)


### PR DESCRIPTION
## What

Fuses the durable agent workflow's pre-executor activity chain — up to **6 sequential Temporal round-trips per turn** — into a single `prepare_agent_turn_activity`, gated behind one `workflow.patched()` marker.

> Note: this PR was rewritten from scratch; the previous revision of this branch was discarded.

### Before (per turn, sequential)

1. `resolve_agent_preset_config_activity` (preset runs)
2. `resolve_custom_model_provider_config_activity` (custom providers, root + per subagent)
3. `load_session_activity`
4. `resolve_agents_config_activity`
5. `create_session_activity`
6. `AgentActivities.build_agent_tool_definitions`

Each step is a task-queue hop, and the orchestration was spread across `run()` / `_build_config` / `_run_with_agent_executor` / `_compile_agent_run` with five interleaved patch markers.

### After

- **`tracecat_ee/agent/prepare.py`** — new module owning the whole prepare phase. `prepare_agent_turn_activity` runs the same steps, in the same order, in one activity, by calling the same underlying functions in-process. The module docstring narrates the five phases; the activity body is a numbered straight-line recipe.
- **`durable.py`** — now reads top-down:
  - `run()` → `_prepare_turn(args)` → `_execute_agent_turns(args, prepared)`
  - `_prepare_turn` is a three-line dispatcher on `FUSED_PREPARE_TURN_PATCH`
  - `_prepare_turn_fused` — one `execute_activity` + workflow-side token minting (`_compile_prepared_agent_run`); tokens stay in the workflow because they embed workflow identity and are re-minted after approval waits
  - `_prepare_turn_legacy` — the old chain moved **verbatim**, explicitly marked replay-only, with all of its historical patch markers intact
  - `_execute_agent_turns` — the executor/approval loop, moved verbatim

## Replay safety

- Old histories lack the marker → `workflow.patched()` returns `False` → the legacy chain replays with an identical command sequence (pure code motion; no command-producing statement changed).
- New executions record the marker and never touch the legacy path.
- Marker follows the repo convention: keep both branches until pre-fuse histories age out, then `workflow.deprecate_patch(...)`.

## Idempotency, retries, and rollout safety

The prepare phase is idempotent as a group: the only writing step (session upsert) was already convergent by design (`get_or_create_session`, compare-and-set binding reconciliation, `curr_run_id` pinned per run, guarded auto-title, and a pre-executor stream-buffer clear that is harmless to repeat); everything else is reads.

Because of that, the activity deliberately does **not** use `fail_fast`: it retries up to 5 attempts. Every genuine prepare failure raises `ApplicationError(non_retryable=True)` and still stops on the first attempt; what retries are transient infra errors and — critically — **mixed-version rollouts**: during a rolling deploy, a not-yet-updated worker fails the unknown activity with a retryable `NotFoundError`, and the retry lands on an updated worker instead of terminally failing the turn.

**Timeouts**: the legacy chain budgeted 120s *per compiled scope*; a flat small ceiling would regress multi-subagent turns. Instead the activity heartbeats between phases and per compiled scope (`heartbeat_timeout=180s` catches hangs faster than the legacy per-scope budget) under a generous 900s ceiling.

One deliberate deviation from "pure move" in the legacy path: the workflow no longer forwards `sdk_session_data` (`PreparedTurn` doesn't carry it). The load activity stopped producing it in #2665 (May 2026) and the executor loads SDK history from the DB, falling back correctly when the payload field is `None` — a temporal test now asserts the workflow drops a stale legacy value rather than forwarding it.

## Tests

- `tests/unit/test_durable_agent_workflow_search_attributes.py`: patch-marker call-order assertions updated; new fused-path test asserting the activity schedule, input plumbing, and compiled run.
- `tests/unit/test_agent_prepare.py` (new): direct coverage of the binding-preservation / subagent-resolution / preset-override logic that moved from workflow code into the activity (this logic was previously covered indirectly through mocked per-step activities in the temporal tests).
- `tests/temporal/test_durable_agent_workflow.py`: new `create_mock_prepare_turn_activity` factory; first-turn prepare data now flows from it, while mid-loop reload/reconcile mocks are unchanged. The legacy-SDK-JSONL replay test was retargeted to fused-prepare histories (new code can no longer produce legacy JSONL payload histories, and asserts the payload stays unset).
- `tests/integration/test_agent_worker.py`: prepare mock added; the default worker registers the real activity. Also fixes the stale `test_session_activities_registered` set that was missing `finalize_turn_activity` (pre-existing failure).
- `tests/integration/test_dsl_agent_wiring.py`: prepare mock added (the by-name replacement pattern there is bypassed by the fused path); the session-reuse assertion moved from `CreateSessionInput` to `PrepareAgentTurnInput.continue_existing_session`.

Verified locally: repo-wide ruff + basedpyright clean; `tests/unit` green; `tests/temporal/test_durable_agent_workflow.py` 16 passed, 4 skipped against a live Temporal; `tests/integration/test_agent_worker.py` green.

## Review guide

1. `tracecat_ee/agent/prepare.py` — check step parity with the legacy chain (order and semantics).
2. `durable.py::_prepare_turn_legacy` — should be a pure move of the old code (diff is best read side-by-side with `main`).
3. `durable.py::_prepare_turn_fused` / `_compile_prepared_agent_run` — error unwrapping (`ActivityError.cause` → `ApplicationError`) preserves the pre-stream error streaming semantics; token minting parity with the legacy `_compile_agent_run`.
