### PR TITLE
fix(integrations): support mcp resource content blocks

### DIFF
--- a/tests/unit/test_agent_mcp_http_limits.py
+++ b/tests/unit/test_agent_mcp_http_limits.py
@@ -1,0 +1,157 @@
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from tracecat.agent.mcp.http_limits import (
+    MCP_MAX_RESPONSE_BYTES,
+    BoundedResponseTransport,
+    MCPResponseTooLargeError,
+    create_bounded_mcp_http_client,
+)
+
+
+class _AsyncStream(httpx.AsyncByteStream):
+    """Async byte stream so MockTransport responses support ``await aclose()``."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.anyio
+async def test_under_cap_response_passes_through_byte_identical() -> None:
+    body = b"x" * 4096
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body)
+
+    transport = BoundedResponseTransport(httpx.MockTransport(handler), limit=1_000_000)
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get("http://mcp.test/x")
+
+    assert response.content == body
+
+
+@pytest.mark.anyio
+async def test_over_cap_streamed_response_raises_mid_stream() -> None:
+    """No Content-Length, chunked body over the cap trips the counting stream."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=_AsyncStream([b"y" * 50] * 10))
+
+    transport = BoundedResponseTransport(httpx.MockTransport(handler), limit=100)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(MCPResponseTooLargeError):
+            await client.get("http://mcp.test/x")
+
+
+@pytest.mark.anyio
+async def test_content_length_over_cap_aborts_before_body() -> None:
+    stream = _AsyncStream([b"z"])
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-length": "999999"}, stream=stream)
+
+    transport = BoundedResponseTransport(httpx.MockTransport(handler), limit=100)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(MCPResponseTooLargeError) as excinfo:
+            await client.get("http://mcp.test/x")
+
+    assert excinfo.value.observed == 999999
+    assert stream.closed is True
+
+
+@pytest.mark.anyio
+async def test_gzip_content_encoding_is_rejected() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, headers={"content-encoding": "gzip"}, stream=_AsyncStream([b"small"])
+        )
+
+    transport = BoundedResponseTransport(httpx.MockTransport(handler), limit=1_000_000)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(MCPResponseTooLargeError):
+            await client.get("http://mcp.test/x")
+
+
+@pytest.mark.anyio
+async def test_outgoing_request_forces_identity_accept_encoding() -> None:
+    seen: dict[str, str | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["accept-encoding"] = request.headers.get("accept-encoding")
+        return httpx.Response(200, content=b"ok")
+
+    transport = BoundedResponseTransport(httpx.MockTransport(handler))
+    async with httpx.AsyncClient(transport=transport) as client:
+        await client.get("http://mcp.test/x")
+
+    assert seen["accept-encoding"] == "identity"
+
+
+@pytest.mark.anyio
+async def test_identity_content_encoding_is_allowed() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, headers={"content-encoding": "identity"}, content=b"ok"
+        )
+
+    transport = BoundedResponseTransport(httpx.MockTransport(handler))
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get("http://mcp.test/x")
+
+    assert response.content == b"ok"
+
+
+def test_factory_mirrors_mcp_defaults_and_installs_bounded_transport() -> None:
+    client = create_bounded_mcp_http_client()
+
+    assert client.follow_redirects is True
+    assert client.timeout.read == 300.0
+    assert isinstance(client._transport, BoundedResponseTransport)
+
+
+def test_factory_accepts_follow_redirects_kwarg() -> None:
+    """fastmcp's HTTP transport passes follow_redirects to the factory."""
+    client = create_bounded_mcp_http_client(follow_redirects=True)
+
+    assert client.follow_redirects is True
+    assert isinstance(client._transport, BoundedResponseTransport)
+
+
+def test_factory_forwards_extra_httpx_kwargs() -> None:
+    client = create_bounded_mcp_http_client(
+        base_url="https://mcp.test/base",
+        max_redirects=7,
+        trust_env=False,
+    )
+
+    assert str(client.base_url) == "https://mcp.test/base/"
+    assert client.max_redirects == 7
+    assert client.trust_env is False
+    assert isinstance(client._transport, BoundedResponseTransport)
+
+
+def test_default_cap_is_16_mib() -> None:
+    assert MCP_MAX_RESPONSE_BYTES == 16 * 1024 * 1024
+
+
+def test_factory_wraps_env_proxy_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env-derived proxy transports must also be bounded, not just _transport."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.test:8080")
+
+    client = create_bounded_mcp_http_client()
+
+    assert isinstance(client._transport, BoundedResponseTransport)
+    assert client._mounts, "expected an env-derived proxy mount"
+    for mount in client._mounts.values():
+        if mount is not None:
+            assert isinstance(mount, BoundedResponseTransport)

