### PR TITLE
perf(sync): batch GitHub export writes to avoid rate limits

### DIFF
--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -2066,8 +2066,10 @@ async def test_github_write_files_retry_budget_exhaustion_reraises(
             create_pr=False,
         )
 
-    assert [call.args[0] for call in sleep.await_args_list] == pytest.approx([0.6, 0.4])
-    assert repo.call_counts["create_git_tree"] == 3
+    # The first Retry-After (0.6) fits the 1.0 budget; the second (0.6) exceeds
+    # the remaining 0.4 and re-raises without a truncated sleep or early retry.
+    assert [call.args[0] for call in sleep.await_args_list] == pytest.approx([0.6])
+    assert repo.call_counts["create_git_tree"] == 2
     assert repo.call_counts["create_git_commit"] == 0
     assert repo.call_counts["ref.edit"] == 0
 

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -1969,6 +1969,34 @@ async def test_github_write_files_reraises_nonpositive_retry_after(
 
 
 @pytest.mark.anyio
+async def test_github_write_files_splits_tree_chunks_by_payload_size(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    files = {
+        MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
+        "workflows/a/definition.yml": "a" * 300,
+        "workflows/b/definition.yml": "b" * 300,
+        "workflows/c/definition.yml": "c" * 300,
+    }
+    repo = _FakeGitHubRepo(files={}, branch_exists=True, ahead_by=0)
+
+    # Each large element serializes past half the patched cap, so no two of
+    # them may share a chunk despite the 128-entry count limit.
+    with patch("tracecat.workspace_sync.transport._GITHUB_TREE_CHUNK_MAX_BYTES", 500):
+        result = await _write_files_with_fake_repo(
+            repo,
+            service=workspace_sync_service,
+            files=files,
+            create_pr=False,
+        )
+
+    assert result.status is PushStatus.COMMITTED
+    assert repo.call_counts["create_git_tree"] == 4
+    assert all(len(tree.elements) == 1 for tree in repo.trees)
+    assert repo.final_files == files
+
+
+@pytest.mark.anyio
 async def test_github_write_files_logs_pygithub_serialized_payload_size(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -1980,9 +1980,10 @@ async def test_github_write_files_splits_tree_chunks_by_payload_size(
     }
     repo = _FakeGitHubRepo(files={}, branch_exists=True, ahead_by=0)
 
-    # Each large element serializes past half the patched cap, so no two of
-    # them may share a chunk despite the 128-entry count limit.
-    with patch("tracecat.workspace_sync.transport._GITHUB_TREE_CHUNK_MAX_BYTES", 500):
+    # Every element stays under the 700-byte cap individually (manifest ~525,
+    # workflow entries ~387 serialized), but no two fit a chunk together, so
+    # the packer must emit one chunk per element despite the 128-entry limit.
+    with patch("tracecat.workspace_sync.transport._GITHUB_TREE_CHUNK_MAX_BYTES", 700):
         result = await _write_files_with_fake_repo(
             repo,
             service=workspace_sync_service,
@@ -1991,8 +1992,47 @@ async def test_github_write_files_splits_tree_chunks_by_payload_size(
         )
 
     assert result.status is PushStatus.COMMITTED
+    assert repo.call_counts["create_git_blob"] == 0
     assert repo.call_counts["create_git_tree"] == 4
     assert all(len(tree.elements) == 1 for tree in repo.trees)
+    assert repo.final_files == files
+
+
+@pytest.mark.anyio
+async def test_github_write_files_uploads_oversized_entries_as_blobs(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    files = {
+        MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
+        "workflows/big/definition.yml": "x" * 2000,
+        "workflows/small/definition.yml": "version: 1\n",
+    }
+    repo = _FakeGitHubRepo(files={}, branch_exists=True, ahead_by=0)
+
+    # Only the big file's inline entry serializes past the 1000-byte cap
+    # (manifest ~525, small ~103), so it alone must ship through the blob
+    # endpoint and appear in the tree as a SHA reference.
+    with patch("tracecat.workspace_sync.transport._GITHUB_TREE_CHUNK_MAX_BYTES", 1000):
+        result = await _write_files_with_fake_repo(
+            repo,
+            service=workspace_sync_service,
+            files=files,
+            create_pr=False,
+        )
+
+    assert result.status is PushStatus.COMMITTED
+    assert repo.call_counts["create_git_blob"] == 1
+    assert repo.blobs == [("x" * 2000, "utf-8")]
+    identities = [
+        cast(Any, element)._identity for tree in repo.trees for element in tree.elements
+    ]
+    big_identity = next(
+        identity
+        for identity in identities
+        if identity["path"] == "workflows/big/definition.yml"
+    )
+    assert "content" not in big_identity
+    assert big_identity["sha"] == "blob-1"
     assert repo.final_files == files
 
 
@@ -2261,6 +2301,7 @@ class _FakeGitHubRepo:
         self._get_git_tree_error = get_git_tree_error
         self._create_git_tree_errors = list(create_git_tree_errors or ())
         self._create_git_ref_errors = list(create_git_ref_errors or ())
+        self._blob_contents: dict[str, str] = {}
         self._tree_truncated = tree_truncated
         self.created_refs: list[tuple[str, str]] = []
         self.compare_calls: list[tuple[str, str]] = []
@@ -2331,7 +2372,9 @@ class _FakeGitHubRepo:
     def create_git_blob(self, content: str, encoding: str):
         self.call_counts["create_git_blob"] += 1
         self.blobs.append((content, encoding))
-        return SimpleNamespace(sha=f"blob-{len(self.blobs)}")
+        sha = f"blob-{len(self.blobs)}"
+        self._blob_contents[sha] = content
+        return SimpleNamespace(sha=sha)
 
     def create_git_tree(self, elements: list[object], *, base_tree: object):
         self.call_counts["create_git_tree"] += 1
@@ -2345,9 +2388,10 @@ class _FakeGitHubRepo:
             if "content" in identity:
                 assert "sha" not in identity
                 tree_files[path] = identity["content"]
-            else:
-                assert identity["sha"] is None
+            elif identity["sha"] is None:
                 tree_files.pop(path, None)
+            else:
+                tree_files[path] = self._blob_contents[identity["sha"]]
         tree = SimpleNamespace(
             sha=f"tree-{len(self.trees) + 1}",
             elements=elements,

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -2037,16 +2037,23 @@ async def test_github_write_files_uploads_oversized_entries_as_blobs(
 
 
 @pytest.mark.anyio
-async def test_github_write_files_logs_pygithub_serialized_payload_size(
+async def test_github_write_files_logs_pygithub_payload_size_per_chunk(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:
     sync_logger = Mock()
     repo = _FakeGitHubRepo(files={}, branch_exists=True, ahead_by=0)
+    files = {
+        MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
+        **{
+            f"workflows/generated-{index:04d}/definition.yml": "version: 1\n"
+            for index in range(_GITHUB_TREE_CHUNK_SIZE)
+        },
+    }
 
     await _write_files_with_fake_repo(
         repo,
         service=workspace_sync_service,
-        files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+        files=files,
         create_pr=False,
         logger=sync_logger,
     )
@@ -2058,7 +2065,7 @@ async def test_github_write_files_logs_pygithub_serialized_payload_size(
     )
     # PyGithub's Requester serializes with json.dumps default separators; the
     # logged size must match that framing, not a compact serialization.
-    expected_payload_size = sum(
+    expected_payload_sizes = [
         len(
             json.dumps(
                 {
@@ -2068,8 +2075,16 @@ async def test_github_write_files_logs_pygithub_serialized_payload_size(
             ).encode("utf-8")
         )
         for tree in repo.trees
+    ]
+    assert tree_log.kwargs["max_tree_payload_size_bytes"] == max(expected_payload_sizes)
+    chunk_logs = [
+        call
+        for call in sync_logger.info.call_args_list
+        if call.args and call.args[0] == "Created GitHub workspace sync tree chunk"
+    ]
+    assert [call.kwargs["tree_payload_size_bytes"] for call in chunk_logs] == (
+        expected_payload_sizes
     )
-    assert tree_log.kwargs["tree_payload_size_bytes"] == expected_payload_size
 
 
 @pytest.mark.anyio
@@ -2366,7 +2381,7 @@ class _FakeGitHubRepo:
                 SimpleNamespace(path=path, sha=_git_blob_sha(content), type="blob")
                 for path, content in sorted(tree_files.items())
             ],
-            raw_data={"truncated": self._tree_truncated},
+            truncated=self._tree_truncated,
         )
 
     def create_git_blob(self, content: str, encoding: str):

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -1902,6 +1902,39 @@ async def test_github_write_files_retries_429_with_retry_after(
 
 
 @pytest.mark.anyio
+async def test_github_write_files_retries_branch_creation_with_retry_after(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    retry_error = GithubException(
+        status=403,
+        data={"message": "Request blocked"},
+        headers={"Retry-After": "0.25"},
+    )
+    repo = _FakeGitHubRepo(
+        files={},
+        branch_exists=False,
+        ahead_by=0,
+        create_git_ref_errors=[retry_error],
+    )
+
+    with patch(
+        "tracecat.workspace_sync.transport.asyncio.sleep", new_callable=AsyncMock
+    ) as sleep:
+        result = await _write_files_with_fake_repo(
+            repo,
+            service=workspace_sync_service,
+            files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+            create_pr=False,
+        )
+
+    assert result.status is PushStatus.COMMITTED
+    sleep.assert_awaited_once_with(0.25)
+    assert repo.call_counts["create_git_ref"] == 2
+    assert len(repo.created_refs) == 1
+    assert repo.call_counts["ref.edit"] == 1
+
+
+@pytest.mark.anyio
 async def test_github_write_files_reraises_nonpositive_retry_after(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:
@@ -2188,6 +2221,7 @@ class _FakeGitHubRepo:
         existing_pr: object | None = None,
         get_git_tree_error: GithubException | None = None,
         create_git_tree_errors: list[GithubException] | None = None,
+        create_git_ref_errors: list[GithubException] | None = None,
         tree_truncated: bool = False,
     ) -> None:
         self._files = dict(files)
@@ -2196,6 +2230,7 @@ class _FakeGitHubRepo:
         self._existing_pr = existing_pr
         self._get_git_tree_error = get_git_tree_error
         self._create_git_tree_errors = list(create_git_tree_errors or ())
+        self._create_git_ref_errors = list(create_git_ref_errors or ())
         self._tree_truncated = tree_truncated
         self.created_refs: list[tuple[str, str]] = []
         self.compare_calls: list[tuple[str, str]] = []
@@ -2226,6 +2261,8 @@ class _FakeGitHubRepo:
 
     def create_git_ref(self, *, ref: str, sha: str) -> None:
         self.call_counts["create_git_ref"] += 1
+        if self._create_git_ref_errors:
+            raise self._create_git_ref_errors.pop(0)
         self.created_refs.append((ref, sha))
         self._branch_exists = True
 

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import base64
 import uuid
+from collections import Counter
+from math import ceil
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -54,8 +56,10 @@ from tracecat.workspace_sync.schemas import (
 from tracecat.workspace_sync.serialization import canonical_json_text
 from tracecat.workspace_sync.service import WorkspaceSyncService, _table_names
 from tracecat.workspace_sync.transport import (
+    _GITHUB_TREE_CHUNK_SIZE,
     GitHubWorkspaceSyncTransport,
     VcsTreeSnapshot,
+    _git_blob_sha,
     unsupported_transport,
 )
 from tracecat.workspace_sync.workflow import (
@@ -1622,6 +1626,11 @@ async def test_github_write_files_noop_skips_pr_for_branch_without_commits(
     assert result.pr_url is None
     assert repo.created_refs == [("refs/heads/sync/agents-1", "a" * 40)]
     assert repo.compare_calls == [("main", "sync/agents-1")]
+    assert repo.call_counts["get_contents"] == 0
+    assert repo.call_counts["create_git_blob"] == 0
+    assert repo.call_counts["get_git_tree"] == 1
+    assert repo.call_counts["create_git_tree"] == 0
+    assert repo.call_counts["ref.edit"] == 0
     repo.create_pull.assert_not_called()
 
 
@@ -1685,7 +1694,7 @@ async def test_github_write_files_uses_tree_sha_for_stale_path_scan(
     files = {MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())}
     repo = _FakeGitHubRepo(
         files={
-            MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
+            MANIFEST_FILENAME: "{}\n",
             "workflows/stale/definition.yml": "version: 1\n",
         },
         branch_exists=True,
@@ -1703,6 +1712,34 @@ async def test_github_write_files_uses_tree_sha_for_stale_path_scan(
     assert result.status is PushStatus.COMMITTED
     assert repo.get_git_tree_calls == [f"tree-{'a' * 40}"]
     assert len(repo.trees) == 1
+    assert [
+        cast(Any, element)._identity["path"] for element in repo.trees[0].elements
+    ] == [MANIFEST_FILENAME, "workflows/stale/definition.yml"]
+    assert repo.final_files == files
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_sha"),
+    [
+        pytest.param(
+            "",
+            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+            id="empty",
+        ),
+        pytest.param(
+            "hello\n",
+            "ce013625030ba8dba906f756967f9e9ca394464a",
+            id="ascii",
+        ),
+        pytest.param(
+            "café ☕\n",
+            "df113425d6f29a3f8cfb2ca897bebf8703e56d20",
+            id="multibyte_utf8",
+        ),
+    ],
+)
+def test_git_blob_sha_matches_git_hash_object(content: str, expected_sha: str) -> None:
+    assert _git_blob_sha(content) == expected_sha
 
 
 @pytest.mark.anyio
@@ -1743,11 +1780,132 @@ async def test_github_write_files_builds_complete_tree_delta_for_large_projectio
     assert result.status is PushStatus.COMMITTED
     assert len(files) == 807
     assert len(expected_changed_paths) == expected_tree_entry_count
-    assert len(repo.blobs) == expected_tree_entry_count
-    assert len(repo.trees) == 1
-    assert {
-        cast(Any, element)._identity["path"] for element in repo.trees[0].elements
-    } == expected_changed_paths
+    assert repo.call_counts["get_contents"] == 0
+    assert repo.call_counts["create_git_blob"] == 0
+    assert repo.call_counts["get_git_tree"] == 1
+    assert repo.call_counts["create_git_tree"] == ceil(
+        expected_tree_entry_count / _GITHUB_TREE_CHUNK_SIZE
+    )
+    assert repo.call_counts["ref.edit"] == 1
+    assert len(repo.trees) == ceil(expected_tree_entry_count / _GITHUB_TREE_CHUNK_SIZE)
+    inline_entries = [
+        cast(Any, element)._identity for tree in repo.trees for element in tree.elements
+    ]
+    assert {entry["path"] for entry in inline_entries} == expected_changed_paths
+    assert [entry["path"] for entry in inline_entries] == sorted(expected_changed_paths)
+    assert all("content" in entry and "sha" not in entry for entry in inline_entries)
+    assert unchanged_paths.isdisjoint(entry["path"] for entry in inline_entries)
+    assert repo.final_files == files
+
+
+@pytest.mark.anyio
+async def test_github_write_files_truncated_tree_rewrites_all_and_skips_deletions(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    sync_logger = Mock()
+    files = {
+        MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
+        "workflows/current/definition.yml": "version: 1\n",
+    }
+    stale_path = "workflows/stale/definition.yml"
+    repo = _FakeGitHubRepo(
+        files={**files, stale_path: "version: 1\n"},
+        branch_exists=True,
+        ahead_by=0,
+        tree_truncated=True,
+    )
+
+    result = await _write_files_with_fake_repo(
+        repo,
+        service=workspace_sync_service,
+        files=files,
+        create_pr=False,
+        delete_missing_paths_under=("workflows",),
+        logger=sync_logger,
+    )
+
+    assert result.status is PushStatus.COMMITTED
+    assert repo.call_counts["get_git_tree"] == 1
+    assert repo.call_counts["create_git_tree"] == 1
+    identities = [cast(Any, element)._identity for element in repo.trees[0].elements]
+    assert {identity["path"] for identity in identities} == set(files)
+    assert all(
+        "content" in identity and "sha" not in identity for identity in identities
+    )
+    assert repo.final_files == {**files, stale_path: "version: 1\n"}
+    sync_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_github_write_files_retries_403_with_retry_after(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    retry_error = GithubException(
+        status=403,
+        data={"message": "Request blocked"},
+        headers={"Retry-After": "0.25"},
+    )
+    repo = _FakeGitHubRepo(
+        files={},
+        branch_exists=True,
+        ahead_by=0,
+        create_git_tree_errors=[retry_error],
+    )
+
+    with patch(
+        "tracecat.workspace_sync.transport.asyncio.sleep", new_callable=AsyncMock
+    ) as sleep:
+        result = await _write_files_with_fake_repo(
+            repo,
+            service=workspace_sync_service,
+            files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+            create_pr=False,
+        )
+
+    assert result.status is PushStatus.COMMITTED
+    sleep.assert_awaited_once_with(0.25)
+    assert repo.call_counts["create_git_tree"] == 2
+    assert repo.call_counts["ref.edit"] == 1
+
+
+@pytest.mark.anyio
+async def test_github_write_files_retry_budget_exhaustion_reraises(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    retry_errors = [
+        GithubException(
+            status=403,
+            data={"message": "Request blocked"},
+            headers={"Retry-After": "0.6"},
+        )
+        for _ in range(3)
+    ]
+    repo = _FakeGitHubRepo(
+        files={},
+        branch_exists=True,
+        ahead_by=0,
+        create_git_tree_errors=retry_errors,
+    )
+
+    with (
+        patch("tracecat.workspace_sync.transport._GITHUB_RETRY_BUDGET_SECONDS", 1.0),
+        patch(
+            "tracecat.workspace_sync.transport.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep,
+        pytest.raises(GitHubAppError),
+    ):
+        await _write_files_with_fake_repo(
+            repo,
+            service=workspace_sync_service,
+            files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+            create_pr=False,
+        )
+
+    assert [call.args[0] for call in sleep.await_args_list] == pytest.approx([0.6, 0.4])
+    assert repo.call_counts["create_git_tree"] == 3
+    assert repo.call_counts["create_git_commit"] == 0
+    assert repo.call_counts["ref.edit"] == 0
 
 
 @pytest.mark.anyio
@@ -1759,7 +1917,7 @@ async def test_github_write_files_logs_rate_limit_response_headers(
         files={},
         branch_exists=True,
         ahead_by=0,
-        contents_error=GithubException(
+        get_git_tree_error=GithubException(
             status=403,
             data={"message": "Request blocked"},
             headers={
@@ -1781,8 +1939,8 @@ async def test_github_write_files_logs_rate_limit_response_headers(
 
     error_log = sync_logger.error.call_args
     assert error_log.args == ("GitHub workspace sync request failed",)
-    assert error_log.kwargs["stage"] == "compare_projected_files"
-    assert error_log.kwargs["github_endpoint"].endswith("/contents/{path}")
+    assert error_log.kwargs["stage"] == "read_target_tree"
+    assert error_log.kwargs["github_endpoint"].endswith("/git/trees/{sha}")
     assert error_log.kwargs["github_status"] == 403
     assert error_log.kwargs["github_request_id"] == "request-id"
     assert error_log.kwargs["github_retry_after"] == "60"
@@ -1925,15 +2083,20 @@ class _FakeGitHubRepo:
         branch_exists: bool,
         ahead_by: int,
         existing_pr: object | None = None,
-        contents_error: GithubException | None = None,
+        get_git_tree_error: GithubException | None = None,
+        create_git_tree_errors: list[GithubException] | None = None,
+        tree_truncated: bool = False,
     ) -> None:
-        self._files = files
+        self._files = dict(files)
         self._branch_exists = branch_exists
         self._ahead_by = ahead_by
         self._existing_pr = existing_pr
-        self._contents_error = contents_error
+        self._get_git_tree_error = get_git_tree_error
+        self._create_git_tree_errors = list(create_git_tree_errors or ())
+        self._tree_truncated = tree_truncated
         self.created_refs: list[tuple[str, str]] = []
         self.compare_calls: list[tuple[str, str]] = []
+        self.call_counts: Counter[str] = Counter()
         self.create_pull = Mock(
             return_value=SimpleNamespace(
                 html_url="https://github.com/TracecatHQ/sync/pull/8",
@@ -1944,53 +2107,88 @@ class _FakeGitHubRepo:
         self.trees: list[SimpleNamespace] = []
         self.commits: list[object] = []
         self.get_git_tree_calls: list[str] = []
+        self._tree_files: dict[str, dict[str, str]] = {}
+        self._commits_by_sha: dict[str, SimpleNamespace] = {}
+        self._ref = _FakeGitRef(self, "heads/sync/agents-1")
+
+    @property
+    def final_files(self) -> dict[str, str]:
+        return dict(self._files)
 
     def get_branch(self, name: str):
+        self.call_counts["get_branch"] += 1
         if name == "main" or self._branch_exists:
             return SimpleNamespace(commit=SimpleNamespace(sha="a" * 40))
         raise GithubException(status=404, data={"message": "Not Found"})
 
     def create_git_ref(self, *, ref: str, sha: str) -> None:
+        self.call_counts["create_git_ref"] += 1
         self.created_refs.append((ref, sha))
         self._branch_exists = True
 
     def get_contents(self, path: str, *, ref: str):
-        if self._contents_error is not None:
-            raise self._contents_error
+        self.call_counts["get_contents"] += 1
         if path not in self._files:
             raise GithubException(status=404, data={"message": "Not Found"})
         encoded = base64.b64encode(self._files[path].encode()).decode()
         return SimpleNamespace(content=encoded)
 
     def compare(self, base: str, head: str):
+        self.call_counts["compare"] += 1
         self.compare_calls.append((base, head))
         return SimpleNamespace(ahead_by=self._ahead_by)
 
     def get_git_commit(self, sha: str):
-        return SimpleNamespace(tree=SimpleNamespace(sha=f"tree-{sha}"))
+        self.call_counts["get_git_commit"] += 1
+        tree_sha = f"tree-{sha}"
+        self._tree_files.setdefault(tree_sha, dict(self._files))
+        return SimpleNamespace(tree=SimpleNamespace(sha=tree_sha))
 
     def get_git_tree(self, *, sha: str, recursive: bool):
+        self.call_counts["get_git_tree"] += 1
         self.get_git_tree_calls.append(sha)
+        if self._get_git_tree_error is not None:
+            raise self._get_git_tree_error
+        tree_files = self._tree_files.get(sha, self._files)
         return SimpleNamespace(
             tree=[
-                SimpleNamespace(path=path, type="blob") for path in sorted(self._files)
-            ]
+                SimpleNamespace(path=path, sha=_git_blob_sha(content), type="blob")
+                for path, content in sorted(tree_files.items())
+            ],
+            raw_data={"truncated": self._tree_truncated},
         )
 
     def create_git_blob(self, content: str, encoding: str):
+        self.call_counts["create_git_blob"] += 1
         self.blobs.append((content, encoding))
         return SimpleNamespace(sha=f"blob-{len(self.blobs)}")
 
     def create_git_tree(self, elements: list[object], *, base_tree: object):
+        self.call_counts["create_git_tree"] += 1
+        if self._create_git_tree_errors:
+            raise self._create_git_tree_errors.pop(0)
+        base_tree_sha = cast(Any, base_tree).sha
+        tree_files = dict(self._tree_files[base_tree_sha])
+        for element in elements:
+            identity = cast(Any, element)._identity
+            path = identity["path"]
+            if "content" in identity:
+                assert "sha" not in identity
+                tree_files[path] = identity["content"]
+            else:
+                assert identity["sha"] is None
+                tree_files.pop(path, None)
         tree = SimpleNamespace(
             sha=f"tree-{len(self.trees) + 1}",
             elements=elements,
             base_tree=base_tree,
         )
+        self._tree_files[tree.sha] = tree_files
         self.trees.append(tree)
         return tree
 
     def create_git_commit(self, message: str, tree: object, parents: list[object]):
+        self.call_counts["create_git_commit"] += 1
         commit = SimpleNamespace(
             sha=f"commit-{len(self.commits) + 1}",
             message=message,
@@ -1998,24 +2196,32 @@ class _FakeGitHubRepo:
             parents=parents,
         )
         self.commits.append(commit)
+        self._commits_by_sha[commit.sha] = commit
         return commit
 
     def get_git_ref(self, ref: str):
-        return _FakeGitRef(ref)
+        self.call_counts["get_git_ref"] += 1
+        self._ref.ref = ref
+        return self._ref
 
     def get_pulls(self, *, state: str, head: str, base: str):
+        self.call_counts["get_pulls"] += 1
         if self._existing_pr is None:
             return iter(())
         return iter((self._existing_pr,))
 
 
 class _FakeGitRef:
-    def __init__(self, ref: str) -> None:
+    def __init__(self, repo: _FakeGitHubRepo, ref: str) -> None:
+        self._repo = repo
         self.ref = ref
         self.edits: list[str] = []
 
     def edit(self, *, sha: str) -> None:
+        self._repo.call_counts["ref.edit"] += 1
         self.edits.append(sha)
+        commit = self._repo._commits_by_sha[sha]
+        self._repo._files = dict(self._repo._tree_files[cast(Any, commit.tree).sha])
 
 
 class _FakeGitHubReadRepo:

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import uuid
 from collections import Counter
 from math import ceil
@@ -1866,6 +1867,108 @@ async def test_github_write_files_retries_403_with_retry_after(
     sleep.assert_awaited_once_with(0.25)
     assert repo.call_counts["create_git_tree"] == 2
     assert repo.call_counts["ref.edit"] == 1
+
+
+@pytest.mark.anyio
+async def test_github_write_files_retries_429_with_retry_after(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    retry_error = GithubException(
+        status=429,
+        data={"message": "Too many requests"},
+        headers={"Retry-After": "0.25"},
+    )
+    repo = _FakeGitHubRepo(
+        files={},
+        branch_exists=True,
+        ahead_by=0,
+        create_git_tree_errors=[retry_error],
+    )
+
+    with patch(
+        "tracecat.workspace_sync.transport.asyncio.sleep", new_callable=AsyncMock
+    ) as sleep:
+        result = await _write_files_with_fake_repo(
+            repo,
+            service=workspace_sync_service,
+            files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+            create_pr=False,
+        )
+
+    assert result.status is PushStatus.COMMITTED
+    sleep.assert_awaited_once_with(0.25)
+    assert repo.call_counts["create_git_tree"] == 2
+    assert repo.call_counts["ref.edit"] == 1
+
+
+@pytest.mark.anyio
+async def test_github_write_files_reraises_nonpositive_retry_after(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    retry_error = GithubException(
+        status=403,
+        data={"message": "Request blocked"},
+        headers={"Retry-After": "0"},
+    )
+    repo = _FakeGitHubRepo(
+        files={},
+        branch_exists=True,
+        ahead_by=0,
+        create_git_tree_errors=[retry_error],
+    )
+
+    with (
+        patch(
+            "tracecat.workspace_sync.transport.asyncio.sleep", new_callable=AsyncMock
+        ) as sleep,
+        pytest.raises(GitHubAppError),
+    ):
+        await _write_files_with_fake_repo(
+            repo,
+            service=workspace_sync_service,
+            files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+            create_pr=False,
+        )
+
+    sleep.assert_not_awaited()
+    assert repo.call_counts["create_git_tree"] == 1
+    assert repo.call_counts["ref.edit"] == 0
+
+
+@pytest.mark.anyio
+async def test_github_write_files_logs_pygithub_serialized_payload_size(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    sync_logger = Mock()
+    repo = _FakeGitHubRepo(files={}, branch_exists=True, ahead_by=0)
+
+    await _write_files_with_fake_repo(
+        repo,
+        service=workspace_sync_service,
+        files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+        create_pr=False,
+        logger=sync_logger,
+    )
+
+    tree_log = next(
+        call
+        for call in sync_logger.info.call_args_list
+        if call.args and call.args[0] == "Creating GitHub workspace sync tree"
+    )
+    # PyGithub's Requester serializes with json.dumps default separators; the
+    # logged size must match that framing, not a compact serialization.
+    expected_payload_size = sum(
+        len(
+            json.dumps(
+                {
+                    "base_tree": f"tree-{'a' * 40}",
+                    "tree": [cast(Any, element)._identity for element in tree.elements],
+                }
+            ).encode("utf-8")
+        )
+        for tree in repo.trees
+    )
+    assert tree_log.kwargs["tree_payload_size_bytes"] == expected_payload_size
 
 
 @pytest.mark.anyio

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -174,6 +174,13 @@ Tree entries embed file content inline, so entry count alone does not bound
 request size. A file whose inline entry alone exceeds the cap is uploaded
 through the blob endpoint and referenced by SHA instead."""
 
+_GITHUB_TREE_ENVELOPE_BYTES = 128
+"""Bytes reserved for the create-tree JSON envelope.
+
+Covers the ``{"base_tree": "<sha>", "tree": [...]}`` framing so a chunk
+measured element-by-element cannot exceed the cap once fully serialized;
+per-element ``", "`` separators are charged to each element instead."""
+
 _GITHUB_RETRY_BUDGET_SECONDS = 45.0
 """Maximum shared Retry-After delay budget for one GitHub export."""
 
@@ -525,8 +532,15 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     type="blob",
                     content=content,
                 )
-                inline_bytes = len(json.dumps(inline_element._identity).encode("utf-8"))
-                if inline_bytes <= _GITHUB_TREE_CHUNK_MAX_BYTES:
+                # Charge the ", " separator to the element so element-by-element
+                # accounting matches the fully serialized request.
+                inline_bytes = (
+                    len(json.dumps(inline_element._identity).encode("utf-8")) + 2
+                )
+                if (
+                    inline_bytes
+                    <= _GITHUB_TREE_CHUNK_MAX_BYTES - _GITHUB_TREE_ENVELOPE_BYTES
+                ):
                     elements.append(inline_element)
                     continue
                 # Inline content above the chunk cap would recreate the
@@ -554,11 +568,11 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             current_chunk: list[InputGitTreeElement] = []
             current_chunk_bytes = 0
             for element in elements:
-                element_bytes = len(json.dumps(element._identity).encode("utf-8"))
+                element_bytes = len(json.dumps(element._identity).encode("utf-8")) + 2
                 if current_chunk and (
                     len(current_chunk) >= _GITHUB_TREE_CHUNK_SIZE
                     or current_chunk_bytes + element_bytes
-                    > _GITHUB_TREE_CHUNK_MAX_BYTES
+                    > _GITHUB_TREE_CHUNK_MAX_BYTES - _GITHUB_TREE_ENVELOPE_BYTES
                 ):
                     element_chunks.append(current_chunk)
                     current_chunk = []

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -409,6 +409,7 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         gh = await gh_svc.get_github_client_for_repo(url)
         github_stage = "resolve_repository"
         github_endpoint = "GET /repos/{owner}/{repo}"
+        retry_budget = _GitHubRetryBudget(_GITHUB_RETRY_BUDGET_SECONDS)
         try:
             repo = await asyncio.to_thread(gh.get_repo, f"{url.org}/{url.repo}")
             github_stage = "prepare_branch"
@@ -425,10 +426,12 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             except GithubException as e:
                 if e.status != 404:
                     raise
-                await asyncio.to_thread(
-                    repo.create_git_ref,
-                    ref=f"refs/heads/{branch}",
-                    sha=base_branch.commit.sha,
+                await _github_write_with_retry(
+                    lambda: repo.create_git_ref(
+                        ref=f"refs/heads/{branch}",
+                        sha=base_branch.commit.sha,
+                    ),
+                    budget=retry_budget,
                 )
                 target_branch = await asyncio.to_thread(repo.get_branch, branch)
 
@@ -543,7 +546,6 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 tree_chunk_count=len(element_chunks),
                 tree_payload_size_bytes=tree_payload_size_bytes,
             )
-            retry_budget = _GitHubRetryBudget(_GITHUB_RETRY_BUDGET_SECONDS)
             tree = target_commit.tree
             for chunk_index, chunk in enumerate(element_chunks, start=1):
                 github_stage = "create_tree_chunk"

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -171,8 +171,8 @@ _GITHUB_TREE_CHUNK_MAX_BYTES = 2 * 1024 * 1024
 """Cap the serialized payload per create-tree call.
 
 Tree entries embed file content inline, so entry count alone does not bound
-request size. A single entry larger than the cap still ships alone because an
-entry cannot be split."""
+request size. A file whose inline entry alone exceeds the cap is uploaded
+through the blob endpoint and referenced by SHA instead."""
 
 _GITHUB_RETRY_BUDGET_SECONDS = 45.0
 """Maximum shared Retry-After delay budget for one GitHub export."""
@@ -517,15 +517,35 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     message="No changes detected; nothing to commit.",
                 )
 
-            elements = [
-                InputGitTreeElement(
+            elements: list[InputGitTreeElement] = []
+            for path, content in sorted(changed_files.items()):
+                inline_element = InputGitTreeElement(
                     path=path,
                     mode="100644",
                     type="blob",
                     content=content,
                 )
-                for path, content in sorted(changed_files.items())
-            ]
+                inline_bytes = len(json.dumps(inline_element._identity).encode("utf-8"))
+                if inline_bytes <= _GITHUB_TREE_CHUNK_MAX_BYTES:
+                    elements.append(inline_element)
+                    continue
+                # Inline content above the chunk cap would recreate the
+                # oversized-request failure the cap prevents; upload the blob
+                # separately and reference its SHA in the tree instead.
+                github_stage = "create_blob"
+                github_endpoint = "POST /repos/{owner}/{repo}/git/blobs"
+                blob = await _github_write_with_retry(
+                    lambda content=content: repo.create_git_blob(content, "utf-8"),
+                    budget=retry_budget,
+                )
+                elements.append(
+                    InputGitTreeElement(
+                        path=path,
+                        mode="100644",
+                        type="blob",
+                        sha=blob.sha,
+                    )
+                )
             elements.extend(
                 InputGitTreeElement(path=path, mode="100644", type="blob", sha=None)
                 for path in sorted(stale_paths)

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -10,11 +10,13 @@ import json
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Any, Protocol
 from urllib.parse import quote, urlparse
 
 import httpx
 from github.GithubException import GithubException
+from github.GitTreeElement import GitTreeElement
 from github.InputGitTreeElement import InputGitTreeElement
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
@@ -174,13 +176,6 @@ Tree entries embed file content inline, so entry count alone does not bound
 request size. A file whose inline entry alone exceeds the cap is uploaded
 through the blob endpoint and referenced by SHA instead."""
 
-_GITHUB_TREE_ENVELOPE_BYTES = 128
-"""Bytes reserved for the create-tree JSON envelope.
-
-Covers the ``{"base_tree": "<sha>", "tree": [...]}`` framing so a chunk
-measured element-by-element cannot exceed the cap once fully serialized;
-per-element ``", "`` separators are charged to each element instead."""
-
 _GITHUB_RETRY_BUDGET_SECONDS = 45.0
 """Maximum shared Retry-After delay budget for one GitHub export."""
 
@@ -207,11 +202,90 @@ class _GitHubRetryBudget:
     remaining_seconds: float
 
 
+@dataclass(frozen=True)
+class _SizedGitTreeElement:
+    """GitHub tree element with its serialized size cached."""
+
+    element: InputGitTreeElement
+    serialized_size_bytes: int
+
+
+@dataclass(frozen=True)
+class _GitHubTreeChunk:
+    """Bounded create-tree request payload."""
+
+    elements: tuple[InputGitTreeElement, ...]
+    payload_size_bytes: int
+
+
 def _git_blob_sha(content: str) -> str:
     """Return the Git blob object SHA for UTF-8 ``content``."""
     content_bytes = content.encode("utf-8")
     framed_content = b"blob " + str(len(content_bytes)).encode() + b"\0" + content_bytes
     return hashlib.sha1(framed_content, usedforsecurity=False).hexdigest()
+
+
+def _sized_git_tree_element(element: InputGitTreeElement) -> _SizedGitTreeElement:
+    """Cache the element size used to enforce create-tree payload limits."""
+    # PyGithub serializes this private identity with json.dumps. Keep that
+    # dependency isolated here so preflight sizing serializes each entry once.
+    serialized_size_bytes = len(json.dumps(element._identity).encode("utf-8"))
+    return _SizedGitTreeElement(
+        element=element,
+        serialized_size_bytes=serialized_size_bytes,
+    )
+
+
+def _git_tree_envelope_size_bytes(base_tree_sha: str) -> int:
+    """Return the create-tree payload size before elements are added."""
+    return len(
+        json.dumps(
+            {
+                "base_tree": base_tree_sha,
+                "tree": [],
+            }
+        ).encode("utf-8")
+    )
+
+
+def _chunk_git_tree_elements(
+    elements: Sequence[_SizedGitTreeElement],
+    *,
+    base_tree_sha: str,
+) -> list[_GitHubTreeChunk]:
+    """Pack tree elements under both entry-count and payload-size limits."""
+    chunks: list[_GitHubTreeChunk] = []
+    current_chunk: list[_SizedGitTreeElement] = []
+    envelope_size_bytes = _git_tree_envelope_size_bytes(base_tree_sha)
+    current_chunk_bytes = envelope_size_bytes
+
+    for element in elements:
+        separator_bytes = 2 if current_chunk else 0
+        if current_chunk and (
+            len(current_chunk) >= _GITHUB_TREE_CHUNK_SIZE
+            or current_chunk_bytes + separator_bytes + element.serialized_size_bytes
+            > _GITHUB_TREE_CHUNK_MAX_BYTES
+        ):
+            chunks.append(
+                _GitHubTreeChunk(
+                    elements=tuple(item.element for item in current_chunk),
+                    payload_size_bytes=current_chunk_bytes,
+                )
+            )
+            current_chunk = []
+            current_chunk_bytes = envelope_size_bytes
+            separator_bytes = 0
+        current_chunk.append(element)
+        current_chunk_bytes += separator_bytes + element.serialized_size_bytes
+
+    if current_chunk:
+        chunks.append(
+            _GitHubTreeChunk(
+                elements=tuple(item.element for item in current_chunk),
+                payload_size_bytes=current_chunk_bytes,
+            )
+        )
+    return chunks
 
 
 async def _github_write_with_retry[T](
@@ -463,13 +537,7 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 sha=target_commit.tree.sha,
                 recursive=True,
             )
-            target_tree_truncated = target_tree.raw_data.get("truncated") is True
-            target_blob_shas = {
-                item.path: item.sha
-                for item in target_tree.tree
-                if item.type == "blob" and item.path
-            }
-            if target_tree_truncated:
+            if target_tree.truncated:
                 changed_files = dict(files)
                 stale_paths: set[str] = set()
                 self.logger.warning(
@@ -478,6 +546,11 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     tree_sha=target_commit.tree.sha,
                 )
             else:
+                target_blob_shas = {
+                    item.path: item.sha
+                    for item in target_tree.tree
+                    if item.type == "blob" and item.path
+                }
                 changed_files = {
                     path: content
                     for path, content in files.items()
@@ -524,24 +597,22 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     message="No changes detected; nothing to commit.",
                 )
 
-            elements: list[InputGitTreeElement] = []
+            sized_elements: list[_SizedGitTreeElement] = []
+            max_inline_element_bytes = (
+                _GITHUB_TREE_CHUNK_MAX_BYTES
+                - _git_tree_envelope_size_bytes(target_commit.tree.sha)
+            )
             for path, content in sorted(changed_files.items()):
-                inline_element = InputGitTreeElement(
-                    path=path,
-                    mode="100644",
-                    type="blob",
-                    content=content,
+                inline_element = _sized_git_tree_element(
+                    InputGitTreeElement(
+                        path=path,
+                        mode="100644",
+                        type="blob",
+                        content=content,
+                    )
                 )
-                # Charge the ", " separator to the element so element-by-element
-                # accounting matches the fully serialized request.
-                inline_bytes = (
-                    len(json.dumps(inline_element._identity).encode("utf-8")) + 2
-                )
-                if (
-                    inline_bytes
-                    <= _GITHUB_TREE_CHUNK_MAX_BYTES - _GITHUB_TREE_ENVELOPE_BYTES
-                ):
-                    elements.append(inline_element)
+                if inline_element.serialized_size_bytes <= max_inline_element_bytes:
+                    sized_elements.append(inline_element)
                     continue
                 # Inline content above the chunk cap would recreate the
                 # oversized-request failure the cap prevents; upload the blob
@@ -552,63 +623,50 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     lambda content=content: repo.create_git_blob(content, "utf-8"),
                     budget=retry_budget,
                 )
-                elements.append(
+                sized_elements.append(
+                    _sized_git_tree_element(
+                        InputGitTreeElement(
+                            path=path,
+                            mode="100644",
+                            type="blob",
+                            sha=blob.sha,
+                        )
+                    )
+                )
+            sized_elements.extend(
+                _sized_git_tree_element(
                     InputGitTreeElement(
                         path=path,
                         mode="100644",
                         type="blob",
-                        sha=blob.sha,
+                        sha=None,
                     )
                 )
-            elements.extend(
-                InputGitTreeElement(path=path, mode="100644", type="blob", sha=None)
                 for path in sorted(stale_paths)
             )
-            element_chunks: list[list[InputGitTreeElement]] = []
-            current_chunk: list[InputGitTreeElement] = []
-            current_chunk_bytes = 0
-            for element in elements:
-                element_bytes = len(json.dumps(element._identity).encode("utf-8")) + 2
-                if current_chunk and (
-                    len(current_chunk) >= _GITHUB_TREE_CHUNK_SIZE
-                    or current_chunk_bytes + element_bytes
-                    > _GITHUB_TREE_CHUNK_MAX_BYTES - _GITHUB_TREE_ENVELOPE_BYTES
-                ):
-                    element_chunks.append(current_chunk)
-                    current_chunk = []
-                    current_chunk_bytes = 0
-                current_chunk.append(element)
-                current_chunk_bytes += element_bytes
-            if current_chunk:
-                element_chunks.append(current_chunk)
-            # Mirror PyGithub's Requester serialization (json.dumps with default
-            # separators) so the logged size matches the transmitted payload.
-            tree_payload_size_bytes = sum(
-                len(
-                    json.dumps(
-                        {
-                            "base_tree": target_commit.tree.sha,
-                            "tree": [element._identity for element in chunk],
-                        }
-                    ).encode("utf-8")
-                )
-                for chunk in element_chunks
+            element_chunks = _chunk_git_tree_elements(
+                sized_elements,
+                base_tree_sha=target_commit.tree.sha,
             )
 
             self.logger.info(
                 "Creating GitHub workspace sync tree",
-                tree_entry_count=len(elements),
+                tree_entry_count=len(sized_elements),
                 tree_chunk_count=len(element_chunks),
-                tree_payload_size_bytes=tree_payload_size_bytes,
+                max_tree_payload_size_bytes=max(
+                    chunk.payload_size_bytes for chunk in element_chunks
+                ),
             )
             tree = target_commit.tree
             for chunk_index, chunk in enumerate(element_chunks, start=1):
                 github_stage = "create_tree_chunk"
                 github_endpoint = "POST /repos/{owner}/{repo}/git/trees"
                 base_tree = tree
+                chunk_elements = list(chunk.elements)
                 tree = await _github_write_with_retry(
-                    lambda chunk=chunk, base_tree=base_tree: repo.create_git_tree(
-                        chunk,
+                    partial(
+                        repo.create_git_tree,
+                        chunk_elements,
                         base_tree=base_tree,
                     ),
                     budget=retry_budget,
@@ -617,7 +675,8 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     "Created GitHub workspace sync tree chunk",
                     tree_chunk_index=chunk_index,
                     tree_chunk_count=len(element_chunks),
-                    tree_entry_count=len(chunk),
+                    tree_entry_count=len(chunk.elements),
+                    tree_payload_size_bytes=chunk.payload_size_bytes,
                     tree_sha=tree.sha,
                 )
 
@@ -690,7 +749,7 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
     def _stale_paths_under_roots(
         self,
         *,
-        tree_entries: Sequence[Any],
+        tree_entries: Sequence[GitTreeElement],
         files: dict[str, str],
         roots: Sequence[str],
     ) -> set[str]:

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -216,7 +216,9 @@ async def _github_write_with_retry[T](
 
     GitHub signals rate limiting with either 403 or 429. A nonpositive
     Retry-After is re-raised rather than retried so a persistent zero-delay
-    response cannot spin without consuming budget.
+    response cannot spin without consuming budget, and a Retry-After larger
+    than the remaining budget is re-raised rather than truncated — retrying
+    before the requested delay elapses can extend secondary throttling.
     """
     while True:
         try:
@@ -234,11 +236,10 @@ async def _github_write_with_retry[T](
                 retry_after = float(retry_after_header)
             except (TypeError, ValueError):
                 raise
-            if retry_after <= 0:
+            if retry_after <= 0 or retry_after > budget.remaining_seconds:
                 raise
-            sleep_seconds = min(retry_after, budget.remaining_seconds)
-            budget.remaining_seconds -= sleep_seconds
-            await asyncio.sleep(sleep_seconds)
+            budget.remaining_seconds -= retry_after
+            await asyncio.sleep(retry_after)
 
 
 class BaseWorkspaceSyncTransport(BaseWorkspaceService):

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import hashlib
 import itertools
+import json
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -13,7 +14,6 @@ from typing import Any, Protocol
 from urllib.parse import quote, urlparse
 
 import httpx
-import orjson
 from github.GithubException import GithubException
 from github.InputGitTreeElement import InputGitTreeElement
 from pydantic import BaseModel
@@ -205,7 +205,12 @@ async def _github_write_with_retry[T](
     *,
     budget: _GitHubRetryBudget,
 ) -> T:
-    """Run a GitHub write call, honoring Retry-After within ``budget``."""
+    """Run a GitHub write call, honoring Retry-After within ``budget``.
+
+    GitHub signals rate limiting with either 403 or 429. A nonpositive
+    Retry-After is re-raised rather than retried so a persistent zero-delay
+    response cannot spin without consuming budget.
+    """
     while True:
         try:
             return await asyncio.to_thread(call)
@@ -213,14 +218,16 @@ async def _github_write_with_retry[T](
             headers = {key.lower(): value for key, value in (e.headers or {}).items()}
             retry_after_header = headers.get("retry-after")
             if (
-                e.status != 403
+                e.status not in (403, 429)
                 or retry_after_header is None
                 or budget.remaining_seconds <= 0
             ):
                 raise
             try:
-                retry_after = max(float(retry_after_header), 0.0)
+                retry_after = float(retry_after_header)
             except (TypeError, ValueError):
+                raise
+            if retry_after <= 0:
                 raise
             sleep_seconds = min(retry_after, budget.remaining_seconds)
             budget.remaining_seconds -= sleep_seconds
@@ -516,14 +523,16 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 elements[index : index + _GITHUB_TREE_CHUNK_SIZE]
                 for index in range(0, len(elements), _GITHUB_TREE_CHUNK_SIZE)
             ]
+            # Mirror PyGithub's Requester serialization (json.dumps with default
+            # separators) so the logged size matches the transmitted payload.
             tree_payload_size_bytes = sum(
                 len(
-                    orjson.dumps(
+                    json.dumps(
                         {
                             "base_tree": target_commit.tree.sha,
                             "tree": [element._identity for element in chunk],
                         }
-                    )
+                    ).encode("utf-8")
                 )
                 for chunk in element_chunks
             )

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -167,6 +167,13 @@ _GITHUB_BLOB_CONCURRENCY = 8
 _GITHUB_TREE_CHUNK_SIZE = 128
 """Balance request count against GitHub create-tree timeouts (observed as 422)."""
 
+_GITHUB_TREE_CHUNK_MAX_BYTES = 2 * 1024 * 1024
+"""Cap the serialized payload per create-tree call.
+
+Tree entries embed file content inline, so entry count alone does not bound
+request size. A single entry larger than the cap still ships alone because an
+entry cannot be split."""
+
 _GITHUB_RETRY_BUDGET_SECONDS = 45.0
 """Maximum shared Retry-After delay budget for one GitHub export."""
 
@@ -522,10 +529,23 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 InputGitTreeElement(path=path, mode="100644", type="blob", sha=None)
                 for path in sorted(stale_paths)
             )
-            element_chunks = [
-                elements[index : index + _GITHUB_TREE_CHUNK_SIZE]
-                for index in range(0, len(elements), _GITHUB_TREE_CHUNK_SIZE)
-            ]
+            element_chunks: list[list[InputGitTreeElement]] = []
+            current_chunk: list[InputGitTreeElement] = []
+            current_chunk_bytes = 0
+            for element in elements:
+                element_bytes = len(json.dumps(element._identity).encode("utf-8"))
+                if current_chunk and (
+                    len(current_chunk) >= _GITHUB_TREE_CHUNK_SIZE
+                    or current_chunk_bytes + element_bytes
+                    > _GITHUB_TREE_CHUNK_MAX_BYTES
+                ):
+                    element_chunks.append(current_chunk)
+                    current_chunk = []
+                    current_chunk_bytes = 0
+                current_chunk.append(element)
+                current_chunk_bytes += element_bytes
+            if current_chunk:
+                element_chunks.append(current_chunk)
             # Mirror PyGithub's Requester serialization (json.dumps with default
             # separators) so the logged size matches the transmitted payload.
             tree_payload_size_bytes = sum(

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import itertools
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
@@ -163,6 +164,12 @@ def _path_is_under_roots(path: str, roots: Sequence[str]) -> bool:
 _GITHUB_BLOB_CONCURRENCY = 8
 """Maximum concurrent GitHub blob/content calls during sync reads and writes."""
 
+_GITHUB_TREE_CHUNK_SIZE = 128
+"""Balance request count against GitHub create-tree timeouts (observed as 422)."""
+
+_GITHUB_RETRY_BUDGET_SECONDS = 45.0
+"""Maximum shared Retry-After delay budget for one GitHub export."""
+
 _GITHUB_RATE_LIMIT_HEADER_NAMES = (
     "x-ratelimit-limit",
     "x-ratelimit-remaining",
@@ -177,6 +184,47 @@ _GITLAB_PAGE_SIZE = 100
 
 _GITLAB_BLOB_CONCURRENCY = 8
 """Maximum concurrent GitLab blob calls during sync reads."""
+
+
+@dataclass
+class _GitHubRetryBudget:
+    """Mutable Retry-After delay budget shared by one GitHub export."""
+
+    remaining_seconds: float
+
+
+def _git_blob_sha(content: str) -> str:
+    """Return the Git blob object SHA for UTF-8 ``content``."""
+    content_bytes = content.encode("utf-8")
+    framed_content = b"blob " + str(len(content_bytes)).encode() + b"\0" + content_bytes
+    return hashlib.sha1(framed_content, usedforsecurity=False).hexdigest()
+
+
+async def _github_write_with_retry[T](
+    call: Callable[[], T],
+    *,
+    budget: _GitHubRetryBudget,
+) -> T:
+    """Run a GitHub write call, honoring Retry-After within ``budget``."""
+    while True:
+        try:
+            return await asyncio.to_thread(call)
+        except GithubException as e:
+            headers = {key.lower(): value for key, value in (e.headers or {}).items()}
+            retry_after_header = headers.get("retry-after")
+            if (
+                e.status != 403
+                or retry_after_header is None
+                or budget.remaining_seconds <= 0
+            ):
+                raise
+            try:
+                retry_after = max(float(retry_after_header), 0.0)
+            except (TypeError, ValueError):
+                raise
+            sleep_seconds = min(retry_after, budget.remaining_seconds)
+            budget.remaining_seconds -= sleep_seconds
+            await asyncio.sleep(sleep_seconds)
 
 
 class BaseWorkspaceSyncTransport(BaseWorkspaceService):
@@ -377,58 +425,44 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 )
                 target_branch = await asyncio.to_thread(repo.get_branch, branch)
 
-            content_semaphore = asyncio.Semaphore(_GITHUB_BLOB_CONCURRENCY)
-
-            async def changed_file(path: str, content: str) -> tuple[str, str] | None:
-                """Return ``(path, content)`` when the branch content differs."""
-                existing_content: str | None = None
-                try:
-                    async with content_semaphore:
-                        existing = await asyncio.to_thread(
-                            repo.get_contents,
-                            path,
-                            ref=branch,
-                        )
-                    if not isinstance(existing, list):
-                        existing_content = base64.b64decode(existing.content).decode(
-                            "utf-8"
-                        )
-                except GithubException as e:
-                    if e.status != 404:
-                        raise
-                if existing_content != content:
-                    return path, content
-                return None
-
-            github_stage = "compare_projected_files"
-            github_endpoint = "GET /repos/{owner}/{repo}/contents/{path}"
-            changed_file_entries = await asyncio.gather(
-                *(
-                    changed_file(path, content)
-                    for path, content in sorted(files.items())
-                )
-            )
-            changed_files = {
-                path: content
-                for entry in changed_file_entries
-                if entry is not None
-                for path, content in (entry,)
-            }
-
             github_stage = "resolve_target_commit"
             github_endpoint = "GET /repos/{owner}/{repo}/git/commits/{sha}"
             target_commit = await asyncio.to_thread(
                 repo.get_git_commit,
                 target_branch.commit.sha,
             )
-            github_stage = "scan_stale_paths"
+            github_stage = "read_target_tree"
             github_endpoint = "GET /repos/{owner}/{repo}/git/trees/{sha}"
-            stale_paths = await self._stale_paths_under_roots(
-                repo=repo,
-                tree_sha=target_commit.tree.sha,
-                files=files,
-                roots=delete_missing_paths_under,
+            target_tree = await asyncio.to_thread(
+                repo.get_git_tree,
+                sha=target_commit.tree.sha,
+                recursive=True,
             )
+            target_tree_truncated = target_tree.raw_data.get("truncated") is True
+            target_blob_shas = {
+                item.path: item.sha
+                for item in target_tree.tree
+                if item.type == "blob" and item.path
+            }
+            if target_tree_truncated:
+                changed_files = dict(files)
+                stale_paths: set[str] = set()
+                self.logger.warning(
+                    "Skipping GitHub workspace sync stale-path deletion because "
+                    "the recursive tree response was truncated",
+                    tree_sha=target_commit.tree.sha,
+                )
+            else:
+                changed_files = {
+                    path: content
+                    for path, content in files.items()
+                    if target_blob_shas.get(path) != _git_blob_sha(content)
+                }
+                stale_paths = self._stale_paths_under_roots(
+                    tree_entries=target_tree.tree,
+                    files=files,
+                    roots=delete_missing_paths_under,
+                )
 
             pr_url: str | None = None
             pr_number: int | None = None
@@ -465,71 +499,81 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     message="No changes detected; nothing to commit.",
                 )
 
-            blob_create_semaphore = asyncio.Semaphore(_GITHUB_BLOB_CONCURRENCY)
-
-            async def create_blob_element(
-                path: str,
-                content: str,
-            ) -> InputGitTreeElement:
-                """Create a Git blob and return its tree element."""
-                async with blob_create_semaphore:
-                    blob = await asyncio.to_thread(
-                        repo.create_git_blob,
-                        content,
-                        "utf-8",
-                    )
-                return InputGitTreeElement(
+            elements = [
+                InputGitTreeElement(
                     path=path,
                     mode="100644",
                     type="blob",
-                    sha=blob.sha,
+                    content=content,
                 )
-
-            github_stage = "create_blobs"
-            github_endpoint = "POST /repos/{owner}/{repo}/git/blobs"
-            elements = list(
-                await asyncio.gather(
-                    *(
-                        create_blob_element(path, content)
-                        for path, content in sorted(changed_files.items())
-                    )
-                )
-            )
+                for path, content in sorted(changed_files.items())
+            ]
             elements.extend(
                 InputGitTreeElement(path=path, mode="100644", type="blob", sha=None)
                 for path in sorted(stale_paths)
             )
-            tree_payload_size_bytes = len(
-                orjson.dumps(
-                    {
-                        "base_tree": target_commit.tree.sha,
-                        "tree": [element._identity for element in elements],
-                    }
+            element_chunks = [
+                elements[index : index + _GITHUB_TREE_CHUNK_SIZE]
+                for index in range(0, len(elements), _GITHUB_TREE_CHUNK_SIZE)
+            ]
+            tree_payload_size_bytes = sum(
+                len(
+                    orjson.dumps(
+                        {
+                            "base_tree": target_commit.tree.sha,
+                            "tree": [element._identity for element in chunk],
+                        }
+                    )
                 )
+                for chunk in element_chunks
             )
 
             self.logger.info(
                 "Creating GitHub workspace sync tree",
                 tree_entry_count=len(elements),
+                tree_chunk_count=len(element_chunks),
                 tree_payload_size_bytes=tree_payload_size_bytes,
             )
-            github_stage = "create_tree"
-            github_endpoint = "POST /repos/{owner}/{repo}/git/trees"
-            tree = await asyncio.to_thread(
-                repo.create_git_tree,
-                elements,
-                base_tree=target_commit.tree,
+            retry_budget = _GitHubRetryBudget(_GITHUB_RETRY_BUDGET_SECONDS)
+            tree = target_commit.tree
+            for chunk_index, chunk in enumerate(element_chunks, start=1):
+                github_stage = "create_tree_chunk"
+                github_endpoint = "POST /repos/{owner}/{repo}/git/trees"
+                base_tree = tree
+                tree = await _github_write_with_retry(
+                    lambda chunk=chunk, base_tree=base_tree: repo.create_git_tree(
+                        chunk,
+                        base_tree=base_tree,
+                    ),
+                    budget=retry_budget,
+                )
+                self.logger.info(
+                    "Created GitHub workspace sync tree chunk",
+                    tree_chunk_index=chunk_index,
+                    tree_chunk_count=len(element_chunks),
+                    tree_entry_count=len(chunk),
+                    tree_sha=tree.sha,
+                )
+
+            github_stage = "create_commit"
+            github_endpoint = "POST /repos/{owner}/{repo}/git/commits"
+            commit = await _github_write_with_retry(
+                lambda: repo.create_git_commit(
+                    message,
+                    tree,
+                    [target_commit],
+                ),
+                budget=retry_budget,
             )
-            github_stage = "finalize_commit"
-            github_endpoint = "POST|PATCH /repos/{owner}/{repo}/git/commits|refs"
-            commit = await asyncio.to_thread(
-                repo.create_git_commit,
-                message,
-                tree,
-                [target_commit],
-            )
+            github_stage = "resolve_target_ref"
+            github_endpoint = "GET /repos/{owner}/{repo}/git/ref/heads/{branch}"
             ref = await asyncio.to_thread(repo.get_git_ref, f"heads/{branch}")
-            await asyncio.to_thread(ref.edit, sha=commit.sha)
+            github_stage = "update_target_ref"
+            github_endpoint = "PATCH /repos/{owner}/{repo}/git/refs/heads/{branch}"
+            await _github_write_with_retry(
+                lambda: ref.edit(sha=commit.sha),
+                budget=retry_budget,
+            )
             self.logger.info(
                 "Updated GitHub workspace sync ref",
                 tree_sha=tree.sha,
@@ -577,15 +621,14 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         finally:
             gh.close()
 
-    async def _stale_paths_under_roots(
+    def _stale_paths_under_roots(
         self,
         *,
-        repo: Any,
-        tree_sha: str,
+        tree_entries: Sequence[Any],
         files: dict[str, str],
         roots: Sequence[str],
     ) -> set[str]:
-        """Return managed blob paths at ``tree_sha`` no longer in ``files``.
+        """Return managed blob paths in ``tree_entries`` no longer in ``files``.
 
         These are the stale files under ``roots`` that an export should delete so
         the branch mirrors the projected workspace exactly.
@@ -594,14 +637,9 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         if not managed_roots:
             return set()
 
-        tree = await asyncio.to_thread(
-            repo.get_git_tree,
-            sha=tree_sha,
-            recursive=True,
-        )
         return {
             item.path
-            for item in tree.tree
+            for item in tree_entries
             if item.type == "blob"
             and item.path
             and item.path not in files


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch GitHub export writes by diffing a single recursive tree and sending changed files inline in incremental create-tree chunks, bounded by entry count and serialized payload size. Oversized entries upload as blobs by SHA; this cuts large exports (e.g., 807 files) from ~1,800 requests to ~12 and adds robust 403/429 Retry-After handling with a shared budget, including branch creation. Addresses ENG-1538.

- **Refactors**
  - Compute Git blob SHAs locally and diff against one recursive tree; skip stale deletions when the tree is truncated.
  - Pack inline tree entries greedily; enforce 128-entry and 2MB serialized caps by reserving JSON envelope and separator bytes; split into sequential tree chunks and log per-chunk payload size using `json.dumps` to match `PyGithub`.
  - Upload entries that exceed the per-chunk cap via blob uploads and reference by SHA.
  - Route write calls (branch creation, blob upload, tree chunks, commit, ref update) through a shared Retry-After helper; retry 403/429, and re-raise on nonpositive delays or when exceeding the budget.

<sup>Written for commit d7d86fdcc323ae26d448ea01495856ae7167e9a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

