### PR TITLE
refactor(api): encapsulate lifespan background tasks

### DIFF
--- a/tests/unit/test_api_lifespan.py
+++ b/tests/unit/test_api_lifespan.py
@@ -1,0 +1,156 @@
+import asyncio
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+
+import pytest
+
+import tracecat.api.lifespan as lifespan_module
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("context_factory", "task_factory_name"),
+    [
+        (
+            lifespan_module.temporal_search_attributes_lifespan,
+            "add_temporal_search_attributes",
+        ),
+        (
+            lifespan_module.platform_registry_sync_lifespan,
+            "sync_platform_registry_on_startup",
+        ),
+        (
+            lifespan_module.platform_catalog_load_lifespan,
+            "load_platform_catalog_on_startup",
+        ),
+    ],
+)
+async def test_one_shot_lifespan_context_starts_task(
+    monkeypatch: pytest.MonkeyPatch,
+    context_factory: Callable[[], AbstractAsyncContextManager[None]],
+    task_factory_name: str,
+) -> None:
+    started = asyncio.Event()
+
+    async def run() -> None:
+        started.set()
+
+    monkeypatch.setattr(lifespan_module, task_factory_name, run)
+
+    async with context_factory():
+        await started.wait()
+
+
+@pytest.mark.anyio
+async def test_case_trigger_lifespan_cancels_enabled_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+    keep_running = asyncio.Event()
+
+    async def consume() -> None:
+        started.set()
+        try:
+            await keep_running.wait()
+        finally:
+            stopped.set()
+
+    monkeypatch.setattr(
+        lifespan_module,
+        "start_case_trigger_consumer",
+        consume,
+    )
+    monkeypatch.setattr(
+        lifespan_module.config,
+        "TRACECAT__CASE_TRIGGERS_ENABLED",
+        True,
+    )
+
+    async with lifespan_module.case_trigger_consumer_lifespan():
+        await started.wait()
+
+    assert stopped.is_set()
+
+
+@pytest.mark.anyio
+async def test_case_trigger_lifespan_skips_disabled_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = False
+
+    async def consume() -> None:
+        nonlocal started
+        started = True
+
+    monkeypatch.setattr(
+        lifespan_module,
+        "start_case_trigger_consumer",
+        consume,
+    )
+    monkeypatch.setattr(
+        lifespan_module.config,
+        "TRACECAT__CASE_TRIGGERS_ENABLED",
+        False,
+    )
+
+    async with lifespan_module.case_trigger_consumer_lifespan():
+        await asyncio.sleep(0)
+
+    assert not started
+
+
+@pytest.mark.anyio
+async def test_lifespan_task_propagates_owner_cancellation_during_cleanup() -> None:
+    child_started = asyncio.Event()
+    child_cleanup_started = asyncio.Event()
+    keep_running = asyncio.Event()
+    cleanup_blocker = asyncio.Event()
+    owner_continued = False
+
+    async def run_child() -> None:
+        child_started.set()
+        try:
+            await keep_running.wait()
+        except asyncio.CancelledError:
+            child_cleanup_started.set()
+            await cleanup_blocker.wait()
+            raise
+
+    async def run_owner() -> None:
+        nonlocal owner_continued
+        async with lifespan_module._lifespan_task(run_child, name="test_child"):
+            await child_started.wait()
+        owner_continued = True
+
+    owner_task = asyncio.create_task(run_owner())
+    await child_cleanup_started.wait()
+    owner_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await owner_task
+
+    assert not owner_continued
+
+
+@pytest.mark.anyio
+async def test_lifespan_task_cancels_after_shutdown_timeout() -> None:
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+    keep_running = asyncio.Event()
+
+    async def run() -> None:
+        started.set()
+        try:
+            await keep_running.wait()
+        finally:
+            stopped.set()
+
+    async with lifespan_module._lifespan_task(
+        run,
+        name="test_task",
+        shutdown_timeout=0,
+    ):
+        await started.wait()
+
+    assert stopped.is_set()

--- a/tests/unit/test_api_lifespan.py
+++ b/tests/unit/test_api_lifespan.py
@@ -134,6 +134,41 @@ async def test_lifespan_task_propagates_owner_cancellation_during_cleanup() -> N
 
 
 @pytest.mark.anyio