--- a/tests/unit/test_agent_mcp_proxy_server.py
+++ b/tests/unit/test_agent_mcp_proxy_server.py
@@ -102,7 +102,7 @@ async def test_registry_proxy_handler_strips_metadata_and_forwards_tool_call_id(
 ) -> None:
     call_tool = AsyncMock(
         return_value=SimpleNamespace(
-            content=[SimpleNamespace(text='{"ok": true}')],
+            content=[mt.TextContent(type="text", text='{"ok": true}')],
             is_error=False,
         )
     )
@@ -154,7 +154,7 @@ async def test_proxy_handler_returns_mcp_error_result_when_trusted_tool_errors(
 ) -> None:
     call_tool = AsyncMock(
         return_value=SimpleNamespace(
-            content=[SimpleNamespace(text="external MCP rejected")],
+            content=[mt.TextContent(type="text", text="external MCP rejected")],
             is_error=True,
         )
     )
@@ -246,7 +246,7 @@ async def test_registry_proxy_server_accepts_hook_injected_metadata_during_tool_
 ) -> None:
     call_tool = AsyncMock(
         return_value=SimpleNamespace(
-            content=[SimpleNamespace(text='{"ok": true}')],
+            content=[mt.TextContent(type="text", text='{"ok": true}')],
             is_error=False,
         )
     )

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -85,6 +85,27 @@ async def test_execute_user_mcp_tool_returns_descriptive_error_on_execution_erro
 
 
 @pytest.mark.anyio
