### PR TITLE
feat(cases): add payload copy button

### DIFF
--- a/frontend/src/components/cases/case-payload-section.tsx
+++ b/frontend/src/components/cases/case-payload-section.tsx
@@ -10,6 +10,7 @@ export function CasePayloadSection({ caseData }: { caseData: CaseRead }) {
           src={caseData.payload}
           defaultExpanded={true}
           showControls={true}
+          copyMode="jsonpath-and-payload"
         />
       ) : (
         <NoPaylod />


### PR DESCRIPTION
## Summary

- expose the shared JSON payload copy control in the Case payload view
- match the copy behavior already available on workflow-run payloads

## User impact

Users can copy a complete Case payload directly from the Payload section instead of selecting JSON manually.

## Validation

- `pnpm -C frontend exec biome check src/components/cases/case-payload-section.tsx`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`
- pre-commit hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copy button to the Case payload section so users can copy the full JSON payload or a JSONPath selection. Matches the workflow-run payload copy behavior.

<sup>Written for commit 16e5a4b09d1ade428a9de7b420439bd5f24935ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

