### PR TITLE
perf(ui): defer case linked-row hydration to tables tab

### DIFF
--- a/frontend/src/components/cases/case-linked-rows-section.tsx
+++ b/frontend/src/components/cases/case-linked-rows-section.tsx
@@ -1,17 +1,26 @@
 "use client"
 
 import { useMemo } from "react"
-import type { CaseRead, CaseTableRowRead, TableRowRead } from "@/client"
-import { Spinner } from "@/components/loading/spinner"
+import type { CaseTableRowRead, TableRowRead } from "@/client"
+import { CenteredSpinner, Spinner } from "@/components/loading/spinner"
 import { AgGridTable } from "@/components/tables/ag-grid-table"
-import { useGetTable } from "@/lib/hooks"
-import { useWorkspaceId } from "@/providers/workspace-id"
+import { useGetTable, useListCaseRows } from "@/lib/hooks"
 
-export function CaseLinkedRowsSection({ caseData }: { caseData: CaseRead }) {
-  const workspaceId = useWorkspaceId()
-  const rows = (
-    (caseData as CaseRead & { rows?: CaseTableRowRead[] }).rows ?? []
-  ).filter((row) => row.row_data)
+interface CaseLinkedRowsSectionProps {
+  caseId: string
+  workspaceId: string
+}
+
+/** Display the hydrated table rows linked to a case. */
+export function CaseLinkedRowsSection({
+  caseId,
+  workspaceId,
+}: CaseLinkedRowsSectionProps) {
+  const { caseRows, caseRowsIsLoading, caseRowsError } = useListCaseRows(
+    caseId,
+    workspaceId
+  )
+  const rows = caseRows.filter((row) => row.row_data)
 
   const grouped = useMemo(() => {
     const map = new Map<
@@ -35,6 +44,18 @@ export function CaseLinkedRowsSection({ caseData }: { caseData: CaseRead }) {
       rows: value.rows,
     }))
   }, [rows])