+async def test_execute_user_mcp_tool_passes_string_result_through_unwrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flattened text must not be quote-wrapped and re-escaped by json.dumps."""
+    flattened = 'status: "ok"\n\nline two'
+    mock_client = AsyncMock()
+    mock_client.call_tool.return_value = flattened
+    monkeypatch.setattr(trusted_server, "UserMCPClient", lambda _: mock_client)
+    claims = _build_claims(
+        allowed_actions=["core.http_request", "mcp__Jira__getIssue"],
+        user_mcp_servers=[
+            UserMCPServerClaim(name="Jira", url="https://mcp.atlassian.com/v1/mcp")
+        ],
+    )
+
+    result = await trusted_server._execute_user_mcp("Jira", "getIssue", {}, claims)
+
+    assert result == flattened
+
+
+@pytest.mark.anyio
 async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_agent_mcp_user_client.py
+++ b/tests/unit/test_agent_mcp_user_client.py
@@ -1,9 +1,24 @@
+import base64
+from typing import Any
+
 import httpx
 import pytest
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+from mcp.types import (
+    BlobResourceContents,
+    ContentBlock,
+    EmbeddedResource,
+    TextContent,
+    TextResourceContents,
+)
+from pydantic import AnyUrl
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
 from tracecat.agent.mcp.user_client import UserMCPClient, _create_transport
+from tracecat.agent.mcp.utils import (
+    MCP_TOOL_RESULT_MAX_BYTES,
+    flatten_mcp_content_blocks,
+)
 
 
 def _mcp_server(name: str) -> MCPHttpServerConfig:
@@ -217,3 +232,123 @@ def test_sse_transport_also_strips_forwarded_auth() -> None:
 
     assert "authorization" not in client.headers
     assert client.headers["wiz-client-id"] == "svc-account-id"
+
+
+def test_flatten_keeps_status_text_and_nested_embedded_resource_body() -> None:
+    """Both the status line and the nested file body must survive."""
+    file_body = "def main():\n    return 42\n"
+    blocks: list[ContentBlock] = [
+        TextContent(
+            type="text",
+            text="successfully downloaded text file (SHA: abc123)",
+        ),
+        EmbeddedResource(
+            type="resource",
+            resource=TextResourceContents(
+                uri=AnyUrl("https://example.test/repo/main.py"),
+                mimeType="text/plain",
+                text=file_body,
+            ),
+        ),
+    ]
+
+    flattened = flatten_mcp_content_blocks(blocks)
+
+    assert "successfully downloaded text file (SHA: abc123)" in flattened
+    assert file_body in flattened
+    # A pydantic repr means the nested lookup fell through to str(block).
+    assert "TextResourceContents(" not in flattened
+    assert flattened == (
+        f"successfully downloaded text file (SHA: abc123)\n\n{file_body}"
+    )
+
+
+def test_flatten_emits_placeholder_for_blob_resource_without_leaking_base64() -> None:
+    """Binary payloads must be described, never inlined as base64."""
+    blob = base64.b64encode(b"\x89PNG\r\n\x1a\n" * 512).decode()
+    blocks: list[ContentBlock] = [
+        EmbeddedResource(
+            type="resource",
+            resource=BlobResourceContents(
+                uri=AnyUrl("https://example.test/repo/logo.png"),
+                mimeType="image/png",
+                blob=blob,
+            ),
+        ),
+    ]
+
+    flattened = flatten_mcp_content_blocks(blocks)
+
+    assert flattened == (
+        "[binary resource: https://example.test/repo/logo.png (image/png)]"
+    )
+    assert blob not in flattened
+    assert "iVBOR" not in flattened
+
+
+def test_flatten_truncates_over_cap_with_loud_marker() -> None:
+    """Over-cap results are truncated loudly, not silently dropped."""
+    oversized = "x" * (MCP_TOOL_RESULT_MAX_BYTES + 2_000_000)
+    blocks: list[ContentBlock] = [TextContent(type="text", text=oversized)]
+
+    flattened = flatten_mcp_content_blocks(blocks)
+
+    assert "[truncated:" in flattened
+    assert "omitted]" in flattened
+    assert len(flattened) < len(oversized)
+    assert len(flattened.encode("utf-8")) < MCP_TOOL_RESULT_MAX_BYTES + 1024
+    assert flattened.startswith("x" * 1000)
+
+
+def test_flatten_single_text_block_is_unchanged() -> None:
+    """Regression: the common single-block case keeps its exact prior value."""
+    blocks: list[ContentBlock] = [TextContent(type="text", text="plain result")]
+
+    assert flatten_mcp_content_blocks(blocks) == "plain result"
+
+
+@pytest.mark.parametrize("content", [None, []])
+def test_flatten_empty_content_returns_empty_string(
+    content: list[ContentBlock] | None,
+) -> None:
+    assert flatten_mcp_content_blocks(content) == ""
+
+
+@pytest.mark.anyio
+async def test_call_tool_returns_all_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: call_tool must not drop the embedded file body."""
+
+    class _StubResult:
+        content: list[ContentBlock] = [
+            TextContent(type="text", text="successfully downloaded text file"),
+            EmbeddedResource(
+                type="resource",
+                resource=TextResourceContents(
+                    uri=AnyUrl("https://example.test/a.txt"),
+                    mimeType="text/plain",
+                    text="the real file body",
+                ),
+            ),
+        ]
+
+    class _StubClient:
+        def __init__(self, transport: Any) -> None:
+            del transport
+
+        async def __aenter__(self) -> "_StubClient":
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            return None
+
+        async def call_tool(self, tool_name: str, args: dict[str, Any]) -> _StubResult:
+            del tool_name, args
+            return _StubResult()
+
+    monkeypatch.setattr("tracecat.agent.mcp.user_client.Client", _StubClient)
+    client = UserMCPClient([_mcp_server("github")])
+
+    result = await client.call_tool("github", "get_file_contents", {"path": "a.txt"})
+
+    assert "successfully downloaded text file" in result
+    assert "the real file body" in result