+async def test_lifespan_task_propagates_suppressed_owner_cancellation() -> None:
+    child_started = asyncio.Event()
+    child_cleanup_started = asyncio.Event()
+    keep_running = asyncio.Event()
+    cleanup_blocker = asyncio.Event()
+    owner_continued = False
+
+    async def run_child() -> None:
+        child_started.set()
+        try:
+            await keep_running.wait()
+        except asyncio.CancelledError:
+            child_cleanup_started.set()
+            try:
+                await cleanup_blocker.wait()
+            except asyncio.CancelledError:
+                return
+
+    async def run_owner() -> None:
+        nonlocal owner_continued
+        async with lifespan_module._lifespan_task(run_child, name="test_child"):
+            await child_started.wait()
+        owner_continued = True
+
+    owner_task = asyncio.create_task(run_owner())
+    await child_cleanup_started.wait()
+    owner_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await owner_task
+
+    assert not owner_continued
+
+
+@pytest.mark.anyio
 async def test_lifespan_task_cancels_after_shutdown_timeout() -> None:
     started = asyncio.Event()
     stopped = asyncio.Event()

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -1,6 +1,5 @@
-import asyncio
 from collections.abc import Callable
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 
 from fastapi import (
     APIRouter,
@@ -27,7 +26,6 @@ from tracecat import config
 from tracecat.admin.agent.router import router as admin_agent_router
 from tracecat.admin.registry.router import router as admin_registry_router
 from tracecat.agent.access.router import router as agent_model_access_router
-from tracecat.agent.catalog.loader import load_platform_catalog_on_startup
 from tracecat.agent.catalog.router import router as agent_catalog_router
 from tracecat.agent.channels.management_router import (
     router as agent_channels_management_router,
@@ -45,12 +43,17 @@ from tracecat.agent.tags.definitions_router import (
 )
 from tracecat.agent.tags.router import router as agent_preset_tags_router
 from tracecat.api.common import (
-    add_temporal_search_attributes,
     bootstrap_role,
     custom_generate_unique_id,
     generic_exception_handler,
     http_exception_handler,
     tracecat_exception_handler,
+)
+from tracecat.api.lifespan import (
+    case_trigger_consumer_lifespan,
+    platform_catalog_load_lifespan,
+    platform_registry_sync_lifespan,
+    temporal_search_attributes_lifespan,
 )
 from tracecat.auth.credentials import authenticated_user_only
 from tracecat.auth.dependencies import (
@@ -88,7 +91,6 @@ from tracecat.cases.tag_definitions.router import (
     router as case_tag_definitions_router,
 )
 from tracecat.cases.tags.router import router as case_tags_router
-from tracecat.cases.triggers.consumer import start_case_trigger_consumer
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import AsyncDBSessionBypass
 from tracecat.db.engine import (
@@ -126,7 +128,6 @@ from tracecat.organization.management import (
 from tracecat.organization.router import router as org_router
 from tracecat.registry.actions.router import router as registry_actions_router
 from tracecat.registry.repositories.router import router as registry_repos_router
-from tracecat.registry.sync.jobs import sync_platform_registry_on_startup
 from tracecat.secrets.router import org_router as org_secrets_router
 from tracecat.secrets.router import router as secrets_router
 from tracecat.service_accounts.router import (
@@ -168,129 +169,48 @@ from tracecat.workspaces.service import WorkspaceService
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # USER_AUTH_SECRET is required for all auth types — UserManager uses it
-    # for password reset and email verification token signing. Validated here
-    # (not in create_app) because the app module is imported at collection time
-    # by tests and OpenAPI generation, before secrets are available.
-    get_user_auth_secret()
-    assert_soft_delete_listener_registered()
+    async with AsyncExitStack() as task_stack:
+        # USER_AUTH_SECRET is required for all auth types — UserManager uses it
+        # for password reset and email verification token signing. Validated here
+        # (not in create_app) because the app module is imported at collection time
+        # by tests and OpenAPI generation, before secrets are available.
+        get_user_auth_secret()
+        assert_soft_delete_listener_registered()
 
-    # Temporal
-    # Run in background to avoid blocking startup
-    asyncio.create_task(add_temporal_search_attributes())
-    logger.debug("Spawned lifespan task to add temporal search attributes")
+        await task_stack.enter_async_context(temporal_search_attributes_lifespan())
 
-    # Storage
-    await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS)
-    await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY)
-    await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_SKILLS)
-    if is_feature_enabled(FeatureFlag.AGENT_FS_PERSISTENCE):
-        await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_AGENT)
+        # Storage
+        await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS)
+        await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY)
+        await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_SKILLS)
+        if is_feature_enabled(FeatureFlag.AGENT_FS_PERSISTENCE):
+            await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_AGENT)
 
