### PR TITLE
feat(agents): thread catalog context-window into agent runtime

### DIFF
--- a/tests/unit/test_agent_catalog_service.py
+++ b/tests/unit/test_agent_catalog_service.py
@@ -12,7 +12,10 @@ from tracecat.agent.catalog.schemas import (
     AzureOpenAICatalogUpdate,
     BedrockCatalogUpdate,
 )
-from tracecat.agent.catalog.service import AgentCatalogService
+from tracecat.agent.catalog.service import (
+    AgentCatalogService,
+    context_window_from_metadata,
+)
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.db.models import (
@@ -49,6 +52,79 @@ def _user_role(organization_id: uuid.UUID) -> Role:
         service_id="tracecat-api",
         scopes=frozenset({"*"}),
     )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected"),
+    [
+        (None, None),
+        ({}, None),
+        ({"max_input_tokens": 200_000}, 200_000),
+        ({"context_window": 272_000, "max_input_tokens": 100}, 272_000),
+        ({"context_length": 262_144.0}, 262_144),
+        ({"max_input_tokens": 0}, None),
+        ({"max_input_tokens": -1}, None),
+        ({"max_input_tokens": True}, None),
+        ({"max_input_tokens": "200000"}, None),
+    ],
+)
+def test_context_window_from_metadata(
+    metadata: dict | None, expected: int | None
+) -> None:
+    assert context_window_from_metadata(metadata) == expected
+
+
+@pytest.mark.anyio
+async def test_get_context_windows_scopes_to_visible_rows(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    service = AgentCatalogService(session=session)
+    other_org = Organization(name="Other org", slug=f"other-{uuid.uuid4()}")
+    session.add(other_org)
+    await session.flush()
+
+    platform_row = AgentCatalog(
+        organization_id=None,
+        model_provider="mistral",
+        model_name=f"mistral-large-{uuid.uuid4()}",
+        model_metadata={"max_input_tokens": 262_144},
+    )
+    org_row = AgentCatalog(
+        organization_id=svc_organization.id,
+        model_provider="custom-model-provider",
+        model_name=f"prod-gpt-{uuid.uuid4()}",
+        model_metadata={"context_window": 272_000},
+    )
+    no_window_row = AgentCatalog(
+        organization_id=svc_organization.id,
+        model_provider="custom-model-provider",
+        model_name=f"mystery-{uuid.uuid4()}",
+        model_metadata={"id": "mystery"},
+    )
+    other_org_row = AgentCatalog(
+        organization_id=other_org.id,
+        model_provider="custom-model-provider",
+        model_name=f"hidden-{uuid.uuid4()}",
+        model_metadata={"context_window": 100_000},
+    )
+    session.add_all([platform_row, org_row, no_window_row, other_org_row])
+    await session.commit()
+
+    windows = await service.get_context_windows(
+        org_id=svc_organization.id,
+        catalog_ids=[
+            platform_row.id,
+            org_row.id,
+            no_window_row.id,
+            other_org_row.id,
+        ],
+    )
+
+    assert windows == {
+        platform_row.id: 262_144,
+        org_row.id: 272_000,
+    }
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_provider_service.py
+++ b/tests/unit/test_agent_provider_service.py
@@ -151,10 +151,13 @@ async def test_refresh_provider_catalog_upserts_models(
         )
     )
 
