### PR TITLE
fix(engine): stop exposing internal API URL

### DIFF
--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -202,6 +202,7 @@ def _make_run_python_context() -> ResolvedContext:
             "script": "def main():\n    return 1",
             "env_vars": {
                 "CUSTOM_VALUE": "kept",
+                "TRACECAT__API_URL": "http://user-supplied-api.invalid",
                 "TRACECAT__WORKSPACE_ID": "user-cannot-shadow-context",
             },
         },
@@ -289,7 +290,6 @@ async def main():
 def _registry_ctx_env_vars() -> dict[str, str]:
     return {
         "TRACECAT__ACTION_GATEWAY_SOCKET": str(ACTION_GATEWAY_SANDBOX_SOCKET),
-        "TRACECAT__API_URL": "http://api.test:8000",
         "TRACECAT__WORKSPACE_ID": "workspace-id",
         "TRACECAT__WORKFLOW_ID": "workflow-id",
         "TRACECAT__RUN_ID": "run-id",
@@ -306,7 +306,7 @@ def _expected_registry_ctx_smoke_result(
     run_id: str = "run-id",
     wf_exec_id: str = "workflow-id/execution-id",
     environment: str = "testing",
-    api_url: str = "http://api.test:8000",
+    api_url: str = "http://api:8000",
     token: str = "executor-token",
 ) -> dict[str, Any]:
     return {
@@ -1111,7 +1111,7 @@ async def test_tracecat_registry_ctx_rejects_sync_call_in_async_code() -> None:
 
 
 @pytest.mark.anyio
-async def test_run_python_backend_always_injects_sdk_context(
+async def test_run_python_backend_injects_sdk_context_without_api_url(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1155,7 +1155,6 @@ async def test_run_python_backend_always_injects_sdk_context(
     assert result.result == {"ok": True}
     assert captured["env_vars"] == {
         "CUSTOM_VALUE": "kept",
-        "TRACECAT__API_URL": "http://api.test:8000",
         "TRACECAT__WORKSPACE_ID": resolved_context.workspace_id,
         "TRACECAT__WORKFLOW_ID": resolved_context.workflow_id,
         "TRACECAT__RUN_ID": resolved_context.run_id,

--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -15,7 +15,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import orjson
 import pytest
 
-from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.dsl.common import create_default_execution_context
@@ -242,7 +241,11 @@ class TestActionRunner:
 
     @pytest.mark.anyio
     async def test_execute_action_sets_sdk_context_env(
-        self, temp_cache_dir, mock_run_action_input, mock_role
+        self,
+        temp_cache_dir,
+        mock_run_action_input,
+        mock_role,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Test direct subprocess execution sets SDK auth/context env vars."""
         runner = ActionRunner(cache_dir=temp_cache_dir)
@@ -253,6 +256,7 @@ class TestActionRunner:
 
         success_response = orjson.dumps({"success": True, "result": {"data": "test"}})
         captured_env: dict[str, str] = {}
+        monkeypatch.setenv("TRACECAT__API_URL", "http://internal-api.invalid")
 
         resolved_context = ResolvedContext(
             secrets={},
@@ -294,7 +298,7 @@ class TestActionRunner:
             )
 
         assert result == {"data": "test"}
-        assert captured_env["TRACECAT__API_URL"] == config.TRACECAT__API_URL
+        assert "TRACECAT__API_URL" not in captured_env
         assert captured_env["TRACECAT__WORKSPACE_ID"] == resolved_context.workspace_id
         assert captured_env["TRACECAT__WORKFLOW_ID"] == resolved_context.workflow_id
         assert captured_env["TRACECAT__RUN_ID"] == resolved_context.run_id
@@ -372,6 +376,69 @@ class TestActionRunner:
         assert (
             captured_env["TRACECAT__ACTION_GATEWAY_SOCKET"]
             == "/var/run/tracecat/action-gateway.sock"
+        )
+
+    @pytest.mark.anyio
+    async def test_execute_sandboxed_omits_api_url(
+        self,
+        temp_cache_dir,
+        mock_run_action_input,
+        mock_role,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sandboxed actions expose the gateway socket, not the API address."""
+        runner = ActionRunner(cache_dir=temp_cache_dir)
+        base_dir = temp_cache_dir / "base"
+        base_dir.mkdir()
+        captured_env: dict[str, str] = {}
+
+        resolved_context = ResolvedContext(
+            secrets={},
+            variables={},
+            action_impl=ActionImplementation(
+                type="udf",
+                action_name="core.table.search_rows",
+                module="tracecat_registry.core.table",
+                name="search_rows",
+            ),
+            evaluated_args={"table": "customers"},
+            workspace_id=str(mock_role.workspace_id),
+            workflow_id=str(mock_run_action_input.run_context.wf_id),
+            run_id=str(mock_run_action_input.run_context.wf_run_id),
+            executor_token="test-executor-token",
+        )
+
+        class FakeNsjailExecutor:
+            async def execute_action(
+                self,
+                job_dir: Path,
+                sandbox_config: action_runner.ActionSandboxConfig,
+            ) -> MagicMock:
+                del job_dir
+                captured_env.update(sandbox_config.env_vars)
+                return MagicMock(success=True, output={"data": "test"})
+
+        monkeypatch.setattr(action_runner, "NsjailExecutor", FakeNsjailExecutor)
+        monkeypatch.setattr(
+            action_runner,
+            "mint_executor_token",
+            lambda **_kwargs: "test-executor-token",
+        )
+
+        result = await runner._execute_sandboxed(
+            input=mock_run_action_input,
+            role=mock_role,
+            registry_paths=[base_dir],
+            secret_projection=_empty_secret_projection(),
+            resolved_context=resolved_context,
+            env_vars={"TRACECAT__API_URL": "http://internal-api.invalid"},
+            timeout=10.0,
+        )
+
+        assert result == {"data": "test"}
+        assert "TRACECAT__API_URL" not in captured_env
+        assert captured_env["TRACECAT__ACTION_GATEWAY_SOCKET"] == str(
+            action_runner.ACTION_GATEWAY_SANDBOX_SOCKET
         )
 
     @pytest.mark.anyio

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -303,9 +303,10 @@ class ActionRunner:
             sandbox_env: dict[str, str] = {}
             if env_vars:
                 sandbox_env.update(env_vars)
+            # Internal SDK requests must use the executor-local Action Gateway.
+            sandbox_env.pop("TRACECAT__API_URL", None)
 
             # SDK context for any registry SDK operations
-            sandbox_env["TRACECAT__API_URL"] = config.TRACECAT__API_URL
             sandbox_env["TRACECAT__WORKSPACE_ID"] = (
                 str(role.workspace_id) if role.workspace_id else ""
             )
@@ -426,10 +427,11 @@ class ActionRunner:
         env = os.environ.copy()
         if env_vars:
             env.update(env_vars)
+        # Do not leak the internal API address inherited from the executor.
+        env.pop("TRACECAT__API_URL", None)
 
         # Ensure SDK context is available for registry actions executed by minimal_runner.
         if resolved_context is not None:
-            env["TRACECAT__API_URL"] = config.TRACECAT__API_URL
             env["TRACECAT__WORKSPACE_ID"] = resolved_context.workspace_id
             env["TRACECAT__WORKFLOW_ID"] = resolved_context.workflow_id
             env["TRACECAT__RUN_ID"] = resolved_context.run_id

--- a/tracecat/executor/backends/base.py
+++ b/tracecat/executor/backends/base.py
@@ -244,9 +244,10 @@ class ExecutorBackend(ABC):
         """Build run_python environment with Tracecat SDK context always enabled."""
 
         env_vars = dict(user_env_vars or {})
+        # Internal SDK requests must use the executor-local Action Gateway.
+        env_vars.pop("TRACECAT__API_URL", None)
         env_vars.update(
             {
-                "TRACECAT__API_URL": config.TRACECAT__API_URL,
                 "TRACECAT__WORKSPACE_ID": resolved_context.workspace_id,
                 "TRACECAT__WORKFLOW_ID": resolved_context.workflow_id,
                 "TRACECAT__RUN_ID": resolved_context.run_id,


### PR DESCRIPTION
## Summary

- stop injecting `TRACECAT__API_URL` into run-python and action execution environments
- strip inherited or caller-supplied values while preserving the executor-local Action Gateway socket
- keep the legacy registry context shape intact for cached registry artifacts

## Why

The registry SDK now requires the executor-local Action Gateway Unix socket and no longer uses the internal API URL for transport. The old environment injection remained after that routing change, unnecessarily exposing the internal service address to sandboxed code.

## Impact

Sandboxed and direct action execution continue to support registry SDK calls through the Action Gateway. Scripts that read `TRACECAT__API_URL` directly will no longer receive the platform's internal API address.

## Validation

- `uv run pytest -q tests/unit/test_action_runner.py tests/unit/executor/test_run_python_sdk_context.py` (35 passed)
- `uv run ruff check tracecat/executor/action_runner.py tracecat/executor/backends/base.py tests/unit/test_action_runner.py tests/unit/executor/test_run_python_sdk_context.py`
- `uv run ruff format --check tracecat/executor/action_runner.py tracecat/executor/backends/base.py tests/unit/test_action_runner.py tests/unit/executor/test_run_python_sdk_context.py`
- `uv run basedpyright tracecat/executor/action_runner.py tracecat/executor/backends/base.py tests/unit/test_action_runner.py tests/unit/executor/test_run_python_sdk_context.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `TRACECAT__API_URL` from run-python and action execution environments to avoid leaking the internal API address. The Registry SDK uses the executor-local Action Gateway socket, which remains available.

- **Bug Fixes**
  - Stop injecting `TRACECAT__API_URL` in sandboxed and direct execution paths and run-python env builder.
  - Strip inherited or caller-supplied `TRACECAT__API_URL` before execution.
  - Preserve `TRACECAT__ACTION_GATEWAY_SOCKET` and SDK context (workspace/workflow/run IDs, executor token).
  - Keep legacy registry context shape for cached artifacts; tests updated to assert the API URL is absent.

<sup>Written for commit 0da446071d00ab2676e3e03533c1a3960f6921b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

