### PR TITLE
feat(cases): add batch case update and delete endpoints

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -107,7 +107,6 @@ export default function CasesPage() {
     isLoading,
     error,
     filters,
-    refetch,
     setSearchQuery,
     setSortBy,
     setStatusFilter,
@@ -190,7 +189,6 @@ export default function CasesPage() {
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={fetchNextPage}
-        refetch={refetch}
       />
     </div>
   )

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6316,6 +6316,100 @@ export const $CaseAttachmentRead = {
   description: "Model for reading a case attachment.",
 } as const
 
+export const $CaseBatchDelete = {
+  properties: {
+    case_ids: {
+      items: {
+        type: "string",
+        format: "uuid",
+      },
+      type: "array",
+      maxItems: 1000,
+      minItems: 1,
+      title: "Case Ids",
+    },
+  },
+  type: "object",
+  required: ["case_ids"],
+  title: "CaseBatchDelete",
+  description: "Request body for deleting multiple cases.",
+} as const
+
+export const $CaseBatchItemResult = {
+  properties: {
+    case_id: {
+      type: "string",
+      format: "uuid",
+      title: "Case Id",
+    },
+    success: {
+      type: "boolean",
+      title: "Success",
+    },
+    error: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Error",
+    },
+  },
+  type: "object",
+  required: ["case_id", "success"],
+  title: "CaseBatchItemResult",
+  description: "Result of a batch operation for one case.",
+} as const
+
+export const $CaseBatchResponse = {
+  properties: {
+    results: {
+      items: {
+        $ref: "#/components/schemas/CaseBatchItemResult",
+      },
+      type: "array",
+      title: "Results",
+    },
+    succeeded: {
+      type: "integer",
+      title: "Succeeded",
+    },
+    failed: {
+      type: "integer",
+      title: "Failed",
+    },
+  },
+  type: "object",
+  required: ["results", "succeeded", "failed"],
+  title: "CaseBatchResponse",
+  description: "Per-case results and aggregate counts for a batch operation.",
+} as const
+
+export const $CaseBatchUpdate = {
+  properties: {
+    case_ids: {
+      items: {
+        type: "string",
+        format: "uuid",
+      },
+      type: "array",
+      maxItems: 1000,
+      minItems: 1,
+      title: "Case Ids",
+    },
+    update: {
+      $ref: "#/components/schemas/CaseUpdate",
+    },
+  },
+  type: "object",
+  required: ["case_ids", "update"],
+  title: "CaseBatchUpdate",
+  description: "Request body for updating multiple cases.",
+} as const
+
 export const $CaseCommentCreate = {
   properties: {
     content: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -308,6 +308,10 @@ import type {
   CaseDurationsUpdateCaseDurationResponse,
   CasesAddTagData,
   CasesAddTagResponse,
+  CasesBatchDeleteCasesData,
+  CasesBatchDeleteCasesResponse,
+  CasesBatchUpdateCasesData,
+  CasesBatchUpdateCasesResponse,
   CasesCreateCaseData,
   CasesCreateCaseResponse,
   CasesCreateCommentData,
@@ -9703,6 +9707,58 @@ export const casesSearchCaseAggregates = (
       updated_before: data.updatedBefore,
       assignee_id: data.assigneeId,
     },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Batch Update Cases
+ * Update multiple cases with per-case results.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns CaseBatchResponse Successful Response
+ * @throws ApiError
+ */
+export const casesBatchUpdateCases = (
+  data: CasesBatchUpdateCasesData
+): CancelablePromise<CasesBatchUpdateCasesResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/cases/batch-update",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Batch Delete Cases
+ * Delete multiple cases with per-case results.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns CaseBatchResponse Successful Response
+ * @throws ApiError
+ */
+export const casesBatchDeleteCases = (
+  data: CasesBatchDeleteCasesData
+): CancelablePromise<CasesBatchDeleteCasesResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/cases/batch-delete",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1634,6 +1634,39 @@ export type CaseAttachmentRead = {
   is_deleted?: boolean
 }
 
+/**
+ * Request body for deleting multiple cases.
+ */
+export type CaseBatchDelete = {
+  case_ids: Array<string>
+}
+
+/**
+ * Result of a batch operation for one case.
+ */
+export type CaseBatchItemResult = {
+  case_id: string
+  success: boolean
+  error?: string | null
+}
+
+/**
+ * Per-case results and aggregate counts for a batch operation.
+ */
+export type CaseBatchResponse = {
+  results: Array<CaseBatchItemResult>
+  succeeded: number
+  failed: number
+}
+
+/**
+ * Request body for updating multiple cases.
+ */
+export type CaseBatchUpdate = {
+  case_ids: Array<string>
+  update: CaseUpdate
+}
+
 export type CaseCommentCreate = {
   content: string
   parent_id?: string | null
@@ -12725,6 +12758,20 @@ export type CasesSearchCaseAggregatesData = {
 
 export type CasesSearchCaseAggregatesResponse = CaseSearchAggregateRead
 
+export type CasesBatchUpdateCasesData = {
+  requestBody: CaseBatchUpdate
+  workspaceId: string
+}
+
+export type CasesBatchUpdateCasesResponse = CaseBatchResponse
+
+export type CasesBatchDeleteCasesData = {
+  requestBody: CaseBatchDelete
+  workspaceId: string
+}
+
+export type CasesBatchDeleteCasesResponse = CaseBatchResponse
+
 export type CasesGetCaseData = {
   caseId: string
   /**
@@ -18511,6 +18558,36 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: CaseSearchAggregateRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/batch-update": {
+    post: {
+      req: CasesBatchUpdateCasesData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseBatchResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/batch-delete": {
+    post: {
+      req: CasesBatchDeleteCasesData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseBatchResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -178,21 +178,25 @@ export function CasesLayout({
   const handleBulkDelete = useCallback(async () => {
     if (selectedCaseIds.size === 0) return
 
+    const caseIds = Array.from(selectedCaseIds)
+    const succeededIds = new Set<string>()
+    let failed = 0
     try {
       setIsDeleting(true)
-      const caseIds = Array.from(selectedCaseIds)
-      let succeeded = 0
-      let failed = 0
       for (const chunk of chunkCaseIds(caseIds)) {
         const response = await batchDeleteCases({ case_ids: chunk })
-        succeeded += response.succeeded
+        for (const result of response.results) {
+          if (result.success) {
+            succeededIds.add(result.case_id)
+          }
+        }
         failed += response.failed
       }
 
       if (failed > 0) {
         toast({
           variant: "destructive",
-          title: `${succeeded} deleted, ${failed} failed`,
+          title: `${succeededIds.size} deleted, ${failed} failed`,
           description: "Some selected cases could not be deleted.",
         })
       } else {
@@ -207,9 +211,17 @@ export function CasesLayout({
       console.error("Failed to delete cases:", err)
       toast({
         variant: "destructive",
-        title: "Failed to delete cases",
-        description: "Please try again.",
+        title:
+          succeededIds.size > 0
+            ? `${succeededIds.size} deleted before a request failed`
+            : "Failed to delete cases",
+        description: "Please retry to delete the remaining cases.",
       })
+      // Keep only unprocessed/failed cases selected so a retry cannot
+      // resubmit already-deleted IDs.
+      setSelectedCaseIds(
+        (prev) => new Set([...prev].filter((id) => !succeededIds.has(id)))
+      )
     } finally {
       setIsDeleting(false)
     }
@@ -223,25 +235,29 @@ export function CasesLayout({
       if (selectedCaseIds.size === 0) return
 
       const caseIds = Array.from(selectedCaseIds)
+      const succeededIds = new Set<string>()
+      let failed = 0
 
       try {
         setIsBulkUpdating(true)
 
-        let succeeded = 0
-        let failed = 0
         for (const chunk of chunkCaseIds(caseIds)) {
           const response = await batchUpdateCases({
             case_ids: chunk,
             update: updates,
           })
-          succeeded += response.succeeded
+          for (const result of response.results) {
+            if (result.success) {
+              succeededIds.add(result.case_id)
+            }
+          }
           failed += response.failed
         }
 
         if (failed > 0) {
           toast({
             variant: "destructive",
-            title: `${succeeded} updated, ${failed} failed`,
+            title: `${succeededIds.size} updated, ${failed} failed`,
             description: "Some selected cases could not be updated.",
           })
         } else {
@@ -258,9 +274,17 @@ export function CasesLayout({
         console.error("Failed to update cases:", err)
         toast({
           variant: "destructive",
-          title: "Failed to update cases",
-          description: "Please try again.",
+          title:
+            succeededIds.size > 0
+              ? `${succeededIds.size} updated before a request failed`
+              : "Failed to update cases",
+          description: "Please retry to update the remaining cases.",
         })
+        // Keep only unprocessed/failed cases selected so a retry targets
+        // just the remainder.
+        setSelectedCaseIds(
+          (prev) => new Set([...prev].filter((id) => !succeededIds.has(id)))
+        )
       } finally {
         setIsBulkUpdating(false)
       }

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -2,19 +2,18 @@
 
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useMemo, useState } from "react"
-import {
-  type CaseDropdownDefinitionRead,
-  type CaseDurationDefinitionRead,
-  type CaseFieldReadMinimal,
-  type CasePriority,
-  type CaseReadMinimal,
-  type CaseSearchAggregateRead,
-  type CaseSeverity,
-  type CaseStatus,
-  type CaseTagRead,
-  type CaseUpdate,
-  casesUpdateCase,
-  type WorkspaceMember,
+import type {
+  CaseDropdownDefinitionRead,
+  CaseDurationDefinitionRead,
+  CaseFieldReadMinimal,
+  CasePriority,
+  CaseReadMinimal,
+  CaseSearchAggregateRead,
+  CaseSeverity,
+  CaseStatus,
+  CaseTagRead,
+  CaseUpdate,
+  WorkspaceMember,
 } from "@/client"
 import { useCaseSelection } from "@/components/cases/case-selection-context"
 import {
@@ -31,11 +30,8 @@ import type {
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useToast } from "@/components/ui/use-toast"
 import type { CaseDateFilterValue, UseCasesFilters } from "@/hooks/use-cases"
-import { useDeleteCase } from "@/lib/hooks"
-import { runWithConcurrencyLimit } from "@/lib/utils"
+import { useBatchDeleteCases, useBatchUpdateCases } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
-
-const BULK_CASE_REQUEST_CONCURRENCY = 8
 
 interface CasesLayoutProps {
   cases: CaseReadMinimal[]
@@ -131,7 +127,8 @@ export function CasesLayout({
   const [caseToDelete, setCaseToDelete] = useState<CaseReadMinimal | null>(null)
 
   const { updateSelection, resetSelection } = useCaseSelection()
-  const { deleteCase } = useDeleteCase({ workspaceId })
+  const { batchDeleteCases } = useBatchDeleteCases({ workspaceId })
+  const { batchUpdateCases } = useBatchUpdateCases({ workspaceId })
   const { toast } = useToast()
 
   const handleSelectCase = useCallback(
@@ -174,15 +171,20 @@ export function CasesLayout({
     try {
       setIsDeleting(true)
       const caseIds = Array.from(selectedCaseIds)
-      await runWithConcurrencyLimit(
-        caseIds.map((caseId) => () => deleteCase(caseId)),
-        BULK_CASE_REQUEST_CONCURRENCY
-      )
+      const response = await batchDeleteCases({ case_ids: caseIds })
 
-      toast({
-        title: `${caseIds.length} case(s) deleted`,
-        description: "The selected cases have been deleted successfully.",
-      })
+      if (response.failed > 0) {
+        toast({
+          variant: "destructive",
+          title: `${response.succeeded} deleted, ${response.failed} failed`,
+          description: "Some selected cases could not be deleted.",
+        })
+      } else {
+        toast({
+          title: `${caseIds.length} case(s) deleted`,
+          description: "The selected cases have been deleted successfully.",
+        })
+      }
 
       refetch?.()
       setSelectedCaseIds(new Set())
@@ -196,7 +198,7 @@ export function CasesLayout({
     } finally {
       setIsDeleting(false)
     }
-  }, [deleteCase, refetch, selectedCaseIds, toast])
+  }, [batchDeleteCases, refetch, selectedCaseIds, toast])
 
   const handleBulkUpdate = useCallback(
     async (
@@ -210,26 +212,27 @@ export function CasesLayout({
       try {
         setIsBulkUpdating(true)
 
-        await runWithConcurrencyLimit(
-          caseIds.map(
-            (caseId) => () =>
-              casesUpdateCase({
-                workspaceId,
-                caseId,
-                requestBody: updates,
-              })
-          ),
-          BULK_CASE_REQUEST_CONCURRENCY
-        )
-
-        toast({
-          title:
-            options?.successTitle ||
-            `Updated ${caseIds.length} case${caseIds.length > 1 ? "s" : ""}`,
-          description:
-            options?.successDescription ||
-            "The selected cases have been updated successfully.",
+        const response = await batchUpdateCases({
+          case_ids: caseIds,
+          update: updates,
         })
+
+        if (response.failed > 0) {
+          toast({
+            variant: "destructive",
+            title: `${response.succeeded} updated, ${response.failed} failed`,
+            description: "Some selected cases could not be updated.",
+          })
+        } else {
+          toast({
+            title:
+              options?.successTitle ||
+              `Updated ${caseIds.length} case${caseIds.length > 1 ? "s" : ""}`,
+            description:
+              options?.successDescription ||
+              "The selected cases have been updated successfully.",
+          })
+        }
 
         refetch?.()
       } catch (err) {
@@ -243,7 +246,7 @@ export function CasesLayout({
         setIsBulkUpdating(false)
       }
     },
-    [refetch, selectedCaseIds, toast, workspaceId]
+    [batchUpdateCases, refetch, selectedCaseIds, toast]
   )
 
   // Sync selection state with context

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import type {
@@ -137,6 +138,7 @@ export function CasesLayout({
   const [caseToDelete, setCaseToDelete] = useState<CaseReadMinimal | null>(null)
 
   const { updateSelection, resetSelection } = useCaseSelection()
+  const queryClient = useQueryClient()
   const { batchDeleteCases } = useBatchDeleteCases({ workspaceId })
   const { batchUpdateCases } = useBatchUpdateCases({ workspaceId })
   const { toast } = useToast()
@@ -227,9 +229,11 @@ export function CasesLayout({
         (prev) => new Set([...prev].filter((id) => !succeededIds.has(id)))
       )
     } finally {
+      // Refetch once per bulk operation, not once per chunk.
+      queryClient.invalidateQueries({ queryKey: ["cases"], exact: false })
       setIsDeleting(false)
     }
-  }, [batchDeleteCases, selectedCaseIds, toast])
+  }, [batchDeleteCases, queryClient, selectedCaseIds, toast])
 
   const handleBulkUpdate = useCallback(
     async (
@@ -295,10 +299,12 @@ export function CasesLayout({
           (prev) => new Set([...prev].filter((id) => !succeededIds.has(id)))
         )
       } finally {
+        // Refetch once per bulk operation, not once per chunk.
+        queryClient.invalidateQueries({ queryKey: ["cases"], exact: false })
         setIsBulkUpdating(false)
       }
     },
-    [batchUpdateCases, selectedCaseIds, toast]
+    [batchUpdateCases, queryClient, selectedCaseIds, toast]
   )
 
   // Sync selection state with context

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -33,6 +33,18 @@ import type { CaseDateFilterValue, UseCasesFilters } from "@/hooks/use-cases"
 import { useBatchDeleteCases, useBatchUpdateCases } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
+// Keep aligned with the CaseBatchUpdate and CaseBatchDelete schema cap.
+const CASE_BATCH_MAX_IDS = 1000
+
+/** Split case IDs into requests that satisfy the server batch-size contract. */
+export function chunkCaseIds(caseIds: string[]): string[][] {
+  const chunks: string[][] = []
+  for (let start = 0; start < caseIds.length; start += CASE_BATCH_MAX_IDS) {
+    chunks.push(caseIds.slice(start, start + CASE_BATCH_MAX_IDS))
+  }
+  return chunks
+}
+
 interface CasesLayoutProps {
   cases: CaseReadMinimal[]
   isLoading: boolean
@@ -73,7 +85,6 @@ interface CasesLayoutProps {
   hasNextPage: boolean
   isFetchingNextPage: boolean
   onLoadMore: () => void
-  refetch?: () => void
 }
 
 export function CasesLayout({
@@ -116,7 +127,6 @@ export function CasesLayout({
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
-  refetch,
 }: CasesLayoutProps) {
   const workspaceId = useWorkspaceId()
   const router = useRouter()
@@ -171,12 +181,18 @@ export function CasesLayout({
     try {
       setIsDeleting(true)
       const caseIds = Array.from(selectedCaseIds)
-      const response = await batchDeleteCases({ case_ids: caseIds })
+      let succeeded = 0
+      let failed = 0
+      for (const chunk of chunkCaseIds(caseIds)) {
+        const response = await batchDeleteCases({ case_ids: chunk })
+        succeeded += response.succeeded
+        failed += response.failed
+      }
 
-      if (response.failed > 0) {
+      if (failed > 0) {
         toast({
           variant: "destructive",
-          title: `${response.succeeded} deleted, ${response.failed} failed`,
+          title: `${succeeded} deleted, ${failed} failed`,
           description: "Some selected cases could not be deleted.",
         })
       } else {
@@ -186,7 +202,6 @@ export function CasesLayout({
         })
       }
 
-      refetch?.()
       setSelectedCaseIds(new Set())
     } catch (err) {
       console.error("Failed to delete cases:", err)
@@ -198,7 +213,7 @@ export function CasesLayout({
     } finally {
       setIsDeleting(false)
     }
-  }, [batchDeleteCases, refetch, selectedCaseIds, toast])
+  }, [batchDeleteCases, selectedCaseIds, toast])
 
   const handleBulkUpdate = useCallback(
     async (
@@ -212,15 +227,21 @@ export function CasesLayout({
       try {
         setIsBulkUpdating(true)
 
-        const response = await batchUpdateCases({
-          case_ids: caseIds,
-          update: updates,
-        })
+        let succeeded = 0
+        let failed = 0
+        for (const chunk of chunkCaseIds(caseIds)) {
+          const response = await batchUpdateCases({
+            case_ids: chunk,
+            update: updates,
+          })
+          succeeded += response.succeeded
+          failed += response.failed
+        }
 
-        if (response.failed > 0) {
+        if (failed > 0) {
           toast({
             variant: "destructive",
-            title: `${response.succeeded} updated, ${response.failed} failed`,
+            title: `${succeeded} updated, ${failed} failed`,
             description: "Some selected cases could not be updated.",
           })
         } else {
@@ -233,8 +254,6 @@ export function CasesLayout({
               "The selected cases have been updated successfully.",
           })
         }
-
-        refetch?.()
       } catch (err) {
         console.error("Failed to update cases:", err)
         toast({
@@ -246,7 +265,7 @@ export function CasesLayout({
         setIsBulkUpdating(false)
       }
     },
-    [batchUpdateCases, refetch, selectedCaseIds, toast]
+    [batchUpdateCases, selectedCaseIds, toast]
   )
 
   // Sync selection state with context

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -199,14 +199,17 @@ export function CasesLayout({
           title: `${succeededIds.size} deleted, ${failed} failed`,
           description: "Some selected cases could not be deleted.",
         })
+        // Keep only failed cases selected so a retry targets the remainder.
+        setSelectedCaseIds(
+          new Set(caseIds.filter((id) => !succeededIds.has(id)))
+        )
       } else {
         toast({
           title: `${caseIds.length} case(s) deleted`,
           description: "The selected cases have been deleted successfully.",
         })
+        setSelectedCaseIds(new Set())
       }
-
-      setSelectedCaseIds(new Set())
     } catch (err) {
       console.error("Failed to delete cases:", err)
       toast({
@@ -260,6 +263,10 @@ export function CasesLayout({
             title: `${succeededIds.size} updated, ${failed} failed`,
             description: "Some selected cases could not be updated.",
           })
+          // Keep only failed cases selected so a retry targets the remainder.
+          setSelectedCaseIds(
+            new Set(caseIds.filter((id) => !succeededIds.has(id)))
+          )
         } else {
           toast({
             title:

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -199,9 +199,10 @@ export function CasesLayout({
           title: `${succeededIds.size} deleted, ${failed} failed`,
           description: "Some selected cases could not be deleted.",
         })
-        // Keep only failed cases selected so a retry targets the remainder.
+        // Drop succeeded cases from the current selection so a retry targets
+        // the remainder without discarding selection changes made mid-flight.
         setSelectedCaseIds(
-          new Set(caseIds.filter((id) => !succeededIds.has(id)))
+          (prev) => new Set([...prev].filter((id) => !succeededIds.has(id)))
         )
       } else {
         toast({
@@ -263,9 +264,10 @@ export function CasesLayout({
             title: `${succeededIds.size} updated, ${failed} failed`,
             description: "Some selected cases could not be updated.",
           })
-          // Keep only failed cases selected so a retry targets the remainder.
+          // Drop succeeded cases from the current selection so a retry targets
+          // the remainder without discarding selection changes made mid-flight.
           setSelectedCaseIds(
-            new Set(caseIds.filter((id) => !succeededIds.has(id)))
+            (prev) => new Set([...prev].filter((id) => !succeededIds.has(id)))
           )
         } else {
           toast({

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -3931,7 +3931,6 @@ export function useDeleteCase({ workspaceId }: { workspaceId: string }) {
 
 /** Update a collection of cases in one server-side batch. */
 export function useBatchUpdateCases({ workspaceId }: { workspaceId: string }) {
-  const queryClient = useQueryClient()
   const {
     mutateAsync: batchUpdateCases,
     isPending: batchUpdateCasesIsPending,
@@ -3939,12 +3938,9 @@ export function useBatchUpdateCases({ workspaceId }: { workspaceId: string }) {
   } = useMutation({
     mutationFn: async (params: CaseBatchUpdate) =>
       await casesBatchUpdateCases({ workspaceId, requestBody: params }),
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["cases"],
-        exact: false,
-      })
-    },
+    // Cache invalidation is the caller's responsibility: bulk operations issue
+    // one request per 1000-ID chunk, and invalidating per chunk would refetch
+    // the case list repeatedly mid-operation.
   })
 
   return {
@@ -3956,7 +3952,6 @@ export function useBatchUpdateCases({ workspaceId }: { workspaceId: string }) {
 
 /** Delete a collection of cases in one server-side batch. */
 export function useBatchDeleteCases({ workspaceId }: { workspaceId: string }) {
-  const queryClient = useQueryClient()
   const {
     mutateAsync: batchDeleteCases,
     isPending: batchDeleteCasesIsPending,
@@ -3964,12 +3959,9 @@ export function useBatchDeleteCases({ workspaceId }: { workspaceId: string }) {
   } = useMutation({
     mutationFn: async (params: CaseBatchDelete) =>
       await casesBatchDeleteCases({ workspaceId, requestBody: params }),
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["cases"],
-        exact: false,
-      })
-    },
+    // Cache invalidation is the caller's responsibility: bulk operations issue
+    // one request per 1000-ID chunk, and invalidating per chunk would refetch
+    // the case list repeatedly mid-operation.
   })
 
   return {

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -38,6 +38,8 @@ import {
   agentSessionsListSessions,
   agentSetDefaultModel,
   agentUpdateProviderCredentials,
+  type CaseBatchDelete,
+  type CaseBatchUpdate,
   type CaseCommentCreate,
   type CaseCommentRead,
   type CaseCommentThreadRead,
@@ -85,6 +87,8 @@ import {
   caseDropdownsUpdateDropdownDefinition,
   caseDropdownsUpdateDropdownOption,
   casesAddTag,
+  casesBatchDeleteCases,
+  casesBatchUpdateCases,
   casesCreateCase,
   casesCreateComment,
   casesCreateTask,
@@ -3922,6 +3926,56 @@ export function useDeleteCase({ workspaceId }: { workspaceId: string }) {
     deleteCase,
     deleteCaseIsPending,
     deleteCaseError,
+  }
+}
+
+/** Update a collection of cases in one server-side batch. */
+export function useBatchUpdateCases({ workspaceId }: { workspaceId: string }) {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: batchUpdateCases,
+    isPending: batchUpdateCasesIsPending,
+    error: batchUpdateCasesError,
+  } = useMutation({
+    mutationFn: async (params: CaseBatchUpdate) =>
+      await casesBatchUpdateCases({ workspaceId, requestBody: params }),
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["cases"],
+        exact: false,
+      })
+    },
+  })
+
+  return {
+    batchUpdateCases,
+    batchUpdateCasesIsPending,
+    batchUpdateCasesError,
+  }
+}
+
+/** Delete a collection of cases in one server-side batch. */
+export function useBatchDeleteCases({ workspaceId }: { workspaceId: string }) {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: batchDeleteCases,
+    isPending: batchDeleteCasesIsPending,
+    error: batchDeleteCasesError,
+  } = useMutation({
+    mutationFn: async (params: CaseBatchDelete) =>
+      await casesBatchDeleteCases({ workspaceId, requestBody: params }),
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["cases"],
+        exact: false,
+      })
+    },
+  })
+
+  return {
+    batchDeleteCases,
+    batchDeleteCasesIsPending,
+    batchDeleteCasesError,
   }
 }
 

--- a/frontend/tests/use-batch-cases.test.tsx
+++ b/frontend/tests/use-batch-cases.test.tsx
@@ -1,0 +1,99 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { casesBatchDeleteCases, casesBatchUpdateCases } from "@/client"
+import { useBatchDeleteCases, useBatchUpdateCases } from "@/lib/hooks"
+
+jest.mock("@/client", () => {
+  const actual = jest.requireActual("@/client")
+  return {
+    ...actual,
+    casesBatchDeleteCases: jest.fn(),
+    casesBatchUpdateCases: jest.fn(),
+  }
+})
+
+const mockBatchDeleteCases = casesBatchDeleteCases as jest.MockedFunction<
+  typeof casesBatchDeleteCases
+>
+const mockBatchUpdateCases = casesBatchUpdateCases as jest.MockedFunction<
+  typeof casesBatchUpdateCases
+>
+
+describe("batch case hooks", () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    })
+    jest.clearAllMocks()
+  })
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+
+  it("updates cases once and invalidates the cases cache once", async () => {
+    mockBatchUpdateCases.mockResolvedValue({
+      results: [{ case_id: "case-1", success: true, error: null }],
+      succeeded: 1,
+      failed: 0,
+    })
+    const invalidateQueries = jest.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(
+      () => useBatchUpdateCases({ workspaceId: "workspace-1" }),
+      { wrapper }
+    )
+
+    await result.current.batchUpdateCases({
+      case_ids: ["case-1"],
+      update: { summary: "Updated" },
+    })
+
+    expect(mockBatchUpdateCases).toHaveBeenCalledTimes(1)
+    expect(mockBatchUpdateCases).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      requestBody: {
+        case_ids: ["case-1"],
+        update: { summary: "Updated" },
+      },
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["cases"],
+      exact: false,
+    })
+  })
+
+  it("deletes cases once and invalidates the cases cache once", async () => {
+    mockBatchDeleteCases.mockResolvedValue({
+      results: [{ case_id: "case-1", success: true, error: null }],
+      succeeded: 1,
+      failed: 0,
+    })
+    const invalidateQueries = jest.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(
+      () => useBatchDeleteCases({ workspaceId: "workspace-1" }),
+      { wrapper }
+    )
+
+    await result.current.batchDeleteCases({ case_ids: ["case-1"] })
+
+    expect(mockBatchDeleteCases).toHaveBeenCalledTimes(1)
+    expect(mockBatchDeleteCases).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      requestBody: { case_ids: ["case-1"] },
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["cases"],
+      exact: false,
+    })
+  })
+})

--- a/frontend/tests/use-batch-cases.test.tsx
+++ b/frontend/tests/use-batch-cases.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { renderHook } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { casesBatchDeleteCases, casesBatchUpdateCases } from "@/client"
+import { chunkCaseIds } from "@/components/cases/cases-layout"
 import { useBatchDeleteCases, useBatchUpdateCases } from "@/lib/hooks"
 
 jest.mock("@/client", () => {
@@ -38,6 +39,15 @@ describe("batch case hooks", () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
   }
+
+  it("chunks case IDs at the server batch limit", () => {
+    const caseIds = Array.from({ length: 2001 }, (_, index) => `case-${index}`)
+
+    const chunks = chunkCaseIds(caseIds)
+
+    expect(chunks.map((chunk) => chunk.length)).toEqual([1000, 1000, 1])
+    expect(chunks.flat()).toEqual(caseIds)
+  })
 
   it("updates cases once and invalidates the cases cache once", async () => {
     mockBatchUpdateCases.mockResolvedValue({

--- a/frontend/tests/use-batch-cases.test.tsx
+++ b/frontend/tests/use-batch-cases.test.tsx
@@ -49,7 +49,7 @@ describe("batch case hooks", () => {
     expect(chunks.flat()).toEqual(caseIds)
   })
 
-  it("updates cases once and invalidates the cases cache once", async () => {
+  it("updates cases once without invalidating the cases cache", async () => {
     mockBatchUpdateCases.mockResolvedValue({
       results: [{ case_id: "case-1", success: true, error: null }],
       succeeded: 1,
@@ -74,14 +74,12 @@ describe("batch case hooks", () => {
         update: { summary: "Updated" },
       },
     })
-    expect(invalidateQueries).toHaveBeenCalledTimes(1)
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["cases"],
-      exact: false,
-    })
+    // Invalidation is owned by the caller (one refetch per bulk operation,
+    // not per 1000-ID chunk) — the hook itself must not invalidate.
+    expect(invalidateQueries).not.toHaveBeenCalled()
   })
 
-  it("deletes cases once and invalidates the cases cache once", async () => {
+  it("deletes cases once without invalidating the cases cache", async () => {
     mockBatchDeleteCases.mockResolvedValue({
       results: [{ case_id: "case-1", success: true, error: null }],
       succeeded: 1,
@@ -100,10 +98,8 @@ describe("batch case hooks", () => {
       workspaceId: "workspace-1",
       requestBody: { case_ids: ["case-1"] },
     })
-    expect(invalidateQueries).toHaveBeenCalledTimes(1)
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["cases"],
-      exact: false,
-    })
+    // Invalidation is owned by the caller (one refetch per bulk operation,
+    // not per 1000-ID chunk) — the hook itself must not invalidate.
+    expect(invalidateQueries).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -31,7 +31,11 @@ from tracecat.cases.schemas import (
 )
 from tracecat.contexts import ctx_role
 from tracecat.db.models import Case, CaseTag, Workspace
-from tracecat.exceptions import EntitlementRequired, TracecatValidationError
+from tracecat.exceptions import (
+    EntitlementRequired,
+    TracecatConflictError,
+    TracecatValidationError,
+)
 from tracecat.pagination import CursorPaginatedResponse
 
 
@@ -839,6 +843,47 @@ async def test_batch_delete_cases_success(
     assert response.json()["succeeded"] == 1
     assert response.json()["failed"] == 0
     mock_svc.batch_delete_cases.assert_awaited_once_with([mock_case.id])
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("path", "payload", "service_method"),
+    [
+        (
+            "/cases/batch-update",
+            {"case_ids": [str(uuid.uuid4())], "update": {"summary": "x"}},
+            "batch_update_cases",
+        ),
+        (
+            "/cases/batch-delete",
+            {"case_ids": [str(uuid.uuid4())]},
+            "batch_delete_cases",
+        ),
+    ],
+)
+async def test_batch_case_lock_conflict_returns_409(
+    client: TestClient,
+    test_admin_role: Role,
+    path: str,
+    payload: dict[str, object],
+    service_method: str,
+) -> None:
+    """Batch lock timeouts map the service conflict to HTTP 409."""
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_svc = AsyncMock()
+        getattr(mock_svc, service_method).side_effect = TracecatConflictError(
+            "Timed out waiting to lock cases"
+        )
+        mock_service_cls.return_value = mock_svc
+
+        response = client.post(
+            path,
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json=payload,
+        )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {"detail": "Timed out waiting to lock cases"}
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -21,12 +21,15 @@ from tracecat.cases.enums import (
     CaseStatus,
 )
 from tracecat.cases.schemas import (
+    CaseBatchItemResult,
+    CaseBatchResponse,
     CaseCommentRead,
     CaseCommentThreadRead,
     CaseReadMinimal,
     CaseSearchAggregateRead,
     CaseStatusGroupCounts,
 )
+from tracecat.contexts import ctx_role
 from tracecat.db.models import Case, CaseTag, Workspace
 from tracecat.exceptions import EntitlementRequired, TracecatValidationError
 from tracecat.pagination import CursorPaginatedResponse
@@ -748,6 +751,154 @@ async def test_update_case_success(
 
         # Verify service was called
         mock_svc.update_case.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_batch_update_cases_success_and_route_non_collision(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """The literal batch route and UUID single-case route dispatch separately."""
+    second_case_id = uuid.uuid4()
+    batch_response = CaseBatchResponse(
+        results=[
+            CaseBatchItemResult(case_id=mock_case.id, success=True),
+            CaseBatchItemResult(
+                case_id=second_case_id,
+                success=False,
+                error="Case not found",
+            ),
+        ],
+        succeeded=1,
+        failed=1,
+    )
+
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_svc = AsyncMock()
+        mock_svc.batch_update_cases.return_value = batch_response
+        mock_svc.get_case.return_value = mock_case
+        mock_service_cls.return_value = mock_svc
+
+        batch_result = client.post(
+            "/cases/batch-update",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "case_ids": [str(mock_case.id), str(second_case_id)],
+                "update": {"summary": "Updated Summary"},
+            },
+        )
+        single_result = client.patch(
+            f"/cases/{mock_case.id}",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"summary": "Single update"},
+        )
+
+    assert batch_result.status_code == status.HTTP_200_OK
+    assert batch_result.json() == {
+        "results": [
+            {"case_id": str(mock_case.id), "success": True, "error": None},
+            {
+                "case_id": str(second_case_id),
+                "success": False,
+                "error": "Case not found",
+            },
+        ],
+        "succeeded": 1,
+        "failed": 1,
+    }
+    assert single_result.status_code == status.HTTP_204_NO_CONTENT
+    mock_svc.batch_update_cases.assert_awaited_once()
+    mock_svc.update_case.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_batch_delete_cases_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """POST /cases/batch-delete returns per-case results."""
+    batch_response = CaseBatchResponse(
+        results=[CaseBatchItemResult(case_id=mock_case.id, success=True)],
+        succeeded=1,
+        failed=0,
+    )
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_svc = AsyncMock()
+        mock_svc.batch_delete_cases.return_value = batch_response
+        mock_service_cls.return_value = mock_svc
+
+        response = client.post(
+            "/cases/batch-delete",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"case_ids": [str(mock_case.id)]},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["succeeded"] == 1
+    assert response.json()["failed"] == 0
+    mock_svc.batch_delete_cases.assert_awaited_once_with([mock_case.id])
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/cases/batch-update", {"case_ids": [], "update": {"summary": "x"}}),
+        ("/cases/batch-delete", {"case_ids": []}),
+    ],
+)
+async def test_batch_case_routes_reject_empty_case_ids(
+    client: TestClient,
+    test_admin_role: Role,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    """Batch routes reject empty case ID lists before calling the service."""
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        response = client.post(
+            path,
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json=payload,
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    mock_service_cls.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "/cases/batch-update",
+            {"case_ids": [str(uuid.uuid4())], "update": {"summary": "x"}},
+        ),
+        ("/cases/batch-delete", {"case_ids": [str(uuid.uuid4())]}),
+    ],
+)
+async def test_batch_case_routes_enforce_scopes(
+    client: TestClient,
+    test_admin_role: Role,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    """Batch routes require their corresponding case mutation scope."""
+    role = test_admin_role.model_copy(update={"scopes": frozenset({"case:read"})})
+    token = ctx_role.set(role)
+    try:
+        with patch.object(cases_router, "CasesService") as mock_service_cls:
+            response = client.post(
+                path,
+                params={"workspace_id": str(test_admin_role.workspace_id)},
+                json=payload,
+            )
+    finally:
+        ctx_role.reset(token)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mock_service_cls.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -335,15 +335,13 @@ class TestCaseCommentsService:
         callbacks: list[object] = []
 
         with (
-            patch(
-                "tracecat.cases.service.add_after_commit_callback",
-                side_effect=lambda _session, _callback: callbacks.append(_callback),
-            ),
+            patch("tracecat.cases.service.AfterCommitQueue.of") as queue_of_mock,
             patch(
                 "tracecat.cases.service.publish_case_event_payload",
                 new=AsyncMock(),
             ) as publish_mock,
         ):
+            queue_of_mock.return_value.add.side_effect = callbacks.append
             created_comment = await case_comments_service.create_comment(
                 test_case,
                 CaseCommentCreate(
@@ -412,10 +410,7 @@ class TestCaseCommentsService:
         existing_audit_count = len(audit_event_calls)
 
         with (
-            patch(
-                "tracecat.cases.service.add_after_commit_callback",
-                side_effect=lambda _session, _callback: None,
-            ),
+            patch("tracecat.cases.service.AfterCommitQueue.of"),
             patch(
                 "tracecat.cases.service.publish_case_event_payload",
                 new=AsyncMock(side_effect=RuntimeError("redis unavailable")),

--- a/tests/unit/test_case_dropdown_service.py
+++ b/tests/unit/test_case_dropdown_service.py
@@ -16,6 +16,7 @@ from tracecat.cases.dropdowns.service import (
     CaseDropdownDefinitionsService,
     CaseDropdownValuesService,
 )
+from tracecat.db.models import Case
 from tracecat.exceptions import (
     ScopeDeniedError,
     TracecatNotFoundError,
@@ -220,6 +221,25 @@ class TestCaseDropdownDefinitionsService:
         # create-only role passes its scope gate (and fails later on lookup).
         with pytest.raises(TracecatNotFoundError):
             await values_service.apply_values(uuid.uuid4(), [])
+
+    async def test_apply_values_rejects_case_model_from_other_workspace(
+        self,
+        session: AsyncSession,
+        dropdown_service: CaseDropdownDefinitionsService,
+    ) -> None:
+        """A Case model input gets the same tenant scoping as a UUID input."""
+        values_service = CaseDropdownValuesService(
+            session=session, role=dropdown_service.role
+        )
+        foreign_case = Case(
+            id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            summary="Foreign workspace case",
+            description="",
+        )
+
+        with pytest.raises(TracecatNotFoundError):
+            await values_service.apply_values(foreign_case, [])
 
     async def test_list_definitions_order_is_deterministic(
         self, dropdown_service: CaseDropdownDefinitionsService

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from sqlalchemy import select, text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload as sa_selectinload
 
@@ -39,13 +41,14 @@ from tracecat.cases.schemas import (
 )
 from tracecat.tags.schemas import TagCreate
 from tracecat.cases.service import (
+    CASE_BATCH_LOCK_TIMEOUT,
     CaseCommentsService,
     CaseFieldsService,
     CasesService,
 )
 from tracecat.cases.tags.service import CaseTagsService
 from tracecat.db.models import Case, CaseComment, Workspace
-from tracecat.exceptions import TracecatAuthorizationError
+from tracecat.exceptions import TracecatAuthorizationError, TracecatConflictError
 from tracecat.pagination import CursorPaginationParams
 from tracecat.tables.enums import SqlType
 
@@ -774,6 +777,131 @@ class TestCasesService:
             updated_case = await cases_service.get_case(case_id)
             assert updated_case is not None
             assert updated_case.summary == "Batch updated"
+
+    async def test_case_batch_lock_statements_use_expected_strength(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+    ) -> None:
+        """Updates use NO KEY UPDATE while deletes retain full UPDATE locks."""
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+
+        with patch.object(
+            session, "execute", new=AsyncMock(return_value=result)
+        ) as mock_execute:
+            await cases_service._lock_cases([uuid.uuid4()], key_share=True)
+            assert mock_execute.await_args is not None
+            update_statement = mock_execute.await_args.args[0]
+
+            await cases_service._lock_cases([uuid.uuid4()])
+            assert mock_execute.await_args is not None
+            delete_statement = mock_execute.await_args.args[0]
+
+        update_sql = str(update_statement.compile(dialect=postgresql.dialect()))
+        delete_sql = str(delete_statement.compile(dialect=postgresql.dialect()))
+        assert "FOR NO KEY UPDATE" in update_sql
+        assert "FOR UPDATE" in delete_sql
+        assert "FOR NO KEY UPDATE" not in delete_sql
+
+    async def test_batch_update_reuses_locked_case_for_dropdown_values(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+    ) -> None:
+        """Batch dropdown writes do not requery their already-locked case."""
+        definition, option = await _create_dropdown_with_option(
+            cases_service,
+            definition_name="Batch Triage",
+            definition_ref="batch_triage",
+            option_label="Escalated",
+            option_ref="escalated",
+        )
+        created_case = await cases_service.create_case(case_create_params)
+
+        with patch.object(
+            cases_service.dropdowns,
+            "_get_case",
+            wraps=cases_service.dropdowns._get_case,
+        ) as mock_get_case:
+            response = await cases_service.batch_update_cases(
+                [created_case.id],
+                CaseUpdate(
+                    dropdown_values=[
+                        CaseDropdownValueInput(
+                            definition_id=definition.id,
+                            option_id=option.id,
+                        )
+                    ]
+                ),
+            )
+
+        assert response.succeeded == 1
+        mock_get_case.assert_not_awaited()
+        values = await cases_service.dropdowns.list_values_for_case(created_case.id)
+        assert len(values) == 1
+        assert values[0].option_id == option.id
+
+    @pytest.mark.parametrize("action", ["update", "delete"])
+    async def test_batch_case_lock_timeout_raises_conflict_and_audits_failure(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+        action: Literal["update", "delete"],
+    ) -> None:
+        """SQLSTATE 55P03 becomes a conflict after rollback and failure audit."""
+
+        class LockNotAvailableError(Exception):
+            sqlstate = "55P03"
+
+        case_ids = [uuid.uuid4(), uuid.uuid4()]
+        lock_error = DBAPIError(
+            "SELECT ... FOR UPDATE",
+            {},
+            LockNotAvailableError(),
+        )
+
+        with (
+            patch.object(
+                AuditService, "create_event", new_callable=AsyncMock
+            ) as mock_audit,
+            patch.object(
+                cases_service,
+                "_lock_cases",
+                side_effect=lock_error,
+            ) as mock_lock_cases,
+            patch.object(session, "execute", new_callable=AsyncMock) as mock_execute,
+            patch.object(session, "rollback", wraps=session.rollback) as mock_rollback,
+        ):
+            with pytest.raises(TracecatConflictError) as exc_info:
+                if action == "update":
+                    await cases_service.batch_update_cases(case_ids, CaseUpdate())
+                else:
+                    await cases_service.batch_delete_cases(case_ids)
+
+        assert exc_info.value.__cause__ is lock_error
+        mock_rollback.assert_awaited_once()
+        assert mock_execute.await_args is not None
+        timeout_statement = mock_execute.await_args.args[0]
+        assert str(timeout_statement) == (
+            f"SET LOCAL lock_timeout = '{CASE_BATCH_LOCK_TIMEOUT}'"
+        )
+        if action == "update":
+            mock_lock_cases.assert_awaited_once_with(
+                case_ids,
+                load_dropdown_values=False,
+                key_share=True,
+            )
+        else:
+            mock_lock_cases.assert_awaited_once_with(case_ids)
+        _assert_batch_audit_calls(
+            mock_audit,
+            action=action,
+            case_ids=case_ids,
+            succeeded=0,
+            failed=2,
+            terminal_status=AuditEventStatus.FAILURE,
+        )
 
     async def test_batch_update_cases_deduplicates_case_ids(
         self,

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload as sa_selectinload
 
@@ -769,6 +769,37 @@ class TestCasesService:
             assert updated_case is not None
             assert updated_case.summary == "Batch updated"
 
+    async def test_batch_update_cases_deduplicates_case_ids(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+    ) -> None:
+        """Duplicate IDs produce one ordered result and audit entry per case."""
+        first_case = await cases_service.create_case(case_create_params)
+        second_case = await cases_service.create_case(
+            case_create_params.model_copy(update={"summary": "Second case"})
+        )
+        case_ids = [first_case.id, second_case.id]
+
+        with patch.object(
+            AuditService, "create_event", new_callable=AsyncMock
+        ) as mock_audit:
+            response = await cases_service.batch_update_cases(
+                [first_case.id, second_case.id, first_case.id],
+                CaseUpdate(summary="Batch updated"),
+            )
+
+        assert response.succeeded == 2
+        assert response.failed == 0
+        assert [result.case_id for result in response.results] == case_ids
+        _assert_batch_audit_calls(
+            mock_audit,
+            action="update",
+            case_ids=case_ids,
+            succeeded=2,
+            failed=0,
+        )
+
     async def test_batch_update_cases_isolates_partial_failure(
         self,
         cases_service: CasesService,
@@ -910,6 +941,104 @@ class TestCasesService:
         )
         for case_id in case_ids:
             assert await cases_service.get_case(case_id) is None
+
+    async def test_batch_delete_cases_deduplicates_case_ids(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+    ) -> None:
+        """Duplicate delete IDs produce one result and count once."""
+        created_case = await cases_service.create_case(case_create_params)
+
+        with patch.object(
+            AuditService, "create_event", new_callable=AsyncMock
+        ) as mock_audit:
+            response = await cases_service.batch_delete_cases(
+                [created_case.id, created_case.id]
+            )
+
+        assert response.succeeded == 1
+        assert response.failed == 0
+        assert [result.case_id for result in response.results] == [created_case.id]
+        _assert_batch_audit_calls(
+            mock_audit,
+            action="delete",
+            case_ids=[created_case.id],
+            succeeded=1,
+            failed=0,
+        )
+
+    async def test_batch_update_cases_discards_callbacks_on_outer_rollback(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+        session: AsyncSession,
+    ) -> None:
+        """A whole-batch rollback cannot publish callbacks on a later commit."""
+        first_case = await cases_service.create_case(case_create_params)
+        second_case = await cases_service.create_case(
+            case_create_params.model_copy(update={"summary": "Second case"})
+        )
+        original_apply_case_update = cases_service._apply_case_update
+
+        async def fail_second_update(case: Case, params: CaseUpdate) -> None:
+            if case.id == second_case.id:
+                raise RuntimeError("Unexpected failure")
+            await original_apply_case_update(case, params)
+
+        mock_publish = AsyncMock()
+        with (
+            patch.object(AuditService, "create_event", new_callable=AsyncMock),
+            patch(
+                "tracecat.cases.service.publish_case_event_payload",
+                new=mock_publish,
+            ),
+            patch.object(
+                cases_service,
+                "_apply_case_update",
+                side_effect=fail_second_update,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Unexpected failure"):
+                await cases_service.batch_update_cases(
+                    [first_case.id, second_case.id],
+                    CaseUpdate(summary="Batch updated"),
+                )
+
+            await session.commit()
+            for _ in range(10):
+                await asyncio.sleep(0)
+
+        mock_publish.assert_not_awaited()
+
+    async def test_batch_update_cases_survives_audit_database_failure(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+        session: AsyncSession,
+    ) -> None:
+        """Audit DB failures occur on sessions isolated from the batch transaction."""
+        created_case = await cases_service.create_case(case_create_params)
+        audit_sessions: list[AsyncSession] = []
+
+        async def fail_audit_event(audit_service: AuditService, **_: Any) -> None:
+            audit_sessions.append(audit_service.session)
+            await audit_service.session.execute(
+                text("SELECT * FROM intentionally_missing_audit_test_table")
+            )
+
+        with patch.object(AuditService, "create_event", new=fail_audit_event):
+            response = await cases_service.batch_update_cases(
+                [created_case.id], CaseUpdate(summary="Batch updated")
+            )
+
+        assert response.succeeded == 1
+        assert response.failed == 0
+        assert len(audit_sessions) == 2
+        assert all(audit_session is not session for audit_session in audit_sessions)
+        updated_case = await cases_service.get_case(created_case.id)
+        assert updated_case is not None
+        assert updated_case.summary == "Batch updated"
 
     async def test_batch_update_cases_audits_whole_batch_failure(
         self,

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -31,15 +31,20 @@ from tracecat.cases.enums import (
     CaseStatus,
 )
 from tracecat.cases.schemas import (
+    CaseCommentCreate,
     CaseCreate,
     CaseFieldCreate,
     CaseReadMinimal,
     CaseUpdate,
 )
 from tracecat.tags.schemas import TagCreate
-from tracecat.cases.service import CaseFieldsService, CasesService
+from tracecat.cases.service import (
+    CaseCommentsService,
+    CaseFieldsService,
+    CasesService,
+)
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.db.models import Case, Workspace
+from tracecat.db.models import Case, CaseComment, Workspace
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.pagination import CursorPaginationParams
 from tracecat.tables.enums import SqlType
@@ -172,6 +177,7 @@ def _assert_batch_audit_calls(
     case_ids: list[uuid.UUID],
     succeeded: int,
     failed: int,
+    terminal_status: AuditEventStatus = AuditEventStatus.SUCCESS,
 ) -> None:
     base_data = {
         "batch": True,
@@ -190,7 +196,7 @@ def _assert_batch_audit_calls(
             resource_type="case",
             action=action,
             resource_id=None,
-            status=AuditEventStatus.SUCCESS,
+            status=terminal_status,
             data={**base_data, "succeeded": succeeded, "failed": failed},
         ),
     ]
@@ -905,6 +911,7 @@ class TestCasesService:
             case_ids=case_ids,
             succeeded=0,
             failed=2,
+            terminal_status=AuditEventStatus.FAILURE,
         )
 
     async def test_batch_delete_cases(
@@ -941,6 +948,36 @@ class TestCasesService:
         )
         for case_id in case_ids:
             assert await cases_service.get_case(case_id) is None
+
+    async def test_batch_delete_cases_with_threaded_comments(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+        session: AsyncSession,
+    ) -> None:
+        """Deleting a case with a reply comment must not trip the parent-id
+        RESTRICT self-FK: replies are unlinked before the case row is deleted
+        and database cascades remove the comments."""
+        created_case = await cases_service.create_case(case_create_params)
+        comments_service = CaseCommentsService(session=session, role=cases_service.role)
+        parent = await comments_service.create_comment(
+            created_case, CaseCommentCreate(content="thread starter")
+        )
+        await comments_service.create_comment(
+            created_case,
+            CaseCommentCreate(content="reply", parent_id=parent.id),
+        )
+        await session.commit()
+
+        response = await cases_service.batch_delete_cases([created_case.id])
+
+        assert response.succeeded == 1
+        assert response.failed == 0
+        assert await cases_service.get_case(created_case.id) is None
+        remaining = await session.execute(
+            select(CaseComment).where(CaseComment.case_id == created_case.id)
+        )
+        assert remaining.scalars().all() == []
 
     async def test_batch_delete_cases_deduplicates_case_ids(
         self,

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -4,13 +4,15 @@ from collections.abc import Iterator
 from decimal import Decimal
 from datetime import UTC, datetime
 from typing import Any, Literal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload as sa_selectinload
 
+from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.service import AuditService
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.cases.dropdowns.schemas import (
@@ -161,6 +163,37 @@ async def _create_dropdown_with_option(
         ),
     )
     return definition, option
+
+
+def _assert_batch_audit_calls(
+    mock_create_event: AsyncMock,
+    *,
+    action: Literal["update", "delete"],
+    case_ids: list[uuid.UUID],
+    succeeded: int,
+    failed: int,
+) -> None:
+    base_data = {
+        "batch": True,
+        "case_ids": [str(case_id) for case_id in case_ids],
+        "count": len(case_ids),
+    }
+    assert mock_create_event.await_args_list == [
+        call(
+            resource_type="case",
+            action=action,
+            resource_id=None,
+            status=AuditEventStatus.ATTEMPT,
+            data=base_data,
+        ),
+        call(
+            resource_type="case",
+            action=action,
+            resource_id=None,
+            status=AuditEventStatus.SUCCESS,
+            data={**base_data, "succeeded": succeeded, "failed": failed},
+        ),
+    ]
 
 
 @pytest.mark.anyio
@@ -674,6 +707,254 @@ class TestCasesService:
         assert retrieved_case.summary == update_params.summary
         assert retrieved_case.status == update_params.status
         assert retrieved_case.priority == update_params.priority
+
+    async def test_batch_update_cases(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+        session: AsyncSession,
+    ) -> None:
+        """Batch updates emit per-case events and commit once."""
+        first_case = await cases_service.create_case(case_create_params)
+        second_case = await cases_service.create_case(
+            case_create_params.model_copy(update={"summary": "Second case"})
+        )
+        case_ids = [first_case.id, second_case.id]
+        original_commit = session.commit
+        mock_publish = AsyncMock()
+
+        async def commit_batch() -> None:
+            mock_publish.assert_not_awaited()
+            await original_commit()
+
+        with (
+            patch.object(
+                AuditService, "create_event", new_callable=AsyncMock
+            ) as mock_audit,
+            patch(
+                "tracecat.cases.service.publish_case_event_payload",
+                new=mock_publish,
+            ),
+            patch.object(
+                cases_service.events,
+                "create_event",
+                wraps=cases_service.events.create_event,
+            ) as mock_create_case_event,
+            patch.object(session, "commit", side_effect=commit_batch) as mock_commit,
+        ):
+            response = await cases_service.batch_update_cases(
+                case_ids, CaseUpdate(summary="Batch updated")
+            )
+            for _ in range(10):
+                if mock_publish.await_count == 2:
+                    break
+                await asyncio.sleep(0)
+
+        assert response.succeeded == 2
+        assert response.failed == 0
+        assert all(result.success for result in response.results)
+        assert mock_create_case_event.await_count == 2
+        assert mock_publish.await_count == 2
+        mock_commit.assert_awaited_once()
+        _assert_batch_audit_calls(
+            mock_audit,
+            action="update",
+            case_ids=case_ids,
+            succeeded=2,
+            failed=0,
+        )
+
+        for case_id in case_ids:
+            updated_case = await cases_service.get_case(case_id)
+            assert updated_case is not None
+            assert updated_case.summary == "Batch updated"
+
+    async def test_batch_update_cases_isolates_partial_failure(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+        session: AsyncSession,
+    ) -> None:
+        """A typed per-case failure rolls back its savepoint only."""
+        first_case = await cases_service.create_case(case_create_params)
+        invalid_case = await cases_service.create_case(
+            case_create_params.model_copy(update={"summary": "Invalid case"})
+        )
+        third_case = await cases_service.create_case(
+            case_create_params.model_copy(update={"summary": "Third case"})
+        )
+        invalid_case_id = invalid_case.id
+        case_ids = [first_case.id, invalid_case.id, third_case.id]
+        apply_case_update = cases_service._apply_case_update
+
+        async def apply_with_one_failure(case: Case, params: CaseUpdate) -> None:
+            if case.id == invalid_case_id:
+                await apply_case_update(case, params)
+                raise ValueError("Invalid case update")
+            await apply_case_update(case, params)
+
+        mock_publish = AsyncMock()
+        with (
+            patch.object(
+                AuditService, "create_event", new_callable=AsyncMock
+            ) as mock_audit,
+            patch(
+                "tracecat.cases.service.publish_case_event_payload",
+                new=mock_publish,
+            ),
+            patch.object(
+                cases_service.events,
+                "create_event",
+                wraps=cases_service.events.create_event,
+            ) as mock_create_case_event,
+            patch.object(
+                cases_service,
+                "_apply_case_update",
+                side_effect=apply_with_one_failure,
+            ),
+            patch.object(session, "commit", wraps=session.commit) as mock_commit,
+        ):
+            response = await cases_service.batch_update_cases(
+                case_ids, CaseUpdate(summary="Batch updated")
+            )
+            for _ in range(10):
+                if mock_publish.await_count == 2:
+                    break
+                await asyncio.sleep(0)
+
+        assert response.succeeded == 2
+        assert response.failed == 1
+        assert response.results[0].success is True
+        assert response.results[1].success is False
+        assert response.results[1].error == "Invalid case update"
+        assert response.results[2].success is True
+        assert mock_create_case_event.await_count == 3
+        assert {
+            published.kwargs["case_id"] for published in mock_publish.await_args_list
+        } == {str(case_ids[0]), str(case_ids[2])}
+        mock_commit.assert_awaited_once()
+        _assert_batch_audit_calls(
+            mock_audit,
+            action="update",
+            case_ids=case_ids,
+            succeeded=2,
+            failed=1,
+        )
+
+        unchanged_case = await cases_service.get_case(invalid_case_id)
+        assert unchanged_case is not None
+        assert unchanged_case.summary == "Invalid case"
+
+    async def test_batch_update_cases_all_not_found(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+    ) -> None:
+        """Missing cases return one failed result per requested ID."""
+        case_ids = [uuid.uuid4(), uuid.uuid4()]
+
+        with (
+            patch.object(
+                AuditService, "create_event", new_callable=AsyncMock
+            ) as mock_audit,
+            patch.object(session, "commit", wraps=session.commit) as mock_commit,
+        ):
+            response = await cases_service.batch_update_cases(
+                case_ids, CaseUpdate(summary="Batch updated")
+            )
+
+        assert response.succeeded == 0
+        assert response.failed == 2
+        assert [result.case_id for result in response.results] == case_ids
+        assert all(result.error == "Case not found" for result in response.results)
+        mock_commit.assert_awaited_once()
+        _assert_batch_audit_calls(
+            mock_audit,
+            action="update",
+            case_ids=case_ids,
+            succeeded=0,
+            failed=2,
+        )
+
+    async def test_batch_delete_cases(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+        session: AsyncSession,
+    ) -> None:
+        """Batch delete removes all found cases with one commit and audit pair."""
+        first_case = await cases_service.create_case(case_create_params)
+        second_case = await cases_service.create_case(
+            case_create_params.model_copy(update={"summary": "Second case"})
+        )
+        case_ids = [first_case.id, second_case.id]
+
+        with (
+            patch.object(
+                AuditService, "create_event", new_callable=AsyncMock
+            ) as mock_audit,
+            patch.object(session, "commit", wraps=session.commit) as mock_commit,
+        ):
+            response = await cases_service.batch_delete_cases(case_ids)
+
+        assert response.succeeded == 2
+        assert response.failed == 0
+        assert all(result.success for result in response.results)
+        mock_commit.assert_awaited_once()
+        _assert_batch_audit_calls(
+            mock_audit,
+            action="delete",
+            case_ids=case_ids,
+            succeeded=2,
+            failed=0,
+        )
+        for case_id in case_ids:
+            assert await cases_service.get_case(case_id) is None
+
+    async def test_batch_update_cases_audits_whole_batch_failure(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+    ) -> None:
+        """Unexpected failures roll back and emit one terminal failure audit."""
+        case_ids = [uuid.uuid4(), uuid.uuid4()]
+
+        with (
+            patch.object(
+                AuditService, "create_event", new_callable=AsyncMock
+            ) as mock_audit,
+            patch.object(
+                cases_service,
+                "_lock_cases",
+                side_effect=RuntimeError("Unexpected failure"),
+            ),
+            patch.object(session, "rollback", wraps=session.rollback) as mock_rollback,
+        ):
+            with pytest.raises(RuntimeError, match="Unexpected failure"):
+                await cases_service.batch_update_cases(case_ids, CaseUpdate())
+
+        mock_rollback.assert_awaited_once()
+        base_data = {
+            "batch": True,
+            "case_ids": [str(case_id) for case_id in case_ids],
+            "count": 2,
+        }
+        assert mock_audit.await_args_list == [
+            call(
+                resource_type="case",
+                action="update",
+                resource_id=None,
+                status=AuditEventStatus.ATTEMPT,
+                data=base_data,
+            ),
+            call(
+                resource_type="case",
+                action="update",
+                resource_id=None,
+                status=AuditEventStatus.FAILURE,
+                data={**base_data, "succeeded": 0, "failed": 2},
+            ),
+        ]
 
     async def test_update_case_close_emits_case_closed_event(
         self, cases_service: CasesService, case_create_params: CaseCreate

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -48,7 +48,11 @@ from tracecat.cases.service import (
 )
 from tracecat.cases.tags.service import CaseTagsService
 from tracecat.db.models import Case, CaseComment, Workspace
-from tracecat.exceptions import TracecatAuthorizationError, TracecatConflictError
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatConflictError,
+    TracecatNotFoundError,
+)
 from tracecat.pagination import CursorPaginationParams
 from tracecat.tables.enums import SqlType
 
@@ -1009,6 +1013,43 @@ class TestCasesService:
         unchanged_case = await cases_service.get_case(invalid_case_id)
         assert unchanged_case is not None
         assert unchanged_case.summary == "Invalid case"
+
+    async def test_batch_update_cases_isolates_not_found_failure(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+    ) -> None:
+        """A per-case lookup failure (e.g. missing dropdown ref) stays per-case."""
+        first_case = await cases_service.create_case(case_create_params)
+        invalid_case = await cases_service.create_case(
+            case_create_params.model_copy(update={"summary": "Invalid case"})
+        )
+        invalid_case_id = invalid_case.id
+        case_ids = [first_case.id, invalid_case.id]
+        apply_case_update = cases_service._apply_case_update
+
+        async def apply_with_missing_ref(case: Case, params: CaseUpdate) -> None:
+            if case.id == invalid_case_id:
+                raise TracecatNotFoundError("Dropdown definition not found")
+            await apply_case_update(case, params)
+
+        with (
+            patch.object(AuditService, "create_event", new_callable=AsyncMock),
+            patch.object(
+                cases_service,
+                "_apply_case_update",
+                side_effect=apply_with_missing_ref,
+            ),
+        ):
+            response = await cases_service.batch_update_cases(
+                case_ids, CaseUpdate(summary="Batch updated")
+            )
+
+        assert response.succeeded == 1
+        assert response.failed == 1
+        assert response.results[0].success is True
+        assert response.results[1].success is False
+        assert response.results[1].error == "Dropdown definition not found"
 
     async def test_batch_update_cases_all_not_found(
         self,

--- a/tests/unit/test_session_events.py
+++ b/tests/unit/test_session_events.py
@@ -3,14 +3,11 @@ import asyncio
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tracecat.db.session_events import (
-    add_after_commit_callback,
-    rollback_after_commit_callbacks,
-)
+from tracecat.db.session_events import AfterCommitQueue
 
 
 @pytest.mark.anyio
-async def test_rollback_after_commit_callbacks_discards_on_cancellation() -> None:
+async def test_checkpointed_discards_callbacks_on_cancellation() -> None:
     """Cancellation removes callbacks registered after the guard checkpoint."""
     session = AsyncSession()
 
@@ -21,15 +18,14 @@ async def test_rollback_after_commit_callbacks_discards_on_cancellation() -> Non
         pass
 
     try:
-        add_after_commit_callback(session, existing_callback)
+        queue = AfterCommitQueue.of(session)
+        queue.add(existing_callback)
 
         with pytest.raises(asyncio.CancelledError):
-            with rollback_after_commit_callbacks(session):
-                add_after_commit_callback(session, cancelled_callback)
+            with queue.checkpointed():
+                queue.add(cancelled_callback)
                 raise asyncio.CancelledError
 
-        assert session.sync_session.info["after_commit_callbacks"] == [
-            existing_callback
-        ]
+        assert queue.callbacks == [existing_callback]
     finally:
         await session.close()

--- a/tests/unit/test_session_events.py
+++ b/tests/unit/test_session_events.py
@@ -1,0 +1,35 @@
+import asyncio
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.db.session_events import (
+    add_after_commit_callback,
+    rollback_after_commit_callbacks,
+)
+
+
+@pytest.mark.anyio
+async def test_rollback_after_commit_callbacks_discards_on_cancellation() -> None:
+    """Cancellation removes callbacks registered after the guard checkpoint."""
+    session = AsyncSession()
+
+    async def existing_callback() -> None:
+        pass
+
+    async def cancelled_callback() -> None:
+        pass
+
+    try:
+        add_after_commit_callback(session, existing_callback)
+
+        with pytest.raises(asyncio.CancelledError):
+            with rollback_after_commit_callbacks(session):
+                add_after_commit_callback(session, cancelled_callback)
+                raise asyncio.CancelledError
+
+        assert session.sync_session.info["after_commit_callbacks"] == [
+            existing_callback
+        ]
+    finally:
+        await session.close()

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -570,13 +570,14 @@ class CaseDropdownValuesService(BaseWorkspaceService):
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def apply_values(
         self,
-        case_id: uuid.UUID,
+        case: Case | uuid.UUID,
         values: Sequence[CaseDropdownValueInput],
         *,
         commit: bool = True,
     ) -> list[CaseDropdownValueRead]:
         """Apply multiple dropdown selections to a case in a single transaction."""
-        case = await self._get_case(case_id)
+        if isinstance(case, uuid.UUID):
+            case = await self._get_case(case)
         seen_definition_ids: set[uuid.UUID] = set()
         results: list[CaseDropdownValueRead] = []
 

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -578,6 +578,9 @@ class CaseDropdownValuesService(BaseWorkspaceService):
         """Apply multiple dropdown selections to a case in a single transaction."""
         if isinstance(case, uuid.UUID):
             case = await self._get_case(case)
+        elif case.workspace_id != self.workspace_id:
+            # Preserve the same tenant scoping _get_case enforces for UUIDs.
+            raise TracecatNotFoundError(f"Case {case.id} not found")
         seen_definition_ids: set[uuid.UUID] = set()
         results: list[CaseDropdownValueRead] = []
 

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -62,6 +62,7 @@ from tracecat.cases.tags.service import CaseTagsService
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import (
     TracecatAuthorizationError,
+    TracecatConflictError,
     TracecatNotFoundError,
     TracecatValidationError,
 )
@@ -517,7 +518,13 @@ async def batch_update_cases(
 ) -> CaseBatchResponse:
     """Update multiple cases with per-case results."""
     service = CasesService(session, role)
-    return await service.batch_update_cases(params.case_ids, params.update)
+    try:
+        return await service.batch_update_cases(params.case_ids, params.update)
+    except TracecatConflictError as exc:
+        raise HTTPException(
+            status_code=HTTP_409_CONFLICT,
+            detail=exc.detail or str(exc),
+        ) from exc
 
 
 @cases_router.post("/batch-delete")
@@ -530,7 +537,13 @@ async def batch_delete_cases(
 ) -> CaseBatchResponse:
     """Delete multiple cases with per-case results."""
     service = CasesService(session, role)
-    return await service.batch_delete_cases(params.case_ids)
+    try:
+        return await service.batch_delete_cases(params.case_ids)
+    except TracecatConflictError as exc:
+        raise HTTPException(
+            status_code=HTTP_409_CONFLICT,
+            detail=exc.detail or str(exc),
+        ) from exc
 
 
 @cases_router.get("/{case_id}")

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -28,6 +28,9 @@ from tracecat.cases.filters import parse_assignee_filter
 from tracecat.cases.rows.service import CaseTableRowsService
 from tracecat.cases.schemas import (
     AssigneeChangedEventRead,
+    CaseBatchDelete,
+    CaseBatchResponse,
+    CaseBatchUpdate,
     CaseCommentCreate,
     CaseCommentRead,
     CaseCommentThreadRead,
@@ -502,6 +505,32 @@ async def search_case_aggregates(
             status_code=HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve case aggregate counts",
         ) from e
+
+
+@cases_router.post("/batch-update")
+@require_scope("case:update")
+async def batch_update_cases(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    params: CaseBatchUpdate,
+) -> CaseBatchResponse:
+    """Update multiple cases with per-case results."""
+    service = CasesService(session, role)
+    return await service.batch_update_cases(params.case_ids, params.update)
+
+
+@cases_router.post("/batch-delete")
+@require_scope("case:delete")
+async def batch_delete_cases(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    params: CaseBatchDelete,
+) -> CaseBatchResponse:
+    """Delete multiple cases with per-case results."""
+    service = CasesService(session, role)
+    return await service.batch_delete_cases(params.case_ids)
 
 
 @cases_router.get("/{case_id}")

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -121,6 +121,35 @@ class CaseUpdate(Schema):
     payload: dict[str, Any] | None = None
 
 
+class CaseBatchUpdate(Schema):
+    """Request body for updating multiple cases."""
+
+    case_ids: list[uuid.UUID] = Field(..., min_length=1, max_length=1000)
+    update: CaseUpdate
+
+
+class CaseBatchDelete(Schema):
+    """Request body for deleting multiple cases."""
+
+    case_ids: list[uuid.UUID] = Field(..., min_length=1, max_length=1000)
+
+
+class CaseBatchItemResult(Schema):
+    """Result of a batch operation for one case."""
+
+    case_id: uuid.UUID
+    success: bool
+    error: str | None = None
+
+
+class CaseBatchResponse(Schema):
+    """Per-case results and aggregate counts for a batch operation."""
+
+    results: list[CaseBatchItemResult]
+    succeeded: int
+    failed: int
+
+
 # Case Fields
 
 

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1154,9 +1154,7 @@ class CasesService(BaseWorkspaceService):
     ) -> None:
         """Emit a batch audit event without allowing audit failures to fail the batch."""
         try:
-            async with AuditService.with_session(
-                role=self.role, session=self.session
-            ) as service:
+            async with AuditService.with_session(role=self.role) as service:
                 await service.create_event(
                     resource_type="case",
                     action=action,
@@ -1191,6 +1189,7 @@ class CasesService(BaseWorkspaceService):
         self, case_ids: list[uuid.UUID], params: CaseUpdate
     ) -> CaseBatchResponse:
         """Update multiple cases atomically with isolated per-case failures."""
+        case_ids = list(dict.fromkeys(case_ids))
         audit_case_ids = [str(case_id) for case_id in case_ids]
         audit_data: dict[str, Any] = {
             "batch": True,
@@ -1206,52 +1205,53 @@ class CasesService(BaseWorkspaceService):
         try:
             cases_by_id = await self._lock_cases(case_ids)
             results: list[CaseBatchItemResult] = []
-            with defer_after_commit_callbacks(self.session):
-                for case_id in case_ids:
-                    if (case := cases_by_id.get(case_id)) is None:
-                        results.append(
-                            CaseBatchItemResult(
-                                case_id=case_id,
-                                success=False,
-                                error="Case not found",
+            with rollback_after_commit_callbacks(self.session):
+                with defer_after_commit_callbacks(self.session):
+                    for case_id in case_ids:
+                        if (case := cases_by_id.get(case_id)) is None:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error="Case not found",
+                                )
                             )
-                        )
-                        continue
+                            continue
 
-                    try:
-                        with rollback_after_commit_callbacks(self.session):
-                            async with self.session.begin_nested():
-                                await self._apply_case_update(case, params)
-                    except TracecatValidationError as exc:
-                        results.append(
-                            CaseBatchItemResult(
-                                case_id=case_id,
-                                success=False,
-                                error=str(exc),
+                        try:
+                            with rollback_after_commit_callbacks(self.session):
+                                async with self.session.begin_nested():
+                                    await self._apply_case_update(case, params)
+                        except TracecatValidationError as exc:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error=str(exc),
+                                )
                             )
-                        )
-                    except ValueError as exc:
-                        results.append(
-                            CaseBatchItemResult(
-                                case_id=case_id,
-                                success=False,
-                                error=str(exc),
+                        except ValueError as exc:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error=str(exc),
+                                )
                             )
-                        )
-                    except DBAPIError:
-                        results.append(
-                            CaseBatchItemResult(
-                                case_id=case_id,
-                                success=False,
-                                error="Database operation failed",
+                        except DBAPIError:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error="Database operation failed",
+                                )
                             )
-                        )
-                    else:
-                        results.append(
-                            CaseBatchItemResult(case_id=case_id, success=True)
-                        )
+                        else:
+                            results.append(
+                                CaseBatchItemResult(case_id=case_id, success=True)
+                            )
 
-            await self.session.commit()
+                await self.session.commit()
         except Exception:
             await self.session.rollback()
             await self._audit_batch_event(
@@ -1285,6 +1285,7 @@ class CasesService(BaseWorkspaceService):
     @require_scope("case:delete")
     async def batch_delete_cases(self, case_ids: list[uuid.UUID]) -> CaseBatchResponse:
         """Delete multiple cases atomically with isolated per-case failures."""
+        case_ids = list(dict.fromkeys(case_ids))
         audit_case_ids = [str(case_id) for case_id in case_ids]
         audit_data: dict[str, Any] = {
             "batch": True,
@@ -1300,52 +1301,53 @@ class CasesService(BaseWorkspaceService):
         try:
             cases_by_id = await self._lock_cases(case_ids)
             results: list[CaseBatchItemResult] = []
-            with defer_after_commit_callbacks(self.session):
-                for case_id in case_ids:
-                    if (case := cases_by_id.get(case_id)) is None:
-                        results.append(
-                            CaseBatchItemResult(
-                                case_id=case_id,
-                                success=False,
-                                error="Case not found",
+            with rollback_after_commit_callbacks(self.session):
+                with defer_after_commit_callbacks(self.session):
+                    for case_id in case_ids:
+                        if (case := cases_by_id.get(case_id)) is None:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error="Case not found",
+                                )
                             )
-                        )
-                        continue
+                            continue
 
-                    try:
-                        with rollback_after_commit_callbacks(self.session):
-                            async with self.session.begin_nested():
-                                await self.session.delete(case)
-                    except TracecatValidationError as exc:
-                        results.append(
-                            CaseBatchItemResult(
-                                case_id=case_id,
-                                success=False,
-                                error=str(exc),
+                        try:
+                            with rollback_after_commit_callbacks(self.session):
+                                async with self.session.begin_nested():
+                                    await self.session.delete(case)
+                        except TracecatValidationError as exc:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error=str(exc),
+                                )
                             )
-                        )
-                    except ValueError as exc:
-                        results.append(
-                            CaseBatchItemResult(
-                                case_id=case_id,
-                                success=False,
-                                error=str(exc),
+                        except ValueError as exc:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error=str(exc),
+                                )
                             )
-                        )
-                    except DBAPIError:
-                        results.append(
-                            CaseBatchItemResult(
-                                case_id=case_id,
-                                success=False,
-                                error="Database operation failed",
+                        except DBAPIError:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error="Database operation failed",
+                                )
                             )
-                        )
-                    else:
-                        results.append(
-                            CaseBatchItemResult(case_id=case_id, success=True)
-                        )
+                        else:
+                            results.append(
+                                CaseBatchItemResult(case_id=case_id, success=True)
+                            )
 
-            await self.session.commit()
+                await self.session.commit()
         except Exception:
             await self.session.rollback()
             await self._audit_batch_event(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -108,6 +108,7 @@ from tracecat.exceptions import (
     EntitlementRequired,
     ScopeDeniedError,
     TracecatAuthorizationError,
+    TracecatConflictError,
     TracecatException,
     TracecatNotFoundError,
     TracecatValidationError,
@@ -204,6 +205,8 @@ def _enum_sort_rank(value: Any, ordered_values: Sequence[str]) -> int:
 
 # Treat multiple views inside this window as a single "view" to avoid spam.
 CASE_VIEW_EVENT_DEDUP_WINDOW = timedelta(minutes=5)
+CASE_BATCH_LOCK_TIMEOUT = "5s"
+CASE_BATCH_LOCK_NOT_AVAILABLE_SQLSTATE = "55P03"
 
 
 class CasesService(BaseWorkspaceService):
@@ -1113,7 +1116,7 @@ class CasesService(BaseWorkspaceService):
                 for value in dropdown_values
             ]
             await self.dropdowns.apply_values(
-                case.id,
+                case,
                 normalized_dropdown_values,
                 commit=False,
             )
@@ -1172,7 +1175,11 @@ class CasesService(BaseWorkspaceService):
             )
 
     async def _lock_cases(
-        self, case_ids: list[uuid.UUID], *, load_dropdown_values: bool = False
+        self,
+        case_ids: list[uuid.UUID],
+        *,
+        load_dropdown_values: bool = False,
+        key_share: bool = False,
     ) -> dict[uuid.UUID, Case]:
         """Lock and return workspace-scoped cases in deterministic ID order.
 
@@ -1191,7 +1198,7 @@ class CasesService(BaseWorkspaceService):
                 Case.id.in_(sorted(case_ids)),
             )
             .order_by(Case.id)
-            .with_for_update()
+            .with_for_update(key_share=key_share)
         )
         result = await self.session.execute(statement)
         return {case.id: case for case in result.scalars().all()}
@@ -1214,11 +1221,25 @@ class CasesService(BaseWorkspaceService):
         )
 
         try:
-            cases_by_id = await self._lock_cases(
-                case_ids,
-                load_dropdown_values=params.status
-                in (CaseStatus.CLOSED, CaseStatus.RESOLVED),
+            await self.session.execute(
+                sa.text(f"SET LOCAL lock_timeout = '{CASE_BATCH_LOCK_TIMEOUT}'")
             )
+            try:
+                cases_by_id = await self._lock_cases(
+                    case_ids,
+                    load_dropdown_values=params.status
+                    in (CaseStatus.CLOSED, CaseStatus.RESOLVED),
+                    key_share=True,
+                )
+            except DBAPIError as exc:
+                if (
+                    getattr(exc.orig, "sqlstate", None)
+                    == CASE_BATCH_LOCK_NOT_AVAILABLE_SQLSTATE
+                ):
+                    raise TracecatConflictError(
+                        "Timed out waiting to lock cases for batch update"
+                    ) from exc
+                raise
             results: list[CaseBatchItemResult] = []
             queue = AfterCommitQueue.of(self.session)
             with queue.checkpointed():
@@ -1316,7 +1337,20 @@ class CasesService(BaseWorkspaceService):
         )
 
         try:
-            cases_by_id = await self._lock_cases(case_ids)
+            await self.session.execute(
+                sa.text(f"SET LOCAL lock_timeout = '{CASE_BATCH_LOCK_TIMEOUT}'")
+            )
+            try:
+                cases_by_id = await self._lock_cases(case_ids)
+            except DBAPIError as exc:
+                if (
+                    getattr(exc.orig, "sqlstate", None)
+                    == CASE_BATCH_LOCK_NOT_AVAILABLE_SQLSTATE
+                ):
+                    raise TracecatConflictError(
+                        "Timed out waiting to lock cases for batch delete"
+                    ) from exc
+                raise
             results: list[CaseBatchItemResult] = []
             queue = AfterCommitQueue.of(self.session)
             with queue.checkpointed():

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1259,6 +1259,14 @@ class CasesService(BaseWorkspaceService):
                             with queue.checkpointed():
                                 async with self.session.begin_nested():
                                     await self._apply_case_update(case, params)
+                        except TracecatNotFoundError as exc:
+                            results.append(
+                                CaseBatchItemResult(
+                                    case_id=case_id,
+                                    success=False,
+                                    error=str(exc),
+                                )
+                            )
                         except TracecatValidationError as exc:
                             results.append(
                                 CaseBatchItemResult(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -14,6 +14,7 @@ from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import raiseload, selectinload
 from sqlalchemy.orm.attributes import flag_modified
+from sqlalchemy.sql.base import ExecutableOption
 from sqlalchemy.sql.elements import ColumnElement
 
 from tracecat.audit.enums import AuditEventStatus
@@ -1179,7 +1180,7 @@ class CasesService(BaseWorkspaceService):
         materialize unrelated collections; `load_dropdown_values` opts into the
         one relationship closure validation reads.
         """
-        options: list[Any] = [raiseload("*")]
+        options: list[ExecutableOption] = [raiseload("*")]
         if load_dropdown_values:
             options.append(selectinload(Case.dropdown_values))
         statement = (
@@ -1304,10 +1305,9 @@ class CasesService(BaseWorkspaceService):
     async def batch_delete_cases(self, case_ids: list[uuid.UUID]) -> CaseBatchResponse:
         """Delete multiple cases atomically with isolated per-case failures."""
         case_ids = list(dict.fromkeys(case_ids))
-        audit_case_ids = [str(case_id) for case_id in case_ids]
         audit_data: dict[str, Any] = {
             "batch": True,
-            "case_ids": audit_case_ids,
+            "case_ids": [str(case_id) for case_id in case_ids],
             "count": len(case_ids),
         }
         await self._audit_batch_event(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1202,10 +1202,9 @@ class CasesService(BaseWorkspaceService):
     ) -> CaseBatchResponse:
         """Update multiple cases atomically with isolated per-case failures."""
         case_ids = list(dict.fromkeys(case_ids))
-        audit_case_ids = [str(case_id) for case_id in case_ids]
         audit_data: dict[str, Any] = {
             "batch": True,
-            "case_ids": audit_case_ids,
+            "case_ids": [str(case_id) for case_id in case_ids],
             "count": len(case_ids),
         }
         await self._audit_batch_event(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -12,7 +12,7 @@ from sqlalchemy import and_, cast, func, or_, select
 from sqlalchemy.dialects.postgresql import UUID, insert
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import raiseload, selectinload
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -1123,15 +1123,19 @@ class CasesService(BaseWorkspaceService):
             old = getattr(case, key, None)
             setattr(case, key, value)
             if key == "assignee_id":
-                events.append(
-                    AssigneeChangedEvent(old=old, new=value, wf_exec_id=wf_exec_id)
-                )
-            elif key == "summary":
-                events.append(
-                    UpdatedEvent(
-                        field="summary", old=old, new=value, wf_exec_id=wf_exec_id
+                # Only record event if the assignee actually changed
+                if old != value:
+                    events.append(
+                        AssigneeChangedEvent(old=old, new=value, wf_exec_id=wf_exec_id)
                     )
-                )
+            elif key == "summary":
+                # Only record event if the summary actually changed
+                if old != value:
+                    events.append(
+                        UpdatedEvent(
+                            field="summary", old=old, new=value, wf_exec_id=wf_exec_id
+                        )
+                    )
             elif key == "payload":
                 # Only record event if payload actually changed
                 if old != value:
@@ -1166,10 +1170,21 @@ class CasesService(BaseWorkspaceService):
                 error=str(exc),
             )
 
-    async def _lock_cases(self, case_ids: list[uuid.UUID]) -> dict[uuid.UUID, Case]:
-        """Lock and return workspace-scoped cases in deterministic ID order."""
+    async def _lock_cases(
+        self, case_ids: list[uuid.UUID], *, load_dropdown_values: bool = False
+    ) -> dict[uuid.UUID, Case]:
+        """Lock and return workspace-scoped cases in deterministic ID order.
+
+        Relationship loading is suppressed so a 1000-case batch does not
+        materialize unrelated collections; `load_dropdown_values` opts into the
+        one relationship closure validation reads.
+        """
+        options: list[Any] = [raiseload("*")]
+        if load_dropdown_values:
+            options.append(selectinload(Case.dropdown_values))
         statement = (
             select(Case)
+            .options(*options)
             .where(
                 Case.workspace_id == self.workspace_id,
                 Case.id.in_(sorted(case_ids)),
@@ -1199,7 +1214,11 @@ class CasesService(BaseWorkspaceService):
         )
 
         try:
-            cases_by_id = await self._lock_cases(case_ids)
+            cases_by_id = await self._lock_cases(
+                case_ids,
+                load_dropdown_values=params.status
+                in (CaseStatus.CLOSED, CaseStatus.RESOLVED),
+            )
             results: list[CaseBatchItemResult] = []
             queue = AfterCommitQueue.of(self.session)
             with queue.checkpointed():
@@ -1270,7 +1289,9 @@ class CasesService(BaseWorkspaceService):
         )
         await self._audit_batch_event(
             action="update",
-            status=AuditEventStatus.SUCCESS,
+            status=AuditEventStatus.SUCCESS
+            if response.succeeded
+            else AuditEventStatus.FAILURE,
             data={
                 **audit_data,
                 "succeeded": response.succeeded,
@@ -1315,7 +1336,27 @@ class CasesService(BaseWorkspaceService):
                         try:
                             with queue.checkpointed():
                                 async with self.session.begin_nested():
-                                    await self.session.delete(case)
+                                    # Rely on database ON DELETE CASCADE instead
+                                    # of ORM cascades, which lazy-load every
+                                    # child collection per case. Reply comments
+                                    # must be unlinked first: the
+                                    # (case_id, parent_id) self-FK is
+                                    # ON DELETE RESTRICT, so a cascading case
+                                    # delete is order-sensitive with threads.
+                                    await self.session.execute(
+                                        sa.update(CaseComment)
+                                        .where(
+                                            CaseComment.case_id == case.id,
+                                            CaseComment.parent_id.is_not(None),
+                                        )
+                                        .values(parent_id=None)
+                                    )
+                                    await self.session.execute(
+                                        sa.delete(Case).where(
+                                            Case.id == case.id,
+                                            Case.workspace_id == self.workspace_id,
+                                        )
+                                    )
                         except TracecatValidationError as exc:
                             results.append(
                                 CaseBatchItemResult(
@@ -1367,7 +1408,9 @@ class CasesService(BaseWorkspaceService):
         )
         await self._audit_batch_event(
             action="delete",
-            status=AuditEventStatus.SUCCESS,
+            status=AuditEventStatus.SUCCESS
+            if response.succeeded
+            else AuditEventStatus.FAILURE,
             data={
                 **audit_data,
                 "succeeded": response.succeeded,

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -10,7 +10,7 @@ from asyncpg import UndefinedColumnError
 from pydantic import ValidationError
 from sqlalchemy import and_, cast, func, or_, select
 from sqlalchemy.dialects.postgresql import UUID, insert
-from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import flag_modified
@@ -39,6 +39,8 @@ from tracecat.cases.enums import (
 )
 from tracecat.cases.schemas import (
     AssigneeChangedEvent,
+    CaseBatchItemResult,
+    CaseBatchResponse,
     CaseCommentCreate,
     CaseCommentRead,
     CaseCommentThreadRead,
@@ -100,7 +102,11 @@ from tracecat.db.models import (
     Workflow,
     WorkspaceSyncResourceMapping,
 )
-from tracecat.db.session_events import add_after_commit_callback
+from tracecat.db.session_events import (
+    add_after_commit_callback,
+    defer_after_commit_callbacks,
+    rollback_after_commit_callbacks,
+)
 from tracecat.exceptions import (
     EntitlementRequired,
     ScopeDeniedError,
@@ -1003,6 +1009,18 @@ class CasesService(BaseWorkspaceService):
             TracecatNotFoundError: If the case has no fields when trying to update fields
         """
 
+        try:
+            await self._apply_case_update(case, params)
+            # Commit once to persist all updates and emitted events atomically
+            await self.session.commit()
+            await self.session.refresh(case)
+            return case
+        except Exception:
+            await self.session.rollback()
+            raise
+
+    async def _apply_case_update(self, case: Case, params: CaseUpdate) -> None:
+        """Apply a case update without committing the active transaction."""
         run_ctx = ctx_run.get()
         wf_exec_id = run_ctx.wf_exec_id if run_ctx else None
 
@@ -1123,18 +1141,240 @@ class CasesService(BaseWorkspaceService):
                 if old != value:
                     events.append(PayloadChangedEvent(wf_exec_id=wf_exec_id))
 
-        try:
-            # If there are any remaining changed fields, record a general update activity
-            for event in events:
-                await self.events.create_event(case=case, event=event)
+        # If there are any remaining changed fields, record a general update activity
+        for event in events:
+            await self.events.create_event(case=case, event=event)
 
-            # Commit once to persist all updates and emitted events atomically
+    async def _audit_batch_event(
+        self,
+        *,
+        action: Literal["update", "delete"],
+        status: AuditEventStatus,
+        data: dict[str, Any],
+    ) -> None:
+        """Emit a batch audit event without allowing audit failures to fail the batch."""
+        try:
+            async with AuditService.with_session(
+                role=self.role, session=self.session
+            ) as service:
+                await service.create_event(
+                    resource_type="case",
+                    action=action,
+                    resource_id=None,
+                    status=status,
+                    data=data,
+                )
+        except Exception as exc:
+            self.logger.warning(
+                "Batch case audit log failed",
+                action=action,
+                status=status,
+                error=str(exc),
+            )
+
+    async def _lock_cases(self, case_ids: list[uuid.UUID]) -> dict[uuid.UUID, Case]:
+        """Lock and return workspace-scoped cases in deterministic ID order."""
+        statement = (
+            select(Case)
+            .where(
+                Case.workspace_id == self.workspace_id,
+                Case.id.in_(sorted(case_ids)),
+            )
+            .order_by(Case.id)
+            .with_for_update()
+        )
+        result = await self.session.execute(statement)
+        return {case.id: case for case in result.scalars().all()}
+
+    @require_scope("case:update")
+    async def batch_update_cases(
+        self, case_ids: list[uuid.UUID], params: CaseUpdate
+    ) -> CaseBatchResponse:
+        """Update multiple cases atomically with isolated per-case failures."""
+        audit_case_ids = [str(case_id) for case_id in case_ids]
+        audit_data: dict[str, Any] = {
+            "batch": True,
+            "case_ids": audit_case_ids,
+            "count": len(case_ids),
+        }
+        await self._audit_batch_event(
+            action="update",
+            status=AuditEventStatus.ATTEMPT,
+            data=audit_data,
+        )
+
+        try:
+            cases_by_id = await self._lock_cases(case_ids)
+            results: list[CaseBatchItemResult] = []
+            with defer_after_commit_callbacks(self.session):
+                for case_id in case_ids:
+                    if (case := cases_by_id.get(case_id)) is None:
+                        results.append(
+                            CaseBatchItemResult(
+                                case_id=case_id,
+                                success=False,
+                                error="Case not found",
+                            )
+                        )
+                        continue
+
+                    try:
+                        with rollback_after_commit_callbacks(self.session):
+                            async with self.session.begin_nested():
+                                await self._apply_case_update(case, params)
+                    except TracecatValidationError as exc:
+                        results.append(
+                            CaseBatchItemResult(
+                                case_id=case_id,
+                                success=False,
+                                error=str(exc),
+                            )
+                        )
+                    except ValueError as exc:
+                        results.append(
+                            CaseBatchItemResult(
+                                case_id=case_id,
+                                success=False,
+                                error=str(exc),
+                            )
+                        )
+                    except DBAPIError:
+                        results.append(
+                            CaseBatchItemResult(
+                                case_id=case_id,
+                                success=False,
+                                error="Database operation failed",
+                            )
+                        )
+                    else:
+                        results.append(
+                            CaseBatchItemResult(case_id=case_id, success=True)
+                        )
+
             await self.session.commit()
-            await self.session.refresh(case)
-            return case
         except Exception:
             await self.session.rollback()
+            await self._audit_batch_event(
+                action="update",
+                status=AuditEventStatus.FAILURE,
+                data={
+                    **audit_data,
+                    "succeeded": 0,
+                    "failed": len(case_ids),
+                },
+            )
             raise
+
+        succeeded = sum(result.success for result in results)
+        response = CaseBatchResponse(
+            results=results,
+            succeeded=succeeded,
+            failed=len(results) - succeeded,
+        )
+        await self._audit_batch_event(
+            action="update",
+            status=AuditEventStatus.SUCCESS,
+            data={
+                **audit_data,
+                "succeeded": response.succeeded,
+                "failed": response.failed,
+            },
+        )
+        return response
+
+    @require_scope("case:delete")
+    async def batch_delete_cases(self, case_ids: list[uuid.UUID]) -> CaseBatchResponse:
+        """Delete multiple cases atomically with isolated per-case failures."""
+        audit_case_ids = [str(case_id) for case_id in case_ids]
+        audit_data: dict[str, Any] = {
+            "batch": True,
+            "case_ids": audit_case_ids,
+            "count": len(case_ids),
+        }
+        await self._audit_batch_event(
+            action="delete",
+            status=AuditEventStatus.ATTEMPT,
+            data=audit_data,
+        )
+
+        try:
+            cases_by_id = await self._lock_cases(case_ids)
+            results: list[CaseBatchItemResult] = []
+            with defer_after_commit_callbacks(self.session):
+                for case_id in case_ids:
+                    if (case := cases_by_id.get(case_id)) is None:
+                        results.append(
+                            CaseBatchItemResult(
+                                case_id=case_id,
+                                success=False,
+                                error="Case not found",
+                            )
+                        )
+                        continue
+
+                    try:
+                        with rollback_after_commit_callbacks(self.session):
+                            async with self.session.begin_nested():
+                                await self.session.delete(case)
+                    except TracecatValidationError as exc:
+                        results.append(
+                            CaseBatchItemResult(
+                                case_id=case_id,
+                                success=False,
+                                error=str(exc),
+                            )
+                        )
+                    except ValueError as exc:
+                        results.append(
+                            CaseBatchItemResult(
+                                case_id=case_id,
+                                success=False,
+                                error=str(exc),
+                            )
+                        )
+                    except DBAPIError:
+                        results.append(
+                            CaseBatchItemResult(
+                                case_id=case_id,
+                                success=False,
+                                error="Database operation failed",
+                            )
+                        )
+                    else:
+                        results.append(
+                            CaseBatchItemResult(case_id=case_id, success=True)
+                        )
+
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            await self._audit_batch_event(
+                action="delete",
+                status=AuditEventStatus.FAILURE,
+                data={
+                    **audit_data,
+                    "succeeded": 0,
+                    "failed": len(case_ids),
+                },
+            )
+            raise
+
+        succeeded = sum(result.success for result in results)
+        response = CaseBatchResponse(
+            results=results,
+            succeeded=succeeded,
+            failed=len(results) - succeeded,
+        )
+        await self._audit_batch_event(
+            action="delete",
+            status=AuditEventStatus.SUCCESS,
+            data={
+                **audit_data,
+                "succeeded": response.succeeded,
+                "failed": response.failed,
+            },
+        )
+        return response
 
     @require_scope("case:delete")
     @audit_log(resource_type="case", action="delete")

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -102,11 +102,7 @@ from tracecat.db.models import (
     Workflow,
     WorkspaceSyncResourceMapping,
 )
-from tracecat.db.session_events import (
-    add_after_commit_callback,
-    defer_after_commit_callbacks,
-    rollback_after_commit_callbacks,
-)
+from tracecat.db.session_events import AfterCommitQueue
 from tracecat.exceptions import (
     EntitlementRequired,
     ScopeDeniedError,
@@ -1205,8 +1201,9 @@ class CasesService(BaseWorkspaceService):
         try:
             cases_by_id = await self._lock_cases(case_ids)
             results: list[CaseBatchItemResult] = []
-            with rollback_after_commit_callbacks(self.session):
-                with defer_after_commit_callbacks(self.session):
+            queue = AfterCommitQueue.of(self.session)
+            with queue.checkpointed():
+                with queue.deferred():
                     for case_id in case_ids:
                         if (case := cases_by_id.get(case_id)) is None:
                             results.append(
@@ -1219,7 +1216,7 @@ class CasesService(BaseWorkspaceService):
                             continue
 
                         try:
-                            with rollback_after_commit_callbacks(self.session):
+                            with queue.checkpointed():
                                 async with self.session.begin_nested():
                                     await self._apply_case_update(case, params)
                         except TracecatValidationError as exc:
@@ -1301,8 +1298,9 @@ class CasesService(BaseWorkspaceService):
         try:
             cases_by_id = await self._lock_cases(case_ids)
             results: list[CaseBatchItemResult] = []
-            with rollback_after_commit_callbacks(self.session):
-                with defer_after_commit_callbacks(self.session):
+            queue = AfterCommitQueue.of(self.session)
+            with queue.checkpointed():
+                with queue.deferred():
                     for case_id in case_ids:
                         if (case := cases_by_id.get(case_id)) is None:
                             results.append(
@@ -1315,7 +1313,7 @@ class CasesService(BaseWorkspaceService):
                             continue
 
                         try:
-                            with rollback_after_commit_callbacks(self.session):
+                            with queue.checkpointed():
                                 async with self.session.begin_nested():
                                     await self.session.delete(case)
                         except TracecatValidationError as exc:
@@ -2695,7 +2693,7 @@ class CaseEventsService(BaseWorkspaceService):
                     created_at=created_at,
                 )
 
-            add_after_commit_callback(self.session, _publish_case_event)
+            AfterCommitQueue.of(self.session).add(_publish_case_event)
 
         # Auto-sync durations whenever an event is created
         durations_service = CaseDurationService(session=self.session, role=self.role)

--- a/tracecat/db/session_events.py
+++ b/tracecat/db/session_events.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
 from typing import Any, Final, cast
 
 import sqlalchemy.orm
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat.logger import logger
 
 _AFTER_COMMIT_KEY: Final[str] = "after_commit_callbacks"
+_DEFER_AFTER_COMMIT_KEY: Final[str] = "defer_after_commit_callbacks"
 _EVENT_LOOP_KEY: Final[str] = "event_loop"
 AsyncCallback = Callable[[], Awaitable[Any]]
 
@@ -44,6 +46,36 @@ def add_after_commit_callback(session: AsyncSession, callback: AsyncCallback) ->
         loop = None
 
 
+@contextmanager
+def defer_after_commit_callbacks(session: AsyncSession) -> Iterator[None]:
+    """Defer callbacks across savepoint releases until the outer commit."""
+    sync = session.sync_session
+    defer_depth = int(sync.info.get(_DEFER_AFTER_COMMIT_KEY, 0))
+    sync.info[_DEFER_AFTER_COMMIT_KEY] = defer_depth + 1
+    try:
+        yield
+    finally:
+        if defer_depth == 0:
+            sync.info.pop(_DEFER_AFTER_COMMIT_KEY, None)
+        else:
+            sync.info[_DEFER_AFTER_COMMIT_KEY] = defer_depth
+
+
+@contextmanager
+def rollback_after_commit_callbacks(session: AsyncSession) -> Iterator[None]:
+    """Discard callbacks registered by work that raises and is rolled back."""
+    callbacks = cast(
+        list[AsyncCallback],
+        session.sync_session.info.setdefault(_AFTER_COMMIT_KEY, []),
+    )
+    checkpoint = len(callbacks)
+    try:
+        yield
+    except Exception:
+        del callbacks[checkpoint:]
+        raise
+
+
 @event.listens_for(sqlalchemy.orm.Session, "after_commit")
 def _run_after_commit(session: sqlalchemy.orm.Session) -> None:  # pyright: ignore[reportUnusedFunction] - registered as SQLAlchemy event listener
     """Execute all registered after-commit callbacks for the given session.
@@ -63,6 +95,9 @@ def _run_after_commit(session: sqlalchemy.orm.Session) -> None:  # pyright: igno
         captured during callback registration. If no loop was captured,
         a new event loop is created.
     """
+    if session.info.get(_DEFER_AFTER_COMMIT_KEY):
+        return
+
     callbacks = cast(list[AsyncCallback], session.info.pop(_AFTER_COMMIT_KEY, []))
     if not callbacks:
         return

--- a/tracecat/db/session_events.py
+++ b/tracecat/db/session_events.py
@@ -71,7 +71,7 @@ def rollback_after_commit_callbacks(session: AsyncSession) -> Iterator[None]:
     checkpoint = len(callbacks)
     try:
         yield
-    except Exception:
+    except BaseException:
         del callbacks[checkpoint:]
         raise
 

--- a/tracecat/db/session_events.py
+++ b/tracecat/db/session_events.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
-from typing import Any, Final, cast
+from dataclasses import dataclass, field
+from typing import Any, Final
 
 import sqlalchemy.orm
 from sqlalchemy import event
@@ -11,107 +12,87 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.logger import logger
 
-_AFTER_COMMIT_KEY: Final[str] = "after_commit_callbacks"
-_DEFER_AFTER_COMMIT_KEY: Final[str] = "defer_after_commit_callbacks"
-_EVENT_LOOP_KEY: Final[str] = "event_loop"
+_QUEUE_KEY: Final[str] = "after_commit_queue"
 AsyncCallback = Callable[[], Awaitable[Any]]
 
 
-def add_after_commit_callback(session: AsyncSession, callback: AsyncCallback) -> None:
-    """Register a callable to run after this session commits.
+@dataclass
+class AfterCommitQueue:
+    """Per-session queue of side effects to run after the session commits."""
 
-    The callable may be sync or async. If async, it will be scheduled onto
-    the event loop captured during registration.
+    callbacks: list[AsyncCallback] = field(default_factory=list)
+    defer_depth: int = 0
+    loop: asyncio.AbstractEventLoop | None = None
 
-    Args:
-        session: The async SQLAlchemy session to register the callback with.
-        callback: The callable function to execute after commit. Should return an awaitable.
+    @classmethod
+    def of(cls, session: AsyncSession | sqlalchemy.orm.Session) -> AfterCommitQueue:
+        """Get or create the queue attached to this session."""
+        info = (
+            session.sync_session.info
+            if isinstance(session, AsyncSession)
+            else session.info
+        )
+        queue = info.get(_QUEUE_KEY)
+        if queue is None:
+            queue = info[_QUEUE_KEY] = cls()
+        return queue
 
-    Returns:
-        None
+    def add(self, callback: AsyncCallback) -> None:
+        """Register a callable to run after this session commits."""
+        logger.debug("Adding after_commit callback", callback=callback)
+        self.callbacks.append(callback)
+        if self.loop is None:
+            try:
+                self.loop = asyncio.get_running_loop()
+            except RuntimeError:
+                pass
 
-    Note:
-        The callback will be executed on the event loop that was active when
-        this function was called. If no event loop is running, the callback
-        will still be registered but may not execute properly.
-    """
-    logger.debug("Adding after_commit callback", callback=callback)
-    sync = session.sync_session
-    sync.info.setdefault(_AFTER_COMMIT_KEY, []).append(callback)
-    # Capture the current loop if available; used to schedule async callbacks.
-    try:
-        loop = asyncio.get_running_loop()
-        sync.info.setdefault(_EVENT_LOOP_KEY, loop)
-    except RuntimeError:
-        loop = None
+    @contextmanager
+    def deferred(self) -> Iterator[None]:
+        """Defer callbacks across savepoint releases until the outer commit."""
+        self.defer_depth += 1
+        try:
+            yield
+        finally:
+            self.defer_depth -= 1
 
+    @contextmanager
+    def checkpointed(self) -> Iterator[None]:
+        """Discard callbacks registered by work that raises and is rolled back."""
+        checkpoint = len(self.callbacks)
+        try:
+            yield
+        except BaseException:
+            del self.callbacks[checkpoint:]
+            raise
 
-@contextmanager
-def defer_after_commit_callbacks(session: AsyncSession) -> Iterator[None]:
-    """Defer callbacks across savepoint releases until the outer commit."""
-    sync = session.sync_session
-    defer_depth = int(sync.info.get(_DEFER_AFTER_COMMIT_KEY, 0))
-    sync.info[_DEFER_AFTER_COMMIT_KEY] = defer_depth + 1
-    try:
-        yield
-    finally:
-        if defer_depth == 0:
-            sync.info.pop(_DEFER_AFTER_COMMIT_KEY, None)
-        else:
-            sync.info[_DEFER_AFTER_COMMIT_KEY] = defer_depth
+    def drain_on_commit(self) -> None:
+        """Run and clear queued callbacks unless delivery is deferred."""
+        if self.defer_depth:
+            return
 
-
-@contextmanager
-def rollback_after_commit_callbacks(session: AsyncSession) -> Iterator[None]:
-    """Discard callbacks registered by work that raises and is rolled back."""
-    callbacks = cast(
-        list[AsyncCallback],
-        session.sync_session.info.setdefault(_AFTER_COMMIT_KEY, []),
-    )
-    checkpoint = len(callbacks)
-    try:
-        yield
-    except BaseException:
-        del callbacks[checkpoint:]
-        raise
+        callbacks, self.callbacks = self.callbacks, []
+        if not callbacks:
+            return
+        logger.debug("Running after_commit callbacks", callbacks=callbacks)
+        if self.loop is None:
+            logger.error("Expected event loop not found in session info")
+            return
+        for cb in callbacks:
+            try:
+                result = cb()
+                if asyncio.iscoroutine(result):
+                    logger.debug("Running after_commit callback", callback=result)
+                    asyncio.run_coroutine_threadsafe(result, self.loop)
+                else:
+                    logger.warning("Callback did not return a coroutine", callback=cb)
+            except Exception as e:
+                logger.error("after_commit callback failed", error=str(e))
 
 
 @event.listens_for(sqlalchemy.orm.Session, "after_commit")
-def _run_after_commit(session: sqlalchemy.orm.Session) -> None:  # pyright: ignore[reportUnusedFunction] - registered as SQLAlchemy event listener
-    """Execute all registered after-commit callbacks for the given session.
-
-    This function is automatically called by SQLAlchemy after a session commits.
-    It retrieves all registered callbacks and executes them, handling both
-    synchronous and asynchronous callbacks appropriately.
-
-    Args:
-        session: The SQLAlchemy session that just committed.
-
-    Returns:
-        None
-
-    Note:
-        Async callbacks are scheduled as tasks on the event loop that was
-        captured during callback registration. If no loop was captured,
-        a new event loop is created.
-    """
-    if session.info.get(_DEFER_AFTER_COMMIT_KEY):
-        return
-
-    callbacks = cast(list[AsyncCallback], session.info.pop(_AFTER_COMMIT_KEY, []))
-    if not callbacks:
-        return
-    logger.debug("Running after_commit callbacks", session=session, callbacks=callbacks)
-    if _EVENT_LOOP_KEY not in session.info:
-        logger.error("Expected event loop not found in session info", session=session)
-        return
-    loop = session.info[_EVENT_LOOP_KEY]
-    for cb in callbacks:
-        try:
-            if (coro := cb()) and asyncio.iscoroutine(coro):
-                logger.debug("Running after_commit callback", callback=coro)
-                asyncio.run_coroutine_threadsafe(coro, loop)
-            else:
-                logger.warning("Callback did not return a coroutine", callback=cb)
-        except Exception as e:
-            logger.error("after_commit callback failed", error=str(e))
+def _run_after_commit(session: sqlalchemy.orm.Session) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Drain callbacks after a session commits."""
+    queue = session.info.get(_QUEUE_KEY)
+    if queue is not None:
+        queue.drain_on_commit()

--- a/tracecat/db/session_events.py
+++ b/tracecat/db/session_events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import Awaitable, Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Final
@@ -32,7 +32,7 @@ class AfterCommitQueue:
             if isinstance(session, AsyncSession)
             else session.info
         )
-        queue = info.get(_QUEUE_KEY)
+        queue: AfterCommitQueue | None = info.get(_QUEUE_KEY)
         if queue is None:
             queue = info[_QUEUE_KEY] = cls()
         return queue
@@ -48,7 +48,7 @@ class AfterCommitQueue:
                 pass
 
     @contextmanager
-    def deferred(self) -> Iterator[None]:
+    def deferred(self) -> Generator[None]:
         """Defer callbacks across savepoint releases until the outer commit."""
         self.defer_depth += 1
         try:
@@ -57,7 +57,7 @@ class AfterCommitQueue:
             self.defer_depth -= 1
 
     @contextmanager
-    def checkpointed(self) -> Iterator[None]:
+    def checkpointed(self) -> Generator[None]:
         """Discard callbacks registered by work that raises and is rolled back."""
         checkpoint = len(self.callbacks)
         try:
@@ -93,6 +93,6 @@ class AfterCommitQueue:
 @event.listens_for(sqlalchemy.orm.Session, "after_commit")
 def _run_after_commit(session: sqlalchemy.orm.Session) -> None:  # pyright: ignore[reportUnusedFunction]
     """Drain callbacks after a session commits."""
-    queue = session.info.get(_QUEUE_KEY)
+    queue: AfterCommitQueue | None = session.info.get(_QUEUE_KEY)
     if queue is not None:
         queue.drain_on_commit()

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -9,7 +9,7 @@ from temporalio import activity
 
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import Schedule, Workflow
-from tracecat.db.session_events import add_after_commit_callback
+from tracecat.db.session_events import AfterCommitQueue
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.identifiers import ScheduleUUID, WorkflowID
 from tracecat.identifiers.schedules import AnyScheduleID
@@ -157,7 +157,7 @@ class WorkflowSchedulesService(BaseWorkspaceService):
                     schedule_role=role_copy,
                 )
 
-        add_after_commit_callback(self.session, _create_schedule)
+        AfterCommitQueue.of(self.session).add(_create_schedule)
 
         # Ensure the SQLAlchemy instance is persistent before refresh.
         # Commit will implicitly flush; when commit=False we must flush explicitly
@@ -268,7 +268,7 @@ class WorkflowSchedulesService(BaseWorkspaceService):
                     schedule_id=schedule_id,
                 )
 
-        add_after_commit_callback(self.session, _update_schedule)
+        AfterCommitQueue.of(self.session).add(_update_schedule)
 
         await self.session.commit()
         await self.session.refresh(schedule)
@@ -321,7 +321,7 @@ class WorkflowSchedulesService(BaseWorkspaceService):
                     schedule_id=schedule_id,
                 )
 
-        add_after_commit_callback(self.session, _delete_schedule)
+        AfterCommitQueue.of(self.session).add(_delete_schedule)
 
         if commit:
             await self.session.commit()


### PR DESCRIPTION
## Summary

Part of ENG-1543 (on-prem case UI slowdown); implements ENG-1545: https://linear.app/tracecat/issue/ENG-1545

Bulk case actions were N independent PATCH/DELETE requests — each taking its own row lock and paying 2 synchronous audit webhook deliveries (10 s timeout each). This PR moves bulk semantics server-side: one request, deterministic lock ordering, per-case partial-failure results, and exactly **one bulk audit event pair per batch** (ATTEMPT + SUCCESS/FAILURE = 2 webhook deliveries instead of 2×N).

Supersedes the client-side concurrency cap from #3091 (now merged) — the frontend rewire removes the cap usage from the bulk handlers.

## Backend

- `POST /cases/batch-update` and `POST /cases/batch-delete` (`case_ids` bounded 1–1000, mirroring the tables batch convention), scopes mirroring the single-case routes.
- All target rows locked in one workspace-scoped, UUID-sorted `SELECT … FOR UPDATE` (deadlock-safe ordering; mirrors the agent-preset skill locking pattern).
- Sequential per-case processing, each in a savepoint so one invalid case doesn't poison the batch; per-case results (`success`/`error`) preserve request order; one outer commit.
- The reusable body of `update_case` is extracted into an undecorated `_apply_case_update`; the single-case PATCH route (including its per-case `@audit_log` events) is behavior-identical and its tests pass unchanged.
- Bulk audit via direct `AuditService.create_event` calls: `action="update"|"delete"`, `resource_id=None`, `data={"batch": true, "case_ids": [...], "count": N, "succeeded": X, "failed": Y}`. No new audit action literals. Both deliveries happen **outside** the lock window (ATTEMPT before locking, terminal after commit). Audit failures never fail the batch.
- Per-case activity events and duration syncs still flow through the existing after-commit queue and fire once on the batch commit. `session_events` gains two scoped helpers so callbacks queued inside a savepoint are deferred to the outer commit and discarded when that savepoint rolls back (SQLAlchemy emits `after_commit` on savepoint release); existing single-commit paths are unaffected (the defer flag is never set outside batch).

## Frontend

- Generated client regenerated (`casesBatchUpdateCases` / `casesBatchDeleteCases`).
- `handleBulkUpdate` / `handleBulkDelete` collapse to one batch call each; new `useBatchUpdateCases` / `useBatchDeleteCases` hooks issue a single broad `["cases"]` invalidation on settle.
- Partial failures surface as a destructive toast with counts (`X updated, Y failed`); full-success UX unchanged.
- `runWithConcurrencyLimit` stays in `lib/utils.ts` (generic helper, tests retained); its bulk-case usage is removed.

## Verification

- Backend: 129 unit tests passed (service + API + events + audit suites), including new coverage: batch happy path, savepoint-isolated partial failure, missing IDs, delete, exactly-one ATTEMPT+terminal audit pair with payload, after-commit callback deferral/rollback, `/{case_id}` vs `batch-update` routing non-collision.
- `just gen-client-ci` clean; ruff/format/basedpyright clean.
- Frontend: biome + typecheck clean; 95 suites / 524 tests passed (incl. new one-call/one-invalidation hook tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side batch update and delete for cases to replace N PATCH/DELETE calls with one request, returning per-case results and a single audit pair. Implements ENG-1545 to speed up the on‑prem case UI by reducing lock contention and webhook load, and hardens behavior for partial and lookup failures.

- **New Features**
  - API: `POST /workspaces/{workspace_id}/cases/batch-update` and `POST /workspaces/{workspace_id}/cases/batch-delete` (1–1000 IDs). Deduplicates IDs, preserves order, returns per-case success/error and totals.
  - Processing: Workspace-scoped, UUID-ordered locks with `raiseload('*')`; updates use `FOR NO KEY UPDATE`, deletes use `FOR UPDATE`. `SET LOCAL lock_timeout = '5s'` bounds waits; lock timeouts map to HTTP 409. Optional `selectinload` of `dropdown_values` only for closing updates. Deletes rely on DB `ON DELETE CASCADE` via core `DELETE` and unlink reply comments first to avoid the self-FK RESTRICT. Per-case savepoints; missing IDs reported; DB errors mapped. Dropdown writes reuse the already-locked `Case`.
  - Auditing: Exactly one ATTEMPT and one terminal event for the batch; emitted outside the lock; terminal is FAILURE when zero cases succeeded; `case_ids` are strings; audit failures never fail the batch.
  - Frontend: New hooks `useBatchUpdateCases`/`useBatchDeleteCases` call generated `casesBatchUpdateCases`/`casesBatchDeleteCases`, chunk IDs to 1000, and leave cache invalidation to the caller (one ["cases"] invalidation per bulk op). Added tests to pin this contract.

- **Bug Fixes**
  - UI: On partial chunk failures, keep only unprocessed/failed cases selected, preserve mid‑flight selection changes, and show accurate partial‑failure toasts so retries don’t resubmit already‑processed IDs.
  - Dropdowns: Lookup failures (e.g. missing definition/option) are isolated per case and surfaced as per‑case errors; keep tenant scoping when passing a `Case` model to `apply_values`.
  - Events: Skip no‑op assignee/summary change activity events.
  - Audit/DB: AfterCommitQueue encapsulates after-commit callbacks; callbacks defer during savepoints and are dropped on checkpointed rollbacks; type-safe lookups. Extensive tests cover lock conflicts (409), route non-collision, per-case isolation, and cascade delete behavior.

<sup>Written for commit 19d6133a44830d2681a03786b69a01601d1b1d58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

