### PR TITLE
test(webhooks): cover successful router dispatch

### DIFF
--- a/tests/integration/test_webhook_start_ack_integration.py
+++ b/tests/integration/test_webhook_start_ack_integration.py
@@ -59,6 +59,28 @@ async def _import_webhook_workflow(role: Role) -> tuple[str, str]:
 
 
 @pytest.mark.anyio
+async def test_webhook_returns_200_when_temporal_acknowledges_start(
+    svc_role: Role,
+) -> None:
+    workflow_id, secret = await _import_webhook_workflow(svc_role)
+
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            f"/webhooks/{workflow_id}/{secret}",
+            json={"text": "hello"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["message"] == "Workflow execution started"
+    assert body["wf_id"] == str(WorkflowUUID.new(workflow_id))
+    assert body["wf_exec_id"].startswith(f"{workflow_id}/exec_")
+
+
+@pytest.mark.anyio
 async def test_webhook_returns_500_when_temporal_start_fails(
     svc_role: Role, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- add an HTTP-level success-path test for the public webhook router
- exercise the real FastAPI app, webhook validation, workflow lookup, payload storage, and Temporal start acknowledgment
- assert the `200` response contract and generated execution identifiers

## Why

The existing router integration coverage only exercised Temporal start failure. This adds a positive smoke test that will fail if a valid webhook can no longer reach and start a workflow through the actual application router.

## Impact

No production behavior changes. This adds regression coverage for webhook availability and the successful dispatch response contract.

## Validation

- `uv run pytest tests/integration/test_webhook_start_ack_integration.py -q`
- `uv run ruff check tests/integration/test_webhook_start_ack_integration.py`
- `uv run ruff format --check tests/integration/test_webhook_start_ack_integration.py`
- `uv run basedpyright tests/integration/test_webhook_start_ack_integration.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an HTTP-level integration test for the webhook router’s success path to ensure a valid webhook starts a workflow and returns the correct 200 response. This exercises the real `FastAPI` app, validation, workflow lookup, payload storage, and Temporal start acknowledgment, and verifies `wf_id` and `wf_exec_id` are set correctly.

<sup>Written for commit bd1bcfaa8761ec21dc4f45e4d8b42d8939b783b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

