### PR TITLE
chore: remove Kubernetes submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "deployments/k8s"]
-	path = deployments/k8s
-	url = git@github.com:TracecatHQ/k8s.git
-	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,9 +248,9 @@ just gen-functions
 ## Infra and migrations
 
 - Infrastructure changes must be reviewed across all relevant deployment
-  targets: `docker-compose*.yml`, `deployments/fargate/`,
-  `deployments/k8s/eks/`, `deployments/k8s/eks/modules/eks/`, and
-  `deployments/k8s/helm/`.
+  targets: `docker-compose*.yml` and `deployments/fargate/`. Kubernetes
+  infrastructure lives in the separate `TracecatHQ/k8s` repository and must be
+  reviewed there when relevant.
 - Check the matching `values.yaml`, `variables.tf`, and `main.tf` files before
   closing out infra work.
 - For Alembic work, bring up the database first, check the cluster port with

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Sandboxed-by-default with [`nsjail`](https://github.com/google/nsjail) and run o
 This repo is available under the [AGPL-3.0 license](https://github.com/TracecatHQ/tracecat/blob/main/LICENSE) with the following exceptions:
 
 - `packages/tracecat-ee` directory is under Tracecat's paid EE (Enterprise Edition) license.
-- `deployments/k8s` is a git submodule under the source available [PolyForm Shield License](https://polyformproject.org/licenses/shield/1.0.0). It contains the Tracecat Helm chart and EKS deployment templates for internal use only. The Helm chart is distributed as a private OCI artifact hosted in AWS ECR.
 - Any code that gates `ee` features across the repo
 
 Code that fall under the above exceptions must not be redistributed, sold, or otherwise commercialized without permission.

--- a/docs/self-hosting/aws-fargate.mdx
+++ b/docs/self-hosting/aws-fargate.mdx
@@ -113,7 +113,7 @@ If you are using Temporal Cloud or another external Temporal cluster, set `disab
 <AccordionGroup>
   <Accordion title="Is untrusted code execution safe on Fargate?">
     Fargate does not support the permissions model required by `nsjail`. Tracecat uses a fallback executor without `nsjail` isolation on Fargate.
-    If you need the highest isolation for untrusted code execution (like custom registry actions or `core.script.run_python`), deploy Tracecat on Kubernetes using the [Helm chart](https://github.com/TracecatHQ/tracecat/tree/main/deployments/k8s/helm), where `nsjail` is enabled by default.
+    If you need the highest isolation for untrusted code execution (like custom registry actions or `core.script.run_python`), [deploy Tracecat on Kubernetes](/self-hosting/kubernetes), where `nsjail` is enabled by default.
   </Accordion>
 
   <Accordion title="What infrastructure does this stack create?">


### PR DESCRIPTION
We don't actuially use this properly.

## Summary

- Remove the `deployments/k8s` gitlink and the repository's `.gitmodules` configuration.
- Update licensing and contributor guidance now that Kubernetes infrastructure lives in `TracecatHQ/k8s`.
- Replace the stale in-repository Helm chart URL with the existing Kubernetes deployment guide.

## Impact

Fresh clones no longer initialize the Kubernetes repository as a submodule. The release workflow continues to dispatch version bumps to the separate `TracecatHQ/k8s` repository.

## Validation

- `uv run ruff check .`
- `git diff HEAD^ --check`
- `jq empty docs/docs.json`
- Verified that the repository has no remaining gitlinks.
- Commit-time pre-commit hooks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Kubernetes submodule and `.gitmodules`, and updated docs to point to `TracecatHQ/k8s` and the Kubernetes deployment guide. Fresh clones are simpler; release workflow still dispatches version bumps to `TracecatHQ/k8s`.

- **Refactors**
  - Deleted `deployments/k8s` gitlink and removed `.gitmodules`.
  - Replaced in-repo Helm chart link with `/self-hosting/kubernetes`.
  - Clarified in `AGENTS.md` and `README.md` that Kubernetes infra lives in `TracecatHQ/k8s`.

<sup>Written for commit e1c93402a197a93c2c6dad8dc2836a997e5b5844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

