### PR TITLE
fix(logging): simplify workflow execution logs

### DIFF
--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -1604,7 +1604,12 @@ class WorkflowExecutionsService:
             )
 
         logger.info(
-            f"Executing DSL workflow: {dsl.title}",
+            "Executing DSL workflow",
+            wf_exec_id=wf_exec_id,
+            workflow_id=wf_id,
+        )
+        logger.debug(
+            "DSL workflow execution details",
             role=self.role,
             wf_exec_id=wf_exec_id,
             run_config=dsl.config,
@@ -1613,6 +1618,7 @@ class WorkflowExecutionsService:
             execution_type=execution_type,
             registry_lock=registry_lock,
             stored_type=trigger_inputs_ref.type if trigger_inputs_ref else "<none>",
+            workflow_id=wf_id,
         )
 
         pairs = [trigger_type.to_temporal_search_attr_pair()]
@@ -1754,7 +1760,12 @@ class WorkflowExecutionsService:
         start_timeout = min(dispatch_timeout_seconds, 30.0)
 
         logger.info(
-            f"Starting DSL workflow: {dsl.title}",
+            "Starting DSL workflow",
+            wf_exec_id=wf_exec_id,
+            workflow_id=wf_id,
+        )
+        logger.debug(
+            "DSL workflow start details",
             role=self.role,
             wf_exec_id=wf_exec_id,
             run_config=dsl.config,


### PR DESCRIPTION
## Summary

- keep INFO-level workflow execution logs limited to static messages and correlation IDs
- move verbose role, runtime configuration, trigger, registry, storage, and queue context to DEBUG
- omit user-controlled workflow titles from both levels to avoid exposing possible PII

## Root cause

Workflow start and execution events serialized detailed runtime objects at INFO and interpolated the workflow title directly into the message. This made routine production logs excessively large and could expose user-provided title content.

## Validation

- `uv run pytest tests/unit/test_webhook_execution_path.py -q` (39 passed)
- `uv run ruff check tracecat/workflow/executions/service.py`
- `uv run ruff format --check tracecat/workflow/executions/service.py`
- `uv run basedpyright tracecat/workflow/executions/service.py`
- repository pre-commit hooks, including generated-client and Python type checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified workflow execution logs to keep INFO lean and reduce PII risk. Detailed context now logs at DEBUG, and workflow titles are removed from all logs.

- **Bug Fixes**
  - INFO now logs fixed messages for starting/executing with wf_exec_id and workflow_id.
  - Moved role, run_config, trigger, execution_type, registry_lock, and storage type to DEBUG with clear messages.
  - Removed user-provided workflow titles from logs to avoid PII and cut log size.

<sup>Written for commit 5e000cadc1bfcd62e27033dcd981141f29ef9aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