--- a/tests/unit/test_agent_mcp_user_client.py
+++ b/tests/unit/test_agent_mcp_user_client.py
@@ -14,9 +14,9 @@ from mcp.types import (
 from pydantic import AnyUrl
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
+from tracecat.agent.mcp.http_limits import BoundedResponseTransport
 from tracecat.agent.mcp.user_client import UserMCPClient, _create_transport
 from tracecat.agent.mcp.utils import (
-    MCP_TOOL_RESULT_MAX_BYTES,
     flatten_mcp_content_blocks,
 )
 
@@ -232,6 +232,7 @@ def test_sse_transport_also_strips_forwarded_auth() -> None:
 
     assert "authorization" not in client.headers
     assert client.headers["wiz-client-id"] == "svc-account-id"
+    assert isinstance(client._transport, BoundedResponseTransport)
 
 
 def test_flatten_keeps_status_text_and_nested_embedded_resource_body() -> None:
@@ -286,25 +287,35 @@ def test_flatten_emits_placeholder_for_blob_resource_without_leaking_base64() ->
     assert "iVBOR" not in flattened
 
 
-def test_flatten_truncates_over_cap_with_loud_marker() -> None:
-    """Over-cap results are truncated loudly, not silently dropped."""
-    oversized = "x" * (MCP_TOOL_RESULT_MAX_BYTES + 2_000_000)
-    blocks: list[ContentBlock] = [TextContent(type="text", text=oversized)]
-
-    flattened = flatten_mcp_content_blocks(blocks)
-
-    assert "[truncated:" in flattened
-    assert "omitted]" in flattened
-    assert len(flattened) < len(oversized)
-    assert len(flattened.encode("utf-8")) < MCP_TOOL_RESULT_MAX_BYTES + 1024
-    assert flattened.startswith("x" * 1000)
-
-
 def test_flatten_single_text_block_is_unchanged() -> None:
     """Regression: the common single-block case keeps its exact prior value."""
     blocks: list[ContentBlock] = [TextContent(type="text", text="plain result")]
 
     assert flatten_mcp_content_blocks(blocks) == "plain result"
+
+
+def test_flatten_replaces_lone_surrogates_instead_of_raising() -> None:
+    """Lone surrogates cannot cross JSON serialization; replace, don't raise."""
+    blocks: list[ContentBlock] = [TextContent(type="text", text="ok\ud800end")]
+
+    flattened = flatten_mcp_content_blocks(blocks)
+
+    assert "\ud800" not in flattened
+    assert "ok" in flattened
+    assert "end" in flattened
+    flattened.encode("utf-8")
+
+
+def test_flatten_multiblock_under_cap_is_identical_join() -> None:
+    """Multi-block under-cap output is the exact "\\n\\n"-joined text."""
+    bodies = ["first block", "second block\nwith newline", "third"]
+    blocks: list[ContentBlock] = [
+        TextContent(type="text", text=body) for body in bodies
+    ]
+
+    flattened = flatten_mcp_content_blocks(blocks)
+
+    assert flattened == "\n\n".join(bodies)
 
 
 @pytest.mark.parametrize("content", [None, []])
@@ -352,3 +363,75 @@ async def test_call_tool_returns_all_blocks(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert "successfully downloaded text file" in result
     assert "the real file body" in result
+
+
+@pytest.mark.anyio
+async def test_call_tool_converts_response_too_large_to_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The byte-cap error becomes a descriptive ToolError, not a raw error."""
+    from fastmcp.exceptions import ToolError
+
+    from tracecat.agent.mcp.http_limits import MCPResponseTooLargeError
+
+    class _StubClient:
+        def __init__(self, transport: Any) -> None:
+            del transport
+
+        async def __aenter__(self) -> "_StubClient":
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            return None
+
+        async def call_tool(self, tool_name: str, args: dict[str, Any]) -> Any:
+            del tool_name, args
+            # Mirror the tools/call surfacing: bare error under an anyio group.
+            group = ExceptionGroup(
+                "unhandled errors in a TaskGroup",
+                [MCPResponseTooLargeError(16 * 1024 * 1024, observed=17_000_000)],
+            )
+            raise MCPResponseTooLargeError(
+                16 * 1024 * 1024, observed=17_000_000
+            ) from group
+
+    monkeypatch.setattr("tracecat.agent.mcp.user_client.Client", _StubClient)
+    client = UserMCPClient([_mcp_server("github")])
+
+    with pytest.raises(ToolError, match="16 MiB"):
+        await client.call_tool("github", "big_tool", {})
+
+
+@pytest.mark.anyio
+async def test_call_tool_propagates_cancellation_carrying_cap_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CancelledError with the cap error in __context__ must not become ToolError."""
+    import asyncio
+
+    from tracecat.agent.mcp.http_limits import MCPResponseTooLargeError
+
+    class _StubClient:
+        def __init__(self, transport: Any) -> None:
+            del transport
+
+        async def __aenter__(self) -> "_StubClient":
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            return None
+
+        async def call_tool(self, tool_name: str, args: dict[str, Any]) -> Any:
+            del tool_name, args
+            # Teardown cancellation carrying the cap error as its __context__;
+            # implicit chaining is the point, so keep the bare re-raise.
+            try:
+                raise MCPResponseTooLargeError(16 * 1024 * 1024, observed=17_000_000)
+            except MCPResponseTooLargeError:
+                raise asyncio.CancelledError()  # noqa: B904
+
+    monkeypatch.setattr("tracecat.agent.mcp.user_client.Client", _StubClient)
+    client = UserMCPClient([_mcp_server("github")])
+
+    with pytest.raises(asyncio.CancelledError):
+        await client.call_tool("github", "big_tool", {})

--- a/tracecat/agent/mcp/http_limits.py
+++ b/tracecat/agent/mcp/http_limits.py
@@ -1,0 +1,136 @@
+"""Byte-capped httpx transport for user MCP HTTP/SSE clients.
+
+A malicious user MCP server can OOM the in-process trusted server: the mcp SDK
+calls ``response.aread()`` with no size limit and httpx auto-decompresses gzip.
+This module forces identity encoding and enforces a hard per-response byte cap
+at the transport layer, below httpx's decode step.
+
+The cap is per-response and is only safe because ``UserMCPClient`` opens a fresh
+client per tool call (short-lived sessions). A long-lived client with a
+persistent SSE stream would accumulate bytes across messages and break this
+assumption.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+MCP_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+
+
+class MCPResponseTooLargeError(Exception):
+    """Raised when a user MCP response exceeds the byte cap."""
+
+    def __init__(self, limit: int, observed: int | None = None) -> None:
+        self.limit = limit
+        self.observed = observed
+        detail = (
+            f" (observed at least {observed} bytes)" if observed is not None else ""
+        )
+        super().__init__(f"MCP server response exceeded {limit} byte limit{detail}")
+
+
+class _CountingByteStream(httpx.AsyncByteStream):
+    """Wrap a byte stream and abort once cumulative bytes exceed the cap."""
+
+    def __init__(self, stream: httpx.AsyncByteStream, limit: int) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._seen = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        async for chunk in self._stream:
+            self._seen += len(chunk)
+            if self._seen > self._limit:
+                raise MCPResponseTooLargeError(self._limit, observed=self._seen)
+            yield chunk
+
+    async def aclose(self) -> None:
+        await self._stream.aclose()
+
+
+class BoundedResponseTransport(httpx.AsyncBaseTransport):
+    """Force identity encoding and cap response bytes on the wrapped transport."""
+
+    def __init__(
+        self,
+        transport: httpx.AsyncBaseTransport,
+        limit: int = MCP_MAX_RESPONSE_BYTES,
+    ) -> None:
+        self._transport = transport
+        self._limit = limit
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        # Identity encoding makes wire bytes == decoded bytes; a transport-level
+        # cap cannot bound decoded size while httpx decodes above us.
+        request.headers["accept-encoding"] = "identity"
+
+        response = await self._transport.handle_async_request(request)
+
+        content_length = response.headers.get("content-length")
+        if content_length is not None:
+            try:
+                declared = int(content_length)
+            except ValueError:
+                declared = None
+            if declared is not None and declared > self._limit:
+                await response.aclose()
+                raise MCPResponseTooLargeError(self._limit, observed=declared)
+
+        # Server ignored our identity request; decoding would reopen the hole.
+        encoding = response.headers.get("content-encoding")
+        if encoding is not None and encoding.strip().lower() not in ("", "identity"):
+            await response.aclose()
+            raise MCPResponseTooLargeError(self._limit)
+
+        # Async transport always yields an async stream; guard narrows the type.
+        if isinstance(response.stream, httpx.AsyncByteStream):
+            response.stream = _CountingByteStream(response.stream, self._limit)
+        return response
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+
+def create_bounded_mcp_http_client(
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+    follow_redirects: bool = True,
+    **kwargs: Any,
+) -> httpx.AsyncClient:
+    """Create an httpx client mirroring MCP defaults with a bounded transport.
+
+    Matches ``mcp.shared._httpx_utils.McpHttpClientFactory`` so fastmcp
+    transports can install it via ``httpx_client_factory``. The extra
+    ``follow_redirects`` keyword is accepted because fastmcp's HTTP transport
+    passes it positionally-by-name to the factory. Additional keyword arguments
+    are forwarded to ``httpx.AsyncClient``.
+
+    ``httpx`` does not expose a public ``TypedDict`` for these constructor
+    options. Keeping this passthrough typed as ``Any`` avoids coupling to
+    private aliases while ``AsyncClient`` still validates the arguments.
+    """
+    if timeout is None:
+        timeout = httpx.Timeout(30.0, read=300.0)
+
+    client = httpx.AsyncClient(
+        follow_redirects=follow_redirects,
+        timeout=timeout,
+        headers=headers,
+        auth=auth,
+        **kwargs,
+    )
+    # Wrapping the private transports is the only way to bound httpx's
+    # env-derived default and proxy transports without re-implementing proxy
+    # resolution. A None mount means "no proxy for this pattern" (NO_PROXY);
+    # preserve it. Requests matching a mount bypass _transport, so wrap both.
+    client._transport = BoundedResponseTransport(client._transport)
+    client._mounts = {
+        pattern: BoundedResponseTransport(mount) if mount is not None else None
+        for pattern, mount in client._mounts.items()
+    }
+    return client

--- a/tracecat/agent/mcp/proxy_server.py
+++ b/tracecat/agent/mcp/proxy_server.py
@@ -27,7 +27,10 @@ from tracecat.agent.mcp.metadata import (
     extract_proxy_tool_call_id,
 )
 from tracecat.agent.mcp.user_client import UserMCPClient
-from tracecat.agent.mcp.utils import action_name_to_mcp_tool_name
+from tracecat.agent.mcp.utils import (
+    action_name_to_mcp_tool_name,
+    flatten_mcp_content_blocks,
+)
 from tracecat.logger import logger
 
 __all__ = [
@@ -119,11 +122,7 @@ def _make_tool_handler(
                     payload,
                 )
 
-            # Extract result text from content
-            result_text = ""
-            if call_result.content and len(call_result.content) > 0:
-                first_block = call_result.content[0]
-                result_text = getattr(first_block, "text", str(first_block))
+            result_text = flatten_mcp_content_blocks(call_result.content)
 
             if call_result.is_error:
                 logger.error(

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -767,6 +767,10 @@ async def _execute_user_mcp(
             workspace_id=str(claims.workspace_id),
         )
 
+        # Flattened text is already a string; dumps would quote-wrap it and
+        # double-escape it on the CLI stdout leg.
+        if isinstance(result, str):
+            return result
         return json.dumps(result, default=str)
     except ToolError:
         raise

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -28,6 +28,7 @@ from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
 from tracecat.agent.mcp.utils import (
     LEGACY_REGISTRY_MCP_SERVER_NAME,
     REGISTRY_MCP_SERVER_NAME,
+    flatten_mcp_content_blocks,
 )
 from tracecat.integrations.schemas import MCPToolSummary
 from tracecat.logger import logger
@@ -338,13 +339,9 @@ class UserMCPClient:
         async with Client(transport) as client:
             result = await client.call_tool(tool_name, args)
 
-            # Extract result from CallToolResult
-            if result.content and len(result.content) > 0:
-                first_block = result.content[0]
-                # TextContent has a .text attribute
-                return getattr(first_block, "text", str(first_block))
-
-            return ""
+            # Flatten every block: file bodies arrive as EmbeddedResource,
+            # not as the leading TextContent status line.
+            return flatten_mcp_content_blocks(result.content)
 
     @staticmethod
     def _is_tracecat_registry_server_name(server_name: str) -> bool:

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 import httpx
 from fastmcp import Client
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+from fastmcp.exceptions import ToolError
 from mcp import McpError
 from mcp.shared._httpx_utils import McpHttpClientFactory
 from tenacity import (
@@ -25,6 +26,10 @@ from tenacity import (
 )
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
+from tracecat.agent.mcp.http_limits import (
+    MCPResponseTooLargeError,
+    create_bounded_mcp_http_client,
+)
 from tracecat.agent.mcp.utils import (
     LEGACY_REGISTRY_MCP_SERVER_NAME,
     REGISTRY_MCP_SERVER_NAME,
@@ -60,7 +65,7 @@ def _drop_forwarded_authorization(
         if timeout is None:
             timeout = httpx.Timeout(30.0, read=300.0)
         kwargs.setdefault("follow_redirects", True)
-        return httpx.AsyncClient(
+        return create_bounded_mcp_http_client(
             headers=merged,
             timeout=timeout,
             auth=auth,
@@ -131,6 +136,30 @@ def _iter_exception_chain(exc: BaseException) -> list[BaseException]:
         chain.append(current)
         current = current.__cause__ or current.__context__
     return chain
+
+
+def _contains_response_too_large(exc: BaseException) -> bool:
+    """Walk cause/context and ExceptionGroup members for the byte-cap error.
+
+    The cap raise surfaces differently by path: bare on tools/call, wrapped in
+    a connect RuntimeError on the handshake, and nested inside an anyio
+    ExceptionGroup in either case.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException] = [exc]
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, MCPResponseTooLargeError):
+            return True
+        if isinstance(current, BaseExceptionGroup):
+            stack.extend(current.exceptions)
+        for linked in (current.__cause__, current.__context__):
+            if linked is not None:
+                stack.append(linked)
+    return False
 
 
 def _is_retryable_discovery_error_leaf(exc: BaseException) -> bool:
