### PR TITLE
chore: prefer fd for file searches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,8 @@ just gen-functions
   hardcoded literal so `.env` overrides still work. In `.env.example`, use an
   explicit `true` or `false`, never a blank value. Update
   `tests/unit/test_config.py` when adding deployment env files.
-- Use `pnpm` instead of `npm`, and prefer `rg` over slower text-search tools.
+- Use `pnpm` instead of `npm`, prefer `rg` over slower text-search tools, and
+  prefer `fd` over `find` when `fd` is available.
 - Ask clarifying questions when the task lacks enough context to make a safe
   change.
 


### PR DESCRIPTION
## Summary

- prefer `fd` over `find` in repository agent guidance when `fd` is available
- retain `find` as the fallback for environments without `fd`

## Testing

- pre-commit hooks
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update AGENTS.md to prefer `fd` over `find` for file searches when available, keeping `find` as the fallback. This clarifies guidance and aligns with using faster tools like `rg`.

<sup>Written for commit 0190bf67cd77d46a0bd935137fc60c46d014db37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

