### PR TITLE
fix(redis): retry only transient errors and make stream TTL opt-in

### DIFF
--- a/tests/unit/test_redis_client.py
+++ b/tests/unit/test_redis_client.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 
 import pytest
 import tenacity
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError
 
 from tracecat.redis.client import RedisClient
 
@@ -31,13 +33,15 @@ class DummyRedis:
     expire_call_count = 0
     _xadd_raised_once = False
     raise_on_xadd_once = False
+    xreadgroup_call_count = 0
+    xreadgroup_error: Exception | None = None
 
     def __init__(self, *, connection_pool: DummyConnectionPool) -> None:
         self.connection_pool = connection_pool
         self.closed = False
         DummyRedis.instances.append(self)
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         self.closed = True
 
     async def ping(self) -> bool:
@@ -59,6 +63,14 @@ class DummyRedis:
     ) -> list[tuple[str, list[tuple[str, dict[str, str]]]]]:
         return []
 
+    async def xreadgroup(
+        self, *args, **kwargs
+    ) -> list[tuple[str, list[tuple[str, dict[str, str]]]]]:
+        DummyRedis.xreadgroup_call_count += 1
+        if DummyRedis.xreadgroup_error is not None:
+            raise DummyRedis.xreadgroup_error
+        return []
+
     async def xrange(self, *args, **kwargs) -> list[tuple[str, dict[str, str]]]:
         return []
 
@@ -69,6 +81,8 @@ class DummyRedis:
         cls.expire_call_count = 0
         cls._xadd_raised_once = False
         cls.raise_on_xadd_once = False
+        cls.xreadgroup_call_count = 0
+        cls.xreadgroup_error = None
 
 
 def fake_from_url(*args, **kwargs) -> SimpleNamespace:
@@ -101,13 +115,20 @@ def patch_redis(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
 
 @pytest.fixture(autouse=True)
 def no_retry_wait() -> Generator[None, None, None]:
-    retry_controller = RedisClient.xadd.retry  # type: ignore[attr-defined]
-    original_wait = retry_controller.wait
-    retry_controller.wait = tenacity.wait.wait_fixed(0)
+    retry_controllers = [
+        RedisClient.xadd.retry,  # type: ignore[attr-defined]
+        RedisClient.xreadgroup.retry,  # type: ignore[attr-defined]
+    ]
+    original_waits = [controller.wait for controller in retry_controllers]
+    for controller in retry_controllers:
+        controller.wait = tenacity.wait.wait_fixed(0)
     try:
         yield
     finally:
-        retry_controller.wait = original_wait
+        for controller, original_wait in zip(
+            retry_controllers, original_waits, strict=True
+        ):
+            controller.wait = original_wait
 
 
 async def _two_clients_same_loop(client: RedisClient):
@@ -152,17 +173,55 @@ def test_xadd_retries_after_transport_error() -> None:
     assert DummyRedis.instances[0].closed is True
 
 
-def test_xadd_applies_default_ttl() -> None:
+def test_xadd_skips_ttl_by_default() -> None:
     client = RedisClient()
 
     asyncio.run(client.xadd("stream", {"field": "value"}))
 
+    assert DummyRedis.expire_call_count == 0
+
+
+def test_xadd_applies_explicit_ttl() -> None:
+    client = RedisClient()
+
+    asyncio.run(client.xadd("stream", {"field": "value"}, expire_seconds=60))
+
     assert DummyRedis.expire_call_count == 1
 
 
-def test_xadd_allows_disabling_ttl() -> None:
+def test_xreadgroup_response_error_does_not_retry_or_reset() -> None:
     client = RedisClient()
+    error = ResponseError("NOGROUP No such key or consumer group")
+    DummyRedis.xreadgroup_error = error
 
-    asyncio.run(client.xadd("stream", {"field": "value"}, expire_seconds=None))
+    with pytest.raises(ResponseError) as exc_info:
+        asyncio.run(
+            client.xreadgroup(
+                group_name="group",
+                consumer_name="consumer",
+                streams={"stream": ">"},
+            )
+        )
 
-    assert DummyRedis.expire_call_count == 0
+    assert exc_info.value is error
+    assert DummyRedis.xreadgroup_call_count == 1
+    assert len(DummyConnectionPool.instances) == 1
+    assert DummyConnectionPool.instances[0].disconnected is False
+
+
+def test_xreadgroup_exhausted_retries_raise_original_exception() -> None:
+    client = RedisClient()
+    error = RedisConnectionError("connection lost")
+    DummyRedis.xreadgroup_error = error
+
+    with pytest.raises(RedisConnectionError) as exc_info:
+        asyncio.run(
+            client.xreadgroup(
+                group_name="group",
+                consumer_name="consumer",
+                streams={"stream": ">"},
+            )
+        )
+
+    assert exc_info.value is error
+    assert DummyRedis.xreadgroup_call_count == 3

--- a/tracecat/agent/stream/connector.py
+++ b/tracecat/agent/stream/connector.py
@@ -32,6 +32,7 @@ from tracecat.agent.stream.events import (
 )
 from tracecat.agent.types import ModelMessageTA, StreamKey
 from tracecat.chat import tokens
+from tracecat.config import REDIS_CHAT_TTL_SECONDS
 from tracecat.logger import logger
 from tracecat.redis.client import RedisClient, get_redis_client
 
@@ -94,6 +95,7 @@ class AgentStream:
             {tokens.DATA_KEY: orjson.dumps(event, default=to_jsonable_python).decode()},
             maxlen=10000,
             approximate=True,
+            expire_seconds=REDIS_CHAT_TTL_SECONDS,
         )
 
     async def error(self, error: str) -> None:

