### PR TITLE
docs: discourage untyped dictionaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,11 @@ just gen-functions
   attribution is product behavior for user-initiated sync PRs.
 - Do not assume PostgreSQL superuser access in migrations, queries, or scripts.
 - Never add methods to `tracecat/db/models.py`; keep database models minimal.
+- Never use untyped dictionaries unless there is a compelling reason. Model
+  structured data with a dataclass or Pydantic model as appropriate; if
+  dictionary semantics are required, prefer `TypedDict`. Any unavoidable
+  untyped-dictionary exception must include a clear nearby explanation of why
+  the typed alternatives are unsuitable.
 - Never branch on exception or error-message strings to choose behavior, status
   codes, or retry policy. Use explicit exception types, machine-readable error
   codes in exception details, or structured error objects instead.


### PR DESCRIPTION
## Summary

- add a repo-wide rule against untyped dictionaries
- prefer dataclasses or Pydantic models for structured data
- prefer `TypedDict` when dictionary semantics are required
- require a nearby explanation for unavoidable exceptions

## Why

Typed representations make data contracts explicit and easier to validate, maintain, and review. The guidance also makes rare exceptions deliberate and visible.

## Impact

This affects future contributor and agent guidance only. It does not change runtime behavior.

## Validation

- `uv run ruff check .`
- `git diff --check`
- BasedPyright is not applicable to this Markdown-only change; targeting `AGENTS.md` causes it to parse Markdown as Python.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added repo-wide guidance in AGENTS.md discouraging untyped dictionaries; prefer `dataclasses` or `pydantic` models for structured data, and `TypedDict` when dictionary semantics are required.
Requires a nearby explanation for any unavoidable exceptions; documentation-only change with no runtime impact.

<sup>Written for commit d7f8611f2b56b82e9f3da8dc0fad37d01bf362b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

