### PR TITLE
docs: prefer dataclass slots and typed attribute access

### DIFF
--- a/tracecat/AGENTS.md
+++ b/tracecat/AGENTS.md
@@ -13,6 +13,9 @@ set for related Python packages in this repo.
 - Avoid `type: ignore`. If imports are cyclical, prefer `if TYPE_CHECKING:`.
 - Prefer `frozen=True` dataclasses for immutable value objects.
 - Prefer `slots=True` when defining dataclasses.
+- Avoid `getattr()`; use direct attribute access so the type checker can verify
+  the attribute. If `getattr()` is unavoidable, add a nearby comment clearly
+  explaining why it is needed.
 - Prefer `TypedDict` for structured dictionaries and `Protocol` for structural
   typing.
 - Use `TypedDict` with `NotRequired` for optional configuration keys.

--- a/tracecat/AGENTS.md
+++ b/tracecat/AGENTS.md
@@ -12,6 +12,7 @@ set for related Python packages in this repo.
 - Use `uv pip install` for package installation.
 - Avoid `type: ignore`. If imports are cyclical, prefer `if TYPE_CHECKING:`.
 - Prefer `frozen=True` dataclasses for immutable value objects.
+- Prefer `slots=True` when defining dataclasses.
 - Prefer `TypedDict` for structured dictionaries and `Protocol` for structural
   typing.
 - Use `TypedDict` with `NotRequired` for optional configuration keys.


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Adds a backend Python guideline to `tracecat/AGENTS.md`: prefer `slots=True` when defining dataclasses. Placed alongside the existing `frozen=True` dataclass guidance in the Python standards section.

## Related Issues

N/A

## Screenshots / Recordings

N/A (docs-only change)

## Steps to QA

Docs-only change — review the added bullet in `tracecat/AGENTS.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Python guidelines in `AGENTS.md`: prefer `slots=True` for `dataclasses` to reduce memory and prevent dynamic attributes. Avoid `getattr()`; use direct attribute access so type checkers can verify it, and add a brief nearby comment if `getattr()` is unavoidable.

<sup>Written for commit df276dab3b7ae1ec75752aca9f5448f75e580f2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

