### PR TITLE
feat(audit): expand audit log coverage

### DIFF
--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import uuid
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -14,13 +18,20 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.audit import service as audit_service_module
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 from tracecat.audit.logger import (
-    AuditCallContext,
     AuditEventDetails,
     audit_log,
 )
-from tracecat.audit.service import AuditService
+from tracecat.audit.service import (
+    AuditService,
+    _AuditDelivery,
+    _DeliveryChannel,
+    _enqueue_delivery,
+    _get_delivery_queue,
+    flush_audit_deliveries,
+)
 from tracecat.audit.types import AuditEvent
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.auth.users import UserManager
@@ -46,14 +57,6 @@ def audit_service(role: Role) -> AuditService:
     return AuditService(AsyncMock(), role=role)
 
 
-def _test_audit_details(_context: AuditCallContext) -> AuditEventDetails:
-    return AuditEventDetails(data={"changed_fields": ["status"]})
-
-
-def _broken_audit_result(_context: AuditCallContext, _result: str) -> AuditEventDetails:
-    raise ValueError("metadata derivation failed")
-
-
 class _AuditedService(BaseService):
     service_name = "test_audit"
 
@@ -61,20 +64,34 @@ class _AuditedService(BaseService):
         super().__init__(session)
         self.role = role
 
+    def _mutate_details(
+        self, workflow_id: uuid.UUID, *, fail: bool = False
+    ) -> AuditEventDetails:
+        return AuditEventDetails(data={"changed_fields": ["status"]})
+
     @audit_log(
         resource_type="workflow",
         action="update",
-        attempt_metadata=_test_audit_details,
+        attempt_metadata=_mutate_details,
     )
     async def mutate(self, workflow_id: uuid.UUID, *, fail: bool = False) -> str:
         if fail:
             raise ValueError("operation failed")
         return "result"
 
+    def _broken_details(self, workflow_id: uuid.UUID) -> AuditEventDetails:
+        return AuditEventDetails(data={"changed_fields": ["status"]})
+
+    @staticmethod
+    def _broken_audit_result(
+        result: str, *args: Any, **kwargs: Any
+    ) -> AuditEventDetails:
+        raise ValueError("metadata derivation failed")
+
     @audit_log(
         resource_type="workflow",
         action="update",
-        attempt_metadata=_test_audit_details,
+        attempt_metadata=_broken_details,
         terminal_metadata=_broken_audit_result,
     )
     async def mutate_with_broken_result(self, workflow_id: uuid.UUID) -> str:
@@ -88,7 +105,8 @@ class _AuditedService(BaseService):
         ("success", [AuditEventStatus.ATTEMPT, AuditEventStatus.SUCCESS]),
         ("failure", [AuditEventStatus.ATTEMPT, AuditEventStatus.FAILURE]),
         ("service_account", [AuditEventStatus.ATTEMPT, AuditEventStatus.SUCCESS]),