-    # Workflow bucket with lifecycle expiration
-    await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW)
-    if config.TRACECAT__WORKFLOW_ARTIFACT_RETENTION_DAYS > 0:
-        await configure_bucket_lifecycle(
-            bucket=config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW,
-            expiration_days=config.TRACECAT__WORKFLOW_ARTIFACT_RETENTION_DAYS,
+        # Workflow bucket with lifecycle expiration
+        await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW)
+        if config.TRACECAT__WORKFLOW_ARTIFACT_RETENTION_DAYS > 0:
+            await configure_bucket_lifecycle(
+                bucket=config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW,
+                expiration_days=config.TRACECAT__WORKFLOW_ARTIFACT_RETENTION_DAYS,
+            )
+
+        await ensure_default_organization()
+
+        async with get_async_session_bypass_rls_context_manager() as session:
+            await setup_rbac_defaults(session)
+
+        await task_stack.enter_async_context(platform_registry_sync_lifespan())
+        await task_stack.enter_async_context(platform_catalog_load_lifespan())
+        await task_stack.enter_async_context(case_trigger_consumer_lifespan())
+
+        logger.info(
+            "Feature flags",
+            feature_flags=[f.value for f in config.TRACECAT__FEATURE_FLAGS],
         )
+        logger.info("RLS mode", rls_mode=config.TRACECAT__RLS_MODE.value)
+        logger.info("API startup complete")
 
-    await ensure_default_organization()
-
-    async with get_async_session_bypass_rls_context_manager() as session:
-        await setup_rbac_defaults(session)
-
-    # Spawn platform registry sync as background task (non-blocking)
-    # Uses leader election to prevent race conditions across multiple API processes
-    registry_sync_task = asyncio.create_task(
-        sync_platform_registry_on_startup(),
-        name="platform_registry_sync",
-    )
-    logger.debug("Spawned background task for platform registry sync")
-
-    platform_catalog_task = asyncio.create_task(
-        load_platform_catalog_on_startup(),
-        name="platform_catalog_load",
-    )
-    logger.debug("Spawned background task for platform catalog load")
-
-    case_trigger_task = None
-    if config.TRACECAT__CASE_TRIGGERS_ENABLED:
-        case_trigger_task = asyncio.create_task(
-            start_case_trigger_consumer(),
-            name="case_trigger_consumer",
-        )
-        logger.debug("Spawned background task for case trigger consumer")
-
-    logger.info(
-        "Feature flags", feature_flags=[f.value for f in config.TRACECAT__FEATURE_FLAGS]
-    )
-    logger.info("RLS mode", rls_mode=config.TRACECAT__RLS_MODE.value)
-    logger.info("API startup complete")
-
-    yield
-
-    # Gracefully handle the registry sync task during shutdown
-    if not registry_sync_task.done():
-        logger.info("Waiting for platform registry sync task to complete...")
-        try:
-            # Give the task a reasonable time to complete
-            await asyncio.wait_for(registry_sync_task, timeout=10.0)
-            logger.info("Platform registry sync task completed")
-        except TimeoutError:
-            logger.warning(
-                "Platform registry sync task did not complete in time, cancelling"
-            )
-            registry_sync_task.cancel()
-            try:
-                await registry_sync_task
-            except asyncio.CancelledError:
-                logger.debug("Platform registry sync task cancelled")
-        except Exception as e:
-            logger.warning(
-                "Platform registry sync task failed during shutdown", error=e
-            )
-    else:
-        # Task already completed - retrieve result to surface any exceptions
-        try:
-            registry_sync_task.result()
-            logger.debug("Platform registry sync task had already completed")
-        except Exception as e:
-            logger.warning(
-                "Platform registry sync task failed before shutdown", error=e
-            )
-
-    if not platform_catalog_task.done():
-        logger.info("Waiting for platform catalog load task to complete...")
-        try:
-            await asyncio.wait_for(platform_catalog_task, timeout=10.0)
-            logger.info("Platform catalog load task completed")
-        except TimeoutError:
-            logger.warning(
-                "Platform catalog load task did not complete in time, cancelling"
-            )
-            platform_catalog_task.cancel()
-            try:
-                await platform_catalog_task
-            except asyncio.CancelledError:
-                logger.debug("Platform catalog load task cancelled")
-        except Exception as e:
-            logger.warning("Platform catalog load task failed during shutdown", error=e)
-    else:
-        try:
-            platform_catalog_task.result()
-            logger.debug("Platform catalog load task had already completed")
-        except Exception as e:
-            logger.warning("Platform catalog load task failed before shutdown", error=e)
-
-    if case_trigger_task is not None:
-        case_trigger_task.cancel()
-        try:
-            await case_trigger_task
-        except asyncio.CancelledError:
-            logger.debug("Case trigger consumer task cancelled")
-        except Exception as e:
-            logger.warning("Case trigger consumer stopped with error", error=e)
+        yield
 
     await close_storage_client_cache()
 

