### PR TITLE
fix(executor): offload secret masking

### DIFF
--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -11,6 +11,7 @@ from tracecat_registry import (
 
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatCredentialsError
+from tracecat.executor import service as executor_service
 from tracecat.integrations.enums import OAuthGrantType
 from tracecat.secrets import secrets_manager
 
@@ -322,4 +323,58 @@ async def test_extract_templated_secrets_detects_nested_complex_expressions():
             "zendesk.ZENDESK_EMAIL",
             "zendesk.ZENDESK_API_TOKEN",
         ]
+    )
+
+
+@pytest.mark.anyio
+async def test_invoke_once_offloads_root_secret_masking(mocker):
+    role = Role(
+        type="service",
+        organization_id=UUID(int=1),
+        service_id="tracecat-executor",
+    )
+    action_input = mocker.Mock()
+    action_input.task.action = "core.transform.reshape"
+    action_input.registry_lock = {}
+    action_input.exec_context = {}
+    action_result = {"value": "secret"}
+    masked_result = {"value": "***"}
+    resolved_context = mocker.Mock(logical_time=mocker.sentinel.logical_time)
+    prepared_context = executor_service.PreparedContext(
+        resolved_context=resolved_context,
+        mask_values={"secret"},
+    )
+
+    mocker.patch.object(
+        executor_service.registry_resolver,
+        "prefetch_lock",
+        new=mocker.AsyncMock(),
+    )
+    mocker.patch.object(
+        executor_service,
+        "prepare_resolved_context",
+        new=mocker.AsyncMock(return_value=prepared_context),
+    )
+    mocker.patch.object(
+        executor_service,
+        "_invoke_step",
+        new=mocker.AsyncMock(return_value=action_result),
+    )
+    to_thread = mocker.patch.object(
+        executor_service.asyncio,
+        "to_thread",
+        new=mocker.AsyncMock(return_value=masked_result),
+    )
+
+    result = await executor_service.invoke_once(
+        backend=mocker.Mock(),
+        input=action_input,
+        ctx=executor_service.DispatchActionContext(role=role),
+    )
+
+    assert result == masked_result
+    to_thread.assert_awaited_once_with(
+        executor_service.apply_masks_object,
+        action_result,
+        masks={"secret"},
     )

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from cryptography.fernet import Fernet, InvalidToken
 
+from tracecat.secrets import common as secrets_common
 from tracecat.secrets.common import apply_masks, apply_masks_object
 from tracecat.secrets.encryption import (
     decrypt_bytes,
@@ -226,6 +227,34 @@ class TestObjectMasking:
             "key3": {"subkey1": "password123", "subkey2": "No secret"},
         }
         assert apply_masks_object(input_data, []) == input_data
