### PR TITLE
fix(agents): exclude run_python from agent tools

### DIFF
--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -164,6 +164,7 @@ import {
   buildDuplicateAgentPresetPayload,
   buildSkillCommandItemValue,
 } from "@/lib/agent-presets"
+import { isAgentToolSelectable } from "@/lib/agent-tools"
 import type { ModelInfo } from "@/lib/chat"
 import { getApiErrorDetail } from "@/lib/errors"
 import {
@@ -526,6 +527,7 @@ export function AgentPresetsBuilder({
       return []
     }
     return registryActions
+      .filter((action) => isAgentToolSelectable(action.action))
       .map((action) => ({
         ...registryActionToSuggestion(action),
         label: action.default_title ?? action.name,
@@ -697,6 +699,7 @@ export function AgentPresetArtifactView({
       return []
     }
     return registryActions
+      .filter((action) => isAgentToolSelectable(action.action))
       .map((action) => ({
         ...registryActionToSuggestion(action),
         label: action.default_title ?? action.name,

--- a/frontend/src/components/chat/action-multiselect.tsx
+++ b/frontend/src/components/chat/action-multiselect.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
+import { isAgentToolSelectable } from "@/lib/agent-tools"
 import { useBuilderRegistryActions } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 
@@ -42,7 +43,8 @@ export function ActionMultiselect<T extends FieldValues>({
   const suggestions = useMemo(() => {
     return (
       registryActions
-        ?.map((action) => ({
+        ?.filter((action) => isAgentToolSelectable(action.action))
+        .map((action) => ({
           id: action.action,
           label: action.default_title || action.action,
           value: action.action,

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -110,6 +110,7 @@ import {
   useVercelChat,
 } from "@/hooks/use-chat"
 import { useOverflowBadges } from "@/hooks/use-overflow-badges"
+import { isAgentToolSelectable } from "@/lib/agent-tools"
 import {
   type ApprovalCard,
   CANCELLED_DATA_PART_TYPE,
@@ -615,6 +616,7 @@ export function ChatSessionPane({
   const toolSuggestions = useMemo<ToolSuggestion[]>(() => {
     const actions = registryActions ?? []
     return actions
+      .filter((action) => isAgentToolSelectable(action.action))
       .map((action) => ({
         value: action.action,
         label: action.default_title || action.action,

--- a/frontend/src/components/chat/chat-tools-picker.test.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.test.tsx
@@ -135,11 +135,11 @@ describe("ChatToolsPicker", () => {
       <ChatToolsPicker
         registryActions={[
           registryAction("core.script.run_python", {
-            default_title: "Run Python",
+            default_title: "Run Python script",
             display_group: "Core",
           }),
-          registryAction("core.script.run_script", {
-            default_title: "Run Script",
+          registryAction("core.http_request", {
+            default_title: "HTTP Request",
             display_group: "Core",
           }),
         ]}
@@ -153,12 +153,12 @@ describe("ChatToolsPicker", () => {
 
     fireEvent.change(
       screen.getByPlaceholderText("Search capabilities & tools..."),
-      { target: { value: "run" } }
+      { target: { value: "request" } }
     )
 
-    expect(screen.queryByText("Run Python")).not.toBeInTheDocument()
-    expect(screen.queryByText("Run Script")).not.toBeInTheDocument()
-    expect(screen.getByText(/No tools found/)).toBeInTheDocument()
+    // Excluded action is not offered, but ordinary core.* actions still are.
+    expect(screen.queryByText("Run Python script")).not.toBeInTheDocument()
+    expect(screen.getByText("HTTP Request")).toBeInTheDocument()
   })
 
   it("disables the add toggle for an unselected tool once the limit is reached", () => {

--- a/frontend/src/components/chat/chat-tools-picker.test.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.test.tsx
@@ -130,6 +130,37 @@ describe("ChatToolsPicker", () => {
     mockToast.mockClear()
   })
 
+  it("does not offer actions excluded from agent toolsets", () => {
+    render(
+      <ChatToolsPicker
+        registryActions={[
+          registryAction("core.script.run_python", {
+            default_title: "Run Python",
+            display_group: "Core",
+          }),
+          registryAction("core.script.run_script", {
+            default_title: "Run Script",
+            display_group: "Core",
+          }),
+        ]}
+        selectedTools={[]}
+        onToolsChange={jest.fn()}
+        mcpIntegrations={[]}
+        selectedMcpIntegrations={[]}
+        onMcpChange={jest.fn()}
+      />
+    )
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Search capabilities & tools..."),
+      { target: { value: "run" } }
+    )
+
+    expect(screen.queryByText("Run Python")).not.toBeInTheDocument()
+    expect(screen.queryByText("Run Script")).not.toBeInTheDocument()
+    expect(screen.getByText(/No tools found/)).toBeInTheDocument()
+  })
+
   it("disables the add toggle for an unselected tool once the limit is reached", () => {
     const onToolsChange = jest.fn()
     const selected = Array.from({ length: 50 }, (_, i) => `extra.tool.t${i}`)

--- a/frontend/src/components/chat/chat-tools-picker.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/popover"
 import { Switch } from "@/components/ui/switch"
 import { toast } from "@/components/ui/use-toast"
+import { isAgentToolSelectable } from "@/lib/agent-tools"
 import { cn } from "@/lib/utils"
 import type { ChatSurface } from "@/types/chat-surface"
 
@@ -225,6 +226,7 @@ export function ChatToolsPicker({
   const toolOptions = useMemo<ToolOption[]>(
     () =>
       registryActions
+        .filter((action) => isAgentToolSelectable(action.action))
         .map((action) => ({
           value: action.action,
           label: action.default_title || action.action,

--- a/frontend/src/lib/agent-tools.ts
+++ b/frontend/src/lib/agent-tools.ts
@@ -1,7 +1,4 @@
-const EXCLUDED_AGENT_TOOL_ACTIONS = new Set([
-  "core.script.run_python",
-  "core.script.run_script",
-])
+const EXCLUDED_AGENT_TOOL_ACTIONS = new Set(["core.script.run_python"])
 
 /** Return whether a registry action should be offered as an agent tool. */
 export function isAgentToolSelectable(action: string): boolean {

--- a/frontend/src/lib/agent-tools.ts
+++ b/frontend/src/lib/agent-tools.ts
@@ -1,0 +1,9 @@
+const EXCLUDED_AGENT_TOOL_ACTIONS = new Set([
+  "core.script.run_python",
+  "core.script.run_script",
+])
+
+/** Return whether a registry action should be offered as an agent tool. */
+export function isAgentToolSelectable(action: string): boolean {
+  return !EXCLUDED_AGENT_TOOL_ACTIONS.has(action)
+}

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -259,7 +259,7 @@ class TestClaudeAgentRuntimeRun:
             "Accept-Encoding": "identity",
         }
 
-    def test_system_prompt_documents_duckdb_cli(
+    def test_system_prompt_documents_command_line_tools(
         self, mock_socket_writer: MagicMock
     ) -> None:
         """Runtime prompt should document local CLI tools available in shell."""
@@ -270,6 +270,9 @@ class TestClaudeAgentRuntimeRun:
         prompt = runtime._build_system_prompt("Preset instructions.")
 
         assert "<CommandLineTools>" in prompt
+        assert "`python3`" in prompt
+        assert "Python 3 is installed in the runtime environment" in prompt
+        assert "Use it through Bash" in prompt
         assert "`duckdb`" in prompt
         assert "DuckDB CLI" in prompt
         assert "`json`, `httpfs`, `inet`, and `fts` extensions" in prompt

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -11,6 +11,7 @@ import pytest
 
 from tracecat.agent.tools import (
     ToolExecutionError,
+    build_agent_tools,
     denormalize_tool_name,
 )
 from tracecat.agent.types import Tool
@@ -113,6 +114,30 @@ class TestToolExecutionError:
         """Test that ToolExecutionError inherits from Exception."""
         error = ToolExecutionError("test")
         assert isinstance(error, Exception)
+
+
+# =============================================================================
+# build_agent_tools Tests
+# =============================================================================
+
+
+class TestBuildAgentTools:
+    """Tests for shared agent tool filtering."""
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "action_name",
+        ["core.script.run_python", "core.script.run_script"],
+    )
+    async def test_excludes_agent_actions_before_registry_lookup(
+        self,
+        action_name: str,
+    ) -> None:
+        """Excluded actions are unavailable to every agent harness."""
+        result = await build_agent_tools(actions=[action_name])
+
+        assert result.tools == []
+        assert result.collected_secrets == set()
 
 
 # =============================================================================

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -125,16 +125,9 @@ class TestBuildAgentTools:
     """Tests for shared agent tool filtering."""
 
     @pytest.mark.anyio
-    @pytest.mark.parametrize(
-        "action_name",
-        ["core.script.run_python", "core.script.run_script"],
-    )
-    async def test_excludes_agent_actions_before_registry_lookup(
-        self,
-        action_name: str,
-    ) -> None:
+    async def test_excludes_agent_actions_before_registry_lookup(self) -> None:
         """Excluded actions are unavailable to every agent harness."""
-        result = await build_agent_tools(actions=[action_name])
+        result = await build_agent_tools(actions=["core.script.run_python"])
 
         assert result.tools == []
         assert result.collected_secrets == set()

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -226,6 +226,9 @@ INTERNET_TOOLS = [
 
 COMMAND_LINE_TOOLS_PROMPT = (
     "<CommandLineTools>\n"
+    "- `python3`: Python 3 is installed in the runtime environment. Use it "
+    "through Bash for local scripting and data processing; no separate "
+    "Tracecat action or MCP tool is needed.\n"
     "- `duckdb`: The runtime shell includes the DuckDB CLI. Use it for local "
     "SQL and tabular data inspection over files such as CSV, JSON, Parquet, "
     "and DuckDB database files. The CLI is configured with the `json`, "

--- a/tracecat/agent/tools.py
+++ b/tracecat/agent/tools.py
@@ -21,10 +21,17 @@ from tracecat_registry import RegistrySecretType
 from tracecat.agent.types import Tool
 from tracecat.config import TRACECAT__AGENT_MAX_TOOLS
 from tracecat.contexts import ctx_role
+from tracecat.dsl.enums import PlatformAction
 from tracecat.logger import logger
 from tracecat.registry.actions.service import (
     IndexedActionResult,
     RegistryActionsService,
+)
+
+# This controls which registry actions are exposed to agents. Execution-policy
+# enforcement is handled separately.
+EXCLUDED_AGENT_ACTIONS: frozenset[str] = frozenset(
+    {PlatformAction.RUN_PYTHON, "core.script.run_script"}
 )
 
 
@@ -272,7 +279,8 @@ async def build_agent_tools(
 
     Args:
         namespaces: Optional list of namespace prefixes to filter by
-        actions: List of canonical action names to build tools for
+        actions: List of canonical action names to build tools for. Excluded agent
+            actions are ignored.
         tool_approvals: Tool approval requirements by tool name
         max_tools: Maximum number of tools allowed
 
@@ -282,7 +290,12 @@ async def build_agent_tools(
     Raises:
         ValueError: If actions are missing/failed or max_tools exceeded
     """
-    if not actions:
+    included_actions = [
+        action_name
+        for action_name in actions or []
+        if action_name not in EXCLUDED_AGENT_ACTIONS
+    ]
+    if not included_actions:
         return BuildToolsResult(tools=[], collected_secrets=set())
 
     tools: list[Tool] = []
@@ -290,13 +303,13 @@ async def build_agent_tools(
 
     async with RegistryActionsService.with_session() as service:
         # Use index-based lookup instead of querying action tables
-        indexed_results = await service.get_actions_from_index(actions)
+        indexed_results = await service.get_actions_from_index(included_actions)
 
         failed_actions: set[str] = set()
 
         # Check for missing actions
         found_actions = set(indexed_results.keys())
-        missing_actions = set(actions) - found_actions
+        missing_actions = set(included_actions) - found_actions
 
         for action_name, indexed_result in indexed_results.items():
             logger.debug(f"Building tool for action: {action_name}")

--- a/tracecat/agent/tools.py
+++ b/tracecat/agent/tools.py
@@ -30,9 +30,7 @@ from tracecat.registry.actions.service import (
 
 # This controls which registry actions are exposed to agents. Execution-policy
 # enforcement is handled separately.
-EXCLUDED_AGENT_ACTIONS: frozenset[str] = frozenset(
-    {PlatformAction.RUN_PYTHON, "core.script.run_script"}
-)
+EXCLUDED_AGENT_ACTIONS: frozenset[str] = frozenset({PlatformAction.RUN_PYTHON})
 
 
 class ToolExecutionError(Exception):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exclude `core.script.run_python` from agent tool pickers and tool-building to prevent unsafe code execution. The Claude Code runtime prompt now instructs users to run `python3` via Bash instead of using a Tracecat action.

- **Bug Fixes**
  - Frontend: filter the excluded action across chat tools, multiselect, and presets via `isAgentToolSelectable`.
  - Backend: ignore the excluded action in `build_agent_tools` before registry lookup.
  - Runtime: document local `python3` availability and usage in the Claude Code system prompt.
  - Tests: add coverage for picker filtering, tool exclusion, and the updated runtime prompt.

<sup>Written for commit 93bcedd67233753435c725c537a6e347ce68d419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