-    with patch.object(
-        service,
-        "_discover_models",
-        return_value=[{"id": "model-a"}, {"id": "model-b"}],
+    with (
+        patch.object(
+            service,
+            "_discover_models",
+            return_value=[{"id": "model-a"}, {"id": "model-b"}],
+        ),
+        patch.object(service, "_fetch_metadata_rows", return_value=[]),
     ):
         await service.refresh_provider_catalog(provider.id)
 
@@ -171,6 +174,99 @@ async def test_refresh_provider_catalog_upserts_models(
     )
 
     assert {row.model_name for row in catalog_rows} == {"model-a", "model-b"}
+
+
+@pytest.mark.anyio
+async def test_refresh_provider_catalog_annotates_context_windows(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    """/model/info windows land in catalog metadata; pre-annotated models are kept."""
+    service = AgentCustomProviderService(session=session, role=_role(svc_organization))
+    provider = await service.create_provider(
+        AgentCustomProviderCreate(
+            display_name="Gateway",
+            base_url="https://api.example.com",
+        )
+    )
+
+    async def _fake_metadata_rows(path: str, **_kwargs: object) -> list[dict]:
+        if path == "/model/info":
+            return [
+                {"model_name": "prod-gpt", "model_info": {"max_input_tokens": 272000}},
+                {"model_name": "prod-null", "model_info": {"max_input_tokens": None}},
+            ]
+        # prod-null stays unresolved, so the /model_group/info fallback fires.
+        assert path == "/model_group/info"
+        return []
+
+    with (
+        patch.object(
+            service,
+            "_discover_models",
+            return_value=[
+                {"id": "prod-gpt"},
+                {"id": "prod-null"},
+                {"id": "big-model", "context_length": 1_000_000},
+            ],
+        ),
+        patch.object(service, "_fetch_metadata_rows", side_effect=_fake_metadata_rows),
+    ):
+        await service.refresh_provider_catalog(provider.id)
+
+    rows = (
+        (
+            await session.execute(
+                select(AgentCatalog).where(
+                    AgentCatalog.custom_provider_id == provider.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    metadata_by_name = {row.model_name: row.model_metadata or {} for row in rows}
+
+    assert metadata_by_name["prod-gpt"]["context_window"] == 272000
+    assert "context_window" not in metadata_by_name["prod-null"]
+    assert metadata_by_name["big-model"]["context_length"] == 1_000_000
+
+
+@pytest.mark.anyio
+async def test_refresh_provider_catalog_falls_back_to_model_group_info(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    """Wildcard-routed gateways only resolve windows via /model_group/info."""
+    service = AgentCustomProviderService(session=session, role=_role(svc_organization))
+    provider = await service.create_provider(
+        AgentCustomProviderCreate(
+            display_name="Wildcard gateway",
+            base_url="https://api.example.com",
+        )
+    )
+
+    async def _fake_metadata_rows(path: str, **_kwargs: object) -> list[dict]:
+        if path == "/model/info":
+            return [
+                {"model_name": "openai/*", "model_info": {"max_input_tokens": None}}
+            ]
+        assert path == "/model_group/info"
+        return [{"model_group": "prod-gpt", "max_input_tokens": 272000.0}]
+
+    with (
+        patch.object(service, "_discover_models", return_value=[{"id": "prod-gpt"}]),
+        patch.object(service, "_fetch_metadata_rows", side_effect=_fake_metadata_rows),
+    ):
+        await service.refresh_provider_catalog(provider.id)
+
+    row = (
+        await session.execute(
+            select(AgentCatalog).where(AgentCatalog.custom_provider_id == provider.id)
+        )
+    ).scalar_one()
+
+    assert (row.model_metadata or {})["context_window"] == 272000
 
 
 @pytest.mark.anyio
@@ -202,11 +298,14 @@ async def test_refresh_provider_catalog_uses_migrated_encrypted_base_url_fallbac
     session.add(provider)
     await session.commit()
 
-    with patch.object(
-        service,
-        "_discover_models",
-        return_value=[{"id": "migrated-model"}],
-    ) as discover:
+    with (
+        patch.object(
+            service,
+            "_discover_models",
+            return_value=[{"id": "migrated-model"}],
+        ) as discover,
+        patch.object(service, "_fetch_metadata_rows", return_value=[]),
+    ):
         await service.refresh_provider_catalog(provider.id)
 
     discover.assert_awaited_once_with(

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -1237,6 +1237,90 @@ class TestClaudeAgentRuntimeRun:
 
         assert env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "1"
 
+    def test_no_auto_compact_window_for_anthropic_models(
+        self,
+        sample_init_payload: RuntimeInitPayload,
+    ) -> None:
+        env = ClaudeAgentRuntime._sdk_env(sample_init_payload)
+
+        assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in env
+
+    def test_sets_auto_compact_window_from_resolved_context_window(
+        self,
+        sample_init_payload: RuntimeInitPayload,
+    ) -> None:
+        payload = replace(
+            sample_init_payload,
+            config=sample_init_payload.config.model_copy(
+                update={
+                    "model_provider": "mistral",
+                    "model_name": "mistral-large-latest",
+                    "context_window": 262_144,
+                }
+            ),
+        )
+
+        env = ClaudeAgentRuntime._sdk_env(payload)
+
+        assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "262144"
+
+    def test_auto_compact_window_uses_min_across_subagents(
+        self,
+        sample_init_payload: RuntimeInitPayload,
+    ) -> None:
+        """Unknown custom-provider subagents floor the process-wide window at 128k."""
+        child = SandboxSubagentConfig(
+            alias="analyst",
+            description="Use for enrichment analysis.",
+            prompt="Analyze enrichment data.",
+            config=sample_init_payload.config.model_copy(
+                update={"model_provider": "custom-model-provider"}
+            ),
+            mcp_auth_token="child-mcp-token",
+        )
+        payload = replace(
+            sample_init_payload,
+            config=sample_init_payload.config.model_copy(
+                update={
+                    "model_provider": "custom-model-provider",
+                    "context_window": 262_144,
+                }
+            ),
+            subagents=[child],
+        )
+
+        env = ClaudeAgentRuntime._sdk_env(payload)
+
+        assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "128000"
+
+    def test_anthropic_subagent_does_not_lower_window(
+        self,
+        sample_init_payload: RuntimeInitPayload,
+    ) -> None:
+        child = SandboxSubagentConfig(
+            alias="analyst",
+            description="Use for enrichment analysis.",
+            prompt="Analyze enrichment data.",
+            config=sample_init_payload.config.model_copy(
+                update={"context_window": 180_000}
+            ),
+            mcp_auth_token="child-mcp-token",
+        )
+        payload = replace(
+            sample_init_payload,
+            config=sample_init_payload.config.model_copy(
+                update={
+                    "model_provider": "custom-model-provider",
+                    "context_window": 400_000,
+                }
+            ),
+            subagents=[child],
+        )
+
+        env = ClaudeAgentRuntime._sdk_env(payload)
+
+        assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "400000"
+
     @pytest.mark.anyio
     async def test_agents_toggle_adds_agent_tool_without_custom_subagents(
         self,

--- a/tracecat/agent/catalog/service.py
+++ b/tracecat/agent/catalog/service.py
@@ -1,6 +1,6 @@
 """Service for managing agent model catalog."""
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, TypedDict
@@ -42,6 +42,20 @@ class PlatformCatalogEntry:
     model_provider: str
     model_name: str
     metadata: dict[str, Any] = field(default_factory=dict)
+
+
+_CONTEXT_WINDOW_METADATA_KEYS = ("context_window", "context_length", "max_input_tokens")
+
+
+def context_window_from_metadata(metadata: Mapping[str, Any] | None) -> int | None:
+    """Best-effort context window (tokens) from catalog model metadata."""
+    if not metadata:
+        return None
+    for key in _CONTEXT_WINDOW_METADATA_KEYS:
+        value = metadata.get(key)
+        if isinstance(value, int | float) and not isinstance(value, bool) and value > 0:
+            return int(value)
+    return None
 
 
 class AgentCatalogService(BaseService):
@@ -114,6 +128,33 @@ class AgentCatalogService(BaseService):
         if row is None:
             raise TracecatNotFoundError(f"Catalog entry {catalog_id} not found")
         return row
+
+    async def get_context_windows(
+        self,
+        *,
+        org_id: UUID,
+        catalog_ids: Collection[UUID],
+    ) -> dict[UUID, int]:
+        """Map visible catalog ids to context windows derived from metadata.
+
+        Rows without a usable window key are omitted.
+        """
+        if not catalog_ids:
+            return {}
+        stmt = select(AgentCatalog.id, AgentCatalog.model_metadata).where(
+            AgentCatalog.id.in_(catalog_ids),
+            sa.or_(
+                AgentCatalog.organization_id == org_id,
+                AgentCatalog.organization_id.is_(None),
+            ),
+        )
+        rows = (await self.session.execute(stmt)).all()
+        windows: dict[UUID, int] = {}
+        for catalog_id, metadata in rows:
+            window = context_window_from_metadata(metadata)
+            if window is not None:
+                windows[catalog_id] = window
+        return windows
 
     async def _enabled_catalog_ids_subquery(
         self,

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -181,6 +181,8 @@ class SandboxAgentConfig(BaseModel):
     catalog_id: uuid.UUID | None = None
     base_url: str | None = None
     passthrough: bool = False
+    context_window: int | None = None
+    """Model context window in tokens, when known from catalog metadata."""
 
     # Agent
     instructions: str | None = None
@@ -222,6 +224,7 @@ class SandboxAgentConfig(BaseModel):
             catalog_id=config.catalog_id,
             base_url=config.base_url,
             passthrough=config.passthrough,
+            context_window=config.context_window,
             instructions=config.instructions,
             tool_approvals=config.tool_approvals,
             mcp_servers=config.mcp_servers,

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -26,6 +26,7 @@ from tracecat.agent.cancellation import (
     TURN_CANCEL_POLL_INTERVAL_SECONDS,
     read_turn_cancel_signal,
 )
+from tracecat.agent.catalog.service import AgentCatalogService
 from tracecat.agent.common.config import (
     TRACECAT__AGENT_SANDBOX_MEMORY_MB,
     TRACECAT__AGENT_SANDBOX_TIMEOUT,
@@ -1199,6 +1200,8 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
             subagent.config.mcp_servers, role=input.role
         )
 
+    await _hydrate_context_windows(input)
+
     executor = SandboxedAgentExecutor(input=input)
     result = await executor.run()
 
@@ -1208,6 +1211,34 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
         activity.heartbeat(f"Agent execution failed: {result.error}")
 
     return result
+
+
+async def _hydrate_context_windows(input: AgentExecutorInput) -> None:
+    """Resolve model context windows from catalog metadata for the SDK runtime.
+
+    Best-effort: on lookup failure the runtime falls back to its conservative
+    compaction defaults instead of failing the run.
+    """
+    configs: list[Any] = [input.config, *(s.config for s in input.subagents)]
+    catalog_ids = {
+        config.catalog_id
+        for config in configs
+        if config.catalog_id is not None and config.context_window is None
+    }
+    org_id = input.role.organization_id
+    if not catalog_ids or org_id is None:
+        return
+    try:
+        async with AgentCatalogService.with_session() as svc:
+            windows = await svc.get_context_windows(
+                org_id=org_id, catalog_ids=catalog_ids
+            )
+    except Exception:
+        logger.warning("Failed to resolve model context windows", exc_info=True)
+        return
+    for config in configs:
+        if config.context_window is None and config.catalog_id is not None:
+            config.context_window = windows.get(config.catalog_id)
 
 
 async def _hydrate_sdk_session_history(input: AgentExecutorInput) -> AgentExecutorInput:

--- a/tracecat/agent/provider/service.py
+++ b/tracecat/agent/provider/service.py
@@ -13,7 +13,10 @@ import sqlalchemy as sa
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from tracecat.agent.catalog.service import AgentCatalogService
+from tracecat.agent.catalog.service import (
+    AgentCatalogService,
+    context_window_from_metadata,
+)
 from tracecat.agent.provider.schemas import (
     AgentCustomProviderCreate,
     AgentCustomProviderRead,
@@ -350,6 +353,15 @@ class AgentCustomProviderService(BaseOrgService):
             ),
             api_key_header=provider.api_key_header,
         )
+        await self._annotate_context_windows(
+            models,
+            base_url=base_url,
+            api_key=api_key if isinstance(api_key, str) else None,
+            api_key_header=provider.api_key_header,
+            custom_headers=(
+                custom_headers if isinstance(custom_headers, dict) else None
+            ),
+        )
 
         catalog_service = AgentCatalogService(session=self.session)
         await catalog_service.upsert_discovered_models(
@@ -416,8 +428,9 @@ class AgentCustomProviderService(BaseOrgService):
         api_key_header: str | None,
         custom_headers: dict[str, str] | None,
         timeout: float,
+        path: str = "/models",
     ) -> httpx.Response:
-        """Make a GET /models request against a provider base URL."""
+        """Make a GET request against a provider base URL path."""
         headers = custom_headers.copy() if custom_headers else {}
         if api_key:
             if not api_key_header:
@@ -426,7 +439,7 @@ class AgentCustomProviderService(BaseOrgService):
                 headers[api_key_header] = api_key
         async with httpx.AsyncClient(timeout=timeout) as client:
             return await client.get(
-                f"{base_url.rstrip('/')}/models",
+                f"{base_url.rstrip('/')}{path}",
                 headers=headers,
             )
 
@@ -477,3 +490,87 @@ class AgentCustomProviderService(BaseOrgService):
         if isinstance(data, list):
             return [item for item in data if isinstance(item, dict)]
         raise ValueError(f"Unexpected response format: {type(data)}")
+
+    async def _fetch_metadata_rows(
+        self,
+        path: str,
+        *,
+        base_url: str,
+        api_key: str | None,
+        api_key_header: str | None,
+        custom_headers: dict[str, str] | None,
+    ) -> list[dict[str, Any]]:
+        """GET an optional gateway metadata endpoint; empty list when unsupported."""
+        try:
+            response = await self._fetch_models(
+                base_url=base_url,
+                api_key=api_key,
+                api_key_header=api_key_header,
+                custom_headers=custom_headers,
+                timeout=15.0,
+                path=path,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except (httpx.HTTPError, ValueError):
+            return []
+        rows = data.get("data") if isinstance(data, dict) else data
+        if not isinstance(rows, list):
+            return []
+        return [row for row in rows if isinstance(row, dict)]
+
+    async def _annotate_context_windows(
+        self,
+        models: list[dict[str, object]],
+        *,
+        base_url: str,
+        api_key: str | None,
+        api_key_header: str | None,
+        custom_headers: dict[str, str] | None,
+    ) -> None:
+        """Best-effort ``context_window`` annotation for discovered models.
+
+        LiteLLM-style gateways report ``max_input_tokens`` on ``/model/info``;
+        wildcard-routed deployments only resolve it via ``/model_group/info``.
+        Models neither endpoint resolves keep no window and fall back to the
+        runtime's conservative custom-provider default.
+        """
+        unresolved = {
+            model_id
+            for model in models
+            if isinstance(model_id := model.get("id"), str)
+            and context_window_from_metadata(model) is None
+        }
+        if not unresolved:
+            return
+        request_kwargs: dict[str, Any] = {
+            "base_url": base_url,
+            "api_key": api_key,
+            "api_key_header": api_key_header,
+            "custom_headers": custom_headers,
+        }
+        windows: dict[str, int] = {}
+        for row in await self._fetch_metadata_rows("/model/info", **request_kwargs):
+            name = row.get("model_name")
+            info = row.get("model_info")
+            window = context_window_from_metadata(
+                info if isinstance(info, dict) else None
+            )
+            if isinstance(name, str) and window is not None:
+                windows[name] = window
+        if unresolved - windows.keys():
+            for row in await self._fetch_metadata_rows(
+                "/model_group/info", **request_kwargs
+            ):
+                name = row.get("model_group")
+                window = context_window_from_metadata(row)
+                if isinstance(name, str) and window is not None:
+                    windows.setdefault(name, window)
+        for model in models:
+            model_id = model.get("id")
+            if (
+                isinstance(model_id, str)
+                and model_id in unresolved
+                and (window := windows.get(model_id)) is not None
+            ):
+                model["context_window"] = window

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -253,7 +253,7 @@ TRUSTED_MCP_BRIDGE_URL = f"http://127.0.0.1:{TRACECAT__AGENT_MCP_BRIDGE_PORT}/mc
 # Increase the SDK's stdout/stderr capture buffer above its default 1 MiB so
 # larger tool responses do not truncate during agent execution.
 CLAUDE_SDK_MAX_BUFFER_SIZE_BYTES = 5 * 1024 * 1024
-CUSTOM_MODEL_PROVIDER_AUTO_COMPACT_WINDOW = "128000"
+CUSTOM_MODEL_PROVIDER_AUTO_COMPACT_WINDOW = 128_000
 
 # Cap on how many times the CLI may re-invoke the model to satisfy a Stop hook
 # (e.g. structured-output schema validation). Without a cap the CLI can death-loop
@@ -1455,10 +1455,19 @@ class ClaudeAgentRuntime:
     def _sdk_env(payload: RuntimeInitPayload) -> dict[str, str]:
         """Return child-process environment overrides for the Claude SDK."""
         env = {"ANTHROPIC_AUTH_TOKEN": payload.llm_gateway_auth_token}
-        if payload.config.model_provider == "custom-model-provider":
-            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = (
-                CUSTOM_MODEL_PROVIDER_AUTO_COMPACT_WINDOW
-            )
+        # The CLI assumes an Anthropic-sized (~200k) context window unless told
+        # otherwise; the env var is process-wide, so use the smallest known
+        # non-Anthropic window across the main agent and subagents.
+        windows: list[int] = []
+        for config in (payload.config, *(s.config for s in payload.subagents)):
+            if config.model_provider == "anthropic":
+                continue
+            if config.context_window:
+                windows.append(config.context_window)
+            elif config.model_provider == "custom-model-provider":
+                windows.append(CUSTOM_MODEL_PROVIDER_AUTO_COMPACT_WINDOW)
+        if windows:
+            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(min(windows))
         if payload.config.passthrough or any(
             subagent.config.passthrough for subagent in payload.subagents
         ):

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -127,6 +127,9 @@ class AgentConfig:
     ``agent-{provider}-credentials`` secret."""
     base_url: str | None = None
     passthrough: bool = False
+    context_window: int | None = None
+    """Context window (tokens) from catalog metadata; hydrated in the executor
+    activity, never carried across Temporal payloads."""
     # Agent
     instructions: str | None = None
     output_type: str | dict[str, Any] | None = None


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Threads model context window from catalog metadata through the executor into the Claude runtime, so the SDK auto-compaction matches each model’s true limits and avoids overflow. Provider refresh now annotates catalog entries with context windows when gateways expose them.

- **New Features**
  - Catalog: added `context_window_from_metadata` and `get_context_windows` to resolve windows from metadata, scoped to org + platform rows.
  - Executor: hydrates `context_window` for the main agent and subagents from catalog; best-effort with safe fallback.
  - Runtime: sets `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to the smallest known non-Anthropic window across agent and subagents; defaults to 128k for unknown `custom-model-provider`; Anthropic models don’t set it.
  - Provider: during catalog refresh, annotates discovered models with `context_window` via `/model/info` and `/model_group/info` (LiteLLM-style); preserves pre-annotated values.
  - Types: added `context_window` to `AgentConfig` and `SandboxAgentConfig`.

<sup>Written for commit 72e78159facd121767741cfb3cc26237a4f53b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

