### PR TITLE
refactor(executor): make Action Gateway mandatory

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -231,10 +231,12 @@ jobs:
             uv run pytest tests/temporal -m "not live_secret and not requires_api" -n auto -ra -o faulthandler_timeout=300
 
             # API-backed temporal tests start a local API process against the
-            # test DB. Run them serially to avoid startup races under xdist.
+            # test DB. Run them serially to avoid startup races under xdist,
+            # with enough pool headroom for concurrent gateway-backed actions.
             TRACECAT_TEST_API_MODE=inprocess \
             TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
             TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
+            TRACECAT__DB_MAX_OVERFLOW=9 \
             uv run pytest tests/temporal -m "requires_api and not live_secret" -ra -o faulthandler_timeout=300
           else
             uv run pytest tests/${{ matrix.test_group }} -m "not live_secret" -n auto -ra -o faulthandler_timeout=300

--- a/packages/tracecat-registry/tracecat_registry/context.py
+++ b/packages/tracecat-registry/tracecat_registry/context.py
@@ -103,6 +103,9 @@ class RegistryContext:
         """Get the SDK client for this context."""
         from tracecat_registry.sdk.client import TracecatClient
 
+        if self._client is not None:
+            return self._client
+
         return TracecatClient(
             token=self.token,
             workspace_id=self.workspace_id,

--- a/packages/tracecat-registry/tracecat_registry/context.py
+++ b/packages/tracecat-registry/tracecat_registry/context.py
@@ -104,7 +104,6 @@ class RegistryContext:
         from tracecat_registry.sdk.client import TracecatClient
 
         return TracecatClient(
-            api_url=self.api_url,
             token=self.token,
             workspace_id=self.workspace_id,
         )

--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -25,13 +25,13 @@ if TYPE_CHECKING:
 
 
 class TracecatClient:
-    """HTTP client for Tracecat API with JWT authentication.
+    """HTTP client for the executor-local Action Gateway.
 
     This client is used by registry actions to communicate with the
-    Tracecat API when running in a sandboxed environment.
+    executor-local Action Gateway when running in a sandboxed environment.
 
     Configuration is read from environment variables:
-    - TRACECAT__API_URL: Base URL of the Tracecat API
+    - TRACECAT__ACTION_GATEWAY_SOCKET: Local gateway Unix socket
     - TRACECAT__EXECUTOR_TOKEN: JWT token for authentication
     - TRACECAT__WORKSPACE_ID: Current workspace ID (added to requests)
     """
@@ -39,7 +39,6 @@ class TracecatClient:
     def __init__(
         self,
         *,
-        api_url: str | None = None,
         action_gateway_socket: str | None = None,
         token: str | None = None,
         workspace_id: str | None = None,
@@ -48,21 +47,19 @@ class TracecatClient:
         """Initialize the client.
 
         Args:
-            api_url: Base URL of the Tracecat API. Defaults to TRACECAT__API_URL env var.
-            action_gateway_socket: Compatibility override for the executor-local
-                gateway socket. Defaults to TRACECAT__ACTION_GATEWAY_SOCKET.
+            action_gateway_socket: Executor-local gateway socket. Defaults to
+                TRACECAT__ACTION_GATEWAY_SOCKET and is required.
             token: JWT token for authentication. Defaults to TRACECAT__EXECUTOR_TOKEN env var.
             workspace_id: Workspace ID. Defaults to TRACECAT__WORKSPACE_ID env var.
             timeout: Request timeout in seconds.
         """
-        self._api_url = self._normalize_internal_url(
-            api_url or os.environ.get("TRACECAT__API_URL", "http://api:8000")
-        )
         self._action_gateway_socket = action_gateway_socket or os.environ.get(
             "TRACECAT__ACTION_GATEWAY_SOCKET"
         )
         if not self._action_gateway_socket:
-            self._action_gateway_socket = None
+            raise RuntimeError(
+                "TRACECAT__ACTION_GATEWAY_SOCKET is required for Tracecat SDK calls"
+            )
 
         self._token = token or os.environ.get("TRACECAT__EXECUTOR_TOKEN", "")
         self._workspace_id = workspace_id or os.environ.get(
@@ -78,25 +75,11 @@ class TracecatClient:
         self._variables: VariablesClient | None = None
         self._workflows: WorkflowsClient | None = None
 
-    @staticmethod
-    def _normalize_internal_url(base_url: str) -> str:
-        """Normalize a base URL so SDK paths resolve under /internal."""
-        if base_url.endswith("/internal"):
-            return base_url
-        return base_url.rstrip("/") + "/internal"
-
-    @property
-    def api_url(self) -> str:
-        """Base URL of the Tracecat API."""
-        return self._api_url
-
     def _request_url_and_transport(
         self,
         path: str,
-    ) -> tuple[str, httpx.AsyncHTTPTransport | None]:
-        """Return the target URL and transport for an internal SDK request."""
-        if self._action_gateway_socket is None:
-            return f"{self._api_url}{path}", None
+    ) -> tuple[str, httpx.AsyncHTTPTransport]:
+        """Return the Action Gateway URL and Unix socket transport."""
         return (
             f"http://tracecat-action-gateway/internal{path}",
             httpx.AsyncHTTPTransport(uds=self._action_gateway_socket),
@@ -216,7 +199,7 @@ class TracecatClient:
         json: Any | None = None,
         headers: dict[str, str] | None = None,
     ) -> Any:
-        """Make an authenticated HTTP request to the API.
+        """Make an authenticated HTTP request to the Action Gateway.
 
         Args:
             method: HTTP method (GET, POST, PUT, DELETE, etc.)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,9 @@ TEST_ORG_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 # Worker-specific configuration for pytest-xdist parallel execution
 # Get xdist worker ID, defaults to "master" if not using xdist
 WORKER_ID = os.environ.get("PYTEST_XDIST_WORKER", "master")
+ACTION_GATEWAY_TEST_SOCKET = (
+    Path("/tmp") / f"tracecat-action-gateway-{os.getpid()}-{WORKER_ID}.sock"
+)
 
 # Generate worker-specific port offsets
 # master = 0, gw0 = 0, gw1 = 1, gw2 = 2, etc.
@@ -1225,6 +1228,15 @@ def env_sandbox(monkeysession: pytest.MonkeyPatch):
     monkeysession.setattr(config, "TRACECAT__API_URL", api_url)
     monkeysession.setenv("TRACECAT__API_URL", api_url)
     monkeysession.setenv("TRACECAT__EXECUTOR_URL", executor_url)
+    monkeysession.setattr(
+        config,
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        str(ACTION_GATEWAY_TEST_SOCKET),
+    )
+    monkeysession.setenv(
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        str(ACTION_GATEWAY_TEST_SOCKET),
+    )
     # Use TestBackend for in-process executor (no sandbox overhead) unless overridden
     if not IN_DOCKER:
         monkeysession.setattr(config, "TRACECAT__EXECUTOR_BACKEND", "test")
@@ -1856,15 +1868,21 @@ def threadpool() -> Iterator[ThreadPoolExecutor]:
 
 @pytest.fixture(scope="function")
 async def executor_backend() -> AsyncGenerator[ExecutorBackend, None]:
-    """Initialize executor backend once per test function."""
+    """Initialize the executor backend and its worker-owned action gateway."""
+    from tracecat.executor.action_gateway.server import ActionGateway
     from tracecat.executor.backends import (
         initialize_executor_backend,
         shutdown_executor_backend,
     )
 
-    backend = await initialize_executor_backend()
-    yield backend
-    await shutdown_executor_backend()
+    action_gateway = ActionGateway(socket_path=ACTION_GATEWAY_TEST_SOCKET)
+    await action_gateway.start()
+    try:
+        backend = await initialize_executor_backend()
+        yield backend
+    finally:
+        await shutdown_executor_backend()
+        await action_gateway.stop()
 
 
 @pytest.fixture(scope="function")

--- a/tests/registry/test_cases_characterization.py
+++ b/tests/registry/test_cases_characterization.py
@@ -16,8 +16,8 @@ import base64
 import uuid
 from typing import Any, cast, get_args
 
+import httpx
 import pytest
-import respx
 import sqlalchemy as sa
 from httpx import ASGITransport
 from pydantic import TypeAdapter
@@ -59,7 +59,6 @@ from tracecat_registry.sdk.exceptions import (
 )
 
 from tracecat import config
-from tracecat.api.app import app
 from tracecat.auth.dependencies import (
     ExecutorWorkspaceRole,
     OrgUserRole,
@@ -80,11 +79,14 @@ from tracecat.cases.service import CaseFieldsService
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import get_async_session
 from tracecat.db.models import User, Workspace
+from tracecat.executor.action_gateway.app import create_app as create_action_gateway_app
 
 # Advisory lock ID for serializing case_fields schema creation in tests.
 # This prevents deadlocks when concurrent tests create workspace-scoped tables
 # with FK constraints to the same parent table.
 _CASE_FIELDS_SCHEMA_LOCK_ID = 0x7472616365636174  # "tracecat" in hex
+_ACTION_GATEWAY_SOCKET = "/tmp/tracecat-test-action-gateway.sock"
+app = create_action_gateway_app()
 
 
 def _case_items(
@@ -113,6 +115,7 @@ async def cases_test_role(svc_workspace: Workspace) -> Role:
 async def cases_ctx(
     cases_test_role: Role,
     session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Set up the ctx_role and registry context for case UDF tests.
 
@@ -121,8 +124,10 @@ async def cases_ctx(
     because CREATE TABLE with FK constraints acquires ShareRowExclusiveLock on
     the referenced table, and concurrent schema creations can deadlock.
 
-    Uses SDK path with respx mock to route HTTP calls to the FastAPI app.
+    Routes SDK calls through the Action Gateway ASGI app.
     """
+    monkeypatch.setattr(config, "TRACECAT__DB_ENCRYPTION_KEY", "enabled")
+
     # Acquire advisory lock to serialize schema creation across concurrent tests
     await session.execute(
         sa.text(f"SELECT pg_advisory_xact_lock({_CASE_FIELDS_SCHEMA_LOCK_ID})")
@@ -149,17 +154,16 @@ async def cases_ctx(
         run_id="test-run-id",
         wf_exec_id=wf_exec_id,
         environment="default",
-        api_url=config.TRACECAT__API_URL,
         token=executor_token,
     )
     set_context(registry_ctx)
+    monkeypatch.setenv("TRACECAT__ACTION_GATEWAY_SOCKET", _ACTION_GATEWAY_SOCKET)
 
-    # Set up respx mock to route SDK HTTP calls to the FastAPI app
-    respx_mock = respx.mock(assert_all_mocked=False, assert_all_called=False)
-    respx_mock.start()
-    respx_mock.route(url__startswith=config.TRACECAT__API_URL).mock(
-        side_effect=ASGITransport(app).handle_async_request
-    )
+    def create_gateway_transport(*, uds: str) -> ASGITransport:
+        assert uds == _ACTION_GATEWAY_SOCKET
+        return ASGITransport(app=app)
+
+    monkeypatch.setattr(httpx, "AsyncHTTPTransport", create_gateway_transport)
 
     # Override role dependencies to use our test role
     def override_role():
@@ -190,7 +194,6 @@ async def cases_ctx(
     finally:
         ctx_role.reset(token)
         clear_context()
-        respx_mock.stop()
         app.dependency_overrides.clear()
 
 

--- a/tests/registry/test_context.py
+++ b/tests/registry/test_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from tracecat_registry.context import RegistryContext
+from tracecat_registry.sdk.client import TracecatClient
 
 
 def test_registry_context_preserves_positional_executor_url_token_compat() -> None:
@@ -26,3 +27,16 @@ def test_registry_context_preserves_positional_executor_url_token_compat() -> No
     assert context.api_url == "http://api:8000"
     assert context.executor_url == "http://executor:8000"
     assert context.token == "executor-token"
+
+
+def test_registry_context_uses_injected_client() -> None:
+    """In-process executor backends can bind SDK calls to their gateway."""
+    client = TracecatClient(action_gateway_socket="/tmp/action-gateway.sock")
+    context = RegistryContext(
+        workspace_id="workspace-id",
+        workflow_id="workflow-id",
+        run_id="run-id",
+        _client=client,
+    )
+
+    assert context.client is client

--- a/tests/registry/test_internal_workflow_router.py
+++ b/tests/registry/test_internal_workflow_router.py
@@ -456,9 +456,9 @@ class TestInvalidPatchApplicationRaisesToolError:
 class TestInternalRouterCoversSdkPaths:
     """The internal router must expose every path the workflows SDK calls.
 
-    ``TracecatClient`` normalizes the SDK base URL under ``/internal``, so any
-    SDK method whose path is missing from the internal router 404s when a
-    registry action invokes it. These assertions lock the webhook and
+    ``TracecatClient`` sends SDK paths to the Action Gateway under ``/internal``,
+    so any missing route 404s when a registry action invokes it. These
+    assertions lock the webhook and
     case-trigger routes (added alongside the chat tools that drive them) into
     the router so the SDK<->route contract can't silently drift.
     """

--- a/tests/registry/test_sdk_errors.py
+++ b/tests/registry/test_sdk_errors.py
@@ -9,7 +9,9 @@ from tracecat_registry.sdk.exceptions import (
 
 
 def test_error_response_preserves_message_field() -> None:
-    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    client = TracecatClient(
+        action_gateway_socket="/tmp/action-gateway.sock", token="", workspace_id=""
+    )
     response = httpx.Response(500, json={"message": "database temporarily unavailable"})
 
     with pytest.raises(TracecatAPIError) as exc_info:
@@ -20,7 +22,9 @@ def test_error_response_preserves_message_field() -> None:
 
 
 def test_error_response_preserves_structured_detail() -> None:
-    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    client = TracecatClient(
+        action_gateway_socket="/tmp/action-gateway.sock", token="", workspace_id=""
+    )
     detail = {
         "code": "DATABASE_VALUE_TYPE_MISMATCH",
         "message": "A field received a value with an incompatible type.",
@@ -37,7 +41,9 @@ def test_error_response_preserves_structured_detail() -> None:
 
 @pytest.mark.parametrize("detail", ["", [], {}, 0, False])
 def test_error_response_preserves_falsey_detail_field(detail: object) -> None:
-    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    client = TracecatClient(
+        action_gateway_socket="/tmp/action-gateway.sock", token="", workspace_id=""
+    )
     response = httpx.Response(500, json={"detail": detail, "message": "fallback"})
 
     with pytest.raises(TracecatAPIError) as exc_info:
@@ -48,7 +54,9 @@ def test_error_response_preserves_falsey_detail_field(detail: object) -> None:
 
 
 def test_error_response_uses_message_when_detail_is_null() -> None:
-    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    client = TracecatClient(
+        action_gateway_socket="/tmp/action-gateway.sock", token="", workspace_id=""
+    )
     response = httpx.Response(
         500,
         json={"detail": None, "message": "database temporarily unavailable"},
@@ -68,7 +76,9 @@ def test_error_string_renders_empty_structured_detail() -> None:
 
 
 def test_not_found_response_preserves_message_field() -> None:
-    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    client = TracecatClient(
+        action_gateway_socket="/tmp/action-gateway.sock", token="", workspace_id=""
+    )
     response = httpx.Response(404, json={"message": "variable not found"})
 
     with pytest.raises(TracecatNotFoundError) as exc_info:

--- a/tests/registry/test_table_characterization.py
+++ b/tests/registry/test_table_characterization.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 import uuid
 from typing import get_args
 
+import httpx
 import pytest
-import respx
 from httpx import ASGITransport
 from pydantic import TypeAdapter
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -37,14 +37,16 @@ from tracecat_registry.core.table import (
     update_row,
 )
 
-from tracecat import config
-from tracecat.api.app import app
 from tracecat.auth.dependencies import ExecutorWorkspaceRole
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import get_async_session
 from tracecat.db.models import Workspace
+from tracecat.executor.action_gateway.app import create_app as create_action_gateway_app
+
+_ACTION_GATEWAY_SOCKET = "/tmp/tracecat-test-action-gateway.sock"
+app = create_action_gateway_app()
 
 
 @pytest.fixture
@@ -64,26 +66,26 @@ async def table_test_role(svc_workspace: Workspace) -> Role:
 async def table_ctx(
     table_test_role: Role,
     session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """Set up the ctx_role and registry context for table UDF tests.
 
-    Uses SDK path with respx mock to route HTTP calls to the FastAPI app.
+    Routes SDK calls through the Action Gateway ASGI app.
     """
     registry_ctx = RegistryContext(
         workspace_id=str(table_test_role.workspace_id),
         workflow_id="test-workflow-id",
         run_id="test-run-id",
         environment="default",
-        api_url=config.TRACECAT__API_URL,
     )
     set_context(registry_ctx)
+    monkeypatch.setenv("TRACECAT__ACTION_GATEWAY_SOCKET", _ACTION_GATEWAY_SOCKET)
 
-    # Set up respx mock to route SDK HTTP calls to the FastAPI app
-    respx_mock = respx.mock(assert_all_mocked=False, assert_all_called=False)
-    respx_mock.start()
-    respx_mock.route(url__startswith=config.TRACECAT__API_URL).mock(
-        side_effect=ASGITransport(app).handle_async_request
-    )
+    def create_gateway_transport(*, uds: str) -> ASGITransport:
+        assert uds == _ACTION_GATEWAY_SOCKET
+        return ASGITransport(app=app)
+
+    monkeypatch.setattr(httpx, "AsyncHTTPTransport", create_gateway_transport)
 
     def override_role():
         return table_test_role
@@ -103,7 +105,6 @@ async def table_ctx(
     finally:
         ctx_role.reset(token)
         clear_context()
-        respx_mock.stop()
         app.dependency_overrides.clear()
 
 

--- a/tests/registry/test_tracecat_client.py
+++ b/tests/registry/test_tracecat_client.py
@@ -15,9 +15,7 @@ async def test_request_uses_action_gateway_unix_socket(
 ) -> None:
     """Current SDKs route internal requests through the gateway socket from env.
 
-    This is the normal executor path for freshly loaded SDK code. The client
-    keeps `api_url` unchanged for callers, but selects a UDS transport for the
-    actual request when `TRACECAT__ACTION_GATEWAY_SOCKET` is set.
+    This is the only executor path for freshly loaded SDK code.
     """
     monkeypatch.setenv(
         "TRACECAT__ACTION_GATEWAY_SOCKET",
@@ -65,7 +63,6 @@ async def test_request_uses_action_gateway_unix_socket(
     monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
 
     client = TracecatClient(
-        api_url="http://api:8000",
         token="executor-token",
         timeout=12.0,
     )
@@ -84,77 +81,21 @@ async def test_request_uses_action_gateway_unix_socket(
 
 
 @pytest.mark.anyio
-async def test_empty_action_gateway_socket_env_uses_api_url(
+async def test_empty_action_gateway_socket_env_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An empty socket env var is treated as disabled and falls back to API URL.
-
-    This keeps local/dev environments from accidentally constructing an invalid
-    UDS transport when the socket variable is present but blank.
-    """
+    """An empty socket cannot silently route SDK traffic to the API service."""
     monkeypatch.setenv("TRACECAT__ACTION_GATEWAY_SOCKET", "")
-    captured: dict[str, Any] = {}
 
-    class FakeAsyncClient:
-        def __init__(
-            self,
-            *,
-            transport: object | None,
-            timeout: float,
-        ) -> None:
-            captured["transport"] = transport
-            captured["timeout"] = timeout
-
-        async def __aenter__(self) -> FakeAsyncClient:
-            return self
-
-        async def __aexit__(self, *args: object) -> None:
-            return None
-
-        async def request(
-            self,
-            method: str,
-            url: str,
-            *,
-            params: dict[str, Any] | None,
-            json: Any | None,
-            headers: dict[str, str],
-        ) -> httpx.Response:
-            captured["method"] = method
-            captured["url"] = url
-            captured["params"] = params
-            captured["json"] = json
-            captured["headers"] = headers
-            return httpx.Response(200, json={"ok": True})
-
-    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
-
-    client = TracecatClient(
-        api_url="http://api:8000",
-        token="executor-token",
-        timeout=12.0,
-    )
-
-    result = await client.get("/cases/case-id")
-
-    assert result == {"ok": True}
-    assert captured["transport"] is None
-    assert captured["timeout"] == 12.0
-    assert captured["method"] == "GET"
-    assert captured["url"] == "http://api:8000/internal/cases/case-id"
-    assert captured["headers"]["Authorization"] == "Bearer executor-token"
+    with pytest.raises(RuntimeError, match="ACTION_GATEWAY_SOCKET is required"):
+        TracecatClient(token="executor-token")
 
 
 @pytest.mark.anyio
-async def test_action_gateway_socket_keyword_is_supported_for_compat(
+async def test_action_gateway_socket_keyword_selects_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The rc-era explicit socket keyword remains a TracecatClient-only alias.
-
-    The keyword is kept for direct SDK callers from the rc line, but it does not
-    flow through `RegistryContext`; transport selection remains private to the
-    client/minimal-runner boundary.
-    """
+    """Direct SDK callers can provide the mandatory gateway socket explicitly."""
     monkeypatch.delenv("TRACECAT__ACTION_GATEWAY_SOCKET", raising=False)
     captured: dict[str, Any] = {}
 
@@ -198,7 +139,6 @@ async def test_action_gateway_socket_keyword_is_supported_for_compat(
     monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
 
     client = TracecatClient(
-        api_url="http://api:8000",
         action_gateway_socket="/var/run/tracecat/action-gateway.sock",
         token="executor-token",
         timeout=12.0,
@@ -215,62 +155,11 @@ async def test_action_gateway_socket_keyword_is_supported_for_compat(
 
 
 @pytest.mark.anyio
-async def test_request_uses_api_url_without_action_gateway(
+async def test_missing_action_gateway_socket_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SDK requests keep using TRACECAT__API_URL when no gateway socket exists.
-
-    This covers non-executor contexts and disabled gateway deployments, where
-    the SDK should behave like the pre-gateway client.
-    """
+    """Missing gateway configuration fails before any SDK request is attempted."""
     monkeypatch.delenv("TRACECAT__ACTION_GATEWAY_SOCKET", raising=False)
-    captured: dict[str, Any] = {}
 
-    class FakeAsyncClient:
-        def __init__(
-            self,
-            *,
-            transport: object | None,
-            timeout: float,
-        ) -> None:
-            captured["transport"] = transport
-            captured["timeout"] = timeout
-
-        async def __aenter__(self) -> FakeAsyncClient:
-            return self
-
-        async def __aexit__(self, *args: object) -> None:
-            return None
-
-        async def request(
-            self,
-            method: str,
-            url: str,
-            *,
-            params: dict[str, Any] | None,
-            json: Any | None,
-            headers: dict[str, str],
-        ) -> httpx.Response:
-            captured["method"] = method
-            captured["url"] = url
-            captured["params"] = params
-            captured["json"] = json
-            captured["headers"] = headers
-            return httpx.Response(200, json={"ok": True})
-
-    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
-
-    client = TracecatClient(
-        api_url="http://api:8000",
-        token="executor-token",
-        timeout=12.0,
-    )
-
-    result = await client.get("/cases/case-id")
-
-    assert result == {"ok": True}
-    assert captured["transport"] is None
-    assert captured["timeout"] == 12.0
-    assert captured["method"] == "GET"
-    assert captured["url"] == "http://api:8000/internal/cases/case-id"
-    assert captured["headers"]["Authorization"] == "Bearer executor-token"
+    with pytest.raises(RuntimeError, match="ACTION_GATEWAY_SOCKET is required"):
+        TracecatClient(token="executor-token")

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -7,9 +7,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 from _pytest.fixtures import FixtureRequest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from tracecat.api.app import app
+from tracecat.api.app import app as api_app
 from tracecat.auth.credentials import AuthenticatedUserOnly, SuperuserRole
 from tracecat.auth.dependencies import (
     ExecutorWorkspaceRole,
@@ -32,12 +33,14 @@ from tracecat.authz.scopes import (
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session, get_async_session_bypass_rls
 from tracecat.db.models import Workspace
+from tracecat.executor.action_gateway.app import create_app as create_action_gateway_app
 from tracecat.service_accounts.router import WorkspaceUserOnlyInPath
 from tracecat.workspaces.router import (
     WorkspaceUserInPath,
 )
 
 _FALLBACK_ROLE: Role | None = None
+_ACTION_GATEWAY_APP = create_action_gateway_app()
 
 
 def override_role_dependency() -> Role:
@@ -61,9 +64,11 @@ async def _inject_test_role_middleware(request, call_next):
         ctx_role.reset(token)
 
 
-@pytest.fixture
-def client(request: FixtureRequest) -> Generator[TestClient, None, None]:
-    """Create FastAPI test client.
+def _test_client(
+    app: FastAPI,
+    request: FixtureRequest,
+) -> Generator[TestClient, None, None]:
+    """Create a role-aware FastAPI test client for the requested app.
 
     Uses the existing app instance and relies on ctx_role context
     from test_role/test_admin_role fixtures for authentication.
@@ -117,6 +122,20 @@ def client(request: FixtureRequest) -> Generator[TestClient, None, None]:
     yield client
     # Clean up overrides
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(request: FixtureRequest) -> Generator[TestClient, None, None]:
+    """Create a test client for the public API app."""
+    yield from _test_client(api_app, request)
+
+
+@pytest.fixture
+def action_gateway_client(
+    request: FixtureRequest,
+) -> Generator[TestClient, None, None]:
+    """Create a test client for executor-only Action Gateway routes."""
+    yield from _test_client(_ACTION_GATEWAY_APP, request)
 
 
 @pytest.fixture

--- a/tests/unit/api/test_api_case_rows.py
+++ b/tests/unit/api/test_api_case_rows.py
@@ -142,7 +142,7 @@ async def test_link_case_row_returns_409_for_duplicate_link(
 
 @pytest.mark.anyio
 async def test_internal_link_case_row_returns_404_for_missing_case(
-    client: TestClient, test_admin_role: Role
+    action_gateway_client: TestClient, test_admin_role: Role
 ) -> None:
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()
@@ -156,7 +156,7 @@ async def test_internal_link_case_row_returns_404_for_missing_case(
         )
         mock_service_cls.return_value = mock_service
 
-        response = client.post(
+        response = action_gateway_client.post(
             f"/internal/cases/{case_id}/rows",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"table_id": str(table_id), "row_id": str(row_id)},
@@ -168,7 +168,7 @@ async def test_internal_link_case_row_returns_404_for_missing_case(
 
 @pytest.mark.anyio
 async def test_internal_link_case_row_returns_400_for_value_error(
-    client: TestClient, test_admin_role: Role
+    action_gateway_client: TestClient, test_admin_role: Role
 ) -> None:
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()
@@ -183,7 +183,7 @@ async def test_internal_link_case_row_returns_400_for_value_error(
         )
         mock_service_cls.return_value = mock_service
 
-        response = client.post(
+        response = action_gateway_client.post(
             f"/internal/cases/{case_id}/rows",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"table_id": str(table_id), "row_id": str(row_id)},
@@ -195,7 +195,7 @@ async def test_internal_link_case_row_returns_400_for_value_error(
 
 @pytest.mark.anyio
 async def test_internal_link_case_row_returns_409_for_duplicate_link(
-    client: TestClient, test_admin_role: Role
+    action_gateway_client: TestClient, test_admin_role: Role
 ) -> None:
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()
@@ -208,7 +208,7 @@ async def test_internal_link_case_row_returns_409_for_duplicate_link(
         mock_service.link_row.side_effect = _duplicate_case_row_link_error()
         mock_service_cls.return_value = mock_service
 
-        response = client.post(
+        response = action_gateway_client.post(
             f"/internal/cases/{case_id}/rows",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"table_id": str(table_id), "row_id": str(row_id)},

--- a/tests/unit/api/test_api_internal_cases.py
+++ b/tests/unit/api/test_api_internal_cases.py
@@ -78,7 +78,7 @@ def _build_comment_read(
 
 @pytest.mark.anyio
 async def test_internal_get_case_include_rows_hydrates_rows(
-    client: TestClient, test_admin_role: Role, mock_internal_case: Case
+    action_gateway_client: TestClient, test_admin_role: Role, mock_internal_case: Case
 ) -> None:
     row = _build_case_row(mock_internal_case.id)
     with (
@@ -101,7 +101,7 @@ async def test_internal_get_case_include_rows_hydrates_rows(
         mock_service.fields.list_fields.return_value = []
         mock_service_cls.return_value = mock_service
 
-        response = client.get(
+        response = action_gateway_client.get(
             f"/internal/cases/{mock_internal_case.id}",
             params={
                 "workspace_id": str(test_admin_role.workspace_id),
@@ -118,7 +118,7 @@ async def test_internal_get_case_include_rows_hydrates_rows(
 
 @pytest.mark.anyio
 async def test_internal_update_case_include_rows_hydrates_rows(
-    client: TestClient, test_admin_role: Role, mock_internal_case: Case
+    action_gateway_client: TestClient, test_admin_role: Role, mock_internal_case: Case
 ) -> None:
     row = _build_case_row(mock_internal_case.id)
     with (
@@ -144,7 +144,7 @@ async def test_internal_update_case_include_rows_hydrates_rows(
         mock_service.fields.list_fields.return_value = []
         mock_service_cls.return_value = mock_service
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             f"/internal/cases/{mock_internal_case.id}",
             params={
                 "workspace_id": str(test_admin_role.workspace_id),
@@ -163,7 +163,7 @@ async def test_internal_update_case_include_rows_hydrates_rows(
 
 @pytest.mark.anyio
 async def test_internal_create_case_simple_invalid_numeric_fields_returns_400(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     with patch.object(internal_cases_router, "CasesService") as mock_service_cls:
@@ -173,7 +173,7 @@ async def test_internal_create_case_simple_invalid_numeric_fields_returns_400(
         )
         mock_service_cls.return_value = mock_service
 
-        response = client.post(
+        response = action_gateway_client.post(
             "/internal/cases/simple",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={
@@ -192,7 +192,7 @@ async def test_internal_create_case_simple_invalid_numeric_fields_returns_400(
 
 @pytest.mark.anyio
 async def test_internal_update_case_simple_invalid_integer_fields_returns_400(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_internal_case: Case,
 ) -> None:
@@ -204,7 +204,7 @@ async def test_internal_update_case_simple_invalid_integer_fields_returns_400(
         )
         mock_service_cls.return_value = mock_service
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             f"/internal/cases/{mock_internal_case.id}/simple",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"fields": {"attempts": "1.5"}},
@@ -216,7 +216,7 @@ async def test_internal_update_case_simple_invalid_integer_fields_returns_400(
 
 @pytest.mark.anyio
 async def test_internal_list_cases_validates_field_ids_even_when_page_is_empty(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     with (
@@ -240,7 +240,7 @@ async def test_internal_list_cases_validates_field_ids_even_when_page_is_empty(
         mock_service_cls.return_value = mock_service
         mock_fields_service_cls.return_value = mock_fields_service
 
-        response = client.get(
+        response = action_gateway_client.get(
             "/internal/cases",
             params=[
                 ("workspace_id", str(test_admin_role.workspace_id)),
@@ -258,7 +258,7 @@ async def test_internal_list_cases_validates_field_ids_even_when_page_is_empty(
 
 @pytest.mark.anyio
 async def test_internal_search_cases_validates_field_ids_even_when_page_is_empty(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     with (
@@ -284,7 +284,7 @@ async def test_internal_search_cases_validates_field_ids_even_when_page_is_empty
         mock_service_cls.return_value = mock_service
         mock_fields_service_cls.return_value = mock_fields_service
 
-        response = client.get(
+        response = action_gateway_client.get(
             "/internal/cases/search",
             params=[
                 ("workspace_id", str(test_admin_role.workspace_id)),
@@ -302,7 +302,7 @@ async def test_internal_search_cases_validates_field_ids_even_when_page_is_empty
 
 @pytest.mark.anyio
 async def test_internal_list_comment_threads_success(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_internal_case: Case,
 ) -> None:
@@ -333,7 +333,7 @@ async def test_internal_list_comment_threads_success(
         mock_comments_service.list_comment_threads.return_value = [thread]
         mock_comments_service_cls.return_value = mock_comments_service
 
-        response = client.get(
+        response = action_gateway_client.get(
             f"/internal/cases/{mock_internal_case.id}/comments/threads",
             params={"workspace_id": str(test_admin_role.workspace_id)},
         )
@@ -347,7 +347,7 @@ async def test_internal_list_comment_threads_success(
 
 @pytest.mark.anyio
 async def test_internal_list_comment_threads_requires_case_addons(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_internal_case: Case,
 ) -> None:
@@ -367,7 +367,7 @@ async def test_internal_list_comment_threads_requires_case_addons(
         )
         mock_comments_service_cls.return_value = mock_comments_service
 
-        response = client.get(
+        response = action_gateway_client.get(
             f"/internal/cases/{mock_internal_case.id}/comments/threads",
             params={"workspace_id": str(test_admin_role.workspace_id)},
         )
@@ -378,7 +378,7 @@ async def test_internal_list_comment_threads_requires_case_addons(
 
 @pytest.mark.anyio
 async def test_internal_get_comment_thread_success(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Internal comment-id thread lookups should return the full thread."""
@@ -398,7 +398,7 @@ async def test_internal_get_comment_thread_success(
         mock_comments_service.get_comment_thread.return_value = thread
         mock_comments_service_cls.return_value = mock_comments_service
 
-        response = client.get(
+        response = action_gateway_client.get(
             f"/internal/comments/{reply.id}/thread",
             params={"workspace_id": str(test_admin_role.workspace_id)},
         )
@@ -411,7 +411,7 @@ async def test_internal_get_comment_thread_success(
 
 @pytest.mark.anyio
 async def test_internal_get_comment_thread_requires_case_addons(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     with patch.object(
@@ -423,7 +423,7 @@ async def test_internal_get_comment_thread_requires_case_addons(
         )
         mock_comments_service_cls.return_value = mock_comments_service
 
-        response = client.get(
+        response = action_gateway_client.get(
             f"/internal/comments/{uuid.uuid4()}/thread",
             params={"workspace_id": str(test_admin_role.workspace_id)},
         )
@@ -434,7 +434,7 @@ async def test_internal_get_comment_thread_requires_case_addons(
 
 @pytest.mark.anyio
 async def test_internal_create_comment_simple_reply_requires_case_addons(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_internal_case: Case,
 ) -> None:
@@ -454,7 +454,7 @@ async def test_internal_create_comment_simple_reply_requires_case_addons(
         )
         mock_comments_service_cls.return_value = mock_comments_service
 
-        response = client.post(
+        response = action_gateway_client.post(
             f"/internal/cases/{mock_internal_case.id}/comments/simple",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"content": "Reply", "parent_id": str(uuid.uuid4())},
@@ -466,7 +466,7 @@ async def test_internal_create_comment_simple_reply_requires_case_addons(
 
 @pytest.mark.anyio
 async def test_internal_list_case_events_includes_comment_activity(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_internal_case: Case,
 ) -> None:
@@ -494,7 +494,7 @@ async def test_internal_list_case_events_includes_comment_activity(
         mock_service.events.list_events.return_value = [db_event]
         mock_service_cls.return_value = mock_service
 
-        response = client.get(
+        response = action_gateway_client.get(
             f"/internal/cases/{mock_internal_case.id}/events",
             params={"workspace_id": str(test_admin_role.workspace_id)},
         )
@@ -507,7 +507,7 @@ async def test_internal_list_case_events_includes_comment_activity(
 
 @pytest.mark.anyio
 async def test_internal_update_comment_wrong_case_returns_not_found(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_internal_case: Case,
 ) -> None:
@@ -526,7 +526,7 @@ async def test_internal_update_comment_wrong_case_returns_not_found(
         mock_comments_service.get_comment_in_case.return_value = None
         mock_comments_service_cls.return_value = mock_comments_service
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             f"/internal/cases/{mock_internal_case.id}/comments/{uuid.uuid4()}",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"content": "Updated"},
@@ -538,7 +538,7 @@ async def test_internal_update_comment_wrong_case_returns_not_found(
 
 @pytest.mark.anyio
 async def test_internal_update_comment_reparenting_returns_bad_request(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_internal_case: Case,
 ) -> None:
@@ -560,7 +560,7 @@ async def test_internal_update_comment_reparenting_returns_bad_request(
         )
         mock_comments_service_cls.return_value = mock_comments_service
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             f"/internal/cases/{mock_internal_case.id}/comments/{uuid.uuid4()}",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"parent_id": str(uuid.uuid4())},

--- a/tests/unit/api/test_api_internal_tables.py
+++ b/tests/unit/api/test_api_internal_tables.py
@@ -51,7 +51,7 @@ def mock_table_column(mock_table: Table) -> TableColumn:
 
 @pytest.mark.anyio
 async def test_internal_update_table_returns_metadata(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
 ) -> None:
@@ -63,7 +63,7 @@ async def test_internal_update_table_returns_metadata(
         mock_svc.get_index.return_value = set()
         MockService.return_value = mock_svc
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             "/internal/tables/indicators",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"name": "indicators_v2"},
@@ -79,7 +79,7 @@ async def test_internal_update_table_returns_metadata(
 
 @pytest.mark.anyio
 async def test_internal_update_table_duplicate_name_returns_409(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
 ) -> None:
@@ -91,7 +91,7 @@ async def test_internal_update_table_duplicate_name_returns_409(
         )
         MockService.return_value = mock_svc
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             "/internal/tables/indicators",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"name": "indicators_v2"},
@@ -103,7 +103,7 @@ async def test_internal_update_table_duplicate_name_returns_409(
 
 @pytest.mark.anyio
 async def test_internal_create_column_returns_refreshed_metadata(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
     mock_table_column: TableColumn,
@@ -116,7 +116,7 @@ async def test_internal_create_column_returns_refreshed_metadata(
         mock_svc.get_index.return_value = {"score"}
         MockService.return_value = mock_svc
 
-        response = client.post(
+        response = action_gateway_client.post(
             f"/internal/tables/{mock_table.name}/columns",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"name": "score", "type": "NUMERIC"},
@@ -146,7 +146,7 @@ async def test_internal_create_column_returns_refreshed_metadata(
 
 @pytest.mark.anyio
 async def test_internal_create_column_duplicate_name_returns_409(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
 ) -> None:
@@ -158,7 +158,7 @@ async def test_internal_create_column_duplicate_name_returns_409(
         )
         MockService.return_value = mock_svc
 
-        response = client.post(
+        response = action_gateway_client.post(
             f"/internal/tables/{mock_table.name}/columns",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"name": "score", "type": "NUMERIC"},
@@ -170,7 +170,7 @@ async def test_internal_create_column_duplicate_name_returns_409(
 
 @pytest.mark.anyio
 async def test_internal_create_column_unexpected_db_error_is_sanitized(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
 ) -> None:
@@ -182,7 +182,7 @@ async def test_internal_create_column_unexpected_db_error_is_sanitized(
         )
         MockService.return_value = mock_svc
 
-        response = client.post(
+        response = action_gateway_client.post(
             f"/internal/tables/{mock_table.name}/columns",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"name": "score", "type": "NUMERIC"},
@@ -194,7 +194,7 @@ async def test_internal_create_column_unexpected_db_error_is_sanitized(
 
 @pytest.mark.anyio
 async def test_internal_update_column_404s_when_column_missing(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
 ) -> None:
@@ -203,7 +203,7 @@ async def test_internal_update_column_404s_when_column_missing(
         mock_svc.get_table_by_name.return_value = mock_table
         MockService.return_value = mock_svc
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             f"/internal/tables/{mock_table.name}/columns/missing",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"nullable": False},
@@ -217,7 +217,7 @@ async def test_internal_update_column_404s_when_column_missing(
 
 @pytest.mark.anyio
 async def test_internal_update_column_normalizes_path_name(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
     mock_table_column: TableColumn,
@@ -230,7 +230,7 @@ async def test_internal_update_column_normalizes_path_name(
         mock_svc.get_index.return_value = set()
         MockService.return_value = mock_svc
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             f"/internal/tables/{mock_table.name}/columns/Score",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"nullable": False},
@@ -243,7 +243,7 @@ async def test_internal_update_column_normalizes_path_name(
 
 @pytest.mark.anyio
 async def test_internal_delete_column_normalizes_path_name(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
     mock_table_column: TableColumn,
@@ -264,7 +264,7 @@ async def test_internal_delete_column_normalizes_path_name(
         mock_svc.get_index.return_value = set()
         MockService.return_value = mock_svc
 
-        response = client.delete(
+        response = action_gateway_client.delete(
             f"/internal/tables/{mock_table.name}/columns/Score",
             params={"workspace_id": str(test_admin_role.workspace_id)},
         )
@@ -275,7 +275,7 @@ async def test_internal_delete_column_normalizes_path_name(
 
 @pytest.mark.anyio
 async def test_internal_delete_column_returns_refreshed_metadata(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
     mock_table_column: TableColumn,
@@ -296,7 +296,7 @@ async def test_internal_delete_column_returns_refreshed_metadata(
         mock_svc.get_index.return_value = set()
         MockService.return_value = mock_svc
 
-        response = client.delete(
+        response = action_gateway_client.delete(
             f"/internal/tables/{mock_table.name}/columns/{mock_table_column.name}",
             params={"workspace_id": str(test_admin_role.workspace_id)},
         )
@@ -315,7 +315,7 @@ async def test_internal_delete_column_returns_refreshed_metadata(
 
 @pytest.mark.anyio
 async def test_internal_insert_table_row_invalid_numeric_value_returns_400(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
 ) -> None:
@@ -325,7 +325,7 @@ async def test_internal_insert_table_row_invalid_numeric_value_returns_400(
         mock_svc.insert_row.side_effect = ValueError("Invalid numeric value: 'abc'")
         MockService.return_value = mock_svc
 
-        response = client.post(
+        response = action_gateway_client.post(
             f"/internal/tables/{mock_table.name}/rows",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"data": {"score": "abc"}},
@@ -337,7 +337,7 @@ async def test_internal_insert_table_row_invalid_numeric_value_returns_400(
 
 @pytest.mark.anyio
 async def test_internal_update_table_row_invalid_integer_value_returns_400(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
     mock_table: Table,
 ) -> None:
@@ -347,7 +347,7 @@ async def test_internal_update_table_row_invalid_integer_value_returns_400(
         mock_svc.update_row.side_effect = ValueError("Invalid integer value: '1.5'")
         MockService.return_value = mock_svc
 
-        response = client.patch(
+        response = action_gateway_client.patch(
             f"/internal/tables/{mock_table.name}/rows/{uuid.uuid4()}",
             params={"workspace_id": str(test_admin_role.workspace_id)},
             json={"data": {"attempts": "1.5"}},

--- a/tests/unit/api/test_api_workflow_execution_path_ids.py
+++ b/tests/unit/api/test_api_workflow_execution_path_ids.py
@@ -34,7 +34,7 @@ def _workflow_definition_content(title: str = "Test Workflow") -> dict:
 
 @pytest.mark.anyio
 async def test_internal_get_execution_status_accepts_slash_id(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that the internal router accepts execution IDs with slash delimiter."""
@@ -53,7 +53,9 @@ async def test_internal_get_execution_status_accepts_slash_id(
         "connect",
         AsyncMock(return_value=mock_svc),
     ):
-        response = client.get(f"/internal/workflows/executions/{wf_exec_id}")
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{wf_exec_id}"
+        )
 
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
@@ -64,7 +66,7 @@ async def test_internal_get_execution_status_accepts_slash_id(
 
 @pytest.mark.anyio
 async def test_internal_get_execution_status_accepts_url_encoded_slash(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that URL-encoded slash (%2F) is decoded correctly."""
@@ -89,7 +91,9 @@ async def test_internal_get_execution_status_accepts_url_encoded_slash(
         "connect",
         AsyncMock(return_value=mock_svc),
     ):
-        response = client.get(f"/internal/workflows/executions/{encoded_id}")
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{encoded_id}"
+        )
 
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
@@ -100,7 +104,7 @@ async def test_internal_get_execution_status_accepts_url_encoded_slash(
 
 @pytest.mark.anyio
 async def test_internal_get_execution_status_accepts_colon_delimiter(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that execution IDs with colon delimiter are accepted."""
@@ -119,7 +123,9 @@ async def test_internal_get_execution_status_accepts_colon_delimiter(
         "connect",
         AsyncMock(return_value=mock_svc),
     ):
-        response = client.get(f"/internal/workflows/executions/{wf_exec_id}")
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{wf_exec_id}"
+        )
 
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
@@ -129,7 +135,7 @@ async def test_internal_get_execution_status_accepts_colon_delimiter(
 
 @pytest.mark.anyio
 async def test_internal_get_execution_status_returns_404_when_not_found(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that 404 is returned when execution is not found."""
@@ -143,7 +149,9 @@ async def test_internal_get_execution_status_returns_404_when_not_found(
         "connect",
         AsyncMock(return_value=mock_svc),
     ):
-        response = client.get(f"/internal/workflows/executions/{wf_exec_id}")
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{wf_exec_id}"
+        )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert "not found" in response.json()["detail"].lower()
@@ -151,7 +159,7 @@ async def test_internal_get_execution_status_returns_404_when_not_found(
 
 @pytest.mark.anyio
 async def test_internal_get_execution_status_returns_error_for_failed_workflow(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that error details are returned for failed workflows."""
@@ -181,7 +189,9 @@ async def test_internal_get_execution_status_returns_error_for_failed_workflow(
         "connect",
         AsyncMock(return_value=mock_svc),
     ):
-        response = client.get(f"/internal/workflows/executions/{wf_exec_id}")
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{wf_exec_id}"
+        )
 
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
@@ -192,7 +202,7 @@ async def test_internal_get_execution_status_returns_error_for_failed_workflow(
 
 @pytest.mark.anyio
 async def test_internal_get_execution_status_unwraps_nested_failure_cause(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that nested ActivityError-style causes are unwrapped to root message."""
@@ -230,7 +240,9 @@ async def test_internal_get_execution_status_unwraps_nested_failure_cause(
         "connect",
         AsyncMock(return_value=mock_svc),
     ):
-        response = client.get(f"/internal/workflows/executions/{wf_exec_id}")
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{wf_exec_id}"
+        )
 
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
@@ -245,7 +257,7 @@ async def test_internal_get_execution_status_unwraps_nested_failure_cause(
 
 @pytest.mark.anyio
 async def test_internal_execute_workflow_by_id(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test executing a workflow by workflow_id."""
@@ -293,7 +305,7 @@ async def test_internal_execute_workflow_by_id(
             AsyncMock(return_value=mock_exec_service),
         ),
     ):
-        response = client.post(
+        response = action_gateway_client.post(
             "/internal/workflows/executions",
             json={"workflow_id": workflow_id, "trigger_inputs": {"key": "value"}},
         )
@@ -306,7 +318,7 @@ async def test_internal_execute_workflow_by_id(
 
 @pytest.mark.anyio
 async def test_internal_execute_workflow_by_alias(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test executing a workflow by workflow_alias."""
@@ -368,7 +380,7 @@ async def test_internal_execute_workflow_by_alias(
             AsyncMock(return_value=mock_exec_service),
         ),
     ):
-        response = client.post(
+        response = action_gateway_client.post(
             "/internal/workflows/executions",
             json={"workflow_alias": workflow_alias},
         )
@@ -381,7 +393,7 @@ async def test_internal_execute_workflow_by_alias(
 
 @pytest.mark.anyio
 async def test_internal_execute_workflow_returns_404_for_unknown_alias(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that 404 is returned when workflow alias is not found."""
@@ -400,7 +412,7 @@ async def test_internal_execute_workflow_returns_404_for_unknown_alias(
             mock_wf_service.resolve_workflow_alias,
         ),
     ):
-        response = client.post(
+        response = action_gateway_client.post(
             "/internal/workflows/executions",
             json={"workflow_alias": "nonexistent-alias"},
         )
@@ -411,11 +423,11 @@ async def test_internal_execute_workflow_returns_404_for_unknown_alias(
 
 @pytest.mark.anyio
 async def test_internal_execute_workflow_returns_400_when_no_id_or_alias(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that 400 is returned when neither workflow_id nor workflow_alias provided."""
-    response = client.post(
+    response = action_gateway_client.post(
         "/internal/workflows/executions",
         json={},
     )
@@ -426,7 +438,7 @@ async def test_internal_execute_workflow_returns_400_when_no_id_or_alias(
 
 @pytest.mark.anyio
 async def test_internal_execute_workflow_returns_404_for_missing_definition(
-    client: TestClient,
+    action_gateway_client: TestClient,
     test_admin_role: Role,
 ) -> None:
     """Test that 404 is returned when workflow definition is not found."""
@@ -447,7 +459,7 @@ async def test_internal_execute_workflow_returns_404_for_missing_definition(
             mock_defn_service.get_definition_by_workflow_id,
         ),
     ):
-        response = client.post(
+        response = action_gateway_client.post(
             "/internal/workflows/executions",
             json={"workflow_id": workflow_id},
         )

--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -288,6 +288,7 @@ async def main():
 
 def _registry_ctx_env_vars() -> dict[str, str]:
     return {
+        "TRACECAT__ACTION_GATEWAY_SOCKET": str(ACTION_GATEWAY_SANDBOX_SOCKET),
         "TRACECAT__API_URL": "http://api.test:8000",
         "TRACECAT__WORKSPACE_ID": "workspace-id",
         "TRACECAT__WORKFLOW_ID": "workflow-id",
@@ -951,6 +952,7 @@ def test_registry_pythonpaths_can_import_ctx_without_site_packages(
         env={
             "PYTHONPATH": env_vars["PYTHONPATH"],
             "PYTHONDONTWRITEBYTECODE": "1",
+            "TRACECAT__ACTION_GATEWAY_SOCKET": str(ACTION_GATEWAY_SANDBOX_SOCKET),
         },
     )
 

--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -503,12 +503,6 @@ async def _run_backend_registry_ctx_smoke(
         "TRACECAT__API_URL",
         "http://api.test:8000",
     )
-    monkeypatch.setattr(
-        executor_backend_module.config,
-        "TRACECAT__ACTION_GATEWAY_ENABLED",
-        False,
-    )
-
     input_data = _make_run_python_input()
     resolved_context = _make_run_python_context()
     resolved_context.evaluated_args.update(
@@ -571,11 +565,6 @@ async def _run_backend_registry_ctx_gateway_smoke(
     )
     monkeypatch.setattr(
         executor_backend_module.config,
-        "TRACECAT__ACTION_GATEWAY_ENABLED",
-        True,
-    )
-    monkeypatch.setattr(
-        executor_backend_module.config,
         "TRACECAT__ACTION_GATEWAY_SOCKET",
         str(action_gateway_socket),
     )
@@ -613,13 +602,26 @@ async def _run_backend_registry_ctx_smoke_matrix(
     monkeypatch: pytest.MonkeyPatch,
     cache_dir: Path,
 ) -> None:
-    for backend in (DirectBackend(), EphemeralBackend()):
-        result = await _run_backend_registry_ctx_smoke(
-            backend=backend,
-            monkeypatch=monkeypatch,
-            cache_dir=cache_dir / backend.__class__.__name__,
-        )
-        assert isinstance(result, dict)
+    action_gateway_socket = (
+        Path("/tmp") / f"tracecat-run-python-gateway-{uuid.uuid4().hex}.sock"
+    )
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        str(action_gateway_socket),
+    )
+    action_gateway = ActionGateway(socket_path=action_gateway_socket)
+    await action_gateway.start()
+    try:
+        for backend in (DirectBackend(), EphemeralBackend()):
+            result = await _run_backend_registry_ctx_smoke(
+                backend=backend,
+                monkeypatch=monkeypatch,
+                cache_dir=cache_dir / backend.__class__.__name__,
+            )
+            assert isinstance(result, dict)
+    finally:
+        await action_gateway.stop()
 
 
 async def _run_backend_registry_ctx_gateway_smoke_matrix(
@@ -628,11 +630,6 @@ async def _run_backend_registry_ctx_gateway_smoke_matrix(
     cache_dir: Path,
 ) -> None:
     action_gateway_socket = cache_dir / "action-gateway.sock"
-    monkeypatch.setattr(
-        executor_backend_module.config,
-        "TRACECAT__ACTION_GATEWAY_ENABLED",
-        True,
-    )
     action_gateway = ActionGateway(socket_path=action_gateway_socket)
     await action_gateway.start()
     legacy_registry_root = _write_legacy_registry_sdk(cache_dir / "legacy-registry")
@@ -1376,11 +1373,6 @@ async def test_run_python_pid_sdk_calls_use_action_gateway_with_legacy_registry(
         executor_backend_module.config,
         "TRACECAT__API_URL",
         "http://tracecat-api:8000",
-    )
-    monkeypatch.setattr(
-        executor_backend_module.config,
-        "TRACECAT__ACTION_GATEWAY_ENABLED",
-        True,
     )
     monkeypatch.setattr(
         executor_backend_module.config,

--- a/tests/unit/test_action_gateway_app.py
+++ b/tests/unit/test_action_gateway_app.py
@@ -37,7 +37,7 @@ def test_action_gateway_mounts_internal_routes() -> None:
     app = create_app()
     gateway_routes = _internal_route_keys(app)
 
-    assert api_routes <= gateway_routes
+    assert api_routes.isdisjoint(gateway_routes)
     assert ("/internal/health", "GET") in gateway_routes
     assert not any(
         path.startswith("/internal/capabilities") for path, _ in gateway_routes

--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -6,13 +6,9 @@ These tests cover tarball caching, cache key computation, and execution logic.
 from __future__ import annotations
 
 import asyncio
-import json
 import tempfile
-import threading
 import uuid
-from contextlib import contextmanager
 from datetime import UTC, datetime
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -34,62 +30,6 @@ from tracecat.executor.schemas import (
 from tracecat.executor.secret_preprocessors import SecretEnvProjection
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.registry.lock.types import RegistryLock
-
-
-@contextmanager
-def _mock_tracecat_api_server(expected_token: str):
-    """Start a lightweight HTTP server for SDK integration testing."""
-    state: dict[str, object] = {"requests": []}
-
-    class Handler(BaseHTTPRequestHandler):
-        def do_POST(self) -> None:  # noqa: N802
-            content_length = int(self.headers.get("Content-Length", "0"))
-            raw_body = self.rfile.read(content_length)
-            payload = json.loads(raw_body.decode() or "{}")
-            authorization = self.headers.get("Authorization")
-
-            requests = state["requests"]
-            if isinstance(requests, list):
-                requests.append(
-                    {
-                        "path": self.path,
-                        "payload": payload,
-                        "authorization": authorization,
-                    }
-                )
-
-            if self.path != "/internal/tables/customers/search":
-                self.send_response(404)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(b'{"detail":"Not Found"}')
-                return
-
-            if authorization != f"Bearer {expected_token}":
-                self.send_response(401)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(b'{"detail":"Unauthorized"}')
-                return
-
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(b'[{"id":"row-1","name":"Alice"}]')
-
-        def log_message(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
-            return
-
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    base_url = f"http://127.0.0.1:{server.server_address[1]}"
-    try:
-        yield base_url, state
-    finally:
-        server.shutdown()
-        thread.join(timeout=5)
-        server.server_close()
 
 
 def _empty_secret_projection() -> SecretEnvProjection:
@@ -368,21 +308,18 @@ class TestActionRunner:
         assert captured_env["TRACECAT__EXECUTOR_TOKEN"] == "test-executor-token"
 
     @pytest.mark.anyio
-    async def test_execute_action_sets_action_gateway_env_when_enabled(
+    async def test_execute_action_sets_action_gateway_env(
         self,
         temp_cache_dir,
         mock_run_action_input,
         mock_role,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Action gateway mode injects the local socket path into action SDK env."""
+        """Direct execution injects the mandatory gateway socket into SDK env."""
         runner = ActionRunner(cache_dir=temp_cache_dir)
         base_dir = temp_cache_dir / "base"
         base_dir.mkdir()
 
-        monkeypatch.setattr(
-            action_runner.config, "TRACECAT__ACTION_GATEWAY_ENABLED", True
-        )
         monkeypatch.setattr(
             action_runner.config,
             "TRACECAT__ACTION_GATEWAY_SOCKET",
@@ -491,56 +428,6 @@ class TestActionRunner:
         ]
         assert captured_args[-2] == action_runner.sys.executable
         assert captured_args[-1].endswith("minimal_runner.py")
-
-    @pytest.mark.anyio
-    async def test_execute_action_registry_sdk_call_succeeds(
-        self, temp_cache_dir, mock_run_action_input, mock_role, monkeypatch
-    ):
-        """Test direct subprocess can execute a real registry SDK table call."""
-        runner = ActionRunner(cache_dir=temp_cache_dir)
-        base_dir = temp_cache_dir / "base"
-        base_dir.mkdir()
-
-        resolved_context = ResolvedContext(
-            secrets={},
-            variables={},
-            action_impl=ActionImplementation(
-                type="udf",
-                action_name="core.table.search_rows",
-                module="tracecat_registry.core.table",
-                name="search_rows",
-            ),
-            evaluated_args={"table": "customers", "search_term": "alice", "limit": 1},
-            workspace_id=str(mock_role.workspace_id),
-            workflow_id=str(mock_run_action_input.run_context.wf_id),
-            run_id=str(mock_run_action_input.run_context.wf_run_id),
-            executor_token="test-executor-token",
-        )
-
-        with _mock_tracecat_api_server("test-executor-token") as (api_url, state):
-            monkeypatch.setattr(config, "TRACECAT__API_URL", api_url)
-            monkeypatch.setattr(config, "TRACECAT__ACTION_GATEWAY_ENABLED", False)
-            result = await runner._execute_direct(
-                input=mock_run_action_input,
-                role=mock_role,
-                registry_paths=[base_dir],
-                secret_projection=_empty_secret_projection(),
-                timeout=10.0,
-                resolved_context=resolved_context,
-            )
-
-        assert result == [{"id": "row-1", "name": "Alice"}]
-        requests = state["requests"]
-        assert isinstance(requests, list)
-        assert len(requests) == 1
-        request = requests[0]
-        assert request["path"] == "/internal/tables/customers/search"
-        assert request["authorization"] == "Bearer test-executor-token"
-        assert request["payload"] == {
-            "search_term": "alice",
-            "limit": 1,
-            "reverse": False,
-        }
 
     @pytest.mark.anyio
     async def test_execute_action_invalid_json_response(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -220,26 +220,6 @@ def test_action_gateway_socket_uses_default_for_empty_string(
         importlib.reload(tracecat_config)
 
 
-def test_action_gateway_enabled_defaults_true_and_allows_false(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    try:
-        with monkeypatch.context() as env:
-            env.delenv("TRACECAT__ACTION_GATEWAY_ENABLED", raising=False)
-            reloaded_config = importlib.reload(tracecat_config)
-            assert reloaded_config.TRACECAT__ACTION_GATEWAY_ENABLED is True
-
-            env.setenv("TRACECAT__ACTION_GATEWAY_ENABLED", "")
-            reloaded_config = importlib.reload(tracecat_config)
-            assert reloaded_config.TRACECAT__ACTION_GATEWAY_ENABLED is True
-
-            env.setenv("TRACECAT__ACTION_GATEWAY_ENABLED", "false")
-            reloaded_config = importlib.reload(tracecat_config)
-            assert reloaded_config.TRACECAT__ACTION_GATEWAY_ENABLED is False
-    finally:
-        importlib.reload(tracecat_config)
-
-
 def test_bound_env_rejects_invalid_numeric_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_executor_sandbox_nsjail.py
+++ b/tests/unit/test_executor_sandbox_nsjail.py
@@ -488,19 +488,17 @@ async def _run_executor_action_smoke_case(
     if reason := _missing_prerequisite(smoke_case):
         _skip_smoke(reason)
 
+    action_gateway_socket = Path("/tmp") / f"tc-action-gateway-{uuid.uuid4().hex}.sock"
     monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
     monkeypatch.setattr(config, "TRACECAT__API_URL", "http://127.0.0.1:8000")
     monkeypatch.setattr(config, "TRACECAT__EXECUTOR_SANDBOX_ENABLED", True)
     monkeypatch.setattr(config, "TRACECAT__EXECUTOR_REGISTRY_SQUASHFS_ENABLED", True)
     monkeypatch.setattr(config, "TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 30.0)
-    monkeypatch.setattr(config, "TRACECAT__ACTION_GATEWAY_ENABLED", False)
-    if smoke_case is SmokeCase.NSJAIL_GATEWAY:
-        monkeypatch.setattr(config, "TRACECAT__ACTION_GATEWAY_ENABLED", True)
-        monkeypatch.setattr(
-            config,
-            "TRACECAT__ACTION_GATEWAY_SOCKET",
-            str(tmp_path / "action-gateway.sock"),
-        )
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        str(action_gateway_socket),
+    )
 
     source_dir = tmp_path / "site-packages"
     tar_gz_path = tmp_path / "site-packages.tar.gz"
@@ -548,12 +546,10 @@ async def _run_executor_action_smoke_case(
         input=action_input,
         role=role,
     )
-    action_gateway: ActionGateway | None = None
+    action_gateway = ActionGateway()
 
     try:
-        if smoke_case is SmokeCase.NSJAIL_GATEWAY:
-            action_gateway = ActionGateway()
-            await action_gateway.start()
+        await action_gateway.start()
 
         patches = [
             patch.object(runner.registry_artifacts, "_sidecar_exists", sidecar_exists),
@@ -612,8 +608,7 @@ async def _run_executor_action_smoke_case(
             else:
                 assert tarball_dir.exists()
     finally:
-        if action_gateway is not None:
-            await action_gateway.stop()
+        await action_gateway.stop()
         _unmount_if_needed(mount_dir)
 
 
@@ -631,7 +626,6 @@ async def _run_current_builtin_smoke_case(
         config, "TRACECAT__EXECUTOR_SANDBOX_ENABLED", smoke_case.force_sandbox
     )
     monkeypatch.setattr(config, "TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 30.0)
-    monkeypatch.setattr(config, "TRACECAT__ACTION_GATEWAY_ENABLED", False)
 
     action_name = "core.transform.reshape"
     role = _make_role()

--- a/tests/unit/test_executor_sandbox_nsjail.py
+++ b/tests/unit/test_executor_sandbox_nsjail.py
@@ -620,12 +620,24 @@ async def _run_current_builtin_smoke_case(
     if reason := _missing_prerequisite(smoke_case):
         _skip_smoke(reason)
 
+    action_gateway_socket = Path("/tmp") / f"tc-action-gateway-{uuid.uuid4().hex}.sock"
     monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
     monkeypatch.setattr(config, "TRACECAT__API_URL", "http://127.0.0.1:8000")
     monkeypatch.setattr(
         config, "TRACECAT__EXECUTOR_SANDBOX_ENABLED", smoke_case.force_sandbox
     )
     monkeypatch.setattr(config, "TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 30.0)
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        str(action_gateway_socket),
+    )
+    # EphemeralBackend executes in a child process, so export the socket path in
+    # addition to patching this process's config module.
+    monkeypatch.setenv(
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        str(action_gateway_socket),
+    )
 
     action_name = "core.transform.reshape"
     role = _make_role()
@@ -637,12 +649,17 @@ async def _run_current_builtin_smoke_case(
     )
 
     backend = EphemeralBackend() if smoke_case.force_sandbox else DirectBackend()
-    result = await backend.execute(
-        input=action_input,
-        role=role,
-        resolved_context=resolved_context,
-        timeout=30,
-    )
+    action_gateway = ActionGateway()
+    try:
+        await action_gateway.start()
+        result = await backend.execute(
+            input=action_input,
+            role=role,
+            resolved_context=resolved_context,
+            timeout=30,
+        )
+    finally:
+        await action_gateway.stop()
 
     assert result.type == "success"
     assert result.result == {"source": "current-builtin"}

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -34,16 +34,11 @@ from tracecat.agent.channels.management_router import (
 )
 from tracecat.agent.channels.router import router as agent_channels_router
 from tracecat.agent.folders.router import router as agent_folders_router
-from tracecat.agent.internal_router import router as internal_agent_router
-from tracecat.agent.preset.internal_router import (
-    router as internal_agent_preset_router,
-)
 from tracecat.agent.preset.router import router as agent_preset_router
 from tracecat.agent.provider.router import router as agent_custom_provider_router
 from tracecat.agent.router import router as agent_router
 from tracecat.agent.router import workspace_router as agent_workspace_router
 from tracecat.agent.session.router import router as agent_session_router
-from tracecat.agent.skill.internal_router import router as internal_agent_skill_router
 from tracecat.agent.skill.router import router as agent_skill_router
 from tracecat.agent.tags.definitions_router import (
     router as agent_tag_definitions_router,
@@ -82,32 +77,16 @@ from tracecat.authz.rbac.router import (
 )
 from tracecat.authz.rbac.router import user_scopes_router
 from tracecat.authz.seeding import seed_all_system_data
-from tracecat.cases.attachments.internal_router import (
-    router as internal_case_attachments_router,
-)
 from tracecat.cases.attachments.router import router as case_attachments_router
 from tracecat.cases.dropdowns.router import definitions_router as case_dropdowns_router
 from tracecat.cases.dropdowns.router import values_router as case_dropdown_values_router
 from tracecat.cases.durations.router import router as case_durations_router
-from tracecat.cases.internal_router import (
-    comments_router as internal_comments_router,
-)
-from tracecat.cases.internal_router import (
-    router as internal_cases_router,
-)
 from tracecat.cases.router import case_fields_router as case_fields_router
 from tracecat.cases.router import cases_router as cases_router
-from tracecat.cases.rows.internal_router import (
-    router as internal_case_rows_router,
-)
 from tracecat.cases.rows.router import router as case_rows_router
-from tracecat.cases.tag_definitions.internal_router import (
-    router as internal_case_tag_definitions_router,
-)
 from tracecat.cases.tag_definitions.router import (
     router as case_tag_definitions_router,
 )
-from tracecat.cases.tags.internal_router import router as internal_case_tags_router
 from tracecat.cases.tags.router import router as case_tags_router
 from tracecat.cases.triggers.consumer import start_case_trigger_consumer
 from tracecat.contexts import ctx_role
@@ -117,9 +96,6 @@ from tracecat.db.engine import (
 )
 from tracecat.db.rls import set_rls_context_from_role
 from tracecat.db.soft_delete import assert_soft_delete_listener_registered
-from tracecat.deduplicate.internal_router import (
-    router as internal_deduplicate_router,
-)
 from tracecat.editor.router import router as editor_router
 from tracecat.exceptions import EntitlementRequired, ScopeDeniedError, TracecatException
 from tracecat.feature_flags import FeatureFlag, FlagLike, is_feature_enabled
@@ -166,17 +142,12 @@ from tracecat.storage.blob import (
     configure_bucket_lifecycle,
     ensure_bucket_exists,
 )
-from tracecat.tables.internal_router import router as internal_tables_router
 from tracecat.tables.router import router as tables_router
 from tracecat.tags.router import router as tags_router
-from tracecat.variables.internal_router import router as internal_variables_router
 from tracecat.variables.router import router as variables_router
 from tracecat.vcs.router import org_router as vcs_router
 from tracecat.webhooks.router import router as webhook_router
 from tracecat.workflow.actions.router import router as workflow_actions_router
-from tracecat.workflow.executions.internal_router import (
-    router as internal_workflows_router,
-)
 from tracecat.workflow.executions.router import (
     router as workflow_executions_router,
 )
@@ -599,21 +570,6 @@ def create_app(**kwargs) -> FastAPI:
         tags=["users"],
         dependencies=[Depends(authenticated_user_only)],
     )
-    # Internal routers
-    app.include_router(internal_agent_router)
-    app.include_router(internal_agent_preset_router)
-    app.include_router(internal_agent_skill_router)
-    app.include_router(internal_case_attachments_router)
-    app.include_router(internal_cases_router)
-    app.include_router(internal_deduplicate_router)
-    app.include_router(internal_case_rows_router)
-    app.include_router(internal_comments_router)
-    app.include_router(internal_case_tags_router)
-    app.include_router(internal_case_tag_definitions_router)
-    app.include_router(internal_tables_router)
-    app.include_router(internal_variables_router)
-    app.include_router(internal_workflows_router)
-
     if AuthType.BASIC in config.TRACECAT__AUTH_TYPES:
         app.include_router(
             fastapi_users.get_auth_router(auth_backend),

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -658,11 +658,6 @@ TRACECAT__EXECUTOR_CLIENT_TIMEOUT = float(
 """Default timeout in seconds for executor client operations (default: 300s)."""
 
 # === Action Gateway === #
-TRACECAT__ACTION_GATEWAY_ENABLED = env_bool(
-    "TRACECAT__ACTION_GATEWAY_ENABLED", default=True
-)
-"""Enable the executor-local action gateway for action SDK calls."""
-
 TRACECAT__ACTION_GATEWAY_SOCKET = (
     os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
     or "/var/run/tracecat/action-gateway.sock"

--- a/tracecat/executor/action_gateway/config.py
+++ b/tracecat/executor/action_gateway/config.py
@@ -10,8 +10,6 @@ ACTION_GATEWAY_SANDBOX_SOCKET = Path("/var/run/tracecat/action-gateway.sock")
 """Path actions use inside nsjail after the host action gateway socket is mounted."""
 
 
-def action_gateway_socket_path() -> Path | None:
-    """Return the host-side action gateway Unix socket path when enabled."""
-    if not config.TRACECAT__ACTION_GATEWAY_ENABLED:
-        return None
+def action_gateway_socket_path() -> Path:
+    """Return the host-side action gateway Unix socket path."""
     return Path(config.TRACECAT__ACTION_GATEWAY_SOCKET)

--- a/tracecat/executor/action_gateway/server.py
+++ b/tracecat/executor/action_gateway/server.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-from tracecat import config
 from tracecat.executor.action_gateway.app import create_app
 from tracecat.executor.action_gateway.config import action_gateway_socket_path
 from tracecat.logger import logger
@@ -23,17 +22,13 @@ class ActionGateway:
         self._socket_path: Path | None = None
 
     async def start(self) -> None:
-        """Start the action gateway when enabled for this executor process."""
-        if not config.TRACECAT__ACTION_GATEWAY_ENABLED:
-            return
+        """Start the action gateway for this executor process."""
         if self._task is not None:
             return
 
         import uvicorn
 
         socket_path = self._configured_socket_path or action_gateway_socket_path()
-        if socket_path is None:
-            return
         socket_path.parent.mkdir(parents=True, exist_ok=True)
         socket_path.unlink(missing_ok=True)
 

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -314,12 +314,9 @@ class ActionRunner:
             sandbox_env["TRACECAT__WF_EXEC_ID"] = str(input.run_context.wf_exec_id)
             sandbox_env["TRACECAT__ENVIRONMENT"] = input.run_context.environment
             action_gateway_socket = action_gateway_socket_path()
-            if action_gateway_socket is not None:
-                sandbox_env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(
-                    ACTION_GATEWAY_SANDBOX_SOCKET
-                )
-            else:
-                sandbox_env.pop("TRACECAT__ACTION_GATEWAY_SOCKET", None)
+            sandbox_env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(
+                ACTION_GATEWAY_SANDBOX_SOCKET
+            )
 
             # Mint an executor token for SDK calls
             if role.workspace_id is None:
@@ -439,10 +436,7 @@ class ActionRunner:
             env["TRACECAT__WF_EXEC_ID"] = str(input.run_context.wf_exec_id)
             env["TRACECAT__ENVIRONMENT"] = input.run_context.environment
             env["TRACECAT__EXECUTOR_TOKEN"] = resolved_context.executor_token
-            if socket_path := action_gateway_socket_path():
-                env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(socket_path)
-            else:
-                env.pop("TRACECAT__ACTION_GATEWAY_SOCKET", None)
+            env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(action_gateway_socket_path())
 
         # Build PYTHONPATH with multiple registry paths (deterministic order)
         pythonpath_parts = [str(p) for p in registry_paths if p.exists()]

--- a/tracecat/executor/backends/pool/pool.py
+++ b/tracecat/executor/backends/pool/pool.py
@@ -334,17 +334,14 @@ class WorkerPool:
         work_dir: Path,
         socket_path: Path,
         env: dict[str, str],
-        action_gateway_socket: Path | None,
+        action_gateway_socket: Path,
     ) -> asyncio.subprocess.Process:
         """Spawn worker as direct subprocess (no nsjail sandbox)."""
         import sys
 
         # Socket path is the actual host path
         env["TRACECAT_WORKER_SOCKET"] = str(socket_path)
-        if action_gateway_socket is not None:
-            env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(action_gateway_socket)
-        else:
-            env.pop("TRACECAT__ACTION_GATEWAY_SOCKET", None)
+        env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(action_gateway_socket)
 
         cmd = [
             sys.executable,
@@ -369,15 +366,12 @@ class WorkerPool:
         work_dir: Path,
         socket_path: Path,
         env: dict[str, str],
-        action_gateway_socket: Path | None,
+        action_gateway_socket: Path,
     ) -> asyncio.subprocess.Process:
         """Spawn worker inside nsjail sandbox."""
         # Socket path inside sandbox
         env["TRACECAT_WORKER_SOCKET"] = "/work/task.sock"
-        if action_gateway_socket is not None:
-            env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(ACTION_GATEWAY_SANDBOX_SOCKET)
-        else:
-            env.pop("TRACECAT__ACTION_GATEWAY_SOCKET", None)
+        env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(ACTION_GATEWAY_SANDBOX_SOCKET)
 
         # Build nsjail config
         nsjail_config = self._build_nsjail_config(
@@ -413,11 +407,8 @@ class WorkerPool:
             "TRACECAT_WORKER_ID",
             "--env",
             "TRACECAT_WORKER_SOCKET",
-            *(
-                ["--env", "TRACECAT__ACTION_GATEWAY_SOCKET"]
-                if "TRACECAT__ACTION_GATEWAY_SOCKET" in env
-                else []
-            ),
+            "--env",
+            "TRACECAT__ACTION_GATEWAY_SOCKET",
             # Set PYTHONPATH explicitly for the sandbox Python
             "--env",
             f"PYTHONPATH={pythonpath}",

--- a/tracecat/executor/backends/test.py
+++ b/tracecat/executor/backends/test.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 from tracecat_registry import secrets as registry_secrets
 from tracecat_registry.context import RegistryContext, set_context
+from tracecat_registry.sdk.client import TracecatClient
 
 from tracecat import config
 from tracecat.contexts import (
@@ -31,6 +32,7 @@ from tracecat.contexts import (
     ctx_run,
     ctx_session_id,
 )
+from tracecat.executor.action_gateway.config import action_gateway_socket_path
 from tracecat.executor.action_runner import get_action_runner
 from tracecat.executor.backends.base import ExecutorBackend
 from tracecat.executor.backends.registry_helpers import get_registry_artifact_uris
@@ -188,6 +190,11 @@ class TestBackend(ExecutorBackend):
             environment=input.run_context.environment,
             api_url=config.TRACECAT__API_URL,
             token=resolved_context.executor_token,
+            _client=TracecatClient(
+                action_gateway_socket=str(action_gateway_socket_path()),
+                token=resolved_context.executor_token,
+                workspace_id=resolved_context.workspace_id,
+            ),
         )
         set_context(registry_ctx)
 


### PR DESCRIPTION
## Summary

- mount executor-only internal routers exclusively on the local Action Gateway
- require registry SDK requests to use the Action Gateway Unix socket
- remove the gateway-enabled flag and always propagate the socket through executor backends
- move internal-route and SDK characterization tests onto the Action Gateway boundary

## Compatibility impact

- `TRACECAT__ACTION_GATEWAY_ENABLED=false` is no longer supported
- `TracecatClient` no longer accepts `api_url` or falls back to the API service
- `/internal/...` executor routes are no longer exposed by the API service

Executor startup already fails when the Action Gateway cannot start, so this makes the SDK and routing contracts match the existing runtime boundary.

## Verification

- 89 API, SDK transport, Action Gateway, runner, and worker-pool tests passed
- 163 registry characterization, context, internal workflow router, and config tests passed
- direct executor registry-action smoke passed
- sandboxed nsjail Action Gateway smoke passed
- in-process backend registry-context smoke passed
- Ruff check and format check passed for all changed Python files
- Basedpyright passed for all changed Python files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the executor-local Action Gateway mandatory for all SDK calls. Remove the API fallback and serve all `/internal` routes only on the Action Gateway.

- **Refactors**
  - `TracecatClient` now requires `TRACECAT__ACTION_GATEWAY_SOCKET`, raises if missing or empty, and no longer accepts `api_url`; all SDK traffic goes to the gateway over UDS.
  - `RegistryContext` uses an injected `_client` when provided and no longer passes `api_url` when creating `TracecatClient`.
  - Removed `TRACECAT__ACTION_GATEWAY_ENABLED`; the gateway server starts unconditionally and executors, worker pools, and nsjail always set and propagate the gateway socket.
  - The public API app no longer mounts internal routers; tests hit internal routes via a new `action_gateway_client` and a UDS-backed `httpx.AsyncHTTPTransport`.
  - Test harness and smoke tests start a per-test Action Gateway and export the socket to child processes (including `EphemeralBackend` and nsjail runs).
  - CI sets `TRACECAT__DB_MAX_OVERFLOW=9` for gateway-backed temporal tests.

- **Migration**
  - Set `TRACECAT__ACTION_GATEWAY_SOCKET` for all executor processes and ensure the path is writable.
  - Stop passing `api_url` to `TracecatClient`; use the gateway socket and executor token instead.
  - Route all internal SDK calls via the Action Gateway; do not rely on `/internal` routes on the public API.

<sup>Written for commit 4487b511acd45451fe02162860aea97983377d77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

