### PR TITLE
fix(integrations): register refresh_token grant and request offline_a…

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { ChevronRight, Loader2, RotateCcw, SquareAsterisk } from "lucide-react"
+import {
+  ChevronRight,
+  Loader2,
+  RotateCcw,
+  SquareAsterisk,
+  TriangleAlert,
+} from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { IntegrationStatus, OAuthGrantType } from "@/client"
@@ -15,6 +21,7 @@ import {
 import { OAuthIntegrationDetailsDialog } from "@/components/integrations/oauth-integration-details-dialog"
 import { OAuthIntegrationDialog } from "@/components/integrations/oauth-integration-dialog"
 import { CenteredSpinner } from "@/components/loading/spinner"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Collapsible,
@@ -183,6 +190,7 @@ export default function IntegrationsPage() {
       const bStatus = getIntegrationStatus(b)
 
       const statusOrder: Record<IntegrationStatus, number> = {
+        reauth_required: 0,
         connected: 0,
         not_configured: 1,
         configured: 1,
@@ -408,9 +416,12 @@ export default function IntegrationsPage() {
                         const status = getIntegrationStatus(item)
                         const isConnected =
                           item.integration_status === "connected"
+                        const needsReauth =
+                          item.integration_status === "reauth_required"
                         const isConfigured = status === "connected"
                         const isClickable =
                           isConnected ||
+                          needsReauth ||
                           (canMutateIntegrations &&
                             item.requires_config &&
                             item.enabled)
@@ -444,7 +455,7 @@ export default function IntegrationsPage() {
                               !isClickable && "cursor-default"
                             )}
                             onClick={() => {
-                              if (isConnected) {
+                              if (isConnected || needsReauth) {
                                 setDetailsProvider({
                                   providerId: item.id,
                                   grantType: item.grant_type,
@@ -485,6 +496,28 @@ export default function IntegrationsPage() {
                               </ItemTitle>
                             </ItemContent>
                             <ItemActions className="ml-auto flex shrink-0 items-center gap-1.5 pl-3">
+                              {needsReauth ? (
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Badge
+                                        variant="outline"
+                                        className="h-5 shrink-0 gap-1 border-amber-300 bg-amber-50 px-1.5 text-[10px] font-medium text-amber-700"
+                                      >
+                                        <TriangleAlert className="size-3" />
+                                        Reconnect required
+                                      </Badge>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>
+                                        The access token expired and no refresh
+                                        token is available. Reconnect to restore
+                                        this integration.
+                                      </p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              ) : null}
                               {isConfigured ? (
                                 <TooltipProvider>
                                   <Tooltip>
@@ -551,7 +584,7 @@ export default function IntegrationsPage() {
                                     {isConnecting ? (
                                       <Loader2 className="mr-1.5 size-3 animate-spin" />
                                     ) : null}
-                                    Connect
+                                    {needsReauth ? "Reconnect" : "Connect"}
                                   </Button>
                                 </>
                               )}

--- a/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
@@ -847,6 +847,10 @@ function McpCatalogCard({
   } else if (locked) {
     statusLabel = "Locked"
     statusClassName = "border-muted bg-muted/30 text-muted-foreground"
+  } else if (entry.state === "reauth_required") {
+    // OAuth token expired with no refresh token: only re-auth revives it.
+    statusLabel = "Reconnect required"
+    statusClassName = "border-amber-200 bg-amber-50 text-amber-700"
   } else if (connected) {
     if (activeToolCount !== null && totalToolCount !== null) {
       const toolCountLabel =

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -14879,7 +14879,7 @@ export const $IntegrationReadMinimal = {
 
 export const $IntegrationStatus = {
   type: "string",
-  enum: ["not_configured", "configured", "connected"],
+  enum: ["not_configured", "configured", "connected", "reauth_required"],
   title: "IntegrationStatus",
   description: "Status of an integration.",
 } as const
@@ -16010,7 +16010,13 @@ export const $MCPIntegrationRead = {
     },
     state: {
       type: "string",
-      enum: ["not_configured", "configured", "connected", "error"],
+      enum: [
+        "not_configured",
+        "configured",
+        "connected",
+        "reauth_required",
+        "error",
+      ],
       title: "State",
     },
     stdio_command: {
@@ -18729,7 +18735,13 @@ export const $PlatformMCPCatalogRead = {
     },
     state: {
       type: "string",
-      enum: ["not_configured", "configured", "connected", "error"],
+      enum: [
+        "not_configured",
+        "configured",
+        "connected",
+        "reauth_required",
+        "error",
+      ],
       title: "State",
     },
     mcp_integration_id: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4568,7 +4568,11 @@ export type IntegrationReadMinimal = {
 /**
  * Status of an integration.
  */
-export type IntegrationStatus = "not_configured" | "configured" | "connected"
+export type IntegrationStatus =
+  | "not_configured"
+  | "configured"
+  | "connected"
+  | "reauth_required"
 
 /**
  * Response for testing integration connection.
@@ -4932,7 +4936,12 @@ export type MCPIntegrationRead = {
   server_uri: string | null
   auth_type: MCPAuthType
   oauth_integration_id: string | null
-  state: "not_configured" | "configured" | "connected" | "error"
+  state:
+    | "not_configured"
+    | "configured"
+    | "connected"
+    | "reauth_required"
+    | "error"
   stdio_command: string | null
   stdio_args: Array<string> | null
   has_stdio_env?: boolean
@@ -4942,7 +4951,12 @@ export type MCPIntegrationRead = {
   updated_at: string
 }
 
-export type state = "not_configured" | "configured" | "connected" | "error"
+export type state =
+  | "not_configured"
+  | "configured"
+  | "connected"
+  | "reauth_required"
+  | "error"
 
 export type MCPIntegrationTestConnectionRequest =
   | MCPHttpIntegrationTestConnectionRequest
@@ -5634,7 +5648,12 @@ export type PlatformMCPCatalogRead = {
    * Whether this platform MCP catalog row is locked by entitlement.
    */
   locked: boolean
-  state: "not_configured" | "configured" | "connected" | "error"
+  state:
+    | "not_configured"
+    | "configured"
+    | "connected"
+    | "reauth_required"
+    | "error"
   mcp_integration_id: string | null
   mcp_server_type?: MCPServerType | null
   mcp_auth_type?: MCPAuthType | null

--- a/frontend/src/components/integrations/oauth-integration-details-dialog.tsx
+++ b/frontend/src/components/integrations/oauth-integration-details-dialog.tsx
@@ -84,6 +84,9 @@ export function OAuthIntegrationDetailsDialog({
 
   const providerName = provider?.metadata.name || providerId
   const isConnected = integration?.status === "connected"
+  // Token expired with no refresh token: only re-authorizing revives it.
+  const needsReauth = integration?.status === "reauth_required"
+  const hasConnection = isConnected || needsReauth
   const isExpired = integration?.is_expired ?? false
 
   const serviceAccountProviders = ["google", "google_sheets", "google_docs"]
@@ -173,12 +176,12 @@ export function OAuthIntegrationDetailsDialog({
               <div className="flex flex-col">
                 <section className="space-y-3 px-6 py-5">
                   <h3 className="text-sm font-semibold">Connection</h3>
-                  {isConnected ? (
+                  {hasConnection ? (
                     <div className="flex items-center justify-between gap-3">
                       <div className="flex min-w-0 flex-1 items-center gap-3">
                         <span
                           className={
-                            isExpired
+                            needsReauth || isExpired
                               ? "flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700"
                               : "flex size-7 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-emerald-700"
                           }
@@ -190,7 +193,14 @@ export function OAuthIntegrationDetailsDialog({
                             <p className="truncate text-sm font-medium text-foreground">
                               {providerName}
                             </p>
-                            {isExpired ? (
+                            {needsReauth ? (
+                              <Badge
+                                variant="outline"
+                                className="h-4 border-amber-300 bg-amber-50 px-1.5 text-[10px] uppercase text-amber-700"
+                              >
+                                Reconnect required
+                              </Badge>
+                            ) : isExpired ? (
                               <Badge
                                 variant="outline"
                                 className="h-4 border-amber-300 bg-amber-50 px-1.5 text-[10px] uppercase text-amber-700"
@@ -200,9 +210,11 @@ export function OAuthIntegrationDetailsDialog({
                             ) : null}
                           </div>
                           <p className="text-xs text-muted-foreground">
-                            {lastUpdatedRelative
-                              ? `Last updated ${lastUpdatedRelative}`
-                              : "Connected"}
+                            {needsReauth
+                              ? "The access token expired and no refresh token is available. Reauthorize to restore this integration."
+                              : lastUpdatedRelative
+                                ? `Last updated ${lastUpdatedRelative}`
+                                : "Connected"}
                           </p>
                         </div>
                       </div>

--- a/frontend/src/components/integrations/oauth-integration-details-dialog.tsx
+++ b/frontend/src/components/integrations/oauth-integration-details-dialog.tsx
@@ -84,7 +84,6 @@ export function OAuthIntegrationDetailsDialog({
 
   const providerName = provider?.metadata.name || providerId
   const isConnected = integration?.status === "connected"
-  // Token expired with no refresh token: only re-authorizing revives it.
   const needsReauth = integration?.status === "reauth_required"
   const hasConnection = isConnected || needsReauth
   const isExpired = integration?.is_expired ?? false
@@ -111,6 +110,13 @@ export function OAuthIntegrationDetailsDialog({
   }, [integration?.expires_at])
 
   const lastUpdatedRelative = formatRelative(integration?.updated_at)
+  let connectionStatusDescription = "Connected"
+  if (needsReauth) {
+    connectionStatusDescription =
+      "The access token expired. Reconnect to restore this integration."
+  } else if (lastUpdatedRelative) {
+    connectionStatusDescription = `Last updated ${lastUpdatedRelative}`
+  }
 
   if (!open) {
     return null
@@ -210,11 +216,7 @@ export function OAuthIntegrationDetailsDialog({
                             ) : null}
                           </div>
                           <p className="text-xs text-muted-foreground">
-                            {needsReauth
-                              ? "The access token expired and no refresh token is available. Reauthorize to restore this integration."
-                              : lastUpdatedRelative
-                                ? `Last updated ${lastUpdatedRelative}`
-                                : "Connected"}
+                            {connectionStatusDescription}
                           </p>
                         </div>
                       </div>

--- a/frontend/tests/oauth-integration-details-dialog.test.tsx
+++ b/frontend/tests/oauth-integration-details-dialog.test.tsx
@@ -129,12 +129,15 @@ const integration: IntegrationRead = {
   is_expired: false,
 }
 
-function setupMocks(grantType: OAuthGrantType) {
+function setupMocks(
+  grantType: OAuthGrantType,
+  integrationOverrides: Partial<IntegrationRead> = {}
+) {
   mockUseIntegrationProvider.mockReturnValue({
     provider: { ...provider, grant_type: grantType },
     providerIsLoading: false,
     providerError: null,
-    integration,
+    integration: { ...integration, ...integrationOverrides },
     integrationIsLoading: false,
     integrationError: null,
   } as unknown as ReturnType<typeof useIntegrationProvider>)
@@ -156,8 +159,11 @@ function setupMocks(grantType: OAuthGrantType) {
   )
 }
 
-function renderDialog(grantType: OAuthGrantType) {
-  setupMocks(grantType)
+function renderDialog(
+  grantType: OAuthGrantType,
+  integrationOverrides: Partial<IntegrationRead> = {}
+) {
+  setupMocks(grantType, integrationOverrides)
 
   render(
     <OAuthIntegrationDetailsDialog
@@ -190,4 +196,25 @@ describe("OAuthIntegrationDetailsDialog", () => {
       screen.queryByRole("button", { name: /reauthorize/i })
     ).not.toBeInTheDocument()
   })
+
+  it.each<OAuthGrantType>(["authorization_code", "client_credentials"])(
+    "uses grant-type-neutral recovery guidance for %s providers",
+    (grantType) => {
+      renderDialog(grantType, {
+        status: "reauth_required",
+        is_expired: true,
+      })
+
+      expect(
+        screen.getByText(
+          "The access token expired. Reconnect to restore this integration."
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(
+          "The access token expired and no refresh token is available. Reauthorize to restore this integration."
+        )
+      ).not.toBeInTheDocument()
+    }
+  )
 })

--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -24,7 +24,7 @@ from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import OAuthIntegration, Workspace
 from tracecat.exceptions import TracecatAuthorizationError
-from tracecat.integrations.enums import OAuthGrantType
+from tracecat.integrations.enums import IntegrationStatus, OAuthGrantType
 from tracecat.integrations.providers.base import (
     AuthorizationCodeOAuthProvider,
     ClientCredentialsOAuthProvider,
@@ -35,6 +35,7 @@ from tracecat.integrations.schemas import (
     ProviderKey,
     ProviderMetadata,
     ProviderScopes,
+    credential_reauth_required,
 )
 from tracecat.integrations.service import (
     InsecureOAuthEndpointError,
@@ -2347,3 +2348,49 @@ class TestIntegrationServiceScopes:
 
         assert config is not None
         assert config.scopes == ["fallback.read", "fallback.write"]
+
+
+def _oauth_integration_row(
+    *,
+    encrypted_refresh_token: bytes | None,
+    expires_at: datetime | None,
+) -> OAuthIntegration:
+    return OAuthIntegration(
+        workspace_id=uuid.uuid4(),
+        provider_id="test_provider",
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        encrypted_access_token=b"access",
+        encrypted_refresh_token=encrypted_refresh_token,
+        expires_at=expires_at,
+    )
+
+
+def test_integration_status_flags_dead_credential_as_reauth_required() -> None:
+    """Expired token with no refresh token is REAUTH_REQUIRED, not CONNECTED."""
+    expired = datetime.now(UTC) - timedelta(minutes=1)
+    live = datetime.now(UTC) + timedelta(hours=1)
+
+    dead = _oauth_integration_row(encrypted_refresh_token=None, expires_at=expired)
+    assert dead.status == IntegrationStatus.REAUTH_REQUIRED
+
+    # Expired with a refresh token self-heals on next use: still CONNECTED.
+    refreshable = _oauth_integration_row(
+        encrypted_refresh_token=b"refresh", expires_at=expired
+    )
+    assert refreshable.status == IntegrationStatus.CONNECTED
+
+    fresh = _oauth_integration_row(encrypted_refresh_token=None, expires_at=live)
+    assert fresh.status == IntegrationStatus.CONNECTED
+
+    non_expiring = _oauth_integration_row(encrypted_refresh_token=None, expires_at=None)
+    assert non_expiring.status == IntegrationStatus.CONNECTED
+
+
+def test_credential_reauth_required_truth_table() -> None:
+    expired = datetime.now(UTC) - timedelta(minutes=1)
+    live = datetime.now(UTC) + timedelta(hours=1)
+
+    assert credential_reauth_required(has_refresh_token=False, expires_at=expired)
+    assert not credential_reauth_required(has_refresh_token=True, expires_at=expired)
+    assert not credential_reauth_required(has_refresh_token=False, expires_at=live)
+    assert not credential_reauth_required(has_refresh_token=False, expires_at=None)

--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -2349,16 +2349,52 @@ class TestIntegrationServiceScopes:
         assert config is not None
         assert config.scopes == ["fallback.read", "fallback.write"]
 
+    async def test_get_provider_config_preserves_explicit_empty_scopes(
+        self,
+        integration_service: IntegrationService,
+        mock_provider: MockOAuthProvider,
+    ) -> None:
+        """Explicitly empty stored scopes must not revert to default scopes."""
+        provider_key = ProviderKey(
+            id=mock_provider.id, grant_type=mock_provider.grant_type
+        )
+
+        # Store with explicitly empty scopes (e.g. narrowed by a DCR echo)
+        integration = await integration_service.store_provider_config(
+            provider_key=provider_key,
+            client_id="test_client_id",
+            client_secret=SecretStr("test_secret"),
+            requested_scopes=[],
+        )
+        assert integration.requested_scopes == ""
+
+        config = integration_service.get_provider_config(
+            integration=integration,
+            default_scopes=["fallback.read", "fallback.write"],
+        )
+
+        assert config is not None
+        assert config.scopes == []
+
+    async def test_parse_scopes_distinguishes_empty_from_unset(
+        self, integration_service: IntegrationService
+    ) -> None:
+        """Empty string parses to an empty list; only None means unconfigured."""
+        assert integration_service.parse_scopes(None) is None
+        assert integration_service.parse_scopes("") == []
+        assert integration_service.parse_scopes("read write") == ["read", "write"]
+
 
 def _oauth_integration_row(
     *,
     encrypted_refresh_token: bytes | None,
     expires_at: datetime | None,
+    grant_type: OAuthGrantType = OAuthGrantType.AUTHORIZATION_CODE,
 ) -> OAuthIntegration:
     return OAuthIntegration(
         workspace_id=uuid.uuid4(),
         provider_id="test_provider",
-        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        grant_type=grant_type,
         encrypted_access_token=b"access",
         encrypted_refresh_token=encrypted_refresh_token,
         expires_at=expires_at,
@@ -2373,6 +2409,11 @@ def test_integration_status_flags_dead_credential_as_reauth_required() -> None:
     dead = _oauth_integration_row(encrypted_refresh_token=None, expires_at=expired)
     assert dead.status == IntegrationStatus.REAUTH_REQUIRED
 
+    empty_refresh = _oauth_integration_row(
+        encrypted_refresh_token=b"", expires_at=expired
+    )
+    assert empty_refresh.status == IntegrationStatus.REAUTH_REQUIRED
+
     # Expired with a refresh token self-heals on next use: still CONNECTED.
     refreshable = _oauth_integration_row(
         encrypted_refresh_token=b"refresh", expires_at=expired
@@ -2384,6 +2425,13 @@ def test_integration_status_flags_dead_credential_as_reauth_required() -> None:
 
     non_expiring = _oauth_integration_row(encrypted_refresh_token=None, expires_at=None)
     assert non_expiring.status == IntegrationStatus.CONNECTED
+
+    client_credentials = _oauth_integration_row(
+        encrypted_refresh_token=None,
+        expires_at=expired,
+        grant_type=OAuthGrantType.CLIENT_CREDENTIALS,
+    )
+    assert client_credentials.status == IntegrationStatus.CONNECTED
 
 
 def test_credential_reauth_required_truth_table() -> None:

--- a/tests/unit/test_mcp_catalog_loader.py
+++ b/tests/unit/test_mcp_catalog_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import orjson
 import pytest
@@ -12,6 +13,7 @@ from tracecat.integrations.catalog import loader
 from tracecat.integrations.catalog.service import PlatformMCPCatalogService
 from tracecat.integrations.catalog.types import RawCatalogRow
 from tracecat.integrations.enums import MCPAuthType
+from tracecat.integrations.schemas import OAuthTokenState
 
 
 class _CatalogResource:
@@ -644,7 +646,7 @@ def test_catalog_state_marks_unverified_non_oauth_mcp_rows_configured() -> None:
             slug="no-auth-mcp",
             auth_type=MCPAuthType.NONE,
         ),
-        encrypted_access_token=None,
+        token_state=None,
     )
 
     assert state == "configured"
@@ -660,7 +662,59 @@ def test_catalog_state_marks_verified_non_oauth_mcp_rows_connected() -> None:
             auth_type=MCPAuthType.NONE,
             tools=[],
         ),
-        encrypted_access_token=None,
+        token_state=None,
+    )
+
+    assert state == "connected"
+
+
+def _oauth_mcp_row() -> MCPIntegration:
+    return MCPIntegration(
+        id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        name="OAuth MCP",
+        slug="oauth-mcp",
+        auth_type=MCPAuthType.OAUTH2,
+        tools=[],
+    )
+
+
+def test_catalog_state_flags_dead_oauth_token_as_reauth_required() -> None:
+    """Expired access token with no refresh token cannot self-heal."""
+    state = PlatformMCPCatalogService._catalog_state(
+        mcp_integration=_oauth_mcp_row(),
+        token_state=OAuthTokenState(
+            encrypted_access_token=b"token",
+            encrypted_refresh_token=None,
+            expires_at=datetime.now(UTC) - timedelta(minutes=1),
+        ),
+    )
+
+    assert state == "reauth_required"
+
+
+def test_catalog_state_keeps_refreshable_expired_oauth_token_connected() -> None:
+    """An expired access token with a refresh token self-heals on next use."""
+    state = PlatformMCPCatalogService._catalog_state(
+        mcp_integration=_oauth_mcp_row(),
+        token_state=OAuthTokenState(
+            encrypted_access_token=b"token",
+            encrypted_refresh_token=b"refresh",
+            expires_at=datetime.now(UTC) - timedelta(minutes=1),
+        ),
+    )
+
+    assert state == "connected"
+
+
+def test_catalog_state_keeps_non_expiring_oauth_token_connected() -> None:
+    state = PlatformMCPCatalogService._catalog_state(
+        mcp_integration=_oauth_mcp_row(),
+        token_state=OAuthTokenState(
+            encrypted_access_token=b"token",
+            encrypted_refresh_token=None,
+            expires_at=None,
+        ),
     )
 
     assert state == "connected"

--- a/tests/unit/test_mcp_catalog_loader.py
+++ b/tests/unit/test_mcp_catalog_loader.py
@@ -12,7 +12,7 @@ from tracecat.db.models import MCPIntegration
 from tracecat.integrations.catalog import loader
 from tracecat.integrations.catalog.service import PlatformMCPCatalogService
 from tracecat.integrations.catalog.types import RawCatalogRow
-from tracecat.integrations.enums import MCPAuthType
+from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
 from tracecat.integrations.schemas import OAuthTokenState
 
 
@@ -647,6 +647,7 @@ def test_catalog_state_marks_unverified_non_oauth_mcp_rows_configured() -> None:
             auth_type=MCPAuthType.NONE,
         ),
         token_state=None,
+        oauth_grant_type=None,
     )
 
     assert state == "configured"
@@ -663,6 +664,7 @@ def test_catalog_state_marks_verified_non_oauth_mcp_rows_connected() -> None:
             tools=[],
         ),
         token_state=None,
+        oauth_grant_type=None,
     )
 
     assert state == "connected"
@@ -688,6 +690,7 @@ def test_catalog_state_flags_dead_oauth_token_as_reauth_required() -> None:
             encrypted_refresh_token=None,
             expires_at=datetime.now(UTC) - timedelta(minutes=1),
         ),
+        oauth_grant_type=OAuthGrantType.AUTHORIZATION_CODE,
     )
 
     assert state == "reauth_required"
@@ -702,6 +705,7 @@ def test_catalog_state_keeps_refreshable_expired_oauth_token_connected() -> None
             encrypted_refresh_token=b"refresh",
             expires_at=datetime.now(UTC) - timedelta(minutes=1),
         ),
+        oauth_grant_type=OAuthGrantType.AUTHORIZATION_CODE,
     )
 
     assert state == "connected"
@@ -715,6 +719,22 @@ def test_catalog_state_keeps_non_expiring_oauth_token_connected() -> None:
             encrypted_refresh_token=None,
             expires_at=None,
         ),
+        oauth_grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+    )
+
+    assert state == "connected"
+
+
+def test_catalog_state_keeps_expired_client_credentials_connected() -> None:
+    """Client credentials renew without an interactive reauthorization flow."""
+    state = PlatformMCPCatalogService._catalog_state(
+        mcp_integration=_oauth_mcp_row(),
+        token_state=OAuthTokenState(
+            encrypted_access_token=b"token",
+            encrypted_refresh_token=None,
+            expires_at=datetime.now(UTC) - timedelta(minutes=1),
+        ),
+        oauth_grant_type=OAuthGrantType.CLIENT_CREDENTIALS,
     )
 
     assert state == "connected"

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -2025,6 +2025,139 @@ class TestMCPIntegrationCRUD:
         query = parse_qs(parsed.query)
         assert query["resource"] == ["https://mcp.example.test/mcp"]
 
+    async def _run_reconnect_scope_case(
+        self,
+        *,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+        provider_id: str,
+        stored_scopes: list[str] | None,
+        advertised_scopes: list[str],
+    ) -> dict[str, object]:
+        """Reconnect an existing custom MCP row and return authorize kwargs.
+
+        Only the authorization endpoint is stored so endpoint resolution falls
+        through to discovery, letting ``advertised_scopes`` drive the flow.
+        """
+        await _seed_service_user(session, integration_service)
+
+        provider_key = ProviderKey(
+            id=provider_id, grant_type=OAuthGrantType.AUTHORIZATION_CODE
+        )
+        oauth_integration = await integration_service.store_provider_config(
+            provider_key=provider_key,
+            client_id="reconnect-client",
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            requested_scopes=stored_scopes,
+        )
+        mcp_integration = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name="Reconnect Scope MCP",
+            slug=f"reconnect-scope-mcp-{uuid.uuid4().hex[:8]}",
+            server_type="http",
+            server_uri="https://mcp.example.test/mcp",
+            auth_type=MCPAuthType.OAUTH2,
+            oauth_integration_id=oauth_integration.id,
+        )
+        session.add(mcp_integration)
+        await session.commit()
+
+        async def fake_discover(
+            *,
+            server_uri: str,
+        ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
+            assert server_uri == "https://mcp.example.test/mcp"
+            return integration_service_module.MCPOAuthDiscoveryEndpoints(
+                authorization_endpoint="https://auth.example.test/oauth/authorize",
+                token_endpoint="https://auth.example.test/oauth/token",
+                token_methods=["none"],
+                scopes_supported=advertised_scopes,
+                registration_endpoint=None,
+                resource="https://mcp.example.test/mcp",
+            )
+
+        monkeypatch.setattr(
+            integration_service, "_discover_mcp_oauth_endpoints", fake_discover
+        )
+        captured: dict[str, object] = {}
+        _patch_mcp_oauth_client(monkeypatch, authorize_captured=captured)
+
+        result = await integration_service._start_existing_custom_mcp_oauth(
+            mcp_integration=mcp_integration
+        )
+        assert result is not None
+        assert result.oauth_connect is not None
+        return captured
+
+    async def test_reconnect_narrowed_scopes_not_re_expanded(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A DCR-narrowed stored set is sent verbatim, without re-adding offline_access."""
+        captured = await self._run_reconnect_scope_case(
+            integration_service=integration_service,
+            session=session,
+            monkeypatch=monkeypatch,
+            provider_id="custom_mcp_reconnect_narrowed",
+            stored_scopes=["mcp:read"],
+            advertised_scopes=["mcp:read", "offline_access"],
+        )
+        assert captured["scope"] == "mcp:read"
+
+    async def test_reconnect_legacy_null_scopes_expand_with_offline_access(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Legacy rows with NULL requested_scopes still expand on reconnect."""
+        captured = await self._run_reconnect_scope_case(
+            integration_service=integration_service,
+            session=session,
+            monkeypatch=monkeypatch,
+            provider_id="custom_mcp_reconnect_legacy",
+            stored_scopes=None,
+            advertised_scopes=["offline_access"],
+        )
+        assert captured["scope"] == "offline_access"
+
+    async def test_reconnect_stored_offline_access_sent_unchanged(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stored set already carrying offline_access is not duplicated."""
+        captured = await self._run_reconnect_scope_case(
+            integration_service=integration_service,
+            session=session,
+            monkeypatch=monkeypatch,
+            provider_id="custom_mcp_reconnect_stored_offline",
+            stored_scopes=["mcp:read", "offline_access"],
+            advertised_scopes=["mcp:read", "offline_access"],
+        )
+        assert captured["scope"] == "mcp:read offline_access"
+
+    async def test_reconnect_empty_stored_scopes_stay_empty(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit-empty stored set stays empty and omits the scope param."""
+        captured = await self._run_reconnect_scope_case(
+            integration_service=integration_service,
+            session=session,
+            monkeypatch=monkeypatch,
+            provider_id="custom_mcp_reconnect_empty",
+            stored_scopes=[],
+            advertised_scopes=["offline_access"],
+        )
+        assert "scope" not in captured
+
     async def test_get_mcp_integration(
         self,
         integration_service: IntegrationService,
@@ -3961,7 +4094,7 @@ class TestMCPProviderOAuth:
                 "token_endpoint": "https://mcp.example.com/oauth/token",
                 "registration_endpoint": "https://mcp.example.com/oauth/register",
                 "token_endpoint_auth_methods_supported": ["none"],
-                "scopes_supported": ["read", "offline_access", 42],
+                "scopes_supported": ["read", "offline_access"],
             },
         }
 
@@ -3974,8 +4107,25 @@ class TestMCPProviderOAuth:
             server_uri="https://mcp.example.com/mcp",
         )
 
-        # Malformed non-string entries are dropped by the metadata validator.
         assert endpoints.scopes_supported == ["read", "offline_access"]
+
+    def test_oauth_server_metadata_rejects_malformed_string_lists(self) -> None:
+        """Known metadata fields must retain their declared wire types."""
+        with pytest.raises(ValidationError):
+            OAuthServerMetadata.from_json({"scopes_supported": ["read", 42]})
+
+    @pytest.mark.parametrize(
+        "grant_types",
+        ["authorization_code", ["authorization_code", 42]],
+    )
+    def test_dcr_response_rejects_malformed_grant_types(
+        self, grant_types: object
+    ) -> None:
+        """Malformed DCR grants cannot masquerade as omitted or narrowed grants."""
+        with pytest.raises(ValidationError):
+            DCRResponse.model_validate(
+                {"client_id": "dcr-client", "grant_types": grant_types}
+            )
 
     async def test_resolve_mcp_static_endpoints_have_empty_scopes_supported(
         self,
@@ -5359,7 +5509,7 @@ class TestMCPProviderOAuth:
             metadata: ProviderMetadata = ProviderMetadata(  # type: ignore[assignment]
                 id="narrowed_mcp",
                 name="Narrowed MCP",
-                description="MCP provider with narrowed registered scopes",
+                description="MCP provider with echoed registered scopes",
                 requires_config=False,
                 enabled=True,
             )
@@ -5398,7 +5548,7 @@ class TestMCPProviderOAuth:
             return DCRResponse(
                 client_id="narrowed-client",
                 token_endpoint_auth_method="none",
-                scope="read",
+                scope="read admin",
             )
 
         monkeypatch.setattr(
@@ -5416,8 +5566,8 @@ class TestMCPProviderOAuth:
         auth_url, _ = await provider.get_authorization_url(state="test-state")
 
         assert registration_payload["scope"] == "read offline_access"
-        assert provider.requested_scopes == ["read"]
-        assert parse_qs(urlparse(auth_url).query)["scope"] == ["read"]
+        assert provider.requested_scopes == ["read", "admin"]
+        assert parse_qs(urlparse(auth_url).query)["scope"] == ["read admin"]
 
     async def test_mcp_provider_sync_constructor_honors_dcr_scope_echo(
         self,
@@ -5468,6 +5618,120 @@ class TestMCPProviderOAuth:
 
         assert provider.requested_scopes == ["read"]
         assert parse_qs(urlparse(auth_url).query)["scope"] == ["read"]
+
+    async def test_mcp_provider_instantiate_existing_client_keeps_stored_scopes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reusing a client_id with stored scopes must not re-add offline_access."""
+
+        class DummyMCPProvider(MCPAuthProvider):
+            id: str = "existing_client_mcp"  # type: ignore[assignment]
+            mcp_server_uri: str = "https://existing.example/mcp"  # type: ignore[assignment]
+            scopes: ProviderScopes = ProviderScopes(default=[])  # type: ignore[assignment]
+            metadata: ProviderMetadata = ProviderMetadata(  # type: ignore[assignment]
+                id="existing_client_mcp",
+                name="Existing Client MCP",
+                description="MCP provider reusing a stored client",
+                requires_config=False,
+                enabled=True,
+            )
+
+        monkeypatch.setenv("TRACECAT__PUBLIC_APP_URL", "https://app.test")
+        discovery = OAuthDiscoveryResult(
+            authorization_endpoint="https://existing.example/oauth/authorize",
+            token_endpoint="https://existing.example/oauth/token",
+            token_methods=["none"],
+            scopes_supported=["mcp:read", "offline_access"],
+            registration_endpoint="https://existing.example/oauth/register",
+        )
+
+        async def fake_discover(
+            cls,
+            logger_instance,
+            *,
+            discovered_auth_endpoint=None,
+            discovered_token_endpoint=None,
+        ) -> OAuthDiscoveryResult:
+            _ = (
+                cls,
+                logger_instance,
+                discovered_auth_endpoint,
+                discovered_token_endpoint,
+            )
+            return discovery
+
+        async def fail_register(
+            endpoint: str, payload: dict[str, object]
+        ) -> DCRResponse:
+            _ = payload
+            raise AssertionError(
+                f"DCR must not run with an existing client: {endpoint}"
+            )
+
+        monkeypatch.setattr(
+            DummyMCPProvider,
+            "_discover_oauth_endpoints_async",
+            classmethod(fake_discover),
+        )
+        monkeypatch.setattr(
+            DummyMCPProvider,
+            "_submit_registration_request",
+            staticmethod(fail_register),
+        )
+
+        provider_config = ProviderConfig(
+            client_id="existing-client",
+            scopes=["mcp:read"],
+        )
+        provider = await DummyMCPProvider.instantiate(config=provider_config)
+        auth_url, _ = await provider.get_authorization_url(state="test-state")
+
+        assert provider.requested_scopes == ["mcp:read"]
+        assert parse_qs(urlparse(auth_url).query)["scope"] == ["mcp:read"]
+
+    async def test_mcp_provider_sync_existing_client_keeps_stored_scopes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The sync constructor also sends stored scopes verbatim with a known client."""
+
+        class DummyMCPProvider(MCPAuthProvider):
+            id: str = "sync_existing_client_mcp"  # type: ignore[assignment]
+            mcp_server_uri: str = "https://sync-existing.example/mcp"  # type: ignore[assignment]
+            scopes: ProviderScopes = ProviderScopes(default=[])  # type: ignore[assignment]
+            metadata: ProviderMetadata = ProviderMetadata(  # type: ignore[assignment]
+                id="sync_existing_client_mcp",
+                name="Sync Existing Client MCP",
+                description="MCP provider reusing a stored client synchronously",
+                requires_config=False,
+                enabled=True,
+            )
+
+        monkeypatch.setenv("TRACECAT__PUBLIC_APP_URL", "https://app.test")
+
+        def fail_register(self: MCPAuthProvider) -> DynamicRegistrationResult:
+            raise AssertionError("DCR must not run with an existing client")
+
+        monkeypatch.setattr(
+            DummyMCPProvider,
+            "_perform_dynamic_registration",
+            fail_register,
+        )
+
+        provider = DummyMCPProvider(
+            client_id="sync-existing-client",
+            scopes=["mcp:read"],
+            discovered_auth_endpoint="https://sync-existing.example/oauth/authorize",
+            discovered_token_endpoint="https://sync-existing.example/oauth/token",
+            registration_endpoint="https://sync-existing.example/oauth/register",
+            token_methods=["none"],
+            scopes_supported=["mcp:read", "offline_access"],
+        )
+        auth_url, _ = await provider.get_authorization_url(state="test-state")
+
+        assert provider.requested_scopes == ["mcp:read"]
+        assert parse_qs(urlparse(auth_url).query)["scope"] == ["mcp:read"]
 
     async def test_mcp_provider_default_resource_uses_full_mcp_uri(
         self,
@@ -5648,12 +5912,15 @@ class TestMCPProviderOAuth:
     @pytest.mark.parametrize(
         ("registered_scope_echo", "expected_authorize_scopes"),
         [
-            # AS narrowed the registration: authorize scope is the intersection.
+            # AS narrowed the registration: authorize with the registered set.
             ("read", ["read"]),
             # AS omitted the scope echo: requested set used verbatim.
             (None, ["read", "write", "offline_access"]),
-            # AS echoed extra scopes we never requested: extras must NOT be added.
-            ("read write offline_access admin", ["read", "write", "offline_access"]),
+            # The registration response is authoritative, including added scopes.
+            (
+                "read write offline_access admin",
+                ["read", "write", "offline_access", "admin"],
+            ),
         ],
     )
     async def test_connect_mcp_oauth_discovery_uses_effective_scopes(
@@ -5664,7 +5931,7 @@ class TestMCPProviderOAuth:
         registered_scope_echo: str | None,
         expected_authorize_scopes: list[str],
     ) -> None:
-        """Authorize URL scope is requested-intersect-registered, order preserved."""
+        """Authorize with registered scopes, or requested scopes when unreported."""
         await _seed_service_user(session, integration_service)
 
         endpoints = integration_service_module.MCPOAuthDiscoveryEndpoints(

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -20,7 +20,7 @@ import httpx
 import pytest
 from authlib.integrations.base_client.errors import OAuthError
 from pydantic import SecretStr, TypeAdapter, ValidationError
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
@@ -4127,6 +4127,12 @@ class TestMCPProviderOAuth:
                 {"client_id": "dcr-client", "grant_types": grant_types}
             )
 
+    @pytest.mark.parametrize("scope", [42, ["read"]])
+    def test_dcr_response_rejects_malformed_scope(self, scope: object) -> None:
+        """Malformed DCR scope echoes cannot masquerade as an omitted echo."""
+        with pytest.raises(ValidationError):
+            DCRResponse.model_validate({"client_id": "dcr-client", "scope": scope})
+
     async def test_resolve_mcp_static_endpoints_have_empty_scopes_supported(
         self,
         integration_service: IntegrationService,
@@ -4941,13 +4947,16 @@ class TestMCPProviderOAuth:
         )
 
         async def fake_refresh(
-            *, integration: OAuthIntegration, refresh_token: str
+            _service: IntegrationService,
+            *,
+            integration: OAuthIntegration,
+            refresh_token: str,
         ) -> OAuthIntegration:
             _ = integration, refresh_token
             raise OAuthError(error="invalid_grant", description="session expired")
 
         monkeypatch.setattr(
-            integration_service, "_refresh_custom_mcp_integration", fake_refresh
+            IntegrationService, "_refresh_custom_mcp_integration", fake_refresh
         )
 
         result = await integration_service.refresh_token_if_needed(integration)
@@ -4955,32 +4964,33 @@ class TestMCPProviderOAuth:
         assert result.encrypted_refresh_token is None
         assert result.status == IntegrationStatus.REAUTH_REQUIRED
 
-    async def test_refresh_invalid_grant_keeps_concurrently_rotated_token(
+    async def test_refresh_stale_caller_keeps_concurrently_rotated_token(
         self,
         integration_service: IntegrationService,
         session: AsyncSession,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A losing refresh must not clear a token rotated by a concurrent winner."""
+        """A stale caller observes the token persisted by a concurrent winner."""
         integration = await self._store_expired_mcp_integration(
             integration_service, session
         )
-
-        async def fake_refresh(
-            *, integration: OAuthIntegration, refresh_token: str
-        ) -> OAuthIntegration:
-            _ = refresh_token
-            # Simulate a concurrent refresh winning: a new token lands in the row
-            # before this attempt's invalid_grant (rotation reuse detection).
-            integration.encrypted_refresh_token = integration_service._encrypt_token(
-                "rotated-refresh-token"
+        # Keep the caller's ORM object stale while a winner persists a complete
+        # rotation. The refresh transaction must reload this row under its lock
+        # and skip presenting the old refresh token.
+        session.expunge(integration)
+        await session.execute(
+            update(OAuthIntegration)
+            .where(OAuthIntegration.id == integration.id)
+            .values(
+                encrypted_access_token=integration_service._encrypt_token(
+                    "rotated-access-token"
+                ),
+                encrypted_refresh_token=integration_service._encrypt_token(
+                    "rotated-refresh-token"
+                ),
+                expires_at=datetime.now(UTC) + timedelta(hours=1),
             )
-            await session.commit()
-            raise OAuthError(error="invalid_grant", description="reuse detected")
-
-        monkeypatch.setattr(
-            integration_service, "_refresh_custom_mcp_integration", fake_refresh
         )
+        await session.commit()
 
         result = await integration_service.refresh_token_if_needed(integration)
 
@@ -5003,13 +5013,16 @@ class TestMCPProviderOAuth:
         )
 
         async def fake_refresh(
-            *, integration: OAuthIntegration, refresh_token: str
+            _service: IntegrationService,
+            *,
+            integration: OAuthIntegration,
+            refresh_token: str,
         ) -> OAuthIntegration:
             _ = integration, refresh_token
             raise OAuthError(error="temporarily_unavailable", description="down")
 
         monkeypatch.setattr(
-            integration_service, "_refresh_custom_mcp_integration", fake_refresh
+            IntegrationService, "_refresh_custom_mcp_integration", fake_refresh
         )
 
         result = await integration_service.refresh_token_if_needed(integration)
@@ -5496,9 +5509,19 @@ class TestMCPProviderOAuth:
         assert provider.requested_scopes == ["offline_access"]
         assert auth_query["scope"] == ["offline_access"]
 
+    @pytest.mark.parametrize(
+        ("scope_echo", "expected_scopes", "expected_authorize_scope"),
+        [
+            ("read admin", ["read", "admin"], "read admin"),
+            ("", [], None),
+        ],
+    )
     async def test_mcp_provider_honors_dcr_scope_echo(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        scope_echo: str,
+        expected_scopes: list[str],
+        expected_authorize_scope: str | None,
     ) -> None:
         """Credential-less built-ins authorize with the registered scope whitelist."""
 
@@ -5548,7 +5571,7 @@ class TestMCPProviderOAuth:
             return DCRResponse(
                 client_id="narrowed-client",
                 token_endpoint_auth_method="none",
-                scope="read admin",
+                scope=scope_echo,
             )
 
         monkeypatch.setattr(
@@ -5566,8 +5589,10 @@ class TestMCPProviderOAuth:
         auth_url, _ = await provider.get_authorization_url(state="test-state")
 
         assert registration_payload["scope"] == "read offline_access"
-        assert provider.requested_scopes == ["read", "admin"]
-        assert parse_qs(urlparse(auth_url).query)["scope"] == ["read admin"]
+        assert provider.requested_scopes == expected_scopes
+        assert parse_qs(urlparse(auth_url).query).get("scope") == (
+            [expected_authorize_scope] if expected_authorize_scope is not None else None
+        )
 
     async def test_mcp_provider_sync_constructor_honors_dcr_scope_echo(
         self,
@@ -5884,6 +5909,7 @@ class TestMCPProviderOAuth:
         ("scope_echo", "expected_registered_scopes"),
         [
             ("read offline_access", ["read", "offline_access"]),
+            ("", []),
             (None, None),
         ],
     )
@@ -5914,6 +5940,8 @@ class TestMCPProviderOAuth:
         [
             # AS narrowed the registration: authorize with the registered set.
             ("read", ["read"]),
+            # An explicit empty echo means no scopes were registered.
+            ("", []),
             # AS omitted the scope echo: requested set used verbatim.
             (None, ["read", "write", "offline_access"]),
             # The registration response is authoritative, including added scopes.
@@ -5995,9 +6023,11 @@ class TestMCPProviderOAuth:
         assert result.oauth_connect is not None
         assert result.mcp_integration is not None
         auth_query = parse_qs(urlparse(result.oauth_connect.auth_url).query)
-        assert auth_query.get("scope") == [" ".join(expected_authorize_scopes)]
+        assert auth_query.get("scope") == (
+            [" ".join(expected_authorize_scopes)] if expected_authorize_scopes else None
+        )
 
-        # Item D: the effective scopes (incl. auto-added offline_access) persist.
+        # The effective registered scopes, including an explicit empty set, persist.
         oauth_integration = await integration_service.session.get(
             OAuthIntegration, result.mcp_integration.oauth_integration_id
         )

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -48,6 +48,7 @@ from tracecat.db.models import (
     OAuthIntegration,
     OAuthStateDB,
     User,
+    Workspace,
 )
 from tracecat.exceptions import EntitlementRequired
 from tracecat.integrations.catalog.loader import catalog_id_for_slug
@@ -63,6 +64,7 @@ from tracecat.integrations.providers.base import (
     MCPAuthProvider,
     OAuthDiscoveryResult,
     build_dcr_payload,
+    mcp_requested_scopes,
 )
 from tracecat.integrations.providers.runreveal.mcp import RunRevealMCPProvider
 from tracecat.integrations.providers.sentry.mcp import SentryMCPProvider
@@ -91,7 +93,7 @@ from tracecat.integrations.service import (
     IntegrationService,
     OAuthRefreshBusyError,
 )
-from tracecat.integrations.types import OAuthServerMetadata
+from tracecat.integrations.types import DCRResponse, OAuthServerMetadata
 from tracecat.tiers import defaults as tier_defaults
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -719,6 +721,150 @@ class TestMCPIntegrationCRUD:
         item = next(item for item in items if item.slug == catalog.slug)
         assert item.state == "connected"
         assert item.mcp_integration_id == live_row.id
+
+    async def test_platform_mcp_catalog_state_prefers_reauth_over_configured(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A newer configured row must not hide an explicit reconnect state."""
+        catalog = _catalog_entry(
+            slug="reauth-priority-mcp",
+            name="Reauth Priority MCP",
+            description="Catalog row with degraded and configured integrations",
+            connection_spec={
+                "kind": "http_oauth2",
+                "server_type": "http",
+                "auth_type": "OAUTH2",
+                "requires_config": False,
+                "config_fields": [],
+                "credentials": [],
+                "server_uri": "https://mcp.example.com/mcp",
+                "scopes": [],
+                "oauth_authorization_endpoint": None,
+                "oauth_token_endpoint": None,
+            },
+            sort_key="0001:reauth-priority-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        reauth_oauth = await integration_service.store_integration(
+            provider_key=ProviderKey(
+                id="custom_mcp_reauth_priority",
+                grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+            ),
+            access_token=SecretStr("expired-access-token"),
+            expires_in=-60,
+        )
+        configured_oauth = await integration_service.store_provider_config(
+            provider_key=ProviderKey(
+                id="custom_mcp_configured_priority",
+                grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+            ),
+            client_id="configured-client",
+        )
+        now = datetime.now(UTC)
+        reauth_row = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name=catalog.name,
+            slug=catalog.slug,
+            catalog_slug=catalog.slug,
+            server_type="http",
+            server_uri="https://mcp.example.com/mcp",
+            auth_type=MCPAuthType.OAUTH2,
+            oauth_integration_id=reauth_oauth.id,
+            created_at=now - timedelta(hours=1),
+            tools=[],
+        )
+        configured_row = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name=catalog.name,
+            slug=f"{catalog.slug}-2",
+            catalog_slug=catalog.slug,
+            server_type="http",
+            server_uri="https://mcp.example.com/mcp",
+            auth_type=MCPAuthType.OAUTH2,
+            oauth_integration_id=configured_oauth.id,
+            created_at=now,
+        )
+        session.add_all([reauth_row, configured_row])
+        await session.commit()
+
+        catalog_service = PlatformMCPCatalogService(session=session)
+        items, _ = await catalog_service.list_catalog(
+            workspace_id=integration_service.workspace_id,
+            agent_addons_entitled=True,
+            q=catalog.slug,
+        )
+
+        item = next(item for item in items if item.slug == catalog.slug)
+        assert item.state == "reauth_required"
+        assert item.mcp_integration_id == reauth_row.id
+
+    async def test_platform_mcp_catalog_ignores_cross_workspace_oauth_state(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Catalog OAuth state must come from the MCP row's workspace."""
+        catalog = _catalog_entry(
+            slug="cross-workspace-oauth-mcp",
+            name="Cross Workspace OAuth MCP",
+            description="Catalog row with a stale cross-workspace OAuth reference",
+            connection_spec={
+                "kind": "http_oauth2",
+                "server_type": "http",
+                "auth_type": "OAUTH2",
+                "requires_config": False,
+                "config_fields": [],
+                "credentials": [],
+                "server_uri": "https://mcp.example.com/mcp",
+                "scopes": [],
+                "oauth_authorization_endpoint": None,
+                "oauth_token_endpoint": None,
+            },
+            sort_key="0001:cross-workspace-oauth-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+        assert integration_service.role.organization_id is not None
+        foreign_workspace = Workspace(
+            name=f"foreign-workspace-{uuid.uuid4()}",
+            organization_id=integration_service.role.organization_id,
+        )
+        session.add(foreign_workspace)
+        await session.flush()
+        foreign_oauth = OAuthIntegration(
+            workspace_id=foreign_workspace.id,
+            provider_id="custom_mcp_cross_workspace",
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+            encrypted_access_token=b"foreign-access-token",
+        )
+        local_mcp = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name=catalog.name,
+            slug=catalog.slug,
+            catalog_slug=catalog.slug,
+            server_type="http",
+            server_uri="https://mcp.example.com/mcp",
+            auth_type=MCPAuthType.OAUTH2,
+            oauth_integration_id=foreign_oauth.id,
+            tools=[],
+        )
+        session.add_all([foreign_oauth, local_mcp])
+        await session.commit()
+
+        catalog_service = PlatformMCPCatalogService(session=session)
+        items, _ = await catalog_service.list_catalog(
+            workspace_id=integration_service.workspace_id,
+            agent_addons_entitled=True,
+            q=catalog.slug,
+        )
+
+        item = next(item for item in items if item.slug == catalog.slug)
+        assert item.state == "configured"
+        assert item.mcp_integration_id == local_mcp.id
 
     async def test_platform_mcp_catalog_connect_requires_entitlement_for_new_rows(
         self,
@@ -2034,7 +2180,7 @@ class TestMCPIntegrationCRUD:
         integration_service: IntegrationService,
         oauth_integration: OAuthIntegration,
     ) -> None:
-        """OAuth2 MCP rows without an access token are configured, not connected."""
+        """OAuth2 MCP state accounts for token presence and grant behavior."""
         configured_oauth = await integration_service.store_provider_config(
             provider_key=ProviderKey(
                 id="configured_mcp_state",
@@ -2044,6 +2190,17 @@ class TestMCPIntegrationCRUD:
             authorization_endpoint="https://auth.example.com/oauth/authorize",
             token_endpoint="https://auth.example.com/oauth/token",
         )
+        client_credentials_oauth = OAuthIntegration(
+            workspace_id=integration_service.workspace_id,
+            provider_id="client_credentials_mcp_state",
+            grant_type=OAuthGrantType.CLIENT_CREDENTIALS,
+            encrypted_access_token=b"expired-access-token",
+            encrypted_client_id=b"client-id",
+            encrypted_client_secret=b"client-secret",
+            expires_at=datetime.now(UTC) - timedelta(minutes=1),
+        )
+        integration_service.session.add(client_credentials_oauth)
+        await integration_service.session.flush()
         connected_mcp = await integration_service.create_mcp_integration(
             params=MCPHttpIntegrationCreate(
                 name="Connected OAuth MCP",
@@ -2060,6 +2217,14 @@ class TestMCPIntegrationCRUD:
                 oauth_integration_id=configured_oauth.id,
             )
         )
+        client_credentials_mcp = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Client Credentials OAuth MCP",
+                server_uri="https://client-credentials.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=client_credentials_oauth.id,
+            )
+        )
         none_mcp = await integration_service.create_mcp_integration(
             params=MCPHttpIntegrationCreate(
                 name="No Auth MCP",
@@ -2069,8 +2234,16 @@ class TestMCPIntegrationCRUD:
         )
         connected_mcp.tools = []
         configured_mcp.tools = []
+        client_credentials_mcp.tools = []
         none_mcp.tools = []
-        integration_service.session.add_all([connected_mcp, configured_mcp, none_mcp])
+        integration_service.session.add_all(
+            [
+                connected_mcp,
+                configured_mcp,
+                client_credentials_mcp,
+                none_mcp,
+            ]
+        )
         await integration_service.session.commit()
 
         rows = await integration_service.list_mcp_integrations_with_state()
@@ -2078,6 +2251,7 @@ class TestMCPIntegrationCRUD:
 
         assert state_by_id[connected_mcp.id] == "connected"
         assert state_by_id[configured_mcp.id] == "configured"
+        assert state_by_id[client_credentials_mcp.id] == "connected"
         assert state_by_id[none_mcp.id] == "connected"
 
     async def test_list_mcp_integrations_source_keeps_matching_user_row_as_workspace(
@@ -3822,20 +3996,26 @@ class TestMCPProviderOAuth:
 
     def test_mcp_requested_scopes_adds_offline_access_when_advertised(self) -> None:
         """offline_access is added only when the AS advertises it, without dupes."""
-        requested = IntegrationService._mcp_requested_scopes
-        assert requested(
+        assert mcp_requested_scopes(
             scopes=["read"], scopes_supported=["read", "offline_access"]
         ) == ["read", "offline_access"]
-        assert requested(scopes=["read"], scopes_supported=["read"]) == ["read"]
-        assert requested(scopes=None, scopes_supported=["offline_access"]) == [
-            "offline_access"
+        assert mcp_requested_scopes(scopes=["read"], scopes_supported=["read"]) == [
+            "read"
         ]
+        assert mcp_requested_scopes(
+            scopes=None, scopes_supported=["offline_access"]
+        ) == ["offline_access"]
         # No duplicate when already present.
-        assert requested(
+        assert mcp_requested_scopes(
             scopes=["offline_access"], scopes_supported=["offline_access"]
         ) == ["offline_access"]
         # Empty when nothing configured and nothing advertised.
-        assert requested(scopes=None, scopes_supported=[]) == []
+        assert mcp_requested_scopes(scopes=None, scopes_supported=[]) == []
+        # An explicit empty grant (e.g. narrowed by a DCR echo) stays empty
+        # even when offline_access is advertised.
+        assert (
+            mcp_requested_scopes(scopes=[], scopes_supported=["offline_access"]) == []
+        )
 
     async def test_mcp_dcr_payload_advertises_refresh_token_grant(
         self,
@@ -3893,8 +4073,10 @@ class TestMCPProviderOAuth:
             client_name="Provider",
             redirect_uris=["https://app.test/callback"],
             token_endpoint_auth_method="none",
+            requested_scopes=["read", "offline_access"],
         )
         assert payload_with_method["token_endpoint_auth_method"] == "none"
+        assert payload_with_method["scope"] == "read offline_access"
 
     @pytest.mark.parametrize(
         ("response_json", "expected_downgraded", "expected_grant_types"),
@@ -4545,6 +4727,58 @@ class TestMCPProviderOAuth:
         await session.refresh(integration)
         return integration
 
+    async def _attach_mcp_to_oauth_integration(
+        self,
+        *,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        integration: OAuthIntegration,
+    ) -> None:
+        session.add(
+            MCPIntegration(
+                workspace_id=integration_service.workspace_id,
+                name="Refresh Response MCP",
+                slug=f"refresh-response-mcp-{uuid.uuid4().hex}",
+                server_type="http",
+                server_uri="https://mcp.example.test/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=integration.id,
+            )
+        )
+        await session.commit()
+
+    async def test_malformed_refresh_response_keeps_refresh_token(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unusable response does not prove that the old token was spent."""
+        integration = await self._store_expired_mcp_integration(
+            integration_service, session
+        )
+        await self._attach_mcp_to_oauth_integration(
+            integration_service=integration_service,
+            session=session,
+            integration=integration,
+        )
+        _patch_mcp_oauth_client(
+            monkeypatch,
+            refresh_response={"refresh_token": "rotated-without-access-token"},
+        )
+
+        result = await integration_service._refresh_custom_mcp_integration(
+            integration=integration,
+            refresh_token="dead-refresh-token",
+        )
+
+        assert result.encrypted_refresh_token is not None
+        assert (
+            integration_service._decrypt_token(result.encrypted_refresh_token)
+            == "dead-refresh-token"
+        )
+        assert result.status == IntegrationStatus.CONNECTED
+
     async def test_refresh_invalid_grant_discards_dead_refresh_token(
         self,
         integration_service: IntegrationService,
@@ -4664,7 +4898,7 @@ class TestMCPProviderOAuth:
         integration = await self._store_expired_mcp_integration(
             integration_service, session
         )
-        integration.encrypted_refresh_token = None
+        integration.encrypted_refresh_token = b""
         session.add(
             MCPIntegration(
                 workspace_id=integration_service.workspace_id,
@@ -5039,6 +5273,202 @@ class TestMCPProviderOAuth:
             == "client_secret_post"
         )
 
+    async def test_mcp_provider_requests_discovered_offline_access(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Credential-less built-ins request advertised offline access end to end."""
+
+        class DummyMCPProvider(MCPAuthProvider):
+            id: str = "offline_mcp"  # type: ignore[assignment]
+            mcp_server_uri: str = "https://offline.example/mcp"  # type: ignore[assignment]
+            scopes: ProviderScopes = ProviderScopes(default=[])  # type: ignore[assignment]
+            metadata: ProviderMetadata = ProviderMetadata(  # type: ignore[assignment]
+                id="offline_mcp",
+                name="Offline MCP",
+                description="MCP provider with advertised offline access",
+                requires_config=False,
+                enabled=True,
+            )
+
+        monkeypatch.setenv("TRACECAT__PUBLIC_APP_URL", "https://app.test")
+        discovery = OAuthDiscoveryResult(
+            authorization_endpoint="https://offline.example/oauth/authorize",
+            token_endpoint="https://offline.example/oauth/token",
+            token_methods=["none"],
+            scopes_supported=["offline_access"],
+            registration_endpoint="https://offline.example/oauth/register",
+        )
+
+        async def fake_discover(
+            cls,
+            logger_instance,
+            *,
+            discovered_auth_endpoint=None,
+            discovered_token_endpoint=None,
+        ) -> OAuthDiscoveryResult:
+            _ = (
+                cls,
+                logger_instance,
+                discovered_auth_endpoint,
+                discovered_token_endpoint,
+            )
+            return discovery
+
+        registration_payload: dict[str, object] = {}
+
+        async def fake_register(
+            endpoint: str, payload: dict[str, object]
+        ) -> DCRResponse:
+            assert endpoint == discovery.registration_endpoint
+            registration_payload.update(payload)
+            return DCRResponse(
+                client_id="offline-client",
+                token_endpoint_auth_method="none",
+            )
+
+        monkeypatch.setattr(
+            DummyMCPProvider,
+            "_discover_oauth_endpoints_async",
+            classmethod(fake_discover),
+        )
+        monkeypatch.setattr(
+            DummyMCPProvider,
+            "_submit_registration_request",
+            staticmethod(fake_register),
+        )
+
+        provider = await DummyMCPProvider.instantiate()
+        auth_url, _ = await provider.get_authorization_url(state="test-state")
+        auth_query = parse_qs(urlparse(auth_url).query)
+
+        assert registration_payload["scope"] == "offline_access"
+        assert provider.requested_scopes == ["offline_access"]
+        assert auth_query["scope"] == ["offline_access"]
+
+    async def test_mcp_provider_honors_dcr_scope_echo(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Credential-less built-ins authorize with the registered scope whitelist."""
+
+        class DummyMCPProvider(MCPAuthProvider):
+            id: str = "narrowed_mcp"  # type: ignore[assignment]
+            mcp_server_uri: str = "https://narrowed.example/mcp"  # type: ignore[assignment]
+            scopes: ProviderScopes = ProviderScopes(default=["read"])  # type: ignore[assignment]
+            metadata: ProviderMetadata = ProviderMetadata(  # type: ignore[assignment]
+                id="narrowed_mcp",
+                name="Narrowed MCP",
+                description="MCP provider with narrowed registered scopes",
+                requires_config=False,
+                enabled=True,
+            )
+
+        monkeypatch.setenv("TRACECAT__PUBLIC_APP_URL", "https://app.test")
+        discovery = OAuthDiscoveryResult(
+            authorization_endpoint="https://narrowed.example/oauth/authorize",
+            token_endpoint="https://narrowed.example/oauth/token",
+            token_methods=["none"],
+            scopes_supported=["read", "offline_access"],
+            registration_endpoint="https://narrowed.example/oauth/register",
+        )
+
+        async def fake_discover(
+            cls,
+            logger_instance,
+            *,
+            discovered_auth_endpoint=None,
+            discovered_token_endpoint=None,
+        ) -> OAuthDiscoveryResult:
+            _ = (
+                cls,
+                logger_instance,
+                discovered_auth_endpoint,
+                discovered_token_endpoint,
+            )
+            return discovery
+
+        registration_payload: dict[str, object] = {}
+
+        async def fake_register(
+            endpoint: str, payload: dict[str, object]
+        ) -> DCRResponse:
+            assert endpoint == discovery.registration_endpoint
+            registration_payload.update(payload)
+            return DCRResponse(
+                client_id="narrowed-client",
+                token_endpoint_auth_method="none",
+                scope="read",
+            )
+
+        monkeypatch.setattr(
+            DummyMCPProvider,
+            "_discover_oauth_endpoints_async",
+            classmethod(fake_discover),
+        )
+        monkeypatch.setattr(
+            DummyMCPProvider,
+            "_submit_registration_request",
+            staticmethod(fake_register),
+        )
+
+        provider = await DummyMCPProvider.instantiate()
+        auth_url, _ = await provider.get_authorization_url(state="test-state")
+
+        assert registration_payload["scope"] == "read offline_access"
+        assert provider.requested_scopes == ["read"]
+        assert parse_qs(urlparse(auth_url).query)["scope"] == ["read"]
+
+    async def test_mcp_provider_sync_constructor_honors_dcr_scope_echo(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The synchronous DCR path applies the same registered-scope narrowing."""
+
+        class DummyMCPProvider(MCPAuthProvider):
+            id: str = "sync_narrowed_mcp"  # type: ignore[assignment]
+            mcp_server_uri: str = "https://sync-narrowed.example/mcp"  # type: ignore[assignment]
+            scopes: ProviderScopes = ProviderScopes(default=["read"])  # type: ignore[assignment]
+            metadata: ProviderMetadata = ProviderMetadata(  # type: ignore[assignment]
+                id="sync_narrowed_mcp",
+                name="Sync Narrowed MCP",
+                description="MCP provider with synchronous DCR",
+                requires_config=False,
+                enabled=True,
+            )
+
+        monkeypatch.setenv("TRACECAT__PUBLIC_APP_URL", "https://app.test")
+
+        def fake_register(self: MCPAuthProvider) -> DynamicRegistrationResult:
+            assert self._registration_requested_scopes == [
+                "read",
+                "offline_access",
+            ]
+            return DynamicRegistrationResult(
+                client_id="sync-narrowed-client",
+                client_secret=None,
+                auth_method="none",
+                registered_scopes=["read"],
+            )
+
+        monkeypatch.setattr(
+            DummyMCPProvider,
+            "_perform_dynamic_registration",
+            fake_register,
+        )
+
+        provider = DummyMCPProvider(
+            discovered_auth_endpoint="https://sync-narrowed.example/oauth/authorize",
+            discovered_token_endpoint="https://sync-narrowed.example/oauth/token",
+            registration_endpoint="https://sync-narrowed.example/oauth/register",
+            token_methods=["none"],
+            scopes_supported=["read", "offline_access"],
+        )
+        auth_url, _ = await provider.get_authorization_url(state="test-state")
+
+        assert provider.requested_scopes == ["read"]
+        assert parse_qs(urlparse(auth_url).query)["scope"] == ["read"]
+
     async def test_mcp_provider_default_resource_uses_full_mcp_uri(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -5082,6 +5512,7 @@ class TestMCPProviderOAuth:
             "token_endpoint": "https://www-api.runreveal.com/oauth/token",
             "registration_endpoint": "https://www-api.runreveal.com/oauth/client",
             "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
+            "scopes_supported": ["offline_access"],
         }
         self._mock_async_discovery(monkeypatch, discovery_doc)
 
@@ -5090,11 +5521,13 @@ class TestMCPProviderOAuth:
             *,
             registration_endpoint: str,
             registration_auth_method: str | None,
+            requested_scopes: list[str],
             logger_instance,
         ) -> DynamicRegistrationResult:
             _ = cls, logger_instance
             assert registration_endpoint == "https://www-api.runreveal.com/oauth/client"
             assert registration_auth_method == "client_secret_post"
+            assert requested_scopes == ["offline_access"]
             return DynamicRegistrationResult(
                 client_id="runreveal-client",
                 client_secret="runreveal-secret",
@@ -5119,6 +5552,8 @@ class TestMCPProviderOAuth:
         assert provider._registration_endpoint == (
             "https://www-api.runreveal.com/oauth/client"
         )
+        auth_url, _ = await provider.get_authorization_url(state="test-state")
+        assert parse_qs(urlparse(auth_url).query)["scope"] == ["offline_access"]
 
     async def test_runreveal_provider_rejects_unallowed_discovered_oauth_host(
         self,

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -18,6 +18,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 import pytest
+from authlib.integrations.base_client.errors import OAuthError
 from pydantic import SecretStr, TypeAdapter, ValidationError
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -51,7 +52,7 @@ from tracecat.db.models import (
 from tracecat.exceptions import EntitlementRequired
 from tracecat.integrations.catalog.loader import catalog_id_for_slug
 from tracecat.integrations.catalog.service import PlatformMCPCatalogService
-from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
+from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGrantType
 from tracecat.integrations.mcp_validation import (
     MCPConfigurationError,
     MCPConnectionVerificationError,
@@ -4516,6 +4517,180 @@ class TestMCPProviderOAuth:
         assert refresh_logs[0]["refresh_token_rotated"] is expected_rotated
         assert refresh_logs[0]["expires_in"] == 1800
         assert refresh_logs[0]["granted_scope"] == "read"
+
+    async def _store_expired_mcp_integration(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+    ) -> OAuthIntegration:
+        """Custom MCP OAuth integration whose access token already expired."""
+        provider_key = ProviderKey(
+            id=f"custom_mcp_dead_refresh_{uuid.uuid4().hex}",
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        )
+        await integration_service.store_provider_config(
+            provider_key=provider_key,
+            client_id="dead-refresh-client",
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            token_endpoint="https://auth.example.test/oauth/token",
+        )
+        integration = await integration_service.store_integration(
+            provider_key=provider_key,
+            access_token=SecretStr("stale-access-token"),
+            refresh_token=SecretStr("dead-refresh-token"),
+            expires_in=3600,
+        )
+        integration.expires_at = datetime.now(UTC) - timedelta(hours=1)
+        await session.commit()
+        await session.refresh(integration)
+        return integration
+
+    async def test_refresh_invalid_grant_discards_dead_refresh_token(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Terminal invalid_grant clears the refresh token and flags re-auth."""
+        integration = await self._store_expired_mcp_integration(
+            integration_service, session
+        )
+
+        async def fake_refresh(
+            *, integration: OAuthIntegration, refresh_token: str
+        ) -> OAuthIntegration:
+            _ = integration, refresh_token
+            raise OAuthError(error="invalid_grant", description="session expired")
+
+        monkeypatch.setattr(
+            integration_service, "_refresh_custom_mcp_integration", fake_refresh
+        )
+
+        result = await integration_service.refresh_token_if_needed(integration)
+
+        assert result.encrypted_refresh_token is None
+        assert result.status == IntegrationStatus.REAUTH_REQUIRED
+
+    async def test_refresh_invalid_grant_keeps_concurrently_rotated_token(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A losing refresh must not clear a token rotated by a concurrent winner."""
+        integration = await self._store_expired_mcp_integration(
+            integration_service, session
+        )
+
+        async def fake_refresh(
+            *, integration: OAuthIntegration, refresh_token: str
+        ) -> OAuthIntegration:
+            _ = refresh_token
+            # Simulate a concurrent refresh winning: a new token lands in the row
+            # before this attempt's invalid_grant (rotation reuse detection).
+            integration.encrypted_refresh_token = integration_service._encrypt_token(
+                "rotated-refresh-token"
+            )
+            await session.commit()
+            raise OAuthError(error="invalid_grant", description="reuse detected")
+
+        monkeypatch.setattr(
+            integration_service, "_refresh_custom_mcp_integration", fake_refresh
+        )
+
+        result = await integration_service.refresh_token_if_needed(integration)
+
+        assert result.encrypted_refresh_token is not None
+        assert (
+            integration_service._decrypt_token(result.encrypted_refresh_token)
+            == "rotated-refresh-token"
+        )
+        assert result.status == IntegrationStatus.CONNECTED
+
+    async def test_refresh_transient_error_keeps_refresh_token(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Non-terminal OAuth errors leave the stored refresh token untouched."""
+        integration = await self._store_expired_mcp_integration(
+            integration_service, session
+        )
+
+        async def fake_refresh(
+            *, integration: OAuthIntegration, refresh_token: str
+        ) -> OAuthIntegration:
+            _ = integration, refresh_token
+            raise OAuthError(error="temporarily_unavailable", description="down")
+
+        monkeypatch.setattr(
+            integration_service, "_refresh_custom_mcp_integration", fake_refresh
+        )
+
+        result = await integration_service.refresh_token_if_needed(integration)
+
+        assert result.encrypted_refresh_token is not None
+        assert result.status == IntegrationStatus.CONNECTED
+
+    async def test_reconnect_catalog_mcp_with_dead_token_returns_oauth_redirect(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A reauth_required row gets a fresh authorize redirect on reconnect.
+
+        Regression: the "already connected" early-return treated a dead token
+        as connected, so reconnect skipped OAuth and 401'd at verification.
+        """
+        catalog = _catalog_entry(
+            slug="dead-token-mcp",
+            name="Dead Token MCP",
+            description="Reconnect regression",
+            connection_spec={
+                "kind": "http_oauth2",
+                "server_type": "http",
+                "auth_type": "OAUTH2",
+                "requires_config": False,
+                "config_fields": [],
+                "credentials": [],
+                "server_uri": "https://mcp.example.test/mcp",
+            },
+            sort_key="0000:dead-token-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        integration = await self._store_expired_mcp_integration(
+            integration_service, session
+        )
+        integration.encrypted_refresh_token = None
+        session.add(
+            MCPIntegration(
+                workspace_id=integration_service.workspace_id,
+                name="Dead Token MCP",
+                slug="dead-token-mcp",
+                catalog_slug=catalog.slug,
+                server_type="http",
+                server_uri="https://mcp.example.test/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=integration.id,
+                tools=[],
+            )
+        )
+        await session.commit()
+        await session.refresh(integration)
+        assert integration.status == IntegrationStatus.REAUTH_REQUIRED
+
+        await _seed_service_user(session, integration_service)
+        _patch_mcp_oauth_client(monkeypatch)
+
+        result = await integration_service.connect_platform_mcp_catalog(
+            catalog_slug=catalog.slug
+        )
+
+        assert result.oauth_connect is not None
+        assert result.oauth_connect.auth_url
 
     async def test_generic_mcp_refresh_rejects_private_token_endpoint_resolution(
         self,

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -14,7 +14,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 import pytest
@@ -61,6 +61,7 @@ from tracecat.integrations.providers.base import (
     DynamicRegistrationResult,
     MCPAuthProvider,
     OAuthDiscoveryResult,
+    build_dcr_payload,
 )
 from tracecat.integrations.providers.runreveal.mcp import RunRevealMCPProvider
 from tracecat.integrations.providers.sentry.mcp import SentryMCPProvider
@@ -182,6 +183,129 @@ def _install_catalog_entry(
         "get_platform_mcp_catalog_entries",
         _entries,
     )
+
+
+async def _noop_validate_oauth_endpoint(endpoint: str) -> None:
+    _ = endpoint
+
+
+def _patch_mcp_dcr_http(
+    monkeypatch: pytest.MonkeyPatch,
+    response_json: dict[str, object],
+    *,
+    captured: dict[str, object] | None = None,
+) -> None:
+    """Stub the DCR POST with a canned response and skip endpoint validation."""
+
+    class FakeAsyncClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            _ = args, kwargs
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            _ = args
+
+        async def post(
+            self, url: str, *, json: dict[str, object], **kwargs: object
+        ) -> httpx.Response:
+            _ = kwargs
+            if captured is not None:
+                captured.update(json)
+            return httpx.Response(
+                200, json=response_json, request=httpx.Request("POST", url)
+            )
+
+    monkeypatch.setattr(
+        integration_service_module.httpx, "AsyncClient", FakeAsyncClient
+    )
+    monkeypatch.setattr(
+        integration_service_module,
+        "validate_oauth_endpoint_resolves_public_async",
+        _noop_validate_oauth_endpoint,
+    )
+
+
+def _patch_mcp_oauth_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    authorize_captured: dict[str, object] | None = None,
+    token_response: dict[str, object] | None = None,
+    refresh_response: dict[str, object] | None = None,
+    init_calls: list[dict[str, object]] | None = None,
+) -> None:
+    """Stub AsyncOAuth2Client (authorize/fetch/refresh) and skip endpoint validation."""
+
+    class FakeOAuthClient:
+        def __init__(self, **kwargs: object) -> None:
+            if init_calls is not None:
+                init_calls.append(kwargs)
+
+        def create_authorization_url(
+            self, authorization_endpoint: str, **kwargs: object
+        ) -> tuple[str, str]:
+            if authorize_captured is not None:
+                authorize_captured.update(kwargs)
+            query: dict[str, str] = {"state": str(kwargs["state"])}
+            if "scope" in kwargs:
+                query["scope"] = str(kwargs["scope"])
+            return (
+                f"{authorization_endpoint}?{urlencode(query)}",
+                str(kwargs["state"]),
+            )
+
+        async def fetch_token(
+            self, *args: object, **kwargs: object
+        ) -> dict[str, object]:
+            _ = args, kwargs
+            assert token_response is not None, "fetch_token was not stubbed"
+            return token_response
+
+        async def refresh_token(
+            self, *args: object, **kwargs: object
+        ) -> dict[str, object]:
+            _ = args, kwargs
+            assert refresh_response is not None, "refresh_token was not stubbed"
+            return refresh_response
+
+    monkeypatch.setattr(
+        integration_service_module, "AsyncOAuth2Client", FakeOAuthClient
+    )
+    monkeypatch.setattr(
+        integration_service_module,
+        "validate_oauth_endpoint_resolves_public_async",
+        _noop_validate_oauth_endpoint,
+    )
+
+
+def _capture_logger_info(
+    monkeypatch: pytest.MonkeyPatch, logger: object
+) -> list[tuple[str, dict[str, object]]]:
+    logged: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        logger, "info", lambda msg, **kwargs: logged.append((msg, kwargs))
+    )
+    return logged
+
+
+async def _seed_service_user(
+    session: AsyncSession, integration_service: IntegrationService
+) -> None:
+    """OAuth authorize flows require the service role's user row to exist."""
+    assert integration_service.role.user_id is not None
+    session.add(
+        User(
+            id=integration_service.role.user_id,
+            email=f"mcp-user-{uuid.uuid4()}@example.com",
+            hashed_password="test_password",
+            is_active=True,
+            is_verified=True,
+            is_superuser=False,
+            last_login_at=None,
+        )
+    )
+    await session.flush()
 
 
 @pytest.fixture
@@ -3648,6 +3772,192 @@ class TestMCPProviderOAuth:
 
         assert endpoints.resource == "https://mcp.app.wiz.io/"
 
+    async def test_generic_mcp_discovery_captures_scopes_supported(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Discovery carries the AS metadata scopes_supported onto endpoints."""
+        docs = {
+            "https://mcp.example.com/.well-known/oauth-protected-resource": None,
+            "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": None,
+            "https://mcp.example.com/.well-known/oauth-authorization-server": {
+                "authorization_endpoint": "https://mcp.example.com/oauth/authorize",
+                "token_endpoint": "https://mcp.example.com/oauth/token",
+                "registration_endpoint": "https://mcp.example.com/oauth/register",
+                "token_endpoint_auth_methods_supported": ["none"],
+                "scopes_supported": ["read", "offline_access", 42],
+            },
+        }
+
+        async def fake_fetch(url: str) -> OAuthServerMetadata | None:
+            return OAuthServerMetadata.from_json(docs[url])
+
+        monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
+
+        endpoints = await integration_service._discover_mcp_oauth_endpoints(
+            server_uri="https://mcp.example.com/mcp",
+        )
+
+        # Malformed non-string entries are dropped by the metadata validator.
+        assert endpoints.scopes_supported == ["read", "offline_access"]
+
+    async def test_resolve_mcp_static_endpoints_have_empty_scopes_supported(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """The static-endpoint branch does not discover scopes_supported."""
+        provider_config = integration_service_module.ProviderConfig(
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            token_endpoint="https://auth.example.test/oauth/token",
+        )
+
+        endpoints = await integration_service._resolve_mcp_oauth_endpoints(
+            server_uri="https://mcp.example.test/mcp",
+            provider_config=provider_config,
+        )
+
+        assert endpoints.scopes_supported == []
+
+    def test_mcp_requested_scopes_adds_offline_access_when_advertised(self) -> None:
+        """offline_access is added only when the AS advertises it, without dupes."""
+        requested = IntegrationService._mcp_requested_scopes
+        assert requested(
+            scopes=["read"], scopes_supported=["read", "offline_access"]
+        ) == ["read", "offline_access"]
+        assert requested(scopes=["read"], scopes_supported=["read"]) == ["read"]
+        assert requested(scopes=None, scopes_supported=["offline_access"]) == [
+            "offline_access"
+        ]
+        # No duplicate when already present.
+        assert requested(
+            scopes=["offline_access"], scopes_supported=["offline_access"]
+        ) == ["offline_access"]
+        # Empty when nothing configured and nothing advertised.
+        assert requested(scopes=None, scopes_supported=[]) == []
+
+    async def test_mcp_dcr_payload_advertises_refresh_token_grant(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Custom MCP DCR requests both grant types and a scope whitelist."""
+        captured: dict[str, object] = {}
+        _patch_mcp_dcr_http(
+            monkeypatch,
+            {"client_id": "dcr-client", "client_secret": None},
+            captured=captured,
+        )
+
+        result = await integration_service._perform_mcp_dynamic_registration(
+            registration_endpoint="https://auth.example.test/oauth/register",
+            client_name="Test MCP",
+            token_auth_method="none",
+            requested_scopes=["read", "offline_access"],
+        )
+
+        assert result.client_id == "dcr-client"
+        assert captured["grant_types"] == ["authorization_code", "refresh_token"]
+        assert captured["scope"] == "read offline_access"
+
+    async def test_mcp_dcr_payload_omits_scope_when_empty(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Custom MCP DCR omits the scope key when nothing is requested."""
+        captured: dict[str, object] = {}
+        _patch_mcp_dcr_http(monkeypatch, {"client_id": "dcr-client"}, captured=captured)
+
+        await integration_service._perform_mcp_dynamic_registration(
+            registration_endpoint="https://auth.example.test/oauth/register",
+            client_name="Test MCP",
+            token_auth_method=None,
+            requested_scopes=[],
+        )
+
+        assert "scope" not in captured
+        assert captured["grant_types"] == ["authorization_code", "refresh_token"]
+
+    def test_build_dcr_payload_advertises_refresh_token_grant(self) -> None:
+        """The shared provider-class DCR builder advertises refresh_token too."""
+        payload = build_dcr_payload(
+            client_name="Provider",
+            redirect_uris=["https://app.test/callback"],
+        )
+        assert payload["grant_types"] == ["authorization_code", "refresh_token"]
+        assert "token_endpoint_auth_method" not in payload
+        assert "scope" not in payload
+        payload_with_method = build_dcr_payload(
+            client_name="Provider",
+            redirect_uris=["https://app.test/callback"],
+            token_endpoint_auth_method="none",
+        )
+        assert payload_with_method["token_endpoint_auth_method"] == "none"
+
+    @pytest.mark.parametrize(
+        ("response_json", "expected_downgraded", "expected_grant_types"),
+        [
+            # AS dropped refresh_token from what we requested.
+            (
+                {
+                    "client_id": "dcr-client",
+                    "grant_types": ["authorization_code"],
+                    "scope": "read",
+                },
+                True,
+                ["authorization_code"],
+            ),
+            # AS echoed both grants back.
+            (
+                {
+                    "client_id": "dcr-client",
+                    "grant_types": ["authorization_code", "refresh_token"],
+                },
+                False,
+                ["authorization_code", "refresh_token"],
+            ),
+            # AS declared grant_types empty: all grants stripped, downgrade.
+            (
+                {"client_id": "dcr-client", "grant_types": []},
+                True,
+                [],
+            ),
+            # AS omitted grant_types entirely: parsed None, no downgrade inferred.
+            ({"client_id": "dcr-client"}, False, None),
+        ],
+    )
+    async def test_mcp_dcr_logs_registered_grant_types_and_downgrade(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+        response_json: dict[str, object],
+        expected_downgraded: bool,
+        expected_grant_types: list[str] | None,
+    ) -> None:
+        """Registration success log reports echoed metadata and downgrade flag."""
+        _patch_mcp_dcr_http(monkeypatch, response_json)
+        logged = _capture_logger_info(monkeypatch, integration_service.logger)
+
+        await integration_service._perform_mcp_dynamic_registration(
+            registration_endpoint="https://auth.example.test/oauth/register",
+            client_name="Test MCP",
+            token_auth_method="none",
+            requested_scopes=["read", "offline_access"],
+        )
+
+        reg_logs = [
+            kw for msg, kw in logged if msg == "Registered custom MCP OAuth client"
+        ]
+        assert len(reg_logs) == 1
+        assert reg_logs[0]["registration_endpoint_host"] == "auth.example.test"
+        assert reg_logs[0]["registered_grant_types"] == expected_grant_types
+        assert reg_logs[0]["grant_types_downgraded"] is expected_downgraded
+        assert reg_logs[0]["registered_scope"] == response_json.get("scope")
+        # Secrets must never appear in the log.
+        assert "client_id" not in reg_logs[0]
+        assert "client_secret" not in reg_logs[0]
+
     async def test_generic_mcp_discovery_rejects_private_metadata_hosts(
         self,
         integration_service: IntegrationService,
@@ -3785,6 +4095,83 @@ class TestMCPProviderOAuth:
         assert "10.0.0.10" not in message
         assert "private" not in message.lower()
 
+    async def _run_authorize_scope_case(
+        self,
+        *,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+        provider_id: str,
+        requested_scopes: list[str],
+    ) -> dict[str, object]:
+        """Drive authorize and return the create_authorization_url kwargs."""
+        await _seed_service_user(session, integration_service)
+
+        provider_key = ProviderKey(
+            id=provider_id, grant_type=OAuthGrantType.AUTHORIZATION_CODE
+        )
+        oauth_integration = await integration_service.store_provider_config(
+            provider_key=provider_key,
+            client_id="scope-client",
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            token_endpoint="https://auth.example.test/oauth/token",
+        )
+        await session.commit()
+
+        captured: dict[str, object] = {}
+        _patch_mcp_oauth_client(monkeypatch, authorize_captured=captured)
+
+        await integration_service._start_custom_mcp_oauth_authorization(
+            integration=oauth_integration,
+            server_uri="https://mcp.example.test/mcp",
+            endpoints=integration_service_module.MCPOAuthDiscoveryEndpoints(
+                authorization_endpoint="https://auth.example.test/oauth/authorize",
+                token_endpoint="https://auth.example.test/oauth/token",
+                token_methods=["none"],
+                registration_endpoint=None,
+                resource="https://mcp.example.test/mcp",
+            ),
+            registration=integration_service_module.MCPOAuthRegistrationResult(
+                client_id="scope-client",
+                client_secret=None,
+                auth_method=None,
+            ),
+            requested_scopes=requested_scopes,
+        )
+        return captured
+
+    async def test_authorize_url_includes_offline_access_when_advertised(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The authorize URL carries the requested scopes when non-empty."""
+        captured = await self._run_authorize_scope_case(
+            integration_service=integration_service,
+            session=session,
+            monkeypatch=monkeypatch,
+            provider_id="custom_mcp_scope_offline",
+            requested_scopes=["read", "offline_access"],
+        )
+        assert captured["scope"] == "read offline_access"
+
+    async def test_authorize_url_omits_scope_when_nothing_requested(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No scope param is sent when there is nothing to request."""
+        captured = await self._run_authorize_scope_case(
+            integration_service=integration_service,
+            session=session,
+            monkeypatch=monkeypatch,
+            provider_id="custom_mcp_scope_empty",
+            requested_scopes=[],
+        )
+        assert "scope" not in captured
+
     async def test_generic_mcp_callback_uses_registered_token_auth_method(
         self,
         integration_service: IntegrationService,
@@ -3885,6 +4272,7 @@ class TestMCPProviderOAuth:
                 client_secret="registered-secret",
                 auth_method="client_secret_post",
             ),
+            requested_scopes=[],
         )
         state_id = uuid.UUID(
             parse_qs(urlparse(oauth_connect.auth_url).query)["state"][0]
@@ -3912,6 +4300,90 @@ class TestMCPProviderOAuth:
         )
         # Persisted so refresh keeps using the registered method.
         assert stored.token_endpoint_auth_method == "client_secret_post"
+
+    async def test_generic_mcp_callback_logs_granted_scope(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The code-exchange log reports the granted scope from the token response."""
+        await _seed_service_user(session, integration_service)
+
+        provider_key = ProviderKey(
+            id="custom_mcp_callback_scope",
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        )
+        oauth_integration = await integration_service.store_provider_config(
+            provider_key=provider_key,
+            client_id="callback-scope-client",
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            token_endpoint="https://auth.example.test/oauth/token",
+        )
+        session.add(
+            MCPIntegration(
+                workspace_id=integration_service.workspace_id,
+                name="Callback Scope MCP",
+                slug="callback-scope-mcp",
+                server_type="http",
+                server_uri="https://mcp.example.test/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+        await session.commit()
+
+        _patch_mcp_oauth_client(
+            monkeypatch,
+            token_response={
+                "access_token": "callback-access-token",
+                "refresh_token": "callback-refresh-token",
+                "expires_in": 3600,
+                "scope": "read offline_access",
+            },
+        )
+
+        oauth_connect = await integration_service._start_custom_mcp_oauth_authorization(
+            integration=oauth_integration,
+            server_uri="https://mcp.example.test/mcp",
+            endpoints=integration_service_module.MCPOAuthDiscoveryEndpoints(
+                authorization_endpoint="https://auth.example.test/oauth/authorize",
+                token_endpoint="https://auth.example.test/oauth/token",
+                token_methods=["none"],
+                registration_endpoint=None,
+                resource="https://mcp.example.test/mcp",
+            ),
+            registration=integration_service_module.MCPOAuthRegistrationResult(
+                client_id="callback-scope-client",
+                client_secret=None,
+                auth_method=None,
+            ),
+            requested_scopes=["read", "offline_access"],
+        )
+        state_id = uuid.UUID(
+            parse_qs(urlparse(oauth_connect.auth_url).query)["state"][0]
+        )
+        oauth_state = await session.get(OAuthStateDB, state_id)
+        assert oauth_state is not None
+
+        logged = _capture_logger_info(monkeypatch, integration_service.logger)
+
+        await integration_service.complete_mcp_oauth_discovery_callback(
+            provider_id=provider_key.id,
+            code="auth-code",
+            state=str(state_id),
+            code_verifier=oauth_state.code_verifier,
+        )
+
+        callback_logs = [
+            kw
+            for msg, kw in logged
+            if msg == "Completed custom MCP OAuth authorization"
+        ]
+        assert len(callback_logs) == 1
+        assert callback_logs[0]["granted_scope"] == "read offline_access"
+        assert callback_logs[0]["has_refresh_token"] is True
+        assert callback_logs[0]["expires_in"] == 3600
 
     async def test_generic_mcp_refresh_uses_persisted_token_auth_method(
         self,
@@ -3959,38 +4431,19 @@ class TestMCPProviderOAuth:
                 resource="https://mcp.example.test/mcp",
             )
 
-        class FakeOAuthClient:
-            init_calls: list[dict[str, object]] = []
-
-            def __init__(self, **kwargs: object) -> None:
-                self.init_calls.append(kwargs)
-
-            async def refresh_token(
-                self, *args: object, **kwargs: object
-            ) -> dict[str, object]:
-                _ = args, kwargs
-                return {
-                    "access_token": "refreshed-access-token",
-                    "refresh_token": "refreshed-refresh-token",
-                    "expires_in": 3600,
-                    "scope": "read",
-                }
-
-        async def fake_validate_oauth_endpoint(endpoint: str) -> None:
-            _ = endpoint
-
+        init_calls: list[dict[str, object]] = []
+        _patch_mcp_oauth_client(
+            monkeypatch,
+            refresh_response={
+                "access_token": "refreshed-access-token",
+                "refresh_token": "refreshed-refresh-token",
+                "expires_in": 3600,
+                "scope": "read",
+            },
+            init_calls=init_calls,
+        )
         monkeypatch.setattr(
             integration_service, "_discover_mcp_oauth_endpoints", fake_discover
-        )
-        monkeypatch.setattr(
-            integration_service_module,
-            "AsyncOAuth2Client",
-            FakeOAuthClient,
-        )
-        monkeypatch.setattr(
-            integration_service_module,
-            "validate_oauth_endpoint_resolves_public_async",
-            fake_validate_oauth_endpoint,
         )
 
         await integration_service._refresh_custom_mcp_integration(
@@ -3998,9 +4451,71 @@ class TestMCPProviderOAuth:
             refresh_token="refresh-token",
         )
 
-        assert FakeOAuthClient.init_calls[-1]["token_endpoint_auth_method"] == (
-            "client_secret_basic"
+        assert init_calls[-1]["token_endpoint_auth_method"] == "client_secret_basic"
+
+    @pytest.mark.parametrize(
+        ("returned_refresh_token", "expected_rotated"),
+        [
+            ("rotated-refresh-token", True),
+            ("refresh-token", False),
+            (None, False),
+        ],
+    )
+    async def test_generic_mcp_refresh_detects_rotation_in_log(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+        returned_refresh_token: str | None,
+        expected_rotated: bool,
+    ) -> None:
+        """Refresh success log reports rotation by comparing plaintext tokens."""
+        provider_key = ProviderKey(
+            id=f"custom_mcp_rotation_{uuid.uuid4().hex}",
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
         )
+        integration = await integration_service.store_provider_config(
+            provider_key=provider_key,
+            client_id="rotation-client",
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            token_endpoint="https://auth.example.test/oauth/token",
+        )
+        session.add(
+            MCPIntegration(
+                workspace_id=integration_service.workspace_id,
+                name="Rotation MCP",
+                slug=f"rotation-mcp-{uuid.uuid4().hex}",
+                server_type="http",
+                server_uri="https://mcp.example.test/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=integration.id,
+            )
+        )
+        await session.commit()
+
+        token_body: dict[str, object] = {
+            "access_token": "rotated-access-token",
+            "expires_in": 1800,
+            "scope": "read",
+        }
+        if returned_refresh_token is not None:
+            token_body["refresh_token"] = returned_refresh_token
+
+        _patch_mcp_oauth_client(monkeypatch, refresh_response=token_body)
+        logged = _capture_logger_info(monkeypatch, integration_service.logger)
+
+        await integration_service._refresh_custom_mcp_integration(
+            integration=integration,
+            refresh_token="refresh-token",
+        )
+
+        refresh_logs = [
+            kw for msg, kw in logged if msg == "Refreshed MCP OAuth integration"
+        ]
+        assert len(refresh_logs) == 1
+        assert refresh_logs[0]["refresh_token_rotated"] is expected_rotated
+        assert refresh_logs[0]["expires_in"] == 1800
+        assert refresh_logs[0]["granted_scope"] == "read"
 
     async def test_generic_mcp_refresh_rejects_private_token_endpoint_resolution(
         self,
@@ -4490,6 +5005,275 @@ class TestMCPProviderOAuth:
             provider._get_additional_token_params()["resource"]
             == SentryMCPProvider.mcp_server_uri
         )
+
+    @pytest.mark.parametrize(
+        ("scope_echo", "expected_registered_scopes"),
+        [
+            ("read offline_access", ["read", "offline_access"]),
+            (None, None),
+        ],
+    )
+    async def test_mcp_dcr_parses_registered_scopes(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+        scope_echo: str | None,
+        expected_registered_scopes: list[str] | None,
+    ) -> None:
+        """DCR result carries the echoed scope whitelist (None when absent)."""
+        response_json: dict[str, object] = {"client_id": "dcr-client"}
+        if scope_echo is not None:
+            response_json["scope"] = scope_echo
+        _patch_mcp_dcr_http(monkeypatch, response_json)
+
+        result = await integration_service._perform_mcp_dynamic_registration(
+            registration_endpoint="https://auth.example.test/oauth/register",
+            client_name="Test MCP",
+            token_auth_method="none",
+            requested_scopes=["read", "offline_access"],
+        )
+
+        assert result.registered_scopes == expected_registered_scopes
+
+    @pytest.mark.parametrize(
+        ("registered_scope_echo", "expected_authorize_scopes"),
+        [
+            # AS narrowed the registration: authorize scope is the intersection.
+            ("read", ["read"]),
+            # AS omitted the scope echo: requested set used verbatim.
+            (None, ["read", "write", "offline_access"]),
+            # AS echoed extra scopes we never requested: extras must NOT be added.
+            ("read write offline_access admin", ["read", "write", "offline_access"]),
+        ],
+    )
+    async def test_connect_mcp_oauth_discovery_uses_effective_scopes(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+        registered_scope_echo: str | None,
+        expected_authorize_scopes: list[str],
+    ) -> None:
+        """Authorize URL scope is requested-intersect-registered, order preserved."""
+        await _seed_service_user(session, integration_service)
+
+        endpoints = integration_service_module.MCPOAuthDiscoveryEndpoints(
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            token_endpoint="https://auth.example.test/oauth/token",
+            token_methods=["none"],
+            registration_endpoint="https://auth.example.test/oauth/register",
+            resource="https://mcp.example.test/mcp",
+            scopes_supported=["read", "write", "offline_access"],
+        )
+
+        async def fake_discover(
+            *,
+            server_uri: str,
+            allowed_endpoint_hosts: frozenset[str] = frozenset(),
+        ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
+            _ = server_uri, allowed_endpoint_hosts
+            return endpoints
+
+        monkeypatch.setattr(
+            integration_service, "_discover_mcp_oauth_endpoints", fake_discover
+        )
+
+        async def fake_register(
+            *,
+            registration_endpoint: str,
+            client_name: str,
+            token_auth_method: str | None,
+            requested_scopes: list[str],
+        ) -> integration_service_module.MCPOAuthRegistrationResult:
+            _ = registration_endpoint, client_name, token_auth_method, requested_scopes
+            return integration_service_module.MCPOAuthRegistrationResult(
+                client_id="dcr-client",
+                client_secret=None,
+                auth_method="none",
+                registered_scopes=(
+                    registered_scope_echo.split()
+                    if registered_scope_echo is not None
+                    else None
+                ),
+            )
+
+        monkeypatch.setattr(
+            integration_service, "_perform_mcp_dynamic_registration", fake_register
+        )
+        _patch_mcp_oauth_client(monkeypatch)
+
+        catalog_spec = MCPHTTPOAuth2ConnectionSpec(
+            server_uri="https://mcp.example.test/mcp",
+            scopes=["read", "write"],
+        )
+        result = await integration_service.connect_mcp_oauth_discovery(
+            params=MCPHttpIntegrationCreate(
+                name="Effective Scopes MCP",
+                server_uri="https://mcp.example.test/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+            ),
+            catalog_spec=catalog_spec,
+        )
+
+        assert result.oauth_connect is not None
+        assert result.mcp_integration is not None
+        auth_query = parse_qs(urlparse(result.oauth_connect.auth_url).query)
+        assert auth_query.get("scope") == [" ".join(expected_authorize_scopes)]
+
+        # Item D: the effective scopes (incl. auto-added offline_access) persist.
+        oauth_integration = await integration_service.session.get(
+            OAuthIntegration, result.mcp_integration.oauth_integration_id
+        )
+        assert oauth_integration is not None
+        provider_config = integration_service.get_provider_config(
+            integration=oauth_integration
+        )
+        assert provider_config is not None
+        assert provider_config.scopes == expected_authorize_scopes
+
+    async def test_connect_then_reconnect_preserves_offline_access(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reconnect over static endpoints keeps the persisted offline_access scope."""
+        await _seed_service_user(session, integration_service)
+
+        endpoints = integration_service_module.MCPOAuthDiscoveryEndpoints(
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            token_endpoint="https://auth.example.test/oauth/token",
+            token_methods=["none"],
+            registration_endpoint="https://auth.example.test/oauth/register",
+            resource="https://mcp.example.test/mcp",
+            scopes_supported=["read", "offline_access"],
+        )
+
+        async def fake_discover(
+            *,
+            server_uri: str,
+            allowed_endpoint_hosts: frozenset[str] = frozenset(),
+        ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
+            _ = server_uri, allowed_endpoint_hosts
+            return endpoints
+
+        monkeypatch.setattr(
+            integration_service, "_discover_mcp_oauth_endpoints", fake_discover
+        )
+
+        async def fake_register(
+            *,
+            registration_endpoint: str,
+            client_name: str,
+            token_auth_method: str | None,
+            requested_scopes: list[str],
+        ) -> integration_service_module.MCPOAuthRegistrationResult:
+            _ = registration_endpoint, client_name, token_auth_method, requested_scopes
+            # No scope echo: effective scopes equal the requested set.
+            return integration_service_module.MCPOAuthRegistrationResult(
+                client_id="dcr-client",
+                client_secret=None,
+                auth_method="none",
+                registered_scopes=None,
+            )
+
+        monkeypatch.setattr(
+            integration_service, "_perform_mcp_dynamic_registration", fake_register
+        )
+        _patch_mcp_oauth_client(monkeypatch)
+
+        catalog_spec = MCPHTTPOAuth2ConnectionSpec(
+            server_uri="https://mcp.example.test/mcp",
+            scopes=["read"],
+        )
+        connect_result = await integration_service.connect_mcp_oauth_discovery(
+            params=MCPHttpIntegrationCreate(
+                name="Round Trip MCP",
+                server_uri="https://mcp.example.test/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+            ),
+            catalog_spec=catalog_spec,
+        )
+        assert connect_result.oauth_connect is not None
+        assert connect_result.mcp_integration is not None
+        connect_query = parse_qs(urlparse(connect_result.oauth_connect.auth_url).query)
+        assert connect_query["scope"] == ["read offline_access"]
+
+        # Persist static endpoints so reconnect resolves scopes_supported=[].
+        oauth_integration = await integration_service.session.get(
+            OAuthIntegration, connect_result.mcp_integration.oauth_integration_id
+        )
+        assert oauth_integration is not None
+        oauth_integration.authorization_endpoint = endpoints.authorization_endpoint
+        oauth_integration.token_endpoint = endpoints.token_endpoint
+        integration_service.session.add(oauth_integration)
+        await integration_service.session.commit()
+
+        mcp_integration = await integration_service.session.get(
+            MCPIntegration, connect_result.mcp_integration.id
+        )
+        assert mcp_integration is not None
+
+        reconnect_result = await integration_service._start_existing_custom_mcp_oauth(
+            mcp_integration=mcp_integration
+        )
+        assert reconnect_result is not None
+        assert reconnect_result.oauth_connect is not None
+        reconnect_query = parse_qs(
+            urlparse(reconnect_result.oauth_connect.auth_url).query
+        )
+        assert "offline_access" in reconnect_query["scope"][0].split()
+
+    async def test_reconnect_emits_connect_log(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reconnect path logs provider/scopes so incidents stay traceable."""
+        await _seed_service_user(session, integration_service)
+
+        provider_key = ProviderKey(
+            id="custom_mcp_reconnect_log",
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        )
+        oauth_integration = await integration_service.store_provider_config(
+            provider_key=provider_key,
+            client_id="reconnect-log-client",
+            authorization_endpoint="https://auth.example.test/oauth/authorize",
+            token_endpoint="https://auth.example.test/oauth/token",
+            requested_scopes=["read", "offline_access"],
+        )
+        mcp_integration = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name="Reconnect Log MCP",
+            slug="reconnect-log-mcp",
+            server_type="http",
+            server_uri="https://mcp.example.test/mcp",
+            auth_type=MCPAuthType.OAUTH2,
+            oauth_integration_id=oauth_integration.id,
+        )
+        session.add(mcp_integration)
+        await session.commit()
+
+        _patch_mcp_oauth_client(monkeypatch)
+        logged = _capture_logger_info(monkeypatch, integration_service.logger)
+
+        await integration_service._start_existing_custom_mcp_oauth(
+            mcp_integration=mcp_integration
+        )
+
+        reconnect_logs = [
+            kw
+            for msg, kw in logged
+            if msg == "Reconnecting custom MCP OAuth integration"
+        ]
+        assert len(reconnect_logs) == 1
+        assert reconnect_logs[0]["provider_id"] == provider_key.id
+        assert reconnect_logs[0]["scopes_supported"] == []
+        logged_requested_scopes = reconnect_logs[0]["requested_scopes"]
+        assert isinstance(logged_requested_scopes, list)
+        assert "offline_access" in logged_requested_scopes
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -8409,6 +8409,70 @@ async def test_list_integrations_returns_mcp_and_provider_inventory(
     )
 
 
+@pytest.mark.parametrize("reauth_first", [False, True])
+@pytest.mark.parametrize(
+    "other_status,expected_status",
+    [
+        (IntegrationStatus.NOT_CONFIGURED, IntegrationStatus.REAUTH_REQUIRED),
+        (IntegrationStatus.CONFIGURED, IntegrationStatus.REAUTH_REQUIRED),
+        (IntegrationStatus.CONNECTED, IntegrationStatus.CONNECTED),
+    ],
+)
+@pytest.mark.anyio
+async def test_integrations_inventory_ranks_status_deterministically(
+    monkeypatch: pytest.MonkeyPatch,
+    reauth_first: bool,
+    other_status: IntegrationStatus,
+    expected_status: IntegrationStatus,
+) -> None:
+    other = SimpleNamespace(
+        provider_id="slack",
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        status=other_status,
+    )
+    reauth_required = SimpleNamespace(
+        provider_id="slack",
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        status=IntegrationStatus.REAUTH_REQUIRED,
+    )
+    integrations = [reauth_required, other]
+    if not reauth_first:
+        integrations.reverse()
+
+    class _SlackProvider:
+        id = "slack"
+        grant_type = OAuthGrantType.AUTHORIZATION_CODE
+        metadata = SimpleNamespace(
+            name="Slack",
+            description="Slack integration",
+            enabled=True,
+            requires_config=False,
+        )
+
+    class _IntegrationService:
+        async def list_integrations(self):
+            return integrations
+
+        async def list_mcp_integrations(self):
+            return []
+
+        async def list_custom_providers(self):
+            return []
+
+    monkeypatch.setattr(mcp_server, "all_providers", lambda: [_SlackProvider])
+    monkeypatch.setattr(
+        mcp_server.IntegrationService,
+        "with_session",
+        lambda role: _AsyncContext(_IntegrationService()),
+    )
+
+    inventory = await mcp_server._build_integrations_inventory(
+        cast(Any, SimpleNamespace())
+    )
+
+    assert inventory.oauth_providers[0].integration_status == expected_status.value
+
+
 @pytest.mark.anyio
 async def test_get_workflow_authoring_context_truncates_embedded_collections(
     monkeypatch: pytest.MonkeyPatch,

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -4516,9 +4516,14 @@ class OAuthIntegration(TimestampMixin, Base):
 
         # Return status based on conditions
         if is_connected:
-            # Expired with a refresh token still self-heals on next use and
-            # stays CONNECTED; expired without one is dead until re-auth.
-            if self.is_expired and self.encrypted_refresh_token is None:
+            # Authorization-code credentials need interactive reauthorization
+            # once expired unless they have a usable refresh token. Client
+            # credentials refresh non-interactively using their stored config.
+            if (
+                self.grant_type == OAuthGrantType.AUTHORIZATION_CODE
+                and self.is_expired
+                and not self.encrypted_refresh_token
+            ):
                 return IntegrationStatus.REAUTH_REQUIRED
             return IntegrationStatus.CONNECTED
         elif is_configured:

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -4516,6 +4516,10 @@ class OAuthIntegration(TimestampMixin, Base):
 
         # Return status based on conditions
         if is_connected:
+            # Expired with a refresh token still self-heals on next use and
+            # stays CONNECTED; expired without one is dead until re-auth.
+            if self.is_expired and self.encrypted_refresh_token is None:
+                return IntegrationStatus.REAUTH_REQUIRED
             return IntegrationStatus.CONNECTED
         elif is_configured:
             return IntegrationStatus.CONFIGURED

--- a/tracecat/integrations/catalog/service.py
+++ b/tracecat/integrations/catalog/service.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from tracecat.db.models import MCPIntegration, OAuthIntegration
 from tracecat.integrations.catalog.loader import get_platform_mcp_catalog_entries
 from tracecat.integrations.catalog.types import PlatformMCPCatalogEntry
-from tracecat.integrations.enums import MCPAuthType
+from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
 from tracecat.integrations.schemas import (
     MCPToolSummary,
     OAuthTokenState,
@@ -28,6 +28,11 @@ from tracecat.service import BaseService
 _CATALOG_STATUSES: frozenset[PlatformMCPCatalogStatus] = frozenset(
     {"available", "coming_soon", "deprecated", "hidden"}
 )
+_CATALOG_WORKSPACE_STATE_RANK: dict[PlatformMCPCatalogState, int] = {
+    "connected": 0,
+    "reauth_required": 1,
+    "configured": 2,
+}
 
 
 class CatalogWorkspaceState(NamedTuple):
@@ -35,6 +40,7 @@ class CatalogWorkspaceState(NamedTuple):
 
     mcp_integration: MCPIntegration
     token_state: OAuthTokenState | None
+    oauth_grant_type: OAuthGrantType | None
 
 
 class PlatformMCPCatalogService(BaseService):
@@ -175,12 +181,16 @@ class PlatformMCPCatalogService(BaseService):
                             "encrypted_refresh_token"
                         ),
                         OAuthIntegration.expires_at.label("token_expires_at"),
+                        OAuthIntegration.grant_type.label("oauth_grant_type"),
                         OAuthIntegration.provider_id.label("provider_id"),
                         MCPIntegration.catalog_slug.label("catalog_slug"),
                     )
                     .outerjoin(
                         OAuthIntegration,
-                        OAuthIntegration.id == MCPIntegration.oauth_integration_id,
+                        sa.and_(
+                            OAuthIntegration.id == MCPIntegration.oauth_integration_id,
+                            OAuthIntegration.workspace_id == workspace_id,
+                        ),
                     )
                     .where(MCPIntegration.workspace_id == workspace_id)
                     .order_by(
@@ -195,8 +205,9 @@ class PlatformMCPCatalogService(BaseService):
 
         # Multiple rows can map to one catalog entry. Rank candidates so an
         # explicit catalog_slug binding beats the legacy provider-slug
-        # heuristic and a connected row beats a stale one; rows iterate
-        # newest-first, so remaining ties go to the most recent row.
+        # heuristic, and connection health beats recency: connected rows win,
+        # followed by rows requiring reauthorization, then configured rows.
+        # Rows iterate newest-first, so remaining ties go to the most recent.
         state_by_catalog_id: dict[uuid.UUID, CatalogWorkspaceState] = {}
         best_rank: dict[uuid.UUID, tuple[int, int]] = {}
         for (
@@ -204,6 +215,7 @@ class PlatformMCPCatalogService(BaseService):
             encrypted_access_token,
             encrypted_refresh_token,
             token_expires_at,
+            oauth_grant_type,
             provider_id,
             catalog_slug,
         ) in rows:
@@ -231,14 +243,17 @@ class PlatformMCPCatalogService(BaseService):
             state = self._catalog_state(
                 mcp_integration=mcp_integration,
                 token_state=token_state,
+                oauth_grant_type=oauth_grant_type,
             )
-            rank = (match_rank, 0 if state == "connected" else 1)
+            state_rank = _CATALOG_WORKSPACE_STATE_RANK.get(state, 3)
+            rank = (match_rank, state_rank)
             current = best_rank.get(catalog_id)
             if current is None or rank < current:
                 best_rank[catalog_id] = rank
                 state_by_catalog_id[catalog_id] = CatalogWorkspaceState(
                     mcp_integration=mcp_integration,
                     token_state=token_state,
+                    oauth_grant_type=oauth_grant_type,
                 )
         return state_by_catalog_id
 
@@ -256,6 +271,7 @@ class PlatformMCPCatalogService(BaseService):
         *,
         mcp_integration: MCPIntegration | None,
         token_state: OAuthTokenState | None,
+        oauth_grant_type: OAuthGrantType | None,
     ) -> PlatformMCPCatalogState:
         if mcp_integration is None:
             return "not_configured"
@@ -265,10 +281,13 @@ class PlatformMCPCatalogService(BaseService):
                 and is_set(token_state.encrypted_access_token)
             ):
                 return "configured"
-            if credential_reauth_required(
-                has_refresh_token=token_state.encrypted_refresh_token is not None
-                and is_set(token_state.encrypted_refresh_token),
-                expires_at=token_state.expires_at,
+            if (
+                oauth_grant_type == OAuthGrantType.AUTHORIZATION_CODE
+                and credential_reauth_required(
+                    has_refresh_token=token_state.encrypted_refresh_token is not None
+                    and is_set(token_state.encrypted_refresh_token),
+                    expires_at=token_state.expires_at,
+                )
             ):
                 return "reauth_required"
         if mcp_integration.tools is None:
@@ -311,6 +330,7 @@ class PlatformMCPCatalogService(BaseService):
     ) -> PlatformMCPCatalogRead:
         mcp_integration = state.mcp_integration if state else None
         token_state = state.token_state if state else None
+        oauth_grant_type = state.oauth_grant_type if state else None
         locked = not agent_addons_entitled and mcp_integration is None
         connection_spec = entry.connection_spec if agent_addons_entitled else None
         connection_options = (
@@ -332,6 +352,7 @@ class PlatformMCPCatalogService(BaseService):
             state=cls._catalog_state(
                 mcp_integration=mcp_integration,
                 token_state=token_state,
+                oauth_grant_type=oauth_grant_type,
             ),
             mcp_integration_id=mcp_integration.id if mcp_integration else None,
             mcp_server_type=cls._mcp_server_type(

--- a/tracecat/integrations/catalog/service.py
+++ b/tracecat/integrations/catalog/service.py
@@ -14,9 +14,11 @@ from tracecat.integrations.catalog.types import PlatformMCPCatalogEntry
 from tracecat.integrations.enums import MCPAuthType
 from tracecat.integrations.schemas import (
     MCPToolSummary,
+    OAuthTokenState,
     PlatformMCPCatalogRead,
     PlatformMCPCatalogState,
     PlatformMCPCatalogStatus,
+    credential_reauth_required,
 )
 from tracecat.integrations.types import MCPServerType
 from tracecat.pagination import BaseCursorPaginator, CursorPaginationParams
@@ -29,10 +31,10 @@ _CATALOG_STATUSES: frozenset[PlatformMCPCatalogStatus] = frozenset(
 
 
 class CatalogWorkspaceState(NamedTuple):
-    """Workspace MCP row backing a catalog entry, with its OAuth token."""
+    """Workspace MCP row backing a catalog entry, with its OAuth token state."""
 
     mcp_integration: MCPIntegration
-    encrypted_access_token: bytes | None
+    token_state: OAuthTokenState | None
 
 
 class PlatformMCPCatalogService(BaseService):
@@ -169,6 +171,10 @@ class PlatformMCPCatalogService(BaseService):
                         OAuthIntegration.encrypted_access_token.label(
                             "encrypted_access_token"
                         ),
+                        OAuthIntegration.encrypted_refresh_token.label(
+                            "encrypted_refresh_token"
+                        ),
+                        OAuthIntegration.expires_at.label("token_expires_at"),
                         OAuthIntegration.provider_id.label("provider_id"),
                         MCPIntegration.catalog_slug.label("catalog_slug"),
                     )
@@ -193,7 +199,19 @@ class PlatformMCPCatalogService(BaseService):
         # newest-first, so remaining ties go to the most recent row.
         state_by_catalog_id: dict[uuid.UUID, CatalogWorkspaceState] = {}
         best_rank: dict[uuid.UUID, tuple[int, int]] = {}
-        for mcp_integration, encrypted_access_token, provider_id, catalog_slug in rows:
+        for (
+            mcp_integration,
+            encrypted_access_token,
+            encrypted_refresh_token,
+            token_expires_at,
+            provider_id,
+            catalog_slug,
+        ) in rows:
+            token_state = OAuthTokenState(
+                encrypted_access_token=encrypted_access_token,
+                encrypted_refresh_token=encrypted_refresh_token,
+                expires_at=token_expires_at,
+            )
             if isinstance(catalog_slug, str) and (
                 slug_catalog_id := catalog_slug_to_id.get(catalog_slug)
             ):
@@ -212,7 +230,7 @@ class PlatformMCPCatalogService(BaseService):
 
             state = self._catalog_state(
                 mcp_integration=mcp_integration,
-                encrypted_access_token=encrypted_access_token,
+                token_state=token_state,
             )
             rank = (match_rank, 0 if state == "connected" else 1)
             current = best_rank.get(catalog_id)
@@ -220,7 +238,7 @@ class PlatformMCPCatalogService(BaseService):
                 best_rank[catalog_id] = rank
                 state_by_catalog_id[catalog_id] = CatalogWorkspaceState(
                     mcp_integration=mcp_integration,
-                    encrypted_access_token=encrypted_access_token,
+                    token_state=token_state,
                 )
         return state_by_catalog_id
 
@@ -237,14 +255,22 @@ class PlatformMCPCatalogService(BaseService):
     def _catalog_state(
         *,
         mcp_integration: MCPIntegration | None,
-        encrypted_access_token: bytes | None,
+        token_state: OAuthTokenState | None,
     ) -> PlatformMCPCatalogState:
         if mcp_integration is None:
             return "not_configured"
-        if mcp_integration.auth_type == MCPAuthType.OAUTH2 and not (
-            encrypted_access_token is not None and is_set(encrypted_access_token)
-        ):
-            return "configured"
+        if mcp_integration.auth_type == MCPAuthType.OAUTH2:
+            if token_state is None or not (
+                token_state.encrypted_access_token is not None
+                and is_set(token_state.encrypted_access_token)
+            ):
+                return "configured"
+            if credential_reauth_required(
+                has_refresh_token=token_state.encrypted_refresh_token is not None
+                and is_set(token_state.encrypted_refresh_token),
+                expires_at=token_state.expires_at,
+            ):
+                return "reauth_required"
         if mcp_integration.tools is None:
             return "configured"
         return "connected"
@@ -284,7 +310,7 @@ class PlatformMCPCatalogService(BaseService):
         now: datetime,
     ) -> PlatformMCPCatalogRead:
         mcp_integration = state.mcp_integration if state else None
-        encrypted_access_token = state.encrypted_access_token if state else None
+        token_state = state.token_state if state else None
         locked = not agent_addons_entitled and mcp_integration is None
         connection_spec = entry.connection_spec if agent_addons_entitled else None
         connection_options = (
@@ -305,7 +331,7 @@ class PlatformMCPCatalogService(BaseService):
             locked=locked,
             state=cls._catalog_state(
                 mcp_integration=mcp_integration,
-                encrypted_access_token=encrypted_access_token,
+                token_state=token_state,
             ),
             mcp_integration_id=mcp_integration.id if mcp_integration else None,
             mcp_server_type=cls._mcp_server_type(

--- a/tracecat/integrations/enums.py
+++ b/tracecat/integrations/enums.py
@@ -10,6 +10,8 @@ class IntegrationStatus(StrEnum):
     """The integration is configured but not connected."""
     CONNECTED = "connected"
     """The integration is connected."""
+    REAUTH_REQUIRED = "reauth_required"
+    """The stored token expired with no usable refresh token; reconnect to restore."""
 
 
 class OAuthGrantType(StrEnum):

--- a/tracecat/integrations/providers/base.py
+++ b/tracecat/integrations/providers/base.py
@@ -508,11 +508,7 @@ class BaseOAuthProvider(ABC):
             client_id=registration_response.client_id,
             client_secret=registration_response.client_secret,
             auth_method=auth_method,
-            registered_scopes=(
-                registration_response.scope.split()
-                if registration_response.scope
-                else None
-            ),
+            registered_scopes=registration_response.registered_scopes,
         )
 
     def _dynamic_registration_auth_method(self) -> str | None:
@@ -1246,11 +1242,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             client_id=registration_response.client_id,
             client_secret=registration_response.client_secret,
             auth_method=auth_method,
-            registered_scopes=(
-                registration_response.scope.split()
-                if registration_response.scope
-                else None
-            ),
+            registered_scopes=registration_response.registered_scopes,
         )
 
     def _get_token_endpoint_auth_method(self) -> str | None:

--- a/tracecat/integrations/providers/base.py
+++ b/tracecat/integrations/providers/base.py
@@ -172,17 +172,24 @@ def build_dcr_payload(
 
 
 def mcp_requested_scopes(
-    *, scopes: list[str] | None, scopes_supported: list[str]
+    *, scopes: list[str] | None, scopes_supported: list[str], expand: bool = True
 ) -> list[str]:
     """Add offline access when the OAuth server advertises support for it.
 
     ``scopes=[]`` is an explicit empty grant (e.g. narrowed by a DCR echo)
     and stays empty; ``scopes=None`` means unconfigured and may expand.
+    ``expand=False`` returns the scopes verbatim (used when reusing an
+    already-registered client, where re-expanding a DCR-narrowed set can trip
+    whitelist-enforcing servers).
     """
     if scopes is not None and not scopes:
         return []
     requested = list(scopes or [])
-    if "offline_access" in scopes_supported and "offline_access" not in requested:
+    if (
+        expand
+        and "offline_access" in scopes_supported
+        and "offline_access" not in requested
+    ):
         requested.append("offline_access")
     return requested
 
@@ -328,13 +335,14 @@ class BaseOAuthProvider(ABC):
         self._registration_endpoint: str | None = getattr(
             self, "_registration_endpoint", None
         )
+        # Use provided scopes or fall back to defaults. Dynamic registration
+        # needs these before client credentials are resolved.
+        self.requested_scopes = self.scopes.default if scopes is None else scopes
 
         # Resolve client credentials, allowing subclasses to supply defaults
         credentials = self._resolve_client_credentials(client_id, client_secret)
         self.client_id = credentials.client_id
         self.client_secret = credentials.client_secret
-        # Use provided scopes or fall back to defaults
-        self.requested_scopes = self.scopes.default if scopes is None else scopes
         # Resolve endpoints from overrides or defaults
         resolved_authorization_endpoint = authorization_endpoint or getattr(
             self, "default_authorization_endpoint", None
@@ -456,20 +464,6 @@ class BaseOAuthProvider(ABC):
         response.raise_for_status()
         return DCRResponse.model_validate(response.json())
 
-    def _build_dynamic_registration_payload(
-        self, registration_auth_method: str | None
-    ) -> dict[str, Any]:
-        """Build the dynamic client registration request payload."""
-        payload: dict[str, Any] = {
-            "client_name": self.metadata.name,
-            "redirect_uris": [self.__class__.redirect_uri()],  # pyright: ignore[reportAttributeAccessIssue]
-            "grant_types": ["authorization_code"],
-            "response_types": ["code"],
-        }
-        if registration_auth_method:
-            payload["token_endpoint_auth_method"] = registration_auth_method
-        return payload
-
     def _perform_dynamic_registration(self) -> DynamicRegistrationResult:
         """Register a public client using OAuth 2.0 Dynamic Client Registration."""
 
@@ -477,8 +471,11 @@ class BaseOAuthProvider(ABC):
             raise ValueError("Dynamic registration endpoint is not available")
 
         registration_auth_method = self._dynamic_registration_auth_method()
-        registration_payload = self._build_dynamic_registration_payload(
-            registration_auth_method
+        registration_payload = build_dcr_payload(
+            client_name=self.metadata.name,
+            redirect_uris=[self.__class__.redirect_uri()],  # pyright: ignore[reportAttributeAccessIssue]
+            token_endpoint_auth_method=registration_auth_method,
+            requested_scopes=self.requested_scopes,
         )
 
         try:
@@ -836,17 +833,20 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             discovery_result.token_methods or []
         )
         configured_scopes = kwargs.pop("scopes", None)
-        # Empty provider defaults mean unconfigured (None), unlike an explicit
-        # empty scope set from stored config, which must stay empty.
+        # DCR runs in _resolve_client_credentials only without a client_id; a
+        # stored set reused with an existing client goes out verbatim.
+        will_register = not self._clean_credential(kwargs.get("client_id")) and bool(
+            self._registration_endpoint
+        )
         requested_scopes = mcp_requested_scopes(
             scopes=configured_scopes
             if configured_scopes is not None
             else (self.scopes.default or None),
             scopes_supported=discovery_result.scopes_supported,
+            expand=configured_scopes is None or will_register,
         )
-        self._registration_requested_scopes = self._effective_registered_scopes(
-            requested_scopes=requested_scopes,
-            registered_scopes=registered_scopes,
+        self._registration_requested_scopes = (
+            registered_scopes if registered_scopes is not None else requested_scopes
         )
 
         super().__init__(
@@ -1159,13 +1159,12 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             registration_result = self._perform_dynamic_registration()
             resolved_client_id = registration_result.client_id
             resolved_client_secret = registration_result.client_secret
-            effective_scopes = self._effective_registered_scopes(
-                requested_scopes=self._registration_requested_scopes,
-                registered_scopes=registration_result.registered_scopes,
-            )
-            # BaseOAuthProvider.__init__ already holds this list as its `scopes`
-            # argument, so mutate it in place before it initializes the client.
-            self._registration_requested_scopes[:] = effective_scopes
+            if registration_result.registered_scopes is not None:
+                # BaseOAuthProvider.__init__ already holds this list as its
+                # `scopes` argument, so update it before client initialization.
+                self._registration_requested_scopes[:] = (
+                    registration_result.registered_scopes
+                )
 
         if not resolved_client_id:
             raise ValueError("Missing hosted client credential: client_id")
@@ -1186,29 +1185,6 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
         if "none" in methods:
             return "none"
         return None
-
-    @staticmethod
-    def _effective_registered_scopes(
-        *,
-        requested_scopes: list[str],
-        registered_scopes: list[str] | None,
-    ) -> list[str]:
-        """Restrict requested scopes to the DCR scope echo, preserving order."""
-        if registered_scopes is None:
-            return requested_scopes
-        registered = set(registered_scopes)
-        return [scope for scope in requested_scopes if scope in registered]
-
-    def _build_dynamic_registration_payload(
-        self, registration_auth_method: str | None
-    ) -> dict[str, Any]:
-        """Build the MCP dynamic client registration request payload."""
-        return build_dcr_payload(
-            client_name=self.metadata.name,
-            redirect_uris=[self.__class__.redirect_uri()],
-            token_endpoint_auth_method=registration_auth_method,
-            requested_scopes=self._registration_requested_scopes,
-        )
 
     def _dynamic_registration_auth_method(self) -> str | None:
         return self._select_dynamic_registration_auth_method(
@@ -1324,14 +1300,6 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             if config and config.scopes is not None
             else kwargs.get("scopes")
         )
-        # Empty provider defaults mean unconfigured (None), unlike an explicit
-        # empty scope set from stored config, which must stay empty.
-        scopes = mcp_requested_scopes(
-            scopes=configured_scopes
-            if configured_scopes is not None
-            else (cls.scopes.default or None),
-            scopes_supported=discovery_result.scopes_supported,
-        )
 
         if config:
             client_id = cls._clean_credential(config.client_id)
@@ -1339,6 +1307,17 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
         else:
             client_id = cls._clean_credential(kwargs.get("client_id"))
             client_secret = cls._clean_credential(kwargs.get("client_secret"))
+
+        # A stored set reused with an existing client goes out verbatim; only
+        # expand when DCR will register the expanded set or scopes are unset.
+        will_register = not client_id and bool(discovery_result.registration_endpoint)
+        scopes = mcp_requested_scopes(
+            scopes=configured_scopes
+            if configured_scopes is not None
+            else (cls.scopes.default or None),
+            scopes_supported=discovery_result.scopes_supported,
+            expand=configured_scopes is None or will_register,
+        )
 
         registration_auth_method = None
         registered_scopes: list[str] | None = None
@@ -1356,10 +1335,6 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             client_secret = registration_result.client_secret
             registration_auth_method = registration_result.auth_method
             registered_scopes = registration_result.registered_scopes
-            scopes = cls._effective_registered_scopes(
-                requested_scopes=scopes,
-                registered_scopes=registered_scopes,
-            )
 
         if not client_id:
             raise ValueError("Missing hosted client credential: client_id")

--- a/tracecat/integrations/providers/base.py
+++ b/tracecat/integrations/providers/base.py
@@ -54,6 +54,9 @@ class DynamicRegistrationResult(BaseModel):
     auth_method: str | None = Field(
         None, description="Token endpoint authentication method"
     )
+    registered_scopes: list[str] | None = Field(
+        default=None, description="Scopes echoed by the authorization server"
+    )
 
 
 class OAuthDiscoveryResult(BaseModel):
@@ -65,6 +68,9 @@ class OAuthDiscoveryResult(BaseModel):
     token_endpoint: str = Field(..., description="OAuth token endpoint URL")
     token_methods: list[str] = Field(
         default_factory=list, description="Supported token endpoint auth methods"
+    )
+    scopes_supported: list[str] = Field(
+        default_factory=list, description="Scopes advertised by the OAuth server"
     )
     registration_endpoint: str | None = Field(
         None, description="Dynamic client registration endpoint URL"
@@ -145,6 +151,7 @@ def build_dcr_payload(
     client_name: str,
     redirect_uris: list[str],
     token_endpoint_auth_method: str | None = None,
+    requested_scopes: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build the RFC 7591 dynamic client registration request payload.
 
@@ -159,7 +166,25 @@ def build_dcr_payload(
     }
     if token_endpoint_auth_method:
         payload["token_endpoint_auth_method"] = token_endpoint_auth_method
+    if requested_scopes:
+        payload["scope"] = " ".join(requested_scopes)
     return payload
+
+
+def mcp_requested_scopes(
+    *, scopes: list[str] | None, scopes_supported: list[str]
+) -> list[str]:
+    """Add offline access when the OAuth server advertises support for it.
+
+    ``scopes=[]`` is an explicit empty grant (e.g. narrowed by a DCR echo)
+    and stays empty; ``scopes=None`` means unconfigured and may expand.
+    """
+    if scopes is not None and not scopes:
+        return []
+    requested = list(scopes or [])
+    if "offline_access" in scopes_supported and "offline_access" not in requested:
+        requested.append("offline_access")
+    return requested
 
 
 def _is_disallowed_oauth_address(
@@ -430,6 +455,72 @@ class BaseOAuthProvider(ABC):
             response = await client.post(endpoint, json=payload, timeout=10.0)
         response.raise_for_status()
         return DCRResponse.model_validate(response.json())
+
+    def _build_dynamic_registration_payload(
+        self, registration_auth_method: str | None
+    ) -> dict[str, Any]:
+        """Build the dynamic client registration request payload."""
+        payload: dict[str, Any] = {
+            "client_name": self.metadata.name,
+            "redirect_uris": [self.__class__.redirect_uri()],  # pyright: ignore[reportAttributeAccessIssue]
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"],
+        }
+        if registration_auth_method:
+            payload["token_endpoint_auth_method"] = registration_auth_method
+        return payload
+
+    def _perform_dynamic_registration(self) -> DynamicRegistrationResult:
+        """Register a public client using OAuth 2.0 Dynamic Client Registration."""
+
+        if not self._registration_endpoint:
+            raise ValueError("Dynamic registration endpoint is not available")
+
+        registration_auth_method = self._dynamic_registration_auth_method()
+        registration_payload = self._build_dynamic_registration_payload(
+            registration_auth_method
+        )
+
+        try:
+            registration_response = asyncio.run(
+                self._submit_registration_request(
+                    self._registration_endpoint, registration_payload
+                )
+            )
+        except RuntimeError as exc:
+            message = str(exc)
+            if "event loop" in message.lower() and "running" in message.lower():
+                raise RuntimeError(
+                    "Dynamic client registration must be awaited. Use the async "
+                    "instantiate() helper when creating providers in async contexts."
+                ) from exc
+            raise
+
+        auth_method = (
+            registration_response.token_endpoint_auth_method or registration_auth_method
+        )
+        if auth_method:
+            self._client_registration_auth_method = auth_method
+
+        self.logger.info(
+            "Registered OAuth client dynamically",
+            provider=self.id,
+        )
+
+        return DynamicRegistrationResult(
+            client_id=registration_response.client_id,
+            client_secret=registration_response.client_secret,
+            auth_method=auth_method,
+            registered_scopes=(
+                registration_response.scope.split()
+                if registration_response.scope
+                else None
+            ),
+        )
+
+    def _dynamic_registration_auth_method(self) -> str | None:
+        """Preferred token endpoint auth method when registering dynamically."""
+        return None
 
     def _get_token_endpoint_auth_method(self) -> str | None:
         """Return auth method to use when calling the token endpoint."""
@@ -717,6 +808,8 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
         discovered_token_endpoint: str | None = None,
         registration_endpoint: str | None = None,
         token_methods: list[str] | None = None,
+        scopes_supported: list[str] | None = None,
+        registered_scopes: list[str] | None = None,
         **kwargs,
     ):
         """Initialize MCP provider with dynamic endpoint discovery."""
@@ -735,16 +828,31 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             discovered_token_endpoint=discovered_token_endpoint,
             registration_endpoint=registration_endpoint,
             token_methods_override=token_methods,
+            scopes_supported_override=scopes_supported,
         )
 
         self._registration_endpoint = discovery_result.registration_endpoint
         self._token_endpoint_auth_methods_supported = (
             discovery_result.token_methods or []
         )
+        configured_scopes = kwargs.pop("scopes", None)
+        # Empty provider defaults mean unconfigured (None), unlike an explicit
+        # empty scope set from stored config, which must stay empty.
+        requested_scopes = mcp_requested_scopes(
+            scopes=configured_scopes
+            if configured_scopes is not None
+            else (self.scopes.default or None),
+            scopes_supported=discovery_result.scopes_supported,
+        )
+        self._registration_requested_scopes = self._effective_registered_scopes(
+            requested_scopes=requested_scopes,
+            registered_scopes=registered_scopes,
+        )
 
         super().__init__(
             authorization_endpoint=discovery_result.authorization_endpoint,
             token_endpoint=discovery_result.token_endpoint,
+            scopes=self._registration_requested_scopes,
             **kwargs,
         )
 
@@ -755,6 +863,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
         discovered_token_endpoint: str | None,
         registration_endpoint: str | None,
         token_methods_override: list[str] | None,
+        scopes_supported_override: list[str] | None,
     ) -> OAuthDiscoveryResult:
         """Return discovery result for initialization, performing lookup when needed."""
         if discovered_auth_endpoint and discovered_token_endpoint:
@@ -762,6 +871,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
                 authorization_endpoint=discovered_auth_endpoint,
                 token_endpoint=discovered_token_endpoint,
                 token_methods=token_methods_override or [],
+                scopes_supported=scopes_supported_override or [],
                 registration_endpoint=registration_endpoint,
             )
 
@@ -774,6 +884,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             authorization_endpoint=discovered.authorization_endpoint,
             token_endpoint=discovered.token_endpoint,
             token_methods=token_methods_override or discovered.token_methods,
+            scopes_supported=scopes_supported_override or discovered.scopes_supported,
             registration_endpoint=registration_endpoint
             or discovered.registration_endpoint,
         )
@@ -881,6 +992,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
                     authorization_endpoint=auth_endpoint,
                     token_endpoint=token_endpoint,
                     token_methods=token_methods,
+                    scopes_supported=metadata.scopes_supported,
                     registration_endpoint=registration_endpoint,
                 )
         except Exception as e:
@@ -980,6 +1092,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
                 authorization_endpoint=authorization_endpoint,
                 token_endpoint=token_endpoint,
                 token_methods=token_methods,
+                scopes_supported=metadata.scopes_supported,
                 registration_endpoint=registration_endpoint,
             )
         except Exception as e:
@@ -1046,6 +1159,13 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             registration_result = self._perform_dynamic_registration()
             resolved_client_id = registration_result.client_id
             resolved_client_secret = registration_result.client_secret
+            effective_scopes = self._effective_registered_scopes(
+                requested_scopes=self._registration_requested_scopes,
+                registered_scopes=registration_result.registered_scopes,
+            )
+            # BaseOAuthProvider.__init__ already holds this list as its `scopes`
+            # argument, so mutate it in place before it initializes the client.
+            self._registration_requested_scopes[:] = effective_scopes
 
         if not resolved_client_id:
             raise ValueError("Missing hosted client credential: client_id")
@@ -1067,51 +1187,32 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             return "none"
         return None
 
-    def _perform_dynamic_registration(self) -> DynamicRegistrationResult:
-        """Register a public client using OAuth 2.0 Dynamic Client Registration."""
+    @staticmethod
+    def _effective_registered_scopes(
+        *,
+        requested_scopes: list[str],
+        registered_scopes: list[str] | None,
+    ) -> list[str]:
+        """Restrict requested scopes to the DCR scope echo, preserving order."""
+        if registered_scopes is None:
+            return requested_scopes
+        registered = set(registered_scopes)
+        return [scope for scope in requested_scopes if scope in registered]
 
-        if not self._registration_endpoint:
-            raise ValueError("Dynamic registration endpoint is not available")
-
-        registration_auth_method = self._select_dynamic_registration_auth_method(
-            self._token_endpoint_auth_methods_supported
-        )
-        registration_payload = build_dcr_payload(
+    def _build_dynamic_registration_payload(
+        self, registration_auth_method: str | None
+    ) -> dict[str, Any]:
+        """Build the MCP dynamic client registration request payload."""
+        return build_dcr_payload(
             client_name=self.metadata.name,
             redirect_uris=[self.__class__.redirect_uri()],
             token_endpoint_auth_method=registration_auth_method,
+            requested_scopes=self._registration_requested_scopes,
         )
 
-        try:
-            registration_response = asyncio.run(
-                self._submit_registration_request(
-                    self._registration_endpoint, registration_payload
-                )
-            )
-        except RuntimeError as exc:
-            message = str(exc)
-            if "event loop" in message.lower() and "running" in message.lower():
-                raise RuntimeError(
-                    "Dynamic client registration must be awaited. Use the async "
-                    "instantiate() helper when creating providers in async contexts."
-                ) from exc
-            raise
-
-        auth_method = (
-            registration_response.token_endpoint_auth_method or registration_auth_method
-        )
-        if auth_method:
-            self._client_registration_auth_method = auth_method
-
-        self.logger.info(
-            "Registered OAuth client dynamically",
-            provider=self.id,
-        )
-
-        return DynamicRegistrationResult(
-            client_id=registration_response.client_id,
-            client_secret=registration_response.client_secret,
-            auth_method=auth_method,
+    def _dynamic_registration_auth_method(self) -> str | None:
+        return self._select_dynamic_registration_auth_method(
+            self._token_endpoint_auth_methods_supported
         )
 
     @classmethod
@@ -1120,6 +1221,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
         *,
         registration_endpoint: str,
         registration_auth_method: str | None,
+        requested_scopes: list[str],
         logger_instance,
     ) -> DynamicRegistrationResult:
         """Execute dynamic registration without blocking the event loop."""
@@ -1128,6 +1230,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             client_name=cls.metadata.name,
             redirect_uris=[cls.redirect_uri()],
             token_endpoint_auth_method=registration_auth_method,
+            requested_scopes=requested_scopes,
         )
 
         logger_instance.info(
@@ -1167,6 +1270,11 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             client_id=registration_response.client_id,
             client_secret=registration_response.client_secret,
             auth_method=auth_method,
+            registered_scopes=(
+                registration_response.scope.split()
+                if registration_response.scope
+                else None
+            ),
         )
 
     def _get_token_endpoint_auth_method(self) -> str | None:
@@ -1211,10 +1319,18 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             discovered_token_endpoint=discovered_token_endpoint,
         )
 
-        scopes = (
+        configured_scopes = (
             config.scopes
             if config and config.scopes is not None
             else kwargs.get("scopes")
+        )
+        # Empty provider defaults mean unconfigured (None), unlike an explicit
+        # empty scope set from stored config, which must stay empty.
+        scopes = mcp_requested_scopes(
+            scopes=configured_scopes
+            if configured_scopes is not None
+            else (cls.scopes.default or None),
+            scopes_supported=discovery_result.scopes_supported,
         )
 
         if config:
@@ -1225,6 +1341,7 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             client_secret = cls._clean_credential(kwargs.get("client_secret"))
 
         registration_auth_method = None
+        registered_scopes: list[str] | None = None
         if not client_id and discovery_result.registration_endpoint:
             registration_auth_method = cls._select_dynamic_registration_auth_method(
                 discovery_result.token_methods
@@ -1232,11 +1349,17 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             registration_result = await cls._perform_dynamic_registration_async(
                 registration_endpoint=discovery_result.registration_endpoint,
                 registration_auth_method=registration_auth_method,
+                requested_scopes=scopes,
                 logger_instance=logger_instance,
             )
             client_id = registration_result.client_id
             client_secret = registration_result.client_secret
             registration_auth_method = registration_result.auth_method
+            registered_scopes = registration_result.registered_scopes
+            scopes = cls._effective_registered_scopes(
+                requested_scopes=scopes,
+                registered_scopes=registered_scopes,
+            )
 
         if not client_id:
             raise ValueError("Missing hosted client credential: client_id")
@@ -1250,6 +1373,8 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             token_endpoint=discovery_result.token_endpoint,
             registration_endpoint=discovery_result.registration_endpoint,
             token_methods=discovery_result.token_methods,
+            scopes_supported=discovery_result.scopes_supported,
+            registered_scopes=registered_scopes,
         )
 
         provider = cls(**init_kwargs)

--- a/tracecat/integrations/providers/base.py
+++ b/tracecat/integrations/providers/base.py
@@ -140,6 +140,28 @@ def oauth_authorization_server_metadata_urls(issuer: str) -> list[str]:
     return urls
 
 
+def build_dcr_payload(
+    *,
+    client_name: str,
+    redirect_uris: list[str],
+    token_endpoint_auth_method: str | None = None,
+) -> dict[str, Any]:
+    """Build the RFC 7591 dynamic client registration request payload.
+
+    Advertise ``refresh_token`` so the AS mints refresh-capable clients (MCP
+    spec: clients SHOULD include ``refresh_token`` in ``grant_types``).
+    """
+    payload: dict[str, Any] = {
+        "client_name": client_name,
+        "redirect_uris": redirect_uris,
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+    }
+    if token_endpoint_auth_method:
+        payload["token_endpoint_auth_method"] = token_endpoint_auth_method
+    return payload
+
+
 def _is_disallowed_oauth_address(
     address: ipaddress.IPv4Address | ipaddress.IPv6Address,
 ) -> bool:
@@ -408,61 +430,6 @@ class BaseOAuthProvider(ABC):
             response = await client.post(endpoint, json=payload, timeout=10.0)
         response.raise_for_status()
         return DCRResponse.model_validate(response.json())
-
-    def _perform_dynamic_registration(self) -> DynamicRegistrationResult:
-        """Register a public client using OAuth 2.0 Dynamic Client Registration."""
-
-        if not self._registration_endpoint:
-            raise ValueError("Dynamic registration endpoint is not available")
-
-        registration_payload = {
-            "client_name": self.metadata.name,
-            "redirect_uris": [self.__class__.redirect_uri()],  # pyright: ignore[reportAttributeAccessIssue]
-            "grant_types": ["authorization_code"],
-            "response_types": ["code"],
-        }
-
-        registration_auth_method = self._dynamic_registration_auth_method()
-        if registration_auth_method:
-            registration_payload["token_endpoint_auth_method"] = (
-                registration_auth_method
-            )
-
-        try:
-            registration_response = asyncio.run(
-                self._submit_registration_request(
-                    self._registration_endpoint, registration_payload
-                )
-            )
-        except RuntimeError as exc:
-            message = str(exc)
-            if "event loop" in message.lower() and "running" in message.lower():
-                raise RuntimeError(
-                    "Dynamic client registration must be awaited. Use the async "
-                    "instantiate() helper when creating providers in async contexts."
-                ) from exc
-            raise
-
-        auth_method = (
-            registration_response.token_endpoint_auth_method or registration_auth_method
-        )
-        if auth_method:
-            self._client_registration_auth_method = auth_method
-
-        self.logger.info(
-            "Registered OAuth client dynamically",
-            provider=self.id,
-        )
-
-        return DynamicRegistrationResult(
-            client_id=registration_response.client_id,
-            client_secret=registration_response.client_secret,
-            auth_method=auth_method,
-        )
-
-    def _dynamic_registration_auth_method(self) -> str | None:
-        """Preferred token endpoint auth method when registering dynamically."""
-        return None
 
     def _get_token_endpoint_auth_method(self) -> str | None:
         """Return auth method to use when calling the token endpoint."""
@@ -1100,6 +1067,53 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             return "none"
         return None
 
+    def _perform_dynamic_registration(self) -> DynamicRegistrationResult:
+        """Register a public client using OAuth 2.0 Dynamic Client Registration."""
+
+        if not self._registration_endpoint:
+            raise ValueError("Dynamic registration endpoint is not available")
+
+        registration_auth_method = self._select_dynamic_registration_auth_method(
+            self._token_endpoint_auth_methods_supported
+        )
+        registration_payload = build_dcr_payload(
+            client_name=self.metadata.name,
+            redirect_uris=[self.__class__.redirect_uri()],
+            token_endpoint_auth_method=registration_auth_method,
+        )
+
+        try:
+            registration_response = asyncio.run(
+                self._submit_registration_request(
+                    self._registration_endpoint, registration_payload
+                )
+            )
+        except RuntimeError as exc:
+            message = str(exc)
+            if "event loop" in message.lower() and "running" in message.lower():
+                raise RuntimeError(
+                    "Dynamic client registration must be awaited. Use the async "
+                    "instantiate() helper when creating providers in async contexts."
+                ) from exc
+            raise
+
+        auth_method = (
+            registration_response.token_endpoint_auth_method or registration_auth_method
+        )
+        if auth_method:
+            self._client_registration_auth_method = auth_method
+
+        self.logger.info(
+            "Registered OAuth client dynamically",
+            provider=self.id,
+        )
+
+        return DynamicRegistrationResult(
+            client_id=registration_response.client_id,
+            client_secret=registration_response.client_secret,
+            auth_method=auth_method,
+        )
+
     @classmethod
     async def _perform_dynamic_registration_async(
         cls,
@@ -1110,16 +1124,11 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
     ) -> DynamicRegistrationResult:
         """Execute dynamic registration without blocking the event loop."""
 
-        registration_payload = {
-            "client_name": cls.metadata.name,
-            "redirect_uris": [cls.redirect_uri()],
-            "grant_types": ["authorization_code"],
-            "response_types": ["code"],
-        }
-        if registration_auth_method:
-            registration_payload["token_endpoint_auth_method"] = (
-                registration_auth_method
-            )
+        registration_payload = build_dcr_payload(
+            client_name=cls.metadata.name,
+            redirect_uris=[cls.redirect_uri()],
+            token_endpoint_auth_method=registration_auth_method,
+        )
 
         logger_instance.info(
             "Attempting dynamic client registration",
@@ -1158,11 +1167,6 @@ class MCPAuthProvider(BaseMCPProvider, AuthorizationCodeOAuthProvider):
             client_id=registration_response.client_id,
             client_secret=registration_response.client_secret,
             auth_method=auth_method,
-        )
-
-    def _dynamic_registration_auth_method(self) -> str | None:
-        return self._select_dynamic_registration_auth_method(
-            self._token_endpoint_auth_methods_supported
         )
 
     def _get_token_endpoint_auth_method(self) -> str | None:

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -556,6 +556,13 @@ async def get_integration(
                     provider_id=integration.provider_id,
                 )
 
+    # Defaults apply only when scopes were never configured; an explicitly
+    # empty stored set (e.g. narrowed by a DCR echo) is reported as empty.
+    if integration.requested_scopes is None:
+        requested_scopes = provider_info.impl.scopes.default
+    else:
+        requested_scopes = [s for s in integration.requested_scopes.split(" ") if s]
+
     return IntegrationRead(
         id=integration.id,
         user_id=integration.user_id,
@@ -563,9 +570,7 @@ async def get_integration(
         token_type=integration.token_type,
         expires_at=integration.expires_at,
         granted_scopes=integration.scope.split(" ") if integration.scope else None,
-        requested_scopes=integration.requested_scopes.split(" ")
-        if integration.requested_scopes
-        else provider_info.impl.scopes.default,
+        requested_scopes=requested_scopes,
         authorization_endpoint=authorization_endpoint,
         token_endpoint=token_endpoint,
         created_at=integration.created_at,

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -6,8 +6,8 @@ Terminology:
 """
 
 import uuid
-from datetime import datetime
-from typing import Annotated, Any, Literal, Self, TypedDict
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal, NamedTuple, Self, TypedDict
 from urllib.parse import urlparse
 
 from pydantic import (
@@ -602,8 +602,28 @@ PlatformMCPCatalogState = Literal[
     "not_configured",
     "configured",
     "connected",
+    "reauth_required",
     "error",
 ]
+
+
+class OAuthTokenState(NamedTuple):
+    """Credential columns needed to derive connection state without the full row."""
+
+    encrypted_access_token: bytes | None
+    encrypted_refresh_token: bytes | None
+    expires_at: datetime | None
+
+
+def credential_reauth_required(
+    *, has_refresh_token: bool, expires_at: datetime | None
+) -> bool:
+    """Dead credential: expired with no refresh token to revive it."""
+    if has_refresh_token:
+        return False
+    return expires_at is not None and datetime.now(UTC) >= expires_at
+
+
 MCPCatalogConnectStatus = Literal["configured", "connected", "oauth_redirect"]
 MCPVerificationStatus = Literal[
     "idle", "verifying", "succeeded", "failed", "superseded"

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 import httpx
 import orjson
 import sqlalchemy as sa
+from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.oauth2.rfc7636 import create_s256_code_challenge
 from pydantic import SecretStr
@@ -59,7 +60,11 @@ from tracecat.integrations.catalog.loader import (
     get_platform_mcp_catalog_entry_by_slug,
 )
 from tracecat.integrations.catalog.types import PlatformMCPCatalogEntry
-from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
+from tracecat.integrations.enums import (
+    IntegrationStatus,
+    MCPAuthType,
+    OAuthGrantType,
+)
 from tracecat.integrations.mcp_validation import (
     ALLOWED_MCP_COMMANDS,
     MAX_SERVER_NAME_LENGTH,
@@ -98,11 +103,13 @@ from tracecat.integrations.schemas import (
     MCPToolPolicyUpdate,
     MCPToolSummary,
     MCPVerificationStatusRead,
+    OAuthTokenState,
     PlatformMCPCatalogState,
     ProviderConfig,
     ProviderKey,
     ProviderMetadata,
     ProviderScopes,
+    credential_reauth_required,
     validate_url_credential_values,
 )
 from tracecat.integrations.types import (
@@ -1828,6 +1835,17 @@ class IntegrationService(BaseWorkspaceService):
                             except Exception as e:
                                 refresh_error = e
                                 await refresh_session.refresh(locked)
+                                if (
+                                    isinstance(e, OAuthError)
+                                    and e.error == "invalid_grant"
+                                ):
+                                    locked.encrypted_refresh_token = None
+                                    refresh_service.logger.warning(
+                                        "Authorization server rejected the refresh "
+                                        "token; re-authorization required",
+                                        provider=locked.provider_id,
+                                        user_id=locked.user_id,
+                                    )
 
                             await refresh_session.commit()
                             if refresh_error is not None:
@@ -2820,10 +2838,13 @@ class IntegrationService(BaseWorkspaceService):
         oauth_integration = await self.session.get(
             OAuthIntegration, mcp_integration.oauth_integration_id
         )
+        # CONNECTED covers "token present and alive (or refreshable)"; a
+        # reauth_required row must fall through to the reconnect redirect.
         return bool(
             oauth_integration
             and oauth_integration.workspace_id == self.workspace_id
             and is_set(oauth_integration.encrypted_access_token)
+            and oauth_integration.status == IntegrationStatus.CONNECTED
         )
 
     async def _start_existing_custom_mcp_oauth(
@@ -3261,22 +3282,30 @@ class IntegrationService(BaseWorkspaceService):
         ]
 
     @staticmethod
-    def _mcp_integration_state_from_access_token(
+    def _mcp_integration_state_from_token(
         *,
         mcp_integration: MCPIntegration,
-        encrypted_access_token: bytes | None,
+        token_state: OAuthTokenState | None,
     ) -> PlatformMCPCatalogState:
-        if mcp_integration.auth_type == MCPAuthType.OAUTH2 and not (
-            encrypted_access_token is not None and is_set(encrypted_access_token)
-        ):
-            return "configured"
+        if mcp_integration.auth_type == MCPAuthType.OAUTH2:
+            if token_state is None or not (
+                token_state.encrypted_access_token is not None
+                and is_set(token_state.encrypted_access_token)
+            ):
+                return "configured"
+            if credential_reauth_required(
+                has_refresh_token=token_state.encrypted_refresh_token is not None
+                and is_set(token_state.encrypted_refresh_token),
+                expires_at=token_state.expires_at,
+            ):
+                return "reauth_required"
         if mcp_integration.tools is None:
             return "configured"
         return "connected"
 
-    async def _mcp_oauth_access_tokens_by_id(
+    async def _mcp_oauth_token_states_by_id(
         self, mcp_integrations: Sequence[MCPIntegration]
-    ) -> dict[uuid.UUID, bytes | None]:
+    ) -> dict[uuid.UUID, OAuthTokenState]:
         oauth_integration_ids = {
             oauth_integration_id
             for mcp_integration in mcp_integrations
@@ -3288,13 +3317,20 @@ class IntegrationService(BaseWorkspaceService):
             return {}
 
         result = await self.session.execute(
-            select(OAuthIntegration.id, OAuthIntegration.encrypted_access_token).where(
+            select(
+                OAuthIntegration.id,
+                OAuthIntegration.encrypted_access_token,
+                OAuthIntegration.encrypted_refresh_token,
+                OAuthIntegration.expires_at,
+            ).where(
                 OAuthIntegration.workspace_id == self.workspace_id,
                 OAuthIntegration.id.in_(oauth_integration_ids),
             )
         )
-        rows = result.tuples().all()
-        return dict(rows)
+        return {
+            row_id: OAuthTokenState(access_token, refresh_token, expires_at)
+            for row_id, access_token, refresh_token, expires_at in result.tuples().all()
+        }
 
     async def mcp_oauth_authorization_pending(
         self, *, mcp_integration: MCPIntegration
@@ -3311,8 +3347,11 @@ class IntegrationService(BaseWorkspaceService):
         oauth_integration_id = mcp_integration.oauth_integration_id
         if oauth_integration_id is None:
             return True
-        tokens_by_id = await self._mcp_oauth_access_tokens_by_id([mcp_integration])
-        encrypted_access_token = tokens_by_id.get(oauth_integration_id)
+        tokens_by_id = await self._mcp_oauth_token_states_by_id([mcp_integration])
+        token_state = tokens_by_id.get(oauth_integration_id)
+        encrypted_access_token = (
+            token_state.encrypted_access_token if token_state else None
+        )
         return not (
             encrypted_access_token is not None and is_set(encrypted_access_token)
         )
@@ -3320,16 +3359,16 @@ class IntegrationService(BaseWorkspaceService):
     async def mcp_integration_state(
         self, *, mcp_integration: MCPIntegration
     ) -> PlatformMCPCatalogState:
-        tokens_by_id = await self._mcp_oauth_access_tokens_by_id([mcp_integration])
+        tokens_by_id = await self._mcp_oauth_token_states_by_id([mcp_integration])
         oauth_integration_id = mcp_integration.oauth_integration_id
-        encrypted_access_token = (
+        token_state = (
             tokens_by_id.get(oauth_integration_id)
             if oauth_integration_id is not None
             else None
         )
-        return self._mcp_integration_state_from_access_token(
+        return self._mcp_integration_state_from_token(
             mcp_integration=mcp_integration,
-            encrypted_access_token=encrypted_access_token,
+            token_state=token_state,
         )
 
     async def list_mcp_integrations_with_state(
@@ -3337,11 +3376,11 @@ class IntegrationService(BaseWorkspaceService):
     ) -> Sequence[MCPIntegrationWithState]:
         """List MCP integrations with OAuth-backed connection state."""
         integrations = await self.list_mcp_integrations(source=source)
-        tokens_by_id = await self._mcp_oauth_access_tokens_by_id(integrations)
+        tokens_by_id = await self._mcp_oauth_token_states_by_id(integrations)
         items: list[MCPIntegrationWithState] = []
         for integration in integrations:
             oauth_integration_id = integration.oauth_integration_id
-            encrypted_access_token = (
+            token_state = (
                 tokens_by_id.get(oauth_integration_id)
                 if oauth_integration_id is not None
                 else None
@@ -3349,9 +3388,9 @@ class IntegrationService(BaseWorkspaceService):
             items.append(
                 MCPIntegrationWithState(
                     integration=integration,
-                    state=self._mcp_integration_state_from_access_token(
+                    state=self._mcp_integration_state_from_token(
                         mcp_integration=integration,
-                        encrypted_access_token=encrypted_access_token,
+                        token_state=token_state,
                     ),
                 )
             )

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -82,6 +82,7 @@ from tracecat.integrations.providers.base import (
     CustomOAuthProviderMixin,
     MCPAuthProvider,
     build_dcr_payload,
+    mcp_requested_scopes,
     oauth_authorization_server_metadata_urls,
     validate_oauth_endpoint,
     validate_oauth_endpoint_resolves_public_async,
@@ -149,6 +150,14 @@ class MCPIntegrationWithState:
 
     integration: MCPIntegration
     state: PlatformMCPCatalogState
+
+
+@dataclass(frozen=True)
+class MCPOAuthConnectionState:
+    """OAuth credential fields needed to derive an MCP connection state."""
+
+    token_state: OAuthTokenState
+    grant_type: OAuthGrantType
 
 
 class InsecureOAuthEndpointError(ValueError):
@@ -1015,11 +1024,8 @@ class IntegrationService(BaseWorkspaceService):
             client_name=client_name,
             redirect_uris=[self._mcp_oauth_redirect_uri()],
             token_endpoint_auth_method=token_auth_method,
+            requested_scopes=requested_scopes,
         )
-        # RFC 7591 `scope` whitelists what the client may later request; keep it
-        # aligned with the authorize-time scope set so strict AS don't strip it.
-        if requested_scopes:
-            payload["scope"] = " ".join(requested_scopes)
 
         await validate_oauth_endpoint_resolves_public_async(registration_endpoint)
         async with httpx.AsyncClient() as client:
@@ -1110,19 +1116,6 @@ class IntegrationService(BaseWorkspaceService):
         if integration is None:
             raise ValueError("Failed to create MCP OAuth integration")
         return integration
-
-    @staticmethod
-    def _mcp_requested_scopes(
-        *, scopes: list[str] | None, scopes_supported: list[str]
-    ) -> list[str]:
-        """Configured scopes plus offline_access when the AS advertises it.
-
-        Only adds, never filters: catalog scopes are hand-curated and kept as-is.
-        """
-        requested = list(scopes or [])
-        if "offline_access" in scopes_supported and "offline_access" not in requested:
-            requested.append("offline_access")
-        return requested
 
     async def _start_custom_mcp_oauth_authorization(
         self,
@@ -1235,8 +1228,10 @@ class IntegrationService(BaseWorkspaceService):
         # Request offline_access only when the AS advertises it, so refresh
         # tokens survive session-bound authorization policies. Computed once and
         # threaded to both DCR and the authorize URL so the two can't disagree.
-        requested_scopes = self._mcp_requested_scopes(
-            scopes=scopes, scopes_supported=endpoints.scopes_supported
+        # A fresh connect has no stored grant, so an empty catalog scope list
+        # means unconfigured and may still expand with offline_access.
+        requested_scopes = mcp_requested_scopes(
+            scopes=scopes or None, scopes_supported=endpoints.scopes_supported
         )
         self.logger.info(
             "Connecting custom MCP OAuth integration",
@@ -1516,20 +1511,22 @@ class IntegrationService(BaseWorkspaceService):
         )
         token_endpoint = provider_config.token_endpoint or endpoints.token_endpoint
         await validate_oauth_endpoint_resolves_public_async(token_endpoint)
+        oauth_response = await client.refresh_token(
+            token_endpoint,
+            refresh_token=refresh_token,
+            resource=endpoints.resource,
+        )
         try:
             token = TokenResponse.from_oauth_response(
-                await client.refresh_token(
-                    token_endpoint,
-                    refresh_token=refresh_token,
-                    resource=endpoints.resource,
-                ),
+                oauth_response,
                 default_refresh_token=refresh_token,
                 default_expires_in=None,
                 default_scope=integration.scope or "",
             )
         except ValueError:
-            # The token endpoint call already consumed the refresh token here;
-            # the old refresh token is spent regardless of this parse failure.
+            # A malformed response does not prove that the server spent or
+            # rotated the refresh token. Keep it until an explicit terminal
+            # OAuth error such as invalid_grant confirms it is unusable.
             self.logger.warning(
                 "MCP OAuth refresh response could not be parsed",
                 provider_id=integration.provider_id,
@@ -2243,6 +2240,9 @@ class IntegrationService(BaseWorkspaceService):
                 configured_authorization=integration.authorization_endpoint,
                 configured_token=integration.token_endpoint,
             )
+            # Fall back to defaults only when scopes were never configured; an
+            # explicitly empty stored set (DCR granted nothing) stays empty.
+            parsed_scopes = self.parse_scopes(integration.requested_scopes)
             return ProviderConfig(
                 client_id=client_id,
                 client_secret=SecretStr(client_secret)
@@ -2250,8 +2250,7 @@ class IntegrationService(BaseWorkspaceService):
                 else None,
                 authorization_endpoint=authorization_endpoint,
                 token_endpoint=token_endpoint,
-                scopes=self.parse_scopes(integration.requested_scopes)
-                or default_scopes,
+                scopes=parsed_scopes if parsed_scopes is not None else default_scopes,
             )
         except InsecureOAuthEndpointError as e:
             self.logger.error(
@@ -2306,8 +2305,14 @@ class IntegrationService(BaseWorkspaceService):
         return True
 
     def parse_scopes(self, scopes: str | None) -> list[str] | None:
-        """Parse a space-separated string of scopes into a list of scopes."""
-        return scopes.split(" ") if scopes else None
+        """Parse a space-separated string of scopes into a list of scopes.
+
+        ``""`` is an explicit empty scope set (e.g. narrowed by a DCR echo)
+        and parses to ``[]``; only ``None`` means unconfigured.
+        """
+        if scopes is None:
+            return None
+        return scopes.split(" ") if scopes else []
 
     async def _auto_create_mcp_integration_if_needed(
         self,
@@ -2877,7 +2882,7 @@ class IntegrationService(BaseWorkspaceService):
             if provider_config.client_secret
             else None
         )
-        requested_scopes = self._mcp_requested_scopes(
+        requested_scopes = mcp_requested_scopes(
             scopes=provider_config.scopes,
             scopes_supported=endpoints.scopes_supported,
         )
@@ -3286,6 +3291,7 @@ class IntegrationService(BaseWorkspaceService):
         *,
         mcp_integration: MCPIntegration,
         token_state: OAuthTokenState | None,
+        oauth_grant_type: OAuthGrantType | None,
     ) -> PlatformMCPCatalogState:
         if mcp_integration.auth_type == MCPAuthType.OAUTH2:
             if token_state is None or not (
@@ -3293,19 +3299,22 @@ class IntegrationService(BaseWorkspaceService):
                 and is_set(token_state.encrypted_access_token)
             ):
                 return "configured"
-            if credential_reauth_required(
-                has_refresh_token=token_state.encrypted_refresh_token is not None
-                and is_set(token_state.encrypted_refresh_token),
-                expires_at=token_state.expires_at,
+            if (
+                oauth_grant_type == OAuthGrantType.AUTHORIZATION_CODE
+                and credential_reauth_required(
+                    has_refresh_token=token_state.encrypted_refresh_token is not None
+                    and is_set(token_state.encrypted_refresh_token),
+                    expires_at=token_state.expires_at,
+                )
             ):
                 return "reauth_required"
         if mcp_integration.tools is None:
             return "configured"
         return "connected"
 
-    async def _mcp_oauth_token_states_by_id(
+    async def _mcp_oauth_states_by_id(
         self, mcp_integrations: Sequence[MCPIntegration]
-    ) -> dict[uuid.UUID, OAuthTokenState]:
+    ) -> dict[uuid.UUID, MCPOAuthConnectionState]:
         oauth_integration_ids = {
             oauth_integration_id
             for mcp_integration in mcp_integrations
@@ -3322,14 +3331,24 @@ class IntegrationService(BaseWorkspaceService):
                 OAuthIntegration.encrypted_access_token,
                 OAuthIntegration.encrypted_refresh_token,
                 OAuthIntegration.expires_at,
+                OAuthIntegration.grant_type,
             ).where(
                 OAuthIntegration.workspace_id == self.workspace_id,
                 OAuthIntegration.id.in_(oauth_integration_ids),
             )
         )
         return {
-            row_id: OAuthTokenState(access_token, refresh_token, expires_at)
-            for row_id, access_token, refresh_token, expires_at in result.tuples().all()
+            row_id: MCPOAuthConnectionState(
+                token_state=OAuthTokenState(access_token, refresh_token, expires_at),
+                grant_type=grant_type,
+            )
+            for (
+                row_id,
+                access_token,
+                refresh_token,
+                expires_at,
+                grant_type,
+            ) in result.tuples().all()
         }
 
     async def mcp_oauth_authorization_pending(
@@ -3347,10 +3366,10 @@ class IntegrationService(BaseWorkspaceService):
         oauth_integration_id = mcp_integration.oauth_integration_id
         if oauth_integration_id is None:
             return True
-        tokens_by_id = await self._mcp_oauth_token_states_by_id([mcp_integration])
-        token_state = tokens_by_id.get(oauth_integration_id)
+        oauth_states_by_id = await self._mcp_oauth_states_by_id([mcp_integration])
+        oauth_state = oauth_states_by_id.get(oauth_integration_id)
         encrypted_access_token = (
-            token_state.encrypted_access_token if token_state else None
+            oauth_state.token_state.encrypted_access_token if oauth_state else None
         )
         return not (
             encrypted_access_token is not None and is_set(encrypted_access_token)
@@ -3359,16 +3378,17 @@ class IntegrationService(BaseWorkspaceService):
     async def mcp_integration_state(
         self, *, mcp_integration: MCPIntegration
     ) -> PlatformMCPCatalogState:
-        tokens_by_id = await self._mcp_oauth_token_states_by_id([mcp_integration])
+        oauth_states_by_id = await self._mcp_oauth_states_by_id([mcp_integration])
         oauth_integration_id = mcp_integration.oauth_integration_id
-        token_state = (
-            tokens_by_id.get(oauth_integration_id)
+        oauth_state = (
+            oauth_states_by_id.get(oauth_integration_id)
             if oauth_integration_id is not None
             else None
         )
         return self._mcp_integration_state_from_token(
             mcp_integration=mcp_integration,
-            token_state=token_state,
+            token_state=oauth_state.token_state if oauth_state else None,
+            oauth_grant_type=oauth_state.grant_type if oauth_state else None,
         )
 
     async def list_mcp_integrations_with_state(
@@ -3376,12 +3396,12 @@ class IntegrationService(BaseWorkspaceService):
     ) -> Sequence[MCPIntegrationWithState]:
         """List MCP integrations with OAuth-backed connection state."""
         integrations = await self.list_mcp_integrations(source=source)
-        tokens_by_id = await self._mcp_oauth_token_states_by_id(integrations)
+        oauth_states_by_id = await self._mcp_oauth_states_by_id(integrations)
         items: list[MCPIntegrationWithState] = []
         for integration in integrations:
             oauth_integration_id = integration.oauth_integration_id
-            token_state = (
-                tokens_by_id.get(oauth_integration_id)
+            oauth_state = (
+                oauth_states_by_id.get(oauth_integration_id)
                 if oauth_integration_id is not None
                 else None
             )
@@ -3390,7 +3410,10 @@ class IntegrationService(BaseWorkspaceService):
                     integration=integration,
                     state=self._mcp_integration_state_from_token(
                         mcp_integration=integration,
-                        token_state=token_state,
+                        token_state=oauth_state.token_state if oauth_state else None,
+                        oauth_grant_type=(
+                            oauth_state.grant_type if oauth_state else None
+                        ),
                     ),
                 )
             )

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1058,9 +1058,7 @@ class IntegrationService(BaseWorkspaceService):
         )
         # RFC 7591 `scope` echoes the scopes the AS registered (its whitelist);
         # None when the response omits it.
-        registered_scopes = (
-            registration_response.scope.split() if registration_response.scope else None
-        )
+        registered_scopes = registration_response.registered_scopes
         self.logger.info(
             "Registered custom MCP OAuth client",
             registration_endpoint_host=urlparse(registration_endpoint).hostname,

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -8,7 +8,7 @@ import uuid
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
@@ -201,6 +201,10 @@ class MCPOAuthCallbackState:
 
     code_verifier: str | None
     token_auth_method: str | None
+
+
+class _AuthorizeUrlKwargs(TypedDict, total=False):
+    scope: str
 
 
 _CUSTOM_MCP_OAUTH_PROVIDER_PREFIX = "custom_mcp_"
@@ -1165,7 +1169,7 @@ class IntegrationService(BaseWorkspaceService):
         )
         # Only send a scope param when we have something to request; today's
         # behavior omits it entirely when there are no scopes.
-        authorize_kwargs: dict[str, Any] = {}
+        authorize_kwargs: _AuthorizeUrlKwargs = {}
         if requested_scopes:
             authorize_kwargs["scope"] = " ".join(requested_scopes)
         auth_url, _ = client.create_authorization_url(
@@ -1260,17 +1264,15 @@ class IntegrationService(BaseWorkspaceService):
                 ),
                 requested_scopes=requested_scopes,
             )
-        # RFC 7591: the DCR scope echo is the AS whitelist, possibly narrowed.
-        # Intersect (preserving requested order) rather than adopting verbatim,
-        # since some AS echo broader default sets than we requested.
-        if registration.registered_scopes is not None:
-            registered_set = set(registration.registered_scopes)
-            effective_scopes = [s for s in requested_scopes if s in registered_set]
-        else:
-            effective_scopes = requested_scopes
+        # RFC 7591: a DCR scope echo is the authoritative registered set.
+        effective_scopes = (
+            registration.registered_scopes
+            if registration.registered_scopes is not None
+            else requested_scopes
+        )
         if effective_scopes != requested_scopes:
             self.logger.info(
-                "Narrowed custom MCP OAuth scopes to AS registration",
+                "Using registered custom MCP OAuth scopes",
                 integration_name=params.name,
                 requested_scopes=requested_scopes,
                 registered_scopes=registration.registered_scopes,
@@ -2882,9 +2884,12 @@ class IntegrationService(BaseWorkspaceService):
             if provider_config.client_secret
             else None
         )
+        # Reconnect reuses the registered client, so stored scopes go out
+        # verbatim; legacy NULL rows still expand with offline_access.
         requested_scopes = mcp_requested_scopes(
             scopes=provider_config.scopes,
             scopes_supported=endpoints.scopes_supported,
+            expand=provider_config.scopes is None,
         )
         self.logger.info(
             "Reconnecting custom MCP OAuth integration",

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -6,7 +6,7 @@ import re
 import secrets
 import uuid
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from urllib.parse import urlparse, urlunparse
@@ -76,6 +76,7 @@ from tracecat.integrations.providers.base import (
     ClientCredentialsOAuthProvider,
     CustomOAuthProviderMixin,
     MCPAuthProvider,
+    build_dcr_payload,
     oauth_authorization_server_metadata_urls,
     validate_oauth_endpoint,
     validate_oauth_endpoint_resolves_public_async,
@@ -164,6 +165,7 @@ class MCPOAuthDiscoveryEndpoints:
     token_methods: list[str]
     registration_endpoint: str | None
     resource: str
+    scopes_supported: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -173,6 +175,8 @@ class MCPOAuthRegistrationResult:
     client_id: str
     client_secret: str | None
     auth_method: str | None
+    # RFC 7591 scope echo (AS-registered whitelist); None = no echo / not from DCR.
+    registered_scopes: list[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -955,6 +959,7 @@ class IntegrationService(BaseWorkspaceService):
             if registration_endpoint
             else None,
             resource=resource_uri,
+            scopes_supported=direct_metadata.scopes_supported,
         )
 
     async def _resolve_mcp_oauth_endpoints(
@@ -997,15 +1002,17 @@ class IntegrationService(BaseWorkspaceService):
         registration_endpoint: str,
         client_name: str,
         token_auth_method: str | None,
+        requested_scopes: list[str],
     ) -> MCPOAuthRegistrationResult:
-        payload: dict[str, object] = {
-            "client_name": client_name,
-            "redirect_uris": [self._mcp_oauth_redirect_uri()],
-            "grant_types": ["authorization_code"],
-            "response_types": ["code"],
-        }
-        if token_auth_method:
-            payload["token_endpoint_auth_method"] = token_auth_method
+        payload = build_dcr_payload(
+            client_name=client_name,
+            redirect_uris=[self._mcp_oauth_redirect_uri()],
+            token_endpoint_auth_method=token_auth_method,
+        )
+        # RFC 7591 `scope` whitelists what the client may later request; keep it
+        # aligned with the authorize-time scope set so strict AS don't strip it.
+        if requested_scopes:
+            payload["scope"] = " ".join(requested_scopes)
 
         await validate_oauth_endpoint_resolves_public_async(registration_endpoint)
         async with httpx.AsyncClient() as client:
@@ -1025,10 +1032,30 @@ class IntegrationService(BaseWorkspaceService):
         auth_method = (
             registration_response.token_endpoint_auth_method or token_auth_method
         )
+        # RFC 7591 responses echo the AS-registered metadata; flag when the AS
+        # dropped the refresh_token grant we requested. An absent echo (None)
+        # means "as requested"; a declared-empty [] means the AS stripped grants.
+        grant_types_downgraded = (
+            registration_response.grant_types is not None
+            and "refresh_token" not in registration_response.grant_types
+        )
+        # RFC 7591 `scope` echoes the scopes the AS registered (its whitelist);
+        # None when the response omits it.
+        registered_scopes = (
+            registration_response.scope.split() if registration_response.scope else None
+        )
+        self.logger.info(
+            "Registered custom MCP OAuth client",
+            registration_endpoint_host=urlparse(registration_endpoint).hostname,
+            registered_grant_types=registration_response.grant_types,
+            registered_scope=registration_response.scope,
+            grant_types_downgraded=grant_types_downgraded,
+        )
         return MCPOAuthRegistrationResult(
             client_id=registration_response.client_id,
             client_secret=registration_response.client_secret,
             auth_method=auth_method,
+            registered_scopes=registered_scopes,
         )
 
     async def _generate_custom_mcp_provider_id(self, *, name: str) -> str:
@@ -1077,6 +1104,19 @@ class IntegrationService(BaseWorkspaceService):
             raise ValueError("Failed to create MCP OAuth integration")
         return integration
 
+    @staticmethod
+    def _mcp_requested_scopes(
+        *, scopes: list[str] | None, scopes_supported: list[str]
+    ) -> list[str]:
+        """Configured scopes plus offline_access when the AS advertises it.
+
+        Only adds, never filters: catalog scopes are hand-curated and kept as-is.
+        """
+        requested = list(scopes or [])
+        if "offline_access" in scopes_supported and "offline_access" not in requested:
+            requested.append("offline_access")
+        return requested
+
     async def _start_custom_mcp_oauth_authorization(
         self,
         *,
@@ -1084,6 +1124,7 @@ class IntegrationService(BaseWorkspaceService):
         server_uri: str,
         endpoints: MCPOAuthDiscoveryEndpoints,
         registration: MCPOAuthRegistrationResult,
+        requested_scopes: list[str],
     ) -> IntegrationOAuthConnect:
         if self.role.user_id is None:
             raise ValueError("User ID is required")
@@ -1122,12 +1163,18 @@ class IntegrationService(BaseWorkspaceService):
             token_auth_method=token_auth_method,
             with_response_type=True,
         )
+        # Only send a scope param when we have something to request; today's
+        # behavior omits it entirely when there are no scopes.
+        authorize_kwargs: dict[str, Any] = {}
+        if requested_scopes:
+            authorize_kwargs["scope"] = " ".join(requested_scopes)
         auth_url, _ = client.create_authorization_url(
             endpoints.authorization_endpoint,
             state=str(state_id),
             code_challenge=code_challenge,
             code_challenge_method="S256",
             resource=endpoints.resource,
+            **authorize_kwargs,
         )
         return IntegrationOAuthConnect(
             auth_url=auth_url,
@@ -1178,6 +1225,19 @@ class IntegrationService(BaseWorkspaceService):
             server_uri=params.server_uri,
             allowed_endpoint_hosts=allowed_endpoint_hosts,
         )
+        # Request offline_access only when the AS advertises it, so refresh
+        # tokens survive session-bound authorization policies. Computed once and
+        # threaded to both DCR and the authorize URL so the two can't disagree.
+        requested_scopes = self._mcp_requested_scopes(
+            scopes=scopes, scopes_supported=endpoints.scopes_supported
+        )
+        self.logger.info(
+            "Connecting custom MCP OAuth integration",
+            provider_id=params.catalog_slug,
+            integration_name=params.name,
+            scopes_supported=endpoints.scopes_supported,
+            requested_scopes=requested_scopes,
+        )
         # Prefer user-supplied OAuth client credentials; otherwise fall back to
         # dynamic client registration (DCR) against the discovered endpoint.
         registration = self._mcp_oauth_client_registration_from_credentials(
@@ -1196,13 +1256,30 @@ class IntegrationService(BaseWorkspaceService):
                 token_auth_method=self._select_mcp_registration_auth_method(
                     endpoints.token_methods
                 ),
+                requested_scopes=requested_scopes,
+            )
+        # RFC 7591: the DCR scope echo is the AS whitelist, possibly narrowed.
+        # Intersect (preserving requested order) rather than adopting verbatim,
+        # since some AS echo broader default sets than we requested.
+        if registration.registered_scopes is not None:
+            registered_set = set(registration.registered_scopes)
+            effective_scopes = [s for s in requested_scopes if s in registered_set]
+        else:
+            effective_scopes = requested_scopes
+        if effective_scopes != requested_scopes:
+            self.logger.info(
+                "Narrowed custom MCP OAuth scopes to AS registration",
+                integration_name=params.name,
+                requested_scopes=requested_scopes,
+                registered_scopes=registration.registered_scopes,
+                effective_scopes=effective_scopes,
             )
         oauth_integration = await self._create_custom_mcp_oauth_provider(
             name=params.name,
             description=params.description,
             endpoints=endpoints,
             registration=registration,
-            scopes=scopes,
+            scopes=effective_scopes,
         )
         if existing_mcp_integration is not None:
             existing_mcp_integration.oauth_integration_id = oauth_integration.id
@@ -1225,6 +1302,7 @@ class IntegrationService(BaseWorkspaceService):
             server_uri=mcp_integration.server_uri or params.server_uri,
             endpoints=endpoints,
             registration=registration,
+            requested_scopes=effective_scopes,
         )
         return PlatformMCPCatalogConnectResult(
             mcp_integration=mcp_integration,
@@ -1372,6 +1450,13 @@ class IntegrationService(BaseWorkspaceService):
             raise ValueError(
                 "MCP OAuth token response did not include access_token"
             ) from exc
+        self.logger.info(
+            "Completed custom MCP OAuth authorization",
+            provider_id=provider_id,
+            granted_scope=token.scope,
+            has_refresh_token=token.refresh_token is not None,
+            expires_in=token.expires_in,
+        )
         return await self.store_integration(
             provider_key=provider_key,
             user_id=self.role.user_id,
@@ -1436,20 +1521,35 @@ class IntegrationService(BaseWorkspaceService):
                 default_scope=integration.scope or "",
             )
         except ValueError:
+            # The token endpoint call already consumed the refresh token here;
+            # the old refresh token is spent regardless of this parse failure.
+            self.logger.warning(
+                "MCP OAuth refresh response could not be parsed",
+                provider_id=integration.provider_id,
+            )
             return integration
         integration.encrypted_access_token = self._encrypt_token(
             token.access_token.get_secret_value()
         )
-        if token.refresh_token:
-            integration.encrypted_refresh_token = self._encrypt_token(
-                token.refresh_token.get_secret_value()
-            )
+        new_refresh_token = (
+            token.refresh_token.get_secret_value() if token.refresh_token else None
+        )
+        rotated = new_refresh_token is not None and new_refresh_token != refresh_token
+        if new_refresh_token:
+            integration.encrypted_refresh_token = self._encrypt_token(new_refresh_token)
         if token.expires_in is not None:
             integration.expires_at = datetime.now(UTC) + timedelta(
                 seconds=token.expires_in
             )
         if token.scope:
             integration.scope = token.scope
+        self.logger.info(
+            "Refreshed MCP OAuth integration",
+            provider_id=integration.provider_id,
+            refresh_token_rotated=rotated,
+            expires_in=token.expires_in,
+            granted_scope=token.scope,
+        )
         return integration
 
     @staticmethod
@@ -2756,6 +2856,16 @@ class IntegrationService(BaseWorkspaceService):
             if provider_config.client_secret
             else None
         )
+        requested_scopes = self._mcp_requested_scopes(
+            scopes=provider_config.scopes,
+            scopes_supported=endpoints.scopes_supported,
+        )
+        self.logger.info(
+            "Reconnecting custom MCP OAuth integration",
+            provider_id=oauth_integration.provider_id,
+            scopes_supported=endpoints.scopes_supported,
+            requested_scopes=requested_scopes,
+        )
         oauth_connect = await self._start_custom_mcp_oauth_authorization(
             integration=oauth_integration,
             server_uri=mcp_integration.server_uri,
@@ -2765,6 +2875,7 @@ class IntegrationService(BaseWorkspaceService):
                 client_secret=client_secret,
                 auth_method=None,
             ),
+            requested_scopes=requested_scopes,
         )
         return PlatformMCPCatalogConnectResult(
             mcp_integration=mcp_integration,

--- a/tracecat/integrations/types.py
+++ b/tracecat/integrations/types.py
@@ -8,13 +8,6 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 type MCPServerType = Literal["http", "stdio"]
 
 
-def _filter_string_items(value: object) -> list[str] | None:
-    """String items for list input, else None. Both models parse untrusted metadata."""
-    if isinstance(value, list):
-        return [item for item in value if isinstance(item, str)]
-    return None
-
-
 class OAuthServerMetadata(BaseModel):
     """Authorization-server / protected-resource metadata (untrusted RFC 8414/9728)."""
 
@@ -27,17 +20,6 @@ class OAuthServerMetadata(BaseModel):
     registration_endpoint: str | None = None
     token_endpoint_auth_methods_supported: list[str] = Field(default_factory=list)
     scopes_supported: list[str] = Field(default_factory=list)
-
-    @field_validator(
-        "authorization_servers",
-        "token_endpoint_auth_methods_supported",
-        "scopes_supported",
-        mode="before",
-    )
-    @classmethod
-    def _only_strings(cls, value: object) -> list[str]:
-        """Drop malformed list items rather than rejecting the metadata document."""
-        return _filter_string_items(value) or []
 
     @field_validator(
         "resource",
@@ -73,11 +55,6 @@ class DCRResponse(BaseModel):
     # None = grant_types omitted ("as requested"); [] = AS stripped all grants.
     grant_types: list[str] | None = None
     scope: str | None = None
-
-    @field_validator("grant_types", mode="before")
-    @classmethod
-    def _only_strings(cls, value: object) -> list[str] | None:
-        return _filter_string_items(value)
 
     @field_validator("client_id")
     @classmethod

--- a/tracecat/integrations/types.py
+++ b/tracecat/integrations/types.py
@@ -8,6 +8,13 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 type MCPServerType = Literal["http", "stdio"]
 
 
+def _filter_string_items(value: object) -> list[str] | None:
+    """String items for list input, else None. Both models parse untrusted metadata."""
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return None
+
+
 class OAuthServerMetadata(BaseModel):
     """Authorization-server / protected-resource metadata (untrusted RFC 8414/9728)."""
 
@@ -19,20 +26,18 @@ class OAuthServerMetadata(BaseModel):
     token_endpoint: str | None = None
     registration_endpoint: str | None = None
     token_endpoint_auth_methods_supported: list[str] = Field(default_factory=list)
+    scopes_supported: list[str] = Field(default_factory=list)
 
     @field_validator(
         "authorization_servers",
         "token_endpoint_auth_methods_supported",
+        "scopes_supported",
         mode="before",
     )
     @classmethod
     def _only_strings(cls, value: object) -> list[str]:
         """Drop malformed list items rather than rejecting the metadata document."""
-        return (
-            [item for item in value if isinstance(item, str)]
-            if isinstance(value, list)
-            else []
-        )
+        return _filter_string_items(value) or []
 
     @field_validator(
         "resource",
@@ -64,6 +69,15 @@ class DCRResponse(BaseModel):
     client_id: str = Field(min_length=1)
     client_secret: str | None = None
     token_endpoint_auth_method: str | None = None
+    # RFC 7591 echoes the final registered metadata, incl. AS modifications.
+    # None = grant_types omitted ("as requested"); [] = AS stripped all grants.
+    grant_types: list[str] | None = None
+    scope: str | None = None
+
+    @field_validator("grant_types", mode="before")
+    @classmethod
+    def _only_strings(cls, value: object) -> list[str] | None:
+        return _filter_string_items(value)
 
     @field_validator("client_id")
     @classmethod
@@ -73,7 +87,9 @@ class DCRResponse(BaseModel):
             raise ValueError("Dynamic client registration did not return client_id")
         return client_id
 
-    @field_validator("client_secret", "token_endpoint_auth_method", mode="before")
+    @field_validator(
+        "client_secret", "token_endpoint_auth_method", "scope", mode="before"
+    )
     @classmethod
     def _optional_string(cls, value: object) -> str | None:
         return value if isinstance(value, str) and value else None

--- a/tracecat/integrations/types.py
+++ b/tracecat/integrations/types.py
@@ -64,12 +64,15 @@ class DCRResponse(BaseModel):
             raise ValueError("Dynamic client registration did not return client_id")
         return client_id
 
-    @field_validator(
-        "client_secret", "token_endpoint_auth_method", "scope", mode="before"
-    )
+    @field_validator("client_secret", "token_endpoint_auth_method", mode="before")
     @classmethod
     def _optional_string(cls, value: object) -> str | None:
         return value if isinstance(value, str) and value else None
+
+    @property
+    def registered_scopes(self) -> list[str] | None:
+        """Return the echoed scope whitelist, preserving omitted versus empty."""
+        return self.scope.split() if self.scope is not None else None
 
 
 class _OAuthTokenWireResponse(BaseModel):

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -510,7 +510,8 @@ async def _build_integrations_inventory(role: Role) -> IntegrationsInventoryResp
         status_rank = {
             IntegrationStatus.NOT_CONFIGURED: 0,
             IntegrationStatus.CONFIGURED: 1,
-            IntegrationStatus.CONNECTED: 2,
+            IntegrationStatus.REAUTH_REQUIRED: 2,
+            IntegrationStatus.CONNECTED: 3,
         }
         existing: dict[tuple[str, OAuthGrantType], Any] = {}
         for integration in integrations:


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds refresh-token support for MCP OAuth clients and requests `offline_access` only when discovery advertises it. Introduces a `reauth_required` state for expired auth-code tokens without refresh, and updates API, inventory/catalog ranking, and UI with clear “Reconnect required” messaging.

- **New Features**
  - Shared DCR `build_dcr_payload` advertises `authorization_code` + `refresh_token`; discovery exposes `scopes_supported`; request `offline_access` at DCR and authorize only when advertised.
  - Track requested vs granted grants/scopes; log granted scopes on code exchange and refresh; detect refresh rotation; warn on unparseable refresh responses.
  - Minimal `OAuthTokenState`; default scopes only when never configured; preserve explicitly empty `requested_scopes`; surface and rank `reauth_required` in inventory/catalog and UI.

- **Bug Fixes**
  - Return and display `reauth_required` when an auth-code token is expired with no refresh token; update API enums/types and list sorting; UI shows “Reconnect required” in integration lists, catalog cards, and the details dialog.

<sup>Written for commit 233b4658d7c550e25e97baa6f03d01e617ca9837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<img width="1714" height="957" alt="image" src="https://github.com/user-attachments/assets/6a6e59cb-26a6-4e77-a2a1-a58100a6a9cf" />


