### PR TITLE
chore: ignore pi subagent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,4 @@ cython_debug/
 
 # Claude Code local runtime state (keep tracked commands/settings/skills)
 .claude/scheduled_tasks.lock
+.pi-subagents/


### PR DESCRIPTION
### Motivation
- Prevent local `.pi-subagents` runtime state from being tracked in the repository by ignoring the directory.

### Description
- Add `.pi-subagents/` to `.gitignore`.

### Testing
- Ran `git diff --check` and `git check-ignore -v --no-index .pi-subagents/example`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fbc1c84e883208e4f50df3840e58b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.pi-subagents/` to `.gitignore` to keep local Pi subagent runtime state out of version control. This prevents noisy diffs and accidental commits of transient files.

<sup>Written for commit b625d774c4d424c347b7ad1ea842d501e62d8e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