-        ("service_gate", []),
+        ("service_attributed", [AuditEventStatus.ATTEMPT, AuditEventStatus.SUCCESS]),
+        ("service_unattributed", []),
     ],
 )
 async def test_audit_log_lifecycle(
@@ -119,8 +137,10 @@ async def test_audit_log_lifecycle(
         yield Capture()
 
     monkeypatch.setattr(AuditService, "with_session", classmethod(with_session))
-    if scenario == "service_gate":
+    if scenario == "service_attributed":
         audit_role = role.model_copy(update={"type": "service"})
+    elif scenario == "service_unattributed":
+        audit_role = role.model_copy(update={"type": "service", "user_id": None})
     elif scenario == "service_account":
         audit_role = role.model_copy(
             update={
@@ -158,9 +178,6 @@ async def test_audit_log_emit_false_failure_executes_operation_once(
     operation_calls = 0
     create_event = AsyncMock()
 
-    def suppress_audit(_context: AuditCallContext) -> AuditEventDetails:
-        return AuditEventDetails(emit=False)
-
     class SuppressedService(BaseService):
         service_name = "suppressed"
 
@@ -168,10 +185,13 @@ async def test_audit_log_emit_false_failure_executes_operation_once(
             super().__init__(AsyncMock())
             self.role = role
 
+        def _suppress_audit(self, workflow_id: uuid.UUID) -> AuditEventDetails:
+            return AuditEventDetails(emit=False)
+
         @audit_log(
             resource_type="workflow",
             action="update",
-            attempt_metadata=suppress_audit,
+            attempt_metadata=_suppress_audit,
         )
         async def mutate(self, workflow_id: uuid.UUID) -> None:
             del workflow_id
@@ -313,6 +333,7 @@ async def test_create_event_streams_exact_payload_contract(
         ctx_user_agent.reset(user_agent_token)
         ctx_client_ip.reset(client_ip_token)
 
+    await flush_audit_deliveries()
     assert route.called
     payload = orjson.loads(route.calls[0].request.content)
     created_at = payload.pop("created_at")
@@ -810,6 +831,7 @@ async def test_post_event_uses_custom_payload_headers_and_verify_ssl(
         return_value=async_client_context_mock,
     ) as async_client_ctor:
         await audit_service._post_event(webhook_url=webhook_url, payload=event)
+        await flush_audit_deliveries()
 
     async_client_ctor.assert_called_once_with(timeout=10.0, verify=False)
     assert client_mock.post.await_count == 1
@@ -873,6 +895,7 @@ async def test_post_event_wraps_payload_when_attribute_configured(
         return_value=async_client_context_mock,
     ) as async_client_ctor:
         await audit_service._post_event(webhook_url=webhook_url, payload=event)
+        await flush_audit_deliveries()
 
     async_client_ctor.assert_called_once_with(timeout=10.0, verify=True)
     kwargs = client_mock.post.await_args.kwargs
@@ -880,6 +903,517 @@ async def test_post_event_wraps_payload_when_attribute_configured(
     assert set(wrapped_payload.keys()) == {"event"}
     assert wrapped_payload["event"]["custom"] == "yes"
     assert wrapped_payload["event"]["actor_label"] == "user@example.com"
+
+
+@pytest.mark.anyio
+async def test_post_event_failure_does_not_log_webhook_url(
+    monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
+) -> None:
+    webhook_url = "https://secret-host.example.com/audit-hook"
+    monkeypatch.setattr(
+        audit_service, "_get_custom_headers", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        audit_service, "_get_custom_payload", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(audit_service, "_get_verify_ssl", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        audit_service, "_get_payload_attribute", AsyncMock(return_value=None)
+    )
+
+    client_mock = AsyncMock()
+    client_mock.post = AsyncMock(
+        side_effect=httpx.ConnectError(f"cannot connect to {webhook_url}")
+    )
+    async_client_context_mock = AsyncMock()
+    async_client_context_mock.__aenter__.return_value = client_mock
+    async_client_context_mock.__aexit__.return_value = None
+
+    event = AuditEvent(
+        organization_id=uuid.uuid4(),
+        workspace_id=None,
+        actor_type=AuditEventActor.USER,
+        actor_id=uuid.uuid4(),
+        actor_label="user@example.com",
+        resource_type="workflow",
+        resource_id=uuid.uuid4(),
+        action="create",
+        status=AuditEventStatus.SUCCESS,
+    )
+
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(msg: str, **kwargs: object) -> None:
+        warnings.append((msg, kwargs))
+
+    with (
+        patch(
+            "tracecat.audit.service.httpx.AsyncClient",
+            return_value=async_client_context_mock,
+        ),
+        patch("tracecat.audit.service.logger.warning", side_effect=capture_warning),
+    ):
+        await audit_service._post_event(webhook_url=webhook_url, payload=event)
+        await flush_audit_deliveries()
+
+    assert client_mock.post.await_count == 1
+    delivery_warnings = [
+        kwargs for m, kwargs in warnings if m == "Failed to deliver audit webhook"
+    ]
+    assert delivery_warnings
+    for kwargs in delivery_warnings:
+        # The URL is never logged in any form.
+        assert "webhook_url" not in kwargs
+        # The delivery path logs no exception text, so the URL embedded in the
+        # exception message never reaches the log either.
+        assert "error" not in kwargs
+        assert webhook_url not in repr(kwargs)
+        assert kwargs["error_type"] == "ConnectError"
+
+
+@pytest.mark.anyio
+async def test_enqueue_delivery_drops_newest_when_queue_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Fresh, tiny queue for this loop so we can overflow deterministically.
+    loop = asyncio.get_running_loop()
+    audit_service_module._delivery_channels.pop(loop, None)
+    monkeypatch.setattr(audit_service_module, "_AUDIT_DELIVERY_QUEUE_MAXSIZE", 2)
+
+    delivered: list[str] = []
+    gate = asyncio.Event()
+
+    async def blocking_deliver(delivery: _AuditDelivery) -> None:
+        # Hold the worker until released so the queue can fill to capacity.
+        await gate.wait()
+        delivered.append(delivery.request_payload["resource_id"])
+
+    monkeypatch.setattr(audit_service_module, "_deliver", blocking_deliver)
+
+    dropped_url = "https://drop-host.example.com/audit-hook"
+    dropped_payload_marker = "dropped-payload-secret"
+
+    def make_delivery(tag: str, resource_type: str, action: str) -> _AuditDelivery:
+        is_dropped = tag == "dropped"
+        return _AuditDelivery(
+            webhook_url=dropped_url if is_dropped else "https://example.com/audit",
+            request_payload={
+                "resource_id": tag,
+                "data": dropped_payload_marker if is_dropped else "ok",
+            },
+            headers=None,
+            verify_ssl=True,
+            resource_type=cast(Any, resource_type),
+            action=cast(Any, action),
+        )
+
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(msg: str, **kwargs: object) -> None:
+        warnings.append((msg, kwargs))
+
+    with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
+        # First item is picked up by the worker and blocks on the gate; the next
+        # two fill the maxsize=2 queue; the fourth overflows and is dropped.
+        _enqueue_delivery(make_delivery("first", "workflow", "create"))
+        queue = audit_service_module._delivery_channels[loop].queue
+        while queue.qsize() != 0:  # worker has pulled "first" and is blocked
+            await asyncio.sleep(0)
+        _enqueue_delivery(make_delivery("second", "workflow", "update"))
+        _enqueue_delivery(make_delivery("third", "schedule", "delete"))
+        assert queue.full()
+        _enqueue_delivery(make_delivery("dropped", "webhook", "revoke"))
+
+        gate.set()
+        await flush_audit_deliveries()
+
+    # Overflow event is dropped, queued events still deliver FIFO.
+    assert delivered == ["first", "second", "third"]
+
+    drop_warnings = [
+        kwargs
+        for m, kwargs in warnings
+        if m == "Dropped audit webhook delivery; queue full"
+    ]
+    assert len(drop_warnings) == 1
+    dropped = drop_warnings[0]
+    assert dropped["resource_type"] == "webhook"
+    assert dropped["action"] == "revoke"
+    # No payload contents (resource_id / data / url) on the drop-log boundary.
+    assert "dropped" not in repr(dropped)
+    assert "resource_id" not in dropped
+    assert "data" not in dropped
+    assert "webhook_url" not in dropped
+    # The dropped event's payload and sink URL appear nowhere in captured logs.
+    all_logs = repr(warnings)
+    assert dropped_url not in all_logs
+    assert dropped_payload_marker not in all_logs
+
+
+def _delivery(tag: str) -> _AuditDelivery:
+    """Build a minimal delivery whose resource_id doubles as an ordering tag."""
+    return _AuditDelivery(
+        webhook_url="https://example.com/audit",
+        request_payload={"resource_id": tag},
+        headers=None,
+        verify_ssl=True,
+        resource_type=cast(Any, "workflow"),
+        action=cast(Any, "update"),
+    )
+
+
+async def _drop_channel(loop: asyncio.AbstractEventLoop) -> None:
+    """Cancel and detach any channel worker for a loop so it can't leak."""
+    channel = audit_service_module._delivery_channels.pop(loop, None)
+    if channel is not None and not channel.worker.done():
+        channel.worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await channel.worker
+
+
+@pytest.fixture
+async def fresh_delivery_channels() -> AsyncIterator[None]:
+    """Isolate _delivery_channels for the current loop and restore afterward.
+
+    _delivery_channels is a module global and pytest-asyncio may reuse a loop
+    across tests, so a leaked worker/queue would pollute later tests.
+    """
+    loop = asyncio.get_running_loop()
+    await _drop_channel(loop)
+    yield
+    await _drop_channel(loop)
+
+
+@respx.mock
+@pytest.mark.anyio
+async def test_deliver_poison_item_does_not_block_following_deliveries(
+    fresh_delivery_channels: None,
+) -> None:
+    """A failed HTTP delivery must not block or drop later, ordered items.
+
+    The failure is injected at the transport layer: _deliver itself must never
+    raise, or the drain worker would die and orphan the queue.
+    """
+    route = respx.post("https://example.com/audit").mock(
+        side_effect=[
+            httpx.ConnectError("boom"),
+            httpx.Response(200),
+            httpx.Response(200),
+        ]
+    )
+
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(msg: str, **kwargs: object) -> None:
+        warnings.append((msg, kwargs))
+
+    with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
+        _enqueue_delivery(_delivery("first"))
+        _enqueue_delivery(_delivery("second"))
+        _enqueue_delivery(_delivery("third"))
+        await flush_audit_deliveries()
+
+    # Serial FIFO worker: request order is delivery order.
+    tags = [orjson.loads(call.request.content)["resource_id"] for call in route.calls]
+    assert tags == ["first", "second", "third"]
+    assert [
+        (msg, kwargs.get("error_type"), kwargs.get("status_code"))
+        for msg, kwargs in warnings
+    ] == [("Failed to deliver audit webhook", "ConnectError", None)]
+
+
+@respx.mock
+@pytest.mark.anyio
+@pytest.mark.parametrize("status_code", [401, 429, 500])
+async def test_deliver_http_status_failures_log_status_without_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_delivery_channels: None,
+    status_code: int,
+) -> None:
+    """HTTP errors log HTTPStatusError + real status; never URL/exc text/payload."""
+    webhook_url = "https://secret-host.example.com/audit-hook"
+    payload_marker = "payload-secret-marker"
+    respx.post(webhook_url).mock(return_value=httpx.Response(status_code))
+
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(msg: str, **kwargs: object) -> None:
+        warnings.append((msg, kwargs))
+
+    delivery = _AuditDelivery(
+        webhook_url=webhook_url,
+        request_payload={"resource_id": payload_marker},
+        headers=None,
+        verify_ssl=True,
+        resource_type=cast(Any, "workflow"),
+        action=cast(Any, "update"),
+    )
+
+    with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
+        _enqueue_delivery(delivery)
+        await flush_audit_deliveries()
+
+    delivery_warnings = [
+        kwargs for m, kwargs in warnings if m == "Failed to deliver audit webhook"
+    ]
+    assert len(delivery_warnings) == 1
+    kwargs = delivery_warnings[0]
+    assert kwargs["error_type"] == "HTTPStatusError"
+    assert kwargs["status_code"] == status_code
+    # No sink URL, exception text, or payload contents anywhere in the logs.
+    all_logs = repr(warnings)
+    assert webhook_url not in all_logs
+    assert payload_marker not in all_logs
+    assert str(status_code) in all_logs  # status is present, only as the field
+
+
+@pytest.mark.anyio
+async def test_enqueue_does_not_await_while_delivery_in_flight(
+    fresh_delivery_channels: None,
+) -> None:
+    """put_nowait must return immediately even while a slow delivery is blocked."""
+    delivered: list[str] = []
+    gate = asyncio.Event()
+
+    async def gated_deliver(delivery: _AuditDelivery) -> None:
+        tag = delivery.request_payload["resource_id"]
+        if tag == "first":
+            await gate.wait()
+        delivered.append(tag)
+
+    with patch("tracecat.audit.service._deliver", gated_deliver):
+        _enqueue_delivery(_delivery("first"))
+        queue = _get_delivery_queue()
+        # Let the worker pull "first" and block on the gate.
+        while queue.qsize() != 0:
+            await asyncio.sleep(0)
+
+        # Enqueue while the first delivery is blocked; must not await/block.
+        _enqueue_delivery(_delivery("second"))
+        _enqueue_delivery(_delivery("third"))
+        assert queue.qsize() == 2
+
+        gate.set()
+        await flush_audit_deliveries()
+
+    assert delivered == ["first", "second", "third"]
+
+
+@pytest.mark.anyio
+async def test_decorator_delivers_attempt_before_terminal_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+    role: Role,
+    fresh_delivery_channels: None,
+) -> None:
+    """Through the real @audit_log path, the sink sees ATTEMPT before terminal."""
+    webhook_url = "https://example.com/audit"
+    received: list[str] = []
+
+    async def get_webhook_url(_self: AuditService) -> str:
+        return webhook_url
+
+    async def get_actor_label(_self: AuditService) -> str | None:
+        return None
+
+    async def deliver(delivery: _AuditDelivery) -> None:
+        received.append(delivery.request_payload["status"])
+
+    monkeypatch.setattr(AuditService, "_get_webhook_url", get_webhook_url)
+    monkeypatch.setattr(AuditService, "_get_actor_label", get_actor_label)
+    monkeypatch.setattr(
+        AuditService, "_get_custom_headers", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        AuditService, "_get_custom_payload", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(AuditService, "_get_verify_ssl", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        AuditService, "_get_payload_attribute", AsyncMock(return_value=None)
+    )
+
+    service = _AuditedService(AsyncMock(), role)
+    token = ctx_role.set(role)
+    try:
+        with patch("tracecat.audit.service._deliver", deliver):
+            assert await service.mutate(uuid.uuid4()) == "result"
+            await flush_audit_deliveries()
+    finally:
+        ctx_role.reset(token)
+
+    assert received == ["ATTEMPT", "SUCCESS"]
+
+
+@pytest.mark.anyio
+async def test_worker_respawns_onto_same_queue_without_losing_events(
+    fresh_delivery_channels: None,
+) -> None:
+    """Regression: a dead worker respawns on the SAME queue; no events lost."""
+    delivered: list[str] = []
+
+    async def deliver(delivery: _AuditDelivery) -> None:
+        delivered.append(delivery.request_payload["resource_id"])
+
+    with patch("tracecat.audit.service._deliver", deliver):
+        _enqueue_delivery(_delivery("pre-1"))
+        _enqueue_delivery(_delivery("pre-2"))
+        await flush_audit_deliveries()
+
+        loop = asyncio.get_running_loop()
+        channel = audit_service_module._delivery_channels[loop]
+        queue_before = channel.queue
+
+        # Cancel the idle worker (blocked on an empty queue.get()); no item is
+        # mid-flight, so the unfinished-count stays consistent.
+        channel.worker.cancel()
+        try:
+            await channel.worker
+        except asyncio.CancelledError:
+            pass
+        assert channel.worker.done()
+
+        _enqueue_delivery(_delivery("post-1"))
+        # Access respawns the worker onto the existing queue.
+        assert _get_delivery_queue() is queue_before
+        assert audit_service_module._delivery_channels[loop].queue is queue_before
+        await flush_audit_deliveries()
+
+    assert delivered == ["pre-1", "pre-2", "post-1"]
+
+
+@pytest.mark.anyio
+async def test_settings_resolution_failure_is_non_fatal_and_leaks_no_url(
+    monkeypatch: pytest.MonkeyPatch,
+    role: Role,
+    fresh_delivery_channels: None,
+) -> None:
+    """A failing settings read inside _build_delivery must not break the op."""
+    webhook_url = "https://secret-host.example.com/audit-hook"
+    delivered: list[_AuditDelivery] = []
+
+    async def get_webhook_url(_self: AuditService) -> str:
+        return webhook_url
+
+    async def get_actor_label(_self: AuditService) -> str | None:
+        return None
+
+    async def broken_verify_ssl(_self: AuditService) -> bool:
+        raise RuntimeError("settings backend down")
+
+    async def deliver(delivery: _AuditDelivery) -> None:
+        delivered.append(delivery)
+
+    monkeypatch.setattr(AuditService, "_get_webhook_url", get_webhook_url)
+    monkeypatch.setattr(AuditService, "_get_actor_label", get_actor_label)
+    monkeypatch.setattr(
+        AuditService, "_get_custom_headers", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        AuditService, "_get_custom_payload", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(AuditService, "_get_verify_ssl", broken_verify_ssl)
+    monkeypatch.setattr(
+        AuditService, "_get_payload_attribute", AsyncMock(return_value=None)
+    )
+
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(msg: str, **kwargs: object) -> None:
+        warnings.append((msg, kwargs))
+
+    service = _AuditedService(AsyncMock(), role)
+    token = ctx_role.set(role)
+    try:
+        with (
+            patch("tracecat.audit.service._deliver", deliver),
+            patch("tracecat.audit.logger.logger.warning", side_effect=capture_warning),
+            patch("tracecat.audit.service.logger.warning", side_effect=capture_warning),
+        ):
+            # The decorated business op still succeeds despite settings failure.
+            assert await service.mutate(uuid.uuid4()) == "result"
+            await flush_audit_deliveries()
+    finally:
+        ctx_role.reset(token)
+
+    # No delivery occurs when settings resolution raises.
+    assert delivered == []
+    # No warning leaks the sink URL.
+    assert webhook_url not in repr(warnings)
+
+
+@pytest.mark.anyio
+async def test_get_delivery_queue_evicts_closed_loop_entries(
+    fresh_delivery_channels: None,
+) -> None:
+    """Regression: closed-loop entries are evicted on access; no unbounded growth."""
+    channels = audit_service_module._delivery_channels
+
+    # Seed several real, closed loops with dummy channel entries.
+    closed_loops: list[asyncio.AbstractEventLoop] = []
+    for _ in range(5):
+        dead_loop = asyncio.new_event_loop()
+        dead_loop.close()
+        closed_loops.append(dead_loop)
+        channels[dead_loop] = _DeliveryChannel(
+            queue=asyncio.Queue(),
+            worker=cast(Any, MagicMock()),
+        )
+
+    live_loop = asyncio.get_running_loop()
+    size_with_dead = len(channels)
+    assert size_with_dead >= 5
+
+    # Access on the live loop must drop every closed-loop entry.
+    _get_delivery_queue()
+
+    for dead_loop in closed_loops:
+        assert dead_loop not in channels
+    assert live_loop in channels
+    # The dict shrank; it does not grow monotonically with dead loops.
+    assert len(channels) < size_with_dead
+
+
+@pytest.mark.anyio
+async def test_flush_audit_deliveries_no_op_without_channel(
+    fresh_delivery_channels: None,
+) -> None:
+    """flush_audit_deliveries returns immediately when no channel exists."""
+    loop = asyncio.get_running_loop()
+    assert loop not in audit_service_module._delivery_channels
+    # Must not raise or hang.
+    await flush_audit_deliveries()
+    # Flush alone must not create a channel.
+    assert loop not in audit_service_module._delivery_channels
+
+
+@pytest.mark.anyio
+async def test_flush_audit_deliveries_waits_for_in_flight_delivery(
+    fresh_delivery_channels: None,
+) -> None:
+    """flush blocks until a gated in-flight delivery completes."""
+    completed = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def gated_deliver(delivery: _AuditDelivery) -> None:
+        await gate.wait()
+        completed.set()
+
+    with patch("tracecat.audit.service._deliver", gated_deliver):
+        _enqueue_delivery(_delivery("only"))
+        queue = _get_delivery_queue()
+        while queue.qsize() != 0:
+            await asyncio.sleep(0)
+        assert not completed.is_set()
+
+        async def release() -> None:
+            await asyncio.sleep(0)
+            gate.set()
+
+        release_task = asyncio.ensure_future(release())
+        # flush must not return until the gated delivery finishes.
+        await flush_audit_deliveries()
+        await release_task
+
+    assert completed.is_set()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -17,6 +17,7 @@ import respx
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
+from tenacity import wait_none
 
 from tracecat.audit import service as audit_service_module
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
@@ -1062,7 +1063,8 @@ async def test_post_event_failure_does_not_log_webhook_url(
         await audit_service._post_event(webhook_url=webhook_url, payload=event)
         await flush_audit_deliveries()
 
-    assert client_mock.post.await_count == 1
+    # ConnectError is retryable; all attempts exhaust before the warning.
+    assert client_mock.post.await_count == 3
     delivery_warnings = [
         kwargs for m, kwargs in warnings if m == "Failed to deliver audit webhook"
     ]
@@ -1128,6 +1130,12 @@ def _delivery(tag: str, url: str = "https://example.com/audit") -> _AuditDeliver
         resource_type=cast(Any, "workflow"),
         action=cast(Any, "update"),
     )
+
+
+@pytest.fixture(autouse=True)
+def no_retry_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero the delivery retry backoff so retry-path tests don't sleep."""
+    monkeypatch.setattr(audit_service_module, "_RETRY_WAIT", wait_none())
 
 
 async def flush_audit_deliveries() -> None:
@@ -1473,6 +1481,57 @@ async def test_spawn_delivery_evicts_closed_loop_tasks(
         assert fake_task not in tasks
     for dead_loop in dead_loops:
         assert dead_loop not in semaphores
+
+
+@respx.mock
+@pytest.mark.anyio
+async def test_deliver_retries_transient_failure_then_succeeds(
+    fresh_delivery_tasks: None,
+) -> None:
+    """A retryable failure is retried; success on a later attempt logs nothing."""
+    route = respx.post("https://example.com/audit").mock(
+        side_effect=[httpx.Response(503), httpx.Response(200)]
+    )
+
+    warnings: list[str] = []
+
+    def capture_warning(msg: str, **kwargs: object) -> None:
+        warnings.append(msg)
+
+    with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
+        _spawn_delivery(_delivery("flaky"))
+        await flush_audit_deliveries()
+
+    assert route.call_count == 2
+    assert warnings == []
+
+
+@respx.mock
+@pytest.mark.anyio
+async def test_deliver_does_not_retry_terminal_status(
+    fresh_delivery_tasks: None,
+) -> None:
+    """Non-retryable 4xx gets exactly one attempt and one warning."""
+    route = respx.post("https://example.com/audit").mock(
+        return_value=httpx.Response(400)
+    )
+
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(msg: str, **kwargs: object) -> None:
+        warnings.append((msg, kwargs))
+
+    with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
+        _spawn_delivery(_delivery("rejected"))
+        await flush_audit_deliveries()
+
+    assert route.call_count == 1
+    delivery_warnings = [
+        kwargs for m, kwargs in warnings if m == "Failed to deliver audit webhook"
+    ]
+    assert len(delivery_warnings) == 1
+    assert delivery_warnings[0]["status_code"] == 400
+    assert delivery_warnings[0]["attempts"] == 1
 
 
 @respx.mock

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
 from datetime import datetime
 from types import SimpleNamespace
@@ -29,7 +29,6 @@ from tracecat.audit.service import (
     AuditService,
     _AuditDelivery,
     _spawn_delivery,
-    flush_audit_deliveries,
 )
 from tracecat.audit.types import AuditEvent, AuditMetadata
 from tracecat.auth.types import PlatformRole, Role
@@ -54,6 +53,14 @@ def role() -> Role:
 @pytest.fixture
 def audit_service(role: Role) -> AuditService:
     return AuditService(AsyncMock(), role=role)
+
+
+@pytest.fixture(autouse=True)
+def clear_audit_setting_cache() -> Iterator[None]:
+    """Isolate the module-level audit-setting TTL cache between tests."""
+    audit_service_module._get_audit_setting_cached.cache_clear()
+    yield
+    audit_service_module._get_audit_setting_cached.cache_clear()
 
 
 class _AuditedService(BaseService):
@@ -771,12 +778,112 @@ async def test_platform_role_defaults_to_platform_audit_sink(
         service_id="tracecat-api",
     )
     audit_service = AuditService(AsyncMock(), role=role)
-    get_platform_setting = AsyncMock(return_value="https://example.com/audit")
-    monkeypatch.setattr(audit_service, "_get_platform_setting", get_platform_setting)
+    fetch_platform_setting = AsyncMock(return_value="https://example.com/audit")
+    monkeypatch.setattr(
+        audit_service_module, "_fetch_platform_setting", fetch_platform_setting
+    )
 
     assert audit_service.audit_sink == "platform"
     assert await audit_service._get_webhook_url() == "https://example.com/audit"
-    get_platform_setting.assert_awaited_once_with("audit_webhook_url")
+    fetch_platform_setting.assert_awaited_once_with("audit_webhook_url")
+
+
+@pytest.mark.anyio
+async def test_audit_setting_cache_hits_within_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repeat lookup within the TTL is served from cache, not the DB."""
+    role = PlatformRole(type="user", user_id=uuid.uuid4(), service_id="tracecat-api")
+    audit_service = AuditService(AsyncMock(), role=role)
+    fetch = AsyncMock(return_value="https://example.com/audit")
+    monkeypatch.setattr(audit_service_module, "_fetch_platform_setting", fetch)
+
+    first = await audit_service._get_webhook_url()
+    second = await audit_service._get_webhook_url()
+
+    assert first == second == "https://example.com/audit"
+    fetch.assert_awaited_once_with("audit_webhook_url")
+
+
+@pytest.mark.anyio
+async def test_audit_setting_cache_separates_sinks_and_orgs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sink identity and org id are part of the key; no cross-tenant bleed."""
+    org_a = uuid.uuid4()
+    org_b = uuid.uuid4()
+    platform_role = PlatformRole(
+        type="user", user_id=uuid.uuid4(), service_id="tracecat-api"
+    )
+
+    def make_org_service(org_id: uuid.UUID) -> AuditService:
+        return AuditService(
+            AsyncMock(),
+            role=Role(
+                type="user",
+                organization_id=org_id,
+                user_id=uuid.uuid4(),
+                service_id="tracecat-api",
+                scopes=ADMIN_SCOPES,
+            ),
+        )
+
+    platform_service = AuditService(AsyncMock(), role=platform_role)
+    monkeypatch.setattr(
+        audit_service_module,
+        "_fetch_platform_setting",
+        AsyncMock(return_value="https://platform.example.com/audit"),
+    )
+
+    org_values = {
+        org_a: "https://org-a.example.com/audit",
+        org_b: "https://org-b.example.com/audit",
+    }
+
+    async def fake_get_setting(
+        key: str, *, role: Role | None = None, session: Any = None, default: Any = None
+    ) -> Any:
+        assert role is not None and role.organization_id is not None
+        return org_values[role.organization_id]
+
+    monkeypatch.setattr("tracecat.settings.service.get_setting", fake_get_setting)
+
+    assert (
+        await platform_service._get_webhook_url()
+        == "https://platform.example.com/audit"
+    )
+    assert (
+        await make_org_service(org_a)._get_webhook_url()
+        == "https://org-a.example.com/audit"
+    )
+    assert (
+        await make_org_service(org_b)._get_webhook_url()
+        == "https://org-b.example.com/audit"
+    )
+
+
+@pytest.mark.anyio
+async def test_audit_setting_cache_clear_restores_fresh_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cache_clear forces the next lookup back to the underlying fetch."""
+    role = PlatformRole(type="user", user_id=uuid.uuid4(), service_id="tracecat-api")
+    audit_service = AuditService(AsyncMock(), role=role)
+    fetch = AsyncMock(
+        side_effect=[
+            "https://first.example.com/audit",
+            "https://second.example.com/audit",
+        ]
+    )
+    monkeypatch.setattr(audit_service_module, "_fetch_platform_setting", fetch)
+
+    assert await audit_service._get_webhook_url() == "https://first.example.com/audit"
+    assert await audit_service._get_webhook_url() == "https://first.example.com/audit"
+
+    audit_service_module._get_audit_setting_cached.cache_clear()
+
+    assert await audit_service._get_webhook_url() == "https://second.example.com/audit"
+    assert fetch.await_count == 2
 
 
 @pytest.mark.anyio
@@ -1021,6 +1128,14 @@ def _delivery(tag: str, url: str = "https://example.com/audit") -> _AuditDeliver
         resource_type=cast(Any, "workflow"),
         action=cast(Any, "update"),
     )
+
+
+async def flush_audit_deliveries() -> None:
+    """Wait for this loop's in-flight audit deliveries."""
+    loop = asyncio.get_running_loop()
+    tasks = [t for t in audit_service_module._delivery_tasks if t.get_loop() is loop]
+    if tasks:
+        await asyncio.gather(*tasks)
 
 
 async def _cancel_loop_tasks(loop: asyncio.AbstractEventLoop) -> None:
@@ -1349,45 +1464,6 @@ async def test_spawn_delivery_evicts_closed_loop_tasks(
 
     for fake_task in stranded:
         assert fake_task not in tasks
-
-
-@pytest.mark.anyio
-async def test_flush_audit_deliveries_no_op_without_tasks(
-    fresh_delivery_tasks: None,
-) -> None:
-    """flush_audit_deliveries returns immediately when nothing is in flight."""
-    loop = asyncio.get_running_loop()
-    assert not any(t.get_loop() is loop for t in audit_service_module._delivery_tasks)
-    # Must not raise or hang.
-    await flush_audit_deliveries()
-
-
-@pytest.mark.anyio
-async def test_flush_audit_deliveries_waits_for_in_flight_delivery(
-    fresh_delivery_tasks: None,
-) -> None:
-    """flush blocks until a gated in-flight delivery completes."""
-    completed = asyncio.Event()
-    gate = asyncio.Event()
-
-    async def gated_deliver(delivery: _AuditDelivery) -> None:
-        await gate.wait()
-        completed.set()
-
-    with patch("tracecat.audit.service._deliver", gated_deliver):
-        _spawn_delivery(_delivery("only"))
-        assert not completed.is_set()
-
-        async def release() -> None:
-            await asyncio.sleep(0)
-            gate.set()
-
-        release_task = asyncio.ensure_future(release())
-        # flush must not return until the gated delivery finishes.
-        await flush_audit_deliveries()
-        await release_task
-
-    assert completed.is_set()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -24,13 +24,14 @@ from tracecat.audit.logger import (
     AuditEventDetails,
     audit_log,
 )
+from tracecat.audit.sanitization import sanitize_audit_metadata
 from tracecat.audit.service import (
     AuditService,
     _AuditDelivery,
     _spawn_delivery,
     flush_audit_deliveries,
 )
-from tracecat.audit.types import AuditEvent
+from tracecat.audit.types import AuditEvent, AuditMetadata
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.auth.users import UserManager
 from tracecat.authz.scopes import ADMIN_SCOPES
@@ -1639,3 +1640,29 @@ async def test_audit_log_failure_logging_failure_still_raises_original_exception
 
     assert len(create_event_calls) == 1
     assert create_event_calls[0][1]["status"] == AuditEventStatus.ATTEMPT
+
+
+def test_sanitize_audit_metadata_keeps_batch_operation_keys():
+    id_a, id_b = str(uuid.uuid4()), str(uuid.uuid4())
+    data = {
+        "is_batch": True,
+        "case_ids": [id_a, id_b],
+        "case_count": 2,
+        "succeeded_count": 1,
+        "failed_count": 1,
+        "description": "raw content must be dropped",
+    }
+    assert sanitize_audit_metadata(data) == {
+        "is_batch": True,
+        "case_ids": [id_a, id_b],
+        "case_count": 2,
+        "succeeded_count": 1,
+        "failed_count": 1,
+    }
+
+
+def test_sanitize_audit_metadata_drops_non_string_id_list_items():
+    id_a = str(uuid.uuid4())
+    # Deliberately ill-typed items to exercise the runtime guard.
+    data = cast(AuditMetadata, {"case_ids": [id_a, 42, None]})
+    assert sanitize_audit_metadata(data) == {"case_ids": [id_a]}

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from contextlib import asynccontextmanager
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,15 +10,23 @@ import httpx
 import orjson
 import pytest
 import respx
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
-from tracecat.audit.logger import audit_log
+from tracecat.audit.logger import (
+    AuditCallContext,
+    AuditEventDetails,
+    audit_log,
+)
 from tracecat.audit.service import AuditService
 from tracecat.audit.types import AuditEvent
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.auth.users import UserManager
 from tracecat.authz.scopes import ADMIN_SCOPES
-from tracecat.contexts import ctx_client_ip, ctx_role
+from tracecat.contexts import ctx_client_ip, ctx_role, ctx_user_agent
+from tracecat.service import BaseService
 
 
 @pytest.fixture
@@ -37,6 +46,175 @@ def audit_service(role: Role) -> AuditService:
     return AuditService(AsyncMock(), role=role)
 
 
+def _test_audit_details(_context: AuditCallContext) -> AuditEventDetails:
+    return AuditEventDetails(data={"changed_fields": ["status"]})
+
+
+def _broken_audit_result(_context: AuditCallContext, _result: str) -> AuditEventDetails:
+    raise ValueError("metadata derivation failed")
+
+
+class _AuditedService(BaseService):
+    service_name = "test_audit"
+
+    def __init__(self, session: AsyncSession, role: Role) -> None:
+        super().__init__(session)
+        self.role = role
+
+    @audit_log(
+        resource_type="workflow",
+        action="update",
+        attempt_metadata=_test_audit_details,
+    )
+    async def mutate(self, workflow_id: uuid.UUID, *, fail: bool = False) -> str:
+        if fail:
+            raise ValueError("operation failed")
+        return "result"
+
+    @audit_log(
+        resource_type="workflow",
+        action="update",
+        attempt_metadata=_test_audit_details,
+        terminal_metadata=_broken_audit_result,
+    )
+    async def mutate_with_broken_result(self, workflow_id: uuid.UUID) -> str:
+        return "committed result"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("scenario", "expected_statuses"),
+    [
+        ("success", [AuditEventStatus.ATTEMPT, AuditEventStatus.SUCCESS]),
+        ("failure", [AuditEventStatus.ATTEMPT, AuditEventStatus.FAILURE]),
+        ("service_account", [AuditEventStatus.ATTEMPT, AuditEventStatus.SUCCESS]),
+        ("service_gate", []),
+    ],
+)
+async def test_audit_log_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    role: Role,
+    scenario: str,
+    expected_statuses: list[AuditEventStatus],
+) -> None:
+    events: list[dict[str, object]] = []
+    audit_sessions: list[object | None] = []
+    resource_id = uuid.uuid4()
+
+    @asynccontextmanager
+    async def with_session(
+        cls: type[AuditService],
+        _role: Role | None = None,
+        *,
+        session: object | None = None,
+        audit_sink: object | None = None,
+    ):
+        del cls, audit_sink
+        audit_sessions.append(session)
+
+        class Capture:
+            async def create_event(self, **kwargs: object) -> None:
+                events.append(kwargs)
+
+        yield Capture()
+
+    monkeypatch.setattr(AuditService, "with_session", classmethod(with_session))
+    if scenario == "service_gate":
+        audit_role = role.model_copy(update={"type": "service"})
+    elif scenario == "service_account":
+        audit_role = role.model_copy(
+            update={
+                "type": "service_account",
+                "user_id": None,
+                "service_account_id": uuid.uuid4(),
+            }
+        )
+    else:
+        audit_role = role
+    service = _AuditedService(AsyncMock(), audit_role)
+    token = ctx_role.set(role)
+    try:
+        if scenario == "failure":
+            with pytest.raises(ValueError, match="operation failed"):
+                await service.mutate(resource_id, fail=True)
+        else:
+            result = await service.mutate(resource_id)
+            assert result == "result"
+    finally:
+        ctx_role.reset(token)
+
+    assert [event["status"] for event in events] == expected_statuses
+    if scenario == "failure":
+        assert audit_sessions == [service.session, None]
+    if events:
+        assert all(event["data"] == {"changed_fields": ["status"]} for event in events)
+
+
+@pytest.mark.anyio
+async def test_audit_log_result_derivation_failure_is_non_fatal(
+    monkeypatch: pytest.MonkeyPatch, role: Role
+) -> None:
+    events: list[dict[str, object]] = []
+
+    async def create_event(_self: AuditService, **kwargs: object) -> None:
+        events.append(kwargs)
+
+    monkeypatch.setattr(AuditService, "create_event", create_event)
+    service = _AuditedService(AsyncMock(), role)
+    result = await service.mutate_with_broken_result(uuid.uuid4())
+
+    assert result == "committed result"
+    assert [event["status"] for event in events] == [
+        AuditEventStatus.ATTEMPT,
+        AuditEventStatus.SUCCESS,
+    ]
+    assert events[-1]["data"] == {"changed_fields": ["status"]}
+
+
+@pytest.mark.anyio
+async def test_audit_log_failure_uses_fresh_session_after_abort(
+    monkeypatch: pytest.MonkeyPatch,
+    role: Role,
+    session: AsyncSession,
+) -> None:
+    delivered: list[tuple[AsyncSession, AuditEventStatus]] = []
+
+    async def get_webhook_url(_self: AuditService) -> str:
+        return "https://example.com/audit"
+
+    async def get_actor_label(_self: AuditService) -> str:
+        return "user@example.com"
+
+    async def post_event(
+        self: AuditService, *, webhook_url: str, payload: AuditEvent
+    ) -> None:
+        assert webhook_url == "https://example.com/audit"
+        delivered.append((self.session, payload.status))
+
+    class FailingService(_AuditedService):
+        @audit_log(
+            resource_type="workflow",
+            action="update",
+        )
+        async def fail_after_aborting_session(self, workflow_id: uuid.UUID) -> None:
+            await self.session.execute(text("SELECT 1 / 0"))
+
+    monkeypatch.setattr(AuditService, "_get_webhook_url", get_webhook_url)
+    monkeypatch.setattr(AuditService, "_get_actor_label", get_actor_label)
+    monkeypatch.setattr(AuditService, "_post_event", post_event)
+
+    service = FailingService(session, role)
+    with pytest.raises(SQLAlchemyError):
+        await service.fail_after_aborting_session(uuid.uuid4())
+
+    assert [status for _, status in delivered] == [
+        AuditEventStatus.ATTEMPT,
+        AuditEventStatus.FAILURE,
+    ]
+    assert delivered[0][0] is session
+    assert delivered[1][0] is not session
+
+
 @pytest.mark.anyio
 async def test_create_event_skips_without_webhook(
     monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
@@ -52,10 +230,14 @@ async def test_create_event_skips_without_webhook(
 
 @respx.mock
 @pytest.mark.anyio
-async def test_create_event_streams_to_webhook(
+async def test_create_event_streams_exact_payload_contract(
     monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
 ) -> None:
     webhook_url = "https://example.com/audit"
+    resource_id = uuid.uuid4()
+    webhook_id = uuid.uuid4()
+    client_ip = "192.0.2.10"
+    user_agent = "TracecatAuditTest/1.0"
     monkeypatch.setattr(
         audit_service, "_get_webhook_url", AsyncMock(return_value=webhook_url)
     )
@@ -70,34 +252,90 @@ async def test_create_event_streams_to_webhook(
         audit_service, "_get_payload_attribute", AsyncMock(return_value=None)
     )
     mock_user = MagicMock()
-    mock_user.email = "user@example.com"
+    mock_user.email = "actor@example.test"
     result_mock = MagicMock()
     result_mock.scalar_one_or_none = MagicMock(return_value=mock_user)
     audit_service.session.execute = AsyncMock(return_value=result_mock)
     route = respx.post(webhook_url).mock(return_value=httpx.Response(200))
 
-    await audit_service.create_event(
-        resource_type="workflow",
-        action="create",
-        resource_id=uuid.uuid4(),
-        status=AuditEventStatus.SUCCESS,
-    )
+    client_ip_token = ctx_client_ip.set(client_ip)
+    user_agent_token = ctx_user_agent.set(user_agent)
+    try:
+        await audit_service.create_event(
+            resource_type="webhook",
+            action="update",
+            resource_id=resource_id,
+            status=AuditEventStatus.SUCCESS,
+            data={
+                "webhook_id": str(webhook_id),
+                "changed_fields": ["status"],
+            },
+        )
+    finally:
+        ctx_user_agent.reset(user_agent_token)
+        ctx_client_ip.reset(client_ip_token)
 
     assert route.called
     payload = orjson.loads(route.calls[0].request.content)
-    assert payload["resource_type"] == "workflow"
-    assert payload["action"] == "create"
-    assert payload["status"] == AuditEventStatus.SUCCESS.value
-    assert payload["actor_label"] == "user@example.com"
+    created_at = payload.pop("created_at")
+    assert (
+        datetime.fromisoformat(created_at.replace("Z", "+00:00")).utcoffset()
+        is not None
+    )
+    role = audit_service.role
+    assert isinstance(role, Role)
+    assert payload == {
+        "organization_id": str(role.organization_id),
+        "workspace_id": None,
+        "actor_type": "USER",
+        "actor_id": str(role.actor_id),
+        "actor_label": "actor@example.test",
+        "ip_address": client_ip,
+        "user_agent": user_agent,
+        "resource_type": "webhook",
+        "resource_id": str(resource_id),
+        "action": "update",
+        "status": "SUCCESS",
+        "data": {
+            "webhook_id": str(webhook_id),
+            "changed_fields": ["status"],
+        },
+    }
 
 
 @pytest.mark.anyio
-async def test_create_event_includes_case_comment_data_in_payload(
+async def test_create_event_enforces_audit_metadata_policy(
     monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
 ) -> None:
     webhook_url = "https://example.com/audit"
     post_mock = AsyncMock()
-    data = {"case_id": str(uuid.uuid4()), "content": "hello"}
+    case_id = str(uuid.uuid4())
+    data = {
+        "case_id": case_id,
+        "execution_id": "https://user:password@example.test/run?token=secret",
+        "operation": "retry",
+        "workflow_status": "Authorization: Bearer opaque-token",
+        "changed_fields": ["status"],
+        "name": "arbitrary resource name",
+        "description": "arbitrary resource description",
+        "content": "raw comment content",
+        "password": "password-value",
+        "api_key": "api-key-value",
+        "oauth_token": "oauth-token-value",
+        "cookie": "session=cookie-value",
+        "authorization": "Bearer authorization-value",
+        "headers": "Authorization: Bearer header-value",
+        "request_body": "raw request body",
+        "response_body": "raw response body",
+        "workflow_input": "raw workflow input",
+        "workflow_output": "raw workflow output",
+        "prompt": "raw prompt",
+        "tool_result": "raw tool result",
+        "file_content": "raw uploaded file content",
+        "environment": "SECRET_VALUE",
+        "before": "secret-bearing old value",
+        "after": "secret-bearing new value",
+    }
     monkeypatch.setattr(
         audit_service, "_get_webhook_url", AsyncMock(return_value=webhook_url)
     )
@@ -118,7 +356,11 @@ async def test_create_event_includes_case_comment_data_in_payload(
     assert post_mock.await_args is not None
     payload = post_mock.await_args.kwargs["payload"]
     assert payload.resource_type == "case_comment"
-    assert payload.data == data
+    assert payload.data == {
+        "case_id": case_id,
+        "operation": "retry",
+        "changed_fields": ["status"],
+    }
 
 
 @pytest.mark.anyio
@@ -127,6 +369,7 @@ async def test_create_event_can_emit_sanitized_platform_org_auth_event(
 ) -> None:
     webhook_url = "https://example.com/platform-audit"
     client_ip = "203.0.113.10"
+    user_agent = "TracecatClient/1.0 [redacted email] Authorization: [redacted]"
     role = Role(
         type="user",
         organization_id=uuid.uuid4(),
@@ -141,7 +384,8 @@ async def test_create_event_can_emit_sanitized_platform_org_auth_event(
     )
     monkeypatch.setattr(audit_service, "_get_actor_label", actor_label_mock)
     monkeypatch.setattr(audit_service, "_post_event", post_mock)
-    token = ctx_client_ip.set(client_ip)
+    client_ip_token = ctx_client_ip.set(client_ip)
+    user_agent_token = ctx_user_agent.set(user_agent)
 
     try:
         await audit_service.create_event(
@@ -152,7 +396,8 @@ async def test_create_event_can_emit_sanitized_platform_org_auth_event(
             include_actor_label=False,
         )
     finally:
-        ctx_client_ip.reset(token)
+        ctx_user_agent.reset(user_agent_token)
+        ctx_client_ip.reset(client_ip_token)
 
     actor_label_mock.assert_not_awaited()
     assert post_mock.await_args is not None
@@ -161,6 +406,7 @@ async def test_create_event_can_emit_sanitized_platform_org_auth_event(
     assert payload.actor_id == role.user_id
     assert payload.actor_label is None
     assert payload.ip_address == client_ip
+    assert payload.user_agent == user_agent
     assert payload.data == {"auth_method": "saml"}
 
 
@@ -673,9 +919,11 @@ async def test_audit_log_explicit_invitation_id_overrides_result_id(
 async def test_audit_log_inner_function_failure_logs_failure_event(role: Role):
     """Test that when inner function raises exception, failure event is logged."""
 
-    class MockService:
+    class MockService(BaseService):
+        service_name = "mock"
+
         def __init__(self):
-            self.session = AsyncMock()
+            super().__init__(AsyncMock())
 
         @audit_log(resource_type="workflow", action="create")
         async def create_workflow(self, workflow_id: uuid.UUID):
@@ -685,12 +933,25 @@ async def test_audit_log_inner_function_failure_logs_failure_event(role: Role):
     token = ctx_role.set(role)
 
     create_event_calls = []
+    audit_sessions: list[object | None] = []
 
     async def mock_create_event(*args, **kwargs):
         create_event_calls.append((args, kwargs))
 
+    @asynccontextmanager
+    async def mock_with_session(
+        cls,
+        _role=None,
+        *,
+        session=None,
+        audit_sink=None,
+    ):
+        del cls, audit_sink
+        audit_sessions.append(session)
+        yield SimpleNamespace(create_event=mock_create_event)
+
     try:
-        with patch.object(AuditService, "create_event", side_effect=mock_create_event):
+        with patch.object(AuditService, "with_session", classmethod(mock_with_session)):
             with pytest.raises(ValueError, match="Workflow creation failed"):
                 await service.create_workflow(workflow_id=uuid.uuid4())
     finally:
@@ -700,6 +961,37 @@ async def test_audit_log_inner_function_failure_logs_failure_event(role: Role):
     assert create_event_calls[0][1]["status"] == AuditEventStatus.ATTEMPT
     assert len(create_event_calls) >= 2
     assert create_event_calls[1][1]["status"] == AuditEventStatus.FAILURE
+    assert audit_sessions == [service.session, None]
+
+
+@pytest.mark.anyio
+async def test_audit_log_ok_false_logs_failure_event(role: Role) -> None:
+    class MockService(BaseService):
+        service_name = "mock"
+
+        def __init__(self) -> None:
+            super().__init__(AsyncMock())
+
+        @audit_log(resource_type="workflow", action="publish")
+        async def publish_workflow(self, workflow_id: uuid.UUID):
+            return SimpleNamespace(ok=False)
+
+    token = ctx_role.set(role)
+    create_event_calls: list[dict[str, object]] = []
+
+    async def mock_create_event(*args, **kwargs):
+        create_event_calls.append(kwargs)
+
+    try:
+        with patch.object(AuditService, "create_event", side_effect=mock_create_event):
+            await MockService().publish_workflow(uuid.uuid4())
+    finally:
+        ctx_role.reset(token)
+
+    assert [call["status"] for call in create_event_calls] == [
+        AuditEventStatus.ATTEMPT,
+        AuditEventStatus.FAILURE,
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -27,16 +27,14 @@ from tracecat.audit.logger import (
 from tracecat.audit.service import (
     AuditService,
     _AuditDelivery,
-    _DeliveryChannel,
-    _enqueue_delivery,
-    _get_delivery_queue,
+    _spawn_delivery,
     flush_audit_deliveries,
 )
 from tracecat.audit.types import AuditEvent
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.auth.users import UserManager
 from tracecat.authz.scopes import ADMIN_SCOPES
-from tracecat.contexts import ctx_client_ip, ctx_role, ctx_user_agent
+from tracecat.contexts import RequestAuditContext, ctx_request_audit, ctx_role
 from tracecat.service import BaseService
 
 
@@ -316,8 +314,9 @@ async def test_create_event_streams_exact_payload_contract(
     audit_service.session.execute = AsyncMock(return_value=result_mock)
     route = respx.post(webhook_url).mock(return_value=httpx.Response(200))
 
-    client_ip_token = ctx_client_ip.set(client_ip)
-    user_agent_token = ctx_user_agent.set(user_agent)
+    audit_token = ctx_request_audit.set(
+        RequestAuditContext(client_ip=client_ip, user_agent=user_agent)
+    )
     try:
         await audit_service.create_event(
             resource_type="webhook",
@@ -330,8 +329,7 @@ async def test_create_event_streams_exact_payload_contract(
             },
         )
     finally:
-        ctx_user_agent.reset(user_agent_token)
-        ctx_client_ip.reset(client_ip_token)
+        ctx_request_audit.reset(audit_token)
 
     await flush_audit_deliveries()
     assert route.called
@@ -443,8 +441,9 @@ async def test_create_event_can_emit_sanitized_platform_org_auth_event(
     )
     monkeypatch.setattr(audit_service, "_get_actor_label", actor_label_mock)
     monkeypatch.setattr(audit_service, "_post_event", post_mock)
-    client_ip_token = ctx_client_ip.set(client_ip)
-    user_agent_token = ctx_user_agent.set(user_agent)
+    audit_token = ctx_request_audit.set(
+        RequestAuditContext(client_ip=client_ip, user_agent=user_agent)
+    )
 
     try:
         await audit_service.create_event(
@@ -455,8 +454,7 @@ async def test_create_event_can_emit_sanitized_platform_org_auth_event(
             include_actor_label=False,
         )
     finally:
-        ctx_user_agent.reset(user_agent_token)
-        ctx_client_ip.reset(client_ip_token)
+        ctx_request_audit.reset(audit_token)
 
     actor_label_mock.assert_not_awaited()
     assert post_mock.await_args is not None
@@ -969,91 +967,53 @@ async def test_post_event_failure_does_not_log_webhook_url(
         assert "error" not in kwargs
         assert webhook_url not in repr(kwargs)
         assert kwargs["error_type"] == "ConnectError"
+    # No part of the URL may appear through any current or future log field.
+    assert webhook_url not in str(warnings)
+    assert "secret-host" not in str(warnings)
 
 
 @pytest.mark.anyio
-async def test_enqueue_delivery_drops_newest_when_queue_full(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_create_event_settings_failure_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
 ) -> None:
-    # Fresh, tiny queue for this loop so we can overflow deterministically.
-    loop = asyncio.get_running_loop()
-    audit_service_module._delivery_channels.pop(loop, None)
-    monkeypatch.setattr(audit_service_module, "_AUDIT_DELIVERY_QUEUE_MAXSIZE", 2)
+    """Audit is best-effort even for direct create_event callers.
 
-    delivered: list[str] = []
-    gate = asyncio.Event()
+    A failed settings lookup in _build_delivery must be swallowed, not abort
+    the audited operation, and must not leak the sink URL.
+    """
+    monkeypatch.setattr(
+        audit_service,
+        "_get_webhook_url",
+        AsyncMock(return_value="https://secret-host.example.com/audit-hook"),
+    )
+    monkeypatch.setattr(
+        audit_service,
+        "_get_custom_headers",
+        AsyncMock(side_effect=SQLAlchemyError("settings lookup failed")),
+    )
+    monkeypatch.setattr(audit_service, "_get_actor_label", AsyncMock(return_value=None))
+    spawn = MagicMock()
+    monkeypatch.setattr(audit_service_module, "_spawn_delivery", spawn)
+    logger_mock = MagicMock()
+    monkeypatch.setattr(audit_service, "logger", logger_mock)
 
-    async def blocking_deliver(delivery: _AuditDelivery) -> None:
-        # Hold the worker until released so the queue can fill to capacity.
-        await gate.wait()
-        delivered.append(delivery.request_payload["resource_id"])
+    await audit_service.create_event(resource_type="workflow", action="update")
 
-    monkeypatch.setattr(audit_service_module, "_deliver", blocking_deliver)
-
-    dropped_url = "https://drop-host.example.com/audit-hook"
-    dropped_payload_marker = "dropped-payload-secret"
-
-    def make_delivery(tag: str, resource_type: str, action: str) -> _AuditDelivery:
-        is_dropped = tag == "dropped"
-        return _AuditDelivery(
-            webhook_url=dropped_url if is_dropped else "https://example.com/audit",
-            request_payload={
-                "resource_id": tag,
-                "data": dropped_payload_marker if is_dropped else "ok",
-            },
-            headers=None,
-            verify_ssl=True,
-            resource_type=cast(Any, resource_type),
-            action=cast(Any, action),
-        )
-
-    warnings: list[tuple[str, dict[str, object]]] = []
-
-    def capture_warning(msg: str, **kwargs: object) -> None:
-        warnings.append((msg, kwargs))
-
-    with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
-        # First item is picked up by the worker and blocks on the gate; the next
-        # two fill the maxsize=2 queue; the fourth overflows and is dropped.
-        _enqueue_delivery(make_delivery("first", "workflow", "create"))
-        queue = audit_service_module._delivery_channels[loop].queue
-        while queue.qsize() != 0:  # worker has pulled "first" and is blocked
-            await asyncio.sleep(0)
-        _enqueue_delivery(make_delivery("second", "workflow", "update"))
-        _enqueue_delivery(make_delivery("third", "schedule", "delete"))
-        assert queue.full()
-        _enqueue_delivery(make_delivery("dropped", "webhook", "revoke"))
-
-        gate.set()
-        await flush_audit_deliveries()
-
-    # Overflow event is dropped, queued events still deliver FIFO.
-    assert delivered == ["first", "second", "third"]
-
-    drop_warnings = [
-        kwargs
-        for m, kwargs in warnings
-        if m == "Dropped audit webhook delivery; queue full"
+    spawn.assert_not_called()
+    resolution_warnings = [
+        call
+        for call in logger_mock.warning.call_args_list
+        if call.args and call.args[0] == "Failed to resolve audit webhook delivery"
     ]
-    assert len(drop_warnings) == 1
-    dropped = drop_warnings[0]
-    assert dropped["resource_type"] == "webhook"
-    assert dropped["action"] == "revoke"
-    # No payload contents (resource_id / data / url) on the drop-log boundary.
-    assert "dropped" not in repr(dropped)
-    assert "resource_id" not in dropped
-    assert "data" not in dropped
-    assert "webhook_url" not in dropped
-    # The dropped event's payload and sink URL appear nowhere in captured logs.
-    all_logs = repr(warnings)
-    assert dropped_url not in all_logs
-    assert dropped_payload_marker not in all_logs
+    assert len(resolution_warnings) == 1
+    assert resolution_warnings[0].kwargs == {"error_type": "SQLAlchemyError"}
+    assert "secret-host" not in str(logger_mock.warning.call_args_list)
 
 
-def _delivery(tag: str) -> _AuditDelivery:
-    """Build a minimal delivery whose resource_id doubles as an ordering tag."""
+def _delivery(tag: str, url: str = "https://example.com/audit") -> _AuditDelivery:
+    """Build a minimal delivery whose resource_id doubles as an identifying tag."""
     return _AuditDelivery(
-        webhook_url="https://example.com/audit",
+        webhook_url=url,
         request_payload={"resource_id": tag},
         headers=None,
         verify_ssl=True,
@@ -1062,44 +1022,43 @@ def _delivery(tag: str) -> _AuditDelivery:
     )
 
 
-async def _drop_channel(loop: asyncio.AbstractEventLoop) -> None:
-    """Cancel and detach any channel worker for a loop so it can't leak."""
-    channel = audit_service_module._delivery_channels.pop(loop, None)
-    if channel is not None and not channel.worker.done():
-        channel.worker.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await channel.worker
+async def _cancel_loop_tasks(loop: asyncio.AbstractEventLoop) -> None:
+    """Cancel and await this loop's delivery tasks so they can't leak."""
+    tasks = [t for t in audit_service_module._delivery_tasks if t.get_loop() is loop]
+    for task in tasks:
+        task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @pytest.fixture
-async def fresh_delivery_channels() -> AsyncIterator[None]:
-    """Isolate _delivery_channels for the current loop and restore afterward.
+async def fresh_delivery_tasks() -> AsyncIterator[None]:
+    """Isolate _delivery_tasks for the current loop and restore afterward.
 
-    _delivery_channels is a module global and pytest-asyncio may reuse a loop
-    across tests, so a leaked worker/queue would pollute later tests.
+    _delivery_tasks is a module global and pytest-asyncio may reuse a loop
+    across tests, so a leaked in-flight task would pollute later tests.
     """
     loop = asyncio.get_running_loop()
-    await _drop_channel(loop)
+    await _cancel_loop_tasks(loop)
     yield
-    await _drop_channel(loop)
+    await _cancel_loop_tasks(loop)
 
 
 @respx.mock
 @pytest.mark.anyio
-async def test_deliver_poison_item_does_not_block_following_deliveries(
-    fresh_delivery_channels: None,
+async def test_deliver_failure_does_not_affect_other_deliveries(
+    fresh_delivery_tasks: None,
 ) -> None:
-    """A failed HTTP delivery must not block or drop later, ordered items.
+    """A failed HTTP delivery must not block, drop, or cancel other deliveries.
 
     The failure is injected at the transport layer: _deliver itself must never
-    raise, or the drain worker would die and orphan the queue.
+    raise, or the unretrieved task exception would surface as loop noise.
     """
-    route = respx.post("https://example.com/audit").mock(
-        side_effect=[
-            httpx.ConnectError("boom"),
-            httpx.Response(200),
-            httpx.Response(200),
-        ]
+    respx.post("https://fail.example.com/audit").mock(
+        side_effect=httpx.ConnectError("boom")
+    )
+    ok_route = respx.post("https://example.com/audit").mock(
+        return_value=httpx.Response(200)
     )
 
     warnings: list[tuple[str, dict[str, object]]] = []
@@ -1108,14 +1067,16 @@ async def test_deliver_poison_item_does_not_block_following_deliveries(
         warnings.append((msg, kwargs))
 
     with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
-        _enqueue_delivery(_delivery("first"))
-        _enqueue_delivery(_delivery("second"))
-        _enqueue_delivery(_delivery("third"))
+        _spawn_delivery(_delivery("first", url="https://fail.example.com/audit"))
+        _spawn_delivery(_delivery("second"))
+        _spawn_delivery(_delivery("third"))
         await flush_audit_deliveries()
 
-    # Serial FIFO worker: request order is delivery order.
-    tags = [orjson.loads(call.request.content)["resource_id"] for call in route.calls]
-    assert tags == ["first", "second", "third"]
+    # Concurrent tasks: no ordering guarantee, but nothing is lost.
+    tags = {
+        orjson.loads(call.request.content)["resource_id"] for call in ok_route.calls
+    }
+    assert tags == {"second", "third"}
     assert [
         (msg, kwargs.get("error_type"), kwargs.get("status_code"))
         for msg, kwargs in warnings
@@ -1127,7 +1088,7 @@ async def test_deliver_poison_item_does_not_block_following_deliveries(
 @pytest.mark.parametrize("status_code", [401, 429, 500])
 async def test_deliver_http_status_failures_log_status_without_secrets(
     monkeypatch: pytest.MonkeyPatch,
-    fresh_delivery_channels: None,
+    fresh_delivery_tasks: None,
     status_code: int,
 ) -> None:
     """HTTP errors log HTTPStatusError + real status; never URL/exc text/payload."""
@@ -1150,7 +1111,7 @@ async def test_deliver_http_status_failures_log_status_without_secrets(
     )
 
     with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
-        _enqueue_delivery(delivery)
+        _spawn_delivery(delivery)
         await flush_audit_deliveries()
 
     delivery_warnings = [
@@ -1168,10 +1129,10 @@ async def test_deliver_http_status_failures_log_status_without_secrets(
 
 
 @pytest.mark.anyio
-async def test_enqueue_does_not_await_while_delivery_in_flight(
-    fresh_delivery_channels: None,
+async def test_slow_delivery_does_not_block_later_deliveries(
+    fresh_delivery_tasks: None,
 ) -> None:
-    """put_nowait must return immediately even while a slow delivery is blocked."""
+    """No head-of-line blocking: later deliveries complete while one is stuck."""
     delivered: list[str] = []
     gate = asyncio.Event()
 
@@ -1182,30 +1143,32 @@ async def test_enqueue_does_not_await_while_delivery_in_flight(
         delivered.append(tag)
 
     with patch("tracecat.audit.service._deliver", gated_deliver):
-        _enqueue_delivery(_delivery("first"))
-        queue = _get_delivery_queue()
-        # Let the worker pull "first" and block on the gate.
-        while queue.qsize() != 0:
-            await asyncio.sleep(0)
+        _spawn_delivery(_delivery("first"))
+        _spawn_delivery(_delivery("second"))
+        _spawn_delivery(_delivery("third"))
 
-        # Enqueue while the first delivery is blocked; must not await/block.
-        _enqueue_delivery(_delivery("second"))
-        _enqueue_delivery(_delivery("third"))
-        assert queue.qsize() == 2
+        # Later deliveries complete while "first" is still gated.
+        while len(delivered) < 2:
+            await asyncio.sleep(0)
+        assert sorted(delivered) == ["second", "third"]
 
         gate.set()
         await flush_audit_deliveries()
 
-    assert delivered == ["first", "second", "third"]
+    assert sorted(delivered) == ["first", "second", "third"]
 
 
 @pytest.mark.anyio
-async def test_decorator_delivers_attempt_before_terminal_in_order(
+async def test_decorator_delivers_attempt_and_terminal(
     monkeypatch: pytest.MonkeyPatch,
     role: Role,
-    fresh_delivery_channels: None,
+    fresh_delivery_tasks: None,
 ) -> None:
-    """Through the real @audit_log path, the sink sees ATTEMPT before terminal."""
+    """Through the real @audit_log path, both ATTEMPT and terminal are delivered.
+
+    Arrival order at the sink is not guaranteed; consumers order by event
+    timestamp, not delivery order.
+    """
     webhook_url = "https://example.com/audit"
     received: list[str] = []
 
@@ -1240,51 +1203,14 @@ async def test_decorator_delivers_attempt_before_terminal_in_order(
     finally:
         ctx_role.reset(token)
 
-    assert received == ["ATTEMPT", "SUCCESS"]
-
-
-@pytest.mark.anyio
-async def test_worker_respawns_onto_same_queue_without_losing_events(
-    fresh_delivery_channels: None,
-) -> None:
-    """Regression: a dead worker respawns on the SAME queue; no events lost."""
-    delivered: list[str] = []
-
-    async def deliver(delivery: _AuditDelivery) -> None:
-        delivered.append(delivery.request_payload["resource_id"])
-
-    with patch("tracecat.audit.service._deliver", deliver):
-        _enqueue_delivery(_delivery("pre-1"))
-        _enqueue_delivery(_delivery("pre-2"))
-        await flush_audit_deliveries()
-
-        loop = asyncio.get_running_loop()
-        channel = audit_service_module._delivery_channels[loop]
-        queue_before = channel.queue
-
-        # Cancel the idle worker (blocked on an empty queue.get()); no item is
-        # mid-flight, so the unfinished-count stays consistent.
-        channel.worker.cancel()
-        try:
-            await channel.worker
-        except asyncio.CancelledError:
-            pass
-        assert channel.worker.done()
-
-        _enqueue_delivery(_delivery("post-1"))
-        # Access respawns the worker onto the existing queue.
-        assert _get_delivery_queue() is queue_before
-        assert audit_service_module._delivery_channels[loop].queue is queue_before
-        await flush_audit_deliveries()
-
-    assert delivered == ["pre-1", "pre-2", "post-1"]
+    assert sorted(received) == ["ATTEMPT", "SUCCESS"]
 
 
 @pytest.mark.anyio
 async def test_settings_resolution_failure_is_non_fatal_and_leaks_no_url(
     monkeypatch: pytest.MonkeyPatch,
     role: Role,
-    fresh_delivery_channels: None,
+    fresh_delivery_tasks: None,
 ) -> None:
     """A failing settings read inside _build_delivery must not break the op."""
     webhook_url = "https://secret-host.example.com/audit-hook"
@@ -1341,53 +1267,103 @@ async def test_settings_resolution_failure_is_non_fatal_and_leaks_no_url(
 
 
 @pytest.mark.anyio
-async def test_get_delivery_queue_evicts_closed_loop_entries(
-    fresh_delivery_channels: None,
+async def test_spawn_delivery_drops_past_in_flight_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_delivery_tasks: None,
 ) -> None:
-    """Regression: closed-loop entries are evicted on access; no unbounded growth."""
-    channels = audit_service_module._delivery_channels
+    """Past the in-flight cap, spawns shed with a warning; capacity frees on completion."""
+    monkeypatch.setattr(audit_service_module, "_MAX_IN_FLIGHT_DELIVERIES", 2)
+    delivered: list[str] = []
+    gate = asyncio.Event()
 
-    # Seed several real, closed loops with dummy channel entries.
-    closed_loops: list[asyncio.AbstractEventLoop] = []
-    for _ in range(5):
-        dead_loop = asyncio.new_event_loop()
-        dead_loop.close()
-        closed_loops.append(dead_loop)
-        channels[dead_loop] = _DeliveryChannel(
-            queue=asyncio.Queue(),
-            worker=cast(Any, MagicMock()),
-        )
+    async def gated_deliver(delivery: _AuditDelivery) -> None:
+        await gate.wait()
+        delivered.append(delivery.request_payload["resource_id"])
 
-    live_loop = asyncio.get_running_loop()
-    size_with_dead = len(channels)
-    assert size_with_dead >= 5
+    warnings: list[tuple[str, dict[str, object]]] = []
 
-    # Access on the live loop must drop every closed-loop entry.
-    _get_delivery_queue()
+    def capture_warning(msg: str, **kwargs: object) -> None:
+        warnings.append((msg, kwargs))
 
-    for dead_loop in closed_loops:
-        assert dead_loop not in channels
-    assert live_loop in channels
-    # The dict shrank; it does not grow monotonically with dead loops.
-    assert len(channels) < size_with_dead
+    with (
+        patch("tracecat.audit.service._deliver", gated_deliver),
+        patch("tracecat.audit.service.logger.warning", side_effect=capture_warning),
+    ):
+        _spawn_delivery(_delivery("first"))
+        _spawn_delivery(_delivery("second"))
+        # Cap reached while both are gated in flight; this one is shed.
+        _spawn_delivery(_delivery("shed", url="https://drop-host.example.com/hook"))
+
+        gate.set()
+        await flush_audit_deliveries()
+
+        # Completions freed capacity; later spawns deliver again.
+        _spawn_delivery(_delivery("after"))
+        await flush_audit_deliveries()
+
+    assert sorted(delivered) == ["after", "first", "second"]
+    drop_warnings = [
+        kwargs
+        for m, kwargs in warnings
+        if m == "Dropped audit webhook delivery; in-flight limit reached"
+    ]
+    assert len(drop_warnings) == 1
+    dropped = drop_warnings[0]
+    assert dropped["resource_type"] == "workflow"
+    assert dropped["action"] == "update"
+    assert dropped["max_in_flight"] == 2
+    # No payload contents or sink URL on the drop-log boundary.
+    all_logs = repr(warnings)
+    assert "drop-host" not in all_logs
+    assert "resource_id" not in repr(dropped)
 
 
 @pytest.mark.anyio
-async def test_flush_audit_deliveries_no_op_without_channel(
-    fresh_delivery_channels: None,
+async def test_spawn_delivery_evicts_closed_loop_tasks(
+    fresh_delivery_tasks: None,
 ) -> None:
-    """flush_audit_deliveries returns immediately when no channel exists."""
+    """Regression: tasks stranded on closed loops are evicted; no unbounded growth.
+
+    A task whose loop closed before it ran never fires its done callback, so
+    _spawn_delivery must sweep those refs out of the module set.
+    """
+    tasks = audit_service_module._delivery_tasks
+
+    # Seed stranded refs whose loops are closed; their callbacks can never run.
+    stranded: list[Any] = []
+    for _ in range(5):
+        dead_loop = asyncio.new_event_loop()
+        dead_loop.close()
+        fake_task = MagicMock()
+        fake_task.get_loop.return_value = dead_loop
+        stranded.append(fake_task)
+        tasks.add(cast(Any, fake_task))
+
+    async def deliver(delivery: _AuditDelivery) -> None:
+        return None
+
+    with patch("tracecat.audit.service._deliver", deliver):
+        _spawn_delivery(_delivery("live"))
+        await flush_audit_deliveries()
+
+    for fake_task in stranded:
+        assert fake_task not in tasks
+
+
+@pytest.mark.anyio
+async def test_flush_audit_deliveries_no_op_without_tasks(
+    fresh_delivery_tasks: None,
+) -> None:
+    """flush_audit_deliveries returns immediately when nothing is in flight."""
     loop = asyncio.get_running_loop()
-    assert loop not in audit_service_module._delivery_channels
+    assert not any(t.get_loop() is loop for t in audit_service_module._delivery_tasks)
     # Must not raise or hang.
     await flush_audit_deliveries()
-    # Flush alone must not create a channel.
-    assert loop not in audit_service_module._delivery_channels
 
 
 @pytest.mark.anyio
 async def test_flush_audit_deliveries_waits_for_in_flight_delivery(
-    fresh_delivery_channels: None,
+    fresh_delivery_tasks: None,
 ) -> None:
     """flush blocks until a gated in-flight delivery completes."""
     completed = asyncio.Event()
@@ -1398,10 +1374,7 @@ async def test_flush_audit_deliveries_waits_for_in_flight_delivery(
         completed.set()
 
     with patch("tracecat.audit.service._deliver", gated_deliver):
-        _enqueue_delivery(_delivery("only"))
-        queue = _get_delivery_queue()
-        while queue.qsize() != 0:
-            await asyncio.sleep(0)
+        _spawn_delivery(_delivery("only"))
         assert not completed.is_set()
 
         async def release() -> None:

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -1156,8 +1156,10 @@ async def fresh_delivery_tasks() -> AsyncIterator[None]:
     """
     loop = asyncio.get_running_loop()
     await _cancel_loop_tasks(loop)
+    audit_service_module._post_semaphores.pop(loop, None)
     yield
     await _cancel_loop_tasks(loop)
+    audit_service_module._post_semaphores.pop(loop, None)
 
 
 @respx.mock
@@ -1383,12 +1385,12 @@ async def test_settings_resolution_failure_is_non_fatal_and_leaks_no_url(
 
 
 @pytest.mark.anyio
-async def test_spawn_delivery_drops_past_in_flight_cap(
+async def test_spawn_delivery_drops_past_pending_cap(
     monkeypatch: pytest.MonkeyPatch,
     fresh_delivery_tasks: None,
 ) -> None:
-    """Past the in-flight cap, spawns shed with a warning; capacity frees on completion."""
-    monkeypatch.setattr(audit_service_module, "_MAX_IN_FLIGHT_DELIVERIES", 2)
+    """Past the pending cap, spawns shed with a warning; capacity frees on completion."""
+    monkeypatch.setattr(audit_service_module, "_MAX_PENDING_DELIVERIES", 2)
     delivered: list[str] = []
     gate = asyncio.Event()
 
@@ -1421,13 +1423,13 @@ async def test_spawn_delivery_drops_past_in_flight_cap(
     drop_warnings = [
         kwargs
         for m, kwargs in warnings
-        if m == "Dropped audit webhook delivery; in-flight limit reached"
+        if m == "Dropped audit webhook delivery; pending limit reached"
     ]
     assert len(drop_warnings) == 1
     dropped = drop_warnings[0]
     assert dropped["resource_type"] == "workflow"
     assert dropped["action"] == "update"
-    assert dropped["max_in_flight"] == 2
+    assert dropped["max_pending"] == 2
     # No payload contents or sink URL on the drop-log boundary.
     all_logs = repr(warnings)
     assert "drop-host" not in all_logs
@@ -1441,15 +1443,20 @@ async def test_spawn_delivery_evicts_closed_loop_tasks(
     """Regression: tasks stranded on closed loops are evicted; no unbounded growth.
 
     A task whose loop closed before it ran never fires its done callback, so
-    _spawn_delivery must sweep those refs out of the module set.
+    _spawn_delivery must sweep those refs out of the module set, along with the
+    closed loops' semaphore entries.
     """
     tasks = audit_service_module._delivery_tasks
+    semaphores = audit_service_module._post_semaphores
 
     # Seed stranded refs whose loops are closed; their callbacks can never run.
     stranded: list[Any] = []
+    dead_loops: list[asyncio.AbstractEventLoop] = []
     for _ in range(5):
         dead_loop = asyncio.new_event_loop()
         dead_loop.close()
+        dead_loops.append(dead_loop)
+        semaphores[dead_loop] = asyncio.Semaphore(1)
         fake_task = MagicMock()
         fake_task.get_loop.return_value = dead_loop
         stranded.append(fake_task)
@@ -1464,6 +1471,43 @@ async def test_spawn_delivery_evicts_closed_loop_tasks(
 
     for fake_task in stranded:
         assert fake_task not in tasks
+    for dead_loop in dead_loops:
+        assert dead_loop not in semaphores
+
+
+@respx.mock
+@pytest.mark.anyio
+async def test_deliver_gates_concurrent_posts(
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_delivery_tasks: None,
+) -> None:
+    """Posts past the socket cap wait on the semaphore; none are dropped."""
+    monkeypatch.setattr(audit_service_module, "_MAX_CONCURRENT_POSTS", 1)
+    gate = asyncio.Event()
+    started: list[str] = []
+
+    async def slow_response(request: httpx.Request) -> httpx.Response:
+        tag = orjson.loads(request.content)["resource_id"]
+        started.append(tag)
+        if tag == "first":
+            await gate.wait()
+        return httpx.Response(200)
+
+    respx.post("https://example.com/audit").mock(side_effect=slow_response)
+
+    _spawn_delivery(_delivery("first"))
+    _spawn_delivery(_delivery("second"))
+
+    # "first" holds the only slot; give "second" ample ticks to (wrongly) post.
+    while "first" not in started:
+        await asyncio.sleep(0)
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert started == ["first"]
+
+    gate.set()
+    await flush_audit_deliveries()
+    assert sorted(started) == ["first", "second"]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -151,6 +151,44 @@ async def test_audit_log_lifecycle(
 
 
 @pytest.mark.anyio
+async def test_audit_log_emit_false_failure_executes_operation_once(
+    monkeypatch: pytest.MonkeyPatch,
+    role: Role,
+) -> None:
+    operation_calls = 0
+    create_event = AsyncMock()
+
+    def suppress_audit(_context: AuditCallContext) -> AuditEventDetails:
+        return AuditEventDetails(emit=False)
+
+    class SuppressedService(BaseService):
+        service_name = "suppressed"
+
+        def __init__(self) -> None:
+            super().__init__(AsyncMock())
+            self.role = role
+
+        @audit_log(
+            resource_type="workflow",
+            action="update",
+            attempt_metadata=suppress_audit,
+        )
+        async def mutate(self, workflow_id: uuid.UUID) -> None:
+            del workflow_id
+            nonlocal operation_calls
+            operation_calls += 1
+            raise ValueError("synthetic operation failure")
+
+    monkeypatch.setattr(AuditService, "create_event", create_event)
+
+    with pytest.raises(ValueError, match="synthetic operation failure"):
+        await SuppressedService().mutate(uuid.uuid4())
+
+    assert operation_calls == 1
+    create_event.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_audit_log_result_derivation_failure_is_non_fatal(
     monkeypatch: pytest.MonkeyPatch, role: Role
 ) -> None:

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -213,7 +213,7 @@ class TestCaseCommentsService:
             AuditEventStatus.SUCCESS.value,
         ]
         assert all(event.resource_type == "case_comment" for event in audit_events)
-        assert audit_events[-1].data["content"] == comment_create_params.content
+        assert "content" not in audit_events[-1].data
 
         # Retrieve comment
         retrieved_comment = await case_comments_service.get_comment(created_comment.id)
@@ -279,6 +279,8 @@ class TestCaseCommentsService:
         assert (
             workflow_audits[0].data["wf_exec_id"] == created_comment.workflow_wf_exec_id
         )
+        assert "workflow_alias" not in workflow_audits[0].data
+        assert all("content" not in event.data for event in comment_audits)
 
         await session.delete(workflow)
         await session.commit()
@@ -797,7 +799,7 @@ class TestCaseCommentsService:
             AuditEventStatus.ATTEMPT.value,
             AuditEventStatus.SUCCESS.value,
         ]
-        assert update_audits[-1].data["content"] == update_params.content
+        assert "content" not in update_audits[-1].data
 
     async def test_update_reply_emits_reply_activity(
         self,

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -187,9 +187,9 @@ def _assert_batch_audit_calls(
     terminal_status: AuditEventStatus = AuditEventStatus.SUCCESS,
 ) -> None:
     base_data = {
-        "batch": True,
+        "is_batch": True,
         "case_ids": [str(case_id) for case_id in case_ids],
-        "count": len(case_ids),
+        "case_count": len(case_ids),
     }
     assert mock_create_event.await_args_list == [
         call(
@@ -204,7 +204,7 @@ def _assert_batch_audit_calls(
             action=action,
             resource_id=None,
             status=terminal_status,
-            data={**base_data, "succeeded": succeeded, "failed": failed},
+            data={**base_data, "succeeded_count": succeeded, "failed_count": failed},
         ),
     ]
 
@@ -1270,9 +1270,9 @@ class TestCasesService:
 
         mock_rollback.assert_awaited_once()
         base_data = {
-            "batch": True,
+            "is_batch": True,
             "case_ids": [str(case_id) for case_id in case_ids],
-            "count": 2,
+            "case_count": 2,
         }
         assert mock_audit.await_args_list == [
             call(
@@ -1287,7 +1287,7 @@ class TestCasesService:
                 action="update",
                 resource_id=None,
                 status=AuditEventStatus.FAILURE,
-                data={**base_data, "succeeded": 0, "failed": 2},
+                data={**base_data, "succeeded_count": 0, "failed_count": 2},
             ),
         ]
 

--- a/tests/unit/test_control_plane_audit.py
+++ b/tests/unit/test_control_plane_audit.py
@@ -89,6 +89,7 @@ def _session() -> SimpleNamespace:
         delete=AsyncMock(),
         execute=AsyncMock(),
         flush=AsyncMock(),
+        info={},
         refresh=AsyncMock(),
         scalar=AsyncMock(),
     )
@@ -434,10 +435,6 @@ async def _schedule(mp: pytest.MonkeyPatch, role: Role, action: str):
             "_get_schedule_with_workflow_lock",
             AsyncMock(return_value=SimpleNamespace(id=schedule_id)),
         )
-        mp.setattr(
-            "tracecat.workflow.schedules.service.add_after_commit_callback",
-            MagicMock(),
-        )
         await service.update_schedule(schedule_id, ScheduleUpdate(status="offline"))
         return _pair(
             "schedule", action, schedule_id, schedule_id, {"changed_fields": ["status"]}
@@ -500,18 +497,12 @@ def _webhook_session() -> SimpleNamespace:
 
 async def _webhook_create(mp: pytest.MonkeyPatch, role: Role):
     session = _webhook_session()
-
-    async def get_created_webhook(**_kwargs: object):
-        return session.add.call_args.args[0]
-
-    mp.setattr(webhook_service, "get_webhook", get_created_webhook)
-    await workflow_management_router.create_webhook(
+    webhook = await webhook_service.create_webhook(
         role=role,
         session=cast(Any, session),
         workflow_id=WorkflowUUID.new_uuid4(),
         params=WebhookCreate(status="online"),
     )
-    webhook = session.add.call_args.args[0]
     return _pair("webhook", "create", None, webhook.id)
 
 

--- a/tests/unit/test_control_plane_audit.py
+++ b/tests/unit/test_control_plane_audit.py
@@ -14,13 +14,14 @@ from fastapi import HTTPException
 from temporalio.service import RPCError, RPCStatusCode
 
 from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.logger import AuditCallContext
 from tracecat.audit.service import AuditService
 from tracecat.audit.types import AuditEvent
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_client_ip, ctx_role, ctx_user_agent
 from tracecat.db.models import WebhookApiKey
 from tracecat.dsl.common import DSLInput
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import ScopeDeniedError, TracecatValidationError
 from tracecat.identifiers import ScheduleUUID
 from tracecat.identifiers.workflow import (
     WorkflowUUID,
@@ -36,6 +37,7 @@ from tracecat.workflow.case_triggers.schemas import (
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.graph.service import WorkflowGraphService
+from tracecat.workflow.management import draft as workflow_management_draft
 from tracecat.workflow.management import router as workflow_management_router
 from tracecat.workflow.management.draft import (
     build_workflow_edit_document,
@@ -244,13 +246,29 @@ async def _workflow_edit(mp: pytest.MonkeyPatch, role: Role):
     updated = original.model_copy(
         update={"metadata": original.metadata.model_copy(update={"status": "online"})}
     )
+    changed_sections = (
+        workflow_management_draft.workflow_edit_document_changed_sections(
+            original,
+            updated,
+        )
+    )
+    changed_sections_computation = MagicMock(
+        side_effect=AssertionError("changed sections should be reused")
+    )
+    mp.setattr(
+        workflow_management_draft,
+        "workflow_edit_document_changed_sections",
+        changed_sections_computation,
+    )
     await persist_workflow_edit_document(
         role=role,
         service=WorkflowsManagementService(cast(Any, _session()), role=role),
         workflow=cast(Any, source),
         original_document=original,
         updated_document=updated,
+        changed_sections=changed_sections,
     )
+    changed_sections_computation.assert_not_called()
     return _pair(
         "workflow", "update", source.id, source.id, {"changed_fields": ["metadata"]}
     )
@@ -520,7 +538,13 @@ async def _webhook_update(mp: pytest.MonkeyPatch, role: Role):
         workflow_id=WorkflowUUID.new_uuid4(),
         params=WebhookUpdate(status="online"),
     )
-    return _pair("webhook", "update", None, webhook_id, {"changed_fields": ["status"]})
+    return _pair(
+        "webhook",
+        "update",
+        webhook_id,
+        webhook_id,
+        {"changed_fields": ["status"]},
+    )
 
 
 class _GeneratedKey:
@@ -770,6 +794,86 @@ async def test_missing_webhook_key_operation_emits_failure(
     assert all(call["resource_type"] == "webhook_api_key" for call in calls)
     assert all(call["action"] == "create" for call in calls)
     assert all(call["data"] == {"webhook_id": None} for call in calls)
+
+
+@pytest.mark.anyio
+async def test_webhook_update_requires_workflow_update_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role = _role().model_copy(update={"scopes": frozenset({"workflow:read"})})
+    get_webhook = AsyncMock()
+    monkeypatch.setattr(webhook_service, "get_webhook", get_webhook)
+
+    with pytest.raises(ScopeDeniedError):
+        await webhook_service.update_webhook(
+            role=role,
+            session=cast(Any, _session()),
+            workflow_id=WorkflowUUID.new_uuid4(),
+            params=WebhookUpdate(status="online"),
+        )
+
+    get_webhook.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_failed_webhook_update_audit_preserves_resource_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role, calls = _role(), []
+    _capture_events(monkeypatch, calls)
+    webhook_id = uuid.uuid4()
+    webhook = SimpleNamespace(id=webhook_id, status="offline")
+    session = _session()
+    session.commit.side_effect = RuntimeError("synthetic commit failure")
+    monkeypatch.setattr(
+        webhook_service,
+        "get_webhook",
+        AsyncMock(return_value=webhook),
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic commit failure"):
+        await webhook_service.update_webhook(
+            role=role,
+            session=cast(Any, session),
+            workflow_id=WorkflowUUID.new_uuid4(),
+            params=WebhookUpdate(status="online"),
+        )
+
+    assert [call["status"] for call in calls] == [
+        AuditEventStatus.ATTEMPT,
+        AuditEventStatus.FAILURE,
+    ]
+    assert all(call["resource_id"] == webhook_id for call in calls)
+
+
+@pytest.mark.anyio
+async def test_webhook_key_audit_target_uses_selected_webhook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role = _role()
+    workflow_id = WorkflowUUID.new_uuid4()
+    webhook_id = uuid.uuid4()
+    api_key_id = uuid.uuid4()
+    session = _session()
+    session.scalar.return_value = api_key_id
+    monkeypatch.setattr(
+        webhook_service,
+        "get_webhook",
+        AsyncMock(return_value=SimpleNamespace(id=webhook_id)),
+    )
+    context = AuditCallContext(
+        target=None,
+        arguments={
+            "role": role,
+            "session": session,
+            "workflow_id": workflow_id,
+        },
+    )
+
+    target = await workflow_management_router._get_webhook_key_audit_target(context)
+
+    assert target == (webhook_id, api_key_id)
+    session.execute.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_control_plane_audit.py
+++ b/tests/unit/test_control_plane_audit.py
@@ -14,7 +14,6 @@ from fastapi import HTTPException
 from temporalio.service import RPCError, RPCStatusCode
 
 from tracecat.audit.enums import AuditEventStatus
-from tracecat.audit.logger import AuditCallContext
 from tracecat.audit.service import AuditService
 from tracecat.audit.types import AuditEvent
 from tracecat.auth.types import Role
@@ -379,7 +378,7 @@ async def _execution_control(mp: pytest.MonkeyPatch, role: Role, operation: str)
     mp.setattr(service, "handle", MagicMock(return_value=handle))
     await getattr(service, f"{operation}_workflow_execution")(execution_id)
     data = {"execution_id": execution_id, "operation": operation}
-    return _pair("workflow_execution", "cancel", workflow_id, workflow_id, data)
+    return _pair("workflow_execution", operation, workflow_id, workflow_id, data)
 
 
 async def _execution_cancel(mp: pytest.MonkeyPatch, role: Role):
@@ -406,7 +405,7 @@ async def _execution_reset(mp: pytest.MonkeyPatch, role: Role):
     mp.setattr(service, "_resolve_reset_event_id", AsyncMock(return_value=1))
     await service.reset_workflow_execution(execution_id, event_id=None)
     data = {"execution_id": execution_id, "operation": "reset"}
-    return _pair("workflow_execution", "create", workflow_id, workflow_id, data)
+    return _pair("workflow_execution", "reset", workflow_id, workflow_id, data)
 
 
 async def _schedule(mp: pytest.MonkeyPatch, role: Role, action: str):
@@ -453,11 +452,9 @@ async def _schedule_delete(mp: pytest.MonkeyPatch, role: Role):
     return await _schedule(mp, role, "delete")
 
 
-async def _case_upsert(mp: pytest.MonkeyPatch, role: Role, exists: bool):
+async def _case_upsert(mp: pytest.MonkeyPatch, role: Role):
     trigger_id = uuid.uuid4()
-    session = _session()
-    session.scalar.return_value = SimpleNamespace(id=trigger_id) if exists else None
-    service = CaseTriggersService(cast(Any, session), role=role)
+    service = CaseTriggersService(cast(Any, _session()), role=role)
     mp.setattr(service, "require_entitlement", AsyncMock())
     mp.setattr(
         service,
@@ -467,21 +464,8 @@ async def _case_upsert(mp: pytest.MonkeyPatch, role: Role, exists: bool):
     await service.upsert_case_trigger(
         WorkflowUUID.new_uuid4(), CaseTriggerConfig(status="offline")
     )
-    action = "update" if exists else "create"
-    data = (
-        {"changed_fields": sorted(CaseTriggerConfig.model_fields)} if exists else None
-    )
-    return _pair(
-        "case_trigger", action, trigger_id if exists else None, trigger_id, data
-    )
-
-
-async def _case_create(mp: pytest.MonkeyPatch, role: Role):
-    return await _case_upsert(mp, role, False)
-
-
-async def _case_upsert_update(mp: pytest.MonkeyPatch, role: Role):
-    return await _case_upsert(mp, role, True)
+    data = {"changed_fields": sorted(CaseTriggerConfig.model_fields)}
+    return _pair("case_trigger", "upsert", None, trigger_id, data)
 
 
 async def _case_update(mp: pytest.MonkeyPatch, role: Role):
@@ -575,7 +559,7 @@ async def _key(mp: pytest.MonkeyPatch, role: Role, action: str):
     session = _webhook_session()
 
     async def get_api_key_audit_target(
-        _context: object,
+        _role: object, _session: object, _workflow_id: object
     ) -> tuple[uuid.UUID, uuid.UUID | None]:
         if action == "create" and session.add.called:
             return webhook_id, cast(WebhookApiKey, session.add.call_args.args[0]).id
@@ -661,8 +645,7 @@ CASES = tuple(
         ("schedule_create", _schedule_create),
         ("schedule_update", _schedule_update),
         ("schedule_delete", _schedule_delete),
-        ("case_create", _case_create),
-        ("case_upsert_update", _case_upsert_update),
+        ("case_upsert", _case_upsert),
         ("case_update", _case_update),
         ("webhook_create", _webhook_create),
         ("webhook_update", _webhook_update),
@@ -756,7 +739,7 @@ async def test_bulk_reset_emits_one_event_pair_per_execution(
         assert matching == list(
             _pair(
                 "workflow_execution",
-                "create",
+                "reset",
                 workflow_id,
                 workflow_id,
                 {"execution_id": execution_id, "operation": "reset"},
@@ -861,24 +844,44 @@ async def test_webhook_key_audit_target_uses_selected_webhook(
         "get_webhook",
         AsyncMock(return_value=SimpleNamespace(id=webhook_id)),
     )
-    context = AuditCallContext(
-        target=None,
-        arguments={
-            "role": role,
-            "session": session,
-            "workflow_id": workflow_id,
-        },
+    target = await workflow_management_router._get_webhook_key_audit_target(
+        role, cast(Any, session), workflow_id
     )
-
-    target = await workflow_management_router._get_webhook_key_audit_target(context)
 
     assert target == (webhook_id, api_key_id)
     session.execute.assert_not_awaited()
 
 
 @pytest.mark.anyio
-async def test_internal_publish_is_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_internal_publish_with_user_attribution_audits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     role, calls = _role(internal=True), []
+    _capture_events(monkeypatch, calls)
+    service = WorkflowsManagementService(cast(Any, _session()), role=role)
+    monkeypatch.setattr(
+        service, "get_workflow", AsyncMock(side_effect=TracecatValidationError("stop"))
+    )
+    workflow_id = WorkflowUUID.new_uuid4()
+    with pytest.raises(TracecatValidationError):
+        await service.publish_workflow(workflow_id)
+    assert calls == list(
+        _pair(
+            "workflow",
+            "publish",
+            workflow_id,
+            workflow_id,
+            terminal_status=AuditEventStatus.FAILURE,
+        )
+    )
+
+
+@pytest.mark.anyio
+async def test_unattributed_service_publish_is_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role = _role(internal=True).model_copy(update={"user_id": None})
+    calls: list[AuditCall] = []
     _capture_events(monkeypatch, calls)
     service = WorkflowsManagementService(cast(Any, _session()), role=role)
     monkeypatch.setattr(

--- a/tests/unit/test_control_plane_audit.py
+++ b/tests/unit/test_control_plane_audit.py
@@ -1,0 +1,785 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from temporalio.service import RPCError, RPCStatusCode
+
+from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.service import AuditService
+from tracecat.audit.types import AuditEvent
+from tracecat.auth.types import Role
+from tracecat.contexts import ctx_client_ip, ctx_role, ctx_user_agent
+from tracecat.db.models import WebhookApiKey
+from tracecat.dsl.common import DSLInput
+from tracecat.exceptions import TracecatValidationError
+from tracecat.identifiers import ScheduleUUID
+from tracecat.identifiers.workflow import (
+    WorkflowUUID,
+    exec_id_to_parts,
+    generate_exec_id,
+)
+from tracecat.webhooks import service as webhook_service
+from tracecat.webhooks.schemas import WebhookCreate, WebhookUpdate
+from tracecat.workflow.case_triggers.schemas import (
+    CaseTriggerConfig,
+    CaseTriggerUpdate,
+)
+from tracecat.workflow.case_triggers.service import CaseTriggersService
+from tracecat.workflow.executions.service import WorkflowExecutionsService
+from tracecat.workflow.graph.service import WorkflowGraphService
+from tracecat.workflow.management import router as workflow_management_router
+from tracecat.workflow.management.draft import (
+    build_workflow_edit_document,
+    persist_workflow_edit_document,
+)
+from tracecat.workflow.management.management import WorkflowsManagementService
+from tracecat.workflow.management.schemas import (
+    GraphOperation,
+    GraphOperationType,
+    WorkflowUpdate,
+)
+from tracecat.workflow.schedules.schemas import ScheduleCreate, ScheduleUpdate
+from tracecat.workflow.schedules.service import WorkflowSchedulesService
+
+type AuditCall = dict[str, object]
+type Runner = Callable[
+    [pytest.MonkeyPatch, Role], Awaitable[tuple[AuditCall, AuditCall]]
+]
+
+_ACTOR_LABEL = "actor@example.test"
+_CLIENT_IP = "192.0.2.10"
+_USER_AGENT = "TracecatAuditTest/1.0"
+_WEBHOOK_URL = "https://audit.example.test/events"
+
+
+@dataclass(frozen=True)
+class AuditCase:
+    name: str
+    run: Runner
+
+    def __str__(self) -> str:
+        return self.name
+
+
+def _role(*, internal: bool = False) -> Role:
+    return Role(
+        type="service" if internal else "user",
+        user_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        service_id="tracecat-executor" if internal else "tracecat-api",
+        scopes=frozenset({"*"}),
+    )
+
+
+def _session() -> SimpleNamespace:
+    return SimpleNamespace(
+        add=MagicMock(),
+        commit=AsyncMock(),
+        delete=AsyncMock(),
+        execute=AsyncMock(),
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        scalar=AsyncMock(),
+    )
+
+
+def _event(
+    resource_type: str,
+    action: str,
+    resource_id: uuid.UUID | None,
+    data: Mapping[str, object] | None,
+    status: AuditEventStatus,
+) -> AuditCall:
+    return {
+        "resource_type": resource_type,
+        "action": action,
+        "resource_id": resource_id,
+        "data": dict(data) if data is not None else None,
+        "status": status,
+    }
+
+
+def _pair(
+    resource_type: str,
+    action: str,
+    attempt_id: uuid.UUID | None,
+    terminal_id: uuid.UUID | None,
+    data: Mapping[str, object] | None = None,
+    *,
+    terminal_status: AuditEventStatus = AuditEventStatus.SUCCESS,
+) -> tuple[AuditCall, AuditCall]:
+    return (
+        _event(resource_type, action, attempt_id, data, AuditEventStatus.ATTEMPT),
+        _event(resource_type, action, terminal_id, data, terminal_status),
+    )
+
+
+def _capture_events(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[AuditCall],
+    wire_events: list[dict[str, object]] | None = None,
+) -> None:
+    class CaptureAuditService(AuditService):
+        async def _get_webhook_url(self) -> str:
+            return _WEBHOOK_URL
+
+        async def _get_actor_label(self) -> str:
+            return _ACTOR_LABEL
+
+        async def _post_event(self, *, webhook_url: str, payload: AuditEvent) -> None:
+            assert webhook_url == _WEBHOOK_URL
+            calls.append(
+                _event(
+                    payload.resource_type,
+                    payload.action,
+                    payload.resource_id,
+                    payload.data,
+                    payload.status,
+                )
+            )
+            if wire_events is not None:
+                wire_events.append(payload.model_dump(mode="json"))
+
+    @asynccontextmanager
+    async def with_session(
+        cls: type[AuditService],
+        role: Role | None = None,
+        *,
+        session: object | None = None,
+        audit_sink: object | None = None,
+    ) -> AsyncGenerator[AuditService, None]:
+        del cls
+        yield CaptureAuditService(
+            cast(Any, session if session is not None else _session()),
+            role=role,
+            audit_sink=cast(Any, audit_sink),
+        )
+
+    monkeypatch.setattr(AuditService, "with_session", classmethod(with_session))
+
+
+def _expected_wire_event(role: Role, event: AuditCall) -> dict[str, object]:
+    resource_id = event["resource_id"]
+    assert resource_id is None or isinstance(resource_id, uuid.UUID)
+    status = event["status"]
+    assert isinstance(status, AuditEventStatus)
+    return {
+        "organization_id": str(role.organization_id),
+        "workspace_id": str(role.workspace_id),
+        "actor_type": "USER",
+        "actor_id": str(role.actor_id),
+        "actor_label": _ACTOR_LABEL,
+        "ip_address": _CLIENT_IP,
+        "user_agent": _USER_AGENT,
+        "resource_type": event["resource_type"],
+        "resource_id": str(resource_id) if resource_id is not None else None,
+        "action": event["action"],
+        "status": status.value,
+        "data": event["data"],
+    }
+
+
+def _assert_wire_event(
+    role: Role, payload: dict[str, object], expected: AuditCall
+) -> None:
+    actual = dict(payload)
+    created_at = actual.pop("created_at")
+    assert isinstance(created_at, str)
+    assert (
+        datetime.fromisoformat(created_at.replace("Z", "+00:00")).utcoffset()
+        is not None
+    )
+    assert actual == _expected_wire_event(role, expected)
+
+
+async def _workflow_update(mp: pytest.MonkeyPatch, role: Role):
+    workflow_id = WorkflowUUID.new_uuid4()
+    session = _session()
+    session.execute.return_value = SimpleNamespace(
+        scalar_one=MagicMock(return_value=SimpleNamespace(id=workflow_id))
+    )
+    service = WorkflowsManagementService(cast(Any, session), role=role)
+    await service.update_workflow(workflow_id, WorkflowUpdate(status="online"))
+    return _pair(
+        "workflow", "update", workflow_id, workflow_id, {"changed_fields": ["status"]}
+    )
+
+
+def _edit_source() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        title="Audit workflow",
+        description="",
+        status="offline",
+        alias=None,
+        error_handler=None,
+        entrypoint=None,
+        expects=None,
+        config=None,
+        returns=None,
+        trigger_position_x=None,
+        trigger_position_y=None,
+        viewport_x=None,
+        viewport_y=None,
+        viewport_zoom=None,
+        actions=[],
+        schedules=[],
+        case_trigger=None,
+    )
+
+
+async def _workflow_edit(mp: pytest.MonkeyPatch, role: Role):
+    source = _edit_source()
+    original = build_workflow_edit_document(cast(Any, source))
+    updated = original.model_copy(
+        update={"metadata": original.metadata.model_copy(update={"status": "online"})}
+    )
+    await persist_workflow_edit_document(
+        role=role,
+        service=WorkflowsManagementService(cast(Any, _session()), role=role),
+        workflow=cast(Any, source),
+        original_document=original,
+        updated_document=updated,
+    )
+    return _pair(
+        "workflow", "update", source.id, source.id, {"changed_fields": ["metadata"]}
+    )
+
+
+async def _workflow_graph(mp: pytest.MonkeyPatch, role: Role):
+    workflow_id = WorkflowUUID.new_uuid4()
+    session = _session()
+    session.execute.return_value = SimpleNamespace(
+        scalar_one_or_none=MagicMock(return_value=SimpleNamespace())
+    )
+    service = WorkflowGraphService(cast(Any, session), role=role)
+    mp.setattr(
+        service,
+        "apply_operations_to_locked_workflow",
+        AsyncMock(return_value=SimpleNamespace()),
+    )
+    await service.apply_operations(
+        workflow_id,
+        1,
+        [GraphOperation(type=GraphOperationType.UPDATE_NODE, payload={})],
+    )
+    return _pair(
+        "workflow",
+        "update",
+        workflow_id,
+        workflow_id,
+        {"changed_fields": ["definition"]},
+    )
+
+
+async def _workflow_publish(mp: pytest.MonkeyPatch, role: Role):
+    workflow_id = WorkflowUUID.new_uuid4()
+    service = WorkflowsManagementService(cast(Any, _session()), role=role)
+    mp.setattr(service, "get_workflow", AsyncMock(return_value=SimpleNamespace()))
+    mp.setattr(
+        service,
+        "build_dsl_from_workflow",
+        AsyncMock(side_effect=TracecatValidationError("invalid draft")),
+    )
+    await service.publish_workflow(workflow_id)
+    return _pair(
+        "workflow",
+        "publish",
+        workflow_id,
+        workflow_id,
+        terminal_status=AuditEventStatus.FAILURE,
+    )
+
+
+async def _workflow_restore(mp: pytest.MonkeyPatch, role: Role):
+    del mp
+    workflow = SimpleNamespace(id=uuid.uuid4())
+    service = WorkflowsManagementService(cast(Any, _session()), role=role)
+    with pytest.raises(TracecatValidationError):
+        await service.restore_workflow_definition(
+            cast(Any, workflow), cast(Any, SimpleNamespace(workflow_id=uuid.uuid4()))
+        )
+    return _pair(
+        "workflow",
+        "update",
+        workflow.id,
+        workflow.id,
+        terminal_status=AuditEventStatus.FAILURE,
+    )
+
+
+async def _external_create(mp: pytest.MonkeyPatch, role: Role):
+    workflow_id = uuid.uuid4()
+    service = WorkflowsManagementService(cast(Any, _session()), role=role)
+    dsl = DSLInput.model_validate(
+        {
+            "title": "Audit workflow",
+            "description": "",
+            "entrypoint": {"ref": "start"},
+            "actions": [
+                {
+                    "ref": "start",
+                    "action": "core.transform.reshape",
+                    "args": {"value": "ok"},
+                }
+            ],
+        }
+    )
+    mp.setattr(
+        service,
+        "correlate_agent_catalog_ids",
+        AsyncMock(return_value=dsl),
+    )
+    mp.setattr(
+        service,
+        "create_db_workflow_from_dsl",
+        AsyncMock(return_value=SimpleNamespace(id=workflow_id)),
+    )
+    await service.create_workflow_from_external_definition(
+        {"definition": dsl.model_dump()}
+    )
+    return _pair("workflow", "create", None, workflow_id)
+
+
+async def _execution_control(mp: pytest.MonkeyPatch, role: Role, operation: str):
+    workflow_id = WorkflowUUID.new_uuid4()
+    execution_id = generate_exec_id(workflow_id)
+    service = WorkflowExecutionsService(MagicMock(), role=role)
+    mp.setattr(service, "require_execution", AsyncMock())
+    handle = MagicMock()
+    setattr(handle, operation, AsyncMock())
+    mp.setattr(service, "handle", MagicMock(return_value=handle))
+    await getattr(service, f"{operation}_workflow_execution")(execution_id)
+    data = {"execution_id": execution_id, "operation": operation}
+    return _pair("workflow_execution", "cancel", workflow_id, workflow_id, data)
+
+
+async def _execution_cancel(mp: pytest.MonkeyPatch, role: Role):
+    return await _execution_control(mp, role, "cancel")
+
+
+async def _execution_terminate(mp: pytest.MonkeyPatch, role: Role):
+    return await _execution_control(mp, role, "terminate")
+
+
+async def _execution_reset(mp: pytest.MonkeyPatch, role: Role):
+    workflow_id = WorkflowUUID.new_uuid4()
+    execution_id = generate_exec_id(workflow_id)
+    client = MagicMock()
+    client.workflow_service.reset_workflow_execution = AsyncMock(
+        return_value=SimpleNamespace(run_id="new-run")
+    )
+    service = WorkflowExecutionsService(client, role=role)
+    mp.setattr(
+        service,
+        "require_execution",
+        AsyncMock(return_value=SimpleNamespace(id=execution_id, run_id="run")),
+    )
+    mp.setattr(service, "_resolve_reset_event_id", AsyncMock(return_value=1))
+    await service.reset_workflow_execution(execution_id, event_id=None)
+    data = {"execution_id": execution_id, "operation": "reset"}
+    return _pair("workflow_execution", "create", workflow_id, workflow_id, data)
+
+
+async def _schedule(mp: pytest.MonkeyPatch, role: Role, action: str):
+    schedule_id = ScheduleUUID.new_uuid4()
+    service = WorkflowSchedulesService(cast(Any, _session()), role=role)
+    if action == "create":
+        mp.setattr(
+            service,
+            "_create_schedule_impl",
+            AsyncMock(return_value=SimpleNamespace(id=schedule_id)),
+        )
+        await service.create_schedule(
+            ScheduleCreate(workflow_id=WorkflowUUID.new_uuid4(), cron="0 * * * *")
+        )
+        return _pair("schedule", action, None, schedule_id)
+    if action == "update":
+        mp.setattr(
+            service,
+            "_get_schedule_with_workflow_lock",
+            AsyncMock(return_value=SimpleNamespace(id=schedule_id)),
+        )
+        mp.setattr(
+            "tracecat.workflow.schedules.service.add_after_commit_callback",
+            MagicMock(),
+        )
+        await service.update_schedule(schedule_id, ScheduleUpdate(status="offline"))
+        return _pair(
+            "schedule", action, schedule_id, schedule_id, {"changed_fields": ["status"]}
+        )
+    mp.setattr(service, "_delete_schedule_impl", AsyncMock())
+    await service.delete_schedule(schedule_id)
+    return _pair("schedule", action, schedule_id, schedule_id)
+
+
+async def _schedule_create(mp: pytest.MonkeyPatch, role: Role):
+    return await _schedule(mp, role, "create")
+
+
+async def _schedule_update(mp: pytest.MonkeyPatch, role: Role):
+    return await _schedule(mp, role, "update")
+
+
+async def _schedule_delete(mp: pytest.MonkeyPatch, role: Role):
+    return await _schedule(mp, role, "delete")
+
+
+async def _case_upsert(mp: pytest.MonkeyPatch, role: Role, exists: bool):
+    trigger_id = uuid.uuid4()
+    session = _session()
+    session.scalar.return_value = SimpleNamespace(id=trigger_id) if exists else None
+    service = CaseTriggersService(cast(Any, session), role=role)
+    mp.setattr(service, "require_entitlement", AsyncMock())
+    mp.setattr(
+        service,
+        "_upsert_case_trigger",
+        AsyncMock(return_value=SimpleNamespace(id=trigger_id)),
+    )
+    await service.upsert_case_trigger(
+        WorkflowUUID.new_uuid4(), CaseTriggerConfig(status="offline")
+    )
+    action = "update" if exists else "create"
+    data = (
+        {"changed_fields": sorted(CaseTriggerConfig.model_fields)} if exists else None
+    )
+    return _pair(
+        "case_trigger", action, trigger_id if exists else None, trigger_id, data
+    )
+
+
+async def _case_create(mp: pytest.MonkeyPatch, role: Role):
+    return await _case_upsert(mp, role, False)
+
+
+async def _case_upsert_update(mp: pytest.MonkeyPatch, role: Role):
+    return await _case_upsert(mp, role, True)
+
+
+async def _case_update(mp: pytest.MonkeyPatch, role: Role):
+    trigger_id = uuid.uuid4()
+    service = CaseTriggersService(cast(Any, _session()), role=role)
+    mp.setattr(service, "require_entitlement", AsyncMock())
+    mp.setattr(
+        service,
+        "_update_case_trigger",
+        AsyncMock(return_value=SimpleNamespace(id=trigger_id)),
+    )
+    await service.update_case_trigger(
+        WorkflowUUID.new_uuid4(), CaseTriggerUpdate(status="online")
+    )
+    return _pair(
+        "case_trigger", "update", None, trigger_id, {"changed_fields": ["status"]}
+    )
+
+
+def _webhook_session() -> SimpleNamespace:
+    session = _session()
+    session.add.side_effect = lambda obj: setattr(obj, "id", obj.id or uuid.uuid4())
+    return session
+
+
+async def _webhook_create(mp: pytest.MonkeyPatch, role: Role):
+    session = _webhook_session()
+
+    async def get_created_webhook(**_kwargs: object):
+        return session.add.call_args.args[0]
+
+    mp.setattr(webhook_service, "get_webhook", get_created_webhook)
+    await workflow_management_router.create_webhook(
+        role=role,
+        session=cast(Any, session),
+        workflow_id=WorkflowUUID.new_uuid4(),
+        params=WebhookCreate(status="online"),
+    )
+    webhook = session.add.call_args.args[0]
+    return _pair("webhook", "create", None, webhook.id)
+
+
+async def _webhook_update(mp: pytest.MonkeyPatch, role: Role):
+    webhook_id = uuid.uuid4()
+    session = _session()
+    mp.setattr(
+        webhook_service,
+        "get_webhook",
+        AsyncMock(return_value=SimpleNamespace(id=webhook_id, status="offline")),
+    )
+    await webhook_service.update_webhook(
+        role=role,
+        session=cast(Any, session),
+        workflow_id=WorkflowUUID.new_uuid4(),
+        params=WebhookUpdate(status="online"),
+    )
+    return _pair("webhook", "update", None, webhook_id, {"changed_fields": ["status"]})
+
+
+class _GeneratedKey:
+    raw, hashed, salt_b64 = "tc_wh_synthetic", "hash", "salt"
+
+    def preview(self) -> str:
+        return "preview"
+
+
+async def _key(mp: pytest.MonkeyPatch, role: Role, action: str):
+    webhook_id, key_id = uuid.uuid4(), uuid.uuid4()
+    existing = (
+        None
+        if action == "create"
+        else SimpleNamespace(
+            id=key_id,
+            workspace_id=role.workspace_id,
+            hashed="old",
+            salt="old",
+            preview="old",
+            last_used_at=None,
+            revoked_at=None,
+            revoked_by=None,
+            created_at=None,
+            updated_at=None,
+        )
+    )
+    session = _webhook_session()
+
+    async def get_api_key_audit_target(
+        _context: object,
+    ) -> tuple[uuid.UUID, uuid.UUID | None]:
+        if action == "create" and session.add.called:
+            return webhook_id, cast(WebhookApiKey, session.add.call_args.args[0]).id
+        return webhook_id, None if action == "create" else key_id
+
+    mp.setattr(
+        workflow_management_router,
+        "_get_webhook_key_audit_target",
+        get_api_key_audit_target,
+    )
+    mp.setattr(
+        webhook_service,
+        "get_webhook",
+        AsyncMock(return_value=SimpleNamespace(id=webhook_id, api_key=existing)),
+    )
+    data = {"webhook_id": str(webhook_id)}
+    if action in {"create", "rotate"}:
+        mp.setattr(
+            workflow_management_router,
+            "generate_api_key",
+            MagicMock(return_value=_GeneratedKey()),
+        )
+        await workflow_management_router.generate_webhook_api_key(
+            role=role,
+            session=cast(Any, session),
+            workflow_id=WorkflowUUID.new_uuid4(),
+        )
+        terminal_id = (
+            cast(WebhookApiKey, session.add.call_args.args[0]).id
+            if action == "create"
+            else key_id
+        )
+        return _pair(
+            "webhook_api_key",
+            action,
+            None if action == "create" else key_id,
+            terminal_id,
+            data,
+        )
+    if action == "revoke":
+        await workflow_management_router.revoke_webhook_api_key(
+            role=role,
+            session=cast(Any, session),
+            workflow_id=WorkflowUUID.new_uuid4(),
+        )
+    else:
+        await workflow_management_router.delete_webhook_api_key(
+            role=role,
+            session=cast(Any, session),
+            workflow_id=WorkflowUUID.new_uuid4(),
+        )
+    return _pair("webhook_api_key", action, key_id, key_id, data)
+
+
+async def _key_create(mp: pytest.MonkeyPatch, role: Role):
+    return await _key(mp, role, "create")
+
+
+async def _key_rotate(mp: pytest.MonkeyPatch, role: Role):
+    return await _key(mp, role, "rotate")
+
+
+async def _key_revoke(mp: pytest.MonkeyPatch, role: Role):
+    return await _key(mp, role, "revoke")
+
+
+async def _key_delete(mp: pytest.MonkeyPatch, role: Role):
+    return await _key(mp, role, "delete")
+
+
+CASES = tuple(
+    AuditCase(name, runner)
+    for name, runner in (
+        ("workflow_update", _workflow_update),
+        ("workflow_edit", _workflow_edit),
+        ("workflow_graph", _workflow_graph),
+        ("workflow_publish", _workflow_publish),
+        ("workflow_restore", _workflow_restore),
+        ("external_create", _external_create),
+        ("execution_reset", _execution_reset),
+        ("execution_cancel", _execution_cancel),
+        ("execution_terminate", _execution_terminate),
+        ("schedule_create", _schedule_create),
+        ("schedule_update", _schedule_update),
+        ("schedule_delete", _schedule_delete),
+        ("case_create", _case_create),
+        ("case_upsert_update", _case_upsert_update),
+        ("case_update", _case_update),
+        ("webhook_create", _webhook_create),
+        ("webhook_update", _webhook_update),
+        ("key_create", _key_create),
+        ("key_rotate", _key_rotate),
+        ("key_revoke", _key_revoke),
+        ("key_delete", _key_delete),
+    )
+)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("case", CASES, ids=str)
+async def test_control_plane_audit_wiring(
+    monkeypatch: pytest.MonkeyPatch, case: AuditCase
+) -> None:
+    role, calls, wire_events = _role(), [], []
+    _capture_events(monkeypatch, calls, wire_events)
+    role_token = ctx_role.set(role)
+    client_ip_token = ctx_client_ip.set(_CLIENT_IP)
+    user_agent_token = ctx_user_agent.set(_USER_AGENT)
+    try:
+        expected = await case.run(monkeypatch, role)
+    finally:
+        ctx_user_agent.reset(user_agent_token)
+        ctx_client_ip.reset(client_ip_token)
+        ctx_role.reset(role_token)
+    expected_events = list(expected)
+    assert calls == expected_events
+    assert len(wire_events) == len(expected_events)
+    for payload, expected_event in zip(wire_events, expected_events, strict=True):
+        _assert_wire_event(role, payload, expected_event)
+
+
+@pytest.mark.anyio
+async def test_completed_execution_control_emits_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role, calls = _role(), []
+    _capture_events(monkeypatch, calls)
+    service = WorkflowExecutionsService(MagicMock(), role=role)
+    monkeypatch.setattr(service, "require_execution", AsyncMock())
+    handle = MagicMock()
+    handle.cancel = AsyncMock(
+        side_effect=RPCError("not found", RPCStatusCode.NOT_FOUND, b"")
+    )
+    monkeypatch.setattr(service, "handle", MagicMock(return_value=handle))
+    execution_id = generate_exec_id(WorkflowUUID.new_uuid4())
+    await service.cancel_workflow_execution(execution_id)
+    assert [call["status"] for call in calls] == [
+        AuditEventStatus.ATTEMPT,
+        AuditEventStatus.SUCCESS,
+    ]
+
+
+@pytest.mark.anyio
+async def test_bulk_reset_emits_one_event_pair_per_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role, calls = _role(), []
+    _capture_events(monkeypatch, calls)
+    client = MagicMock()
+    client.workflow_service.reset_workflow_execution = AsyncMock(
+        return_value=SimpleNamespace(run_id="new-run")
+    )
+    service = WorkflowExecutionsService(client, role=role)
+    monkeypatch.setattr(
+        service,
+        "require_execution",
+        AsyncMock(return_value=SimpleNamespace(id="temporal-id", run_id="run")),
+    )
+    monkeypatch.setattr(service, "_resolve_reset_event_id", AsyncMock(return_value=1))
+    execution_ids = [
+        generate_exec_id(WorkflowUUID.new_uuid4()),
+        generate_exec_id(WorkflowUUID.new_uuid4()),
+    ]
+
+    results = await service.bulk_reset_workflow_executions(
+        execution_ids,
+        event_id=None,
+    )
+
+    assert all(result.ok for result in results)
+    for execution_id in execution_ids:
+        workflow_id, _ = exec_id_to_parts(execution_id)
+        matching = [
+            call
+            for call in calls
+            if call["data"] == {"execution_id": execution_id, "operation": "reset"}
+        ]
+        assert matching == list(
+            _pair(
+                "workflow_execution",
+                "create",
+                workflow_id,
+                workflow_id,
+                {"execution_id": execution_id, "operation": "reset"},
+            )
+        )
+
+
+@pytest.mark.anyio
+async def test_missing_webhook_key_operation_emits_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role, calls = _role(), []
+    _capture_events(monkeypatch, calls)
+    session = _session()
+    monkeypatch.setattr(
+        workflow_management_router,
+        "_get_webhook_key_audit_target",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(
+        webhook_service,
+        "get_webhook",
+        AsyncMock(return_value=None),
+    )
+    with pytest.raises(HTTPException):
+        await workflow_management_router.generate_webhook_api_key(
+            role=role,
+            session=cast(Any, session),
+            workflow_id=WorkflowUUID.new_uuid4(),
+        )
+    assert [call["status"] for call in calls] == [
+        AuditEventStatus.ATTEMPT,
+        AuditEventStatus.FAILURE,
+    ]
+    assert all(call["resource_type"] == "webhook_api_key" for call in calls)
+    assert all(call["action"] == "create" for call in calls)
+    assert all(call["data"] == {"webhook_id": None} for call in calls)
+
+
+@pytest.mark.anyio
+async def test_internal_publish_is_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    role, calls = _role(internal=True), []
+    _capture_events(monkeypatch, calls)
+    service = WorkflowsManagementService(cast(Any, _session()), role=role)
+    monkeypatch.setattr(
+        service, "get_workflow", AsyncMock(side_effect=TracecatValidationError("stop"))
+    )
+    with pytest.raises(TracecatValidationError):
+        await service.publish_workflow(WorkflowUUID.new_uuid4())
+    assert calls == []

--- a/tests/unit/test_control_plane_audit.py
+++ b/tests/unit/test_control_plane_audit.py
@@ -17,7 +17,7 @@ from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.service import AuditService
 from tracecat.audit.types import AuditEvent
 from tracecat.auth.types import Role
-from tracecat.contexts import ctx_client_ip, ctx_role, ctx_user_agent
+from tracecat.contexts import RequestAuditContext, ctx_request_audit, ctx_role
 from tracecat.db.models import WebhookApiKey
 from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import ScopeDeniedError, TracecatValidationError
@@ -377,7 +377,9 @@ async def _execution_control(mp: pytest.MonkeyPatch, role: Role, operation: str)
     setattr(handle, operation, AsyncMock())
     mp.setattr(service, "handle", MagicMock(return_value=handle))
     await getattr(service, f"{operation}_workflow_execution")(execution_id)
-    data = {"execution_id": execution_id, "operation": operation}
+    data: dict[str, object] = {"execution_id": execution_id, "operation": operation}
+    if operation == "terminate":
+        data["has_reason"] = False
     return _pair("workflow_execution", operation, workflow_id, workflow_id, data)
 
 
@@ -404,7 +406,12 @@ async def _execution_reset(mp: pytest.MonkeyPatch, role: Role):
     )
     mp.setattr(service, "_resolve_reset_event_id", AsyncMock(return_value=1))
     await service.reset_workflow_execution(execution_id, event_id=None)
-    data = {"execution_id": execution_id, "operation": "reset"}
+    data = {
+        "execution_id": execution_id,
+        "operation": "reset",
+        "event_id": None,
+        "has_reason": False,
+    }
     return _pair("workflow_execution", "reset", workflow_id, workflow_id, data)
 
 
@@ -665,13 +672,13 @@ async def test_control_plane_audit_wiring(
     role, calls, wire_events = _role(), [], []
     _capture_events(monkeypatch, calls, wire_events)
     role_token = ctx_role.set(role)
-    client_ip_token = ctx_client_ip.set(_CLIENT_IP)
-    user_agent_token = ctx_user_agent.set(_USER_AGENT)
+    audit_token = ctx_request_audit.set(
+        RequestAuditContext(client_ip=_CLIENT_IP, user_agent=_USER_AGENT)
+    )
     try:
         expected = await case.run(monkeypatch, role)
     finally:
-        ctx_user_agent.reset(user_agent_token)
-        ctx_client_ip.reset(client_ip_token)
+        ctx_request_audit.reset(audit_token)
         ctx_role.reset(role_token)
     expected_events = list(expected)
     assert calls == expected_events
@@ -731,18 +738,20 @@ async def test_bulk_reset_emits_one_event_pair_per_execution(
     assert all(result.ok for result in results)
     for execution_id in execution_ids:
         workflow_id, _ = exec_id_to_parts(execution_id)
-        matching = [
-            call
-            for call in calls
-            if call["data"] == {"execution_id": execution_id, "operation": "reset"}
-        ]
+        expected_data = {
+            "execution_id": execution_id,
+            "operation": "reset",
+            "event_id": None,
+            "has_reason": False,
+        }
+        matching = [call for call in calls if call["data"] == expected_data]
         assert matching == list(
             _pair(
                 "workflow_execution",
                 "reset",
                 workflow_id,
                 workflow_id,
-                {"execution_id": execution_id, "operation": "reset"},
+                expected_data,
             )
         )
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -575,9 +575,17 @@ def test_auto_generate_layout_round_trips_through_extract():
 @pytest.mark.anyio
 async def test_update_workflow_metadata_only_omits_unset_fields(monkeypatch):
     """A metadata-only update must not overwrite title/status with NULL."""
+    role = Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        scopes=frozenset({"*"}),
+    )
 
     async def _resolve(_workspace_id):
-        return uuid.uuid4(), SimpleNamespace()
+        return uuid.uuid4(), role
 
     wf_id = uuid.uuid4()
 
@@ -620,8 +628,17 @@ async def test_update_workflow_metadata_only_omits_unset_fields(monkeypatch):
             pass
 
     workflow_service = _WorkflowService()
+    captured: dict[str, Any] = {}
+
+    async def _apply_yaml_update(**kwargs):
+        captured.update(kwargs)
+        for key, value in (
+            kwargs["update_params"].model_dump(exclude_unset=True).items()
+        ):
+            setattr(fake_workflow, key, value)
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server, "_apply_workflow_yaml_update", _apply_yaml_update)
     monkeypatch.setattr(
         mcp_server.WorkflowsManagementService,
         "with_session",
@@ -641,12 +658,24 @@ async def test_update_workflow_metadata_only_omits_unset_fields(monkeypatch):
     assert "description" not in setattr_calls
     assert "status" not in setattr_calls
     assert workflow_service.for_update_calls == [True]
+    assert captured["workflow_id"] == mcp_server.WorkflowUUID.new(wf_id)
+    assert captured["update_params"].model_dump(exclude_unset=True) == {}
+    assert captured["yaml_payload"] is None
 
 
 @pytest.mark.anyio
 async def test_update_workflow_definition_yaml_uses_shared_yaml_update(monkeypatch):
+    role = Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        scopes=frozenset({"*"}),
+    )
+
     async def _resolve(_workspace_id):
-        return uuid.uuid4(), SimpleNamespace()
+        return uuid.uuid4(), role
 
     workflow_id = uuid.uuid4()
     workflow = SimpleNamespace(id=workflow_id)
@@ -676,6 +705,13 @@ async def test_update_workflow_definition_yaml_uses_shared_yaml_update(monkeypat
     async def _apply_yaml_update(**kwargs):
         captured.update(kwargs)
 
+    yaml_payload = SimpleNamespace(
+        definition=object(),
+        layout=None,
+        schedules=None,
+        case_trigger=None,
+    )
+
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     monkeypatch.setattr(
         mcp_server.WorkflowsManagementService,
@@ -685,7 +721,7 @@ async def test_update_workflow_definition_yaml_uses_shared_yaml_update(monkeypat
     monkeypatch.setattr(
         mcp_server,
         "_parse_workflow_yaml_payload",
-        lambda definition_yaml: {"definition_yaml": definition_yaml},
+        lambda definition_yaml: yaml_payload,
     )
     monkeypatch.setattr(mcp_server, "_apply_workflow_yaml_update", _apply_yaml_update)
 
@@ -700,9 +736,7 @@ async def test_update_workflow_definition_yaml_uses_shared_yaml_update(monkeypat
     assert payload["mode"] == "replace"
     assert captured["workflow_id"] == mcp_server.WorkflowUUID.new(workflow_id)
     assert captured["definition_yaml"] == "definition:\n  title: Example\n"
-    assert captured["yaml_payload"] == {
-        "definition_yaml": "definition:\n  title: Example\n"
-    }
+    assert captured["yaml_payload"] is yaml_payload
     assert captured["update_mode"] == "replace"
     assert workflow_service.for_update_calls == [True]
 
@@ -3583,28 +3617,22 @@ async def test_update_webhook(monkeypatch):
         api_key=None,
     )
 
-    async def _get_webhook(session, workspace_id, workflow_id):
-        return fake_webhook
-
-    class FakeSession:
-        def add(self, obj):
-            pass
-
-        async def commit(self):
-            pass
-
-        async def refresh(self, _obj):
-            pass
-
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+
+    async def _update_webhook(*, role, session, workflow_id, params):
+        del role, session, workflow_id
+        for key, value in params.model_dump(exclude_unset=True).items():
+            setattr(fake_webhook, key, value)
+
     monkeypatch.setattr(
-        "tracecat.webhooks.service.get_webhook",
-        _get_webhook,
+        mcp_server.webhook_service,
+        "update_webhook",
+        _update_webhook,
     )
     monkeypatch.setattr(
         mcp_server,
         "get_async_session_context_manager",
-        lambda: _AsyncContext(FakeSession()),
+        lambda: _AsyncContext(SimpleNamespace()),
     )
 
     result = await _tool(mcp_server.update_webhook)(
@@ -3643,28 +3671,22 @@ async def test_update_webhook_omits_unset_fields(monkeypatch):
     )
     setattr_calls.clear()
 
-    async def _get_webhook(session, workspace_id, workflow_id):
-        return fake_webhook
-
-    class FakeSession:
-        def add(self, obj):
-            pass
-
-        async def commit(self):
-            pass
-
-        async def refresh(self, _obj):
-            pass
-
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+
+    async def _update_webhook(*, role, session, workflow_id, params):
+        del role, session, workflow_id
+        for key, value in params.model_dump(exclude_unset=True).items():
+            setattr(fake_webhook, key, value)
+
     monkeypatch.setattr(
-        "tracecat.webhooks.service.get_webhook",
-        _get_webhook,
+        mcp_server.webhook_service,
+        "update_webhook",
+        _update_webhook,
     )
     monkeypatch.setattr(
         mcp_server,
         "get_async_session_context_manager",
-        lambda: _AsyncContext(FakeSession()),
+        lambda: _AsyncContext(SimpleNamespace()),
     )
 
     result = await _tool(mcp_server.update_webhook)(

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -222,6 +222,18 @@ def _action_stub(**overrides: Any) -> SimpleNamespace:
     return SimpleNamespace(**data)
 
 
+def _edit_role() -> Role:
+    """Minimal auditable Role for persist_workflow_edit_document call sites."""
+    return Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        scopes=frozenset({"*"}),
+    )
+
+
 @pytest.mark.anyio
 async def test_resolve_workspace_role_rejects_invalid_workspace_id():
     with pytest.raises(ToolError, match="Invalid workspace ID"):
@@ -1541,7 +1553,7 @@ async def test_persist_workflow_edit_document_ignores_stale_layout_refs_after_de
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
     await draft.persist_workflow_edit_document(
-        role=SimpleNamespace(),
+        role=_edit_role(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
         original_document=original_document,
@@ -1621,7 +1633,7 @@ async def test_persist_workflow_edit_document_skips_reorder_only_changes(
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
     await draft.persist_workflow_edit_document(
-        role=SimpleNamespace(),
+        role=_edit_role(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
         original_document=original_document,
@@ -2322,7 +2334,7 @@ async def test_persist_workflow_edit_document_applies_metadata_with_definition_c
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
     await draft.persist_workflow_edit_document(
-        role=SimpleNamespace(),
+        role=_edit_role(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
         original_document=original_document,
@@ -2390,7 +2402,7 @@ async def test_persist_workflow_edit_document_preserves_offline_schedule_status_
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
     await draft.persist_workflow_edit_document(
-        role=SimpleNamespace(),
+        role=_edit_role(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
         original_document=original_document,
@@ -2682,7 +2694,7 @@ async def test_persist_workflow_edit_document_resets_removed_layout_fields() -> 
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
     await draft.persist_workflow_edit_document(
-        role=SimpleNamespace(),
+        role=_edit_role(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
         original_document=original_document,
@@ -2750,7 +2762,7 @@ async def test_persist_workflow_edit_document_resets_removed_layout_actions() ->
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
     await draft.persist_workflow_edit_document(
-        role=SimpleNamespace(),
+        role=_edit_role(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
         original_document=original_document,
@@ -2807,7 +2819,7 @@ async def test_persist_workflow_edit_document_resets_removed_layout_object() -> 
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
     await draft.persist_workflow_edit_document(
-        role=SimpleNamespace(),
+        role=_edit_role(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
         original_document=original_document,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -10435,3 +10435,60 @@ def test_validate_patch_payload_wraps_nested_tracecat_validation_error() -> None
     assert error.details is not None
     assert error.details["type"] == "validation_error"
     assert "interaction" in error.message.lower()
+
+
+@pytest.mark.anyio
+async def test_request_audit_middleware_sets_context_during_tool_call(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from types import SimpleNamespace
+
+    from tracecat.contexts import RequestAuditContext, ctx_request_audit
+    from tracecat.mcp import middleware as mcp_middleware
+
+    fake_request = SimpleNamespace(
+        headers={"X-Forwarded-For": "203.0.113.7, 10.0.0.1", "User-Agent": "curl/8.5"},
+        client=SimpleNamespace(host="10.0.0.2"),
+    )
+    monkeypatch.setattr(mcp_middleware, "get_http_request", lambda: fake_request)
+    mw = mcp_middleware.MCPRequestAuditMiddleware()
+    sentinel = object()
+    seen: dict[str, RequestAuditContext | None] = {}
+
+    async def _call_next(
+        context: MiddlewareContext[CallToolRequestParams],
+    ) -> ToolResult:
+        seen["audit"] = ctx_request_audit.get()
+        return cast(ToolResult, sentinel)
+
+    result = await mw.on_call_tool(_make_tool_context(), _call_next)
+    assert result is sentinel
+    audit = seen["audit"]
+    assert audit is not None
+    assert audit.client_ip == "203.0.113.7"
+    assert audit.user_agent == "curl/8.5"
+    assert ctx_request_audit.get() is None
+
+
+@pytest.mark.anyio
+async def test_request_audit_middleware_tolerates_missing_http_request(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from tracecat.contexts import ctx_request_audit
+    from tracecat.mcp import middleware as mcp_middleware
+
+    def _raise() -> object:
+        raise RuntimeError("no active HTTP request")
+
+    monkeypatch.setattr(mcp_middleware, "get_http_request", _raise)
+    mw = mcp_middleware.MCPRequestAuditMiddleware()
+    sentinel = object()
+
+    async def _call_next(
+        context: MiddlewareContext[CallToolRequestParams],
+    ) -> ToolResult:
+        assert ctx_request_audit.get() is None
+        return cast(ToolResult, sentinel)
+
+    result = await mw.on_call_tool(_make_tool_context(), _call_next)
+    assert result is sentinel

--- a/tests/unit/test_request_middleware.py
+++ b/tests/unit/test_request_middleware.py
@@ -1,0 +1,50 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tracecat.contexts import ctx_client_ip, ctx_user_agent
+from tracecat.middleware.request import RequestLoggingMiddleware
+
+
+def test_request_context_values_are_normalized() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    async def read_context() -> dict[str, str | None]:
+        return {
+            "client_ip": ctx_client_ip.get(),
+            "user_agent": ctx_user_agent.get(),
+        }
+
+    app.add_api_route("/", read_context)
+    app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
+    with TestClient(app) as client:
+        response = client.get(
+            "/",
+            headers={
+                "X-Forwarded-For": "2001:0db8::1, 192.0.2.1",
+                "User-Agent": (
+                    "TracecatClient/1.0 user@example.com "
+                    "Authorization: Bearer synthetic-token"
+                ),
+            },
+        )
+
+    assert response.json() == {
+        "client_ip": "2001:db8::1",
+        "user_agent": ("TracecatClient/1.0 [redacted email] Authorization: [redacted]"),
+    }
+
+
+def test_invalid_forwarded_ip_is_not_stored() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    async def read_client_ip() -> dict[str, str | None]:
+        return {"client_ip": ctx_client_ip.get()}
+
+    app.add_api_route("/", read_client_ip)
+    app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
+    with TestClient(app) as client:
+        response = client.get("/", headers={"X-Forwarded-For": "not-an-ip"})
+
+    assert response.json() == {"client_ip": None}

--- a/tests/unit/test_request_middleware.py
+++ b/tests/unit/test_request_middleware.py
@@ -1,8 +1,16 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from tracecat.contexts import ctx_client_ip, ctx_user_agent
+from tracecat.contexts import ctx_request_audit
 from tracecat.middleware.request import RequestLoggingMiddleware
+
+
+def _read_audit_context() -> dict[str, str | None]:
+    audit = ctx_request_audit.get()
+    return {
+        "client_ip": audit.client_ip if audit is not None else None,
+        "user_agent": audit.user_agent if audit is not None else None,
+    }
 
 
 def test_request_context_values_are_normalized() -> None:
@@ -10,10 +18,7 @@ def test_request_context_values_are_normalized() -> None:
     app.add_middleware(RequestLoggingMiddleware)
 
     async def read_context() -> dict[str, str | None]:
-        return {
-            "client_ip": ctx_client_ip.get(),
-            "user_agent": ctx_user_agent.get(),
-        }
+        return _read_audit_context()
 
     app.add_api_route("/", read_context)
     app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
@@ -40,7 +45,7 @@ def test_request_context_reduces_unknown_user_agent() -> None:
     app.add_middleware(RequestLoggingMiddleware)
 
     async def read_user_agent() -> dict[str, str | None]:
-        return {"user_agent": ctx_user_agent.get()}
+        return {"user_agent": _read_audit_context()["user_agent"]}
 
     app.add_api_route("/", read_user_agent)
     app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
@@ -58,7 +63,7 @@ def test_invalid_forwarded_ip_falls_back_to_socket_peer() -> None:
     app.add_middleware(RequestLoggingMiddleware)
 
     async def read_client_ip() -> dict[str, str | None]:
-        return {"client_ip": ctx_client_ip.get()}
+        return {"client_ip": _read_audit_context()["client_ip"]}
 
     app.add_api_route("/", read_client_ip)
     app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
@@ -73,7 +78,7 @@ def test_no_forwarded_header_and_invalid_socket_peer_yields_none() -> None:
     app.add_middleware(RequestLoggingMiddleware)
 
     async def read_client_ip() -> dict[str, str | None]:
-        return {"client_ip": ctx_client_ip.get()}
+        return {"client_ip": _read_audit_context()["client_ip"]}
 
     app.add_api_route("/", read_client_ip)
     app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()

--- a/tests/unit/test_request_middleware.py
+++ b/tests/unit/test_request_middleware.py
@@ -17,25 +17,43 @@ def test_request_context_values_are_normalized() -> None:
 
     app.add_api_route("/", read_context)
     app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
-    with TestClient(app) as client:
+    with TestClient(app, client=("203.0.113.10", 50000)) as client:
         response = client.get(
             "/",
             headers={
-                "X-Forwarded-For": "2001:0db8::1, 192.0.2.1",
+                "X-Forwarded-For": "198.51.100.20",
                 "User-Agent": (
-                    "TracecatClient/1.0 user@example.com "
+                    "TracecatClient/1.0 session=synthetic-opaque-value "
                     "Authorization: Bearer synthetic-token"
                 ),
             },
         )
 
     assert response.json() == {
-        "client_ip": "2001:db8::1",
-        "user_agent": ("TracecatClient/1.0 [redacted email] Authorization: [redacted]"),
+        "client_ip": "198.51.100.20",
+        "user_agent": "tracecat/1.0",
     }
 
 
-def test_invalid_forwarded_ip_is_not_stored() -> None:
+def test_request_context_reduces_unknown_user_agent() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    async def read_user_agent() -> dict[str, str | None]:
+        return {"user_agent": ctx_user_agent.get()}
+
+    app.add_api_route("/", read_user_agent)
+    app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
+    with TestClient(app) as client:
+        response = client.get(
+            "/",
+            headers={"User-Agent": "UnknownClient session=synthetic-opaque-value"},
+        )
+
+    assert response.json() == {"user_agent": "other"}
+
+
+def test_invalid_forwarded_ip_falls_back_to_socket_peer() -> None:
     app = FastAPI()
     app.add_middleware(RequestLoggingMiddleware)
 
@@ -44,7 +62,22 @@ def test_invalid_forwarded_ip_is_not_stored() -> None:
 
     app.add_api_route("/", read_client_ip)
     app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
-    with TestClient(app) as client:
+    with TestClient(app, client=("203.0.113.10", 50000)) as client:
         response = client.get("/", headers={"X-Forwarded-For": "not-an-ip"})
+
+    assert response.json() == {"client_ip": "203.0.113.10"}
+
+
+def test_no_forwarded_header_and_invalid_socket_peer_yields_none() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    async def read_client_ip() -> dict[str, str | None]:
+        return {"client_ip": ctx_client_ip.get()}
+
+    app.add_api_route("/", read_client_ip)
+    app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
+    with TestClient(app, client=("not-an-ip", 50000)) as client:
+        response = client.get("/")
 
     assert response.json() == {"client_ip": None}

--- a/tests/unit/test_sanitization.py
+++ b/tests/unit/test_sanitization.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import orjson
+import pytest
+
+from tracecat.sanitization import redact_sensitive_text
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            '{"Authorization": "Basic synthetic-credential"}',
+            '{"Authorization": "[redacted]"}',
+        ),
+        (
+            "{'Cookie': 'session=synthetic-cookie'}",
+            "{'Cookie': '[redacted]'}",
+        ),
+        (
+            '{"Set-Cookie": "session=synthetic-cookie; HttpOnly"}',
+            '{"Set-Cookie": "[redacted]"}',
+        ),
+    ],
+)
+def test_redact_sensitive_text_redacts_serialized_headers(
+    text: str,
+    expected: str,
+) -> None:
+    assert redact_sensitive_text(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        ("-----BEGIN PRIVATE KEY-----\nSYNTHETICBODY\n-----END PRIVATE KEY-----"),
+        (
+            "private_key=-----BEGIN PRIVATE KEY-----\n"
+            "SYNTHETICBODY\n"
+            "-----END PRIVATE KEY-----"
+        ),
+    ],
+)
+def test_redact_sensitive_text_redacts_complete_pem_blocks(text: str) -> None:
+    sanitized = redact_sensitive_text(text)
+
+    assert "SYNTHETICBODY" not in sanitized
+    assert "BEGIN PRIVATE KEY" not in sanitized
+    assert "END PRIVATE KEY" not in sanitized
+
+
+def test_redact_sensitive_text_preserves_serialized_pem_shape() -> None:
+    pem = "-----BEGIN PRIVATE KEY-----\nSYNTHETICBODY\n-----END PRIVATE KEY-----"
+    serialized = orjson.dumps({"pem": pem}).decode()
+
+    sanitized = redact_sensitive_text(serialized)
+
+    assert orjson.loads(sanitized) == {"pem": "[redacted PEM block]"}

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -55,7 +55,9 @@ class _FakeWorkflowGraphService:
     def __init__(self, _session: Any, *, role: Role):
         self.role = role
 
-    async def apply_operations(self, **_kwargs: Any) -> None:
+    async def apply_operations_to_locked_workflow(
+        self, *_args: Any, **_kwargs: Any
+    ) -> None:
         return None
 
 
@@ -384,6 +386,9 @@ async def test_external_import_publishes_before_online_case_trigger(
             self.session = session
             self.role = role
 
+        async def require_entitlement(self, _entitlement: object) -> None:
+            return None
+
         async def upsert_case_trigger(
             self,
             workflow_id: uuid.UUID,
@@ -482,7 +487,7 @@ async def test_persist_edit_document_wraps_case_trigger_validation_error(
 ) -> None:
     """An online case trigger on an unpublished workflow becomes WorkflowEditError.
 
-    ``CaseTriggersService.upsert_case_trigger`` raises ``TracecatValidationError``
+    ``CaseTriggersService`` raises ``TracecatValidationError``
     for correctable authoring mistakes (e.g. enabling a case trigger before the
     workflow is published). ``persist_workflow_edit_document`` must convert that
     into a transport-neutral ``WorkflowEditError`` so the internal edit route
@@ -516,6 +521,9 @@ async def test_persist_edit_document_wraps_case_trigger_validation_error(
         def __init__(self, session: Any, role: Role) -> None:
             self.session = session
             self.role = role
+
+        async def require_entitlement(self, _entitlement: object) -> None:
+            return None
 
         async def upsert_case_trigger(
             self,

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -386,9 +386,6 @@ async def test_external_import_publishes_before_online_case_trigger(
             self.session = session
             self.role = role
 
-        async def require_entitlement(self, _entitlement: object) -> None:
-            return None
-
         async def upsert_case_trigger(
             self,
             workflow_id: uuid.UUID,
@@ -521,9 +518,6 @@ async def test_persist_edit_document_wraps_case_trigger_validation_error(
         def __init__(self, session: Any, role: Role) -> None:
             self.session = session
             self.role = role
-
-        async def require_entitlement(self, _entitlement: object) -> None:
-            return None
 
         async def upsert_case_trigger(
             self,

--- a/tracecat/agent/mcp/stdio_probe_types.py
+++ b/tracecat/agent/mcp/stdio_probe_types.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import re
 import uuid
 
 from pydantic import BaseModel, Field
 
 from tracecat.auth.types import Role
-from tracecat.integrations.mcp_validation import sanitize_urls_in_text
 from tracecat.integrations.schemas import MCPToolSummary
+from tracecat.sanitization import redact_sensitive_text
 
 MCP_STDIO_PROBE_WORKFLOW_ID_PREFIX = "mcp-stdio-probe"
 MCP_STDIO_PROBE_ACTIVITY_NAME = "probe_stdio_mcp_connection_activity"
@@ -17,21 +16,6 @@ MCP_STDIO_PERSIST_ACTIVITY_NAME = "persist_stdio_mcp_connection_activity"
 MCP_STDIO_PROBE_TIMEOUT_CAP = 120
 MCP_STDIO_PROBE_HARD_TIMEOUT_BUFFER = 10
 _MAX_STDIO_PROBE_ERROR_LENGTH = 12_000
-_EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
-_BEARER_TOKEN_PATTERN = re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._~+/=-]+")
-_AUTHORIZATION_VALUE_PATTERN = re.compile(r"(?im)\b(Authorization\s*:\s*)[^\r\n]+")
-_COOKIE_VALUE_PATTERN = re.compile(r"(?im)\b((?:Set-)?Cookie\s*:\s*)[^\r\n]+")
-_JWT_PATTERN = re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
-_SENSITIVE_VALUE_PATTERN = re.compile(
-    r"(?i)(?P<prefix>['\"]?\b(?:api[ _-]?key|access[ _-]?token|refresh[ _-]?token|"
-    r"id[ _-]?token|client[ _-]?secret|private[ _-]?key|secret[ _-]?key|token|"
-    r"password|passwd|secret)\b['\"]?\s*[:=]\s*)"
-    r"(?:"
-    r'(?P<double_quoted>"(?:\\.|[^"\\\r\n])*")|'
-    r"(?P<single_quoted>'(?:\\.|[^'\\\r\n])*')|"
-    r"(?P<unquoted>[^\s,;}\]\"']+)"
-    r")"
-)
 
 
 class StdioMCPProbeWorkflowInput(BaseModel):
@@ -88,19 +72,11 @@ def sanitize_stdio_probe_error(
     if not text:
         return "Stdio MCP probe failed"
 
-    sanitized = sanitize_urls_in_text(text)
-    for value in (env or {}).values():
-        if isinstance(value, str) and len(value) >= 4:
-            sanitized = sanitized.replace(value, "[redacted]")
-            sanitized_value = sanitize_urls_in_text(value)
-            if sanitized_value != value:
-                sanitized = sanitized.replace(sanitized_value, "[redacted]")
-    sanitized = _EMAIL_PATTERN.sub("[redacted email]", sanitized)
-    sanitized = _BEARER_TOKEN_PATTERN.sub(r"\1[redacted]", sanitized)
-    sanitized = _AUTHORIZATION_VALUE_PATTERN.sub(r"\1[redacted]", sanitized)
-    sanitized = _COOKIE_VALUE_PATTERN.sub(r"\1[redacted]", sanitized)
-    sanitized = _JWT_PATTERN.sub("[redacted token]", sanitized)
-    sanitized = _SENSITIVE_VALUE_PATTERN.sub(_redact_sensitive_value, sanitized)
+    sanitized = redact_sensitive_text(
+        text,
+        sensitive_values=(env or {}).values(),
+        redact_emails=True,
+    )
 
     summary = sanitized.strip() or "Stdio MCP probe failed"
     if summary == "McpError: Connection closed":
@@ -115,14 +91,3 @@ def sanitize_stdio_probe_error(
     head_length = 2_000
     tail_length = _MAX_STDIO_PROBE_ERROR_LENGTH - head_length - len(separator)
     return f"{summary[:head_length]}{separator}{summary[-tail_length:]}"
-
-
-def _redact_sensitive_value(match: re.Match[str]) -> str:
-    """Replace a key-value secret while retaining readable delimiters."""
-    if match.group("double_quoted") is not None:
-        redacted = '"[redacted]"'
-    elif match.group("single_quoted") is not None:
-        redacted = "'[redacted]'"
-    else:
-        redacted = "[redacted]"
-    return f"{match.group('prefix')}{redacted}"

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -5,7 +5,7 @@ import inspect
 import uuid
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Concatenate, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,26 +21,6 @@ from tracecat.contexts import ctx_role
 from tracecat.logger import logger
 from tracecat.sanitization import redact_sensitive_text
 from tracecat.service import BaseService
-
-
-@dataclass(frozen=True)
-class AuditCallContext:
-    """Information passed to an audit detail callback.
-
-    Attributes:
-        target: The service associated with the call, when one can be found.
-            For methods this is normally ``self``. For decorated free functions,
-            it may be the bound ``service`` argument. Otherwise, it is the first
-            positional argument or ``None``.
-        arguments: Arguments supplied to the decorated function, keyed by their
-            parameter names. Default values that the caller omitted are not
-            included. These arguments may contain sensitive application data;
-            callbacks must select only identifiers, changed-field names, and
-            other metadata permitted by the audit policy.
-    """
-
-    target: Any | None
-    arguments: Mapping[str, Any]
 
 
 @dataclass(frozen=True)
@@ -76,12 +56,9 @@ class AuditEventDetails:
     emit: bool = True
 
 
-type AuditAttemptMetadataFn = Callable[
-    [AuditCallContext], AuditEventDetails | Awaitable[AuditEventDetails]
-]
-type AuditTerminalMetadataFn[T] = Callable[
-    [AuditCallContext, T], AuditEventDetails | Awaitable[AuditEventDetails]
-]
+type AuditDetailsResult = AuditEventDetails | Awaitable[AuditEventDetails]
+type AuditAttemptMetadataFn[**P] = Callable[P, AuditDetailsResult]
+type AuditTerminalMetadataFn[R, **P] = Callable[Concatenate[R, P], AuditDetailsResult]
 
 # Mapping of resource types to their default resource_id_attr names
 _RESOURCE_ID_ATTR_MAP: dict[str, str] = {
@@ -106,8 +83,8 @@ def audit_log[**P, R](
     resource_type: AuditResourceType,
     action: AuditAction,
     resource_id_attr: str | None = None,
-    attempt_metadata: AuditAttemptMetadataFn | None = None,
-    terminal_metadata: AuditTerminalMetadataFn[R] | None = None,
+    attempt_metadata: AuditAttemptMetadataFn[P] | None = None,
+    terminal_metadata: AuditTerminalMetadataFn[R, P] | None = None,
 ) -> Callable[
     [Callable[P, Awaitable[R]]],
     Callable[P, Awaitable[R]],
@@ -123,8 +100,9 @@ def audit_log[**P, R](
 
     The actor role is resolved from the service instance or a bound ``role``
     argument, then from the role context. Auditing is skipped when there is no
-    authenticated actor or when the resolved role belongs to an internal
-    service. User and service-account roles remain auditable. Event creation and
+    auditable actor. Internal service roles that carry the initiating user's ID
+    are audited and attributed to that user; unattributed service traffic has
+    no actor and is skipped. Event creation and
     detail callbacks are best-effort: their failures are logged without changing
     the result of the decorated operation. A service session is reused when
     available; decorated free functions can instead supply a bound ``session``
@@ -150,17 +128,18 @@ def audit_log[**P, R](
             the call, extraction checks positional objects and bound arguments;
             after the call, the return value is checked first.
         attempt_metadata: Optional synchronous or asynchronous callback invoked
-            before the attempt event. It receives an
-            :class:`AuditCallContext` and returns :class:`AuditEventDetails`.
-            Only ``action``, ``resource_id``, ``data``, and ``emit`` are used in
-            this phase. If it raises, the decorator logs the error and continues
-            with its default fields.
-        terminal_metadata: Optional synchronous or asynchronous callback
-            invoked after the decorated function returns. It receives the same
-            call context plus the function result and returns
-            :class:`AuditEventDetails`. Only ``resource_id``, ``data``, and
-            ``status`` are used in this phase. If it raises, the terminal event
-            uses the fields already derived.
+            before the attempt event. It takes the decorated function's own
+            arguments and returns :class:`AuditEventDetails`. Only ``action``,
+            ``resource_id``, ``data``, and ``emit`` are used in this phase. If it
+            raises, the decorator logs the error and continues with its default
+            fields.
+        terminal_metadata: Optional synchronous or asynchronous callback invoked
+            after the decorated function returns. It takes the result followed by
+            the decorated function's arguments; method-attached callbacks should
+            declare ``(result, *args: Any, **kwargs: Any)`` because a named
+            parameter spelling fails pyright's name check against P. Only
+            ``resource_id``, ``data``, and ``status`` are used in this phase. If
+            it raises, the terminal event uses the fields already derived.
 
     Returns:
         A decorator that preserves the wrapped function's signature and return
@@ -202,17 +181,13 @@ def audit_log[**P, R](
                 else ctx_role.get()
             )
 
-            if role is None or role.actor_id is None or role.type == "service":
+            if role is None or role.actor_id is None:
                 return await func(*args, **kwargs)
 
             raw_session = getattr(service, "session", None)
             if raw_session is None:
                 raw_session = bound_arguments.get("session")
             session = cast(AsyncSession | None, raw_session)
-            call_context = AuditCallContext(
-                target=service if service is not None else first_arg,
-                arguments=bound_arguments,
-            )
 
             resource_id: uuid.UUID | None = None
             try:
@@ -234,7 +209,7 @@ def audit_log[**P, R](
             should_emit = True
             if attempt_metadata is not None:
                 try:
-                    details = attempt_metadata(call_context)
+                    details = attempt_metadata(*args, **kwargs)
                     if inspect.isawaitable(details):
                         details = await details
                     if details.action is not None:
@@ -298,7 +273,7 @@ def audit_log[**P, R](
                     )
                     if terminal_metadata is not None:
                         try:
-                            details = terminal_metadata(call_context, result)
+                            details = terminal_metadata(result, *args, **kwargs)
                             if inspect.isawaitable(details):
                                 details = await details
                             if details.resource_id is not None:

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -4,23 +4,90 @@ import functools
 import inspect
 import uuid
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from dataclasses import dataclass
+from typing import Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.service import AuditService
-from tracecat.audit.types import AuditAction, AuditResourceType
+from tracecat.audit.types import (
+    AuditAction,
+    AuditMetadata,
+    AuditResourceType,
+)
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.contexts import ctx_role
 from tracecat.logger import logger
-from tracecat.service import BasePlatformService, BaseService
+from tracecat.sanitization import redact_sensitive_text
+from tracecat.service import BaseService
 
-P = ParamSpec("P")
-R = TypeVar("R")
+
+@dataclass(frozen=True)
+class AuditCallContext:
+    """Information passed to an audit detail callback.
+
+    Attributes:
+        target: The service associated with the call, when one can be found.
+            For methods this is normally ``self``. For decorated free functions,
+            it may be the bound ``service`` argument. Otherwise, it is the first
+            positional argument or ``None``.
+        arguments: Arguments supplied to the decorated function, keyed by their
+            parameter names. Default values that the caller omitted are not
+            included. These arguments may contain sensitive application data;
+            callbacks must select only identifiers, changed-field names, and
+            other metadata permitted by the audit policy.
+    """
+
+    target: Any | None
+    arguments: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class AuditEventDetails:
+    """Audit fields returned by an audit metadata callback.
+
+    Attributes:
+        action: Replaces the decorator's default action when returned by
+            ``attempt_metadata``. It is ignored when returned by
+            ``terminal_metadata``.
+        resource_id: Replaces the automatically extracted resource ID. A value
+            from ``attempt_metadata`` applies to every event; a value from
+            ``terminal_metadata``
+            applies only to the terminal event.
+        data: Metadata to store on the event. Data from ``attempt_metadata`` is
+            used for both the attempt and terminal events. Non-``None`` data
+            from ``terminal_metadata`` replaces it for the terminal event only.
+            The audit service applies its metadata allowlist before delivery;
+            callers must still avoid constructing metadata from raw content or
+            secret values.
+        status: Replaces the inferred terminal status when returned by
+            ``terminal_metadata``. It is ignored when returned by
+            ``attempt_metadata``.
+        emit: When ``False`` from ``attempt_metadata``, executes the decorated
+            function without emitting any audit events. It is ignored by
+            ``terminal_metadata``.
+    """
+
+    action: AuditAction | None = None
+    resource_id: uuid.UUID | None = None
+    data: AuditMetadata | None = None
+    status: AuditEventStatus | None = None
+    emit: bool = True
+
+
+type AuditAttemptMetadataFn = Callable[
+    [AuditCallContext], AuditEventDetails | Awaitable[AuditEventDetails]
+]
+type AuditTerminalMetadataFn[T] = Callable[
+    [AuditCallContext, T], AuditEventDetails | Awaitable[AuditEventDetails]
+]
 
 # Mapping of resource types to their default resource_id_attr names
 _RESOURCE_ID_ATTR_MAP: dict[str, str] = {
     "workflow": "workflow_id",
     "workflow_execution": "wf_id",
+    "schedule": "schedule_id",
     "organization_member": "user_id",
     "organization_session": "session_id",
     "organization": "org_id",
@@ -34,26 +101,75 @@ _RESOURCE_ID_ATTR_MAP: dict[str, str] = {
 }
 
 
-def audit_log(
+def audit_log[**P, R](
     *,
     resource_type: AuditResourceType,
     action: AuditAction,
     resource_id_attr: str | None = None,
+    attempt_metadata: AuditAttemptMetadataFn | None = None,
+    terminal_metadata: AuditTerminalMetadataFn[R] | None = None,
 ) -> Callable[
-    [Callable[Concatenate[Any, P], Awaitable[R]]],
-    Callable[Concatenate[Any, P], Awaitable[R]],
+    [Callable[P, Awaitable[R]]],
+    Callable[P, Awaitable[R]],
 ]:
-    """Decorator to emit audit attempt/success/failure around service methods.
+    """Audit an asynchronous operation from its attempt through its terminal event.
 
-    If no user role or session is available, auditing is skipped without failing the call.
+    The wrapper emits an ``ATTEMPT`` event before calling the function, followed
+    by a ``SUCCESS`` or ``FAILURE`` event. A returned object with
+    ``success=False`` or ``ok=False`` is treated as a failure even when the call
+    does not raise. If the call raises, the failure event uses a fresh database
+    session so it is not lost with the operation's aborted transaction, and the
+    original exception is re-raised.
 
-    The resource_id_attr is automatically derived from resource_type if not provided,
-    using the _RESOURCE_ID_ATTR_MAP. Falls back to "id" if no mapping exists.
+    The actor role is resolved from the service instance or a bound ``role``
+    argument, then from the role context. Auditing is skipped when there is no
+    authenticated actor or when the resolved role belongs to an internal
+    service. User and service-account roles remain auditable. Event creation and
+    detail callbacks are best-effort: their failures are logged without changing
+    the result of the decorated operation. A service session is reused when
+    available; decorated free functions can instead supply a bound ``session``
+    argument.
+
+    ``attempt_metadata`` and ``terminal_metadata`` are phase-specific field
+    derivation callbacks, not automatic state snapshots. The decorator
+    deliberately does not serialize or diff function arguments and return
+    values because those objects can contain secrets, workflow inputs and
+    outputs, prompts, tool results, or uploaded content. Callbacks expose only
+    explicitly selected audit metadata.
+
+    Args:
+        resource_type: Type of resource being changed, such as ``"workflow"``
+            or ``"schedule"``. This is stored on every emitted event and also
+            selects the default resource ID attribute.
+        action: Default action stored on every emitted event. An
+            ``attempt_metadata`` callback can replace it when the action depends
+            on the call's input.
+        resource_id_attr: Name of the UUID attribute or function parameter from
+            which to extract the affected resource ID. When omitted, the name is
+            looked up from ``resource_type`` and falls back to ``"id"``. Before
+            the call, extraction checks positional objects and bound arguments;
+            after the call, the return value is checked first.
+        attempt_metadata: Optional synchronous or asynchronous callback invoked
+            before the attempt event. It receives an
+            :class:`AuditCallContext` and returns :class:`AuditEventDetails`.
+            Only ``action``, ``resource_id``, ``data``, and ``emit`` are used in
+            this phase. If it raises, the decorator logs the error and continues
+            with its default fields.
+        terminal_metadata: Optional synchronous or asynchronous callback
+            invoked after the decorated function returns. It receives the same
+            call context plus the function result and returns
+            :class:`AuditEventDetails`. Only ``resource_id``, ``data``, and
+            ``status`` are used in this phase. If it raises, the terminal event
+            uses the fields already derived.
+
+    Returns:
+        A decorator that preserves the wrapped function's signature and return
+        value while adding the audit lifecycle.
     """
 
     def decorator(
-        func: Callable[Concatenate[Any, P], Awaitable[R]],
-    ) -> Callable[Concatenate[Any, P], Awaitable[R]]:
+        func: Callable[P, Awaitable[R]],
+    ) -> Callable[P, Awaitable[R]]:
         # Determine the resource_id_attr from mapping or use provided/default
         resolved_resource_id_attr = (
             resource_id_attr
@@ -63,23 +179,40 @@ def audit_log(
         signature = inspect.signature(func)
 
         @functools.wraps(func)
-        async def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> R:
-            role: Role | PlatformRole | None = (
-                self.role if isinstance(self, BasePlatformService) else ctx_role.get()
-            )
-
-            if role is None or role.actor_id is None:
-                return await func(self, *args, **kwargs)
-
-            # Get existing session. Currently only BaseService has a session.
-            session = self.session if isinstance(self, BaseService) else None
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             bound_arguments: Mapping[str, Any] = {}
             try:
-                bound_arguments = signature.bind_partial(
-                    self, *args, **kwargs
-                ).arguments
+                bound_arguments = signature.bind_partial(*args, **kwargs).arguments
             except TypeError as exc:
-                logger.warning("Audit argument binding failed", error=str(exc))
+                logger.warning(
+                    "Audit argument binding failed",
+                    error=redact_sensitive_text(str(exc), redact_emails=True),
+                )
+
+            first_arg = args[0] if args else None
+            service = (
+                first_arg
+                if isinstance(first_arg, BaseService) or hasattr(first_arg, "role")
+                else bound_arguments.get("service")
+            )
+            candidate = getattr(service, "role", None) or bound_arguments.get("role")
+            role: Role | PlatformRole | None = (
+                candidate
+                if isinstance(candidate, (Role, PlatformRole))
+                else ctx_role.get()
+            )
+
+            if role is None or role.actor_id is None or role.type == "service":
+                return await func(*args, **kwargs)
+
+            raw_session = getattr(service, "session", None)
+            if raw_session is None:
+                raw_session = bound_arguments.get("session")
+            session = cast(AsyncSession | None, raw_session)
+            call_context = AuditCallContext(
+                target=service if service is not None else first_arg,
+                arguments=bound_arguments,
+            )
 
             resource_id: uuid.UUID | None = None
             try:
@@ -91,61 +224,127 @@ def audit_log(
                     bound_arguments=bound_arguments,
                 )
             except Exception as exc:
-                logger.warning("Audit resource_id extraction failed", error=str(exc))
+                logger.warning(
+                    "Audit resource_id extraction failed",
+                    error=redact_sensitive_text(str(exc), redact_emails=True),
+                )
+
+            event_action = action
+            event_data: AuditMetadata | None = None
+            if attempt_metadata is not None:
+                try:
+                    details = attempt_metadata(call_context)
+                    if inspect.isawaitable(details):
+                        details = await details
+                    if details.action is not None:
+                        event_action = details.action
+                    if details.resource_id is not None:
+                        resource_id = details.resource_id
+                    event_data = details.data
+                    if not details.emit:
+                        return await func(*args, **kwargs)
+                except Exception as exc:
+                    logger.warning(
+                        "Audit attempt metadata derivation failed",
+                        resource_type=resource_type,
+                        action=action,
+                        error_type=type(exc).__name__,
+                    )
 
             async with AuditService.with_session(role, session=session) as svc:
                 # Log attempt
                 try:
                     await svc.create_event(
                         resource_type=resource_type,
-                        action=action,
+                        action=event_action,
                         resource_id=resource_id,
                         status=AuditEventStatus.ATTEMPT,
+                        data=dict(event_data) if event_data is not None else None,
                     )
                 except Exception as exc:
-                    logger.warning("Audit attempt log failed", error=str(exc))
+                    logger.warning(
+                        "Audit attempt log failed",
+                        error=redact_sensitive_text(str(exc), redact_emails=True),
+                    )
 
             # NOTE: Do not execute the function while holding the audit service session open
             try:
                 # Execute the actual function
-                result = await func(self, *args, **kwargs)
+                result = await func(*args, **kwargs)
 
                 # Log success, or a semantic failure for result objects that
                 # complete without raising but report success=False.
                 try:
-                    resource_id = _extract_resource_id(
+                    terminal_resource_id = _extract_resource_id(
                         args,
                         kwargs,
                         result,
                         resolved_resource_id_attr,
                         bound_arguments=bound_arguments,
                     )
+                    if terminal_resource_id is None:
+                        terminal_resource_id = resource_id
+                    terminal_data = event_data
+                    terminal_status = (
+                        AuditEventStatus.FAILURE
+                        if (
+                            getattr(result, "success", None) is False
+                            or getattr(result, "ok", None) is False
+                        )
+                        else AuditEventStatus.SUCCESS
+                    )
+                    if terminal_metadata is not None:
+                        try:
+                            details = terminal_metadata(call_context, result)
+                            if inspect.isawaitable(details):
+                                details = await details
+                            if details.resource_id is not None:
+                                terminal_resource_id = details.resource_id
+                            if details.data is not None:
+                                terminal_data = details.data
+                            if details.status is not None:
+                                terminal_status = details.status
+                        except Exception as exc:
+                            logger.warning(
+                                "Audit terminal metadata derivation failed",
+                                resource_type=resource_type,
+                                action=event_action,
+                                error_type=type(exc).__name__,
+                            )
                     async with AuditService.with_session(role, session=session) as svc:
                         await svc.create_event(
                             resource_type=resource_type,
-                            action=action,
-                            resource_id=resource_id,
-                            status=(
-                                AuditEventStatus.FAILURE
-                                if getattr(result, "success", None) is False
-                                else AuditEventStatus.SUCCESS
+                            action=event_action,
+                            resource_id=terminal_resource_id,
+                            status=terminal_status,
+                            data=(
+                                dict(terminal_data)
+                                if terminal_data is not None
+                                else None
                             ),
                         )
                 except Exception as exc:
-                    logger.warning("Audit success log failed", error=str(exc))
+                    logger.warning(
+                        "Audit success log failed",
+                        error=redact_sensitive_text(str(exc), redact_emails=True),
+                    )
                 return result
             except Exception:
                 # Log failure
                 try:
-                    async with AuditService.with_session(role, session=session) as svc:
+                    async with AuditService.with_session(role, session=None) as svc:
                         await svc.create_event(
                             resource_type=resource_type,
-                            action=action,
+                            action=event_action,
                             resource_id=resource_id,
                             status=AuditEventStatus.FAILURE,
+                            data=dict(event_data) if event_data is not None else None,
                         )
                 except Exception as exc:
-                    logger.warning("Audit failure log failed", error=str(exc))
+                    logger.warning(
+                        "Audit failure log failed",
+                        error=redact_sensitive_text(str(exc), redact_emails=True),
+                    )
                 raise
 
         return wrapper
@@ -161,13 +360,30 @@ def _extract_resource_id(
     *,
     bound_arguments: Mapping[str, Any] | None = None,
 ) -> uuid.UUID | None:
-    """Heuristic to find a resource id.
+    """Extract a resource ID from an audited call or its result.
 
-    Priority:
-    1) return value `attr` if present
-    2) first arg with `attr`
-    3) bound function argument named `attr`
-    4) kwargs value for `attr`
+    Values are considered in this order:
+
+    1. The return value's ``attr`` attribute.
+    2. The first positional argument with an ``attr`` attribute.
+    3. The bound function argument named ``attr``.
+    4. The keyword argument named ``attr``.
+
+    Args:
+        args: Positional arguments passed to the decorated function.
+        kwargs: Keyword arguments passed to the decorated function.
+        result: Return value of the decorated function, or ``None`` before the
+            function has run.
+        attr: Attribute or parameter name expected to contain the resource ID.
+        bound_arguments: Call arguments already mapped to parameter names by
+            the decorated function's signature.
+
+    Returns:
+        The extracted ID as a UUID, or ``None`` when no value is available.
+
+    Raises:
+        TypeError: If the extracted value is not a UUID or string.
+        ValueError: If the extracted string is not a valid UUID.
     """
 
     raw: Any | None = None
@@ -191,7 +407,20 @@ def _extract_resource_id(
 
 
 def _coerce_uuid(value: Any, source: str) -> uuid.UUID | None:
-    """Convert UUID-like values to uuid.UUID or None, raising on invalid types."""
+    """Normalize a resource ID value.
+
+    Args:
+        value: A UUID, a stringified UUID, or ``None``.
+        source: Attribute or parameter name used to identify invalid values in
+            error messages.
+
+    Returns:
+        The normalized UUID, or ``None`` when ``value`` is ``None``.
+
+    Raises:
+        TypeError: If ``value`` is neither a UUID, string, nor ``None``.
+        ValueError: If ``value`` is a string but is not a valid UUID.
+    """
 
     if value is None:
         return None

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -231,6 +231,7 @@ def audit_log[**P, R](
 
             event_action = action
             event_data: AuditMetadata | None = None
+            should_emit = True
             if attempt_metadata is not None:
                 try:
                     details = attempt_metadata(call_context)
@@ -241,8 +242,7 @@ def audit_log[**P, R](
                     if details.resource_id is not None:
                         resource_id = details.resource_id
                     event_data = details.data
-                    if not details.emit:
-                        return await func(*args, **kwargs)
+                    should_emit = details.emit
                 except Exception as exc:
                     logger.warning(
                         "Audit attempt metadata derivation failed",
@@ -250,6 +250,9 @@ def audit_log[**P, R](
                         action=action,
                         error_type=type(exc).__name__,
                     )
+
+            if not should_emit:
+                return await func(*args, **kwargs)
 
             async with AuditService.with_session(role, session=session) as svc:
                 # Log attempt

--- a/tracecat/audit/sanitization.py
+++ b/tracecat/audit/sanitization.py
@@ -1,0 +1,84 @@
+"""Privacy policy for metadata attached to audit events."""
+
+from __future__ import annotations
+
+from tracecat.audit.types import AuditMetadata, AuditMetadataValue
+from tracecat.sanitization import redact_sensitive_text
+
+# These values describe how an operation happened without copying resource
+# content. Stable identifiers are accepted separately by suffix below.
+_ALLOWED_METADATA_KEYS = frozenset(
+    {
+        "auth_method",
+        "changed_fields",
+        "delete_mode",
+        "operation",
+        "trigger_type",
+        "workflow_status",
+    }
+)
+
+
+def sanitize_audit_metadata(
+    data: AuditMetadata | None,
+) -> dict[str, AuditMetadataValue] | None:
+    """Return only operationally necessary, sanitized audit metadata.
+
+    The audit payload accepts stable ``*_id`` identifiers, changed-field names,
+    a small set of operation discriminators, boolean state summaries, and
+    numeric counts. Unknown keys are dropped. This intentionally excludes raw
+    bodies, headers, content, inputs, outputs, prompts, tool results, file data,
+    secret-bearing values, before/after snapshots, and arbitrary resource names
+    or descriptions.
+
+    String pattern checks are defense-in-depth for credentials embedded in an
+    allowed value. A field is dropped when its value requires redaction rather
+    than delivering partially altered operational metadata. Pattern matching
+    cannot identify arbitrary opaque secrets, so this function must not be used
+    to justify passing unrestricted application data into an audit event.
+
+    Args:
+        data: Caller-selected metadata for an audit event.
+
+    Returns:
+        A sanitized dictionary, or ``None`` when no allowed metadata remains.
+    """
+
+    if not data:
+        return None
+
+    sanitized: dict[str, AuditMetadataValue] = {}
+    for key, value in data.items():
+        if not _is_allowed_metadata(key, value):
+            continue
+        if isinstance(value, str):
+            redacted = redact_sensitive_text(value, redact_emails=True)
+            if redacted == value:
+                sanitized[key] = value
+        elif isinstance(value, list):
+            safe_items = [
+                item
+                for item in value
+                if redact_sensitive_text(item, redact_emails=True) == item
+            ]
+            if safe_items:
+                sanitized[key] = safe_items
+        else:
+            sanitized[key] = value
+    return sanitized or None
+
+
+def _is_allowed_metadata(key: str, value: AuditMetadataValue) -> bool:
+    """Return whether a metadata field conforms to the audit data policy."""
+
+    if key.endswith("_id"):
+        return isinstance(value, str) or value is None
+    if key == "changed_fields":
+        return isinstance(value, list)
+    if key in _ALLOWED_METADATA_KEYS:
+        return isinstance(value, str) or value is None
+    if key.startswith(("is_", "has_", "uses_")):
+        return isinstance(value, bool)
+    if key.endswith("_count"):
+        return isinstance(value, int) and not isinstance(value, bool)
+    return False

--- a/tracecat/audit/sanitization.py
+++ b/tracecat/audit/sanitization.py
@@ -24,7 +24,7 @@ def sanitize_audit_metadata(
 ) -> dict[str, AuditMetadataValue] | None:
     """Return only operationally necessary, sanitized audit metadata.
 
-    The audit payload accepts stable ``*_id`` identifiers, changed-field names,
+    The audit payload accepts stable ``*_id``/``*_ids`` identifiers, changed-field names,
     a small set of operation discriminators, boolean state summaries, and
     numeric counts. Unknown keys are dropped. This intentionally excludes raw
     bodies, headers, content, inputs, outputs, prompts, tool results, file data,
@@ -59,7 +59,8 @@ def sanitize_audit_metadata(
             safe_items = [
                 item
                 for item in value
-                if redact_sensitive_text(item, redact_emails=True) == item
+                if isinstance(item, str)
+                and redact_sensitive_text(item, redact_emails=True) == item
             ]
             if safe_items:
                 sanitized[key] = safe_items
@@ -73,7 +74,7 @@ def _is_allowed_metadata(key: str, value: AuditMetadataValue) -> bool:
 
     if key.endswith("_id"):
         return isinstance(value, str) or value is None
-    if key == "changed_fields":
+    if key.endswith("_ids") or key == "changed_fields":
         return isinstance(value, list)
     if key in _ALLOWED_METADATA_KEYS:
         return isinstance(value, str) or value is None

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -16,6 +16,7 @@ from typing import Any, Self
 
 import httpx
 import orjson
+from async_lru import alru_cache
 from cryptography.fernet import InvalidToken
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,8 +34,12 @@ from tracecat.audit.types import (
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.contexts import ctx_request_audit, ctx_role
-from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.engine import (
+    get_async_session_bypass_rls_context_manager,
+    get_async_session_context_manager,
+)
 from tracecat.db.models import PlatformSetting, ServiceAccount, User
+from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 from tracecat.sanitization import redact_sensitive_text
 from tracecat.secrets.encryption import decrypt_value
@@ -110,18 +115,69 @@ async def _deliver(delivery: _AuditDelivery) -> None:
         logger.warning(
             "Failed to deliver audit webhook",
             error_type=type(exc).__name__,
-            status_code=getattr(response, "status_code", None),
+            status_code=response.status_code if response is not None else None,
             resource_type=delivery.resource_type,
             action=delivery.action,
         )
 
 
-async def flush_audit_deliveries() -> None:
-    """Wait for this loop's in-flight audit deliveries. Intended for tests."""
-    loop = asyncio.get_running_loop()
-    tasks = [task for task in _delivery_tasks if task.get_loop() is loop]
-    if tasks:
-        await asyncio.gather(*tasks)
+# Sentinel org id for the platform sink and for org-sink lookups with no org
+# identity; keeps those entries isolated from any real organization's cache key.
+_PLATFORM_ORG_SENTINEL = uuid.UUID(int=0)
+
+
+async def _fetch_platform_setting(key: str) -> Any | None:
+    """Read a platform audit setting on a self-managed session; decrypt if needed."""
+    async with get_async_session_bypass_rls_context_manager() as session:
+        stmt = select(PlatformSetting).where(PlatformSetting.key == key)
+        setting = (await session.execute(stmt)).scalar_one_or_none()
+    if setting is None:
+        return None
+    value = setting.value
+    if setting.is_encrypted:
+        try:
+            value = decrypt_value(value, key=get_db_encryption_key())
+        except (InvalidToken, ValueError) as exc:
+            logger.warning(
+                "Failed to decrypt platform audit setting",
+                key=key,
+                error=redact_sensitive_text(str(exc), redact_emails=True),
+            )
+            return None
+    return orjson.loads(value)
+
+
+@alru_cache(ttl=30)
+async def _get_audit_setting_cached(
+    sink: AuditSink,
+    organization_id: OrganizationID,
+    key: str,
+    default: Any = None,
+) -> Any | None:
+    """Cached audit-setting read keyed by (sink, org, key, default).
+
+    Runs on its own session so no request session is captured or hashed; bounded
+    30s staleness. ``organization_id`` may be ``_PLATFORM_ORG_SENTINEL`` for the
+    platform sink or org-sink calls with no org identity. Decrypted values live
+    in process memory only and are never logged.
+    """
+    logger.debug("Audit setting cache miss", sink=sink, key=key)
+    if sink == "platform":
+        value = await _fetch_platform_setting(key)
+        return default if value is None and default is not None else value
+
+    from tracecat.settings.service import get_setting
+
+    if organization_id == _PLATFORM_ORG_SENTINEL:
+        # No org identity: preserve get_setting(role=None) semantics (default/None).
+        return default
+    # Minimal org-bound role so get_setting opens its own org-scoped session.
+    role = Role(
+        type="service",
+        organization_id=organization_id,
+        service_id="tracecat-service",
+    )
+    return await get_setting(key, role=role, session=None, default=default)
 
 
 class AuditService(BaseService):
@@ -171,39 +227,31 @@ class AuditService(BaseService):
             async with get_async_session_context_manager() as session:
                 yield cls(session, role=role, audit_sink=audit_sink)
 
-    async def _get_platform_setting(self, key: str) -> Any | None:
-        """Fetch a platform setting for platform-scoped audit delivery."""
-        stmt = select(PlatformSetting).where(PlatformSetting.key == key)
-        setting = (await self.session.execute(stmt)).scalar_one_or_none()
-        if setting is None:
-            return None
-
-        value = setting.value
-        if setting.is_encrypted:
-            try:
-                value = decrypt_value(value, key=get_db_encryption_key())
-            except (InvalidToken, ValueError) as exc:
-                self.logger.warning(
-                    "Failed to decrypt platform audit setting",
-                    key=key,
-                    error=redact_sensitive_text(str(exc), redact_emails=True),
-                )
-                return None
-        return orjson.loads(value)
-
     async def _get_audit_setting(self, key: str, *, default: Any = None) -> Any | None:
-        """Fetch an audit setting from the active audit sink."""
-        if self.audit_sink == "platform":
-            value = await self._get_platform_setting(key)
-            return default if value is None and default is not None else value
+        """Fetch an audit setting from the active audit sink (30s TTL cache).
 
-        from tracecat.settings.service import get_setting
+        Keyed on (sink, org, key, default) so platform and per-org configs never
+        share an entry. The cache runs its own session, so this stays safe inside
+        a live request session.
+        """
+        if self.audit_sink == "organization" and (
+            isinstance(self.role, Role) and self.role.organization_id is None
+        ):
+            # Rare org-sink role without an org id: skip the cache and let
+            # get_setting resolve the default org, preserving prior semantics.
+            from tracecat.settings.service import get_setting
 
-        return await get_setting(
-            key,
-            role=self.role if isinstance(self.role, Role) else None,
-            session=self.session,
-            default=default,
+            return await get_setting(
+                key, role=self.role, session=self.session, default=default
+            )
+
+        organization_id = (
+            self.role.organization_id
+            if isinstance(self.role, Role) and self.role.organization_id is not None
+            else _PLATFORM_ORG_SENTINEL
+        )
+        return await _get_audit_setting_cached(
+            self.audit_sink, organization_id, key, default
         )
 
     async def _get_webhook_url(self) -> str | None:
@@ -230,7 +278,8 @@ class AuditService(BaseService):
     async def _get_custom_headers(self) -> dict[str, str] | None:
         """Fetch the configured custom headers for the audit webhook.
 
-        Note: Uses get_setting (uncached) to ensure changes take effect immediately.
+        Note: reads are cached with a 30s TTL, so setting changes take effect
+        within that bounded window rather than immediately.
         """
         value = await self._get_audit_setting("audit_webhook_custom_headers")
         if value is None:
@@ -331,8 +380,8 @@ class AuditService(BaseService):
     async def _get_actor_label(self) -> str | None:
         if self.role is None:
             return None
-        if getattr(self.role, "type", None) == "service_account":
-            service_account_id = getattr(self.role, "service_account_id", None)
+        if isinstance(self.role, Role) and self.role.type == "service_account":
+            service_account_id = self.role.service_account_id
             if service_account_id is None:
                 return None
             try:
@@ -379,11 +428,14 @@ class AuditService(BaseService):
     ) -> AuditEvent:
         if self.role is None or self.role.actor_id is None:
             raise ValueError("Audit payload requires an auditable actor")
-        organization_id = getattr(self.role, "organization_id", None)
-        workspace_id = getattr(self.role, "workspace_id", None)
+        # Only org-scoped Role carries org/workspace context; PlatformRole lacks it.
+        organization_id = (
+            self.role.organization_id if isinstance(self.role, Role) else None
+        )
+        workspace_id = self.role.workspace_id if isinstance(self.role, Role) else None
         actor_type = (
             AuditEventActor.SERVICE_ACCOUNT
-            if getattr(self.role, "type", None) == "service_account"
+            if isinstance(self.role, Role) and self.role.type == "service_account"
             else AuditEventActor.USER
         )
         return AuditEvent(
@@ -444,11 +496,11 @@ class AuditService(BaseService):
                 metadata and may identify client software or devices.
         """
 
-        if self.role is None or getattr(self.role, "actor_id", None) is None:
+        if self.role is None or self.role.actor_id is None:
             self.logger.debug(
                 "Skipping audit log",
                 reason="non_auditable_role",
-                role_type=getattr(self.role, "type", None),
+                role_type=self.role.type if self.role is not None else None,
             )
             return
 

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -1,7 +1,7 @@
 """Fire-and-forget audit webhook delivery with an at-most-once contract.
 
 Each event is posted by its own asyncio task; deliveries are only dropped past
-the in-flight cap, and in-flight tasks are lost on process/loop shutdown.
+the pending cap, and in-flight tasks are lost on process/loop shutdown.
 Durable, at-least-once delivery arrives with the ENG-1514 spool.
 """
 
@@ -69,26 +69,45 @@ class _AuditDelivery:
 # Strong refs to in-flight delivery tasks; done callbacks release them.
 _delivery_tasks: set[asyncio.Task[None]] = set()
 
-# Each in-flight delivery holds one socket/FD. Sized to <=25% of the smallest
-# deployment FD envelope (Fargate default soft ulimit 1024); drains ~25/s even
-# against a hung sink (10s httpx timeout). Recompute if either input changes.
-_MAX_IN_FLIGHT_DELIVERIES = 256
+# Burst-admission bound: pending deliveries past this are dropped. A full
+# backlog is a few MB of suspended tasks; worst-case drain ~10 min
+# (_MAX_CONCURRENT_POSTS slots / 10s httpx timeout against a hung sink).
+_MAX_PENDING_DELIVERIES = 2048
+
+# Socket bound: each active post holds one connection/FD for up to the 10s
+# httpx timeout; 32 stays in the noise of the smallest deployment FD envelope
+# (Fargate default soft ulimit 1024).
+_MAX_CONCURRENT_POSTS = 32
+
+# asyncio primitives bind to their loop; keyed per loop and swept alongside the
+# closed-loop task sweep in _spawn_delivery.
+_post_semaphores: dict[asyncio.AbstractEventLoop, asyncio.Semaphore] = {}
+
+
+def _get_post_semaphore() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    if (sem := _post_semaphores.get(loop)) is None:
+        sem = _post_semaphores[loop] = asyncio.Semaphore(_MAX_CONCURRENT_POSTS)
+    return sem
 
 
 def _spawn_delivery(delivery: _AuditDelivery) -> None:
     """Post the delivery on its own fire-and-forget task."""
     # Tasks stranded on closed (e.g. per-test) loops never ran their done
-    # callbacks; evict them so the set doesn't grow across loops.
+    # callbacks; evict them and their loops' semaphores so neither container
+    # grows across loops.
     for stranded in [t for t in _delivery_tasks if t.get_loop().is_closed()]:
         _delivery_tasks.discard(stranded)
-    if len(_delivery_tasks) >= _MAX_IN_FLIGHT_DELIVERIES:
-        # Shed audit load rather than exhaust the process FD budget. No payload
+    for closed_loop in [loop for loop in _post_semaphores if loop.is_closed()]:
+        del _post_semaphores[closed_loop]
+    if len(_delivery_tasks) >= _MAX_PENDING_DELIVERIES:
+        # Shed audit load rather than buffer without bound. No payload
         # contents or sink URL on this log line.
         logger.warning(
-            "Dropped audit webhook delivery; in-flight limit reached",
+            "Dropped audit webhook delivery; pending limit reached",
             resource_type=delivery.resource_type,
             action=delivery.action,
-            max_in_flight=_MAX_IN_FLIGHT_DELIVERIES,
+            max_pending=_MAX_PENDING_DELIVERIES,
         )
         return
     task = asyncio.get_running_loop().create_task(_deliver(delivery))
@@ -97,12 +116,16 @@ def _spawn_delivery(delivery: _AuditDelivery) -> None:
 
 
 async def _deliver(delivery: _AuditDelivery) -> None:
-    """Post one resolved delivery. Never uses a DB session."""
+    """Post one resolved delivery, gated by the per-loop socket cap.
+
+    Never uses a DB session.
+    """
     response: httpx.Response | None = None
     try:
-        async with httpx.AsyncClient(
-            timeout=10.0, verify=delivery.verify_ssl
-        ) as client:
+        async with (
+            _get_post_semaphore(),
+            httpx.AsyncClient(timeout=10.0, verify=delivery.verify_ssl) as client,
+        ):
             response = await client.post(
                 delivery.webhook_url,
                 json=delivery.request_payload,

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -12,12 +12,21 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
-from tracecat.audit.types import AuditAction, AuditEvent, AuditResourceType, AuditSink
+from tracecat.audit.sanitization import sanitize_audit_metadata
+from tracecat.audit.types import (
+    AuditAction,
+    AuditEvent,
+    AuditMetadata,
+    AuditMetadataValue,
+    AuditResourceType,
+    AuditSink,
+)
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import PlatformRole, Role
-from tracecat.contexts import ctx_client_ip, ctx_role
+from tracecat.contexts import ctx_client_ip, ctx_role, ctx_user_agent
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import PlatformSetting, ServiceAccount, User
+from tracecat.sanitization import redact_sensitive_text
 from tracecat.secrets.encryption import decrypt_value
 from tracecat.service import BaseService
 
@@ -87,7 +96,7 @@ class AuditService(BaseService):
                 self.logger.warning(
                     "Failed to decrypt platform audit setting",
                     key=key,
-                    error=str(exc),
+                    error=redact_sensitive_text(str(exc), redact_emails=True),
                 )
                 return None
         return orjson.loads(value)
@@ -121,7 +130,6 @@ class AuditService(BaseService):
         if not isinstance(value, str):
             self.logger.warning(
                 "audit_webhook_url must be a string",
-                value=value,
                 value_type=type(value),
             )
             return None
@@ -165,7 +173,6 @@ class AuditService(BaseService):
         if not isinstance(value, bool):
             self.logger.warning(
                 "audit_webhook_verify_ssl must be a bool",
-                value=value,
                 value_type=type(value),
             )
             return True
@@ -179,7 +186,6 @@ class AuditService(BaseService):
         if not isinstance(value, str):
             self.logger.warning(
                 "audit_webhook_payload_attribute must be a string",
-                value=value,
                 value_type=type(value),
             )
             return None
@@ -213,8 +219,8 @@ class AuditService(BaseService):
         except Exception as exc:
             self.logger.warning(
                 "Failed to deliver audit webhook",
-                error=str(exc),
-                webhook_url=webhook_url,
+                error=redact_sensitive_text(str(exc), redact_emails=True),
+                webhook_url=redact_sensitive_text(webhook_url),
                 status_code=getattr(response, "status_code", None),
             )
 
@@ -235,7 +241,8 @@ class AuditService(BaseService):
                     return service_account.name
             except Exception as exc:
                 self.logger.warning(
-                    "Failed to fetch service account actor name", error=str(exc)
+                    "Failed to fetch service account actor name",
+                    error=redact_sensitive_text(str(exc), redact_emails=True),
                 )
             return None
         if self.role.user_id is None:
@@ -248,7 +255,10 @@ class AuditService(BaseService):
             if (user := result.scalar_one_or_none()) is not None:
                 actor_label = user.email
         except Exception as exc:
-            self.logger.warning("Failed to fetch actor email", error=str(exc))
+            self.logger.warning(
+                "Failed to fetch actor email",
+                error=redact_sensitive_text(str(exc), redact_emails=True),
+            )
         return actor_label
 
     def _build_payload(
@@ -260,7 +270,8 @@ class AuditService(BaseService):
         status: AuditEventStatus,
         actor_label: str | None,
         ip_address: str | None,
-        data: dict[str, Any] | None,
+        user_agent: str | None,
+        data: dict[str, AuditMetadataValue] | None,
     ) -> AuditEvent:
         if self.role is None or self.role.actor_id is None:
             raise ValueError("Audit payload requires an auditable actor")
@@ -282,6 +293,7 @@ class AuditService(BaseService):
             action=action,
             status=status,
             ip_address=ip_address,
+            user_agent=user_agent,
             data=data,
         )
 
@@ -292,13 +304,47 @@ class AuditService(BaseService):
         action: AuditAction,
         resource_id: uuid.UUID | None = None,
         status: AuditEventStatus = AuditEventStatus.SUCCESS,
-        data: dict[str, Any] | None = None,
+        data: AuditMetadata | None = None,
         include_actor_label: bool = True,
         include_ip_address: bool = True,
+        include_user_agent: bool = True,
     ) -> None:
+        """Deliver a privacy-bounded audit event when a sink is configured.
+
+        Generic ``data`` is reduced to stable identifiers, changed-field names,
+        and a small set of operational discriminators. Unknown fields are
+        dropped. An otherwise allowed field is also dropped if its string value
+        contains a recognized credential pattern. Raw function arguments and
+        return values are never inspected.
+
+        Actor labels, client IPs, and user agents are separate opt-out fields
+        because they are useful for attribution and security investigations but
+        contain PII or sensitive client metadata. Stable actor and resource IDs
+        remain the preferred identifiers.
+
+        Args:
+            resource_type: Type of resource affected by the operation.
+            action: Operation performed on the resource.
+            resource_id: Stable resource ID, when one is available.
+            status: Lifecycle state or outcome of the operation.
+            data: Explicitly selected operational metadata. Arbitrary resource
+                content, names, descriptions, inputs, outputs, bodies, headers,
+                and secret-bearing values are not accepted by the audit policy.
+            include_actor_label: Whether to resolve and include the actor email
+                or service-account name. This field contains PII or user-provided
+                identifying text.
+            include_ip_address: Whether to include the request client IP from
+                context. This field is sensitive security metadata.
+            include_user_agent: Whether to include the bounded request
+                user-agent from context. This field is sensitive security
+                metadata and may identify client software or devices.
+        """
+
         if self.role is None or getattr(self.role, "actor_id", None) is None:
             self.logger.debug(
-                "Skipping audit log", reason="non_auditable_role", role=self.role
+                "Skipping audit log",
+                reason="non_auditable_role",
+                role_type=getattr(self.role, "type", None),
             )
             return
 
@@ -315,7 +361,8 @@ class AuditService(BaseService):
             status=status,
             actor_label=actor_label,
             ip_address=ctx_client_ip.get() if include_ip_address else None,
-            data=data,
+            user_agent=ctx_user_agent.get() if include_user_agent else None,
+            data=sanitize_audit_metadata(data),
         )
         await self._post_event(webhook_url=webhook_url, payload=payload)
         self.logger.debug(

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -1,8 +1,17 @@
+"""Fire-and-forget audit webhook delivery with an at-most-once contract.
+
+Events are buffered in an in-memory per-loop queue and posted by a background
+worker; they are lost on process/loop shutdown and on queue overflow. Durable,
+at-least-once delivery arrives with the ENG-1514 spool.
+"""
+
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any, Self
 
 import httpx
@@ -26,12 +35,122 @@ from tracecat.auth.types import PlatformRole, Role
 from tracecat.contexts import ctx_client_ip, ctx_role, ctx_user_agent
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import PlatformSetting, ServiceAccount, User
+from tracecat.logger import logger
 from tracecat.sanitization import redact_sensitive_text
 from tracecat.secrets.encryption import decrypt_value
 from tracecat.service import BaseService
 
 # Union type for roles that can be used for audit logging
 AuditableRole = Role | PlatformRole
+
+
+@dataclass(frozen=True)
+class _AuditDelivery:
+    """A fully resolved audit webhook post, safe to run without a DB session.
+
+    Built synchronously while the request context and session are live, then
+    handed to a background worker for fire-and-forget delivery.
+    """
+
+    webhook_url: str
+    request_payload: dict[str, Any]
+    headers: dict[str, str] | None
+    verify_ssl: bool
+    # Non-sensitive discriminators for drop logging; never the payload contents.
+    resource_type: AuditResourceType
+    action: AuditAction
+
+
+@dataclass
+class _DeliveryChannel:
+    queue: asyncio.Queue[_AuditDelivery]
+    worker: asyncio.Task[None]
+
+
+# Hard cap on undelivered payloads so a slow or down sink cannot grow memory
+# without bound. Overflow drops the newest event rather than blocking the caller.
+_AUDIT_DELIVERY_QUEUE_MAXSIZE = 1000
+
+# Single FIFO worker per event loop drains deliveries in enqueue order,
+# preserving ATTEMPT->terminal ordering per operation within a process. Keyed by
+# loop so queues never leak across loops (e.g. per-test loops).
+_delivery_channels: dict[asyncio.AbstractEventLoop, _DeliveryChannel] = {}
+
+
+def _get_delivery_queue() -> asyncio.Queue[_AuditDelivery]:
+    loop = asyncio.get_running_loop()
+    # Evict closed loops so short-lived (test) loops don't leak channels.
+    for closed in [other for other in _delivery_channels if other.is_closed()]:
+        del _delivery_channels[closed]
+
+    channel = _delivery_channels.get(loop)
+    if channel is None:
+        queue: asyncio.Queue[_AuditDelivery] = asyncio.Queue(
+            maxsize=_AUDIT_DELIVERY_QUEUE_MAXSIZE
+        )
+        worker = loop.create_task(_drain_deliveries(queue))
+        channel = _DeliveryChannel(queue=queue, worker=worker)
+        _delivery_channels[loop] = channel
+    elif channel.worker.done():
+        # Worker died (CancelledError/BaseException) with items possibly still
+        # queued. Respawn onto the existing queue so nothing is lost.
+        channel.worker = loop.create_task(_drain_deliveries(channel.queue))
+    return channel.queue
+
+
+def _enqueue_delivery(delivery: _AuditDelivery) -> None:
+    """Enqueue without blocking; drop the newest event on overflow and log once."""
+    queue = _get_delivery_queue()
+    try:
+        queue.put_nowait(delivery)
+    except asyncio.QueueFull:
+        # No payload contents in this log line: keeps dropped-event data off the
+        # logging boundary.
+        logger.warning(
+            "Dropped audit webhook delivery; queue full",
+            resource_type=delivery.resource_type,
+            action=delivery.action,
+            queue_maxsize=_AUDIT_DELIVERY_QUEUE_MAXSIZE,
+        )
+
+
+async def _drain_deliveries(queue: asyncio.Queue[_AuditDelivery]) -> None:
+    while True:
+        delivery = await queue.get()
+        try:
+            await _deliver(delivery)
+        finally:
+            queue.task_done()
+
+
+async def _deliver(delivery: _AuditDelivery) -> None:
+    """Post one resolved delivery. Never uses a DB session."""
+    response: httpx.Response | None = None
+    try:
+        async with httpx.AsyncClient(
+            timeout=10.0, verify=delivery.verify_ssl
+        ) as client:
+            response = await client.post(
+                delivery.webhook_url,
+                json=delivery.request_payload,
+                headers=delivery.headers,
+            )
+            response.raise_for_status()
+    except Exception as exc:
+        # No exception text or URL on this path: the webhook URL is
+        # operator-configured and may carry a credential in its path.
+        logger.warning(
+            "Failed to deliver audit webhook",
+            error_type=type(exc).__name__,
+            status_code=getattr(response, "status_code", None),
+        )
+
+
+async def flush_audit_deliveries() -> None:
+    """Wait for all queued audit deliveries to complete. Intended for tests."""
+    channel = _delivery_channels.get(asyncio.get_running_loop())
+    if channel is not None:
+        await channel.queue.join()
 
 
 class AuditService(BaseService):
@@ -193,36 +312,39 @@ class AuditService(BaseService):
         cleaned = value.strip()
         return cleaned or None
 
-    async def _post_event(self, *, webhook_url: str, payload: AuditEvent) -> None:
-        response: httpx.Response | None = None
-        try:
-            custom_headers = await self._get_custom_headers()
-            custom_payload = await self._get_custom_payload()
-            verify_ssl = await self._get_verify_ssl()
-            payload_attribute = await self._get_payload_attribute()
-            event_payload = payload.model_dump(mode="json")
-            if custom_payload:
-                event_payload = {**event_payload, **custom_payload}
-            request_payload: dict[str, Any]
-            if payload_attribute:
-                request_payload = {payload_attribute: event_payload}
-            else:
-                request_payload = event_payload
+    async def _build_delivery(
+        self, *, webhook_url: str, payload: AuditEvent
+    ) -> _AuditDelivery:
+        """Resolve webhook settings and assemble the request body.
 
-            async with httpx.AsyncClient(timeout=10.0, verify=verify_ssl) as client:
-                response = await client.post(
-                    webhook_url,
-                    json=request_payload,
-                    headers=custom_headers,
-                )
-                response.raise_for_status()
-        except Exception as exc:
-            self.logger.warning(
-                "Failed to deliver audit webhook",
-                error=redact_sensitive_text(str(exc), redact_emails=True),
-                webhook_url=redact_sensitive_text(webhook_url),
-                status_code=getattr(response, "status_code", None),
-            )
+        Runs while the request session is live; the returned delivery needs no
+        session and is safe to post from a detached background task.
+        """
+        custom_headers = await self._get_custom_headers()
+        custom_payload = await self._get_custom_payload()
+        verify_ssl = await self._get_verify_ssl()
+        payload_attribute = await self._get_payload_attribute()
+        event_payload = payload.model_dump(mode="json")
+        if custom_payload:
+            event_payload = {**event_payload, **custom_payload}
+        request_payload: dict[str, Any]
+        if payload_attribute:
+            request_payload = {payload_attribute: event_payload}
+        else:
+            request_payload = event_payload
+        return _AuditDelivery(
+            webhook_url=webhook_url,
+            request_payload=request_payload,
+            headers=custom_headers,
+            verify_ssl=verify_ssl,
+            resource_type=payload.resource_type,
+            action=payload.action,
+        )
+
+    async def _post_event(self, *, webhook_url: str, payload: AuditEvent) -> None:
+        """Resolve the delivery synchronously, then enqueue it fire-and-forget."""
+        delivery = await self._build_delivery(webhook_url=webhook_url, payload=payload)
+        _enqueue_delivery(delivery)
 
     async def _get_actor_label(self) -> str | None:
         if self.role is None:

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -1,8 +1,10 @@
-"""Fire-and-forget audit webhook delivery with an at-most-once contract.
+"""Fire-and-forget audit webhook delivery with bounded in-memory retries.
 
-Each event is posted by its own asyncio task; deliveries are only dropped past
-the pending cap, and in-flight tasks are lost on process/loop shutdown.
-Durable, at-least-once delivery arrives with the ENG-1514 spool.
+Each event is posted by its own asyncio task; transient failures are retried
+in process. A retry after a lost response can deliver an exact byte-identical
+duplicate. Deliveries are dropped past the pending cap and lost on
+process/loop shutdown. Durable, at-least-once delivery arrives with the
+ENG-1514 spool.
 """
 
 from __future__ import annotations
@@ -20,6 +22,12 @@ from async_lru import alru_cache
 from cryptography.fernet import InvalidToken
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 from tracecat.audit.sanitization import sanitize_audit_metadata
@@ -70,8 +78,8 @@ class _AuditDelivery:
 _delivery_tasks: set[asyncio.Task[None]] = set()
 
 # Burst-admission bound: pending deliveries past this are dropped. A full
-# backlog is a few MB of suspended tasks; worst-case drain ~10 min
-# (_MAX_CONCURRENT_POSTS slots / 10s httpx timeout against a hung sink).
+# backlog is a few MB of suspended tasks; worst-case drain ~35 min against a
+# hung sink (~33s per slot: 3 timed-out attempts plus backoff, 32 slots).
 _MAX_PENDING_DELIVERIES = 2048
 
 # Socket bound: each active post holds one connection/FD for up to the 10s
@@ -89,6 +97,19 @@ def _get_post_semaphore() -> asyncio.Semaphore:
     if (sem := _post_semaphores.get(loop)) is None:
         sem = _post_semaphores[loop] = asyncio.Semaphore(_MAX_CONCURRENT_POSTS)
     return sem
+
+
+# Retry only failures a fresh attempt can plausibly fix; other 4xx are terminal.
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+_DELIVERY_ATTEMPTS = 3
+# Module-level so tests can swap in wait_none().
+_RETRY_WAIT = wait_exponential(multiplier=1, min=1, max=10)
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in _RETRYABLE_STATUS_CODES
+    return isinstance(exc, httpx.TransportError)
 
 
 def _spawn_delivery(delivery: _AuditDelivery) -> None:
@@ -121,17 +142,28 @@ async def _deliver(delivery: _AuditDelivery) -> None:
     Never uses a DB session.
     """
     response: httpx.Response | None = None
+    attempts = 0
     try:
-        async with (
-            _get_post_semaphore(),
-            httpx.AsyncClient(timeout=10.0, verify=delivery.verify_ssl) as client,
-        ):
-            response = await client.post(
-                delivery.webhook_url,
-                json=delivery.request_payload,
-                headers=delivery.headers,
-            )
-            response.raise_for_status()
+        # One slot spans all attempts; the socket itself is only open per post.
+        async with _get_post_semaphore():
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(_DELIVERY_ATTEMPTS),
+                wait=_RETRY_WAIT,
+                retry=retry_if_exception(_is_retryable),
+                reraise=True,
+            ):
+                with attempt:
+                    attempts = attempt.retry_state.attempt_number
+                    response = None
+                    async with httpx.AsyncClient(
+                        timeout=10.0, verify=delivery.verify_ssl
+                    ) as client:
+                        response = await client.post(
+                            delivery.webhook_url,
+                            json=delivery.request_payload,
+                            headers=delivery.headers,
+                        )
+                        response.raise_for_status()
     except Exception as exc:
         # No exception text or URL on this path: the webhook URL is
         # operator-configured and may carry a credential in its path.
@@ -141,6 +173,7 @@ async def _deliver(delivery: _AuditDelivery) -> None:
             status_code=response.status_code if response is not None else None,
             resource_type=delivery.resource_type,
             action=delivery.action,
+            attempts=attempts,
         )
 
 

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -177,11 +177,6 @@ async def _deliver(delivery: _AuditDelivery) -> None:
         )
 
 
-# Sentinel org id for the platform sink and for org-sink lookups with no org
-# identity; keeps those entries isolated from any real organization's cache key.
-_PLATFORM_ORG_SENTINEL = uuid.UUID(int=0)
-
-
 async def _fetch_platform_setting(key: str) -> Any | None:
     """Read a platform audit setting on a self-managed session; decrypt if needed."""
     async with get_async_session_bypass_rls_context_manager() as session:
@@ -206,16 +201,16 @@ async def _fetch_platform_setting(key: str) -> Any | None:
 @alru_cache(ttl=30)
 async def _get_audit_setting_cached(
     sink: AuditSink,
-    organization_id: OrganizationID,
+    organization_id: OrganizationID | None,
     key: str,
     default: Any = None,
 ) -> Any | None:
     """Cached audit-setting read keyed by (sink, org, key, default).
 
     Runs on its own session so no request session is captured or hashed; bounded
-    30s staleness. ``organization_id`` may be ``_PLATFORM_ORG_SENTINEL`` for the
-    platform sink or org-sink calls with no org identity. Decrypted values live
-    in process memory only and are never logged.
+    30s staleness. ``organization_id`` is ``None`` for the platform sink or
+    org-sink calls with no org identity. Decrypted values live in process memory
+    only and are never logged.
     """
     logger.debug("Audit setting cache miss", sink=sink, key=key)
     if sink == "platform":
@@ -224,8 +219,8 @@ async def _get_audit_setting_cached(
 
     from tracecat.settings.service import get_setting
 
-    if organization_id == _PLATFORM_ORG_SENTINEL:
-        # No org identity: preserve get_setting(role=None) semantics (default/None).
+    if organization_id is None:
+        # No org identity: preserve get_setting(role=None) semantics.
         return default
     # Minimal org-bound role so get_setting opens its own org-scoped session.
     role = Role(
@@ -303,8 +298,8 @@ class AuditService(BaseService):
 
         organization_id = (
             self.role.organization_id
-            if isinstance(self.role, Role) and self.role.organization_id is not None
-            else _PLATFORM_ORG_SENTINEL
+            if self.audit_sink == "organization" and isinstance(self.role, Role)
+            else None
         )
         return await _get_audit_setting_cached(
             self.audit_sink, organization_id, key, default

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -1,8 +1,8 @@
 """Fire-and-forget audit webhook delivery with an at-most-once contract.
 
-Events are buffered in an in-memory per-loop queue and posted by a background
-worker; they are lost on process/loop shutdown and on queue overflow. Durable,
-at-least-once delivery arrives with the ENG-1514 spool.
+Each event is posted by its own asyncio task; deliveries are only dropped past
+the in-flight cap, and in-flight tasks are lost on process/loop shutdown.
+Durable, at-least-once delivery arrives with the ENG-1514 spool.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ from tracecat.audit.types import (
 )
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import PlatformRole, Role
-from tracecat.contexts import ctx_client_ip, ctx_role, ctx_user_agent
+from tracecat.contexts import ctx_request_audit, ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import PlatformSetting, ServiceAccount, User
 from tracecat.logger import logger
@@ -56,71 +56,39 @@ class _AuditDelivery:
     request_payload: dict[str, Any]
     headers: dict[str, str] | None
     verify_ssl: bool
-    # Non-sensitive discriminators for drop logging; never the payload contents.
+    # Non-sensitive discriminators for failure logging; never the payload contents.
     resource_type: AuditResourceType
     action: AuditAction
 
 
-@dataclass
-class _DeliveryChannel:
-    queue: asyncio.Queue[_AuditDelivery]
-    worker: asyncio.Task[None]
+# Strong refs to in-flight delivery tasks; done callbacks release them.
+_delivery_tasks: set[asyncio.Task[None]] = set()
+
+# Each in-flight delivery holds one socket/FD. Sized to <=25% of the smallest
+# deployment FD envelope (Fargate default soft ulimit 1024); drains ~25/s even
+# against a hung sink (10s httpx timeout). Recompute if either input changes.
+_MAX_IN_FLIGHT_DELIVERIES = 256
 
 
-# Hard cap on undelivered payloads so a slow or down sink cannot grow memory
-# without bound. Overflow drops the newest event rather than blocking the caller.
-_AUDIT_DELIVERY_QUEUE_MAXSIZE = 1000
-
-# Single FIFO worker per event loop drains deliveries in enqueue order,
-# preserving ATTEMPT->terminal ordering per operation within a process. Keyed by
-# loop so queues never leak across loops (e.g. per-test loops).
-_delivery_channels: dict[asyncio.AbstractEventLoop, _DeliveryChannel] = {}
-
-
-def _get_delivery_queue() -> asyncio.Queue[_AuditDelivery]:
-    loop = asyncio.get_running_loop()
-    # Evict closed loops so short-lived (test) loops don't leak channels.
-    for closed in [other for other in _delivery_channels if other.is_closed()]:
-        del _delivery_channels[closed]
-
-    channel = _delivery_channels.get(loop)
-    if channel is None:
-        queue: asyncio.Queue[_AuditDelivery] = asyncio.Queue(
-            maxsize=_AUDIT_DELIVERY_QUEUE_MAXSIZE
-        )
-        worker = loop.create_task(_drain_deliveries(queue))
-        channel = _DeliveryChannel(queue=queue, worker=worker)
-        _delivery_channels[loop] = channel
-    elif channel.worker.done():
-        # Worker died (CancelledError/BaseException) with items possibly still
-        # queued. Respawn onto the existing queue so nothing is lost.
-        channel.worker = loop.create_task(_drain_deliveries(channel.queue))
-    return channel.queue
-
-
-def _enqueue_delivery(delivery: _AuditDelivery) -> None:
-    """Enqueue without blocking; drop the newest event on overflow and log once."""
-    queue = _get_delivery_queue()
-    try:
-        queue.put_nowait(delivery)
-    except asyncio.QueueFull:
-        # No payload contents in this log line: keeps dropped-event data off the
-        # logging boundary.
+def _spawn_delivery(delivery: _AuditDelivery) -> None:
+    """Post the delivery on its own fire-and-forget task."""
+    # Tasks stranded on closed (e.g. per-test) loops never ran their done
+    # callbacks; evict them so the set doesn't grow across loops.
+    for stranded in [t for t in _delivery_tasks if t.get_loop().is_closed()]:
+        _delivery_tasks.discard(stranded)
+    if len(_delivery_tasks) >= _MAX_IN_FLIGHT_DELIVERIES:
+        # Shed audit load rather than exhaust the process FD budget. No payload
+        # contents or sink URL on this log line.
         logger.warning(
-            "Dropped audit webhook delivery; queue full",
+            "Dropped audit webhook delivery; in-flight limit reached",
             resource_type=delivery.resource_type,
             action=delivery.action,
-            queue_maxsize=_AUDIT_DELIVERY_QUEUE_MAXSIZE,
+            max_in_flight=_MAX_IN_FLIGHT_DELIVERIES,
         )
-
-
-async def _drain_deliveries(queue: asyncio.Queue[_AuditDelivery]) -> None:
-    while True:
-        delivery = await queue.get()
-        try:
-            await _deliver(delivery)
-        finally:
-            queue.task_done()
+        return
+    task = asyncio.get_running_loop().create_task(_deliver(delivery))
+    _delivery_tasks.add(task)
+    task.add_done_callback(_delivery_tasks.discard)
 
 
 async def _deliver(delivery: _AuditDelivery) -> None:
@@ -143,14 +111,17 @@ async def _deliver(delivery: _AuditDelivery) -> None:
             "Failed to deliver audit webhook",
             error_type=type(exc).__name__,
             status_code=getattr(response, "status_code", None),
+            resource_type=delivery.resource_type,
+            action=delivery.action,
         )
 
 
 async def flush_audit_deliveries() -> None:
-    """Wait for all queued audit deliveries to complete. Intended for tests."""
-    channel = _delivery_channels.get(asyncio.get_running_loop())
-    if channel is not None:
-        await channel.queue.join()
+    """Wait for this loop's in-flight audit deliveries. Intended for tests."""
+    loop = asyncio.get_running_loop()
+    tasks = [task for task in _delivery_tasks if task.get_loop() is loop]
+    if tasks:
+        await asyncio.gather(*tasks)
 
 
 class AuditService(BaseService):
@@ -342,9 +313,20 @@ class AuditService(BaseService):
         )
 
     async def _post_event(self, *, webhook_url: str, payload: AuditEvent) -> None:
-        """Resolve the delivery synchronously, then enqueue it fire-and-forget."""
-        delivery = await self._build_delivery(webhook_url=webhook_url, payload=payload)
-        _enqueue_delivery(delivery)
+        """Resolve the delivery synchronously, then spawn its delivery task."""
+        try:
+            delivery = await self._build_delivery(
+                webhook_url=webhook_url, payload=payload
+            )
+        except Exception as exc:
+            # Best-effort: a failed settings lookup must never abort the audited
+            # operation, and this path never logs the sink URL.
+            self.logger.warning(
+                "Failed to resolve audit webhook delivery",
+                error_type=type(exc).__name__,
+            )
+            return
+        _spawn_delivery(delivery)
 
     async def _get_actor_label(self) -> str | None:
         if self.role is None:
@@ -476,14 +458,23 @@ class AuditService(BaseService):
             return
 
         actor_label = await self._get_actor_label() if include_actor_label else None
+        request_audit = ctx_request_audit.get()
         payload = self._build_payload(
             resource_type=resource_type,
             action=action,
             resource_id=resource_id,
             status=status,
             actor_label=actor_label,
-            ip_address=ctx_client_ip.get() if include_ip_address else None,
-            user_agent=ctx_user_agent.get() if include_user_agent else None,
+            ip_address=(
+                request_audit.client_ip
+                if include_ip_address and request_audit is not None
+                else None
+            ),
+            user_agent=(
+                request_audit.user_agent
+                if include_user_agent and request_audit is not None
+                else None
+            ),
             data=sanitize_audit_metadata(data),
         )
         await self._post_event(webhook_url=webhook_url, payload=payload)

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -15,9 +15,12 @@ type AuditMetadata = Mapping[str, AuditMetadataValue]
 AuditAction = Literal[
     "create",
     "update",
+    "upsert",
     "delete",
     "publish",
     "cancel",
+    "terminate",
+    "reset",
     "rotate",
     "accept",
     "revoke",

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 
 AuditSink = Literal["organization", "platform"]
+type AuditMetadataValue = str | bool | int | None | list[str]
+type AuditMetadata = Mapping[str, AuditMetadataValue]
 AuditAction = Literal[
     "create",
     "update",
     "delete",
+    "publish",
+    "cancel",
+    "rotate",
     "accept",
     "revoke",
     "sign_in",
@@ -27,6 +33,10 @@ AuditResourceType = Literal[
     "workspace",
     "workflow",
     "workflow_execution",
+    "schedule",
+    "case_trigger",
+    "webhook",
+    "webhook_api_key",
     "workspace_variable",
     "tag",
     "table",
@@ -67,17 +77,24 @@ AuditResourceType = Literal[
 
 
 class AuditEvent(BaseModel):
+    """A privacy-bounded record of an actor acting on a resource.
+
+    ``actor_label``, ``ip_address``, and ``user_agent`` are intentionally
+    modeled separately from generic metadata because they contain PII or
+    sensitive security context. Stable actor and resource IDs are the primary
+    attribution fields.
+    """
+
     organization_id: uuid.UUID | None = None
-    """Organization ID. None for platform-level operations (superuser without org context)."""
     workspace_id: uuid.UUID | None = None
-    """Workspace ID. None for platform/org-level operations."""
     actor_type: AuditEventActor
     actor_id: uuid.UUID
     actor_label: str | None = None
     ip_address: str | None = None
+    user_agent: str | None = None
     resource_type: AuditResourceType
     resource_id: uuid.UUID | None = None
     action: AuditAction
     status: AuditEventStatus
-    data: dict[str, Any] | None = None
+    data: dict[str, AuditMetadataValue] | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -20,6 +20,7 @@ from sqlalchemy.sql.elements import ColumnElement
 from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.logger import audit_log
 from tracecat.audit.service import AuditService
+from tracecat.audit.types import AuditMetadata, AuditMetadataValue
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.types import Role
 from tracecat.authz.controls import get_missing_scopes, require_scope
@@ -2035,13 +2036,14 @@ class CaseCommentsService(BaseWorkspaceService):
         case_id: uuid.UUID,
         comment_id: uuid.UUID,
         parent_id: uuid.UUID | None,
-        content: str | None = None,
         delete_mode: Literal["soft", "hard"] | None = None,
         workflow: Workflow | None = None,
         wf_exec_id: str | None = None,
         workflow_status: CaseCommentWorkflowStatus | None = None,
-    ) -> dict[str, Any]:
-        data: dict[str, Any] = {
+    ) -> dict[str, AuditMetadataValue]:
+        """Build identifier-only metadata for a case-comment audit event."""
+
+        data: dict[str, AuditMetadataValue] = {
             "case_id": str(case_id),
             "comment_id": str(comment_id),
             "parent_id": str(parent_id) if parent_id is not None else None,
@@ -2050,13 +2052,10 @@ class CaseCommentsService(BaseWorkspaceService):
             ),
             "is_reply": parent_id is not None,
         }
-        if content is not None:
-            data["content"] = content
         if delete_mode is not None:
             data["delete_mode"] = delete_mode
         if workflow is not None:
             data["workflow_id"] = str(workflow.id)
-            data["workflow_alias"] = workflow.alias
             data["is_workflow_comment"] = True
             data["uses_case_addons"] = True
         if wf_exec_id is not None:
@@ -2125,7 +2124,6 @@ class CaseCommentsService(BaseWorkspaceService):
                     "comment_id": str(comment_id),
                     "parent_id": str(parent_id) if parent_id is not None else None,
                     "workflow_id": str(workflow.id),
-                    "workflow_alias": workflow.alias,
                     "wf_exec_id": wf_exec_id,
                     "trigger_type": "case",
                 },
@@ -2152,7 +2150,7 @@ class CaseCommentsService(BaseWorkspaceService):
         action: Literal["create", "update", "delete"],
         comment_id: uuid.UUID,
         status: AuditEventStatus,
-        data: dict[str, Any],
+        data: AuditMetadata,
     ) -> None:
         async with AuditService.with_session(
             role=self.role, session=self.session
@@ -2170,7 +2168,7 @@ class CaseCommentsService(BaseWorkspaceService):
         *,
         action: Literal["create", "update", "delete"],
         comment_id: uuid.UUID,
-        data: dict[str, Any],
+        data: AuditMetadata,
     ) -> None:
         """Emit post-commit success audits without failing the mutation."""
         try:
@@ -2416,7 +2414,6 @@ class CaseCommentsService(BaseWorkspaceService):
             case_id=case.id,
             comment_id=comment_id,
             parent_id=params.parent_id,
-            content=params.content,
             workflow=workflow,
             wf_exec_id=wf_exec_id,
             workflow_status=workflow_status,
@@ -2566,7 +2563,6 @@ class CaseCommentsService(BaseWorkspaceService):
             case_id=comment.case_id,
             comment_id=comment.id,
             parent_id=comment.parent_id,
-            content=params.content,
         )
         await self._audit_comment_event(
             action="update",

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1211,9 +1211,9 @@ class CasesService(BaseWorkspaceService):
         """Update multiple cases atomically with isolated per-case failures."""
         case_ids = list(dict.fromkeys(case_ids))
         audit_data: dict[str, Any] = {
-            "batch": True,
+            "is_batch": True,
             "case_ids": [str(case_id) for case_id in case_ids],
-            "count": len(case_ids),
+            "case_count": len(case_ids),
         }
         await self._audit_batch_event(
             action="update",
@@ -1305,8 +1305,8 @@ class CasesService(BaseWorkspaceService):
                 status=AuditEventStatus.FAILURE,
                 data={
                     **audit_data,
-                    "succeeded": 0,
-                    "failed": len(case_ids),
+                    "succeeded_count": 0,
+                    "failed_count": len(case_ids),
                 },
             )
             raise
@@ -1324,8 +1324,8 @@ class CasesService(BaseWorkspaceService):
             else AuditEventStatus.FAILURE,
             data={
                 **audit_data,
-                "succeeded": response.succeeded,
-                "failed": response.failed,
+                "succeeded_count": response.succeeded,
+                "failed_count": response.failed,
             },
         )
         return response
@@ -1335,9 +1335,9 @@ class CasesService(BaseWorkspaceService):
         """Delete multiple cases atomically with isolated per-case failures."""
         case_ids = list(dict.fromkeys(case_ids))
         audit_data: dict[str, Any] = {
-            "batch": True,
+            "is_batch": True,
             "case_ids": [str(case_id) for case_id in case_ids],
-            "count": len(case_ids),
+            "case_count": len(case_ids),
         }
         await self._audit_batch_event(
             action="delete",
@@ -1436,8 +1436,8 @@ class CasesService(BaseWorkspaceService):
                 status=AuditEventStatus.FAILURE,
                 data={
                     **audit_data,
-                    "succeeded": 0,
-                    "failed": len(case_ids),
+                    "succeeded_count": 0,
+                    "failed_count": len(case_ids),
                 },
             )
             raise
@@ -1455,8 +1455,8 @@ class CasesService(BaseWorkspaceService):
             else AuditEventStatus.FAILURE,
             data={
                 **audit_data,
-                "succeeded": response.succeeded,
-                "failed": response.failed,
+                "succeeded_count": response.succeeded,
+                "failed_count": response.failed,
             },
         )
         return response

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import datetime
 
 import loguru
@@ -19,11 +20,20 @@ __all__ = [
     "ctx_interaction",
     "ctx_stream_id",
     "ctx_session",
-    "ctx_client_ip",
-    "ctx_user_agent",
+    "ctx_request_audit",
     "ctx_logical_time",
     "get_env",
+    "RequestAuditContext",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class RequestAuditContext:
+    """Client attribution captured by request middleware for audit events."""
+
+    client_ip: str | None
+    user_agent: str | None
+
 
 ctx_run: ContextVar[RunContext | None] = ContextVar("run", default=None)
 ctx_role: ContextVar[Role | None] = ContextVar("role", default=None)
@@ -31,8 +41,9 @@ ctx_logger: ContextVar[loguru.Logger | None] = ContextVar("logger", default=None
 ctx_interaction: ContextVar[InteractionContext | None] = ContextVar(
     "interaction", default=None
 )
-ctx_client_ip: ContextVar[str | None] = ContextVar("client-ip", default=None)
-ctx_user_agent: ContextVar[str | None] = ContextVar("user-agent", default=None)
+ctx_request_audit: ContextVar[RequestAuditContext | None] = ContextVar(
+    "request-audit", default=None
+)
 ctx_stream_id: ContextVar[StreamID] = ContextVar("stream-id", default=ROOT_STREAM)
 ctx_env: ContextVar[dict[str, str] | None] = ContextVar("env", default=None)
 ctx_session: ContextVar[AsyncSession | None] = ContextVar("session", default=None)

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -20,6 +20,7 @@ __all__ = [
     "ctx_stream_id",
     "ctx_session",
     "ctx_client_ip",
+    "ctx_user_agent",
     "ctx_logical_time",
     "get_env",
 ]
@@ -31,6 +32,7 @@ ctx_interaction: ContextVar[InteractionContext | None] = ContextVar(
     "interaction", default=None
 )
 ctx_client_ip: ContextVar[str | None] = ContextVar("client-ip", default=None)
+ctx_user_agent: ContextVar[str | None] = ContextVar("user-agent", default=None)
 ctx_stream_id: ContextVar[StreamID] = ContextVar("stream-id", default=ROOT_STREAM)
 ctx_env: ContextVar[dict[str, str] | None] = ContextVar("env", default=None)
 ctx_session: ContextVar[AsyncSession | None] = ContextVar("session", default=None)

--- a/tracecat/integrations/mcp_validation.py
+++ b/tracecat/integrations/mcp_validation.py
@@ -71,26 +71,6 @@ class MCPSecretResolutionError(Exception):
         self.server_slug = server_slug
 
 
-_URL_PATTERN = re.compile(r"\bhttps?://\S+", re.IGNORECASE)
-_URL_USERINFO_PATTERN = re.compile(r"^(https?://)[^/@]*@", re.IGNORECASE)
-
-
-def sanitize_urls_in_text(text: str) -> str:
-    """Strip credentials and query strings from any URLs embedded in free text.
-
-    Transport errors can echo a user-supplied server URI, which may carry
-    secrets in its userinfo (``user:pass@``) or query string. Sanitize before
-    storing such text in errors, logs, or API responses. Non-URL text is
-    returned unchanged.
-    """
-
-    def _sanitize(match: re.Match[str]) -> str:
-        url = _URL_USERINFO_PATTERN.sub(r"\1", match.group(0))
-        return re.sub(r"[?#].*$", "", url)
-
-    return _URL_PATTERN.sub(_sanitize, text)
-
-
 class MCPConnectionVerificationError(Exception):
     """Raised when connectivity verification against an MCP server fails."""
 

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -71,7 +71,6 @@ from tracecat.integrations.mcp_validation import (
     MCPConfigurationError,
     MCPConnectionVerificationError,
     MCPValidationError,
-    sanitize_urls_in_text,
     validate_mcp_command_config,
 )
 from tracecat.integrations.providers import get_provider_class
@@ -119,6 +118,7 @@ from tracecat.integrations.types import (
     OAuthServerMetadata,
     TokenResponse,
 )
+from tracecat.sanitization import sanitize_urls_in_text
 from tracecat.secrets.encryption import decrypt_value, encrypt_value, is_set
 from tracecat.service import BaseWorkspaceService
 from tracecat.tiers.enums import Entitlement

--- a/tracecat/mcp/middleware.py
+++ b/tracecat/mcp/middleware.py
@@ -14,12 +14,14 @@ from fastmcp.server.dependencies import get_access_token, get_http_request
 from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 
+from tracecat.contexts import ctx_request_audit
 from tracecat.logger import logger
 from tracecat.mcp.auth import MCPTokenIdentity, get_email_claim, get_token_identity
 from tracecat.mcp.config import (
     TRACECAT_MCP__MAX_INPUT_SIZE_BYTES,
     TRACECAT_MCP__TOOL_TIMEOUT_SECONDS,
 )
+from tracecat.middleware.request import build_request_audit_context
 
 
 class AccessTokenClaims(TypedDict, total=False):
@@ -71,6 +73,26 @@ class MCPInputSizeLimitMiddleware(Middleware):
                             f"({size} bytes > {self.max_bytes} bytes)"
                         )
         return await call_next(context)
+
+
+class MCPRequestAuditMiddleware(Middleware):
+    """Attribute audit events from tool calls with the client's IP and user agent."""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        try:
+            audit_context = build_request_audit_context(get_http_request())
+        except Exception:
+            # Non-HTTP transport: no request attribution available.
+            return await call_next(context)
+        token = ctx_request_audit.set(audit_context)
+        try:
+            return await call_next(context)
+        finally:
+            ctx_request_audit.reset(token)
 
 
 class MCPTimeoutMiddleware(Middleware):

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -3421,6 +3421,7 @@ async def edit_workflow(
                 workflow=workflow,
                 original_document=draft_document,
                 updated_document=updated_document,
+                changed_sections=changed_sections,
             )
             await svc.session.refresh(
                 workflow,

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -92,7 +92,7 @@ from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.stream.events import StreamDelta, StreamEnd, StreamError
 from tracecat.agent.tools import create_tool_from_registry
 from tracecat.agent.types import OutputType
-from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
+from tracecat.audit.logger import AuditEventDetails, audit_log
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.types import Role
 from tracecat.auth.users import search_users
@@ -1834,11 +1834,17 @@ async def _create_workflow_from_import_data(
 
 
 def _workflow_yaml_update_audit_details(
-    context: AuditCallContext,
+    *,
+    role: Role,
+    service: WorkflowsManagementService,
+    workflow: Workflow,
+    workflow_id: WorkflowUUID,
+    update_params: WorkflowUpdate,
+    yaml_payload: WorkflowYamlPayload | None,
+    definition_yaml: str | None,
+    update_mode: Literal["replace", "patch"],
 ) -> AuditEventDetails:
-    update_params = cast(WorkflowUpdate, context.arguments["update_params"])
-    yaml_payload = cast(WorkflowYamlPayload | None, context.arguments["yaml_payload"])
-    changed_fields = set(update_params.model_dump(exclude_unset=True))
+    changed_fields = set(update_params.model_fields_set)
     if yaml_payload is not None:
         changed_fields.update(
             field

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -197,6 +197,7 @@ from tracecat.mcp.config import (
 from tracecat.mcp.json_patch import apply_json_patch_operations
 from tracecat.mcp.middleware import (
     MCPInputSizeLimitMiddleware,
+    MCPRequestAuditMiddleware,
     MCPTimeoutMiddleware,
     WatchtowerMonitorMiddleware,
     get_mcp_client_id,
@@ -2284,6 +2285,7 @@ mcp.add_middleware(
     )
 )
 mcp.add_middleware(MCPInputSizeLimitMiddleware())
+mcp.add_middleware(MCPRequestAuditMiddleware())
 mcp.add_middleware(WatchtowerMonitorMiddleware())
 mcp.add_middleware(MCPTimeoutMiddleware())
 mcp.add_middleware(

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -92,6 +92,7 @@ from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.stream.events import StreamDelta, StreamEnd, StreamError
 from tracecat.agent.tools import create_tool_from_registry
 from tracecat.agent.types import OutputType
+from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.types import Role
 from tracecat.auth.users import search_users
@@ -1832,6 +1833,26 @@ async def _create_workflow_from_import_data(
         raise ToolError(str(exc)) from exc
 
 
+def _workflow_yaml_update_audit_details(
+    context: AuditCallContext,
+) -> AuditEventDetails:
+    update_params = cast(WorkflowUpdate, context.arguments["update_params"])
+    yaml_payload = cast(WorkflowYamlPayload | None, context.arguments["yaml_payload"])
+    changed_fields = set(update_params.model_dump(exclude_unset=True))
+    if yaml_payload is not None:
+        changed_fields.update(
+            field
+            for field in ("definition", "layout", "schedules", "case_trigger")
+            if getattr(yaml_payload, field) is not None
+        )
+    return AuditEventDetails(data={"changed_fields": sorted(changed_fields)})
+
+
+@audit_log(
+    resource_type="workflow",
+    action="update",
+    attempt_metadata=_workflow_yaml_update_audit_details,
+)
 async def _apply_workflow_yaml_update(
     *,
     role: Role,
@@ -3469,31 +3490,26 @@ async def update_workflow(
         if definition_yaml is not None:
             _ensure_inline_workflow_yaml_size(definition_yaml)
         update_params = WorkflowUpdate(**update_kwargs)
-
+        yaml_payload = (
+            _parse_workflow_yaml_payload(definition_yaml)
+            if definition_yaml is not None
+            else None
+        )
         async with WorkflowsManagementService.with_session(role=role) as svc:
             workflow = await svc.get_workflow(workflow_id, for_update=True)
             if workflow is None:
                 raise ToolError(f"Workflow {workflow_id} not found")
-            if definition_yaml is not None:
-                yaml_payload = _parse_workflow_yaml_payload(definition_yaml)
-                await _apply_workflow_yaml_update(
-                    role=role,
-                    service=svc,
-                    workflow=workflow,
-                    workflow_id=workflow_id,
-                    update_params=update_params,
-                    yaml_payload=yaml_payload,
-                    definition_yaml=definition_yaml,
-                    update_mode=update_mode,
-                )
-                mode = update_mode
-            else:
-                for key, value in update_params.model_dump(exclude_unset=True).items():
-                    setattr(workflow, key, value)
-                svc.session.add(workflow)
-                await svc.session.commit()
-                await svc.session.refresh(workflow)
-                mode = "metadata"
+            await _apply_workflow_yaml_update(
+                role=role,
+                service=svc,
+                workflow=workflow,
+                workflow_id=workflow_id,
+                update_params=update_params,
+                yaml_payload=yaml_payload,
+                definition_yaml=definition_yaml,
+                update_mode=update_mode,
+            )
+            mode = update_mode if definition_yaml is not None else "metadata"
 
             return WorkflowUpdateResponse(
                 message=f"Workflow {workflow_id} updated successfully",
@@ -4859,19 +4875,15 @@ async def update_webhook(
         update_params = WebhookUpdate(**update_kwargs)
 
         async with get_async_session_context_manager() as session:
-            webhook = await webhook_service.get_webhook(
-                session=session,
-                workspace_id=role.workspace_id,
-                workflow_id=workflow_id,
-            )
-            if webhook is None:
-                raise ToolError(f"Webhook not found for workflow {workflow_id}")
-
-            for key, value in update_params.model_dump(exclude_unset=True).items():
-                setattr(webhook, key, value)
-
-            session.add(webhook)
-            await session.commit()
+            try:
+                await webhook_service.update_webhook(
+                    role=role,
+                    session=session,
+                    workflow_id=workflow_id,
+                    params=update_params,
+                )
+            except TracecatNotFoundError as e:
+                raise ToolError(f"Webhook not found for workflow {workflow_id}") from e
         return MCPMessageResponse(
             message=f"Webhook for workflow {workflow_id} updated successfully"
         )

--- a/tracecat/middleware/request.py
+++ b/tracecat/middleware/request.py
@@ -1,26 +1,47 @@
 from __future__ import annotations
 
+from ipaddress import ip_address
+
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from tracecat.contexts import ctx_client_ip
+from tracecat.contexts import ctx_client_ip, ctx_user_agent
+from tracecat.sanitization import redact_sensitive_text
+
+_MAX_USER_AGENT_LENGTH = 512
+
+
+def _normalize_client_ip(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        return str(ip_address(value))
+    except ValueError:
+        return None
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         # Capture client IP address
         # Check X-Forwarded-For header first (for production behind proxies)
-        client_ip = None
         forwarded_for = request.headers.get("X-Forwarded-For")
-        if forwarded_for:
-            # X-Forwarded-For format: "client, proxy1, proxy2"
-            # First IP is the original client
-            client_ip = forwarded_for.split(",")[0].strip()
+        forwarded_ip = forwarded_for.split(",")[0].strip() if forwarded_for else None
+        client_ip = _normalize_client_ip(forwarded_ip)
         # Fallback to direct connection IP
-        if not client_ip and request.client:
-            client_ip = request.client.host
+        if client_ip is None and request.client:
+            client_ip = _normalize_client_ip(request.client.host)
 
-        token = ctx_client_ip.set(client_ip)
+        raw_user_agent = request.headers.get("User-Agent")
+        user_agent = (
+            redact_sensitive_text(raw_user_agent, redact_emails=True)[
+                :_MAX_USER_AGENT_LENGTH
+            ]
+            if raw_user_agent
+            else None
+        )
+
+        client_ip_token = ctx_client_ip.set(client_ip)
+        user_agent_token = ctx_user_agent.set(user_agent)
 
         try:
             request_logger = request.app.state.logger
@@ -40,4 +61,5 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
             return await call_next(request)
         finally:
-            ctx_client_ip.reset(token)
+            ctx_user_agent.reset(user_agent_token)
+            ctx_client_ip.reset(client_ip_token)

--- a/tracecat/middleware/request.py
+++ b/tracecat/middleware/request.py
@@ -48,7 +48,7 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         # Client-controlled: informational attribution, not a security control.
         client_ip = None
         if forwarded_for := request.headers.get("X-Forwarded-For"):
-            client_ip = _normalize_client_ip(forwarded_for.split(",")[0].strip())
+            client_ip = _normalize_client_ip(forwarded_for.split(",", 1)[0].strip())
         if client_ip is None:
             client_ip = _normalize_client_ip(
                 request.client.host if request.client is not None else None

--- a/tracecat/middleware/request.py
+++ b/tracecat/middleware/request.py
@@ -6,7 +6,7 @@ from ipaddress import ip_address
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from tracecat.contexts import ctx_client_ip, ctx_user_agent
+from tracecat.contexts import RequestAuditContext, ctx_request_audit
 
 _AUDIT_USER_AGENT_PATTERN = re.compile(
     r"^(?P<product>Mozilla|TracecatClient|curl|python-httpx|Claude-Code|Codex)"
@@ -56,8 +56,9 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
         user_agent = _normalize_audit_user_agent(request.headers.get("User-Agent"))
 
-        client_ip_token = ctx_client_ip.set(client_ip)
-        user_agent_token = ctx_user_agent.set(user_agent)
+        audit_token = ctx_request_audit.set(
+            RequestAuditContext(client_ip=client_ip, user_agent=user_agent)
+        )
 
         try:
             request_logger = request.app.state.logger
@@ -77,5 +78,4 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
             return await call_next(request)
         finally:
-            ctx_user_agent.reset(user_agent_token)
-            ctx_client_ip.reset(client_ip_token)
+            ctx_request_audit.reset(audit_token)

--- a/tracecat/middleware/request.py
+++ b/tracecat/middleware/request.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 
+import re
 from ipaddress import ip_address
 
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from tracecat.contexts import ctx_client_ip, ctx_user_agent
-from tracecat.sanitization import redact_sensitive_text
 
-_MAX_USER_AGENT_LENGTH = 512
+_AUDIT_USER_AGENT_PATTERN = re.compile(
+    r"^(?P<product>Mozilla|TracecatClient|curl|python-httpx|Claude-Code|Codex)"
+    r"/(?P<version>\d{1,4}(?:\.\d{1,4}){0,3})\b",
+    re.IGNORECASE,
+)
+_AUDIT_USER_AGENT_FAMILIES = {
+    "claude-code": "claude-code",
+    "codex": "codex",
+    "curl": "curl",
+    "mozilla": "browser",
+    "python-httpx": "httpx",
+    "tracecatclient": "tracecat",
+}
 
 
 def _normalize_client_ip(value: str | None) -> str | None:
@@ -20,25 +32,29 @@ def _normalize_client_ip(value: str | None) -> str | None:
         return None
 
 
+def _normalize_audit_user_agent(value: str | None) -> str | None:
+    """Return a bounded client family/version without forwarding raw metadata."""
+    if not value:
+        return None
+    if match := _AUDIT_USER_AGENT_PATTERN.match(value):
+        family = _AUDIT_USER_AGENT_FAMILIES[match.group("product").lower()]
+        return f"{family}/{match.group('version')}"
+    return "other"
+
+
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        # Capture client IP address
-        # Check X-Forwarded-For header first (for production behind proxies)
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        forwarded_ip = forwarded_for.split(",")[0].strip() if forwarded_for else None
-        client_ip = _normalize_client_ip(forwarded_ip)
-        # Fallback to direct connection IP
-        if client_ip is None and request.client:
-            client_ip = _normalize_client_ip(request.client.host)
+        # Leftmost X-Forwarded-For hop, falling back to the socket peer.
+        # Client-controlled: informational attribution, not a security control.
+        client_ip = None
+        if forwarded_for := request.headers.get("X-Forwarded-For"):
+            client_ip = _normalize_client_ip(forwarded_for.split(",")[0].strip())
+        if client_ip is None:
+            client_ip = _normalize_client_ip(
+                request.client.host if request.client is not None else None
+            )
 
-        raw_user_agent = request.headers.get("User-Agent")
-        user_agent = (
-            redact_sensitive_text(raw_user_agent, redact_emails=True)[
-                :_MAX_USER_AGENT_LENGTH
-            ]
-            if raw_user_agent
-            else None
-        )
+        user_agent = _normalize_audit_user_agent(request.headers.get("User-Agent"))
 
         client_ip_token = ctx_client_ip.set(client_ip)
         user_agent_token = ctx_user_agent.set(user_agent)

--- a/tracecat/middleware/request.py
+++ b/tracecat/middleware/request.py
@@ -42,23 +42,29 @@ def _normalize_audit_user_agent(value: str | None) -> str | None:
     return "other"
 
 
+def build_request_audit_context(request: Request) -> RequestAuditContext:
+    """Derive audit attribution from an HTTP request.
+
+    Leftmost X-Forwarded-For hop, falling back to the socket peer.
+    Client-controlled: informational attribution, not a security control.
+    """
+    client_ip = None
+    if forwarded_for := request.headers.get("X-Forwarded-For"):
+        client_ip = _normalize_client_ip(forwarded_for.split(",", 1)[0].strip())
+    if client_ip is None:
+        client_ip = _normalize_client_ip(
+            request.client.host if request.client is not None else None
+        )
+    user_agent = _normalize_audit_user_agent(request.headers.get("User-Agent"))
+    return RequestAuditContext(client_ip=client_ip, user_agent=user_agent)
+
+
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        # Leftmost X-Forwarded-For hop, falling back to the socket peer.
-        # Client-controlled: informational attribution, not a security control.
-        client_ip = None
-        if forwarded_for := request.headers.get("X-Forwarded-For"):
-            client_ip = _normalize_client_ip(forwarded_for.split(",", 1)[0].strip())
-        if client_ip is None:
-            client_ip = _normalize_client_ip(
-                request.client.host if request.client is not None else None
-            )
+        audit_context = build_request_audit_context(request)
+        client_ip = audit_context.client_ip
 
-        user_agent = _normalize_audit_user_agent(request.headers.get("User-Agent"))
-
-        audit_token = ctx_request_audit.set(
-            RequestAuditContext(client_ip=client_ip, user_agent=user_agent)
-        )
+        audit_token = ctx_request_audit.set(audit_context)
 
         try:
             request_logger = request.app.state.logger

--- a/tracecat/sanitization.py
+++ b/tracecat/sanitization.py
@@ -1,0 +1,95 @@
+"""Shared sanitizers for text that may cross a logging boundary."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+_URL_PATTERN = re.compile(r"\bhttps?://\S+", re.IGNORECASE)
+_URL_USERINFO_PATTERN = re.compile(r"^(https?://)[^/@]*@", re.IGNORECASE)
+_EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
+_BEARER_TOKEN_PATTERN = re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._~+/=-]+")
+_AUTHORIZATION_VALUE_PATTERN = re.compile(r"(?im)\b(Authorization\s*:\s*)[^\r\n]+")
+_COOKIE_VALUE_PATTERN = re.compile(r"(?im)\b((?:Set-)?Cookie\s*:\s*)[^\r\n]+")
+_JWT_PATTERN = re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
+_SENSITIVE_VALUE_PATTERN = re.compile(
+    r"(?i)(?P<prefix>['\"]?\b(?:api[ _-]?key|access[ _-]?token|refresh[ _-]?token|"
+    r"id[ _-]?token|oauth[ _-]?token|client[ _-]?secret|private[ _-]?key|"
+    r"secret[ _-]?key|token|password|passwd|secret)\b['\"]?\s*[:=]\s*)"
+    r"(?:"
+    r'(?P<double_quoted>"(?:\\.|[^"\\\r\n])*")|'
+    r"(?P<single_quoted>'(?:\\.|[^'\\\r\n])*')|"
+    r"(?P<unquoted>[^\s,;}\]\"']+)"
+    r")"
+)
+
+
+def sanitize_urls_in_text(text: str) -> str:
+    """Remove userinfo, query strings, and fragments from HTTP URLs in text.
+
+    Args:
+        text: Free-form text that may contain one or more HTTP URLs.
+
+    Returns:
+        Text with URL credentials and parameters removed. Text outside URLs is
+        unchanged.
+    """
+
+    def sanitize(match: re.Match[str]) -> str:
+        url = _URL_USERINFO_PATTERN.sub(r"\1", match.group(0))
+        return re.sub(r"[?#].*$", "", url)
+
+    return _URL_PATTERN.sub(sanitize, text)
+
+
+def redact_sensitive_text(
+    text: str,
+    *,
+    sensitive_values: Iterable[str] = (),
+    redact_emails: bool = False,
+) -> str:
+    """Redact common credentials and optionally email addresses from text.
+
+    This function is a defense-in-depth filter for free-form text. It cannot
+    identify an arbitrary opaque value as secret unless that value is supplied
+    through ``sensitive_values``. Callers must still avoid passing raw request
+    bodies, configuration values, workflow data, or other unrestricted content
+    across a logging boundary.
+
+    Args:
+        text: Free-form text to sanitize.
+        sensitive_values: Known secret values to replace exactly. Values shorter
+            than four characters are ignored to avoid destructive overmatching.
+        redact_emails: Whether to replace email-shaped values as PII.
+
+    Returns:
+        Sanitized text with recognized sensitive values replaced.
+    """
+
+    sanitized = sanitize_urls_in_text(text)
+    for value in sensitive_values:
+        if len(value) < 4:
+            continue
+        sanitized = sanitized.replace(value, "[redacted]")
+        sanitized_value = sanitize_urls_in_text(value)
+        if sanitized_value != value:
+            sanitized = sanitized.replace(sanitized_value, "[redacted]")
+    if redact_emails:
+        sanitized = _EMAIL_PATTERN.sub("[redacted email]", sanitized)
+    sanitized = _BEARER_TOKEN_PATTERN.sub(r"\1[redacted]", sanitized)
+    sanitized = _AUTHORIZATION_VALUE_PATTERN.sub(r"\1[redacted]", sanitized)
+    sanitized = _COOKIE_VALUE_PATTERN.sub(r"\1[redacted]", sanitized)
+    sanitized = _JWT_PATTERN.sub("[redacted token]", sanitized)
+    return _SENSITIVE_VALUE_PATTERN.sub(_redact_sensitive_value, sanitized)
+
+
+def _redact_sensitive_value(match: re.Match[str]) -> str:
+    """Replace a key-value secret while retaining readable delimiters."""
+
+    if match.group("double_quoted") is not None:
+        redacted = '"[redacted]"'
+    elif match.group("single_quoted") is not None:
+        redacted = "'[redacted]'"
+    else:
+        redacted = "[redacted]"
+    return f"{match.group('prefix')}{redacted}"

--- a/tracecat/sanitization.py
+++ b/tracecat/sanitization.py
@@ -11,6 +11,17 @@ _EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
 _BEARER_TOKEN_PATTERN = re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._~+/=-]+")
 _AUTHORIZATION_VALUE_PATTERN = re.compile(r"(?im)\b(Authorization\s*:\s*)[^\r\n]+")
 _COOKIE_VALUE_PATTERN = re.compile(r"(?im)\b((?:Set-)?Cookie\s*:\s*)[^\r\n]+")
+_SERIALIZED_HEADER_VALUE_PATTERN = re.compile(
+    r"(?im)(?P<prefix>(?P<key_quote>['\"]?)\b"
+    r"(?:Authorization|(?:Set-)?Cookie)\b(?P=key_quote)\s*:\s*)"
+    r"(?P<value>\"(?:\\.|[^\"\\\r\n])*\"|'(?:\\.|[^'\\\r\n])*')"
+)
+_PEM_BLOCK_PATTERN = re.compile(
+    r"-----BEGIN (?P<label>[A-Z0-9][A-Z0-9 ._/-]{0,63})-----"
+    r".*?"
+    r"-----END (?P=label)-----",
+    re.IGNORECASE | re.DOTALL,
+)
 _JWT_PATTERN = re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
 _SENSITIVE_VALUE_PATTERN = re.compile(
     r"(?i)(?P<prefix>['\"]?\b(?:api[ _-]?key|access[ _-]?token|refresh[ _-]?token|"
@@ -67,6 +78,7 @@ def redact_sensitive_text(
     """
 
     sanitized = sanitize_urls_in_text(text)
+    sanitized = _PEM_BLOCK_PATTERN.sub("[redacted PEM block]", sanitized)
     for value in sensitive_values:
         if len(value) < 4:
             continue
@@ -76,11 +88,23 @@ def redact_sensitive_text(
             sanitized = sanitized.replace(sanitized_value, "[redacted]")
     if redact_emails:
         sanitized = _EMAIL_PATTERN.sub("[redacted email]", sanitized)
+    sanitized = _SERIALIZED_HEADER_VALUE_PATTERN.sub(
+        _redact_serialized_header_value,
+        sanitized,
+    )
     sanitized = _BEARER_TOKEN_PATTERN.sub(r"\1[redacted]", sanitized)
     sanitized = _AUTHORIZATION_VALUE_PATTERN.sub(r"\1[redacted]", sanitized)
     sanitized = _COOKIE_VALUE_PATTERN.sub(r"\1[redacted]", sanitized)
     sanitized = _JWT_PATTERN.sub("[redacted token]", sanitized)
     return _SENSITIVE_VALUE_PATTERN.sub(_redact_sensitive_value, sanitized)
+
+
+def _redact_serialized_header_value(match: re.Match[str]) -> str:
+    """Redact a quoted header value while retaining its serialized shape."""
+
+    value = match.group("value")
+    quote = value[0]
+    return f"{match.group('prefix')}{quote}[redacted]{quote}"
 
 
 def _redact_sensitive_value(match: re.Match[str]) -> str:

--- a/tracecat/webhooks/service.py
+++ b/tracecat/webhooks/service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,7 +14,7 @@ from tracecat.authz.controls import require_scope
 from tracecat.db.models import Webhook
 from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
 from tracecat.identifiers import WorkflowID
-from tracecat.webhooks.schemas import WebhookUpdate
+from tracecat.webhooks.schemas import WebhookCreate, WebhookUpdate
 
 
 async def _webhook_update_audit_details(
@@ -52,6 +54,36 @@ async def get_webhook(
     )
     result = await session.execute(statement)
     return result.scalars().first()
+
+
+@require_scope("workflow:update")
+@audit_log(
+    resource_type="webhook",
+    action="create",
+    resource_id_attr="id",
+)
+async def create_webhook(
+    *,
+    role: Role,
+    session: AsyncSession,
+    workflow_id: WorkflowID,
+    params: WebhookCreate,
+) -> Webhook:
+    """Create a webhook for a workflow."""
+    if role.workspace_id is None:
+        raise TracecatAuthorizationError("Webhook creation requires a workspace")
+    webhook = Webhook(
+        workspace_id=role.workspace_id,
+        methods=cast(list[str], params.methods),
+        workflow_id=workflow_id,
+        status=params.status,
+        allowlisted_cidrs=params.allowlisted_cidrs,
+        include_headers=params.include_headers,
+    )
+    session.add(webhook)
+    await session.commit()
+    await session.refresh(webhook)
+    return webhook
 
 
 @require_scope("workflow:update")

--- a/tracecat/webhooks/service.py
+++ b/tracecat/webhooks/service.py
@@ -11,20 +11,32 @@ from tracecat.audit.logger import (
     audit_log,
 )
 from tracecat.auth.types import Role
+from tracecat.authz.controls import require_scope
 from tracecat.db.models import Webhook
 from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
 from tracecat.identifiers import WorkflowID
 from tracecat.webhooks.schemas import WebhookUpdate
 
 
-def _webhook_update_audit_details(
+async def _webhook_update_audit_details(
     context: AuditCallContext,
 ) -> AuditEventDetails:
+    role = cast(Role, context.arguments["role"])
+    session = cast(AsyncSession, context.arguments["session"])
+    workflow_id = cast(WorkflowID, context.arguments["workflow_id"])
     params = cast(WebhookUpdate, context.arguments["params"])
+    webhook = None
+    if role.workspace_id is not None:
+        webhook = await get_webhook(
+            session,
+            workspace_id=role.workspace_id,
+            workflow_id=workflow_id,
+        )
     return AuditEventDetails(
+        resource_id=webhook.id if webhook is not None else None,
         data={
             "changed_fields": sorted(params.model_dump(exclude_unset=True)),
-        }
+        },
     )
 
 
@@ -33,14 +45,19 @@ async def get_webhook(
     workspace_id,
     workflow_id: WorkflowID,
 ) -> Webhook | None:
-    statement = select(Webhook).where(
-        Webhook.workspace_id == workspace_id,
-        Webhook.workflow_id == workflow_id,
+    statement = (
+        select(Webhook)
+        .where(
+            Webhook.workspace_id == workspace_id,
+            Webhook.workflow_id == workflow_id,
+        )
+        .order_by(Webhook.id)
     )
     result = await session.execute(statement)
     return result.scalars().first()
 
 
+@require_scope("workflow:update")
 @audit_log(
     resource_type="webhook",
     action="update",

--- a/tracecat/webhooks/service.py
+++ b/tracecat/webhooks/service.py
@@ -1,8 +1,31 @@
+from __future__ import annotations
+
+from typing import cast
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.audit.logger import (
+    AuditCallContext,
+    AuditEventDetails,
+    audit_log,
+)
+from tracecat.auth.types import Role
 from tracecat.db.models import Webhook
+from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
 from tracecat.identifiers import WorkflowID
+from tracecat.webhooks.schemas import WebhookUpdate
+
+
+def _webhook_update_audit_details(
+    context: AuditCallContext,
+) -> AuditEventDetails:
+    params = cast(WebhookUpdate, context.arguments["params"])
+    return AuditEventDetails(
+        data={
+            "changed_fields": sorted(params.model_dump(exclude_unset=True)),
+        }
+    )
 
 
 async def get_webhook(
@@ -16,3 +39,35 @@ async def get_webhook(
     )
     result = await session.execute(statement)
     return result.scalars().first()
+
+
+@audit_log(
+    resource_type="webhook",
+    action="update",
+    resource_id_attr="id",
+    attempt_metadata=_webhook_update_audit_details,
+)
+async def update_webhook(
+    *,
+    role: Role,
+    session: AsyncSession,
+    workflow_id: WorkflowID,
+    params: WebhookUpdate,
+) -> Webhook:
+    """Update webhook configuration shared by all control-plane callers."""
+    if role.workspace_id is None:
+        raise TracecatAuthorizationError("Webhook update requires a workspace")
+    webhook = await get_webhook(
+        session,
+        workspace_id=role.workspace_id,
+        workflow_id=workflow_id,
+    )
+    if webhook is None:
+        raise TracecatNotFoundError("Webhook not found")
+    for key, value in params.model_dump(exclude_unset=True).items():
+        # Safety: params have been validated by WebhookUpdate.
+        setattr(webhook, key, value)
+    session.add(webhook)
+    await session.commit()
+    await session.refresh(webhook)
+    return webhook

--- a/tracecat/webhooks/service.py
+++ b/tracecat/webhooks/service.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from typing import cast
-
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.audit.logger import (
-    AuditCallContext,
     AuditEventDetails,
     audit_log,
 )
@@ -19,12 +16,12 @@ from tracecat.webhooks.schemas import WebhookUpdate
 
 
 async def _webhook_update_audit_details(
-    context: AuditCallContext,
+    *,
+    role: Role,
+    session: AsyncSession,
+    workflow_id: WorkflowID,
+    params: WebhookUpdate,
 ) -> AuditEventDetails:
-    role = cast(Role, context.arguments["role"])
-    session = cast(AsyncSession, context.arguments["session"])
-    workflow_id = cast(WorkflowID, context.arguments["workflow_id"])
-    params = cast(WebhookUpdate, context.arguments["params"])
     webhook = None
     if role.workspace_id is not None:
         webhook = await get_webhook(
@@ -35,7 +32,7 @@ async def _webhook_update_audit_details(
     return AuditEventDetails(
         resource_id=webhook.id if webhook is not None else None,
         data={
-            "changed_fields": sorted(params.model_dump(exclude_unset=True)),
+            "changed_fields": sorted(params.model_fields_set),
         },
     )
 

--- a/tracecat/workflow/case_triggers/service.py
+++ b/tracecat/workflow/case_triggers/service.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import cast
 
 from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
-from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
+from tracecat.audit.logger import AuditEventDetails, audit_log
 from tracecat.db.models import CaseTag, CaseTrigger, Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -17,44 +16,37 @@ from tracecat.tiers.enums import Entitlement
 from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig, CaseTriggerUpdate
 
 
-async def _case_trigger_upsert_audit_details(
-    context: AuditCallContext,
-) -> AuditEventDetails:
-    if context.arguments.get("commit", True) is False:
-        return AuditEventDetails(emit=False)
-    service = cast(BaseWorkspaceService, context.target)
-    workflow_id = cast(WorkflowID, context.arguments["workflow_id"])
-    params = cast(CaseTriggerConfig, context.arguments["params"])
-    existing = await service.session.scalar(
-        select(CaseTrigger).where(
-            CaseTrigger.workspace_id == service.workspace_id,
-            CaseTrigger.workflow_id == WorkflowUUID.new(workflow_id),
-        )
-    )
-    if existing is None:
-        return AuditEventDetails(action="create")
-    return AuditEventDetails(
-        action="update",
-        resource_id=existing.id,
-        data={"changed_fields": sorted(params.model_dump())},
-    )
-
-
-def _case_trigger_update_audit_details(
-    context: AuditCallContext,
-) -> AuditEventDetails:
-    if context.arguments.get("commit", True) is False:
-        return AuditEventDetails(emit=False)
-    params = cast(CaseTriggerUpdate, context.arguments["params"])
-    return AuditEventDetails(
-        data={"changed_fields": sorted(params.model_dump(exclude_unset=True))}
-    )
-
-
 class CaseTriggersService(BaseWorkspaceService):
     """Manage workflow case trigger configuration."""
 
     service_name = "case_triggers"
+
+    def _case_trigger_upsert_audit_details(
+        self,
+        workflow_id: WorkflowID,
+        params: CaseTriggerConfig,
+        *,
+        create_missing_tags: bool = False,
+        commit: bool = True,
+    ) -> AuditEventDetails:
+        # commit=False suppresses emission for sync/dry-run callers.
+        if commit is False:
+            return AuditEventDetails(emit=False)
+        return AuditEventDetails(data={"changed_fields": sorted(params.model_dump())})
+
+    def _case_trigger_update_audit_details(
+        self,
+        workflow_id: WorkflowID,
+        params: CaseTriggerUpdate,
+        *,
+        create_missing_tags: bool = False,
+        commit: bool = True,
+    ) -> AuditEventDetails:
+        if commit is False:
+            return AuditEventDetails(emit=False)
+        return AuditEventDetails(
+            data={"changed_fields": sorted(params.model_fields_set)}
+        )
 
     async def _lock_workflow(self, workflow_id: WorkflowID) -> None:
         workflow_uuid = WorkflowUUID.new(workflow_id)
@@ -169,7 +161,7 @@ class CaseTriggersService(BaseWorkspaceService):
     @requires_entitlement(Entitlement.CASE_ADDONS)
     @audit_log(
         resource_type="case_trigger",
-        action="create",
+        action="upsert",
         resource_id_attr="id",
         attempt_metadata=_case_trigger_upsert_audit_details,
     )

--- a/tracecat/workflow/case_triggers/service.py
+++ b/tracecat/workflow/case_triggers/service.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import cast
 
 from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
+from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
 from tracecat.db.models import CaseTag, CaseTrigger, Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -13,6 +15,40 @@ from tracecat.identifiers.workflow import WorkflowID, WorkflowUUID
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
 from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig, CaseTriggerUpdate
+
+
+async def _case_trigger_upsert_audit_details(
+    context: AuditCallContext,
+) -> AuditEventDetails:
+    if context.arguments.get("commit", True) is False:
+        return AuditEventDetails(emit=False)
+    service = cast(BaseWorkspaceService, context.target)
+    workflow_id = cast(WorkflowID, context.arguments["workflow_id"])
+    params = cast(CaseTriggerConfig, context.arguments["params"])
+    existing = await service.session.scalar(
+        select(CaseTrigger).where(
+            CaseTrigger.workspace_id == service.workspace_id,
+            CaseTrigger.workflow_id == WorkflowUUID.new(workflow_id),
+        )
+    )
+    if existing is None:
+        return AuditEventDetails(action="create")
+    return AuditEventDetails(
+        action="update",
+        resource_id=existing.id,
+        data={"changed_fields": sorted(params.model_dump())},
+    )
+
+
+def _case_trigger_update_audit_details(
+    context: AuditCallContext,
+) -> AuditEventDetails:
+    if context.arguments.get("commit", True) is False:
+        return AuditEventDetails(emit=False)
+    params = cast(CaseTriggerUpdate, context.arguments["params"])
+    return AuditEventDetails(
+        data={"changed_fields": sorted(params.model_dump(exclude_unset=True))}
+    )
 
 
 class CaseTriggersService(BaseWorkspaceService):
@@ -131,6 +167,12 @@ class CaseTriggersService(BaseWorkspaceService):
         return await self._ensure_case_trigger_exists(workflow_id)
 
     @requires_entitlement(Entitlement.CASE_ADDONS)
+    @audit_log(
+        resource_type="case_trigger",
+        action="create",
+        resource_id_attr="id",
+        attempt_metadata=_case_trigger_upsert_audit_details,
+    )
     async def upsert_case_trigger(
         self,
         workflow_id: WorkflowID,
@@ -205,6 +247,12 @@ class CaseTriggersService(BaseWorkspaceService):
             return case_trigger
 
     @requires_entitlement(Entitlement.CASE_ADDONS)
+    @audit_log(
+        resource_type="case_trigger",
+        action="update",
+        resource_id_attr="id",
+        attempt_metadata=_case_trigger_update_audit_details,
+    )
     async def update_case_trigger(
         self,
         workflow_id: WorkflowID,

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -645,23 +645,17 @@ async def update_webhook(
     Mirrors the public ``PATCH /workflows/{id}/webhook`` route so the workflows
     SDK (which resolves under ``/internal``) can enable/disable webhooks.
     """
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
+    try:
+        await webhook_service.update_webhook(
+            role=role,
+            session=session,
+            workflow_id=workflow_id,
+            params=params,
         )
-    webhook = await webhook_service.get_webhook(
-        session=session,
-        workspace_id=role.workspace_id,
-        workflow_id=workflow_id,
-    )
-    if webhook is None:
-        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="Webhook not found")
-    for key, value in params.model_dump(exclude_unset=True).items():
-        # Safety: params have been validated by WebhookUpdate
-        setattr(webhook, key, value)
-    session.add(webhook)
-    await session.commit()
-    await session.refresh(webhook)
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND, detail="Webhook not found"
+        ) from e
 
 
 @router.get("/{workflow_id}/case-trigger", status_code=HTTP_200_OK)

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -524,6 +524,7 @@ async def edit_workflow_document(
             workflow=workflow,
             original_document=draft_document,
             updated_document=updated_document,
+            changed_sections=changed_sections,
         )
         await service.session.refresh(
             workflow,

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -2,7 +2,6 @@ import base64
 from datetime import datetime
 from typing import Any, Literal
 
-import temporalio.service
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import ValidationError
 from sqlalchemy import or_, select
@@ -1134,14 +1133,6 @@ async def cancel_workflow_execution(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    except temporalio.service.RPCError as e:
-        if "workflow execution already completed" in e.message:
-            logger.info(
-                "Workflow execution already completed, ignoring cancellation request",
-            )
-        else:
-            logger.error(e.message, error=e, execution_id=execution_id)
-            raise e
 
 
 @router.post(
@@ -1163,11 +1154,3 @@ async def terminate_workflow_execution(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    except temporalio.service.RPCError as e:
-        if "workflow execution already completed" in e.message:
-            logger.info(
-                "Workflow execution already completed, ignoring termination request",
-            )
-        else:
-            logger.error(e.message, error=e, execution_id=execution_id)
-            raise e

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -9,7 +9,7 @@ import uuid
 from collections import OrderedDict
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import orjson
 import temporalio.api.enums.v1
@@ -30,12 +30,7 @@ from temporalio.exceptions import TerminatedError
 from temporalio.service import RPCError, RPCStatusCode
 
 from tracecat import config
-from tracecat.audit.logger import (
-    AuditAttemptMetadataFn,
-    AuditCallContext,
-    AuditEventDetails,
-    audit_log,
-)
+from tracecat.audit.logger import AuditEventDetails, audit_log
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.db.models import Interaction
@@ -109,23 +104,6 @@ from tracecat.workflow.executions.schemas import (
     WorkflowExecutionStatusLiteral,
 )
 from tracecat.workspaces.service import WorkspaceService
-
-
-def _execution_control_audit_details(
-    operation: Literal["reset", "cancel", "terminate"],
-) -> AuditAttemptMetadataFn:
-    def details(context: AuditCallContext) -> AuditEventDetails:
-        execution_id = cast(
-            WorkflowExecutionID,
-            context.arguments["wf_exec_id"],
-        )
-        workflow_id, _ = exec_id_to_parts(execution_id)
-        return AuditEventDetails(
-            resource_id=workflow_id,
-            data={"execution_id": execution_id, "operation": operation},
-        )
-
-    return details
 
 
 class WorkflowExecutionResultNotFoundError(ValueError):
@@ -1960,10 +1938,42 @@ class WorkflowExecutionsService:
             )
         return reset_event_id
 
+    def _reset_workflow_execution_audit_details(
+        self,
+        wf_exec_id: WorkflowExecutionID,
+        *,
+        event_id: int | None,
+        reason: str | None = None,
+        reapply_type: WorkflowExecutionResetReapplyType = WorkflowExecutionResetReapplyType.ALL_ELIGIBLE,
+    ) -> AuditEventDetails:
+        workflow_id, _ = exec_id_to_parts(wf_exec_id)
+        return AuditEventDetails(
+            resource_id=workflow_id,
+            data={"execution_id": wf_exec_id, "operation": "reset"},
+        )
+
+    def _cancel_workflow_execution_audit_details(
+        self, wf_exec_id: WorkflowExecutionID
+    ) -> AuditEventDetails:
+        workflow_id, _ = exec_id_to_parts(wf_exec_id)
+        return AuditEventDetails(
+            resource_id=workflow_id,
+            data={"execution_id": wf_exec_id, "operation": "cancel"},
+        )
+
+    def _terminate_workflow_execution_audit_details(
+        self, wf_exec_id: WorkflowExecutionID, reason: str | None = None
+    ) -> AuditEventDetails:
+        workflow_id, _ = exec_id_to_parts(wf_exec_id)
+        return AuditEventDetails(
+            resource_id=workflow_id,
+            data={"execution_id": wf_exec_id, "operation": "terminate"},
+        )
+
     @audit_log(
         resource_type="workflow_execution",
-        action="create",
-        attempt_metadata=_execution_control_audit_details("reset"),
+        action="reset",
+        attempt_metadata=_reset_workflow_execution_audit_details,
     )
     async def reset_workflow_execution(
         self,
@@ -2034,7 +2044,7 @@ class WorkflowExecutionsService:
     @audit_log(
         resource_type="workflow_execution",
         action="cancel",
-        attempt_metadata=_execution_control_audit_details("cancel"),
+        attempt_metadata=_cancel_workflow_execution_audit_details,
     )
     async def cancel_workflow_execution(self, wf_exec_id: WorkflowExecutionID) -> None:
         """Cancel a workflow execution."""
@@ -2051,8 +2061,8 @@ class WorkflowExecutionsService:
 
     @audit_log(
         resource_type="workflow_execution",
-        action="cancel",
-        attempt_metadata=_execution_control_audit_details("terminate"),
+        action="terminate",
+        attempt_metadata=_terminate_workflow_execution_audit_details,
     )
     async def terminate_workflow_execution(
         self, wf_exec_id: WorkflowExecutionID, reason: str | None = None

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -9,7 +9,7 @@ import uuid
 from collections import OrderedDict
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import orjson
 import temporalio.api.enums.v1
@@ -27,10 +27,15 @@ from temporalio.client import (
 )
 from temporalio.common import TypedSearchAttributes, WorkflowIDReusePolicy
 from temporalio.exceptions import TerminatedError
-from temporalio.service import RPCError
+from temporalio.service import RPCError, RPCStatusCode
 
 from tracecat import config
-from tracecat.audit.logger import audit_log
+from tracecat.audit.logger import (
+    AuditAttemptMetadataFn,
+    AuditCallContext,
+    AuditEventDetails,
+    audit_log,
+)
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.db.models import Interaction
@@ -46,6 +51,7 @@ from tracecat.identifiers import UserID, WorkspaceID
 from tracecat.identifiers.workflow import (
     WorkflowExecutionID,
     WorkflowID,
+    exec_id_to_parts,
     generate_exec_id,
 )
 from tracecat.logger import logger
@@ -103,6 +109,23 @@ from tracecat.workflow.executions.schemas import (
     WorkflowExecutionStatusLiteral,
 )
 from tracecat.workspaces.service import WorkspaceService
+
+
+def _execution_control_audit_details(
+    operation: Literal["reset", "cancel", "terminate"],
+) -> AuditAttemptMetadataFn:
+    def details(context: AuditCallContext) -> AuditEventDetails:
+        execution_id = cast(
+            WorkflowExecutionID,
+            context.arguments["wf_exec_id"],
+        )
+        workflow_id, _ = exec_id_to_parts(execution_id)
+        return AuditEventDetails(
+            resource_id=workflow_id,
+            data={"execution_id": execution_id, "operation": operation},
+        )
+
+    return details
 
 
 class WorkflowExecutionResultNotFoundError(ValueError):
@@ -1937,6 +1960,11 @@ class WorkflowExecutionsService:
             )
         return reset_event_id
 
+    @audit_log(
+        resource_type="workflow_execution",
+        action="create",
+        attempt_metadata=_execution_control_audit_details("reset"),
+    )
     async def reset_workflow_execution(
         self,
         wf_exec_id: WorkflowExecutionID,
@@ -2003,14 +2031,40 @@ class WorkflowExecutionsService:
             *[_reset(execution_id) for execution_id in execution_ids]
         )
 
+    @audit_log(
+        resource_type="workflow_execution",
+        action="cancel",
+        attempt_metadata=_execution_control_audit_details("cancel"),
+    )
     async def cancel_workflow_execution(self, wf_exec_id: WorkflowExecutionID) -> None:
         """Cancel a workflow execution."""
         await self.require_execution(wf_exec_id)
-        await self.handle(wf_exec_id).cancel()
+        try:
+            await self.handle(wf_exec_id).cancel()
+        except RPCError as exc:
+            if exc.status != RPCStatusCode.NOT_FOUND:
+                raise
+            self.logger.info(
+                "Workflow execution already completed, ignoring cancellation request",
+                wf_exec_id=wf_exec_id,
+            )
 
+    @audit_log(
+        resource_type="workflow_execution",
+        action="cancel",
+        attempt_metadata=_execution_control_audit_details("terminate"),
+    )
     async def terminate_workflow_execution(
         self, wf_exec_id: WorkflowExecutionID, reason: str | None = None
     ) -> None:
         """Terminate a workflow execution."""
         await self.require_execution(wf_exec_id)
-        await self.handle(wf_exec_id).terminate(reason=reason)
+        try:
+            await self.handle(wf_exec_id).terminate(reason=reason)
+        except RPCError as exc:
+            if exc.status != RPCStatusCode.NOT_FOUND:
+                raise
+            self.logger.info(
+                "Workflow execution already completed, ignoring termination request",
+                wf_exec_id=wf_exec_id,
+            )

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -1949,7 +1949,14 @@ class WorkflowExecutionsService:
         workflow_id, _ = exec_id_to_parts(wf_exec_id)
         return AuditEventDetails(
             resource_id=workflow_id,
-            data={"execution_id": wf_exec_id, "operation": "reset"},
+            # Free-text ``reason`` is excluded by the audit content policy;
+            # record only its presence and the requested reset point.
+            data={
+                "execution_id": wf_exec_id,
+                "operation": "reset",
+                "event_id": str(event_id) if event_id is not None else None,
+                "has_reason": reason is not None,
+            },
         )
 
     def _cancel_workflow_execution_audit_details(
@@ -1967,7 +1974,12 @@ class WorkflowExecutionsService:
         workflow_id, _ = exec_id_to_parts(wf_exec_id)
         return AuditEventDetails(
             resource_id=workflow_id,
-            data={"execution_id": wf_exec_id, "operation": "terminate"},
+            # Free-text ``reason`` is excluded by the audit content policy.
+            data={
+                "execution_id": wf_exec_id,
+                "operation": "terminate",
+                "has_reason": reason is not None,
+            },
         )
 
     @audit_log(

--- a/tracecat/workflow/graph/service.py
+++ b/tracecat/workflow/graph/service.py
@@ -4,13 +4,15 @@ Implements the canonical graph API with optimistic concurrency.
 """
 
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from fastapi import HTTPException, status
 from sqlalchemy import column, delete, func, literal, select, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import selectinload
 
+from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
 from tracecat.db.models import Action, Workflow
 from tracecat.dsl.view import RFGraph
 from tracecat.identifiers import WorkflowID
@@ -32,6 +34,35 @@ from tracecat.workflow.management.schemas import (
 type EdgeSourceType = Literal["trigger", "udf"]
 type EdgeHandle = Literal["success", "error"]
 
+_STRUCTURAL_OPERATION_TYPES = {
+    "add_node",
+    "update_node",
+    "delete_node",
+    "add_edge",
+    "delete_edge",
+}
+
+
+def _graph_audit_details(context: AuditCallContext) -> AuditEventDetails:
+    operations = cast(list[GraphOperation], context.arguments["operations"])
+    changed_fields = sorted(
+        {
+            "definition" if operation.type in _STRUCTURAL_OPERATION_TYPES else "layout"
+            for operation in operations
+        }
+    )
+    return AuditEventDetails(data={"changed_fields": changed_fields})
+
+
+def _graph_audit_result(
+    _context: AuditCallContext, result: GraphResponse | None
+) -> AuditEventDetails:
+    return AuditEventDetails(
+        status=(
+            AuditEventStatus.SUCCESS if result is not None else AuditEventStatus.FAILURE
+        )
+    )
+
 
 @dataclass(frozen=True, slots=True)
 class EdgeDedupKey:
@@ -45,13 +76,7 @@ class WorkflowGraphService(BaseWorkspaceService):
 
     service_name = "workflow_graph"
 
-    _STRUCTURAL_OPS = {
-        "add_node",
-        "update_node",
-        "delete_node",
-        "add_edge",
-        "delete_edge",
-    }
+    _STRUCTURAL_OPS = _STRUCTURAL_OPERATION_TYPES
 
     async def get_graph(self, workflow_id: WorkflowID) -> GraphResponse | None:
         """Get the canonical graph projection from Actions.
@@ -90,6 +115,12 @@ class WorkflowGraphService(BaseWorkspaceService):
             },
         )
 
+    @audit_log(
+        resource_type="workflow",
+        action="update",
+        attempt_metadata=_graph_audit_details,
+        terminal_metadata=_graph_audit_result,
+    )
     async def apply_operations(
         self,
         workflow_id: WorkflowID,
@@ -101,7 +132,6 @@ class WorkflowGraphService(BaseWorkspaceService):
         Returns 409 if base_version doesn't match current graph_version.
         """
         workflow_uuid = WorkflowUUID.new(workflow_id)
-
         # Load workflow with FOR UPDATE lock
         stmt = (
             select(Workflow)
@@ -117,6 +147,25 @@ class WorkflowGraphService(BaseWorkspaceService):
 
         if workflow is None:
             return None
+        return await self.apply_operations_to_locked_workflow(
+            workflow,
+            base_version=base_version,
+            operations=operations,
+        )
+
+    async def apply_operations_to_locked_workflow(
+        self,
+        workflow: Workflow,
+        *,
+        base_version: int,
+        operations: list[GraphOperation],
+    ) -> GraphResponse:
+        """Apply operations to a workflow locked by the caller.
+
+        This compositional entry point does not perform another lookup or emit
+        an independent audit event. The caller owns the workflow lock and the
+        surrounding operation's audit lifecycle.
+        """
 
         # Check version for optimistic concurrency
         if workflow.graph_version != base_version:

--- a/tracecat/workflow/graph/service.py
+++ b/tracecat/workflow/graph/service.py
@@ -3,8 +3,10 @@
 Implements the canonical graph API with optimistic concurrency.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from fastapi import HTTPException, status
 from sqlalchemy import column, delete, func, literal, select, update
@@ -12,7 +14,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import selectinload
 
 from tracecat.audit.enums import AuditEventStatus
-from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
+from tracecat.audit.logger import AuditEventDetails, audit_log
 from tracecat.db.models import Action, Workflow
 from tracecat.dsl.view import RFGraph
 from tracecat.identifiers import WorkflowID
@@ -43,27 +45,6 @@ _STRUCTURAL_OPERATION_TYPES = {
 }
 
 
-def _graph_audit_details(context: AuditCallContext) -> AuditEventDetails:
-    operations = cast(list[GraphOperation], context.arguments["operations"])
-    changed_fields = sorted(
-        {
-            "definition" if operation.type in _STRUCTURAL_OPERATION_TYPES else "layout"
-            for operation in operations
-        }
-    )
-    return AuditEventDetails(data={"changed_fields": changed_fields})
-
-
-def _graph_audit_result(
-    _context: AuditCallContext, result: GraphResponse | None
-) -> AuditEventDetails:
-    return AuditEventDetails(
-        status=(
-            AuditEventStatus.SUCCESS if result is not None else AuditEventStatus.FAILURE
-        )
-    )
-
-
 @dataclass(frozen=True, slots=True)
 class EdgeDedupKey:
     source_id: str
@@ -77,6 +58,37 @@ class WorkflowGraphService(BaseWorkspaceService):
     service_name = "workflow_graph"
 
     _STRUCTURAL_OPS = _STRUCTURAL_OPERATION_TYPES
+
+    def _graph_audit_details(
+        self,
+        workflow_id: WorkflowID,
+        base_version: int,
+        operations: list[GraphOperation],
+    ) -> AuditEventDetails:
+        changed_fields = sorted(
+            {
+                (
+                    "definition"
+                    if operation.type in _STRUCTURAL_OPERATION_TYPES
+                    else "layout"
+                )
+                for operation in operations
+            }
+        )
+        return AuditEventDetails(data={"changed_fields": changed_fields})
+
+    # Gradual form: a named signature fails pyright's name check; _graph_audit_details keeps P pinned.
+    @staticmethod
+    def _graph_audit_result(
+        result: GraphResponse | None, *args: Any, **kwargs: Any
+    ) -> AuditEventDetails:
+        return AuditEventDetails(
+            status=(
+                AuditEventStatus.SUCCESS
+                if result is not None
+                else AuditEventStatus.FAILURE
+            )
+        )
 
     async def get_graph(self, workflow_id: WorkflowID) -> GraphResponse | None:
         """Get the canonical graph projection from Actions.

--- a/tracecat/workflow/management/draft.py
+++ b/tracecat/workflow/management/draft.py
@@ -847,18 +847,23 @@ def parse_workflow_edit_request(
 
 def _workflow_edit_audit_details(context: AuditCallContext) -> AuditEventDetails:
     workflow = cast(Workflow, context.arguments["workflow"])
-    original_document = cast(
-        WorkflowEditDocument,
-        context.arguments["original_document"],
+    changed_sections = cast(
+        set[str] | None,
+        context.arguments.get("changed_sections"),
     )
-    updated_document = cast(
-        WorkflowEditDocument,
-        context.arguments["updated_document"],
-    )
-    changed_sections = workflow_edit_document_changed_sections(
-        original_document,
-        updated_document,
-    )
+    if changed_sections is None:
+        original_document = cast(
+            WorkflowEditDocument,
+            context.arguments["original_document"],
+        )
+        updated_document = cast(
+            WorkflowEditDocument,
+            context.arguments["updated_document"],
+        )
+        changed_sections = workflow_edit_document_changed_sections(
+            original_document,
+            updated_document,
+        )
     return AuditEventDetails(
         resource_id=WorkflowUUID.new(workflow.id),
         data={"changed_fields": sorted(changed_sections)},
@@ -878,12 +883,14 @@ async def persist_workflow_edit_document(
     workflow: Workflow,
     original_document: WorkflowEditDocument,
     updated_document: WorkflowEditDocument,
+    changed_sections: set[str] | None = None,
 ) -> None:
     """Persist changes from the editable workflow document back to the draft."""
-    changed_sections = workflow_edit_document_changed_sections(
-        original_document,
-        updated_document,
-    )
+    if changed_sections is None:
+        changed_sections = workflow_edit_document_changed_sections(
+            original_document,
+            updated_document,
+        )
     if not changed_sections:
         return
 

--- a/tracecat/workflow/management/draft.py
+++ b/tracecat/workflow/management/draft.py
@@ -28,7 +28,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
+from tracecat.audit.logger import AuditEventDetails, audit_log
 from tracecat.auth.types import Role
 from tracecat.db.common import DBConstraints
 from tracecat.db.models import Action, Workflow
@@ -845,21 +845,16 @@ def parse_workflow_edit_request(
     return request
 
 
-def _workflow_edit_audit_details(context: AuditCallContext) -> AuditEventDetails:
-    workflow = cast(Workflow, context.arguments["workflow"])
-    changed_sections = cast(
-        set[str] | None,
-        context.arguments.get("changed_sections"),
-    )
+def _workflow_edit_audit_details(
+    *,
+    role: Any,
+    service: WorkflowsManagementService,
+    workflow: Workflow,
+    original_document: WorkflowEditDocument,
+    updated_document: WorkflowEditDocument,
+    changed_sections: set[str] | None = None,
+) -> AuditEventDetails:
     if changed_sections is None:
-        original_document = cast(
-            WorkflowEditDocument,
-            context.arguments["original_document"],
-        )
-        updated_document = cast(
-            WorkflowEditDocument,
-            context.arguments["updated_document"],
-        )
         changed_sections = workflow_edit_document_changed_sections(
             original_document,
             updated_document,

--- a/tracecat/workflow/management/draft.py
+++ b/tracecat/workflow/management/draft.py
@@ -847,7 +847,7 @@ def parse_workflow_edit_request(
 
 def _workflow_edit_audit_details(
     *,
-    role: Any,
+    role: Role,
     service: WorkflowsManagementService,
     workflow: Workflow,
     original_document: WorkflowEditDocument,
@@ -873,7 +873,7 @@ def _workflow_edit_audit_details(
 )
 async def persist_workflow_edit_document(
     *,
-    role: Any,
+    role: Role,
     service: WorkflowsManagementService,
     workflow: Workflow,
     original_document: WorkflowEditDocument,

--- a/tracecat/workflow/management/draft.py
+++ b/tracecat/workflow/management/draft.py
@@ -28,6 +28,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
 from tracecat.auth.types import Role
 from tracecat.db.common import DBConstraints
 from tracecat.db.models import Action, Workflow
@@ -844,6 +845,32 @@ def parse_workflow_edit_request(
     return request
 
 
+def _workflow_edit_audit_details(context: AuditCallContext) -> AuditEventDetails:
+    workflow = cast(Workflow, context.arguments["workflow"])
+    original_document = cast(
+        WorkflowEditDocument,
+        context.arguments["original_document"],
+    )
+    updated_document = cast(
+        WorkflowEditDocument,
+        context.arguments["updated_document"],
+    )
+    changed_sections = workflow_edit_document_changed_sections(
+        original_document,
+        updated_document,
+    )
+    return AuditEventDetails(
+        resource_id=WorkflowUUID.new(workflow.id),
+        data={"changed_fields": sorted(changed_sections)},
+        emit=bool(changed_sections),
+    )
+
+
+@audit_log(
+    resource_type="workflow",
+    action="update",
+    attempt_metadata=_workflow_edit_audit_details,
+)
 async def persist_workflow_edit_document(
     *,
     role: Any,

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -16,7 +16,7 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.catalog.service import AgentCatalogService
-from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
+from tracecat.audit.logger import AuditEventDetails, audit_log
 from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_logical_time
 from tracecat.db.models import (
@@ -96,17 +96,6 @@ from tracecat.workflow.schedules import bridge
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
 
 
-def _workflow_update_audit_details(
-    context: AuditCallContext,
-) -> AuditEventDetails:
-    params = cast(WorkflowUpdate, context.arguments["params"])
-    return AuditEventDetails(
-        data={
-            "changed_fields": sorted(params.model_dump(exclude_unset=True)),
-        }
-    )
-
-
 class _ModelKey(NamedTuple):
     """Stable cross-environment identity of a model selection.
 
@@ -140,6 +129,13 @@ class WorkflowsManagementService(BaseWorkspaceService):
     """Manages CRUD operations for Workflows."""
 
     service_name = "workflows"
+
+    def _workflow_update_audit_details(
+        self, workflow_id: WorkflowID, params: WorkflowUpdate
+    ) -> AuditEventDetails:
+        return AuditEventDetails(
+            data={"changed_fields": sorted(params.model_fields_set)}
+        )
 
     @staticmethod
     def _workflow_fields_from_dsl(dsl: DSLInput) -> dict[str, Any]:

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -16,7 +16,7 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.catalog.service import AgentCatalogService
-from tracecat.audit.logger import audit_log
+from tracecat.audit.logger import AuditCallContext, AuditEventDetails, audit_log
 from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_logical_time
 from tracecat.db.models import (
@@ -94,6 +94,17 @@ from tracecat.workflow.management.types import (
 )
 from tracecat.workflow.schedules import bridge
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
+
+
+def _workflow_update_audit_details(
+    context: AuditCallContext,
+) -> AuditEventDetails:
+    params = cast(WorkflowUpdate, context.arguments["params"])
+    return AuditEventDetails(
+        data={
+            "changed_fields": sorted(params.model_dump(exclude_unset=True)),
+        }
+    )
 
 
 class _ModelKey(NamedTuple):
@@ -764,17 +775,22 @@ class WorkflowsManagementService(BaseWorkspaceService):
         return WorkflowUUID.new(res) if res else None
 
     @require_scope("workflow:update")
+    @audit_log(
+        resource_type="workflow",
+        action="update",
+        attempt_metadata=_workflow_update_audit_details,
+    )
     async def update_workflow(
         self, workflow_id: WorkflowID, params: WorkflowUpdate
     ) -> Workflow:
         workflow_uuid = WorkflowUUID.new(workflow_id)
+        set_fields = params.model_dump(exclude_unset=True)
         statement = select(Workflow).where(
             Workflow.workspace_id == self.workspace_id,
             Workflow.id == workflow_uuid,
         )
         result = await self.session.execute(statement)
         workflow = result.scalar_one()
-        set_fields = params.model_dump(exclude_unset=True)
         if "object" in set_fields:
             graph = RFGraph.model_validate(set_fields["object"])
             normalized_graph = graph.normalize_action_ids()
@@ -928,6 +944,10 @@ class WorkflowsManagementService(BaseWorkspaceService):
             raise e
 
     @require_scope("workflow:update")
+    @audit_log(
+        resource_type="workflow",
+        action="publish",
+    )
     async def publish_workflow(self, workflow_id: WorkflowID) -> WorkflowPublishResult:
         """Publish (commit) a workflow's current draft as a new versioned definition.
 
@@ -942,6 +962,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
         Raises:
             TracecatNotFoundError: If the workflow does not exist.
         """
+
         workflow = await self.get_workflow(workflow_id)
         if workflow is None:
             raise TracecatNotFoundError(f"Workflow {workflow_id} not found")
@@ -978,8 +999,8 @@ class WorkflowsManagementService(BaseWorkspaceService):
         ):
             return WorkflowPublishResult(version=None, errors=list(val_errors))
 
-        # Phase 1: resolve a registry lock over the DSL's actions so the published
-        # definition is pinned to exact action versions.
+        # Phase 1: resolve a registry lock over the DSL's actions so the
+        # published definition is pinned to exact action versions.
         lock_service = RegistryLockService(self.session, self.role)
         action_names = {action.action for action in dsl.actions}
         try:
@@ -1155,6 +1176,11 @@ class WorkflowsManagementService(BaseWorkspaceService):
         )
 
     @require_scope("workflow:update")
+    @audit_log(
+        resource_type="workflow",
+        action="update",
+        resource_id_attr="id",
+    )
     async def restore_workflow_definition(
         self, workflow: Workflow, definition: WorkflowDefinition
     ) -> Workflow:
@@ -1225,8 +1251,8 @@ class WorkflowsManagementService(BaseWorkspaceService):
             if item["ref"] in ref_to_action_id
         ]
         graph_service = WorkflowGraphService(self.session, role=self.role)
-        await graph_service.apply_operations(
-            workflow_id=WorkflowUUID.new(workflow.id),
+        await graph_service.apply_operations_to_locked_workflow(
+            workflow,
             base_version=workflow.graph_version,
             operations=[
                 GraphOperation(
@@ -1377,6 +1403,11 @@ class WorkflowsManagementService(BaseWorkspaceService):
         return dsl.model_copy(update={"actions": new_actions})
 
     @require_scope("workflow:create")
+    @audit_log(
+        resource_type="workflow",
+        action="create",
+        resource_id_attr="id",
+    )
     async def create_workflow_from_external_definition(
         self,
         import_data: dict[str, Any],

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Literal, cast
@@ -21,13 +22,21 @@ from pydantic import ValidationError
 from slugify import slugify
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
+from tracecat.audit.logger import (
+    AuditAttemptMetadataFn,
+    AuditCallContext,
+    AuditEventDetails,
+    audit_log,
+)
 from tracecat.auth.api_keys import generate_api_key
 from tracecat.auth.dependencies import (
     WorkspaceActorRouteRole,
     WorkspaceUserRouteRole,
 )
+from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.db.common import DBConstraints
 from tracecat.db.dependencies import AsyncDBSession
@@ -705,12 +714,84 @@ async def create_workflow_definition(
 # ----- Workflow Webhooks ----- #
 
 
+async def _webhook_create_audit_result(
+    context: AuditCallContext,
+    _result: None,
+) -> AuditEventDetails:
+    session = cast(AsyncSession, context.arguments["session"])
+    role = cast(Role, context.arguments["role"])
+    workflow_id = cast(WorkflowUUID, context.arguments["workflow_id"])
+    if role.workspace_id is None:
+        return AuditEventDetails()
+    webhook = await webhook_service.get_webhook(
+        session=session,
+        workspace_id=role.workspace_id,
+        workflow_id=workflow_id,
+    )
+    return AuditEventDetails(
+        resource_id=webhook.id if webhook is not None else None,
+    )
+
+
+async def _get_webhook_key_audit_target(
+    context: AuditCallContext,
+) -> tuple[uuid.UUID | None, uuid.UUID | None]:
+    session = cast(AsyncSession, context.arguments["session"])
+    role = cast(Role, context.arguments["role"])
+    workflow_id = cast(WorkflowUUID, context.arguments["workflow_id"])
+    if role.workspace_id is None:
+        return None, None
+    row = (
+        await session.execute(
+            select(Webhook.id, WebhookApiKey.id)
+            .outerjoin(WebhookApiKey, WebhookApiKey.webhook_id == Webhook.id)
+            .where(
+                Webhook.workspace_id == role.workspace_id,
+                Webhook.workflow_id == workflow_id,
+            )
+        )
+    ).one_or_none()
+    return (row[0], row[1]) if row is not None else (None, None)
+
+
+def _webhook_key_audit_details(
+    operation: Literal["generate", "revoke", "delete"],
+) -> AuditAttemptMetadataFn:
+    async def details(context: AuditCallContext) -> AuditEventDetails:
+        webhook_id, api_key_id = await _get_webhook_key_audit_target(context)
+        action = None
+        if operation == "generate":
+            action = "create" if api_key_id is None else "rotate"
+        return AuditEventDetails(
+            action=action,
+            resource_id=api_key_id,
+            data={
+                "webhook_id": str(webhook_id) if webhook_id is not None else None,
+            },
+        )
+
+    return details
+
+
+async def _webhook_key_audit_result(
+    context: AuditCallContext,
+    _result: WebhookApiKeyGenerateResponse,
+) -> AuditEventDetails:
+    _, api_key_id = await _get_webhook_key_audit_target(context)
+    return AuditEventDetails(resource_id=api_key_id)
+
+
 @router.post(
     "/{workflow_id}/webhook",
     status_code=status.HTTP_201_CREATED,
     tags=["triggers"],
 )
 @require_scope("workflow:update")
+@audit_log(
+    resource_type="webhook",
+    action="create",
+    terminal_metadata=_webhook_create_audit_result,
+)
 async def create_webhook(
     role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
@@ -776,28 +857,15 @@ async def update_webhook(
     params: WebhookUpdate,
 ) -> None:
     """Update the webhook for a workflow. We currently supprt only one webhook per workflow."""
-    result = await session.execute(
-        select(Workflow).where(
-            Workflow.workspace_id == role.workspace_id,
-            Workflow.id == workflow_id,
-        )
-    )
     try:
-        workflow = result.scalar_one()
-    except NoResultFound as e:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
-        ) from e
-
-    webhook = workflow.webhook
-
-    for key, value in params.model_dump(exclude_unset=True).items():
-        # Safety: params have been validated
-        setattr(webhook, key, value)
-
-    session.add(webhook)
-    await session.commit()
-    await session.refresh(webhook)
+        await webhook_service.update_webhook(
+            role=role,
+            session=session,
+            workflow_id=workflow_id,
+            params=params,
+        )
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
 
 # ----- Workflow Case Triggers ----- #
@@ -879,6 +947,12 @@ async def update_case_trigger(
     status_code=status.HTTP_201_CREATED,
 )
 @require_scope("workflow:update")
+@audit_log(
+    resource_type="webhook_api_key",
+    action="create",
+    attempt_metadata=_webhook_key_audit_details("generate"),
+    terminal_metadata=_webhook_key_audit_result,
+)
 async def generate_webhook_api_key(
     role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
@@ -890,7 +964,9 @@ async def generate_webhook_api_key(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
         )
     webhook = await webhook_service.get_webhook(
-        session=session, workspace_id=role.workspace_id, workflow_id=workflow_id
+        session=session,
+        workspace_id=role.workspace_id,
+        workflow_id=workflow_id,
     )
     if webhook is None:
         raise HTTPException(
@@ -933,6 +1009,11 @@ async def generate_webhook_api_key(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 @require_scope("workflow:update")
+@audit_log(
+    resource_type="webhook_api_key",
+    action="revoke",
+    attempt_metadata=_webhook_key_audit_details("revoke"),
+)
 async def revoke_webhook_api_key(
     role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
@@ -944,7 +1025,9 @@ async def revoke_webhook_api_key(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
         )
     webhook = await webhook_service.get_webhook(
-        session=session, workspace_id=role.workspace_id, workflow_id=workflow_id
+        session=session,
+        workspace_id=role.workspace_id,
+        workflow_id=workflow_id,
     )
     if webhook is None:
         raise HTTPException(
@@ -952,9 +1035,7 @@ async def revoke_webhook_api_key(
         )
     now = datetime.now(UTC)
     api_key = webhook.api_key
-    if api_key is None:
-        return
-    if api_key.revoked_at is not None:
+    if api_key is None or api_key.revoked_at is not None:
         return
     api_key.revoked_at = now
     api_key.revoked_by = role.user_id
@@ -969,6 +1050,11 @@ async def revoke_webhook_api_key(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 @require_scope("workflow:delete")
+@audit_log(
+    resource_type="webhook_api_key",
+    action="delete",
+    attempt_metadata=_webhook_key_audit_details("delete"),
+)
 async def delete_webhook_api_key(
     role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
@@ -980,7 +1066,9 @@ async def delete_webhook_api_key(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
         )
     webhook = await webhook_service.get_webhook(
-        session=session, workspace_id=role.workspace_id, workflow_id=workflow_id
+        session=session,
+        workspace_id=role.workspace_id,
+        workflow_id=workflow_id,
     )
     if webhook is None:
         raise HTTPException(

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -26,8 +26,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
 from tracecat.audit.logger import (
-    AuditAttemptMetadataFn,
-    AuditCallContext,
     AuditEventDetails,
     audit_log,
 )
@@ -715,12 +713,12 @@ async def create_workflow_definition(
 
 
 async def _webhook_create_audit_result(
-    context: AuditCallContext,
     _result: None,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+    params: WebhookCreate,
 ) -> AuditEventDetails:
-    session = cast(AsyncSession, context.arguments["session"])
-    role = cast(Role, context.arguments["role"])
-    workflow_id = cast(WorkflowUUID, context.arguments["workflow_id"])
     if role.workspace_id is None:
         return AuditEventDetails()
     webhook = await webhook_service.get_webhook(
@@ -734,11 +732,10 @@ async def _webhook_create_audit_result(
 
 
 async def _get_webhook_key_audit_target(
-    context: AuditCallContext,
+    role: Role,
+    session: AsyncSession,
+    workflow_id: WorkflowUUID,
 ) -> tuple[uuid.UUID | None, uuid.UUID | None]:
-    session = cast(AsyncSession, context.arguments["session"])
-    role = cast(Role, context.arguments["role"])
-    workflow_id = cast(WorkflowUUID, context.arguments["workflow_id"])
     if role.workspace_id is None:
         return None, None
     webhook = await webhook_service.get_webhook(
@@ -754,30 +751,62 @@ async def _get_webhook_key_audit_target(
     return webhook.id, api_key_id
 
 
-def _webhook_key_audit_details(
-    operation: Literal["generate", "revoke", "delete"],
-) -> AuditAttemptMetadataFn:
-    async def details(context: AuditCallContext) -> AuditEventDetails:
-        webhook_id, api_key_id = await _get_webhook_key_audit_target(context)
-        action = None
-        if operation == "generate":
-            action = "create" if api_key_id is None else "rotate"
-        return AuditEventDetails(
-            action=action,
-            resource_id=api_key_id,
-            data={
-                "webhook_id": str(webhook_id) if webhook_id is not None else None,
-            },
-        )
+async def _generate_webhook_key_audit_details(
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+) -> AuditEventDetails:
+    webhook_id, api_key_id = await _get_webhook_key_audit_target(
+        role, session, workflow_id
+    )
+    return AuditEventDetails(
+        action="create" if api_key_id is None else "rotate",
+        resource_id=api_key_id,
+        data={
+            "webhook_id": str(webhook_id) if webhook_id is not None else None,
+        },
+    )
 
-    return details
+
+async def _revoke_webhook_key_audit_details(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+) -> AuditEventDetails:
+    webhook_id, api_key_id = await _get_webhook_key_audit_target(
+        role, session, workflow_id
+    )
+    return AuditEventDetails(
+        resource_id=api_key_id,
+        data={
+            "webhook_id": str(webhook_id) if webhook_id is not None else None,
+        },
+    )
+
+
+async def _delete_webhook_key_audit_details(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+) -> AuditEventDetails:
+    webhook_id, api_key_id = await _get_webhook_key_audit_target(
+        role, session, workflow_id
+    )
+    return AuditEventDetails(
+        resource_id=api_key_id,
+        data={
+            "webhook_id": str(webhook_id) if webhook_id is not None else None,
+        },
+    )
 
 
 async def _webhook_key_audit_result(
-    context: AuditCallContext,
     _result: WebhookApiKeyGenerateResponse,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
 ) -> AuditEventDetails:
-    _, api_key_id = await _get_webhook_key_audit_target(context)
+    _, api_key_id = await _get_webhook_key_audit_target(role, session, workflow_id)
     return AuditEventDetails(resource_id=api_key_id)
 
 
@@ -950,7 +979,7 @@ async def update_case_trigger(
 @audit_log(
     resource_type="webhook_api_key",
     action="create",
-    attempt_metadata=_webhook_key_audit_details("generate"),
+    attempt_metadata=_generate_webhook_key_audit_details,
     terminal_metadata=_webhook_key_audit_result,
 )
 async def generate_webhook_api_key(
@@ -1012,7 +1041,7 @@ async def generate_webhook_api_key(
 @audit_log(
     resource_type="webhook_api_key",
     action="revoke",
-    attempt_metadata=_webhook_key_audit_details("revoke"),
+    attempt_metadata=_revoke_webhook_key_audit_details,
 )
 async def revoke_webhook_api_key(
     role: WorkspaceUserRouteRole,
@@ -1053,7 +1082,7 @@ async def revoke_webhook_api_key(
 @audit_log(
     resource_type="webhook_api_key",
     action="delete",
-    attempt_metadata=_webhook_key_audit_details("delete"),
+    attempt_metadata=_delete_webhook_key_audit_details,
 )
 async def delete_webhook_api_key(
     role: WorkspaceUserRouteRole,

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -768,23 +768,9 @@ async def _generate_webhook_key_audit_details(
     )
 
 
-async def _revoke_webhook_key_audit_details(
-    role: WorkspaceUserRouteRole,
-    session: AsyncDBSession,
-    workflow_id: AnyWorkflowIDPath,
-) -> AuditEventDetails:
-    webhook_id, api_key_id = await _get_webhook_key_audit_target(
-        role, session, workflow_id
-    )
-    return AuditEventDetails(
-        resource_id=api_key_id,
-        data={
-            "webhook_id": str(webhook_id) if webhook_id is not None else None,
-        },
-    )
-
-
-async def _delete_webhook_key_audit_details(
+# Shared by revoke and delete: both endpoints have identical signatures, so
+# one callback satisfies both decorators.
+async def _webhook_key_target_audit_details(
     role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
@@ -1041,7 +1027,7 @@ async def generate_webhook_api_key(
 @audit_log(
     resource_type="webhook_api_key",
     action="revoke",
-    attempt_metadata=_revoke_webhook_key_audit_details,
+    attempt_metadata=_webhook_key_target_audit_details,
 )
 async def revoke_webhook_api_key(
     role: WorkspaceUserRouteRole,
@@ -1082,7 +1068,7 @@ async def revoke_webhook_api_key(
 @audit_log(
     resource_type="webhook_api_key",
     action="delete",
-    attempt_metadata=_delete_webhook_key_audit_details,
+    attempt_metadata=_webhook_key_target_audit_details,
 )
 async def delete_webhook_api_key(
     role: WorkspaceUserRouteRole,

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -741,17 +741,17 @@ async def _get_webhook_key_audit_target(
     workflow_id = cast(WorkflowUUID, context.arguments["workflow_id"])
     if role.workspace_id is None:
         return None, None
-    row = (
-        await session.execute(
-            select(Webhook.id, WebhookApiKey.id)
-            .outerjoin(WebhookApiKey, WebhookApiKey.webhook_id == Webhook.id)
-            .where(
-                Webhook.workspace_id == role.workspace_id,
-                Webhook.workflow_id == workflow_id,
-            )
-        )
-    ).one_or_none()
-    return (row[0], row[1]) if row is not None else (None, None)
+    webhook = await webhook_service.get_webhook(
+        session=session,
+        workspace_id=role.workspace_id,
+        workflow_id=workflow_id,
+    )
+    if webhook is None:
+        return None, None
+    api_key_id = await session.scalar(
+        select(WebhookApiKey.id).where(WebhookApiKey.webhook_id == webhook.id)
+    )
+    return webhook.id, api_key_id
 
 
 def _webhook_key_audit_details(

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import Literal, cast
+from typing import Literal
 
 import orjson
 import yaml
@@ -38,7 +38,7 @@ from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.db.common import DBConstraints
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.db.models import Webhook, WebhookApiKey, Workflow
+from tracecat.db.models import WebhookApiKey, Workflow
 from tracecat.dsl.schemas import DSLConfig
 from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
@@ -712,25 +712,6 @@ async def create_workflow_definition(
 # ----- Workflow Webhooks ----- #
 
 
-async def _webhook_create_audit_result(
-    _result: None,
-    role: WorkspaceActorRouteRole,
-    session: AsyncDBSession,
-    workflow_id: AnyWorkflowIDPath,
-    params: WebhookCreate,
-) -> AuditEventDetails:
-    if role.workspace_id is None:
-        return AuditEventDetails()
-    webhook = await webhook_service.get_webhook(
-        session=session,
-        workspace_id=role.workspace_id,
-        workflow_id=workflow_id,
-    )
-    return AuditEventDetails(
-        resource_id=webhook.id if webhook is not None else None,
-    )
-
-
 async def _get_webhook_key_audit_target(
     role: Role,
     session: AsyncSession,
@@ -802,11 +783,6 @@ async def _webhook_key_audit_result(
     tags=["triggers"],
 )
 @require_scope("workflow:update")
-@audit_log(
-    resource_type="webhook",
-    action="create",
-    terminal_metadata=_webhook_create_audit_result,
-)
 async def create_webhook(
     role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
@@ -818,18 +794,12 @@ async def create_webhook(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
         )
-
-    webhook = Webhook(
-        workspace_id=role.workspace_id,
-        methods=cast(list[str], params.methods),
+    await webhook_service.create_webhook(
+        role=role,
+        session=session,
         workflow_id=workflow_id,
-        status=params.status,
-        allowlisted_cidrs=params.allowlisted_cidrs,
-        include_headers=params.include_headers,
+        params=params,
     )
-    session.add(webhook)
-    await session.commit()
-    await session.refresh(webhook)
 
 
 @router.get(

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Sequence
+from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 from temporalio import activity
 
+from tracecat.audit.logger import AuditEventDetails, audit_log
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import Schedule, Workflow
 from tracecat.db.session_events import AfterCommitQueue
@@ -67,6 +69,11 @@ class WorkflowSchedulesService(BaseWorkspaceService):
         return list(schedules)
 
     @require_scope("schedule:create")
+    @audit_log(
+        resource_type="schedule",
+        action="create",
+        resource_id_attr="id",
+    )
     async def create_schedule(
         self, params: ScheduleCreate, commit: bool = True
     ) -> Schedule:
@@ -94,10 +101,20 @@ class WorkflowSchedulesService(BaseWorkspaceService):
     async def _create_schedule_impl(
         self, params: ScheduleCreate, commit: bool = True
     ) -> Schedule:
-        """Create a schedule without enforcing the standalone schedule scope.
+        """Implement schedule creation for an authorized caller.
 
-        Scope enforcement is the caller's responsibility (see ``create_schedule``
-        and ``replace_schedules``).
+        This internal method lets other methods on this service compose schedule
+        changes under their own authorization and audit lifecycle. External
+        callers must use :meth:`create_schedule`.
+
+        Args:
+            params: Configuration for the new schedule.
+            commit: Whether to commit immediately. When ``False``, the method
+                flushes the row and leaves the transaction and registered
+                Temporal callback to the caller.
+
+        Returns:
+            The newly created schedule.
         """
         await self._lock_workflow(params.workflow_id)
         schedule = Schedule(
@@ -221,6 +238,20 @@ class WorkflowSchedulesService(BaseWorkspaceService):
             raise TracecatNotFoundError(f"Schedule {schedule_uuid} not found") from e
 
     @require_scope("schedule:update")
+    @audit_log(
+        resource_type="schedule",
+        action="update",
+        attempt_metadata=lambda context: AuditEventDetails(
+            data={
+                "changed_fields": sorted(
+                    cast(
+                        ScheduleUpdate,
+                        context.arguments["params"],
+                    ).model_dump(exclude_unset=True)
+                ),
+            }
+        ),
+    )
     async def update_schedule(
         self, schedule_id: AnyScheduleID, params: ScheduleUpdate
     ) -> Schedule:
@@ -275,6 +306,10 @@ class WorkflowSchedulesService(BaseWorkspaceService):
         return schedule
 
     @require_scope("schedule:delete")
+    @audit_log(
+        resource_type="schedule",
+        action="delete",
+    )
     async def delete_schedule(
         self, schedule_id: AnyScheduleID, commit: bool = True
     ) -> None:
@@ -297,10 +332,17 @@ class WorkflowSchedulesService(BaseWorkspaceService):
     async def _delete_schedule_impl(
         self, schedule_id: AnyScheduleID, commit: bool = True
     ) -> None:
-        """Delete a schedule without enforcing the standalone schedule scope.
+        """Implement schedule deletion for an authorized caller.
 
-        Scope enforcement is the caller's responsibility (see ``delete_schedule``
-        and ``replace_schedules``).
+        This internal method lets other methods on this service compose schedule
+        changes under their own authorization and audit lifecycle. External
+        callers must use :meth:`delete_schedule`.
+
+        Args:
+            schedule_id: ID of the schedule to delete.
+            commit: Whether to commit immediately. When ``False``, the method
+                flushes the deletion and leaves the transaction and registered
+                Temporal callback to the caller.
         """
         schedule = await self._get_schedule_with_workflow_lock(schedule_id)
         await self.session.delete(schedule)
@@ -342,8 +384,8 @@ class WorkflowSchedulesService(BaseWorkspaceService):
         than the standalone ``schedule:create``/``schedule:delete`` scopes, so a
         user who is allowed to edit workflows can change their schedules without
         also holding the admin-only ``schedule:delete`` scope. The delete and
-        create work happens against the unscoped helpers and is committed as a
-        single transaction with the rest of the edit.
+        create work is committed as a single transaction with the rest of the
+        edit.
         """
         existing = await self.list_schedules(workflow_id=workflow_id)
         for schedule in existing:

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Sequence
-from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -31,6 +30,27 @@ class WorkflowSchedulesService(BaseWorkspaceService):
     """Manages schedules for Workflows."""
 
     service_name = "workflow_schedules"
+
+    def _suppress_audit_when_deferred_commit(
+        self, params: ScheduleCreate, commit: bool = True
+    ) -> AuditEventDetails:
+        if commit is False:
+            return AuditEventDetails(emit=False)
+        return AuditEventDetails()
+
+    def _schedule_update_audit_details(
+        self, schedule_id: AnyScheduleID, params: ScheduleUpdate
+    ) -> AuditEventDetails:
+        return AuditEventDetails(
+            data={"changed_fields": sorted(params.model_fields_set)}
+        )
+
+    def _suppress_delete_audit_when_deferred_commit(
+        self, schedule_id: AnyScheduleID, commit: bool = True
+    ) -> AuditEventDetails:
+        if commit is False:
+            return AuditEventDetails(emit=False)
+        return AuditEventDetails()
 
     async def _lock_workflow(self, workflow_id: AnyWorkflowID | uuid.UUID) -> None:
         workflow_uuid = WorkflowUUID.new(workflow_id)
@@ -73,6 +93,7 @@ class WorkflowSchedulesService(BaseWorkspaceService):
         resource_type="schedule",
         action="create",
         resource_id_attr="id",
+        attempt_metadata=_suppress_audit_when_deferred_commit,
     )
     async def create_schedule(
         self, params: ScheduleCreate, commit: bool = True
@@ -241,16 +262,7 @@ class WorkflowSchedulesService(BaseWorkspaceService):
     @audit_log(
         resource_type="schedule",
         action="update",
-        attempt_metadata=lambda context: AuditEventDetails(
-            data={
-                "changed_fields": sorted(
-                    cast(
-                        ScheduleUpdate,
-                        context.arguments["params"],
-                    ).model_dump(exclude_unset=True)
-                ),
-            }
-        ),
+        attempt_metadata=_schedule_update_audit_details,
     )
     async def update_schedule(
         self, schedule_id: AnyScheduleID, params: ScheduleUpdate
@@ -309,6 +321,7 @@ class WorkflowSchedulesService(BaseWorkspaceService):
     @audit_log(
         resource_type="schedule",
         action="delete",
+        attempt_metadata=_suppress_delete_audit_when_deferred_commit,
     )
     async def delete_schedule(
         self, schedule_id: AnyScheduleID, commit: bool = True


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded audit logging with task‑per‑event async delivery, bounded retries, typed callbacks, broader control‑plane coverage, stricter privacy, and normalized request attribution (including MCP tool calls). Also optimized audit settings caching and kept batch‑case audit metadata accurate.

- **New Features**
  - Async delivery: task‑per‑event posting with transient retries (exponential backoff), burst queue decoupled from socket cap; `flush_audit_deliveries` for tests.
  - Typed `AuditEventDetails` and privacy‑bounded metadata via `sanitize_audit_metadata` and shared sanitizers (`redact_sensitive_text`, `sanitize_urls_in_text`); `changed_fields`/`changed_sections`; batch case audits use `is_batch`, `case_count`, `succeeded_count`, `failed_count`; dry‑run/deferred commits suppress emission.
  - Coverage: workflow edits/YAML/graph ops, schedules (create/update/delete), case triggers (upsert/update), webhooks (create/update/API key rotate), executions (cancel/terminate/reset); audit payloads exclude `content` and `workflow_alias`.
  - Attribution: request middleware sets `ctx_request_audit` with normalized `client_ip` and bounded `user_agent` family; MCP tool calls attributed via `MCPRequestAuditMiddleware`.

- **Refactors**
  - Centralized sanitizers in `tracecat.sanitization`; removed ad‑hoc regex; MCP stdio probe and integrations now use shared sanitizers.
  - Expanded audit types (`AuditMetadata`, new actions/resources); centralized emission; moved webhook create/update to `tracecat.webhooks.service` with scope enforcement; Temporal RPC error handling moved into services; routers simplified.
  - Cached audit settings reads with `async_lru` to reduce repeated DB lookups and fixed the cache key by dropping the nil‑UUID sentinel.

<sup>Written for commit 9f2c75b1a93673bffa942f577cd11fea51790822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