+
+    def test_apply_masks_object_compiles_pattern_once(self, mocker):
+        masks = ["secret", "password"]
+        compile_pattern = mocker.spy(secrets_common, "_compile_mask_pattern")
+
+        result = apply_masks_object(
+            {
+                "key1": "This is a secret message",
+                "key2": ["password", "Another secret"],
+            },
+            masks,
+        )
+
+        assert result == {
+            "key1": "This is a *** message",
+            "key2": ["***", "Another ***"],
+        }
+        compile_pattern.assert_called_once_with(masks)
+
+    def test_apply_masks_object_with_mask_generator(self):
+        masks = (mask for mask in ["secret", "password"])
+
+        result = apply_masks_object(
+            ["secret", {"nested": "password"}],
+            masks,
+        )
+
+        assert result == ["***", {"nested": "***"}]
 
 
 class TestSecurityFeatures:

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -827,10 +827,13 @@ async def invoke_once(
             exec_result.loop_vars = input.exec_context.get(ExprContext.LOCAL_VARS)
         raise ExecutionError(info=exec_result) from e
 
-    # Apply secret masking at root level only
-    # Steps don't mask - masking happens once here after all execution completes
+    # Apply secret masking at root level only. Large action results can make this
+    # CPU-bound traversal expensive, so keep it off the activity event loop where
+    # it could otherwise delay heartbeats for every activity on the worker.
     if mask_values:
-        action_result = apply_masks_object(action_result, masks=mask_values)
+        action_result = await asyncio.to_thread(
+            apply_masks_object, action_result, masks=mask_values
+        )
     return action_result
 
 

--- a/tracecat/secrets/common.py
+++ b/tracecat/secrets/common.py
@@ -4,31 +4,44 @@ from collections.abc import Iterable, Mapping, Sequence
 from tracecat.secrets.constants import MASK_VALUE
 
 
-def apply_masks(value: str, masks: Iterable[str]) -> str:
-    if not masks:
-        return value
-
-    # Filter out single-character masks to prevent over-aggressive masking
+def _compile_mask_pattern(masks: Iterable[str]) -> re.Pattern[str] | None:
+    """Compile a reusable pattern for the provided secret values."""
+    # Filter out single-character masks to prevent over-aggressive masking.
     filtered_masks = [mask for mask in masks if len(mask) > 1]
-
     if not filtered_masks:
-        return value
+        return None
 
     # Sort longest-first so a longer secret is not partially matched by a
     # shorter substring that happens to appear earlier in the alternation.
     filtered_masks.sort(key=len, reverse=True)
-    pattern = "|".join(map(re.escape, filtered_masks))
-    return re.sub(pattern, MASK_VALUE, value)
+    return re.compile("|".join(map(re.escape, filtered_masks)))
+
+
+def _apply_mask_pattern(value: str, pattern: re.Pattern[str] | None) -> str:
+    if pattern is None:
+        return value
+    return pattern.sub(MASK_VALUE, value)
+
+
+def apply_masks(value: str, masks: Iterable[str]) -> str:
+    return _apply_mask_pattern(value, _compile_mask_pattern(masks))
+
+
+def _apply_masks_object[T](obj: T, pattern: re.Pattern[str] | None) -> T:
+    match obj:
+        case str():
+            return _apply_mask_pattern(obj, pattern)
+        case Sequence():
+            return type(obj)(_apply_masks_object(item, pattern) for item in obj)  # pyright: ignore[reportCallIssue]
+        case Mapping():
+            masked_items = (
+                (k, _apply_masks_object(v, pattern)) for k, v in obj.items()
+            )
+            return type(obj)(masked_items)  # pyright: ignore[reportCallIssue]
+        case _:
+            return obj
 
 
 def apply_masks_object[T](obj: T, masks: Iterable[str]) -> T:
-    """Process jsonpaths in strings, sequences, and mappings."""
-    match obj:
-        case str():
-            return apply_masks(obj, masks)
-        case Sequence():
-            return type(obj)(apply_masks_object(item, masks) for item in obj)  # pyright: ignore[reportCallIssue]
-        case Mapping():
-            return type(obj)((k, apply_masks_object(v, masks)) for k, v in obj.items())  # pyright: ignore[reportCallIssue]
-        case _:
-            return obj
+    """Mask secret values in strings, sequences, and mappings."""
+    return _apply_masks_object(obj, _compile_mask_pattern(masks))


### PR DESCRIPTION
## Tracking

- [ENG-1550](https://linear.app/tracecat/issue/ENG-1550/prevent-executor-heartbeat-starvation-during-result-masking)

## Summary

- compile the secret-masking regex once per object traversal
- offload root action-result masking from the executor event loop with `asyncio.to_thread()`
- cover compile-once behavior, one-shot mask iterables, and executor offloading

## Why

Large action results can require expensive recursive secret masking. Running that traversal synchronously on the shared executor event loop can delay Temporal activity heartbeats for unrelated actions on the same worker.

A synthetic 20 MB / 600,000-string benchmark improved from 2.25 seconds to 0.39 seconds by compiling the pattern once. Running the traversal through `asyncio.to_thread()` kept the event loop responsive while preserving masking output.

This is the focused hotfix for masking. Result-size limits and streaming/chunked externalization remain separate follow-up work.

## Testing

- `uv run pytest tests/unit/test_secrets.py tests/unit/test_executor_service.py -q` — 53 passed
- `uv run ruff check tracecat/secrets/common.py tracecat/executor/service.py tests/unit/test_secrets.py tests/unit/test_executor_service.py`
- `uv run ruff format --check tracecat/secrets/common.py tracecat/executor/service.py tests/unit/test_secrets.py tests/unit/test_executor_service.py`
- `uv run basedpyright tracecat/secrets/common.py tracecat/executor/service.py tests/unit/test_secrets.py tests/unit/test_executor_service.py`
- required pre-commit hooks, including frontend client generation
