### PR TITLE
perf(cases): drop duplicate exact count from case search

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -9621,6 +9621,7 @@ export const casesCreateCase = (
  * @param data.fieldIds Include only the requested custom field IDs
  * @param data.includeDurations Include case duration values
  * @param data.includePayload Include case payload
+ * @param data.includeTotal Include the exact filtered total (skip when totals come from the aggregates endpoint)
  * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
  * @throws ApiError
  */
@@ -9655,6 +9656,7 @@ export const casesSearchCases = (
       field_ids: data.fieldIds,
       include_durations: data.includeDurations,
       include_payload: data.includePayload,
+      include_total: data.includeTotal,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -12575,6 +12575,10 @@ export type CasesSearchCasesData = {
    */
   includeRows?: boolean
   /**
+   * Include the exact filtered total (skip when totals come from the aggregates endpoint)
+   */
+  includeTotal?: boolean
+  /**
    * Maximum items per page
    */
   limit?: number

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -1071,9 +1071,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
 
   const totalFilteredCaseEstimate = hasImpossibleEnumFilter
     ? 0
-    : (visibleAggregateData?.total ??
-      visibleRowsData?.pages[0]?.total_estimate ??
-      null)
+    : (visibleAggregateData?.total ?? null)
   const isHydrationPending =
     enabled && Boolean(workspaceId) && !hasHydratedFilters
 

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -973,6 +973,8 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
       casesSearchCases({
         workspaceId,
         ...apiQueryParams,
+        // Totals come from the aggregates query; skip the per-page exact count.
+        includeTotal: false,
         orderBy: serverSortParams.orderBy,
         sort: serverSortParams.sort,
         limit: CASES_PAGE_SIZE,

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -1024,6 +1024,7 @@ async def test_search_cases_success(
             prev_cursor=None,
             has_more=False,
             has_previous=False,
+            total_estimate=None,
         )
         MockService.return_value = mock_svc
 
@@ -1042,6 +1043,7 @@ async def test_search_cases_success(
         data = response.json()
         assert len(data["items"]) == 1
         assert data["items"][0]["summary"] == "Test Case Summary"
+        assert data["total_estimate"] is None
         mock_svc.search_cases.assert_called_once()
 
 

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -1024,7 +1024,7 @@ async def test_search_cases_success(
             prev_cursor=None,
             has_more=False,
             has_previous=False,
-            total_estimate=None,
+            total_estimate=1,
         )
         MockService.return_value = mock_svc
 
@@ -1043,8 +1043,11 @@ async def test_search_cases_success(
         data = response.json()
         assert len(data["items"]) == 1
         assert data["items"][0]["summary"] == "Test Case Summary"
-        assert data["total_estimate"] is None
+        assert data["total_estimate"] == 1
         mock_svc.search_cases.assert_called_once()
+        # The exact total stays part of the default contract; the case-list UI
+        # opts out explicitly via include_total=false.
+        assert mock_svc.search_cases.call_args.kwargs["include_total"] is True
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1120,6 +1120,61 @@ class TestCasesService:
 
         assert search_response.model_dump() == list_response.model_dump()
 
+    async def test_search_cases_paginates_without_total_estimate(
+        self, cases_service: CasesService
+    ) -> None:
+        """Search pagination should use cursors without computing a total count."""
+        created_cases = []
+        for index in range(3):
+            created_cases.append(
+                await cases_service.create_case(
+                    CaseCreate(
+                        summary=f"Paginated case {index}",
+                        description=f"Paginated case description {index}",
+                        status=CaseStatus.NEW,
+                        priority=CasePriority.MEDIUM,
+                        severity=CaseSeverity.LOW,
+                    )
+                )
+            )
+        expected_cases = sorted(
+            created_cases,
+            key=lambda case: (case.created_at, case.id),
+        )
+
+        first_page = await cases_service.search_cases(
+            params=CursorPaginationParams(limit=2, cursor=None, reverse=False),
+            order_by="created_at",
+            sort="asc",
+        )
+
+        assert [case.id for case in first_page.items] == [
+            expected_cases[0].id,
+            expected_cases[1].id,
+        ]
+        assert first_page.total_estimate is None
+        assert first_page.has_more is True
+        assert first_page.has_previous is False
+        assert first_page.next_cursor is not None
+        assert first_page.prev_cursor is None
+
+        second_page = await cases_service.search_cases(
+            params=CursorPaginationParams(
+                limit=2,
+                cursor=first_page.next_cursor,
+                reverse=False,
+            ),
+            order_by="created_at",
+            sort="asc",
+        )
+
+        assert [case.id for case in second_page.items] == [expected_cases[2].id]
+        assert second_page.total_estimate is None
+        assert second_page.has_more is False
+        assert second_page.has_previous is True
+        assert second_page.next_cursor is None
+        assert second_page.prev_cursor is not None
+
     async def test_search_cases_gates_duration_selectinload(
         self, cases_service: CasesService
     ) -> None:

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1118,17 +1118,12 @@ class TestCasesService:
             sort="asc",
         )
 
-        # list_cases opts into the exact total; plain search skips it.
-        assert search_response.total_estimate is None
-        assert list_response.total_estimate == 2
-        assert search_response.model_dump(
-            exclude={"total_estimate"}
-        ) == list_response.model_dump(exclude={"total_estimate"})
+        assert search_response.model_dump() == list_response.model_dump()
 
     async def test_search_cases_paginates_without_total_estimate(
         self, cases_service: CasesService
     ) -> None:
-        """Search pagination should use cursors without computing a total count."""
+        """Opting out of the total must not affect cursor pagination."""
         created_cases = []
         for index in range(3):
             created_cases.append(
@@ -1151,6 +1146,7 @@ class TestCasesService:
             params=CursorPaginationParams(limit=2, cursor=None, reverse=False),
             order_by="created_at",
             sort="asc",
+            include_total=False,
         )
 
         assert [case.id for case in first_page.items] == [
@@ -1171,6 +1167,7 @@ class TestCasesService:
             ),
             order_by="created_at",
             sort="asc",
+            include_total=False,
         )
 
         assert [case.id for case in second_page.items] == [expected_cases[2].id]

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1118,7 +1118,12 @@ class TestCasesService:
             sort="asc",
         )
 
-        assert search_response.model_dump() == list_response.model_dump()
+        # list_cases opts into the exact total; plain search skips it.
+        assert search_response.total_estimate is None
+        assert list_response.total_estimate == 2
+        assert search_response.model_dump(
+            exclude={"total_estimate"}
+        ) == list_response.model_dump(exclude={"total_estimate"})
 
     async def test_search_cases_paginates_without_total_estimate(
         self, cases_service: CasesService
@@ -1174,6 +1179,26 @@ class TestCasesService:
         assert second_page.has_previous is True
         assert second_page.next_cursor is None
         assert second_page.prev_cursor is not None
+
+    async def test_list_cases_retains_total_estimate(
+        self, cases_service: CasesService
+    ) -> None:
+        for summary in ("List total A", "List total B", "List total C"):
+            await cases_service.create_case(
+                CaseCreate(
+                    summary=summary,
+                    description="Total estimate coverage",
+                    status=CaseStatus.NEW,
+                    priority=CasePriority.MEDIUM,
+                    severity=CaseSeverity.MEDIUM,
+                )
+            )
+
+        page = await cases_service.list_cases(limit=2)
+
+        assert len(page.items) == 2
+        assert page.total_estimate == 3
+        assert page.has_more is True
 
     async def test_search_cases_gates_duration_selectinload(
         self, cases_service: CasesService

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -325,6 +325,10 @@ async def search_cases(
     ),
     include_durations: bool = Query(False, description="Include case duration values"),
     include_payload: bool = Query(False, description="Include case payload"),
+    include_total: bool = Query(
+        True,
+        description="Include the exact filtered total (skip when totals come from the aggregates endpoint)",
+    ),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     """Search cases with cursor-based pagination, filtering, and sorting."""
     service = CasesService(session, role)
@@ -362,6 +366,7 @@ async def search_cases(
             sort=sort,
             include_durations=include_durations,
             include_payload=include_payload,
+            include_total=include_total,
         )
     except ValueError as e:
         logger.warning(f"Invalid request for search cases: {e}")

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -391,12 +391,13 @@ class CasesService(BaseWorkspaceService):
         sort: Literal["asc", "desc"] | None = None,
         include_durations: bool = False,
         include_payload: bool = False,
-        include_total: bool = False,
+        include_total: bool = True,
     ) -> CursorPaginatedResponse[CaseReadMinimal]:
         """Search cases with cursor-based pagination and filtering.
 
-        The exact filtered total is computed only when ``include_total`` is set;
-        the case-list UI reads totals from the aggregates endpoint instead.
+        The exact filtered total is computed unless ``include_total`` is false;
+        the case-list UI opts out because it reads totals from the aggregates
+        endpoint.
         """
         paginator = BaseCursorPaginator(self.session)
         include_case_addons = await self.has_entitlement(Entitlement.CASE_ADDONS)
@@ -792,7 +793,6 @@ class CasesService(BaseWorkspaceService):
             sort=sort,
             include_durations=include_durations,
             include_payload=include_payload,
-            include_total=True,
         )
 
     async def get_case(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -435,14 +435,6 @@ class CasesService(BaseWorkspaceService):
         for clause in filters:
             stmt = stmt.where(clause)
 
-        # Compute total count with applied filters (workspace scoped)
-        count_stmt = select(func.count()).select_from(Case)
-        for clause in filters:
-            count_stmt = count_stmt.where(clause)
-
-        total_count = await self.session.scalar(count_stmt)
-        total_estimate = int(total_count or 0)
-
         # Determine sort column and direction
         sort_column = order_by or "created_at"
         sort_direction = sort or "desc"
@@ -678,7 +670,7 @@ class CasesService(BaseWorkspaceService):
             prev_cursor=prev_cursor,
             has_more=has_more,
             has_previous=has_previous,
-            total_estimate=total_estimate,
+            total_estimate=None,
         )
 
     async def get_search_case_aggregates(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -391,8 +391,13 @@ class CasesService(BaseWorkspaceService):
         sort: Literal["asc", "desc"] | None = None,
         include_durations: bool = False,
         include_payload: bool = False,
+        include_total: bool = False,
     ) -> CursorPaginatedResponse[CaseReadMinimal]:
-        """Search cases with cursor-based pagination and filtering."""
+        """Search cases with cursor-based pagination and filtering.
+
+        The exact filtered total is computed only when ``include_total`` is set;
+        the case-list UI reads totals from the aggregates endpoint instead.
+        """
         paginator = BaseCursorPaginator(self.session)
         include_case_addons = await self.has_entitlement(Entitlement.CASE_ADDONS)
         filters = self._build_search_filters(
@@ -434,6 +439,13 @@ class CasesService(BaseWorkspaceService):
 
         for clause in filters:
             stmt = stmt.where(clause)
+
+        total_estimate: int | None = None
+        if include_total:
+            count_stmt = select(func.count()).select_from(Case)
+            for clause in filters:
+                count_stmt = count_stmt.where(clause)
+            total_estimate = int(await self.session.scalar(count_stmt) or 0)
 
         # Determine sort column and direction
         sort_column = order_by or "created_at"
@@ -670,7 +682,7 @@ class CasesService(BaseWorkspaceService):
             prev_cursor=prev_cursor,
             has_more=has_more,
             has_previous=has_previous,
-            total_estimate=None,
+            total_estimate=total_estimate,
         )
 
     async def get_search_case_aggregates(
@@ -780,6 +792,7 @@ class CasesService(BaseWorkspaceService):
             sort=sort,
             include_durations=include_durations,
             include_payload=include_payload,
+            include_total=True,
         )
 
     async def get_case(


### PR DESCRIPTION
## Summary

Part of ENG-1543 (on-prem case UI slowdown); implements ENG-1546: https://linear.app/tracecat/issue/ENG-1546

Every case-list page fetch ran a full filtered `COUNT(*)` inside `search_cases` to populate `total_estimate` — while the UI concurrently calls the aggregates endpoint, which computes the same total (plus per-status counts) in one scan, cached per filter set. Pagination never used the count (`has_more` comes from the limit+1 fetch, cursors from row values), and the UI already preferred the aggregate total.

## Design: opt-out, not removal

The exact total stays part of the default search contract — no behavior change for any existing consumer (registry `core.cases.search_cases` workflows, MCP, artifacts `row_count` binding, external API callers, `list_cases`). The only consumer with an alternative total source is the case-list UI, and it now opts out explicitly:

- `GET /cases/search` gains `include_total` (default `true` = original behavior). When `false`, the count query is skipped and `total_estimate` is `null`.
- `search_cases`/`list_cases` service methods default to computing the total, matching the previous contract.
- The case-list UI passes `include_total=false` and drops its dead search-count fallback — totals and per-status counts come from the aggregates query it already issues (cached per filter set, not per page).

Net effect on the hot path: scrolling a filtered case list goes from one full filtered scan **per page** to one aggregate scan **per filter set**. Everyone else keeps exact totals.

## Changes

- `tracecat/cases/service.py`: `include_total: bool = True` on `search_cases`; count computed only when set.
- `tracecat/cases/router.py`: `include_total` query param (default `true`) passed through.
- `frontend/src/hooks/use-cases.ts`: search call passes `includeTotal: false`; aggregate total is the sole UI total source.
- Generated client regenerated for the new param.
- Tests: search/list parity holds at defaults; the opt-out path is pinned (no total, cursor pagination unaffected); the API route test pins `include_total=True` as the default pass-through; `list_cases` total retention covered.

## Verification

- `uv run pytest tests/unit/test_cases_service.py tests/unit/api/test_api_cases.py` — 79 passed
- ruff check / format, basedpyright — clean
- `just gen-client-ci`, frontend biome + typecheck — clean
