### PR TITLE
fix(ui): cap bulk case action request concurrency

### DIFF
--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -32,7 +32,10 @@ import { CenteredSpinner } from "@/components/loading/spinner"
 import { useToast } from "@/components/ui/use-toast"
 import type { CaseDateFilterValue, UseCasesFilters } from "@/hooks/use-cases"
 import { useDeleteCase } from "@/lib/hooks"
+import { runWithConcurrencyLimit } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
+
+const BULK_CASE_REQUEST_CONCURRENCY = 8
 
 interface CasesLayoutProps {
   cases: CaseReadMinimal[]
@@ -171,7 +174,10 @@ export function CasesLayout({
     try {
       setIsDeleting(true)
       const caseIds = Array.from(selectedCaseIds)
-      await Promise.all(caseIds.map((caseId) => deleteCase(caseId)))
+      await runWithConcurrencyLimit(
+        caseIds.map((caseId) => () => deleteCase(caseId)),
+        BULK_CASE_REQUEST_CONCURRENCY
+      )
 
       toast({
         title: `${caseIds.length} case(s) deleted`,
@@ -204,14 +210,16 @@ export function CasesLayout({
       try {
         setIsBulkUpdating(true)
 
-        await Promise.all(
-          caseIds.map((caseId) =>
-            casesUpdateCase({
-              workspaceId,
-              caseId,
-              requestBody: updates,
-            })
-          )
+        await runWithConcurrencyLimit(
+          caseIds.map(
+            (caseId) => () =>
+              casesUpdateCase({
+                workspaceId,
+                caseId,
+                requestBody: updates,
+              })
+          ),
+          BULK_CASE_REQUEST_CONCURRENCY
         )
 
         toast({

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,82 @@
+import { runWithConcurrencyLimit } from "@/lib/utils"
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((fulfill) => {
+    resolve = fulfill
+  })
+  return { promise, resolve }
+}
+
+describe("runWithConcurrencyLimit", () => {
+  it("limits tasks in flight and preserves input order", async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const completionDelays = [30, 5, 20, 1]
+
+    const results = await runWithConcurrencyLimit(
+      completionDelays.map(
+        (delay, index) => () =>
+          new Promise<number>((resolve) => {
+            inFlight += 1
+            maxInFlight = Math.max(maxInFlight, inFlight)
+            setTimeout(() => {
+              inFlight -= 1
+              resolve(index)
+            }, delay)
+          })
+      ),
+      2
+    )
+
+    expect(maxInFlight).toBe(2)
+    expect(results).toEqual([0, 1, 2, 3])
+  })
+
+  it("stops scheduling after the first failure and awaits in-flight tasks", async () => {
+    const firstError = new Error("first failure")
+    const started: number[] = []
+    const inFlightTask = createDeferred()
+    const failingTask = createDeferred()
+
+    const runPromise = runWithConcurrencyLimit(
+      [
+        async () => {
+          started.push(0)
+          await inFlightTask.promise
+        },
+        async () => {
+          started.push(1)
+          await failingTask.promise
+          throw firstError
+        },
+        async () => {
+          started.push(2)
+        },
+      ],
+      2
+    )
+
+    expect(started).toEqual([0, 1])
+    failingTask.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(started).toEqual([0, 1])
+
+    let settled = false
+    void runPromise.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    inFlightTask.resolve()
+    await expect(runPromise).rejects.toBe(firstError)
+  })
+})

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -6,6 +6,50 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Runs promise-returning tasks with at most `concurrencyLimit` tasks in flight.
+ * Stops scheduling new tasks after the first failure and preserves input order.
+ */
+export async function runWithConcurrencyLimit<T>(
+  tasks: readonly (() => Promise<T>)[],
+  concurrencyLimit: number
+): Promise<T[]> {
+  if (!Number.isInteger(concurrencyLimit) || concurrencyLimit < 1) {
+    throw new RangeError("concurrencyLimit must be a positive integer")
+  }
+
+  const results = new Array<T>(tasks.length)
+  let nextIndex = 0
+  let firstError: unknown
+  let hasError = false
+
+  async function runNext(): Promise<void> {
+    while (!hasError && nextIndex < tasks.length) {
+      const currentIndex = nextIndex
+      const task = tasks[currentIndex]
+      nextIndex += 1
+
+      try {
+        results[currentIndex] = await task()
+      } catch (error) {
+        if (!hasError) {
+          hasError = true
+          firstError = error
+        }
+      }
+    }
+  }
+
+  const workerCount = Math.min(concurrencyLimit, tasks.length)
+  await Promise.all(Array.from({ length: workerCount }, () => runNext()))
+
+  if (hasError) {
+    throw firstError
+  }
+
+  return results
+}
+
 // Linear-style design tokens
 export const linearStyles = {
   input: {


### PR DESCRIPTION
## Summary

Part of ENG-1543: https://linear.app/tracecat/issue/ENG-1543/investigate-on-prem-case-ui-slowdown-from-request-amplification

Bulk case actions previously fired one request per selected case inside an unbounded `Promise.all` — selecting up to 100 cases produced 100 simultaneous `PATCH`/`DELETE` requests. Each case mutation holds a `SELECT FOR UPDATE` row lock across synchronous audit-webhook delivery on the backend, so these bursts can saturate API workers and DB connections and make unrelated case reads queue (observed as UI-wide slowdown on an on-prem deployment).

This caps client-side bulk concurrency at 8 until a real batch endpoint exists.

## Changes

- Add `runWithConcurrencyLimit` to `frontend/src/lib/utils.ts`: a small worker-pool runner that keeps at most N tasks in flight, stops scheduling new tasks after the first failure (in-flight requests are still awaited), and preserves input order on success.
- Use it in `handleBulkUpdate` and `handleBulkDelete` in `cases-layout.tsx` with `BULK_CASE_REQUEST_CONCURRENCY = 8`.
- Unit tests for the helper: max in-flight bound, order preservation, stop-scheduling-after-first-failure.

Toast copy, refetch, and selection-clearing behavior are unchanged. No new dependencies.

## Verification

- `pnpm -C frontend exec biome check` — passed
- `pnpm -C frontend run typecheck` — passed
- `pnpm -C frontend test -- src/lib/utils.test.ts` — 2 passed

## Follow-ups (tracked in ENG-1543)

- Real batch case-update endpoint with bounded server-side work and partial-failure semantics.
- Async audit delivery (owned by ENG-1514).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps concurrency for bulk case actions to 8 to stop request bursts that slowed the on‑prem UI. Addresses ENG-1543 by limiting simultaneous case `PATCH`/`DELETE` requests to reduce API/DB saturation.

- **Bug Fixes**
  - Added `runWithConcurrencyLimit` to bound in‑flight tasks, preserve order, and stop scheduling after first failure.
  - Applied to bulk delete and update in `cases-layout.tsx` with a limit of 8.
  - Added unit tests for concurrency cap, order preservation, and failure behavior.

<sup>Written for commit 5b9d530ec55c66024cb7ed359b69c304ef3b2303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