--- a/tracecat/api/lifespan.py
+++ b/tracecat/api/lifespan.py
@@ -25,51 +25,53 @@ async def _stop_lifespan_task(
 ) -> None:
     owner_task = asyncio.current_task()
     owner_cancellation_count = owner_task.cancelling() if owner_task is not None else 0
-    completed_before_shutdown = task.done()
-    if shutdown_timeout is not None and not completed_before_shutdown:
-        logger.info("Waiting for lifespan task to complete", task=name)
+    try:
+        completed_before_shutdown = task.done()
+        if shutdown_timeout is not None and not completed_before_shutdown:
+            logger.info("Waiting for lifespan task to complete", task=name)
+            try:
+                await asyncio.wait_for(task, timeout=shutdown_timeout)
+            except TimeoutError:
+                logger.warning(
+                    "Lifespan task did not complete in time; cancelling",
+                    task=name,
+                    timeout=shutdown_timeout,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Lifespan task failed during shutdown",
+                    task=name,
+                    error=e,
+                )
+                return
+            else:
+                logger.info("Lifespan task completed", task=name)
+                return
+
+        if not task.done():
+            task.cancel()
+
         try:
-            await asyncio.wait_for(task, timeout=shutdown_timeout)
-        except TimeoutError:
-            logger.warning(
-                "Lifespan task did not complete in time; cancelling",
-                task=name,
-                timeout=shutdown_timeout,
-            )
+            await task
+        except asyncio.CancelledError:
+            logger.debug("Lifespan task cancelled", task=name)
         except Exception as e:
             logger.warning(
-                "Lifespan task failed during shutdown",
+                "Lifespan task failed before shutdown"
+                if completed_before_shutdown
+                else "Lifespan task stopped with error",
                 task=name,
                 error=e,
             )
-            return
         else:
-            logger.info("Lifespan task completed", task=name)
-            return
-
-    if not task.done():
-        task.cancel()
-
-    try:
-        await task
-    except asyncio.CancelledError:
+            if completed_before_shutdown:
+                logger.debug("Lifespan task had already completed", task=name)
+    finally:
         if (
             owner_task is not None
             and owner_task.cancelling() > owner_cancellation_count
         ):
-            raise
-        logger.debug("Lifespan task cancelled", task=name)
-    except Exception as e:
-        logger.warning(
-            "Lifespan task failed before shutdown"
-            if completed_before_shutdown
-            else "Lifespan task stopped with error",
-            task=name,
-            error=e,
-        )
-    else:
-        if completed_before_shutdown:
-            logger.debug("Lifespan task had already completed", task=name)
+            raise asyncio.CancelledError
 
 
 @asynccontextmanager