@@ -336,12 +365,20 @@ class UserMCPClient:
             tool_name=tool_name,
         )
 
-        async with Client(transport) as client:
-            result = await client.call_tool(tool_name, args)
+        try:
+            async with Client(transport) as client:
+                result = await client.call_tool(tool_name, args)
 
-            # Flatten every block: file bodies arrive as EmbeddedResource,
-            # not as the leading TextContent status line.
-            return flatten_mcp_content_blocks(result.content)
+                # Flatten every block: file bodies arrive as EmbeddedResource,
+                # not as the leading TextContent status line.
+                return flatten_mcp_content_blocks(result.content)
+        except Exception as e:
+            # Catch Exception, not BaseException: the cap error surfaces bare, in
+            # an ExceptionGroup, or wrapped in RuntimeError (all Exception). A
+            # CancelledError carrying the cap error in __context__ must propagate.
+            if _contains_response_too_large(e):
+                raise ToolError("MCP server response exceeded 16 MiB limit") from e
+            raise
 
     @staticmethod
     def _is_tracecat_registry_server_name(server_name: str) -> bool:

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -33,19 +33,9 @@ if TYPE_CHECKING:
 REGISTRY_MCP_SERVER_NAME = "tracecat-registry"
 LEGACY_REGISTRY_MCP_SERVER_NAME = "tracecat_registry"
 