--- a/tracecat/redis/client.py
+++ b/tracecat/redis/client.py
@@ -2,14 +2,16 @@
 
 import asyncio
 import base64
-from collections.abc import Awaitable, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 import boto3
 import redis.asyncio as redis
 from botocore.exceptions import ClientError
 from redis.asyncio.connection import ConnectionPool
-from redis.exceptions import RedisError, ResponseError
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 from redis.typing import KeyT, StreamIdT
 from tenacity import (
     retry,
@@ -18,8 +20,17 @@ from tenacity import (
     wait_exponential,
 )
 
-from tracecat.config import REDIS_CHAT_TTL_SECONDS, REDIS_URL, REDIS_URL__ARN
+from tracecat.config import REDIS_URL, REDIS_URL__ARN
 from tracecat.logger import logger
+
+TRANSIENT_REDIS_ERRORS = (RedisConnectionError, RedisTimeoutError, RuntimeError)
+
+_retry_transient = retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(TRANSIENT_REDIS_ERRORS),
+    reraise=True,
+)
 
 
 def _resolve_redis_url() -> str:
@@ -110,18 +121,14 @@ class RedisClient:
 
         return RedisClient._client
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xadd(
         self,
         stream_key: str,
         fields: dict[str, Any],
         maxlen: int | None = None,
         approximate: bool = True,
-        expire_seconds: int | None = REDIS_CHAT_TTL_SECONDS,
+        expire_seconds: int | None = None,
     ) -> str:
         """Add an entry to a Redis stream with retry logic.
 
@@ -130,8 +137,8 @@ class RedisClient:
             fields: Dictionary of field-value pairs to add
             maxlen: Maximum stream length (approximate if approximate=True)
             approximate: Whether to use approximate trimming for better performance
-            expire_seconds: TTL in seconds for the stream key. Set to None to disable
-                expiration.
+            expire_seconds: Optional TTL in seconds for the stream key. Streams do not
+                expire by default.
 
         Returns:
             The ID of the added entry
@@ -160,7 +167,7 @@ class RedisClient:
                 message_id=message_id,
             )
             return message_id
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to add entry to Redis stream",
                 stream_key=stream_key,
@@ -169,11 +176,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xread(
         self,
         streams: dict[KeyT, StreamIdT],
@@ -193,7 +196,7 @@ class RedisClient:
         try:
             client = await self._get_client()
             return await client.xread(streams=streams, count=count, block=block)
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to read from Redis stream",
                 streams=list(streams.keys()),
@@ -202,11 +205,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xgroup_create(
         self,
         stream_key: str,
@@ -230,15 +229,8 @@ class RedisClient:
                     group_name=group_name,
                 )
                 return False
-            logger.error(
-                "Failed to create Redis consumer group",
-                stream_key=stream_key,
-                group_name=group_name,
-                error=str(e),
-            )
-            await self._reset_connection()
             raise
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to create Redis consumer group",
                 stream_key=stream_key,
@@ -248,11 +240,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xreadgroup(
         self,
         group_name: str,
@@ -271,7 +259,7 @@ class RedisClient:
                 count=count,
                 block=block,
             )
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to read from Redis consumer group",
                 streams=list(streams.keys()),
@@ -282,11 +270,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xack(
         self, stream_key: str, group_name: str, message_ids: list[str]
     ) -> int:
@@ -294,7 +278,7 @@ class RedisClient:
         try:
             client = await self._get_client()
             return await client.xack(stream_key, group_name, *message_ids)
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to ack Redis stream messages",
                 stream_key=stream_key,
@@ -304,11 +288,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xpending_range(
         self,
         stream_key: str,
@@ -319,8 +299,12 @@ class RedisClient:
         *,
         consumer: str | None = None,
         idle: int | None = None,
-    ) -> list[Any]:
-        """Fetch pending messages in a consumer group."""
+    ) -> list[dict[str, Any]]:
+        """Fetch pending-message dictionaries from a consumer group.
+
+        Each dictionary contains ``message_id``, ``consumer``,
+        ``time_since_delivered``, and ``times_delivered``.
+        """
         try:
             client = await self._get_client()
             return await client.xpending_range(
@@ -332,7 +316,7 @@ class RedisClient:
                 consumername=consumer,
                 idle=idle,
             )
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to fetch pending Redis messages",
                 stream_key=stream_key,
@@ -342,11 +326,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xclaim(
         self,
         stream_key: str,
@@ -365,7 +345,7 @@ class RedisClient:
                 min_idle_time=min_idle_time,
                 message_ids=list(message_ids),
             )
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to claim Redis pending messages",
                 stream_key=stream_key,
@@ -376,11 +356,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xrange(
         self,
         stream_key: str,
@@ -405,7 +381,7 @@ class RedisClient:
                 name=stream_key, min=min_id, max=max_id, count=count
             )
             return result
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to read range from Redis stream",
                 stream_key=stream_key,
@@ -414,11 +390,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def xrevrange(
         self,
         stream_key: str,
@@ -433,7 +405,7 @@ class RedisClient:
                 name=stream_key, max=max_id, min=min_id, count=count
             )
             return result
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to read reverse range from Redis stream",
                 stream_key=stream_key,
@@ -446,23 +418,11 @@ class RedisClient:
         """Check if Redis connection is alive."""
         try:
             client = await self._get_client()
-            ping_result = client.ping()
-            return await self._awaitable_to_bool(ping_result)
+            return bool(await client.ping())  # pyright: ignore[reportGeneralTypeIssues]
         except Exception:
             return False
 
-    async def _awaitable_to_bool(self, value: bool | Awaitable[bool]) -> bool:
-        """Return awaited bool regardless of sync/async Redis ping implementation."""
-        if isinstance(value, Awaitable):
-            resolved = await value
-            return bool(resolved)
-        return bool(value)
-
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def set_if_not_exists(
         self, key: str, value: str, *, expire_seconds: int
     ) -> bool:
@@ -471,7 +431,7 @@ class RedisClient:
             client = await self._get_client()
             result = await client.set(name=key, value=value, nx=True, ex=expire_seconds)
             return bool(result)
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to set Redis key if not exists",
                 key=key,
@@ -480,11 +440,7 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def set(
         self,
         key: str,
@@ -497,7 +453,7 @@ class RedisClient:
             client = await self._get_client()
             result = await client.set(name=key, value=value, ex=expire_seconds)
             return bool(result)
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error(
                 "Failed to set Redis key",
                 key=key,
@@ -506,27 +462,19 @@ class RedisClient:
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def exists(self, key: str) -> bool:
         """Check if a Redis key exists."""
         try:
             client = await self._get_client()
             result = await client.exists(key)
             return bool(result)
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error("Failed to check Redis key existence", key=key, error=str(e))
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def get(self, key: str) -> str | None:
         """Get a Redis key value."""
         try:
@@ -535,22 +483,18 @@ class RedisClient:
             if result is None:
                 return None
             return str(result)
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error("Failed to get Redis key", key=key, error=str(e))
             await self._reset_connection()
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        retry=retry_if_exception_type((RedisError, RuntimeError)),
-    )
+    @_retry_transient
     async def delete(self, key: str) -> int:
         """Delete a Redis key."""
         try:
             client = await self._get_client()
             return await client.delete(key)
-        except (RedisError, RuntimeError) as e:
+        except TRANSIENT_REDIS_ERRORS as e:
             logger.error("Failed to delete Redis key", key=key, error=str(e))
             await self._reset_connection()
             raise
@@ -559,7 +503,7 @@ class RedisClient:
         """Close the Redis connection."""
         closed = False
         if RedisClient._client:
-            await RedisClient._client.close()
+            await RedisClient._client.aclose()
             RedisClient._client = None
             closed = True
         if RedisClient._pool:


### PR DESCRIPTION
## Summary

Hardens `RedisClient` so application-level Redis errors stop being treated as transport failures, and removes a chat-specific TTL default from the generic `xadd` API.

### Retry/reset policy (behavioral fix)

`ResponseError` is a subclass of `RedisError`, so every non-transient, application-level error (NOGROUP, BUSYGROUP, malformed commands) previously triggered:

- 3 retries with exponential backoff that could never succeed,
- a `_reset_connection()` that tears down the **shared** connection pool for all users of the singleton mid-flight, and
- a `tenacity.RetryError` wrapper (tenacity defaults to `reraise=False`), forcing callers like `CaseTriggerConsumer._is_nogroup_error` to unwrap `error.last_attempt` to find the real exception.

Now all methods share one policy: retry (and reset the connection) only on `redis.ConnectionError`, `redis.TimeoutError`, and `RuntimeError` (the event-loop-change recovery path in `_get_client` relies on `RuntimeError` retries), with `reraise=True` so callers always see the original exception, never `RetryError`.

Non-transient errors now propagate immediately on the first attempt: no retry, no error log, no pool reset. Existing `except (ResponseError, RetryError)` handlers in consumers remain compatible — the `RetryError` branch simply becomes dead defensive code.

### `xadd` TTL is now opt-in

`xadd` defaulted `expire_seconds` to `REDIS_CHAT_TTL_SECONDS`, so any stream author who forgot `expire_seconds=None` had their stream silently expired on the chat schedule. The default is now `None`; the agent stream connector passes the chat TTL explicitly (byte-for-byte identical behavior). Audit of all `.xadd(` call sites:

- `tracecat/agent/stream/connector.py` — now passes `REDIS_CHAT_TTL_SECONDS` explicitly (all markers route through `append`)
- `tracecat/cases/triggers/publisher.py` — already passed `expire_seconds=None` explicitly; unchanged

### Smaller fixes

- `xpending_range` return type: `list[Any]` → `list[dict[str, Any]]` (what redis-py actually returns with `decode_responses=True`), so callers can stop shape-sniffing entries
- `ping()` simplified; deleted the `_awaitable_to_bool` helper
- `close()` → `aclose()` (redis-py is pinned to 7.1.0 where `close()` is deprecated)

Out of scope, deliberately unchanged: singleton structure, event-loop-change handling in `_get_client`, and the synchronous Secrets Manager URL resolution.

## Testing

- `tests/unit/test_redis_client.py` updated: TTL default tests inverted; new tests assert a `ResponseError` propagates on the first call with no pool reset (and is the same exception instance, not a wrapper), and that exhausted transient retries re-raise the original `ConnectionError` after exactly 3 attempts, not `RetryError`.
- `uv run pytest tests/unit/test_redis_client.py tests/unit/test_case_trigger_consumer.py` — 22 passed (trigger consumer tests unchanged).
- `ruff check`, `ruff format --check`, `basedpyright --warnings` on touched paths — clean.
