### PR TITLE
fix(ui): keep dialogs within viewport

### DIFF
--- a/frontend/src/components/agents/agents-dashboard.tsx
+++ b/frontend/src/components/agents/agents-dashboard.tsx
@@ -1224,7 +1224,10 @@ function AgentPresetMoveDialog({
                 <ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-[--radix-popover-trigger-width] overflow-hidden p-0">
+            <PopoverContent
+              className="w-[--radix-popover-trigger-width] overflow-hidden p-0"
+              portal={true}
+            >
               <FileTreeCommand
                 items={fileTreeItems}
                 onSelect={handleSelectFolder}

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -2063,6 +2063,7 @@ export function CreateScheduleDialog({ workflowId }: { workflowId: string }) {
                                 <PopoverContent
                                   className="w-auto overflow-hidden p-0"
                                   align="start"
+                                  portal={true}
                                 >
                                   <Calendar
                                     mode="single"
@@ -2169,6 +2170,7 @@ export function CreateScheduleDialog({ workflowId }: { workflowId: string }) {
                                 <PopoverContent
                                   className="w-auto overflow-hidden p-0"
                                   align="start"
+                                  portal={true}
                                 >
                                   <Calendar
                                     mode="single"

--- a/frontend/src/components/cases/case-closure-dialog.tsx
+++ b/frontend/src/components/cases/case-closure-dialog.tsx
@@ -561,7 +561,7 @@ function MultiSelectField({
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[200px] p-0" align="start">
+        <PopoverContent className="w-[200px] p-0" align="start" portal={true}>
           <Command>
             <CommandInput placeholder="Search..." />
             <CommandList>

--- a/frontend/src/components/dashboard/folder-move-dialog.tsx
+++ b/frontend/src/components/dashboard/folder-move-dialog.tsx
@@ -182,7 +182,10 @@ export function FolderMoveDialog({
                 <ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-[--radix-popover-trigger-width] overflow-hidden p-0">
+            <PopoverContent
+              className="w-[--radix-popover-trigger-width] overflow-hidden p-0"
+              portal={true}
+            >
               <FileTreeCommand
                 items={fileTreeItems}
                 onSelect={handleSelectFolder}

--- a/frontend/src/components/dashboard/workflow-move-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-move-dialog.tsx
@@ -138,7 +138,10 @@ export function WorkflowMoveDialog({
                 <ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-[--radix-popover-trigger-width] overflow-hidden p-0">
+            <PopoverContent
+              className="w-[--radix-popover-trigger-width] overflow-hidden p-0"
+              portal={true}
+            >
               <FileTreeCommand
                 items={fileTreeItems}
                 onSelect={handleSelectFolder}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -50,7 +50,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          "fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
           className
         )}
         {...props}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents dialogs from overflowing the viewport and fixes clipped popovers inside them. Sets max-height calc(100dvh - 2rem) with vertical scrolling on `DialogContent`, and enables `portal` on `PopoverContent` across dialogs (agents, folder/workflow move, case closure, and schedule date pickers).

<sup>Written for commit 0c3217f23238f87c9713911a5f9d1705a2d8e710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Before
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/d6b12aee-06a2-4b1c-b5a5-8155fe108d51" />
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/6e23f72f-e22f-41fd-a4a6-821d462a28c7" />
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/fe2d9f7b-788e-420e-bb10-86a4da2a1ac5" />
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/5160718b-a540-482b-9b45-cc844f777468" />


## After
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/2d5d7fd1-9703-4508-b6b9-6099eb6b20b5" />
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/73d6e878-e3ad-422a-891f-5814cb87c5bf" />
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/39574414-e87a-400a-ae68-6dca3f261378" />
<img width="1280" height="600" alt="image" src="https://github.com/user-attachments/assets/699818fd-51e8-4af2-a2b5-93b56547be4e" />