-# Results cross the CLI stdout buffer capped at 5MiB
-# (CLAUDE_SDK_MAX_BUFFER_SIZE_BYTES); stay under it with headroom for framing.
-MCP_TOOL_RESULT_MAX_BYTES = 4 * 1024 * 1024
 
-
-def _format_size(num_bytes: int) -> str:
-    """Human-readable byte size."""
-    value = float(num_bytes)
-    for unit in ("B", "KB", "MB", "GB"):
-        if value < 1024 or unit == "GB":
-            return f"{value:.1f}{unit}" if unit != "B" else f"{int(value)}B"
-        value /= 1024
-    return f"{value:.1f}GB"
+# Lone surrogates cannot cross JSON serialization.
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
 
 
 def _render_content_block(block: ContentBlock) -> str:
@@ -75,28 +65,18 @@ def _render_content_block(block: ContentBlock) -> str:
 
 def flatten_mcp_content_blocks(
     content: Sequence[ContentBlock] | None,
-    *,
-    max_bytes: int = MCP_TOOL_RESULT_MAX_BYTES,
 ) -> str:
-    """Flatten every block of an MCP CallToolResult into a single string.
+    """Flatten an MCP CallToolResult into one string.
 
-    Truncation is marked loudly: a silent cut is the same failure mode as
-    dropping blocks, since the agent cannot tell it received partial data.
+    Size is bounded upstream by the HTTP byte cap in ``http_limits`` and
+    downstream by the CLI's MAX_MCP_OUTPUT_TOKENS spill-to-file limit.
     """
     if not content:
         return ""
-
-    joined = "\n\n".join(_render_content_block(block) for block in content)
-
-    encoded = joined.encode("utf-8")
-    if len(encoded) <= max_bytes:
-        return joined
-
-    head = encoded[:max_bytes].decode("utf-8", errors="ignore")
-    return (
-        f"{head}\n\n[truncated: {_format_size(len(encoded) - max_bytes)} "
-        f"of {_format_size(len(encoded))} omitted]"
-    )
+    text = "\n\n".join(_render_content_block(block) for block in content)
+    if _SURROGATE_RE.search(text):
+        text = text.encode("utf-8", errors="replace").decode("utf-8")
+    return text
 
 
 # Anthropic tool names must match this pattern; stdio MCP servers can report

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -11,14 +11,93 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from mcp.types import (
+    AudioContent,
+    BlobResourceContents,
+    ContentBlock,
+    EmbeddedResource,
+    ImageContent,
+    ResourceLink,
+    TextContent,
+    TextResourceContents,
+)
+
 from tracecat.agent.common.types import MCPToolDefinition
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from tracecat.identifiers import OrganizationID
     from tracecat.registry.lock.types import RegistryLock
 
 REGISTRY_MCP_SERVER_NAME = "tracecat-registry"
 LEGACY_REGISTRY_MCP_SERVER_NAME = "tracecat_registry"
+
+# Results cross the CLI stdout buffer capped at 5MiB
+# (CLAUDE_SDK_MAX_BUFFER_SIZE_BYTES); stay under it with headroom for framing.
+MCP_TOOL_RESULT_MAX_BYTES = 4 * 1024 * 1024
+
+
+def _format_size(num_bytes: int) -> str:
+    """Human-readable byte size."""
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            return f"{value:.1f}{unit}" if unit != "B" else f"{int(value)}B"
+        value /= 1024
+    return f"{value:.1f}GB"
+
+
+def _render_content_block(block: ContentBlock) -> str:
+    """Render a single MCP content block as text.
+
+    EmbeddedResource has no `.text`; the payload is nested on `.resource`.
+    """
+    if isinstance(block, TextContent):
+        return block.text
+    if isinstance(block, EmbeddedResource):
+        resource = block.resource
+        if isinstance(resource, TextResourceContents):
+            return resource.text
+        if isinstance(resource, BlobResourceContents):
+            return (
+                f"[binary resource: {resource.uri} ({resource.mimeType or 'unknown'})]"
+            )
+        return f"[resource: {resource.uri}]"
+    if isinstance(block, ImageContent):
+        return f"[image: {block.mimeType}]"
+    if isinstance(block, AudioContent):
+        return f"[audio: {block.mimeType}]"
+    if isinstance(block, ResourceLink):
+        return f"[resource link: {block.uri} ({block.mimeType or 'unknown'})]"
+    return f"[unsupported content block: {type(block).__name__}]"
+
+
+def flatten_mcp_content_blocks(
+    content: Sequence[ContentBlock] | None,
+    *,
+    max_bytes: int = MCP_TOOL_RESULT_MAX_BYTES,
+) -> str:
+    """Flatten every block of an MCP CallToolResult into a single string.
+
+    Truncation is marked loudly: a silent cut is the same failure mode as
+    dropping blocks, since the agent cannot tell it received partial data.
+    """
+    if not content:
+        return ""
+
+    joined = "\n\n".join(_render_content_block(block) for block in content)
+
+    encoded = joined.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return joined
+
+    head = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return (
+        f"{head}\n\n[truncated: {_format_size(len(encoded) - max_bytes)} "
+        f"of {_format_size(len(encoded))} omitted]"
+    )
+
 
 # Anthropic tool names must match this pattern; stdio MCP servers can report
 # names (e.g. "issue.get") that would put invalid entries in allowed_tools.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for MCP resource content blocks so embedded file bodies and non-text blocks are preserved in tool results, and enforces a 16 MiB, identity-encoded HTTP cap to stop oversized user MCP responses from crashing the trusted server while keeping CLI output safe.

- **Bug Fixes**
  - Added `flatten_mcp_content_blocks` to merge `TextContent` and `EmbeddedResource` (`TextResourceContents`), render `BlobResourceContents` as "[binary resource: ...]", add placeholders for image/audio/resource links, and replace lone surrogates.
  - Updated `proxy_server` and `user_client` to use the flattener and return all blocks, not just the first.
  - Introduced bounded MCP `httpx` client (`create_bounded_mcp_http_client`) that forces `accept-encoding: identity`, rejects compressed `Content-Encoding`, enforces a 16 MiB cap (pre-checks `Content-Length` and counts streamed bytes), and wraps env proxy mounts; installed for both `SSETransport` and `StreamableHttpTransport` via `httpx_client_factory`.
  - In `user_client`, cap breaches found anywhere in the exception chain are converted to a clear `ToolError` ("MCP server response exceeded 16 MiB limit"); cancellations carrying the cap error still propagate. In `trusted_server`, flattened string results pass through unwrapped to avoid double-escaping on the CLI.

<sup>Written for commit 1e57a0a17008017c6c04e87e0dbde112ca70c68b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