--- a/tracecat/api/lifespan.py
+++ b/tracecat/api/lifespan.py
@@ -1,0 +1,137 @@
+"""Context managers for background tasks owned by the API lifespan."""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager
+from typing import Any
+
+from tracecat import config
+from tracecat.agent.catalog.loader import load_platform_catalog_on_startup
+from tracecat.api.common import add_temporal_search_attributes
+from tracecat.cases.triggers.consumer import start_case_trigger_consumer
+from tracecat.logger import logger
+from tracecat.registry.sync.jobs import sync_platform_registry_on_startup
+
+_LIFESPAN_TASK_SHUTDOWN_TIMEOUT_SECONDS = 10.0
+
+type TaskFactory = Callable[[], Coroutine[Any, Any, None]]
+
+
+async def _stop_lifespan_task(
+    task: asyncio.Task[None],
+    *,
+    name: str,
+    shutdown_timeout: float | None,
+) -> None:
+    owner_task = asyncio.current_task()
+    owner_cancellation_count = owner_task.cancelling() if owner_task is not None else 0
+    completed_before_shutdown = task.done()
+    if shutdown_timeout is not None and not completed_before_shutdown:
+        logger.info("Waiting for lifespan task to complete", task=name)
+        try:
+            await asyncio.wait_for(task, timeout=shutdown_timeout)
+        except TimeoutError:
+            logger.warning(
+                "Lifespan task did not complete in time; cancelling",
+                task=name,
+                timeout=shutdown_timeout,
+            )
+        except Exception as e:
+            logger.warning(
+                "Lifespan task failed during shutdown",
+                task=name,
+                error=e,
+            )
+            return
+        else:
+            logger.info("Lifespan task completed", task=name)
+            return
+
+    if not task.done():
+        task.cancel()
+
+    try:
+        await task
+    except asyncio.CancelledError:
+        if (
+            owner_task is not None
+            and owner_task.cancelling() > owner_cancellation_count
+        ):
+            raise
+        logger.debug("Lifespan task cancelled", task=name)
+    except Exception as e:
+        logger.warning(
+            "Lifespan task failed before shutdown"
+            if completed_before_shutdown
+            else "Lifespan task stopped with error",
+            task=name,
+            error=e,
+        )
+    else:
+        if completed_before_shutdown:
+            logger.debug("Lifespan task had already completed", task=name)
+
+
+@asynccontextmanager
+async def _lifespan_task(
+    task_factory: TaskFactory,
+    *,
+    name: str,
+    shutdown_timeout: float | None = None,
+) -> AsyncIterator[None]:
+    task = asyncio.create_task(task_factory(), name=name)
+    logger.debug("Spawned lifespan task", task=name)
+    try:
+        yield
+    finally:
+        await _stop_lifespan_task(
+            task,
+            name=name,
+            shutdown_timeout=shutdown_timeout,
+        )
+
+
+@asynccontextmanager
+async def temporal_search_attributes_lifespan() -> AsyncIterator[None]:
+    """Manage Temporal search attribute registration."""
+    async with _lifespan_task(
+        add_temporal_search_attributes,
+        name="temporal_search_attributes",
+    ):
+        yield
+
+
+@asynccontextmanager
+async def platform_registry_sync_lifespan() -> AsyncIterator[None]:
+    """Manage the non-blocking platform registry startup sync."""
+    async with _lifespan_task(
+        sync_platform_registry_on_startup,
+        name="platform_registry_sync",
+        shutdown_timeout=_LIFESPAN_TASK_SHUTDOWN_TIMEOUT_SECONDS,
+    ):
+        yield
+
+
+@asynccontextmanager
+async def platform_catalog_load_lifespan() -> AsyncIterator[None]:
+    """Manage the non-blocking platform catalog startup load."""
+    async with _lifespan_task(
+        load_platform_catalog_on_startup,
+        name="platform_catalog_load",
+        shutdown_timeout=_LIFESPAN_TASK_SHUTDOWN_TIMEOUT_SECONDS,
+    ):
+        yield
+
+
+@asynccontextmanager
+async def case_trigger_consumer_lifespan() -> AsyncIterator[None]:
+    """Manage the case trigger consumer when it is enabled."""
+    if not config.TRACECAT__CASE_TRIGGERS_ENABLED:
+        yield
+        return
+
+    async with _lifespan_task(
+        start_case_trigger_consumer,
+        name="case_trigger_consumer",
+    ):
+        yield


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR extracts every background task owned by the API lifespan into a dedicated async context manager in `tracecat/api/lifespan.py`.

The refactor:

- keeps Temporal registration before storage initialization and starts the remaining tasks after organization/RBAC setup
- gives registry sync and platform catalog loading their existing 10-second graceful shutdown window
- encapsulates the optional case-trigger consumer as a no-op context when disabled
- manages the previously fire-and-forget Temporal task and unwinds all entered contexts on partial startup failure
- preserves owner-task cancellation while awaiting child cleanup during forced shutdown

`tracecat/api/app.py` now composes these task lifecycles with `AsyncExitStack` instead of creating, cancelling, and awaiting tasks inline.

## Related Issues

N/A

## Screenshots / Recordings

N/A — backend-only refactor.

## Steps to QA

```bash
uv run pytest tests/unit/test_api_lifespan.py tests/unit/test_rls_failure_repros.py -q
uv run ruff check .
uv run ruff format --check .
uv run basedpyright --warnings --threads 4
```

Expected: 38 focused tests pass, Ruff is clean, and basedpyright reports zero errors or warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encapsulates API lifespan background tasks in async context managers in `tracecat/api/lifespan.py`, composed with `AsyncExitStack` in `tracecat/api/app.py` for predictable startup and safer shutdown.

- **Refactors**
  - Added `_lifespan_task` and contexts for Temporal search attributes, platform registry sync, platform catalog load, and the case trigger consumer; registry/catalog wait up to 10s on shutdown; consumer is a no‑op when disabled.
  - Replaced inline spawn/cancel with `AsyncExitStack`; preserves owner cancellation during task cleanup via `_stop_lifespan_task`; ensures partial‑startup unwind; removes ad‑hoc shutdown code in `app.py`.
  - Added focused tests covering task start, conditional consumer, cancellation during cleanup, and shutdown timeouts.

<sup>Written for commit d7e48025aa0d5bf1b21c708237762a71fe6bafab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