+
+  if (caseRowsIsLoading) {
+    return <CenteredSpinner />
+  }
+
+  if (caseRowsError) {
+    return (
+      <p className="p-2 text-sm text-destructive">
+        Failed to load linked table rows.
+      </p>
+    )
+  }
 
   if (grouped.length === 0) {
     return (

--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -704,7 +704,10 @@ export function CasePanelView({
                 </TabsContent>
 
                 <TabsContent value="rows" className="mt-4">
-                  <CaseLinkedRowsSection caseData={caseData} />
+                  <CaseLinkedRowsSection
+                    caseId={caseId}
+                    workspaceId={workspaceId}
+                  />
                 </TabsContent>
 
                 <TabsContent value="payload" className="mt-4">

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -63,6 +63,7 @@ import {
   type CasesListTagsData,
   type CasesListTasksData,
   type CasesSearchCasesData,
+  type CaseTableRowRead,
   type CaseTagCreate,
   type CaseTagRead,
   type CaseTagsCreateCaseTagData,
@@ -90,6 +91,7 @@ import {
   casesDeleteCase,
   casesDeleteComment,
   casesDeleteTask,
+  casesListCaseRows,
   casesListComments,
   casesListCommentThreads,
   casesListEventsWithUsers,
@@ -3727,6 +3729,7 @@ export function useSearchCases(params: CasesSearchCasesData) {
 interface UseGetCaseOptions {
   enabled?: boolean
 }
+
 export function useGetCase(
   { caseId, workspaceId }: CasesGetCaseData,
   options?: UseGetCaseOptions
@@ -3739,7 +3742,7 @@ export function useGetCase(
     queryKey: ["case", caseId],
     queryFn: async () => {
       const response = await apiClient.get<CaseRead>(`/cases/${caseId}`, {
-        params: { workspace_id: workspaceId, include_rows: true },
+        params: { workspace_id: workspaceId },
       })
       return response.data
     },
@@ -3750,6 +3753,42 @@ export function useGetCase(
     caseData,
     caseDataIsLoading,
     caseDataError,
+  }
+}
+
+const CASE_ROWS_PAGE_SIZE = 200
+
+/** Fetch all linked rows for a case, including hydrated row data. */
+export function useListCaseRows(caseId: string, workspaceId: string) {
+  const {
+    data: caseRows = [],
+    isLoading: caseRowsIsLoading,
+    error: caseRowsError,
+  } = useQuery<CaseTableRowRead[], TracecatApiError>({
+    queryKey: ["case-rows", caseId],
+    queryFn: async () => {
+      const rows: CaseTableRowRead[] = []
+      let cursor: string | undefined
+
+      do {
+        const response = await casesListCaseRows({
+          caseId,
+          workspaceId,
+          limit: CASE_ROWS_PAGE_SIZE,
+          cursor,
+        })
+        rows.push(...response.items)
+        cursor = response.next_cursor ?? undefined
+      } while (cursor)
+
+      return rows
+    },
+  })
+
+  return {
+    caseRows,
+    caseRowsIsLoading,
+    caseRowsError,
   }
 }
 

--- a/frontend/tests/use-list-case-rows.test.tsx
+++ b/frontend/tests/use-list-case-rows.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import type { CaseTableRowRead } from "@/client"
+import { casesListCaseRows } from "@/client"
+import { useListCaseRows } from "@/lib/hooks"
+
+jest.mock("@/client", () => {
+  const actual = jest.requireActual("@/client")
+  return {
+    ...actual,
+    casesListCaseRows: jest.fn(),
+  }
+})
+
+const mockListCaseRows = casesListCaseRows as jest.MockedFunction<
+  typeof casesListCaseRows
+>
+
+function createRow(index: number): CaseTableRowRead {
+  return {
+    id: `link-${index}`,
+    case_id: "case-1",
+    table_id: "table-1",
+    table_name: "Table 1",
+    row_id: `row-${index}`,
+    row_data: { value: index },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  }
+}
+
+describe("useListCaseRows", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("concatenates every cursor page in order", async () => {
+    mockListCaseRows
+      .mockResolvedValueOnce({
+        items: [createRow(1), createRow(2)],
+        next_cursor: "cursor-2",
+      })
+      .mockResolvedValueOnce({
+        items: [createRow(3)],
+        next_cursor: "cursor-3",
+      })
+      .mockResolvedValueOnce({
+        items: [createRow(4), createRow(5)],
+        next_cursor: null,
+      })
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    function wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      )
+    }
+
+    const { result } = renderHook(
+      () => useListCaseRows("case-1", "workspace-1"),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current.caseRows).toHaveLength(5)
+    })
+
+    expect(result.current.caseRows.map((row) => row.row_id)).toEqual([
+      "row-1",
+      "row-2",
+      "row-3",
+      "row-4",
+      "row-5",
+    ])
+    expect(mockListCaseRows).toHaveBeenNthCalledWith(1, {
+      caseId: "case-1",
+      workspaceId: "workspace-1",
+      limit: 200,
+      cursor: undefined,
+    })
+    expect(mockListCaseRows).toHaveBeenNthCalledWith(2, {
+      caseId: "case-1",
+      workspaceId: "workspace-1",
+      limit: 200,
+      cursor: "cursor-2",
+    })
+    expect(mockListCaseRows).toHaveBeenNthCalledWith(3, {
+      caseId: "case-1",
+      workspaceId: "workspace-1",
+      limit: 200,
+      cursor: "cursor-3",
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Part of ENG-1543 (on-prem case UI slowdown); implements ENG-1547: https://linear.app/tracecat/issue/ENG-1547

`useGetCase` hard-coded `include_rows: true`, so every `GET /cases/{id}` — case panel open, page title, controls header — paid server-side linked-row hydration: one extra table read per linked row. The row data is consumed by exactly one component (`CaseLinkedRowsSection`), which only mounts inside the panel's "Tables" tab (Radix Tabs unmounts inactive content), and nothing on first paint reads rows.

## Changes

- `useGetCase` no longer requests `include_rows` — the initial case load skips row hydration entirely (backend default returns `rows: []`).
- `CaseLinkedRowsSection` now self-fetches via the existing `GET /cases/{case_id}/rows` endpoint (new `useListCaseRows` hook, query key `["case-rows", caseId]`), mirroring how the sibling tabs (comments, activity, attachments) already self-fetch. Loading spinner and error state added.
- The rows endpoint is cursor-paginated (max limit 200) while the old hydration returned all rows unpaginated — the hook fetches at max limit and follows `next_cursor` until exhausted so the Tables tab still shows every linked row.
- Test covering the pagination loop (pages concatenated in order at limit 200).

Frontend-only; backend `include_rows` param and generated client untouched.

## Verification

- `pnpm -C frontend exec biome check` — passed
- `pnpm -C frontend run typecheck` — passed
- `pnpm -C frontend test` — 95 suites, 523 tests passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers case linked-row hydration to the Tables tab to cut extra server reads and speed up initial case load. Implements Linear ENG-1547 for the ENG-1543 on-prem UI slowdown.

- **Refactors**
  - `useGetCase` no longer requests `include_rows`; initial loads return `rows: []`.
  - `CaseLinkedRowsSection` self-fetches via `useListCaseRows` using `GET /cases/{case_id}/rows` with cursor pagination (fetches all pages at limit 200).
  - Added loading and error states for the Tables tab.
  - Added a test that verifies pages are concatenated in order.

<sup>Written for commit 920bbeb782e03537e90f0e1b0dbbf6fd5d2590ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

