### PR TITLE
fix(agents): separate Claude tool process authority

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 RUN useradd -m -u 1000 sandbox && \
+    useradd -M -u 1001 -g sandbox -d /home/tools -s /usr/sbin/nologin tools && \
     mkdir -p /workspace /work /cache /packages /home/sandbox && \
     chown sandbox:sandbox /workspace /work /cache /packages /home/sandbox
 
@@ -121,7 +122,7 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     acl git openssh-client xmlsec1 libmagic1 curl ca-certificates jq \
     libnl-route-3-200 libprotobuf32 libcap2-bin util-linux \
-    passt squashfs-tools \
+    passt squashfs-tools uidmap \
     && apt-get -y upgrade \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -189,6 +190,7 @@ RUN mkdir -p /var/lib/tracecat/sandbox-rootfs/tmp \
 
 # Create apiuser for non-root runtime (required for pasta userspace networking)
 RUN groupadd -g 1001 apiuser && useradd -m -u 1001 -g apiuser apiuser && \
+    usermod --add-subuids 100000-100000 apiuser && \
     mkdir -p /home/apiuser/.cache/uv /home/apiuser/.cache/s3 /home/apiuser/.cache/tmp /home/apiuser/.local/bin && \
     chown -R apiuser:apiuser /home/apiuser
 

--- a/tests/unit/test_agent_nsjail.py
+++ b/tests/unit/test_agent_nsjail.py
@@ -1,11 +1,216 @@
 from __future__ import annotations
 
+import asyncio
+import json
+import stat
+import sys
+import textwrap
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 import tracecat.agent.sandbox.nsjail as nsjail_module
+from tracecat.agent.sandbox.config import AGENT_CLAUDE_UID, AGENT_TOOL_UID
+
+_TOOL_IDENTITY_PROBE = r"""
+import errno
+import json
+import os
+import pwd
+from pathlib import Path
+
+def denied(operation):
+    try:
+        operation()
+    except OSError as exc:
+        return exc.errno in {errno.EACCES, errno.EPERM}
+    return False
+
+status = {}
+for line in Path('/proc/self/status').read_text().splitlines():
+    key, separator, value = line.partition(':')
+    if separator:
+        status[key] = value.strip()
+
+private = Path('/home/agent')
+tool_home = Path('/home/tools')
+work = Path('/work')
+(tool_home / 'tool.txt').write_text('tool-private')
+(work / 'from-tool.txt').write_text('tool-shared')
+result = {
+    'uid': os.getuid(),
+    'euid': os.geteuid(),
+    'gid': os.getgid(),
+    'user': pwd.getpwuid(os.getuid()).pw_name,
+    'caps': {name: status[name] for name in ('CapInh', 'CapPrm', 'CapEff', 'CapAmb')},
+    'no_new_privs': status['NoNewPrivs'],
+    'home': os.environ['HOME'],
+    'tmpdir': os.environ['TMPDIR'],
+    'read_work': (work / 'from-claude.txt').read_text(),
+    'private_denials': {
+        'stat': denied(lambda: (private / 'stat.txt').stat()),
+        'read': denied(lambda: (private / 'read.txt').read_text()),
+        'write': denied(lambda: (private / 'write.txt').write_text('tampered')),
+        'rename': denied(lambda: (private / 'rename.txt').rename(work / 'stolen.txt')),
+        'delete': denied(lambda: (private / 'delete.txt').unlink()),
+    },
+}
+print(json.dumps(result))
+"""
+
+
+_CLAUDE_IDENTITY_PROBE = r"""
+import base64
+import json
+import os
+import subprocess
+from pathlib import Path
+
+home = Path('/home/agent')
+work = Path('/work')
+for name in ('stat.txt', 'read.txt', 'write.txt', 'rename.txt', 'delete.txt'):
+    (home / name).write_text(name)
+(work / 'from-claude.txt').write_text('claude-shared')
+
+payload = base64.urlsafe_b64encode(json.dumps({
+    'argv': ['/usr/local/bin/python3', '-c', TOOL_SCRIPT],
+    'env': {},
+}).encode()).decode()
+completed = subprocess.run(
+    [
+        '/usr/local/bin/python3',
+        '-I',
+        '/run/tracecat/job/shim_entrypoint.py',
+        '--tracecat-tool-launch',
+        payload,
+    ],
+    capture_output=True,
+    text=True,
+    check=False,
+)
+
+tool_home_denied = False
+try:
+    (Path('/home/tools') / 'tool.txt').read_text()
+except PermissionError:
+    tool_home_denied = True
+
+status = {}
+for line in Path('/proc/self/status').read_text().splitlines():
+    key, separator, value = line.partition(':')
+    if separator:
+        status[key] = value.strip()
+
+print(json.dumps({
+    'uid': os.getuid(),
+    'euid': os.geteuid(),
+    'caps': {name: status[name] for name in ('CapInh', 'CapPrm', 'CapEff', 'CapAmb')},
+    'no_new_privs': status['NoNewPrivs'],
+    'tool_returncode': completed.returncode,
+    'tool_stderr': completed.stderr,
+    'tool': json.loads(completed.stdout) if completed.returncode == 0 else None,
+    'tool_home_denied': tool_home_denied,
+    'read_work': (work / 'from-tool.txt').read_text() if completed.returncode == 0 else None,
+    'private_unchanged': {
+        name: (home / name).read_text() == name
+        for name in ('stat.txt', 'read.txt', 'write.txt', 'rename.txt', 'delete.txt')
+    },
+    'stolen_exists': (work / 'stolen.txt').exists(),
+}))
+"""
+
+
+def test_runtime_directories_use_private_home_and_shared_setgid_work(
+    tmp_path: Path,
+) -> None:
+    session_home = tmp_path / "agent-home"
+    session_work = tmp_path / "agent-work"
+
+    nsjail_module._prepare_runtime_directories(
+        session_home_dir=session_home,
+        session_work_dir=session_work,
+    )
+
+    assert stat.S_IMODE(session_home.stat().st_mode) == 0o700
+    assert stat.S_IMODE(session_work.stat().st_mode) == 0o2770
+    for relative_path in (".config", ".cache", ".local/state", "tmp"):
+        assert stat.S_IMODE((session_home / relative_path).stat().st_mode) == 0o700
+
+
+@pytest.mark.anyio
+async def test_agent_nsjail_separates_claude_and_tool_uids(tmp_path: Path) -> None:
+    """Exercise real UID maps, capability dropping, and private-home access."""
+    nsjail_path = Path(nsjail_module.TRACECAT__SANDBOX_NSJAIL_PATH)
+    rootfs_path = Path(nsjail_module.TRACECAT__SANDBOX_ROOTFS_PATH)
+    if sys.platform != "linux" or not nsjail_path.exists() or not rootfs_path.exists():
+        pytest.skip("real agent nsjail isolation requires the Linux executor image")
+
+    socket_dir = tmp_path / "sockets"
+    socket_dir.mkdir()
+    llm_socket_path = socket_dir / "llm.sock"
+    mcp_socket_path = socket_dir / "mcp.sock"
+    llm_socket_path.touch()
+    mcp_socket_path.touch()
+    session_home = tmp_path / "agent-home"
+    session_work = tmp_path / "agent-work"
+    job_dir = tmp_path / "job"
+    init_payload_path = tmp_path / "init.json"
+    claude_script = (
+        f"TOOL_SCRIPT = {textwrap.dedent(_TOOL_IDENTITY_PROBE)!r}\n"
+        f"{textwrap.dedent(_CLAUDE_IDENTITY_PROBE)}"
+    )
+    init_payload_path.write_text(
+        json.dumps(
+            {
+                "command": ["/usr/local/bin/python3", "-c", claude_script],
+                "env": {},
+                "cwd": "/work",
+                "mcp_bridge_port": 4101,
+            }
+        )
+    )
+
+    spawned = await nsjail_module.spawn_jailed_runtime(
+        socket_dir=socket_dir,
+        init_payload_path=init_payload_path,
+        llm_socket_path=llm_socket_path,
+        mcp_socket_path=mcp_socket_path,
+        control_socket_required=False,
+        pipe_stdin=True,
+        job_dir=job_dir,
+        session_home_dir=session_home,
+        session_work_dir=session_work,
+    )
+    stdout_bytes, stderr_bytes = await asyncio.wait_for(
+        spawned.process.communicate(), timeout=30
+    )
+
+    assert spawned.process.returncode == 0, stderr_bytes.decode(errors="replace")
+    output_lines = stdout_bytes.decode().splitlines()
+    assert output_lines
+    result = json.loads(output_lines[-1])
+    expected_claude_caps = f"{1 << 7:016x}"
+    assert result["uid"] == AGENT_CLAUDE_UID
+    assert result["euid"] == AGENT_CLAUDE_UID
+    assert set(result["caps"].values()) == {expected_claude_caps}
+    assert result["no_new_privs"] == "1"
+    assert result["tool_returncode"] == 0, result["tool_stderr"]
+    assert result["tool_home_denied"] is True
+    assert result["read_work"] == "tool-shared"
+    assert all(result["private_unchanged"].values())
+    assert result["stolen_exists"] is False
+
+    tool_result = result["tool"]
+    assert tool_result["uid"] == AGENT_TOOL_UID
+    assert tool_result["euid"] == AGENT_TOOL_UID
+    assert tool_result["user"] == "tools"
+    assert set(tool_result["caps"].values()) == {"0000000000000000"}
+    assert tool_result["no_new_privs"] == "1"
+    assert tool_result["home"] == "/home/tools"
+    assert tool_result["tmpdir"] == "/home/tools/tmp"
+    assert tool_result["read_work"] == "claude-shared"
+    assert all(tool_result["private_denials"].values())
 
 
 class _FakeProcess:

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -52,6 +52,7 @@ from tracecat.agent.runtime.claude_code.runtime import (
 )
 from tracecat.agent.subagents import AgentSubagentsConfig
 from tracecat.agent.types import AgentConfig
+from tracecat.sandbox.exceptions import SandboxFileSafetyError
 
 
 @pytest.fixture
@@ -2910,6 +2911,59 @@ class TestClaudeAgentRuntimeInternalSessionLines:
 
 class TestClaudeAgentRuntimeSessionLineFlushing:
     """Tests for ClaudeAgentRuntime SDK JSONL flushing."""
+
+    @pytest.mark.anyio
+    async def test_write_session_file_replaces_planted_symlink(
+        self,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Resume hydration must not write through an agent-created symlink."""
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        outside_file = tmp_path / "outside-session.jsonl"
+        outside_file.write_text("host data")
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True)
+        session_file.symlink_to(outside_file)
+
+        await runtime._write_session_file(
+            sdk_session_id,
+            '{"type":"user"}\n',
+        )
+
+        assert outside_file.read_text() == "host data"
+        assert not session_file.is_symlink()
+        assert session_file.read_text() == '{"type":"user"}\n'
+
+    @pytest.mark.anyio
+    async def test_emit_new_session_lines_rejects_planted_symlink(
+        self,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Session flushing must not follow an agent-selected host path."""
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True)
+        session_file.symlink_to("/dev/zero")
+
+        with pytest.raises(SandboxFileSafetyError, match="not safe to read"):
+            await runtime._emit_new_session_lines()
+
+        mock_socket_writer.send_session_line.assert_not_awaited()
 
     @staticmethod
     def _line_bytes(line: dict[str, Any]) -> bytes:

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -2965,6 +2965,93 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
 
         mock_socket_writer.send_session_line.assert_not_awaited()
 
+    @pytest.mark.anyio
+    async def test_emit_new_session_lines_drains_backlog_across_frames(
+        self,
+        mock_socket_writer: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A backlog larger than one frame should flush completely in order."""
+        monkeypatch.setattr(runtime_module, "MAX_PAYLOAD_SIZE", 80)
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+        complete_lines = [
+            self._line_bytes(
+                {
+                    "type": "user",
+                    "uuid": f"line-{index}",
+                    "message": {"content": str(index)},
+                }
+            )
+            for index in range(4)
+        ]
+        partial_line = orjson.dumps(
+            {
+                "type": "assistant",
+                "uuid": "partial-line",
+                "message": {"content": "later"},
+            }
+        )
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True)
+        session_file.write_bytes(b"".join(complete_lines) + partial_line)
+
+        await runtime._emit_new_session_lines()
+
+        emitted_uuids = [
+            orjson.loads(call.args[1])["uuid"]
+            for call in mock_socket_writer.send_session_line.await_args_list
+        ]
+        assert emitted_uuids == [f"line-{index}" for index in range(4)]
+        assert runtime._last_seen_byte_offset == len(b"".join(complete_lines))
+
+    @pytest.mark.anyio
+    async def test_emit_new_session_lines_does_not_advance_past_failed_send(
+        self,
+        mock_socket_writer: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A mid-chunk send failure must not re-send or skip lines on retry.
+
+        Both lines fit in a single chunk, so this pins per-line offset
+        advancement: the sent line is committed, the failed line is not.
+        """
+        monkeypatch.setattr(runtime_module, "MAX_PAYLOAD_SIZE", 200)
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+        first_line = self._line_bytes(
+            {"type": "user", "uuid": "first", "message": {"content": "1"}}
+        )
+        second_line = self._line_bytes(
+            {"type": "user", "uuid": "second", "message": {"content": "2"}}
+        )
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True)
+        session_file.write_bytes(first_line + second_line)
+        mock_socket_writer.send_session_line.side_effect = [
+            None,
+            RuntimeError("send failed"),
+        ]
+
+        with pytest.raises(RuntimeError, match="send failed"):
+            await runtime._emit_new_session_lines()
+
+        assert runtime._last_seen_byte_offset == len(first_line)
+
     @staticmethod
     def _line_bytes(line: dict[str, Any]) -> bytes:
         return orjson.dumps(line) + b"\n"

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -2974,6 +2974,7 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
     ) -> None:
         """A backlog larger than one frame should flush completely in order."""
         monkeypatch.setattr(runtime_module, "MAX_PAYLOAD_SIZE", 80)
+        monkeypatch.setattr(runtime_module, "_SESSION_FRAME_MARGIN", 0)
         runtime = ClaudeAgentRuntime(
             mock_socket_writer,
             transport_factory=lambda _: MagicMock(),
@@ -3025,6 +3026,7 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
         advancement: the sent line is committed, the failed line is not.
         """
         monkeypatch.setattr(runtime_module, "MAX_PAYLOAD_SIZE", 200)
+        monkeypatch.setattr(runtime_module, "_SESSION_FRAME_MARGIN", 0)
         runtime = ClaudeAgentRuntime(
             mock_socket_writer,
             transport_factory=lambda _: MagicMock(),
@@ -3051,6 +3053,42 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
             await runtime._emit_new_session_lines()
 
         assert runtime._last_seen_byte_offset == len(first_line)
+
+    @pytest.mark.anyio
+    async def test_emit_new_session_lines_rejects_line_oversized_after_escaping(
+        self,
+        mock_socket_writer: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A line that fits raw but not after JSON escaping must fail fast.
+
+        Embedding the line in the session envelope re-escapes it, so a raw
+        read limit alone would let the send fail on every flush.
+        """
+        raw_line = self._line_bytes(
+            {"type": "user", "uuid": "big", "message": {"content": '"' * 40}}
+        )
+        # Raw line fits the frame, but its re-escaped serialization does not.
+        monkeypatch.setattr(runtime_module, "MAX_PAYLOAD_SIZE", len(raw_line) + 1)
+        monkeypatch.setattr(runtime_module, "_SESSION_FRAME_MARGIN", 0)
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True)
+        session_file.write_bytes(raw_line)
+
+        with pytest.raises(SandboxFileSafetyError, match="frame limit"):
+            await runtime._emit_new_session_lines()
+
+        assert runtime._last_seen_byte_offset == 0
+        mock_socket_writer.send_session_line.assert_not_awaited()
 
     @staticmethod
     def _line_bytes(line: dict[str, Any]) -> bytes:

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -6,7 +6,9 @@ Tests the runtime execution with mocked Claude SDK.
 from __future__ import annotations
 
 import asyncio
+import base64
 import os
+import shlex
 import tempfile
 import uuid
 from dataclasses import replace
@@ -199,6 +201,14 @@ def make_hook_context() -> HookContext:
 def get_hook_output(result: SyncHookJSONOutput) -> dict[str, Any]:
     """Extract hookSpecificOutput from result."""
     return cast(dict[str, Any], result.get("hookSpecificOutput", {}))
+
+
+def decode_tool_wrapper_payload(encoded_payload: str) -> dict[str, Any]:
+    """Decode a trusted tool-wrapper payload for assertions."""
+    return cast(
+        dict[str, Any],
+        orjson.loads(base64.urlsafe_b64decode(encoded_payload.encode("ascii"))),
+    )
 
 
 def test_pre_tool_use_hook_input_declares_subagent_context_fields() -> None:
@@ -943,8 +953,8 @@ class TestClaudeAgentRuntimeRun:
         }
         assert set(options.allowed_tools) == {
             "mcp__tracecat-registry__core__http_request",
-            "mcp__local-tools__*",
         }
+        assert "mcp__local-tools__*" not in (options.tools or [])
 
     @pytest.mark.anyio
     async def test_root_agent_uses_verified_stdio_tool_inventory(
@@ -1013,6 +1023,14 @@ class TestClaudeAgentRuntimeRun:
             "mcp__tracecat-registry__core__http_request",
             "mcp__sentinel-one__list_alerts",
         }
+        assert set(options.tools or []) == {
+            *runtime_module.BASE_NATIVE_TOOL_INVENTORY,
+            *runtime_module.INTERNET_TOOLS,
+        }
+        assert options.setting_sources == []
+        assert options.settings == "{}"
+        assert options.extra_args == {"strict-mcp-config": None}
+        assert "FutureMutationTool" not in (options.tools or [])
         assert "Verified stdio MCP tools configured for this agent" in (
             options.system_prompt
         )
@@ -1020,6 +1038,44 @@ class TestClaudeAgentRuntimeRun:
         assert "list_alerts: List alerts" in options.system_prompt
         assert "delete_alert" not in options.system_prompt
         assert "legacy_alert" not in options.system_prompt
+
+    def test_stdio_mcp_commands_use_the_uid_demoter_in_nsjail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(runtime_module, "TRACECAT__DISABLE_NSJAIL", False)
+
+        spec = ClaudeAgentRuntime._stdio_mcp_server_spec(
+            source_configs=[
+                cast(
+                    Any,
+                    {
+                        "type": "stdio",
+                        "name": "local-tools",
+                        "command": "npx",
+                        "args": ["-y", "example-mcp"],
+                        "env": {"API_TOKEN": "configured-token"},
+                        "tools": [{"name": "lookup"}],
+                    },
+                )
+            ],
+            name_prefix="subagent-analyst",
+        )
+
+        server = spec.servers["subagent-analyst-local-tools"]
+        assert server["command"] == runtime_module.JAILED_TOOL_WRAPPER_COMMAND
+        wrapper_args = server.get("args")
+        assert wrapper_args is not None
+        assert wrapper_args[:3] == [
+            "-I",
+            runtime_module.JAILED_TOOL_WRAPPER_SCRIPT,
+            runtime_module.JAILED_TOOL_WRAPPER_MODE,
+        ]
+        assert decode_tool_wrapper_payload(wrapper_args[3]) == {
+            "argv": ["npx", "-y", "example-mcp"],
+            "env": {"API_TOKEN": "configured-token"},
+        }
+        assert "env" not in server
 
     @pytest.mark.anyio
     async def test_root_agent_sanitizes_stdio_tool_inventory_and_approvals(
@@ -1317,6 +1373,7 @@ class TestClaudeAgentRuntimeRun:
                             "name": "local-tools",
                             "command": "uvx",
                             "args": ["example-mcp"],
+                            "tools": [{"name": "lookup_local"}],
                         }
                     ],
                     "tool_approvals": {"core.lookup_ip": True},
@@ -1392,7 +1449,7 @@ class TestClaudeAgentRuntimeRun:
             },
         ]
         assert agent_def.tools == [
-            "mcp__subagent-analyst-local-tools__*",
+            "mcp__subagent-analyst-local-tools__lookup_local",
             "mcp__tracecat-registry-analyst__core__lookup_ip",
         ]
         internet_tools = set(runtime_module.INTERNET_TOOLS)
@@ -2250,6 +2307,172 @@ class TestClaudeAgentRuntimePreToolUseHook:
             "hookEventName": "PreToolUse",
             "permissionDecision": "allow",
         }
+
+    @pytest.mark.anyio
+    async def test_unconfigured_future_mcp_tool_is_denied(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: MagicMock()
+        )
+        runtime._available_mcp_tools = {"mcp__approved__lookup"}
+
+        result = await runtime._pre_tool_use_hook(
+            input_data=make_hook_input(
+                tool_name="mcp__approved__future_mutation",
+                tool_input={"path": "/home/agent/session.jsonl"},
+                tool_use_id="call-future",
+            ),
+            tool_use_id="call-future",
+            context=make_hook_context(),
+        )
+
+        hook_output = get_hook_output(result)
+        assert hook_output["permissionDecision"] == "deny"
+        assert (
+            "not in the runtime MCP inventory"
+            in hook_output["permissionDecisionReason"]
+        )
+
+    @pytest.mark.anyio
+    async def test_bash_command_is_wrapped_as_opaque_data_in_nsjail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        monkeypatch.setattr(runtime_module, "TRACECAT__DISABLE_NSJAIL", False)
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: MagicMock()
+        )
+        original_command = "printf '%s' \"$HOME\"; touch '/work/a b'"
+
+        result = await runtime._pre_tool_use_hook(
+            input_data=make_hook_input(
+                tool_name="Bash",
+                tool_input={"command": original_command},
+                tool_use_id="call-bash",
+            ),
+            tool_use_id="call-bash",
+            context=make_hook_context(),
+        )
+
+        hook_output = get_hook_output(result)
+        wrapped_command = hook_output["updatedInput"]["command"]
+        wrapper_argv = shlex.split(wrapped_command)
+        assert wrapper_argv[:4] == [
+            runtime_module.JAILED_TOOL_WRAPPER_COMMAND,
+            "-I",
+            runtime_module.JAILED_TOOL_WRAPPER_SCRIPT,
+            runtime_module.JAILED_TOOL_WRAPPER_MODE,
+        ]
+        assert decode_tool_wrapper_payload(wrapper_argv[4]) == {
+            "argv": ["/bin/bash", "-c", original_command],
+            "env": {},
+        }
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("tool_name", ["Write", "Edit"])
+    async def test_native_mutation_is_canonicalized_beneath_work(
+        self,
+        tool_name: str,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        host_work = tmp_path / "work"
+        (host_work / "nested").mkdir(parents=True)
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            cwd=Path("/work"),
+            cwd_setup_path=host_work,
+        )
+
+        result = await runtime._pre_tool_use_hook(
+            input_data=make_hook_input(
+                tool_name=tool_name,
+                tool_input={"file_path": "nested/output.txt", "content": "safe"},
+                tool_use_id=f"call-{tool_name.lower()}",
+            ),
+            tool_use_id=f"call-{tool_name.lower()}",
+            context=make_hook_context(),
+        )
+
+        hook_output = get_hook_output(result)
+        assert hook_output["permissionDecision"] == "allow"
+        assert hook_output["updatedInput"]["file_path"] == "/work/nested/output.txt"
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "raw_path",
+        [
+            "/home/agent/.claude/session.jsonl",
+            "/work",
+            "../agent-home/session.jsonl",
+            "missing-parent/output.txt",
+            "bad\x00path",
+        ],
+    )
+    async def test_native_mutation_denies_unsafe_paths(
+        self,
+        raw_path: str,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        host_work = tmp_path / "work"
+        host_work.mkdir()
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            cwd=Path("/work"),
+            cwd_setup_path=host_work,
+        )
+
+        result = await runtime._pre_tool_use_hook(
+            input_data=make_hook_input(
+                tool_name="Write",
+                tool_input={"file_path": raw_path, "content": "unsafe"},
+                tool_use_id="call-write",
+                agent_id="child-1",
+                agent_type="analyst",
+            ),
+            tool_use_id="call-write",
+            context=make_hook_context(),
+        )
+
+        hook_output = get_hook_output(result)
+        assert hook_output["permissionDecision"] == "deny"
+
+    @pytest.mark.anyio
+    async def test_native_mutation_denies_symlink_escape(
+        self,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        host_work = tmp_path / "work"
+        outside = tmp_path / "agent-home"
+        host_work.mkdir()
+        outside.mkdir()
+        (host_work / "escape").symlink_to(outside, target_is_directory=True)
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            cwd=Path("/work"),
+            cwd_setup_path=host_work,
+        )
+
+        result = await runtime._pre_tool_use_hook(
+            input_data=make_hook_input(
+                tool_name="Edit",
+                tool_input={"file_path": "/work/escape/session.jsonl"},
+                tool_use_id="call-edit",
+            ),
+            tool_use_id="call-edit",
+            context=make_hook_context(),
+        )
+
+        hook_output = get_hook_output(result)
+        assert hook_output["permissionDecision"] == "deny"
 
     @pytest.mark.anyio
     async def test_tool_requires_approval(

--- a/tests/unit/test_agent_runtime_broker.py
+++ b/tests/unit/test_agent_runtime_broker.py
@@ -92,6 +92,28 @@ def _stdio_mcp_config(command: str) -> McpStdioServerConfig:
     return {"type": "stdio", "command": command}
 
 
+def test_transport_uses_private_claude_home_for_runtime_state(tmp_path: Path) -> None:
+    transport = _make_transport(tmp_path, use_jailed_paths=True)
+
+    env = transport._build_claude_env_overlay()
+
+    assert (
+        env.items()
+        >= {
+            "CLAUDE_CODE_ENTRYPOINT": "sdk-py",
+            "CLAUDE_AGENT_SDK_VERSION": transport_module.__version__,
+            "HOME": "/home/agent",
+            "XDG_CONFIG_HOME": "/home/agent/.config",
+            "XDG_CACHE_HOME": "/home/agent/.cache",
+            "XDG_STATE_HOME": "/home/agent/.local/state",
+            "TMPDIR": "/home/agent/tmp",
+            "TEMP": "/home/agent/tmp",
+            "TMP": "/home/agent/tmp",
+            "PWD": "/work",
+        }.items()
+    )
+
+
 class _FakeSandboxProcess:
     stdin = object()
     stdout = object()

--- a/tests/unit/test_agent_sandbox_entrypoint.py
+++ b/tests/unit/test_agent_sandbox_entrypoint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import socket
 from pathlib import Path
 from typing import Any, cast
@@ -14,12 +15,14 @@ from tracecat.agent.sandbox.shim_entrypoint import (
     INIT_PAYLOAD_ENV_VAR,
     MCP_SOCKET_ENV_VAR,
     LLMBridge,
+    _decode_tool_launch_payload,
     _pump_stdin_to_process,
     _read_stdin_chunk,
     _resolve_init_payload_path,
     _resolve_llm_socket_path,
     _resolve_mcp_socket_path,
     _rewrite_mcp_bridge_command_port,
+    _tool_environment,
     _wait_for_process_with_stdin,
 )
 from tracecat.agent.sandbox.shim_entrypoint import (
@@ -200,6 +203,39 @@ def test_rewrite_mcp_bridge_command_port_replaces_dynamic_urls() -> None:
         "--mcp-config",
         '{"url":"http://127.0.0.1:54321/mcp","other":"http://127.0.0.1:4101/mcp"}',
     ]
+
+
+def test_tool_launch_payload_preserves_argv_as_data() -> None:
+    payload = {
+        "argv": ["/bin/bash", "-c", "touch '/work/a b'; echo $HOME"],
+        "env": {"TOKEN": "configured"},
+    }
+    encoded = base64.urlsafe_b64encode(orjson.dumps(payload)).decode("ascii")
+
+    assert _decode_tool_launch_payload(encoded) == payload
+
+
+def test_tool_environment_is_private_and_does_not_inherit_claude_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "must-not-leak")
+
+    env = _tool_environment({"SERVER_TOKEN": "configured"})
+
+    assert env["HOME"] == "/home/tools"
+    assert env["TMPDIR"] == "/home/tools/tmp"
+    assert env["PWD"] == "/work"
+    assert env["SERVER_TOKEN"] == "configured"
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["PATH", "HOME", "XDG_CONFIG_HOME", "TMPDIR", "USER", "PWD"],
+)
+def test_tool_environment_rejects_private_boundary_overrides(key: str) -> None:
+    with pytest.raises(RuntimeError, match=rf"cannot override {key}"):
+        _tool_environment({key: "/home/agent"})
 
 
 class _FakeStreamWriter:

--- a/tests/unit/test_nsjail_seccomp.py
+++ b/tests/unit/test_nsjail_seccomp.py
@@ -118,19 +118,24 @@ def test_worker_pool_config_mounts_action_gateway_socket(tmp_path: Path):
 
 def test_python_install_uses_job_local_uv_cache(tmp_path: Path) -> None:
     """Install sandboxes must not share a globally writable uv cache."""
+    job_dir = tmp_path / "job"
     executor = NsjailExecutor(
         rootfs_path=str(tmp_path / "rootfs"),
         cache_dir=str(tmp_path / "shared-cache"),
     )
 
     config_text = executor._build_config(
-        job_dir=tmp_path / "job",
+        job_dir=job_dir,
         phase="install",
         config=SandboxConfig(),
     )
     env_map = executor._build_env_map(SandboxConfig(), "install")
 
     assert str(tmp_path / "shared-cache" / "uv-cache") not in config_text
+    assert (
+        f'mount {{ src: "{job_dir}" dst: "/work" is_bind: true rw: false }}'
+        in config_text
+    )
     assert env_map["UV_CACHE_DIR"] == "/cache/uv-cache"
 
 

--- a/tests/unit/test_nsjail_seccomp.py
+++ b/tests/unit/test_nsjail_seccomp.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tracecat.agent.sandbox.config import AgentSandboxConfig, build_agent_nsjail_config
+from tracecat.agent.sandbox.config import (
+    AgentResourceLimits,
+    AgentSandboxConfig,
+    build_agent_nsjail_config,
+)
 from tracecat.executor.backends.pool import WorkerPool
 from tracecat.sandbox.executor import ActionSandboxConfig, NsjailExecutor
 from tracecat.sandbox.seccomp import build_untrusted_seccomp_policy
-from tracecat.sandbox.types import SandboxConfig
+from tracecat.sandbox.types import ResourceLimits, SandboxConfig
 
 _EXPECTED_BLOCKED_SYSCALLS = (
     "ptrace",
@@ -110,3 +114,70 @@ def test_worker_pool_config_mounts_action_gateway_socket(tmp_path: Path):
         f'mount {{ src: "{action_gateway_socket}" dst: "/var/run/tracecat/action-gateway.sock" '
         "is_bind: true rw: false }"
     ) in config_text
+
+
+def test_python_install_uses_job_local_uv_cache(tmp_path: Path) -> None:
+    """Install sandboxes must not share a globally writable uv cache."""
+    executor = NsjailExecutor(
+        rootfs_path=str(tmp_path / "rootfs"),
+        cache_dir=str(tmp_path / "shared-cache"),
+    )
+
+    config_text = executor._build_config(
+        job_dir=tmp_path / "job",
+        phase="install",
+        config=SandboxConfig(),
+    )
+    env_map = executor._build_env_map(SandboxConfig(), "install")
+
+    assert str(tmp_path / "shared-cache" / "uv-cache") not in config_text
+    assert env_map["UV_CACHE_DIR"] == "/cache/uv-cache"
+
+
+def test_nsjail_configs_use_resource_limit_megabyte_units(tmp_path: Path) -> None:
+    """nsjail's rlimit_as and rlimit_fsize protobuf fields are in MiB."""
+    resources = ResourceLimits(memory_mb=321, max_file_size_mb=45)
+    executor = NsjailExecutor(rootfs_path=str(tmp_path / "rootfs"))
+
+    python_config = executor._build_config(
+        job_dir=tmp_path / "python-job",
+        phase="execute",
+        config=SandboxConfig(resources=resources),
+    )
+    action_config = executor._build_action_config(
+        job_dir=tmp_path / "action-job",
+        config=ActionSandboxConfig(
+            registry_paths=[],
+            tracecat_app_dir=tmp_path / "app",
+            resources=resources,
+        ),
+    )
+    agent_config = build_agent_nsjail_config(
+        rootfs=tmp_path / "rootfs",
+        job_dir=tmp_path / "agent-job",
+        socket_dir=tmp_path / "socket",
+        config=AgentSandboxConfig(
+            resources=AgentResourceLimits(memory_mb=321, max_file_size_mb=45)
+        ),
+        site_packages_dir=tmp_path / "site-packages",
+        llm_socket_path=tmp_path / "llm.sock",
+    )
+
+    for config_text in (python_config, action_config, agent_config):
+        assert "rlimit_as: 321" in config_text
+        assert "rlimit_fsize: 45" in config_text
+        assert f"rlimit_as: {321 * 1024 * 1024}" not in config_text
+        assert f"rlimit_fsize: {45 * 1024 * 1024}" not in config_text
+
+
+def test_worker_pool_uses_procfs_scoped_to_pid_namespace(tmp_path: Path) -> None:
+    """Warm workers must not bind the executor container's existing procfs."""
+    pool = WorkerPool()
+
+    config_text = pool._build_nsjail_config(
+        worker_id=1,
+        work_dir=tmp_path / "work",
+    )
+
+    assert 'mount { dst: "/proc" fstype: "proc" rw: false }' in config_text
+    assert 'src: "/proc"' not in config_text

--- a/tests/unit/test_nsjail_seccomp.py
+++ b/tests/unit/test_nsjail_seccomp.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from tracecat.agent.sandbox.config import (
+    AGENT_CLAUDE_UID,
+    AGENT_SHARED_GID,
+    AGENT_TOOL_OUTSIDE_UID,
+    AGENT_TOOL_UID,
     AgentResourceLimits,
     AgentSandboxConfig,
     build_agent_nsjail_config,
@@ -85,6 +90,48 @@ def test_agent_sandbox_config_includes_seccomp_policy(tmp_path: Path):
     )
 
     _assert_seccomp_config(config_text)
+
+
+def test_agent_sandbox_config_separates_claude_and_tool_identities(
+    tmp_path: Path,
+) -> None:
+    """Claude and model-controlled children must have private homes and one work GID."""
+    session_home = tmp_path / "agent-home"
+    session_work = tmp_path / "agent-work"
+    config_text = build_agent_nsjail_config(
+        rootfs=tmp_path / "rootfs",
+        job_dir=tmp_path / "job",
+        socket_dir=tmp_path / "socket",
+        config=AgentSandboxConfig(),
+        site_packages_dir=tmp_path / "site-packages",
+        llm_socket_path=tmp_path / "llm.sock",
+        session_home_dir=session_home,
+        session_work_dir=session_work,
+    )
+
+    assert (
+        f'uidmap {{ inside_id: "{AGENT_CLAUDE_UID}" outside_id: '
+        f'"{os.getuid()}" count: 1 use_newidmap: true }}'
+    ) in config_text
+    assert (
+        f'uidmap {{ inside_id: "{AGENT_TOOL_UID}" outside_id: '
+        f'"{AGENT_TOOL_OUTSIDE_UID}" count: 1 use_newidmap: true }}'
+    ) in config_text
+    assert f'inside_id: "{AGENT_SHARED_GID}"' in config_text
+    assert 'cap: "CAP_SETUID"' in config_text
+    assert (
+        f'mount {{ src: "{session_home}" dst: "/home/agent" is_bind: true rw: true }}'
+        in config_text
+    )
+    assert (
+        f'mount {{ src: "{session_work}" dst: "/work" is_bind: true rw: true }}'
+        in config_text
+    )
+    assert (
+        'dst: "/home/tools" fstype: "tmpfs" rw: true '
+        f'options: "size=64M,mode=0700,uid={AGENT_TOOL_UID},gid={AGENT_SHARED_GID}"'
+        in config_text
+    )
 
 
 def test_worker_pool_config_includes_seccomp_policy(tmp_path: Path):

--- a/tests/unit/test_sandbox_file_io.py
+++ b/tests/unit/test_sandbox_file_io.py
@@ -1,0 +1,150 @@
+"""Regression tests for host I/O over sandbox-controlled bind mounts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tracecat.sandbox.exceptions import SandboxFileSafetyError
+from tracecat.sandbox.file_io import (
+    atomic_write_file_beneath,
+    copy_tree_without_following_symlinks,
+    read_json_object_beneath,
+    read_regular_file_beneath,
+)
+
+
+def test_read_regular_file_beneath_reads_bounded_file(tmp_path: Path) -> None:
+    """A normal result file beneath the trusted root should be readable."""
+    (tmp_path / "result.json").write_text('{"success":true}')
+
+    result = read_json_object_beneath(
+        tmp_path,
+        Path("result.json"),
+        max_bytes=1024,
+    )
+
+    assert result == {"success": True}
+
+
+def test_read_regular_file_beneath_rejects_final_symlink(tmp_path: Path) -> None:
+    """The host must not dereference a result symlink selected by the sandbox."""
+    outside_file = tmp_path.parent / "outside-result.json"
+    outside_file.write_text('{"secret":"host data"}')
+    (tmp_path / "result.json").symlink_to(outside_file)
+
+    with pytest.raises(SandboxFileSafetyError, match="not safe to read"):
+        read_regular_file_beneath(
+            tmp_path,
+            Path("result.json"),
+            max_bytes=1024,
+        )
+
+
+def test_read_regular_file_beneath_rejects_parent_symlink(tmp_path: Path) -> None:
+    """No-follow checks should cover every directory component, not only the file."""
+    outside_dir = tmp_path.parent / "outside-session"
+    outside_dir.mkdir()
+    (outside_dir / "session.jsonl").write_text("host data")
+    (tmp_path / ".claude").symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(SandboxFileSafetyError, match="parent"):
+        read_regular_file_beneath(
+            tmp_path,
+            Path(".claude/session.jsonl"),
+            max_bytes=1024,
+        )
+
+
+def test_read_regular_file_beneath_rejects_fifo_without_blocking(
+    tmp_path: Path,
+) -> None:
+    """A sandbox-created FIFO must not block a trusted executor thread."""
+    fifo_path = tmp_path / "result.json"
+    os.mkfifo(fifo_path)
+
+    with pytest.raises(SandboxFileSafetyError, match="regular file"):
+        read_regular_file_beneath(
+            tmp_path,
+            Path("result.json"),
+            max_bytes=1024,
+        )
+
+
+def test_read_regular_file_beneath_enforces_size_limit(tmp_path: Path) -> None:
+    """A sandbox-controlled file cannot trigger an unbounded host read."""
+    (tmp_path / "result.json").write_bytes(b"x" * 11)
+
+    with pytest.raises(SandboxFileSafetyError, match="read limit"):
+        read_regular_file_beneath(
+            tmp_path,
+            Path("result.json"),
+            max_bytes=10,
+        )
+
+
+def test_atomic_write_replaces_symlink_without_touching_target(tmp_path: Path) -> None:
+    """Session hydration should replace a planted link, not write through it."""
+    outside_file = tmp_path.parent / "outside-session.jsonl"
+    outside_file.write_text("host data")
+    session_dir = tmp_path / ".claude" / "projects"
+    session_dir.mkdir(parents=True)
+    session_file = session_dir / "session.jsonl"
+    session_file.symlink_to(outside_file)
+
+    atomic_write_file_beneath(
+        tmp_path,
+        Path(".claude/projects/session.jsonl"),
+        b"sandbox session",
+    )
+
+    assert outside_file.read_text() == "host data"
+    assert not session_file.is_symlink()
+    assert session_file.read_bytes() == b"sandbox session"
+
+
+def test_atomic_write_rejects_parent_symlink(tmp_path: Path) -> None:
+    """Session hydration must not create files through a planted parent link."""
+    outside_dir = tmp_path.parent / "outside-parent"
+    outside_dir.mkdir()
+    (tmp_path / ".claude").symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(SandboxFileSafetyError, match="parent"):
+        atomic_write_file_beneath(
+            tmp_path,
+            Path(".claude/projects/session.jsonl"),
+            b"sandbox session",
+        )
+
+    assert list(outside_dir.iterdir()) == []
+
+
+def test_copy_tree_preserves_symlinks_instead_of_dereferencing(
+    tmp_path: Path,
+) -> None:
+    """Package promotion must not copy bytes from a symlink's host target."""
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    outside_file = tmp_path / "host-secret"
+    outside_file.write_text("host data")
+    (source / "package-link").symlink_to(outside_file)
+
+    copied = copy_tree_without_following_symlinks(source, destination)
+
+    assert copied is True
+    copied_link = destination / "package-link"
+    assert copied_link.is_symlink()
+    assert os.readlink(copied_link) == str(outside_file)
+
+
+def test_copy_tree_rejects_special_files(tmp_path: Path) -> None:
+    """Package promotion should reject devices, sockets, and FIFOs."""
+    source = tmp_path / "source"
+    source.mkdir()
+    os.mkfifo(source / "package-fifo")
+
+    with pytest.raises(SandboxFileSafetyError, match="special file"):
+        copy_tree_without_following_symlinks(source, tmp_path / "destination")

--- a/tests/unit/test_sandbox_file_io.py
+++ b/tests/unit/test_sandbox_file_io.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 from pathlib import Path
 
 import pytest
 
+import tracecat.sandbox.file_io as file_io_module
 from tracecat.sandbox.exceptions import SandboxFileSafetyError
 from tracecat.sandbox.file_io import (
     atomic_write_file_beneath,
     copy_tree_without_following_symlinks,
+    read_complete_lines_beneath,
     read_json_object_beneath,
     read_regular_file_beneath,
 )
@@ -85,6 +88,61 @@ def test_read_regular_file_beneath_enforces_size_limit(tmp_path: Path) -> None:
         )
 
 
+def test_read_complete_lines_beneath_drains_multiple_chunks(tmp_path: Path) -> None:
+    """Successive bounded reads should drain every complete line in order."""
+    session_data = b"one\n22\nthree\nfour\n"
+    (tmp_path / "session.jsonl").write_bytes(session_data)
+
+    chunks: list[bytes] = []
+    offsets = [0]
+    while True:
+        result = read_complete_lines_beneath(
+            tmp_path,
+            Path("session.jsonl"),
+            offset=offsets[-1],
+            max_bytes=6,
+        )
+        assert result is not None
+        chunk, next_offset = result
+        if not chunk:
+            break
+        assert chunk.endswith(b"\n")
+        chunks.append(chunk)
+        offsets.append(next_offset)
+
+    assert b"".join(chunks) == session_data
+    assert offsets == [0, 4, 7, 13, len(session_data)]
+
+
+def test_read_complete_lines_beneath_excludes_partial_trailing_line(
+    tmp_path: Path,
+) -> None:
+    """An incomplete trailing line should remain unread for the next flush."""
+    (tmp_path / "session.jsonl").write_bytes(b"complete\npartial")
+
+    result = read_complete_lines_beneath(
+        tmp_path,
+        Path("session.jsonl"),
+        offset=0,
+        max_bytes=64,
+    )
+
+    assert result == (b"complete\n", len(b"complete\n"))
+
+
+def test_read_complete_lines_beneath_rejects_oversized_line(tmp_path: Path) -> None:
+    """A line wider than one socket frame can never be emitted safely."""
+    (tmp_path / "session.jsonl").write_bytes(b"123456\n")
+
+    with pytest.raises(SandboxFileSafetyError, match="line exceeding"):
+        read_complete_lines_beneath(
+            tmp_path,
+            Path("session.jsonl"),
+            offset=0,
+            max_bytes=6,
+        )
+
+
 def test_atomic_write_replaces_symlink_without_touching_target(tmp_path: Path) -> None:
     """Session hydration should replace a planted link, not write through it."""
     outside_file = tmp_path.parent / "outside-session.jsonl"
@@ -132,7 +190,12 @@ def test_copy_tree_preserves_symlinks_instead_of_dereferencing(
     outside_file.write_text("host data")
     (source / "package-link").symlink_to(outside_file)
 
-    copied = copy_tree_without_following_symlinks(source, destination)
+    copied = copy_tree_without_following_symlinks(
+        source,
+        destination,
+        max_bytes=1024,
+        max_entries=10,
+    )
 
     assert copied is True
     copied_link = destination / "package-link"
@@ -147,4 +210,59 @@ def test_copy_tree_rejects_special_files(tmp_path: Path) -> None:
     os.mkfifo(source / "package-fifo")
 
     with pytest.raises(SandboxFileSafetyError, match="special file"):
-        copy_tree_without_following_symlinks(source, tmp_path / "destination")
+        copy_tree_without_following_symlinks(
+            source,
+            tmp_path / "destination",
+            max_bytes=1024,
+            max_entries=10,
+        )
+
+
+def test_copy_tree_rejects_aggregate_bytes_over_limit(tmp_path: Path) -> None:
+    """Package promotion should reject trees exceeding the byte budget."""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "package.py").write_bytes(b"1234")
+
+    with pytest.raises(SandboxFileSafetyError, match="byte limit"):
+        copy_tree_without_following_symlinks(
+            source,
+            tmp_path / "destination",
+            max_bytes=3,
+            max_entries=10,
+        )
+
+
+def test_copy_tree_rejects_entries_over_limit(tmp_path: Path) -> None:
+    """Directories, symlinks, and files should all consume the entry budget."""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "package").mkdir()
+    (source / "package" / "module.py").write_text("pass")
+
+    with pytest.raises(SandboxFileSafetyError, match="entry limit"):
+        copy_tree_without_following_symlinks(
+            source,
+            tmp_path / "destination",
+            max_bytes=1024,
+            max_entries=1,
+        )
+
+
+def test_file_io_imports_without_posix_flags_and_fails_at_call_time(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Non-POSIX platforms should import successfully and fail closed on use."""
+    with monkeypatch.context() as platform:
+        platform.delattr(file_io_module.os, "O_NOFOLLOW")
+        importlib.reload(file_io_module)
+
+        with pytest.raises(SandboxFileSafetyError, match="requires a POSIX platform"):
+            file_io_module.read_regular_file_beneath(
+                tmp_path,
+                Path("result.json"),
+                max_bytes=1024,
+            )
+
+    importlib.reload(file_io_module)

--- a/tests/unit/test_sandbox_file_io.py
+++ b/tests/unit/test_sandbox_file_io.py
@@ -193,6 +193,7 @@ def test_copy_tree_preserves_symlinks_instead_of_dereferencing(
     copied = copy_tree_without_following_symlinks(
         source,
         destination,
+        trusted_root=tmp_path,
         max_bytes=1024,
         max_entries=10,
     )
@@ -213,6 +214,7 @@ def test_copy_tree_rejects_special_files(tmp_path: Path) -> None:
         copy_tree_without_following_symlinks(
             source,
             tmp_path / "destination",
+            trusted_root=tmp_path,
             max_bytes=1024,
             max_entries=10,
         )
@@ -228,6 +230,7 @@ def test_copy_tree_rejects_aggregate_bytes_over_limit(tmp_path: Path) -> None:
         copy_tree_without_following_symlinks(
             source,
             tmp_path / "destination",
+            trusted_root=tmp_path,
             max_bytes=3,
             max_entries=10,
         )
@@ -244,9 +247,33 @@ def test_copy_tree_rejects_entries_over_limit(tmp_path: Path) -> None:
         copy_tree_without_following_symlinks(
             source,
             tmp_path / "destination",
+            trusted_root=tmp_path,
             max_bytes=1024,
             max_entries=1,
         )
+
+
+def test_copy_tree_rejects_symlinked_source_parent(tmp_path: Path) -> None:
+    """Package promotion must remain anchored beneath the trusted job root."""
+    trusted_root = tmp_path / "job"
+    trusted_root.mkdir()
+    outside = tmp_path / "outside"
+    source = outside / "site-packages"
+    source.mkdir(parents=True)
+    (source / "package.py").write_text("pass")
+    (trusted_root / "cache").symlink_to(outside, target_is_directory=True)
+
+    destination = tmp_path / "destination"
+    with pytest.raises(SandboxFileSafetyError, match="parent"):
+        copy_tree_without_following_symlinks(
+            trusted_root / "cache" / "site-packages",
+            destination,
+            trusted_root=trusted_root,
+            max_bytes=1024,
+            max_entries=10,
+        )
+
+    assert not destination.exists()
 
 
 def test_file_io_imports_without_posix_flags_and_fails_at_call_time(

--- a/tests/unit/test_sandbox_result_envelope.py
+++ b/tests/unit/test_sandbox_result_envelope.py
@@ -1,0 +1,165 @@
+"""Tests for typed sandbox result-envelope decoding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import orjson
+import pytest
+
+from tracecat.sandbox.result_envelope import (
+    ResultEnvelopeOutcome,
+    decode_result_envelope,
+)
+from tracecat.sandbox.types import SandboxResult
+
+
+def _decode(
+    job_dir: Path,
+    *,
+    output_key: Literal["output", "result"] = "output",
+    max_bytes: int = 1024,
+    stream_source: Literal["envelope", "process"] = "envelope",
+) -> ResultEnvelopeOutcome | None:
+    return decode_result_envelope(
+        job_dir,
+        output_key=output_key,
+        stdout="process stdout",
+        stderr="process stderr",
+        stderr_limit=7,
+        invalid_result_error="invalid result",
+        log_label="sandbox",
+        exit_code=9,
+        execution_time_ms=12.5,
+        max_bytes=max_bytes,
+        stream_source=stream_source,
+        include_error_code=True,
+    )
+
+
+def _assert_invalid_result(outcome: ResultEnvelopeOutcome | None) -> None:
+    assert outcome is not None
+    assert outcome.valid_envelope is False
+    assert outcome.result == SandboxResult(
+        success=False,
+        error="invalid result",
+        stdout="process stdout",
+        stderr="process",
+        exit_code=9,
+        execution_time_ms=12.5,
+    )
+
+
+def test_decode_result_envelope_returns_none_when_file_missing(
+    tmp_path: Path,
+) -> None:
+    assert _decode(tmp_path) is None
+
+
+@pytest.mark.parametrize(
+    "result_bytes",
+    [
+        b"not json",
+        orjson.dumps([{"success": True}]),
+    ],
+)
+def test_decode_result_envelope_rejects_invalid_json_shapes(
+    tmp_path: Path,
+    result_bytes: bytes,
+) -> None:
+    (tmp_path / "result.json").write_bytes(result_bytes)
+
+    _assert_invalid_result(_decode(tmp_path))
+
+
+def test_decode_result_envelope_rejects_oversized_file(tmp_path: Path) -> None:
+    (tmp_path / "result.json").write_bytes(orjson.dumps({"success": True}))
+
+    _assert_invalid_result(_decode(tmp_path, max_bytes=4))
+
+
+def test_decode_result_envelope_rejects_symlinked_result(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-result-envelope.json"
+    outside.write_bytes(orjson.dumps({"success": True}))
+    (tmp_path / "result.json").symlink_to(outside)
+
+    _assert_invalid_result(_decode(tmp_path))
+
+
+@pytest.mark.parametrize("output_key", ["output", "result"])
+@pytest.mark.parametrize(
+    "invalid_fields",
+    [
+        {"success": [True]},
+        {"error": {"message": "failed"}},
+    ],
+)
+def test_decode_result_envelope_rejects_wrong_fields_uniformly(
+    tmp_path: Path,
+    output_key: Literal["output", "result"],
+    invalid_fields: object,
+) -> None:
+    (tmp_path / "result.json").write_bytes(orjson.dumps(invalid_fields))
+
+    _assert_invalid_result(_decode(tmp_path, output_key=output_key))
+
+
+@pytest.mark.parametrize(
+    ("output_key", "expected_output"),
+    [
+        ("output", {"source": "output"}),
+        ("result", {"source": "result"}),
+    ],
+)
+def test_decode_result_envelope_selects_output_key_and_lenient_defaults(
+    tmp_path: Path,
+    output_key: Literal["output", "result"],
+    expected_output: object,
+) -> None:
+    (tmp_path / "result.json").write_bytes(
+        orjson.dumps(
+            {
+                output_key: expected_output,
+                "stdout": "envelope stdout",
+                "stderr": "envelope stderr",
+            }
+        )
+    )
+
+    result = _decode(tmp_path, output_key=output_key)
+
+    assert result is not None
+    assert result.valid_envelope is True
+    assert result.result == SandboxResult(
+        success=False,
+        output=expected_output,
+        stdout="envelope stdout",
+        stderr="envelope stderr",
+        exit_code=9,
+        execution_time_ms=12.5,
+    )
+
+
+def test_decode_result_envelope_can_preserve_process_streams(tmp_path: Path) -> None:
+    """Action envelopes should not override captured process stdout or stderr."""
+    (tmp_path / "result.json").write_bytes(
+        orjson.dumps(
+            {
+                "success": True,
+                "result": "done",
+                "stdout": "envelope stdout",
+                "stderr": "envelope stderr",
+            }
+        )
+    )
+
+    outcome = _decode(
+        tmp_path,
+        output_key="result",
+        stream_source="process",
+    )
+
+    assert outcome is not None
+    assert outcome.result.stdout == "process stdout"
+    assert outcome.result.stderr == "process stderr"

--- a/tests/unit/test_sandbox_result_envelope.py
+++ b/tests/unit/test_sandbox_result_envelope.py
@@ -92,7 +92,7 @@ def test_decode_result_envelope_rejects_symlinked_result(tmp_path: Path) -> None
     "invalid_fields",
     [
         {"success": [True]},
-        {"error": {"message": "failed"}},
+        {"error": 42},
     ],
 )
 def test_decode_result_envelope_rejects_wrong_fields_uniformly(
@@ -139,6 +139,29 @@ def test_decode_result_envelope_selects_output_key_and_lenient_defaults(
         exit_code=9,
         execution_time_ms=12.5,
     )
+
+
+def test_decode_result_envelope_passes_structured_action_errors_through(
+    tmp_path: Path,
+) -> None:
+    """Action failures carry ExecutorActionErrorInfo-shaped dicts in `error`."""
+    structured_error = {
+        "type": "ValueError",
+        "message": "boom",
+        "action_name": "tools.example.action",
+        "filename": "<sandbox>",
+        "function": "run",
+        "lineno": 7,
+    }
+    (tmp_path / "result.json").write_bytes(
+        orjson.dumps({"success": False, "result": None, "error": structured_error})
+    )
+
+    outcome = _decode(tmp_path, output_key="result", stream_source="process")
+
+    assert outcome is not None
+    assert outcome.valid_envelope is True
+    assert outcome.result.error == structured_error
 
 
 @pytest.mark.parametrize("stream_field", ["stdout", "stderr"])

--- a/tests/unit/test_sandbox_result_envelope.py
+++ b/tests/unit/test_sandbox_result_envelope.py
@@ -141,6 +141,19 @@ def test_decode_result_envelope_selects_output_key_and_lenient_defaults(
     )
 
 
+@pytest.mark.parametrize("stream_field", ["stdout", "stderr"])
+def test_decode_result_envelope_rejects_null_streams(
+    tmp_path: Path,
+    stream_field: str,
+) -> None:
+    """Explicit null streams are malformed; SandboxResult streams are str."""
+    (tmp_path / "result.json").write_bytes(
+        orjson.dumps({"success": True, stream_field: None})
+    )
+
+    _assert_invalid_result(_decode(tmp_path))
+
+
 def test_decode_result_envelope_can_preserve_process_streams(tmp_path: Path) -> None:
     """Action envelopes should not override captured process stdout or stderr."""
     (tmp_path / "result.json").write_bytes(

--- a/tests/unit/test_sandbox_validation.py
+++ b/tests/unit/test_sandbox_validation.py
@@ -233,7 +233,7 @@ class TestEnvMap:
         env_map = executor._build_env_map(config, "install")
 
         assert "UV_CACHE_DIR" in env_map
-        assert env_map["UV_CACHE_DIR"] == "/uv-cache"
+        assert env_map["UV_CACHE_DIR"] == "/cache/uv-cache"
 
     def test_no_sensitive_host_vars_leak(self, monkeypatch: pytest.MonkeyPatch):
         """Comprehensive test that common sensitive env vars don't leak.

--- a/tracecat/agent/mcp/stdio_probe.py
+++ b/tracecat/agent/mcp/stdio_probe.py
@@ -410,7 +410,14 @@ async def probe_stdio_mcp_tools_in_sandbox(
                 message="Connection to the MCP server timed out",
                 error=f"Timed out after {timeout_seconds}s while probing stdio MCP server",
             )
-        error = sanitize_stdio_probe_error(result.error or result.stderr, env=env)
+        # Python-sandbox probes report string errors; stringify defensively in
+        # case a structured action-style error ever reaches this path.
+        probe_error = (
+            result.error
+            if isinstance(result.error, str) or result.error is None
+            else str(result.error)
+        )
+        error = sanitize_stdio_probe_error(probe_error or result.stderr, env=env)
         return StdioMCPProbeResult(
             success=False,
             message="Failed to connect to the stdio MCP server",

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -91,6 +91,7 @@ from tracecat.agent.runtime.claude_code.session_lines import (
     is_synthetic_session_line,
 )
 from tracecat.logger import logger
+from tracecat.sandbox.exceptions import SandboxFileSafetyError
 from tracecat.sandbox.file_io import (
     atomic_write_file_beneath,
     read_complete_lines_beneath,
@@ -98,6 +99,9 @@ from tracecat.sandbox.file_io import (
 )
 
 CLAUDE_PROJECT_DIR_MAX_LENGTH = 200
+# Headroom reserved for session-envelope metadata when checking whether a
+# serialized session line still fits inside a MAX_PAYLOAD_SIZE socket frame.
+_SESSION_FRAME_MARGIN = 4096
 CLAUDE_PROJECT_DIR_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
 LOG_PREVIEW_CHARS = 8000
 
@@ -975,6 +979,19 @@ class ClaudeAgentRuntime:
                             byte_offset=line_offset,
                         )
                         return
+
+                    # The line parsed as JSON, so re-escaping it into the session
+                    # envelope grows it at most ~2x. Reject a line whose
+                    # serialized form cannot fit the socket frame instead of
+                    # failing the same doomed send on every flush.
+                    if (
+                        2 * len(line_bytes) + _SESSION_FRAME_MARGIN > MAX_PAYLOAD_SIZE
+                        and len(orjson.dumps(line)) + _SESSION_FRAME_MARGIN
+                        > MAX_PAYLOAD_SIZE
+                    ):
+                        raise SandboxFileSafetyError(
+                            "Session line exceeds the socket frame limit"
+                        )
 
                     internal = self._is_internal_session_line(line_data) or (
                         is_approval_continuation

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -93,7 +93,7 @@ from tracecat.agent.runtime.claude_code.session_lines import (
 from tracecat.logger import logger
 from tracecat.sandbox.file_io import (
     atomic_write_file_beneath,
-    read_regular_file_beneath,
+    read_complete_lines_beneath,
     regular_file_size_beneath,
 )
 
@@ -940,54 +940,55 @@ class ClaudeAgentRuntime:
             session_root, relative_path = self._get_session_file_location(
                 sdk_session_id
             )
-            start_offset = self._last_seen_byte_offset
-            tail = await asyncio.to_thread(
-                read_regular_file_beneath,
-                session_root,
-                relative_path,
-                max_bytes=MAX_PAYLOAD_SIZE,
-                offset=start_offset,
-            )
-            if not tail:
-                return
+            while True:
+                start_offset = self._last_seen_byte_offset
+                chunk = await asyncio.to_thread(
+                    read_complete_lines_beneath,
+                    session_root,
+                    relative_path,
+                    max_bytes=MAX_PAYLOAD_SIZE,
+                    offset=start_offset,
+                )
+                if chunk is None:
+                    return
 
-            line_offset = start_offset
-            for raw_line in tail.splitlines(keepends=True):
-                if not raw_line.endswith(b"\n"):
-                    break
+                tail, _ = chunk
+                if not tail:
+                    return
 
-                next_offset = line_offset + len(raw_line)
-                line_bytes = raw_line.rstrip(b"\r\n")
-                if not line_bytes.strip():
+                line_offset = start_offset
+                for raw_line in tail.splitlines(keepends=True):
+                    next_offset = line_offset + len(raw_line)
+                    line_bytes = raw_line.rstrip(b"\r\n")
+                    if not line_bytes.strip():
+                        self._last_seen_byte_offset = next_offset
+                        line_offset = next_offset
+                        continue
+
+                    # Parse to determine visibility, but send raw line for SDK resume
+                    try:
+                        line = line_bytes.decode("utf-8")
+                        line_data = orjson.loads(line)
+                    except (UnicodeDecodeError, orjson.JSONDecodeError):
+                        logger.debug(
+                            "Stopping at incomplete session line, will retry",
+                            byte_offset=line_offset,
+                        )
+                        return
+
+                    internal = self._is_internal_session_line(line_data) or (
+                        is_approval_continuation
+                        and is_approval_continuation_prompt_line(line_data)
+                    )
+
+                    await self._event_writer.send_session_line(
+                        sdk_session_id, line, internal=internal
+                    )
+
+                    # Only advance the offset after successfully sending the line,
+                    # so a failed send never causes duplicate re-sends on retry.
                     self._last_seen_byte_offset = next_offset
                     line_offset = next_offset
-                    continue
-
-                # Parse to determine visibility, but send raw line for SDK resume
-                try:
-                    line = line_bytes.decode("utf-8")
-                    line_data = orjson.loads(line)
-                except (UnicodeDecodeError, orjson.JSONDecodeError):
-                    # Stop at the first decode failure - this line may be incomplete
-                    # because the SDK is still writing it. We'll retry on the next pass.
-                    logger.debug(
-                        "Stopping at incomplete session line, will retry",
-                        byte_offset=line_offset,
-                    )
-                    break
-
-                internal = self._is_internal_session_line(line_data) or (
-                    is_approval_continuation
-                    and is_approval_continuation_prompt_line(line_data)
-                )
-
-                await self._event_writer.send_session_line(
-                    sdk_session_id, line, internal=internal
-                )
-
-                # Only advance the offset after successfully processing the line.
-                self._last_seen_byte_offset = next_offset
-                line_offset = next_offset
 
     async def _handle_approval_request(
         self,

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -56,6 +56,7 @@ from tracecat.agent.common.config import (
 from tracecat.agent.common.exceptions import AgentSandboxValidationError
 from tracecat.agent.common.output_format import build_sdk_output_format
 from tracecat.agent.common.protocol import RuntimeInitPayload
+from tracecat.agent.common.socket_io import MAX_PAYLOAD_SIZE
 from tracecat.agent.common.stream_types import (
     StreamEventType,
     ToolCallContent,
@@ -90,6 +91,11 @@ from tracecat.agent.runtime.claude_code.session_lines import (
     is_synthetic_session_line,
 )
 from tracecat.logger import logger
+from tracecat.sandbox.file_io import (
+    atomic_write_file_beneath,
+    read_regular_file_beneath,
+    regular_file_size_beneath,
+)
 
 CLAUDE_PROJECT_DIR_MAX_LENGTH = 200
 CLAUDE_PROJECT_DIR_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
@@ -626,8 +632,8 @@ class ClaudeAgentRuntime:
             },
         }
 
-    def _get_session_file_path(self, sdk_session_id: str) -> Path:
-        """Derive the session file path from SDK session ID.
+    def _get_session_file_location(self, sdk_session_id: str) -> tuple[Path, Path]:
+        """Derive the session root and relative path from an SDK session ID.
 
         The Claude SDK stores sessions at:
         ~/.claude/projects/{encoded-cwd}/{session_id}.jsonl
@@ -648,8 +654,15 @@ class ClaudeAgentRuntime:
             raise RuntimeError("Runtime working directory is not configured")
         encoded_cwd = _claude_project_dir_name(self._cwd)
         claude_home_dir = self._session_home_dir or Path.home()
-        claude_dir = claude_home_dir / ".claude" / "projects" / encoded_cwd
-        return claude_dir / f"{sdk_session_id}.jsonl"
+        relative_path = (
+            Path(".claude") / "projects" / encoded_cwd / f"{sdk_session_id}.jsonl"
+        )
+        return claude_home_dir, relative_path
+
+    def _get_session_file_path(self, sdk_session_id: str) -> Path:
+        """Derive the absolute session file path from an SDK session ID."""
+        root, relative_path = self._get_session_file_location(sdk_session_id)
+        return root / relative_path
 
     async def _write_session_file(
         self,
@@ -657,14 +670,15 @@ class ClaudeAgentRuntime:
         sdk_session_data: str,
     ) -> Path:
         """Write session data to local filesystem for SDK resume."""
-        session_file_path = self._get_session_file_path(sdk_session_id)
+        session_root, relative_path = self._get_session_file_location(sdk_session_id)
+        session_file_path = session_root / relative_path
         sdk_session_data = self._session_data_for_disk(sdk_session_data)
-
-        def _write() -> None:
-            session_file_path.parent.mkdir(parents=True, exist_ok=True)
-            session_file_path.write_text(sdk_session_data, encoding="utf-8")
-
-        await asyncio.to_thread(_write)
+        await asyncio.to_thread(
+            atomic_write_file_beneath,
+            session_root,
+            relative_path,
+            sdk_session_data.encode("utf-8"),
+        )
         logger.debug("Wrote session file", path=str(session_file_path))
         return session_file_path
 
@@ -863,13 +877,16 @@ class ClaudeAgentRuntime:
         self._sdk_session_id = sdk_session_id
 
         if previous is None and resume_session_id and fork_session:
-            session_file = self._get_session_file_path(sdk_session_id)
-            try:
-                stat = session_file.stat()
-            except FileNotFoundError:
-                pass
-            else:
-                self._last_seen_byte_offset = stat.st_size
+            session_root, relative_path = self._get_session_file_location(
+                sdk_session_id
+            )
+            size = await asyncio.to_thread(
+                regular_file_size_beneath,
+                session_root,
+                relative_path,
+            )
+            if size is not None:
+                self._last_seen_byte_offset = size
 
         logger.debug(
             "Captured SDK session ID",
@@ -920,18 +937,17 @@ class ClaudeAgentRuntime:
                 return
 
             sdk_session_id = self._sdk_session_id
-            session_file = self._get_session_file_path(sdk_session_id)
+            session_root, relative_path = self._get_session_file_location(
+                sdk_session_id
+            )
             start_offset = self._last_seen_byte_offset
-
-            def _read_tail() -> bytes | None:
-                try:
-                    with session_file.open("rb") as file:
-                        file.seek(start_offset)
-                        return file.read()
-                except FileNotFoundError:
-                    return None
-
-            tail = await asyncio.to_thread(_read_tail)
+            tail = await asyncio.to_thread(
+                read_regular_file_beneath,
+                session_root,
+                relative_path,
+                max_bytes=MAX_PAYLOAD_SIZE,
+                offset=start_offset,
+            )
             if not tail:
                 return
 

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -12,8 +12,10 @@ Key design principles:
 from __future__ import annotations
 
 import asyncio
+import base64
 import os
 import re
+import shlex
 import tempfile
 import uuid
 from collections.abc import AsyncIterator, Callable, Sequence
@@ -182,6 +184,15 @@ class _StdioMCPServerSpec:
     blocked_approval_tools: set[str]
 
 
+@dataclass(frozen=True, slots=True)
+class _ToolCommandSpec:
+    """Executable configuration for a model-controlled child process."""
+
+    command: str
+    args: list[str]
+    env: dict[str, str]
+
+
 def _configure_claude_sdk_process_env() -> None:
     """Prime process-level SDK env before ClaudeSDKClient.connect().
 
@@ -233,6 +244,23 @@ INTERNET_TOOLS = [
     "WebSearch",
     "WebFetch",
 ]
+
+NATIVE_MUTATION_TOOLS = frozenset({"Write", "Edit"})
+BASE_NATIVE_TOOL_INVENTORY = frozenset(
+    {
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "Glob",
+        "Grep",
+        "Skill",
+        "ToolSearch",
+    }
+)
+JAILED_TOOL_WRAPPER_COMMAND = "/usr/local/bin/python3"
+JAILED_TOOL_WRAPPER_SCRIPT = "/run/tracecat/job/shim_entrypoint.py"
+JAILED_TOOL_WRAPPER_MODE = "--tracecat-tool-launch"
 
 COMMAND_LINE_TOOLS_PROMPT = (
     "<CommandLineTools>\n"
@@ -301,6 +329,7 @@ class ClaudeAgentRuntime:
         self.registry_tools: dict[str, MCPToolDefinition] | None = None
         self.tool_approvals: dict[str, bool] | None = None
         self._stdio_approval_blocked_tools: set[str] = set()
+        self._available_mcp_tools: set[str] | None = None
         self._runtime_internet_access_enabled: bool = False
         self._explicit_subagent_aliases: set[str] = set()
         self._registry_mcp_server_names: set[str] = {REGISTRY_MCP_SERVER_NAME}
@@ -376,16 +405,64 @@ class ClaudeAgentRuntime:
         }
 
     @staticmethod
+    def _tool_command_spec(
+        *,
+        command: str,
+        args: Sequence[str] = (),
+        env: dict[str, str] | None = None,
+    ) -> _ToolCommandSpec:
+        """Wrap a model-controlled command with the trusted UID demoter."""
+        configured_env = dict(env or {})
+        if TRACECAT__DISABLE_NSJAIL:
+            return _ToolCommandSpec(
+                command=command,
+                args=list(args),
+                env=configured_env,
+            )
+
+        payload = base64.urlsafe_b64encode(
+            orjson.dumps(
+                {
+                    "argv": [command, *args],
+                    "env": configured_env,
+                }
+            )
+        ).decode("ascii")
+        return _ToolCommandSpec(
+            command=JAILED_TOOL_WRAPPER_COMMAND,
+            args=[
+                "-I",
+                JAILED_TOOL_WRAPPER_SCRIPT,
+                JAILED_TOOL_WRAPPER_MODE,
+                payload,
+            ],
+            env={},
+        )
+
+    @classmethod
+    def _wrapped_bash_input(cls, tool_input: dict[str, Any]) -> dict[str, Any]:
+        """Return a Bash input whose command is passed as opaque wrapper data."""
+        if TRACECAT__DISABLE_NSJAIL:
+            return tool_input
+        original_command = tool_input.get("command")
+        if not isinstance(original_command, str) or not original_command:
+            raise AgentSandboxValidationError("Bash command must be a non-empty string")
+        spec = cls._tool_command_spec(
+            command="/bin/bash",
+            args=("-c", original_command),
+        )
+        return {
+            **tool_input,
+            "command": shlex.join([spec.command, *spec.args]),
+        }
+
+    @staticmethod
     def _mcp_tool_name_for_action(server_name: str, action_name: str) -> str:
         if action_name.startswith("mcp__"):
             concrete_name = action_name
         else:
             concrete_name = action_name_to_mcp_tool_name(action_name)
         return f"mcp__{server_name}__{concrete_name}"
-
-    @staticmethod
-    def _mcp_tool_wildcard_for_server(server_name: str) -> str:
-        return f"mcp__{server_name}__*"
 
     @staticmethod
     def _mcp_tool_name_for_user_mcp_tool(server_name: str, tool_name: str) -> str:
@@ -414,7 +491,10 @@ class ClaudeAgentRuntime:
         tool_names: set[str] = set()
         for server_name in stdio_server_names:
             if server_name not in stdio_tools_by_server:
-                tool_names.add(cls._mcp_tool_wildcard_for_server(server_name))
+                logger.warning(
+                    "Excluding stdio MCP server without a verified tool inventory",
+                    server_name=server_name,
+                )
                 continue
 
             tool_names.update(
@@ -521,14 +601,19 @@ class ClaudeAgentRuntime:
                 suffix += 1
 
             used_names.add(server_name)
+            wrapped_command = cls._tool_command_spec(
+                command=stdio_config["command"],
+                args=stdio_config.get("args", ()),
+                env=stdio_config.get("env"),
+            )
             server_config: dict[str, Any] = {
                 "type": "stdio",
-                "command": stdio_config["command"],
+                "command": wrapped_command.command,
             }
-            if args := stdio_config.get("args"):
-                server_config["args"] = args
-            if env := stdio_config.get("env"):
-                server_config["env"] = env
+            if wrapped_command.args:
+                server_config["args"] = wrapped_command.args
+            if wrapped_command.env:
+                server_config["env"] = wrapped_command.env
             if (timeout := stdio_config.get("timeout")) is not None:
                 server_config["timeout"] = timeout
             servers[server_name] = cast(McpStdioServerConfig, server_config)
@@ -1139,6 +1224,56 @@ class ClaudeAgentRuntime:
             self._interrupt_sent = True
             await self.client.interrupt()
 
+    def _canonical_native_mutation_path(self, raw_path: object) -> str:
+        """Validate and canonicalize a native Write/Edit path beneath /work."""
+        if not isinstance(raw_path, str) or not raw_path or "\x00" in raw_path:
+            raise AgentSandboxValidationError(
+                "Native mutation requires a non-empty file_path without NUL bytes"
+            )
+        if self._cwd is None:
+            raise AgentSandboxValidationError("Runtime work directory is unavailable")
+
+        logical_root = self._cwd
+        host_root_input = self._cwd_setup_path or logical_root
+        requested_path = Path(raw_path)
+        if ".." in requested_path.parts:
+            raise AgentSandboxValidationError(
+                "Native mutation paths cannot contain traversal components"
+            )
+        if requested_path.is_absolute():
+            try:
+                relative_path = requested_path.relative_to(logical_root)
+            except ValueError as exc:
+                raise AgentSandboxValidationError(
+                    "Native mutation is restricted to the runtime work directory"
+                ) from exc
+        else:
+            relative_path = requested_path
+        if relative_path == Path(".") or not relative_path.parts:
+            raise AgentSandboxValidationError(
+                "Native mutation cannot target the work directory itself"
+            )
+
+        try:
+            host_root = host_root_input.resolve(strict=True)
+            candidate = host_root / relative_path
+            resolved_parent = candidate.parent.resolve(strict=True)
+            resolved_parent.relative_to(host_root)
+            canonical_target = resolved_parent / candidate.name
+            if candidate.is_symlink():
+                canonical_target = candidate.resolve(strict=True)
+            canonical_relative = canonical_target.relative_to(host_root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise AgentSandboxValidationError(
+                "Native mutation path could not be safely resolved beneath the work directory"
+            ) from exc
+
+        if canonical_relative == Path(".") or not canonical_relative.parts:
+            raise AgentSandboxValidationError(
+                "Native mutation cannot target the work directory itself"
+            )
+        return str(logical_root / canonical_relative)
+
     async def _pre_tool_use_hook(
         self,
         input_data: HookInput,
@@ -1157,6 +1292,48 @@ class ClaudeAgentRuntime:
 
         tool_name: str = input_data.get("tool_name", "")
         tool_input: dict[str, Any] = input_data.get("tool_input", {})
+
+        if (
+            self._available_mcp_tools is not None
+            and tool_name.startswith("mcp__")
+            and tool_name not in self._available_mcp_tools
+        ):
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        f"Tool '{tool_name}' is not in the runtime MCP inventory."
+                    ),
+                }
+            }
+
+        updated_tool_input = tool_input
+        if tool_name in NATIVE_MUTATION_TOOLS:
+            try:
+                canonical_path = self._canonical_native_mutation_path(
+                    tool_input.get("file_path")
+                )
+            except AgentSandboxValidationError as exc:
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": str(exc),
+                    }
+                }
+            updated_tool_input = {**tool_input, "file_path": canonical_path}
+        elif tool_name == "Bash":
+            try:
+                updated_tool_input = self._wrapped_bash_input(tool_input)
+            except AgentSandboxValidationError as exc:
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": str(exc),
+                    }
+                }
 
         action_name = normalize_mcp_tool_name(tool_name)
         if denial_reason := self._validate_agent_tool_call(
@@ -1229,7 +1406,9 @@ class ClaudeAgentRuntime:
             "hookEventName": "PreToolUse",
             "permissionDecision": "allow",
         }
-        if tool_name in AGENT_TOOL_NAMES:
+        if updated_tool_input is not tool_input:
+            hook_output["updatedInput"] = updated_tool_input
+        elif tool_name in AGENT_TOOL_NAMES:
             sanitized_input = sanitize_agent_tool_input(tool_name, tool_input)
             if sanitized_input != tool_input:
                 hook_output["updatedInput"] = sanitized_input
@@ -1391,6 +1570,7 @@ class ClaudeAgentRuntime:
         self.registry_tools = payload.allowed_actions
         self.tool_approvals = payload.config.tool_approvals
         self._stdio_approval_blocked_tools = set()
+        self._available_mcp_tools = None
         self._agents_enabled = payload.config.agents.enabled
         self._explicit_subagent_aliases = {
             subagent.alias for subagent in payload.subagents
@@ -1446,6 +1626,15 @@ class ClaudeAgentRuntime:
         if self._agents_enabled:
             allowed_tools.extend(sorted(AGENT_TOOL_NAMES))
         return allowed_tools
+
+    def _root_builtin_tool_inventory(self) -> list[str]:
+        """Return the fail-closed Claude built-in tool availability boundary."""
+        inventory = set(BASE_NATIVE_TOOL_INVENTORY)
+        if self._runtime_internet_access_enabled:
+            inventory.update(INTERNET_TOOLS)
+        if self._agents_enabled:
+            inventory.update(AGENT_TOOL_NAMES)
+        return sorted(inventory)
 
     @staticmethod
     def _stdio_tools_system_prompt(
@@ -1533,7 +1722,10 @@ class ClaudeAgentRuntime:
                 if payload.config.enable_thinking
                 else {"type": "disabled"}
             ),
-            setting_sources=["user"],
+            tools=self._root_builtin_tool_inventory(),
+            setting_sources=[],
+            settings="{}",
+            extra_args={"strict-mcp-config": None},
             env=self._sdk_env(payload),
             model=get_litellm_route_model(
                 model_provider=payload.config.model_provider,
@@ -1677,6 +1869,22 @@ class ClaudeAgentRuntime:
             stdio_mcp_servers = stdio_mcp_spec.servers
             mcp_servers.update(stdio_mcp_servers)
             agent_definitions = self._build_agent_definitions(payload=payload)
+            available_mcp_tools = {
+                tool_name
+                for tool_name in self._root_allowed_tools(
+                    actions=payload.allowed_actions,
+                    stdio_server_names=list(stdio_mcp_servers),
+                    stdio_tools_by_server=stdio_mcp_spec.tools_by_server,
+                )
+                if tool_name.startswith("mcp__")
+            }
+            for definition in (agent_definitions or {}).values():
+                available_mcp_tools.update(
+                    tool_name
+                    for tool_name in (definition.tools or [])
+                    if tool_name.startswith("mcp__")
+                )
+            self._available_mcp_tools = available_mcp_tools
 
             def handle_claude_stderr(line: str) -> None:
                 """Forward Claude CLI stderr to loopback via queue."""

--- a/tracecat/agent/runtime/claude_code/transport.py
+++ b/tracecat/agent/runtime/claude_code/transport.py
@@ -476,10 +476,17 @@ class SandboxedCLITransport(Transport):
 
     def _build_claude_env_overlay(self) -> dict[str, str]:
         """Build the Claude child env overlay applied inside the shim."""
+        runtime_home = self._path_mapping.runtime_home_dir
         env = {
             "CLAUDE_CODE_ENTRYPOINT": "sdk-py",
             "CLAUDE_AGENT_SDK_VERSION": __version__,
-            "HOME": str(self._path_mapping.runtime_home_dir),
+            "HOME": str(runtime_home),
+            "XDG_CONFIG_HOME": str(runtime_home / ".config"),
+            "XDG_CACHE_HOME": str(runtime_home / ".cache"),
+            "XDG_STATE_HOME": str(runtime_home / ".local/state"),
+            "TMPDIR": str(runtime_home / "tmp"),
+            "TEMP": str(runtime_home / "tmp"),
+            "TMP": str(runtime_home / "tmp"),
             "PWD": str(self._path_mapping.runtime_work_dir),
             **self._options.env,
         }

--- a/tracecat/agent/runtime/session_paths.py
+++ b/tracecat/agent/runtime/session_paths.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 JAILED_AGENT_HOME_DIR = Path("/home/agent")
+JAILED_TOOL_HOME_DIR = Path("/home/tools")
 JAILED_AGENT_JOB_DIR = Path("/run/tracecat/job")
 JAILED_AGENT_WORK_DIR = Path("/work")
 
@@ -30,8 +31,10 @@ def build_agent_sandbox_path_mapping(
     session_root = Path(tempfile.gettempdir()) / f"tracecat-agent-{session_id}"
     host_home_dir = session_root / "agent-home"
     host_work_dir = session_root / "agent-work-dir"
-    host_home_dir.mkdir(parents=True, exist_ok=True)
-    host_work_dir.mkdir(parents=True, exist_ok=True)
+    host_home_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    host_home_dir.chmod(0o700)
+    host_work_dir.mkdir(parents=True, exist_ok=True, mode=0o2770)
+    host_work_dir.chmod(0o2770)
 
     if disable_nsjail:
         runtime_home_dir = host_home_dir

--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -464,9 +464,9 @@ def build_agent_nsjail_config(
         [
             "",
             "# Resource limits",
-            f"rlimit_as: {config.resources.memory_mb * 1024 * 1024}",
+            f"rlimit_as: {config.resources.memory_mb}",
             f"rlimit_cpu: {config.resources.cpu_seconds}",
-            f"rlimit_fsize: {config.resources.max_file_size_mb * 1024 * 1024}",
+            f"rlimit_fsize: {config.resources.max_file_size_mb}",
             f"rlimit_nofile: {config.resources.max_open_files}",
             f"rlimit_nproc: {config.resources.max_processes}",
             f"time_limit: {config.resources.timeout_seconds}",

--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -40,10 +40,20 @@ from tracecat.agent.runtime.session_paths import (
     JAILED_AGENT_HOME_DIR,
     JAILED_AGENT_JOB_DIR,
     JAILED_AGENT_WORK_DIR,
+    JAILED_TOOL_HOME_DIR,
 )
 
 # Valid environment variable name pattern (POSIX compliant)
 _ENV_VAR_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# The Claude process owns its private runtime state as UID 1000. Model-controlled
+# Bash commands and stdio MCP servers are irreversibly demoted to UID 1001. Both
+# identities use the same mapped group so they can collaborate only through
+# /work.
+AGENT_CLAUDE_UID = 1000
+AGENT_TOOL_UID = 1001
+AGENT_SHARED_GID = 1000
+AGENT_TOOL_OUTSIDE_UID = 100000
 
 
 def _contains_dangerous_chars(value: str) -> tuple[bool, str | None]:
@@ -119,7 +129,17 @@ JAILED_SHIM_ENTRYPOINT_PATH = str(JAILED_AGENT_JOB_DIR / "shim_entrypoint.py")
 AGENT_SANDBOX_BASE_ENV = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
     "HOME": "/home/agent",
+    "XDG_CONFIG_HOME": "/home/agent/.config",
+    "XDG_CACHE_HOME": "/home/agent/.cache",
+    "XDG_STATE_HOME": "/home/agent/.local/state",
+    "TMPDIR": "/home/agent/tmp",
+    "TEMP": "/home/agent/tmp",
+    "TMP": "/home/agent/tmp",
     "USER": "agent",
+    "LOGNAME": "agent",
+    "TRACECAT__AGENT_CLAUDE_UID": str(AGENT_CLAUDE_UID),
+    "TRACECAT__AGENT_TOOL_UID": str(AGENT_TOOL_UID),
+    "TRACECAT__AGENT_SHARED_GID": str(AGENT_SHARED_GID),
     "TRACECAT__DISABLE_NSJAIL": "false",
     "PYTHONDONTWRITEBYTECODE": "1",
     "PYTHONUNBUFFERED": "1",
@@ -309,9 +329,11 @@ def build_agent_nsjail_config(
         "clone_newipc: true",
         "clone_newuts: true",
         "",
-        "# UID/GID mapping - map container user to sandbox user",
-        f'uidmap {{ inside_id: "1000" outside_id: "{os.getuid()}" count: 1 }}',
-        f'gidmap {{ inside_id: "1000" outside_id: "{os.getgid()}" count: 1 }}',
+        "# UID/GID mapping - Claude plus a subordinate tool identity",
+        f'uidmap {{ inside_id: "{AGENT_CLAUDE_UID}" outside_id: "{os.getuid()}" count: 1 use_newidmap: true }}',
+        f'uidmap {{ inside_id: "{AGENT_TOOL_UID}" outside_id: "{AGENT_TOOL_OUTSIDE_UID}" count: 1 use_newidmap: true }}',
+        f'gidmap {{ inside_id: "{AGENT_SHARED_GID}" outside_id: "{os.getgid()}" count: 1 }}',
+        'cap: "CAP_SETUID"',
         "",
         "# Syscall filtering",
         f'seccomp_string: "{build_untrusted_seccomp_policy()}"',
@@ -359,7 +381,7 @@ def build_agent_nsjail_config(
             'mount { src: "/dev/zero" dst: "/dev/zero" is_bind: true rw: false }',
             "",
             "# Temporary filesystems",
-            'mount { dst: "/tmp" fstype: "tmpfs" rw: true options: "size=256M" }',
+            'mount { dst: "/tmp" fstype: "tmpfs" rw: true options: "size=256M,mode=1777" }',
             "",
             "# Tracecat job mountpoint namespace",
             "# The tmpfs only backs files placed directly under this directory;",
@@ -419,7 +441,7 @@ def build_agent_nsjail_config(
             [
                 "",
                 "# Ephemeral agent work dir",
-                f'mount {{ dst: "{JAILED_AGENT_WORK_DIR}" fstype: "tmpfs" rw: true options: "size=256M" }}',
+                f'mount {{ dst: "{JAILED_AGENT_WORK_DIR}" fstype: "tmpfs" rw: true options: "size=256M,mode=2770,uid={AGENT_CLAUDE_UID},gid={AGENT_SHARED_GID}" }}',
             ]
         )
 
@@ -436,9 +458,17 @@ def build_agent_nsjail_config(
             [
                 "",
                 "# Ephemeral agent home",
-                f'mount {{ dst: "{JAILED_AGENT_HOME_DIR}" fstype: "tmpfs" rw: true options: "size=64M" }}',
+                f'mount {{ dst: "{JAILED_AGENT_HOME_DIR}" fstype: "tmpfs" rw: true options: "size=64M,mode=0700,uid={AGENT_CLAUDE_UID},gid={AGENT_SHARED_GID}" }}',
             ]
         )
+
+    lines.extend(
+        [
+            "",
+            "# Ephemeral private home for model-controlled tool processes",
+            f'mount {{ dst: "{JAILED_TOOL_HOME_DIR}" fstype: "tmpfs" rw: true options: "size=64M,mode=0700,uid={AGENT_TOOL_UID},gid={AGENT_SHARED_GID}" }}',
+        ]
+    )
 
     if skills_dir is not None:
         if session_home_dir is not None:

--- a/tracecat/agent/sandbox/nsjail.py
+++ b/tracecat/agent/sandbox/nsjail.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 
 import asyncio
 import os
+import pwd
 import shutil
+import stat
 import sys
 import tempfile
 import uuid
@@ -47,6 +49,7 @@ from tracecat.agent.runtime.session_paths import (
     JAILED_AGENT_WORK_DIR,
 )
 from tracecat.agent.sandbox.config import (
+    AGENT_TOOL_OUTSIDE_UID,
     JAILED_SHIM_ENTRYPOINT_PATH,
     AgentSandboxConfig,
     build_agent_env_map,
@@ -63,6 +66,8 @@ BROKER_SHIM_SCRIPT_NAME = Path(JAILED_SHIM_ENTRYPOINT_PATH).name
 SESSION_HOME_ENV_VAR = "TRACECAT__AGENT_SESSION_HOME_DIR"
 SESSION_WORK_DIR_ENV_VAR = "TRACECAT__AGENT_SESSION_WORK_DIR"
 CLAUDE_SHIM_STDIO_LIMIT_BYTES = 5 * 1024 * 1024
+NEWUIDMAP_PATH = Path("/usr/bin/newuidmap")
+SUBUID_PATH = Path("/etc/subuid")
 
 
 @dataclass(frozen=True)
@@ -123,6 +128,85 @@ def _get_tracecat_pkg_dir() -> Path:
 
     # tracecat.__file__ is /app/tracecat/__init__.py, we want /app/tracecat
     return Path(tracecat.__file__).parent
+
+
+def _subuid_file_allows(*, owner_names: set[str], outside_uid: int) -> bool:
+    """Return whether /etc/subuid assigns the requested identity to this user."""
+    try:
+        lines = SUBUID_PATH.read_text().splitlines()
+    except OSError as exc:
+        raise AgentSandboxExecutionError(
+            f"Could not read subordinate UID configuration: {SUBUID_PATH}"
+        ) from exc
+
+    for line in lines:
+        try:
+            owner, start_text, count_text = line.split(":", maxsplit=2)
+            start = int(start_text)
+            count = int(count_text)
+        except ValueError:
+            continue
+        if owner in owner_names and start <= outside_uid < start + count:
+            return True
+    return False
+
+
+def _validate_tool_uid_mapping() -> None:
+    """Fail closed unless the executor can create the subordinate tool UID map."""
+    try:
+        helper_stat = NEWUIDMAP_PATH.stat()
+    except OSError as exc:
+        raise AgentSandboxExecutionError(
+            f"Required UID mapping helper is unavailable: {NEWUIDMAP_PATH}"
+        ) from exc
+
+    if (
+        helper_stat.st_uid != 0
+        or not stat.S_ISREG(helper_stat.st_mode)
+        or not helper_stat.st_mode & stat.S_ISUID
+        or not os.access(NEWUIDMAP_PATH, os.X_OK)
+    ):
+        raise AgentSandboxExecutionError(
+            f"UID mapping helper must be a root-owned setuid executable: {NEWUIDMAP_PATH}"
+        )
+
+    try:
+        username = pwd.getpwuid(os.getuid()).pw_name
+    except KeyError as exc:
+        raise AgentSandboxExecutionError(
+            "Executor UID has no passwd entry for subordinate UID validation"
+        ) from exc
+    owner_names = {username, str(os.getuid())}
+    if not _subuid_file_allows(
+        owner_names=owner_names,
+        outside_uid=AGENT_TOOL_OUTSIDE_UID,
+    ):
+        raise AgentSandboxExecutionError(
+            "Executor subordinate UID range does not contain the configured tool UID"
+        )
+
+
+def _prepare_runtime_directories(
+    *,
+    session_home_dir: Path | None,
+    session_work_dir: Path | None,
+) -> None:
+    """Create the private Claude home and shared setgid work directory."""
+    if session_home_dir is not None:
+        session_home_dir.mkdir(parents=True, exist_ok=True)
+        session_home_dir.chmod(0o700)
+        for relative_path in (
+            Path(".config"),
+            Path(".cache"),
+            Path(".local/state"),
+            Path("tmp"),
+        ):
+            private_dir = session_home_dir / relative_path
+            private_dir.mkdir(parents=True, exist_ok=True)
+            private_dir.chmod(0o700)
+    if session_work_dir is not None:
+        session_work_dir.mkdir(parents=True, exist_ok=True)
+        session_work_dir.chmod(0o2770)
 
 
 async def spawn_jailed_runtime(
@@ -290,6 +374,12 @@ async def _spawn_direct_runtime(
         JAILED_CONTROL_SOCKET_PATH,
     )
 
+    logger.warning("Agent runtime is using direct mode without UID or mount isolation")
+    _prepare_runtime_directories(
+        session_home_dir=session_home_dir,
+        session_work_dir=session_work_dir,
+    )
+
     control_socket_path = socket_dir / CONTROL_SOCKET_NAME
     shim_script_path = (
         _get_tracecat_pkg_dir() / "agent" / "sandbox" / BROKER_SHIM_SCRIPT_NAME
@@ -328,11 +418,15 @@ async def _spawn_direct_runtime(
         if value := os.environ.get(key):
             env[key] = value
     if session_home_dir is not None:
-        session_home_dir.mkdir(parents=True, exist_ok=True)
         env[SESSION_HOME_ENV_VAR] = str(session_home_dir)
         env["HOME"] = str(session_home_dir)
+        env["XDG_CONFIG_HOME"] = str(session_home_dir / ".config")
+        env["XDG_CACHE_HOME"] = str(session_home_dir / ".cache")
+        env["XDG_STATE_HOME"] = str(session_home_dir / ".local/state")
+        env["TMPDIR"] = str(session_home_dir / "tmp")
+        env["TEMP"] = str(session_home_dir / "tmp")
+        env["TMP"] = str(session_home_dir / "tmp")
     if session_work_dir is not None:
-        session_work_dir.mkdir(parents=True, exist_ok=True)
         env[SESSION_WORK_DIR_ENV_VAR] = str(session_work_dir)
     await _sync_direct_skills_dir(
         skills_dir=skills_dir,
@@ -382,6 +476,7 @@ async def _spawn_nsjail_runtime(
         raise AgentSandboxExecutionError(f"Rootfs not found: {rootfs}")
     if not nsjail.exists():
         raise AgentSandboxExecutionError(f"nsjail binary not found: {nsjail}")
+    _validate_tool_uid_mapping()
     if llm_socket_path is not None and not llm_socket_path.exists():
         raise AgentSandboxExecutionError(f"LLM socket not found: {llm_socket_path}")
     if mcp_socket_path is None:
@@ -403,10 +498,10 @@ async def _spawn_nsjail_runtime(
     jailed_init_payload_path = job_dir / "init.json"
 
     try:
-        if session_home_dir is not None:
-            session_home_dir.mkdir(parents=True, exist_ok=True)
-        if session_work_dir is not None:
-            session_work_dir.mkdir(parents=True, exist_ok=True)
+        _prepare_runtime_directories(
+            session_home_dir=session_home_dir,
+            session_work_dir=session_work_dir,
+        )
         if skills_dir is not None:
             skills_dir.mkdir(parents=True, exist_ok=True)
             if session_home_dir is not None:

--- a/tracecat/agent/sandbox/nsjail.py
+++ b/tracecat/agent/sandbox/nsjail.py
@@ -57,6 +57,7 @@ from tracecat.config import (
     TRACECAT__SANDBOX_ROOTFS_PATH,
 )
 from tracecat.logger import logger
+from tracecat.sandbox.file_io import ensure_directory_beneath
 
 BROKER_SHIM_SCRIPT_NAME = Path(JAILED_SHIM_ENTRYPOINT_PATH).name
 SESSION_HOME_ENV_VAR = "TRACECAT__AGENT_SESSION_HOME_DIR"
@@ -409,9 +410,9 @@ async def _spawn_nsjail_runtime(
         if skills_dir is not None:
             skills_dir.mkdir(parents=True, exist_ok=True)
             if session_home_dir is not None:
-                (session_home_dir / ".claude" / "skills").mkdir(
-                    parents=True,
-                    exist_ok=True,
+                ensure_directory_beneath(
+                    session_home_dir,
+                    Path(".claude/skills"),
                 )
         # Build nsjail config (socket paths are derived from socket_dir internally)
         await asyncio.to_thread(

--- a/tracecat/agent/sandbox/shim_entrypoint.py
+++ b/tracecat/agent/sandbox/shim_entrypoint.py
@@ -8,7 +8,10 @@ host virtualenv's Python dependencies.
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import contextlib
+import ctypes
 import json
 import logging
 import os
@@ -28,6 +31,45 @@ DEFAULT_MCP_SOCKET_PATH = str(DEFAULT_AGENT_RUNTIME_DIR / "mcp.sock")
 LLM_BRIDGE_HOST = "127.0.0.1"
 TRUSTED_MCP_BRIDGE_PATH = "/mcp"
 MAX_BODY_SIZE = 10 * 1024 * 1024
+TOOL_LAUNCH_MODE = "--tracecat-tool-launch"
+CAP_SETUID = 7
+LINUX_CAPABILITY_VERSION_3 = 0x20080522
+PR_CAP_AMBIENT = 47
+PR_CAP_AMBIENT_CLEAR_ALL = 4
+TOOL_ENVIRONMENT_BOUNDARY_KEYS = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_STATE_HOME",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "USER",
+        "LOGNAME",
+        "PWD",
+    }
+)
+
+
+class _CapabilityHeader(ctypes.Structure):
+    _fields_ = [("version", ctypes.c_uint32), ("pid", ctypes.c_int)]
+
+
+class _CapabilityData(ctypes.Structure):
+    _fields_ = [
+        ("effective", ctypes.c_uint32),
+        ("permitted", ctypes.c_uint32),
+        ("inheritable", ctypes.c_uint32),
+    ]
+
+
+class ToolLaunchPayload(TypedDict):
+    """Trusted wrapper payload for one demoted tool process."""
+
+    argv: list[str]
+    env: dict[str, str]
 
 
 class ClaudeShimInitPayload(TypedDict):
@@ -38,6 +80,170 @@ class ClaudeShimInitPayload(TypedDict):
     cwd: str
     mcp_bridge_port: int
     mcp_bridge_fd: NotRequired[int | None]
+
+
+def _required_identity_env(name: str) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        raise RuntimeError(f"{name} is not set")
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be an integer") from exc
+    if parsed < 0:
+        raise RuntimeError(f"{name} must be non-negative")
+    return parsed
+
+
+def _process_status_fields() -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in Path("/proc/self/status").read_text().splitlines():
+        key, separator, value = line.partition(":")
+        if separator:
+            fields[key] = value.strip()
+    return fields
+
+
+def _capability_sets() -> dict[str, int]:
+    status = _process_status_fields()
+    return {
+        field: int(status.get(field, "0"), 16)
+        for field in ("CapInh", "CapPrm", "CapEff", "CapAmb")
+    }
+
+
+def _verify_claude_identity() -> None:
+    """Verify nsjail retained only the capability needed by the trusted shim."""
+    if os.environ.get("TRACECAT__DISABLE_NSJAIL") == "true":
+        return
+
+    claude_uid = _required_identity_env("TRACECAT__AGENT_CLAUDE_UID")
+    shared_gid = _required_identity_env("TRACECAT__AGENT_SHARED_GID")
+    if (os.getuid(), os.geteuid()) != (claude_uid, claude_uid):
+        raise RuntimeError("Claude shim did not start as the configured Claude UID")
+    if (os.getgid(), os.getegid()) != (shared_gid, shared_gid):
+        raise RuntimeError("Claude shim did not start with the shared work GID")
+
+    expected = 1 << CAP_SETUID
+    capability_sets = _capability_sets()
+    if any(value != expected for value in capability_sets.values()):
+        raise RuntimeError(
+            "Claude shim must start with only CAP_SETUID in every capability set"
+        )
+    if _process_status_fields().get("NoNewPrivs") != "1":
+        raise RuntimeError("Claude shim must start with no_new_privs enabled")
+
+
+def _clear_capability_sets() -> None:
+    """Drop effective, permitted, inheritable, and ambient capabilities."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    data = (_CapabilityData * 2)()
+    header = _CapabilityHeader(version=LINUX_CAPABILITY_VERSION_3, pid=0)
+    if libc.capset(ctypes.byref(header), ctypes.byref(data)) != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number))
+    if libc.prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number))
+
+
+def _tool_environment(configured_env: dict[str, str]) -> dict[str, str]:
+    tool_home = Path("/home/tools")
+    env = {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "HOME": str(tool_home),
+        "XDG_CONFIG_HOME": str(tool_home / ".config"),
+        "XDG_CACHE_HOME": str(tool_home / ".cache"),
+        "XDG_STATE_HOME": str(tool_home / ".local/state"),
+        "TMPDIR": str(tool_home / "tmp"),
+        "TEMP": str(tool_home / "tmp"),
+        "TMP": str(tool_home / "tmp"),
+        "USER": "tools",
+        "LOGNAME": "tools",
+        "PWD": "/work",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONUNBUFFERED": "1",
+    }
+    for key, value in configured_env.items():
+        if not key or "=" in key or "\x00" in key or "\x00" in value:
+            raise RuntimeError("Tool environment contains an invalid entry")
+        if key in TOOL_ENVIRONMENT_BOUNDARY_KEYS:
+            raise RuntimeError(f"Tool environment cannot override {key}")
+        env[key] = value
+    return env
+
+
+def _decode_tool_launch_payload(encoded_payload: str) -> ToolLaunchPayload:
+    try:
+        decoded = base64.urlsafe_b64decode(encoded_payload.encode("ascii"))
+        raw_payload = json.loads(decoded)
+    except (binascii.Error, ValueError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Tool launch payload is malformed") from exc
+    if not isinstance(raw_payload, dict):
+        raise RuntimeError("Tool launch payload must be an object")
+    argv = raw_payload.get("argv")
+    env = raw_payload.get("env")
+    if (
+        not isinstance(argv, list)
+        or not argv
+        or not all(isinstance(value, str) and value for value in argv)
+    ):
+        raise RuntimeError("Tool launch argv must be a non-empty list[str]")
+    if not isinstance(env, dict) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in env.items()
+    ):
+        raise RuntimeError("Tool launch env must be a dict[str, str]")
+    return {"argv": argv, "env": env}
+
+
+def _run_demoted_tool(encoded_payload: str) -> None:
+    """Irreversibly demote and replace this process with a configured tool."""
+    if os.environ.get("TRACECAT__DISABLE_NSJAIL") == "true":
+        raise RuntimeError("UID-demoted tool launching is unavailable in direct mode")
+    _verify_claude_identity()
+    payload = _decode_tool_launch_payload(encoded_payload)
+    tool_uid = _required_identity_env("TRACECAT__AGENT_TOOL_UID")
+    shared_gid = _required_identity_env("TRACECAT__AGENT_SHARED_GID")
+
+    os.setresuid(tool_uid, tool_uid, tool_uid)
+    _clear_capability_sets()
+    if (os.getuid(), os.geteuid(), os.getresuid()[2]) != (
+        tool_uid,
+        tool_uid,
+        tool_uid,
+    ):
+        raise RuntimeError("Tool process did not irreversibly enter the tool UID")
+    if (os.getgid(), os.getegid()) != (shared_gid, shared_gid):
+        raise RuntimeError("Tool process lost the shared work GID")
+    if any(_capability_sets().values()):
+        raise RuntimeError("Tool process retained Linux capabilities")
+    if _process_status_fields().get("NoNewPrivs") != "1":
+        raise RuntimeError("Tool process must retain no_new_privs")
+
+    tool_home = Path("/home/tools")
+    for path in (
+        tool_home / ".config",
+        tool_home / ".cache",
+        tool_home / ".local/state",
+        tool_home / "tmp",
+    ):
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chdir("/work")
+    os.umask(0o002)
+    os.execvpe(payload["argv"][0], payload["argv"], _tool_environment(payload["env"]))
+
+
+def _prepare_claude_runtime_home() -> None:
+    home = Path(os.environ["HOME"])
+    for env_name in ("XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME", "TMPDIR"):
+        Path(os.environ.get(env_name, str(home))).mkdir(
+            parents=True,
+            exist_ok=True,
+            mode=0o700,
+        )
+    os.umask(0o002)
 
 
 class LLMBridge:
@@ -254,6 +460,8 @@ def _rewrite_mcp_bridge_command_port(
 
 async def run_sandboxed_claude_shim() -> None:
     """Read shim config, start the LLM bridge, and proxy Claude stdio."""
+    _verify_claude_identity()
+    _prepare_claude_runtime_home()
     llm_bridge: LLMBridge | None = None
     mcp_bridge: LLMBridge | None = None
     process: asyncio.subprocess.Process | None = None
@@ -468,6 +676,11 @@ def main() -> None:
         level=os.environ.get("LOG_LEVEL", "INFO").upper(),
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
+    if len(sys.argv) == 3 and sys.argv[1] == TOOL_LAUNCH_MODE:
+        _run_demoted_tool(sys.argv[2])
+        return
+    if len(sys.argv) != 1:
+        raise RuntimeError("Unsupported sandbox shim invocation")
     asyncio.run(run_sandboxed_claude_shim())
 
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -845,6 +845,16 @@ TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES = int(
 )
 """The maximum size of a payload in bytes the executor can return. Defaults to 1MB"""
 
+TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_BYTES = int(
+    os.environ.get("TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_BYTES") or 5 * 1024**3
+)
+"""Maximum aggregate bytes promoted from a sandbox package cache."""
+
+TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_ENTRIES = int(
+    os.environ.get("TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_ENTRIES") or 200_000
+)
+"""Maximum entries promoted from a sandbox package cache."""
+
 TRACECAT__MAX_FILE_SIZE_BYTES = int(
     os.environ.get("TRACECAT__MAX_FILE_SIZE_BYTES") or 20 * 1024 * 1024  # Default 20MB
 )

--- a/tracecat/executor/backends/pool/pool.py
+++ b/tracecat/executor/backends/pool/pool.py
@@ -551,7 +551,7 @@ class WorkerPool:
                 'mount { src: "/dev/random" dst: "/dev/random" is_bind: true rw: false }',
                 "",
                 "# /proc and /tmp",
-                'mount { src: "/proc" dst: "/proc" is_bind: true rw: false }',
+                'mount { dst: "/proc" fstype: "proc" rw: false }',
                 'mount { dst: "/tmp" fstype: "tmpfs" rw: true }',
             ]
         )

--- a/tracecat/sandbox/exceptions.py
+++ b/tracecat/sandbox/exceptions.py
@@ -19,3 +19,7 @@ class PackageInstallError(SandboxError):
 
 class SandboxValidationError(SandboxError):
     """Input validation failed for sandbox configuration."""
+
+
+class SandboxFileSafetyError(SandboxError):
+    """A sandbox-controlled file failed a host-side safety check."""

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -18,21 +18,19 @@ from tracecat.config import (
 )
 from tracecat.logger import logger
 from tracecat.sandbox.exceptions import (
-    SandboxFileSafetyError,
     SandboxTimeoutError,
     SandboxValidationError,
 )
-from tracecat.sandbox.file_io import read_json_object_beneath
 from tracecat.sandbox.networking import (
     pasta_dns_mount_config_lines,
     pasta_user_net_config_lines,
     write_pasta_network_files,
 )
+from tracecat.sandbox.result_envelope import decode_result_envelope
 from tracecat.sandbox.seccomp import build_untrusted_seccomp_policy
 from tracecat.sandbox.types import (
     ResourceLimits,
     SandboxConfig,
-    SandboxErrorCode,
     SandboxResult,
 )
 
@@ -501,56 +499,22 @@ class NsjailExecutor:
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
 
-        # Try to parse result.json for structured output
-        try:
-            result_data = read_json_object_beneath(
-                job_dir,
-                Path("result.json"),
-                max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
-            )
-        except SandboxFileSafetyError as exc:
-            logger.warning(
-                "Rejected unsafe sandbox result file",
-                error=str(exc),
-            )
-            return SandboxResult(
-                success=False,
-                error="Sandbox produced an invalid result file",
-                stdout=stdout,
-                stderr=stderr[:500],
-                exit_code=process.returncode,
-                execution_time_ms=execution_time_ms,
-            )
-
-        if result_data is not None:
-            try:
-                return SandboxResult(
-                    success=result_data.get("success", False),
-                    output=result_data.get("output"),
-                    stdout=result_data.get("stdout", stdout),
-                    stderr=result_data.get("stderr", stderr),
-                    error=result_data.get("error"),
-                    error_code=(
-                        SandboxErrorCode(error_code)
-                        if (error_code := result_data.get("error_code"))
-                        else None
-                    ),
-                    exit_code=process.returncode,
-                    execution_time_ms=execution_time_ms,
-                )
-            except ValueError as exc:
-                logger.warning(
-                    "Rejected invalid sandbox result fields",
-                    error=str(exc),
-                )
-                return SandboxResult(
-                    success=False,
-                    error="Sandbox produced an invalid result file",
-                    stdout=stdout,
-                    stderr=stderr[:500],
-                    exit_code=process.returncode,
-                    execution_time_ms=execution_time_ms,
-                )
+        outcome = decode_result_envelope(
+            job_dir,
+            output_key="output",
+            stdout=stdout,
+            stderr=stderr,
+            stderr_limit=500,
+            invalid_result_error="Sandbox produced an invalid result file",
+            log_label="sandbox",
+            exit_code=process.returncode,
+            execution_time_ms=execution_time_ms,
+            max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
+            stream_source="envelope",
+            include_error_code=True,
+        )
+        if outcome is not None:
+            return outcome.result
 
         # No result.json - this is an infrastructure error
         if process.returncode != 0:
@@ -941,31 +905,23 @@ class NsjailExecutor:
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
 
-        # Try to parse result.json for structured output
-        try:
-            result_data = read_json_object_beneath(
-                job_dir,
-                Path("result.json"),
-                max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
-            )
-        except SandboxFileSafetyError as exc:
-            logger.warning(
-                "Rejected unsafe action result file",
-                error=str(exc),
-            )
-            return SandboxResult(
-                success=False,
-                error="Action sandbox produced an invalid result file",
-                stdout=stdout,
-                stderr=stderr[:2000],
-                exit_code=process.returncode,
-                execution_time_ms=execution_time_ms,
-            )
-
-        if result_data is not None:
+        outcome = decode_result_envelope(
+            job_dir,
+            output_key="result",
+            stdout=stdout,
+            stderr=stderr,
+            stderr_limit=2000,
+            invalid_result_error="Action sandbox produced an invalid result file",
+            log_label="action",
+            exit_code=process.returncode,
+            execution_time_ms=execution_time_ms,
+            max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
+            stream_source="process",
+        )
+        if outcome is not None:
             # Log subprocess stderr for debugging (contains timing info)
             # Filter out nsjail verbose output, look for Python logs
-            if stderr.strip():
+            if outcome.valid_envelope and stderr.strip():
                 # Extract lines that look like Python logs (not nsjail [I] lines)
                 python_logs = "\n".join(
                     line
@@ -974,15 +930,7 @@ class NsjailExecutor:
                 )
                 if python_logs.strip():
                     logger.info("Subprocess output", output=python_logs[:2000])
-            return SandboxResult(
-                success=result_data.get("success", False),
-                output=result_data.get("result"),
-                stdout=stdout,
-                stderr=stderr,
-                error=result_data.get("error"),
-                exit_code=process.returncode,
-                execution_time_ms=execution_time_ms,
-            )
+            return outcome.result
 
         # No result.json - infrastructure error
         if process.returncode != 0:

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -301,13 +301,15 @@ class NsjailExecutor:
 
         # Phase-specific mounts
         if phase == "install":
-            # Writable cache for package installation
+            # Keep installer inputs read-only and expose only the package cache as
+            # writable. This prevents the sandbox from replacing host-visible
+            # paths that are inspected after the jail exits.
             lines.extend(
                 [
                     "",
-                    "# Install phase mounts - writable cache",
+                    "# Install phase mounts - writable cache, read-only inputs",
                     f'mount {{ src: "{job_dir}/cache" dst: "/cache" is_bind: true rw: true }}',
-                    f'mount {{ src: "{job_dir}" dst: "/work" is_bind: true rw: true }}',
+                    f'mount {{ src: "{job_dir}" dst: "/work" is_bind: true rw: false }}',
                 ]
             )
         else:

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -1,7 +1,6 @@
 """nsjail executor for sandboxed Python execution."""
 
 import asyncio
-import json
 import os
 import re
 import time
@@ -10,6 +9,7 @@ from pathlib import Path
 from typing import Literal
 
 from tracecat.config import (
+    TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
     TRACECAT__SANDBOX_CACHE_DIR,
     TRACECAT__SANDBOX_NSJAIL_PATH,
     TRACECAT__SANDBOX_PYPI_EXTRA_INDEX_URLS,
@@ -17,7 +17,12 @@ from tracecat.config import (
     TRACECAT__SANDBOX_ROOTFS_PATH,
 )
 from tracecat.logger import logger
-from tracecat.sandbox.exceptions import SandboxTimeoutError, SandboxValidationError
+from tracecat.sandbox.exceptions import (
+    SandboxFileSafetyError,
+    SandboxTimeoutError,
+    SandboxValidationError,
+)
+from tracecat.sandbox.file_io import read_json_object_beneath
 from tracecat.sandbox.networking import (
     pasta_dns_mount_config_lines,
     pasta_user_net_config_lines,
@@ -184,7 +189,6 @@ class NsjailExecutor:
         self.rootfs = Path(rootfs_path)
         self.cache_dir = Path(cache_dir)
         self.package_cache = self.cache_dir / "packages"
-        self.uv_cache = self.cache_dir / "uv-cache"
 
     def _build_config(
         self,
@@ -305,7 +309,6 @@ class NsjailExecutor:
                     "",
                     "# Install phase mounts - writable cache",
                     f'mount {{ src: "{job_dir}/cache" dst: "/cache" is_bind: true rw: true }}',
-                    f'mount {{ src: "{self.uv_cache}" dst: "/uv-cache" is_bind: true rw: true }}',
                     f'mount {{ src: "{job_dir}" dst: "/work" is_bind: true rw: true }}',
                 ]
             )
@@ -348,9 +351,9 @@ class NsjailExecutor:
             [
                 "",
                 "# Resource limits",
-                f"rlimit_as: {config.resources.memory_mb * 1024 * 1024}",
+                f"rlimit_as: {config.resources.memory_mb}",
                 f"rlimit_cpu: {config.resources.cpu_seconds}",
-                f"rlimit_fsize: {config.resources.max_file_size_mb * 1024 * 1024}",
+                f"rlimit_fsize: {config.resources.max_file_size_mb}",
                 f"rlimit_nofile: {config.resources.max_open_files}",
                 f"rlimit_nproc: {config.resources.max_processes}",
                 f"time_limit: {config.resources.timeout_seconds}",
@@ -381,7 +384,9 @@ class NsjailExecutor:
         user_pythonpath = config.env_vars.get("PYTHONPATH")
 
         if phase == "install":
-            env_map["UV_CACHE_DIR"] = "/uv-cache"
+            # Keep uv's mutable cache inside this job's private bind mount. A
+            # global writable cache would let one sandbox tamper with another.
+            env_map["UV_CACHE_DIR"] = "/cache/uv-cache"
             # Pass PyPI index URLs to uv for package installation
             env_map["UV_INDEX_URL"] = TRACECAT__SANDBOX_PYPI_INDEX_URL
             if TRACECAT__SANDBOX_PYPI_EXTRA_INDEX_URLS:
@@ -497,10 +502,28 @@ class NsjailExecutor:
         stderr = stderr_bytes.decode("utf-8", errors="replace")
 
         # Try to parse result.json for structured output
-        result_path = job_dir / "result.json"
-        if result_path.exists():
+        try:
+            result_data = read_json_object_beneath(
+                job_dir,
+                Path("result.json"),
+                max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
+            )
+        except SandboxFileSafetyError as exc:
+            logger.warning(
+                "Rejected unsafe sandbox result file",
+                error=str(exc),
+            )
+            return SandboxResult(
+                success=False,
+                error="Sandbox produced an invalid result file",
+                stdout=stdout,
+                stderr=stderr[:500],
+                exit_code=process.returncode,
+                execution_time_ms=execution_time_ms,
+            )
+
+        if result_data is not None:
             try:
-                result_data = json.loads(result_path.read_text())
                 return SandboxResult(
                     success=result_data.get("success", False),
                     output=result_data.get("output"),
@@ -515,8 +538,19 @@ class NsjailExecutor:
                     exit_code=process.returncode,
                     execution_time_ms=execution_time_ms,
                 )
-            except json.JSONDecodeError:
-                logger.warning("Failed to parse result.json", path=str(result_path))
+            except ValueError as exc:
+                logger.warning(
+                    "Rejected invalid sandbox result fields",
+                    error=str(exc),
+                )
+                return SandboxResult(
+                    success=False,
+                    error="Sandbox produced an invalid result file",
+                    stdout=stdout,
+                    stderr=stderr[:500],
+                    exit_code=process.returncode,
+                    execution_time_ms=execution_time_ms,
+                )
 
         # No result.json - this is an infrastructure error
         if process.returncode != 0:
@@ -781,9 +815,9 @@ class NsjailExecutor:
             [
                 "",
                 "# Resource limits",
-                f"rlimit_as: {config.resources.memory_mb * 1024 * 1024}",
+                f"rlimit_as: {config.resources.memory_mb}",
                 f"rlimit_cpu: {config.resources.cpu_seconds}",
-                f"rlimit_fsize: {config.resources.max_file_size_mb * 1024 * 1024}",
+                f"rlimit_fsize: {config.resources.max_file_size_mb}",
                 f"rlimit_nofile: {config.resources.max_open_files}",
                 f"rlimit_nproc: {config.resources.max_processes}",
                 f"time_limit: {int(config.timeout_seconds)}",
@@ -908,34 +942,47 @@ class NsjailExecutor:
         stderr = stderr_bytes.decode("utf-8", errors="replace")
 
         # Try to parse result.json for structured output
-        result_path = job_dir / "result.json"
-        if result_path.exists():
-            try:
-                result_data = json.loads(result_path.read_text())
-                # Log subprocess stderr for debugging (contains timing info)
-                # Filter out nsjail verbose output, look for Python logs
-                if stderr.strip():
-                    # Extract lines that look like Python logs (not nsjail [I] lines)
-                    python_logs = "\n".join(
-                        line
-                        for line in stderr.split("\n")
-                        if not line.startswith("[I]") and not line.startswith("[W]")
-                    )
-                    if python_logs.strip():
-                        logger.info("Subprocess output", output=python_logs[:2000])
-                return SandboxResult(
-                    success=result_data.get("success", False),
-                    output=result_data.get("result"),
-                    stdout=stdout,
-                    stderr=stderr,
-                    error=result_data.get("error"),
-                    exit_code=process.returncode,
-                    execution_time_ms=execution_time_ms,
+        try:
+            result_data = read_json_object_beneath(
+                job_dir,
+                Path("result.json"),
+                max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
+            )
+        except SandboxFileSafetyError as exc:
+            logger.warning(
+                "Rejected unsafe action result file",
+                error=str(exc),
+            )
+            return SandboxResult(
+                success=False,
+                error="Action sandbox produced an invalid result file",
+                stdout=stdout,
+                stderr=stderr[:2000],
+                exit_code=process.returncode,
+                execution_time_ms=execution_time_ms,
+            )
+
+        if result_data is not None:
+            # Log subprocess stderr for debugging (contains timing info)
+            # Filter out nsjail verbose output, look for Python logs
+            if stderr.strip():
+                # Extract lines that look like Python logs (not nsjail [I] lines)
+                python_logs = "\n".join(
+                    line
+                    for line in stderr.split("\n")
+                    if not line.startswith("[I]") and not line.startswith("[W]")
                 )
-            except json.JSONDecodeError:
-                logger.warning(
-                    "Failed to parse action result.json", path=str(result_path)
-                )
+                if python_logs.strip():
+                    logger.info("Subprocess output", output=python_logs[:2000])
+            return SandboxResult(
+                success=result_data.get("success", False),
+                output=result_data.get("result"),
+                stdout=stdout,
+                stderr=stderr,
+                error=result_data.get("error"),
+                exit_code=process.returncode,
+                execution_time_ms=execution_time_ms,
+            )
 
         # No result.json - infrastructure error
         if process.returncode != 0:

--- a/tracecat/sandbox/file_io.py
+++ b/tracecat/sandbox/file_io.py
@@ -17,7 +17,7 @@ import orjson
 from tracecat.sandbox.exceptions import SandboxFileSafetyError
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _PlatformFlags:
     directory_open: int
     regular_file_read: int

--- a/tracecat/sandbox/file_io.py
+++ b/tracecat/sandbox/file_io.py
@@ -8,6 +8,7 @@ import stat
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -15,7 +16,34 @@ import orjson
 
 from tracecat.sandbox.exceptions import SandboxFileSafetyError
 
-_DIRECTORY_OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+
+@dataclass(frozen=True)
+class _PlatformFlags:
+    directory_open: int
+    regular_file_read: int
+    atomic_file_write: int
+
+
+def _platform_flags() -> _PlatformFlags:
+    """Return safe open flags, failing closed on unsupported platforms."""
+    directory = getattr(os, "O_DIRECTORY", None)
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    nonblock = getattr(os, "O_NONBLOCK", None)
+    supports_dir_fd = getattr(os, "supports_dir_fd", frozenset())
+    dir_fd_functions = (os.open, os.mkdir, os.rename, os.unlink)
+    if (
+        directory is None
+        or nofollow is None
+        or nonblock is None
+        or not all(function in supports_dir_fd for function in dir_fd_functions)
+    ):
+        raise SandboxFileSafetyError("Safe sandbox file I/O requires a POSIX platform")
+
+    return _PlatformFlags(
+        directory_open=os.O_RDONLY | directory | nofollow,
+        regular_file_read=os.O_RDONLY | nofollow | nonblock,
+        atomic_file_write=os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
+    )
 
 
 def _relative_parts(relative_path: Path) -> tuple[str, ...]:
@@ -29,10 +57,10 @@ def _relative_parts(relative_path: Path) -> tuple[str, ...]:
     return parts
 
 
-def _open_directory(path: Path) -> int:
+def _open_directory(path: Path, flags: _PlatformFlags) -> int:
     """Open a trusted root without following a replacement symlink."""
     try:
-        return os.open(path, _DIRECTORY_OPEN_FLAGS)
+        return os.open(path, flags.directory_open)
     except OSError as exc:
         raise SandboxFileSafetyError(
             "Sandbox file root is not a safe directory"
@@ -47,32 +75,28 @@ def _open_parent_directory(
     create: bool,
 ) -> Iterator[tuple[int, str]]:
     """Open a file's parent beneath root using no-follow directory handles."""
+    flags = _platform_flags()
     parts = _relative_parts(relative_path)
     if create:
         root.mkdir(parents=True, exist_ok=True)
 
-    directory_fd = _open_directory(root)
+    directory_fd = _open_directory(root, flags)
     try:
         for part in parts[:-1]:
-            try:
-                next_fd = os.open(part, _DIRECTORY_OPEN_FLAGS, dir_fd=directory_fd)
-            except FileNotFoundError:
-                if not create:
-                    raise
+            if create:
                 try:
                     os.mkdir(part, mode=0o700, dir_fd=directory_fd)
                 except FileExistsError:
                     pass
-                try:
-                    next_fd = os.open(
-                        part,
-                        _DIRECTORY_OPEN_FLAGS,
-                        dir_fd=directory_fd,
-                    )
-                except OSError as exc:
-                    raise SandboxFileSafetyError(
-                        "Sandbox file parent is not a safe directory"
-                    ) from exc
+
+            try:
+                next_fd = os.open(
+                    part,
+                    flags.directory_open,
+                    dir_fd=directory_fd,
+                )
+            except FileNotFoundError:
+                raise
             except OSError as exc:
                 raise SandboxFileSafetyError(
                     "Sandbox file parent is not a safe directory"
@@ -80,10 +104,41 @@ def _open_parent_directory(
             os.close(directory_fd)
             directory_fd = next_fd
         yield directory_fd, parts[-1]
-    except FileNotFoundError:
-        raise
     finally:
         os.close(directory_fd)
+
+
+@contextmanager
+def _open_regular_file_beneath(
+    root: Path,
+    relative_path: Path,
+    *,
+    unsafe_message: str,
+) -> Iterator[tuple[int, os.stat_result]]:
+    """Open and validate a regular file beneath root without following links."""
+    with _open_parent_directory(
+        root,
+        relative_path,
+        create=False,
+    ) as (parent_fd, filename):
+        try:
+            file_fd = os.open(
+                filename,
+                _platform_flags().regular_file_read,
+                dir_fd=parent_fd,
+            )
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise SandboxFileSafetyError(unsafe_message) from exc
+
+    try:
+        file_stat = os.fstat(file_fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise SandboxFileSafetyError("Sandbox file is not a regular file")
+        yield file_fd, file_stat
+    finally:
+        os.close(file_fd)
 
 
 def read_regular_file_beneath(
@@ -112,50 +167,75 @@ def read_regular_file_beneath(
         raise ValueError("max_bytes and offset must be non-negative")
 
     try:
-        with _open_parent_directory(
+        with _open_regular_file_beneath(
             root,
             relative_path,
-            create=False,
-        ) as (parent_fd, filename):
-            try:
-                file_fd = os.open(
-                    filename,
-                    os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
-                    dir_fd=parent_fd,
-                )
-            except FileNotFoundError:
-                return None
-            except OSError as exc:
-                raise SandboxFileSafetyError(
-                    "Sandbox file is not safe to read"
-                ) from exc
+            unsafe_message="Sandbox file is not safe to read",
+        ) as (file_fd, file_stat):
+            if max(0, file_stat.st_size - offset) > max_bytes:
+                raise SandboxFileSafetyError("Sandbox file exceeds the read limit")
+
+            os.lseek(file_fd, offset, os.SEEK_SET)
+            chunks: list[bytes] = []
+            remaining = max_bytes + 1
+            while remaining > 0:
+                chunk = os.read(file_fd, min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            data = b"".join(chunks)
+            if len(data) > max_bytes:
+                raise SandboxFileSafetyError("Sandbox file exceeds the read limit")
+            return data
     except FileNotFoundError:
         return None
-
-    try:
-        file_stat = os.fstat(file_fd)
-        if not stat.S_ISREG(file_stat.st_mode):
-            raise SandboxFileSafetyError("Sandbox file is not a regular file")
-        if max(0, file_stat.st_size - offset) > max_bytes:
-            raise SandboxFileSafetyError("Sandbox file exceeds the read limit")
-
-        os.lseek(file_fd, offset, os.SEEK_SET)
-        chunks: list[bytes] = []
-        remaining = max_bytes + 1
-        while remaining > 0:
-            chunk = os.read(file_fd, min(remaining, 64 * 1024))
-            if not chunk:
-                break
-            chunks.append(chunk)
-            remaining -= len(chunk)
-        data = b"".join(chunks)
-        if len(data) > max_bytes:
-            raise SandboxFileSafetyError("Sandbox file exceeds the read limit")
-        return data
     except OSError as exc:
         raise SandboxFileSafetyError("Sandbox file could not be read safely") from exc
-    finally:
-        os.close(file_fd)
+
+
+def read_complete_lines_beneath(
+    root: Path,
+    relative_path: Path,
+    *,
+    offset: int,
+    max_bytes: int,
+) -> tuple[bytes, int] | None:
+    """Read a bounded chunk ending at the last complete line beneath root."""
+    if max_bytes < 0 or offset < 0:
+        raise ValueError("max_bytes and offset must be non-negative")
+
+    try:
+        with _open_regular_file_beneath(
+            root,
+            relative_path,
+            unsafe_message="Sandbox file is not safe to read",
+        ) as (file_fd, _):
+            os.lseek(file_fd, offset, os.SEEK_SET)
+            chunks: list[bytes] = []
+            remaining = max_bytes
+            while remaining > 0:
+                chunk = os.read(file_fd, min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+
+            data = b"".join(chunks)
+            newline_index = data.rfind(b"\n")
+            if newline_index < 0:
+                if max_bytes > 0 and len(data) == max_bytes:
+                    raise SandboxFileSafetyError(
+                        "Sandbox file contains a line exceeding the read limit"
+                    )
+                return b"", offset
+
+            complete_lines = data[: newline_index + 1]
+            return complete_lines, offset + len(complete_lines)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise SandboxFileSafetyError("Sandbox file could not be read safely") from exc
 
 
 def read_json_object_beneath(
@@ -184,33 +264,14 @@ def read_json_object_beneath(
 def regular_file_size_beneath(root: Path, relative_path: Path) -> int | None:
     """Return a regular file's size without following sandbox-created symlinks."""
     try:
-        with _open_parent_directory(
+        with _open_regular_file_beneath(
             root,
             relative_path,
-            create=False,
-        ) as (parent_fd, filename):
-            try:
-                file_fd = os.open(
-                    filename,
-                    os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
-                    dir_fd=parent_fd,
-                )
-            except FileNotFoundError:
-                return None
-            except OSError as exc:
-                raise SandboxFileSafetyError(
-                    "Sandbox file is not safe to inspect"
-                ) from exc
+            unsafe_message="Sandbox file is not safe to inspect",
+        ) as (_, file_stat):
+            return file_stat.st_size
     except FileNotFoundError:
         return None
-
-    try:
-        file_stat = os.fstat(file_fd)
-        if not stat.S_ISREG(file_stat.st_mode):
-            raise SandboxFileSafetyError("Sandbox file is not a regular file")
-        return file_stat.st_size
-    finally:
-        os.close(file_fd)
 
 
 def atomic_write_file_beneath(
@@ -231,7 +292,7 @@ def atomic_write_file_beneath(
         try:
             file_fd = os.open(
                 temporary_name,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                _platform_flags().atomic_file_write,
                 mode,
                 dir_fd=parent_fd,
             )
@@ -263,12 +324,19 @@ def atomic_write_file_beneath(
 
 def ensure_directory_beneath(root: Path, relative_path: Path) -> None:
     """Create a directory beneath root without following existing symlinks."""
+    # The sentinel is never created; its parent walk forces the directory chain.
     sentinel = relative_path / ".directory-sentinel"
     with _open_parent_directory(root, sentinel, create=True):
         pass
 
 
-def copy_tree_without_following_symlinks(source: Path, destination: Path) -> bool:
+def copy_tree_without_following_symlinks(
+    source: Path,
+    destination: Path,
+    *,
+    max_bytes: int,
+    max_entries: int,
+) -> bool:
     """Copy a stopped sandbox's tree while preserving, not following, symlinks.
 
     The sandbox process must be stopped before this function is called so the
@@ -284,15 +352,25 @@ def copy_tree_without_following_symlinks(source: Path, destination: Path) -> boo
     if not stat.S_ISDIR(source_stat.st_mode):
         raise SandboxFileSafetyError("Sandbox package cache is not a directory")
 
-    has_entries = False
+    if max_bytes < 0 or max_entries < 0:
+        raise ValueError("max_bytes and max_entries must be non-negative")
+
+    entry_count = 0
+    total_bytes = 0
     for directory, directory_names, filenames in os.walk(
         source,
         topdown=True,
         followlinks=False,
     ):
         for name in [*directory_names, *filenames]:
-            has_entries = True
-            entry_mode = (Path(directory) / name).lstat().st_mode
+            entry_count += 1
+            if entry_count > max_entries:
+                raise SandboxFileSafetyError(
+                    "Sandbox package cache exceeds the entry limit"
+                )
+
+            entry_stat = (Path(directory) / name).lstat()
+            entry_mode = entry_stat.st_mode
             if not (
                 stat.S_ISREG(entry_mode)
                 or stat.S_ISDIR(entry_mode)
@@ -301,8 +379,14 @@ def copy_tree_without_following_symlinks(source: Path, destination: Path) -> boo
                 raise SandboxFileSafetyError(
                     "Sandbox package cache contains a special file"
                 )
+            if stat.S_ISREG(entry_mode):
+                total_bytes += entry_stat.st_size
+                if total_bytes > max_bytes:
+                    raise SandboxFileSafetyError(
+                        "Sandbox package cache exceeds the byte limit"
+                    )
 
-    if not has_entries:
+    if entry_count == 0:
         return False
     shutil.copytree(source, destination, symlinks=True)
     return True

--- a/tracecat/sandbox/file_io.py
+++ b/tracecat/sandbox/file_io.py
@@ -26,17 +26,18 @@ class _PlatformFlags:
 
 def _platform_flags() -> _PlatformFlags:
     """Return safe open flags, failing closed on unsupported platforms."""
-    directory = getattr(os, "O_DIRECTORY", None)
-    nofollow = getattr(os, "O_NOFOLLOW", None)
-    nonblock = getattr(os, "O_NONBLOCK", None)
-    supports_dir_fd = getattr(os, "supports_dir_fd", frozenset())
+    try:
+        directory = os.O_DIRECTORY
+        nofollow = os.O_NOFOLLOW
+        nonblock = os.O_NONBLOCK
+        supports_dir_fd = os.supports_dir_fd
+    except AttributeError as exc:
+        raise SandboxFileSafetyError(
+            "Safe sandbox file I/O requires a POSIX platform"
+        ) from exc
+
     dir_fd_functions = (os.open, os.mkdir, os.rename, os.unlink)
-    if (
-        directory is None
-        or nofollow is None
-        or nonblock is None
-        or not all(function in supports_dir_fd for function in dir_fd_functions)
-    ):
+    if not all(function in supports_dir_fd for function in dir_fd_functions):
         raise SandboxFileSafetyError("Safe sandbox file I/O requires a POSIX platform")
 
     return _PlatformFlags(
@@ -334,23 +335,48 @@ def copy_tree_without_following_symlinks(
     source: Path,
     destination: Path,
     *,
+    trusted_root: Path,
     max_bytes: int,
     max_entries: int,
 ) -> bool:
     """Copy a stopped sandbox's tree while preserving, not following, symlinks.
 
-    The sandbox process must be stopped before this function is called so the
-    validated tree cannot be changed between validation and copy.
+    The source is first opened beneath ``trusted_root`` without following any
+    parent symlinks. The sandbox process must be stopped before this function is
+    called so the validated tree cannot be changed between validation and copy.
 
     Returns:
         True if a non-empty tree was copied, otherwise False.
     """
     try:
-        source_stat = source.lstat()
+        relative_source = source.relative_to(trusted_root)
+    except ValueError as exc:
+        raise SandboxFileSafetyError(
+            "Sandbox package cache is outside the trusted root"
+        ) from exc
+
+    try:
+        with _open_parent_directory(
+            trusted_root,
+            relative_source,
+            create=False,
+        ) as (parent_fd, directory_name):
+            try:
+                source_fd = os.open(
+                    directory_name,
+                    _platform_flags().directory_open,
+                    dir_fd=parent_fd,
+                )
+            except FileNotFoundError:
+                return False
+            except OSError as exc:
+                raise SandboxFileSafetyError(
+                    "Sandbox package cache is not a safe directory"
+                ) from exc
+            else:
+                os.close(source_fd)
     except FileNotFoundError:
         return False
-    if not stat.S_ISDIR(source_stat.st_mode):
-        raise SandboxFileSafetyError("Sandbox package cache is not a directory")
 
     if max_bytes < 0 or max_entries < 0:
         raise ValueError("max_bytes and max_entries must be non-negative")

--- a/tracecat/sandbox/file_io.py
+++ b/tracecat/sandbox/file_io.py
@@ -1,0 +1,308 @@
+"""Safe host-side file operations for sandbox-controlled bind mounts."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import orjson
+
+from tracecat.sandbox.exceptions import SandboxFileSafetyError
+
+_DIRECTORY_OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+
+
+def _relative_parts(relative_path: Path) -> tuple[str, ...]:
+    """Validate and return components for a path beneath a trusted root."""
+    if relative_path.is_absolute():
+        raise SandboxFileSafetyError("Sandbox file path must be relative")
+
+    parts = relative_path.parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise SandboxFileSafetyError("Sandbox file path contains unsafe components")
+    return parts
+
+
+def _open_directory(path: Path) -> int:
+    """Open a trusted root without following a replacement symlink."""
+    try:
+        return os.open(path, _DIRECTORY_OPEN_FLAGS)
+    except OSError as exc:
+        raise SandboxFileSafetyError(
+            "Sandbox file root is not a safe directory"
+        ) from exc
+
+
+@contextmanager
+def _open_parent_directory(
+    root: Path,
+    relative_path: Path,
+    *,
+    create: bool,
+) -> Iterator[tuple[int, str]]:
+    """Open a file's parent beneath root using no-follow directory handles."""
+    parts = _relative_parts(relative_path)
+    if create:
+        root.mkdir(parents=True, exist_ok=True)
+
+    directory_fd = _open_directory(root)
+    try:
+        for part in parts[:-1]:
+            try:
+                next_fd = os.open(part, _DIRECTORY_OPEN_FLAGS, dir_fd=directory_fd)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    os.mkdir(part, mode=0o700, dir_fd=directory_fd)
+                except FileExistsError:
+                    pass
+                try:
+                    next_fd = os.open(
+                        part,
+                        _DIRECTORY_OPEN_FLAGS,
+                        dir_fd=directory_fd,
+                    )
+                except OSError as exc:
+                    raise SandboxFileSafetyError(
+                        "Sandbox file parent is not a safe directory"
+                    ) from exc
+            except OSError as exc:
+                raise SandboxFileSafetyError(
+                    "Sandbox file parent is not a safe directory"
+                ) from exc
+            os.close(directory_fd)
+            directory_fd = next_fd
+        yield directory_fd, parts[-1]
+    except FileNotFoundError:
+        raise
+    finally:
+        os.close(directory_fd)
+
+
+def read_regular_file_beneath(
+    root: Path,
+    relative_path: Path,
+    *,
+    max_bytes: int,
+    offset: int = 0,
+) -> bytes | None:
+    """Read a bounded regular file beneath root without following symlinks.
+
+    Args:
+        root: Trusted root directory containing sandbox-controlled files.
+        relative_path: File path relative to root.
+        max_bytes: Maximum bytes to read after offset.
+        offset: Byte offset from which to begin reading.
+
+    Returns:
+        File bytes, or None when the file does not exist.
+
+    Raises:
+        SandboxFileSafetyError: If the path is unsafe, not a regular file, or
+            exceeds the read limit.
+    """
+    if max_bytes < 0 or offset < 0:
+        raise ValueError("max_bytes and offset must be non-negative")
+
+    try:
+        with _open_parent_directory(
+            root,
+            relative_path,
+            create=False,
+        ) as (parent_fd, filename):
+            try:
+                file_fd = os.open(
+                    filename,
+                    os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+                    dir_fd=parent_fd,
+                )
+            except FileNotFoundError:
+                return None
+            except OSError as exc:
+                raise SandboxFileSafetyError(
+                    "Sandbox file is not safe to read"
+                ) from exc
+    except FileNotFoundError:
+        return None
+
+    try:
+        file_stat = os.fstat(file_fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise SandboxFileSafetyError("Sandbox file is not a regular file")
+        if max(0, file_stat.st_size - offset) > max_bytes:
+            raise SandboxFileSafetyError("Sandbox file exceeds the read limit")
+
+        os.lseek(file_fd, offset, os.SEEK_SET)
+        chunks: list[bytes] = []
+        remaining = max_bytes + 1
+        while remaining > 0:
+            chunk = os.read(file_fd, min(remaining, 64 * 1024))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > max_bytes:
+            raise SandboxFileSafetyError("Sandbox file exceeds the read limit")
+        return data
+    except OSError as exc:
+        raise SandboxFileSafetyError("Sandbox file could not be read safely") from exc
+    finally:
+        os.close(file_fd)
+
+
+def read_json_object_beneath(
+    root: Path,
+    relative_path: Path,
+    *,
+    max_bytes: int,
+) -> dict[str, Any] | None:
+    """Read a bounded JSON object from a sandbox-controlled directory."""
+    data = read_regular_file_beneath(
+        root,
+        relative_path,
+        max_bytes=max_bytes,
+    )
+    if data is None:
+        return None
+    try:
+        value = orjson.loads(data)
+    except orjson.JSONDecodeError as exc:
+        raise SandboxFileSafetyError("Sandbox result is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise SandboxFileSafetyError("Sandbox result is not a JSON object")
+    return value
+
+
+def regular_file_size_beneath(root: Path, relative_path: Path) -> int | None:
+    """Return a regular file's size without following sandbox-created symlinks."""
+    try:
+        with _open_parent_directory(
+            root,
+            relative_path,
+            create=False,
+        ) as (parent_fd, filename):
+            try:
+                file_fd = os.open(
+                    filename,
+                    os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+                    dir_fd=parent_fd,
+                )
+            except FileNotFoundError:
+                return None
+            except OSError as exc:
+                raise SandboxFileSafetyError(
+                    "Sandbox file is not safe to inspect"
+                ) from exc
+    except FileNotFoundError:
+        return None
+
+    try:
+        file_stat = os.fstat(file_fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise SandboxFileSafetyError("Sandbox file is not a regular file")
+        return file_stat.st_size
+    finally:
+        os.close(file_fd)
+
+
+def atomic_write_file_beneath(
+    root: Path,
+    relative_path: Path,
+    data: bytes,
+    *,
+    mode: int = 0o600,
+) -> None:
+    """Atomically write beneath root without following sandbox-created symlinks."""
+    with _open_parent_directory(
+        root,
+        relative_path,
+        create=True,
+    ) as (parent_fd, filename):
+        temporary_name = f".{filename}.{uuid.uuid4().hex}.tmp"
+        file_fd: int | None = None
+        try:
+            file_fd = os.open(
+                temporary_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                mode,
+                dir_fd=parent_fd,
+            )
+            view = memoryview(data)
+            while view:
+                written = os.write(file_fd, view)
+                view = view[written:]
+            os.fsync(file_fd)
+            os.close(file_fd)
+            file_fd = None
+            os.replace(
+                temporary_name,
+                filename,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+        except OSError as exc:
+            raise SandboxFileSafetyError(
+                "Sandbox file could not be written safely"
+            ) from exc
+        finally:
+            if file_fd is not None:
+                os.close(file_fd)
+            try:
+                os.unlink(temporary_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+
+
+def ensure_directory_beneath(root: Path, relative_path: Path) -> None:
+    """Create a directory beneath root without following existing symlinks."""
+    sentinel = relative_path / ".directory-sentinel"
+    with _open_parent_directory(root, sentinel, create=True):
+        pass
+
+
+def copy_tree_without_following_symlinks(source: Path, destination: Path) -> bool:
+    """Copy a stopped sandbox's tree while preserving, not following, symlinks.
+
+    The sandbox process must be stopped before this function is called so the
+    validated tree cannot be changed between validation and copy.
+
+    Returns:
+        True if a non-empty tree was copied, otherwise False.
+    """
+    try:
+        source_stat = source.lstat()
+    except FileNotFoundError:
+        return False
+    if not stat.S_ISDIR(source_stat.st_mode):
+        raise SandboxFileSafetyError("Sandbox package cache is not a directory")
+
+    has_entries = False
+    for directory, directory_names, filenames in os.walk(
+        source,
+        topdown=True,
+        followlinks=False,
+    ):
+        for name in [*directory_names, *filenames]:
+            has_entries = True
+            entry_mode = (Path(directory) / name).lstat().st_mode
+            if not (
+                stat.S_ISREG(entry_mode)
+                or stat.S_ISDIR(entry_mode)
+                or stat.S_ISLNK(entry_mode)
+            ):
+                raise SandboxFileSafetyError(
+                    "Sandbox package cache contains a special file"
+                )
+
+    if not has_entries:
+        return False
+    shutil.copytree(source, destination, symlinks=True)
+    return True

--- a/tracecat/sandbox/result_envelope.py
+++ b/tracecat/sandbox/result_envelope.py
@@ -26,7 +26,9 @@ class _ResultEnvelope(BaseModel):
     # takes the invalid-result path rather than leaking None into SandboxResult.
     stdout: str = Field(default="")
     stderr: str = Field(default="")
-    error: str | None = Field(default=None)
+    # Action failures carry an ExecutorActionErrorInfo-shaped JSON object that
+    # must pass through opaquely for the consumer to validate (action_runner).
+    error: str | dict[str, Any] | None = Field(default=None)
     error_code: SandboxErrorCode | None = Field(default=None)
 
     @field_validator("error_code", mode="before")

--- a/tracecat/sandbox/result_envelope.py
+++ b/tracecat/sandbox/result_envelope.py
@@ -38,7 +38,7 @@ class _ResultEnvelope(BaseModel):
         return value if value else None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ResultEnvelopeOutcome:
     """Decoded result plus whether it came from a valid envelope."""
 

--- a/tracecat/sandbox/result_envelope.py
+++ b/tracecat/sandbox/result_envelope.py
@@ -1,0 +1,142 @@
+"""Typed decoding for sandbox-produced result envelopes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from tracecat.logger import logger
+from tracecat.sandbox.exceptions import SandboxFileSafetyError
+from tracecat.sandbox.file_io import read_json_object_beneath
+from tracecat.sandbox.types import SandboxErrorCode, SandboxResult
+
+
+class _ResultEnvelope(BaseModel):
+    """Lenient result shape emitted by sandbox wrappers."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    success: bool = Field(default=False)
+    output: Any | None = Field(default=None)
+    result: Any | None = Field(default=None)
+    stdout: str | None = Field(default=None)
+    stderr: str | None = Field(default=None)
+    error: str | None = Field(default=None)
+    error_code: SandboxErrorCode | None = Field(default=None)
+
+    @field_validator("error_code", mode="before")
+    @classmethod
+    def empty_error_code_is_absent(cls, value: object) -> object:
+        """Preserve the existing truthy-only error-code conversion."""
+        return value if value else None
+
+
+@dataclass(frozen=True)
+class ResultEnvelopeOutcome:
+    """Decoded result plus whether it came from a valid envelope."""
+
+    result: SandboxResult
+    valid_envelope: bool
+
+
+def _invalid_result(
+    *,
+    error: str,
+    stdout: str,
+    stderr: str,
+    stderr_limit: int,
+    exit_code: int | None,
+    execution_time_ms: float,
+) -> ResultEnvelopeOutcome:
+    return ResultEnvelopeOutcome(
+        result=SandboxResult(
+            success=False,
+            error=error,
+            stdout=stdout,
+            stderr=stderr[:stderr_limit],
+            exit_code=exit_code,
+            execution_time_ms=execution_time_ms,
+        ),
+        valid_envelope=False,
+    )
+
+
+def decode_result_envelope(
+    job_dir: Path,
+    *,
+    output_key: Literal["output", "result"],
+    stdout: str,
+    stderr: str,
+    stderr_limit: int,
+    invalid_result_error: str,
+    log_label: Literal["sandbox", "action", "PID executor"],
+    exit_code: int | None,
+    execution_time_ms: float,
+    max_bytes: int,
+    stream_source: Literal["envelope", "process"],
+    include_error_code: bool = False,
+) -> ResultEnvelopeOutcome | None:
+    """Decode result.json into a typed outcome, or return None when absent."""
+    try:
+        result_data = read_json_object_beneath(
+            job_dir,
+            Path("result.json"),
+            max_bytes=max_bytes,
+        )
+    except SandboxFileSafetyError as exc:
+        logger.warning(
+            f"Rejected unsafe {log_label} result file",
+            error=str(exc),
+        )
+        return _invalid_result(
+            error=invalid_result_error,
+            stdout=stdout,
+            stderr=stderr,
+            stderr_limit=stderr_limit,
+            exit_code=exit_code,
+            execution_time_ms=execution_time_ms,
+        )
+
+    if result_data is None:
+        return None
+
+    try:
+        envelope = _ResultEnvelope.model_validate(result_data)
+    except (ValidationError, ValueError) as exc:
+        logger.warning(
+            f"Rejected invalid {log_label} result fields",
+            error=str(exc),
+        )
+        return _invalid_result(
+            error=invalid_result_error,
+            stdout=stdout,
+            stderr=stderr,
+            stderr_limit=stderr_limit,
+            exit_code=exit_code,
+            execution_time_ms=execution_time_ms,
+        )
+
+    result_stdout: str = stdout
+    result_stderr: str = stderr
+    if stream_source == "envelope":
+        if "stdout" in envelope.model_fields_set:
+            result_stdout = cast(str, envelope.stdout)
+        if "stderr" in envelope.model_fields_set:
+            result_stderr = cast(str, envelope.stderr)
+
+    return ResultEnvelopeOutcome(
+        result=SandboxResult(
+            success=envelope.success,
+            output=getattr(envelope, output_key),
+            stdout=result_stdout,
+            stderr=result_stderr,
+            error=envelope.error,
+            error_code=envelope.error_code if include_error_code else None,
+            exit_code=exit_code,
+            execution_time_ms=execution_time_ms,
+        ),
+        valid_envelope=True,
+    )

--- a/tracecat/sandbox/result_envelope.py
+++ b/tracecat/sandbox/result_envelope.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
@@ -22,8 +22,10 @@ class _ResultEnvelope(BaseModel):
     success: bool = Field(default=False)
     output: Any | None = Field(default=None)
     result: Any | None = Field(default=None)
-    stdout: str | None = Field(default=None)
-    stderr: str | None = Field(default=None)
+    # Streams must be strings when present; an explicit null is malformed and
+    # takes the invalid-result path rather than leaking None into SandboxResult.
+    stdout: str = Field(default="")
+    stderr: str = Field(default="")
     error: str | None = Field(default=None)
     error_code: SandboxErrorCode | None = Field(default=None)
 
@@ -123,9 +125,9 @@ def decode_result_envelope(
     result_stderr: str = stderr
     if stream_source == "envelope":
         if "stdout" in envelope.model_fields_set:
-            result_stdout = cast(str, envelope.stdout)
+            result_stdout = envelope.stdout
         if "stderr" in envelope.model_fields_set:
-            result_stderr = cast(str, envelope.stderr)
+            result_stderr = envelope.stderr
 
     return ResultEnvelopeOutcome(
         result=SandboxResult(

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -1,5 +1,6 @@
 """High-level sandbox service for Python script execution."""
 
+import asyncio
 import hashlib
 import json
 import os
@@ -259,7 +260,9 @@ class SandboxService:
         temp_dest = dest.parent / f"site-packages.{uuid.uuid4().hex}.tmp"
         try:
             try:
-                copied = copy_tree_without_following_symlinks(
+                # The walk and copy can span gigabytes; keep them off the loop.
+                copied = await asyncio.to_thread(
+                    copy_tree_without_following_symlinks,
                     site_packages,
                     temp_dest,
                     max_bytes=TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_BYTES,
@@ -293,7 +296,7 @@ class SandboxService:
                 )
         finally:
             if temp_dest.exists():
-                shutil.rmtree(temp_dest, ignore_errors=True)
+                await asyncio.to_thread(shutil.rmtree, temp_dest, ignore_errors=True)
 
     async def _prepare_execution(
         self,

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -265,6 +265,7 @@ class SandboxService:
                     copy_tree_without_following_symlinks,
                     site_packages,
                     temp_dest,
+                    trusted_root=job_dir,
                     max_bytes=TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_BYTES,
                     max_entries=TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_ENTRIES,
                 )

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import tempfile
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -23,8 +24,10 @@ from tracecat.logger import logger
 from tracecat.sandbox.exceptions import (
     PackageInstallError,
     SandboxExecutionError,
+    SandboxFileSafetyError,
 )
 from tracecat.sandbox.executor import RUN_PYTHON_ACTION_GATEWAY_SOCKET, NsjailExecutor
+from tracecat.sandbox.file_io import copy_tree_without_following_symlinks
 from tracecat.sandbox.types import ResourceLimits, SandboxConfig
 from tracecat.sandbox.unsafe_pid_executor import UnsafePidExecutor
 from tracecat.sandbox.wrapper import INSTALL_SCRIPT, WRAPPER_SCRIPT
@@ -76,11 +79,9 @@ class SandboxService:
     ):
         self.cache_dir = Path(cache_dir)
         self.package_cache = self.cache_dir / "packages"
-        self.uv_cache = self.cache_dir / "uv-cache"
 
         # Ensure cache directories exist
         self.package_cache.mkdir(parents=True, exist_ok=True)
-        self.uv_cache.mkdir(parents=True, exist_ok=True)
 
         # Initialize executors lazily based on availability
         self._nsjail_executor: NsjailExecutor | None = None
@@ -248,43 +249,47 @@ class SandboxService:
         # This prevents race conditions when multiple concurrent requests
         # try to install the same dependencies.
         site_packages = cache_dir / "site-packages"
-        if site_packages.exists() and any(site_packages.iterdir()):
-            dest = self.package_cache / cache_key / "site-packages"
-            dest.parent.mkdir(parents=True, exist_ok=True)
+        dest = self.package_cache / cache_key / "site-packages"
+        dest.parent.mkdir(parents=True, exist_ok=True)
 
-            # Use atomic rename: copy to temp dir in same parent, then rename.
-            # os.rename is atomic on the same filesystem.
-            temp_dest = dest.parent / f"site-packages.{os.getpid()}.tmp"
+        # The installer has stopped, so validate the tree and preserve symlinks
+        # rather than dereferencing sandbox-selected targets in the host process.
+        temp_dest = dest.parent / f"site-packages.{uuid.uuid4().hex}.tmp"
+        try:
             try:
-                # Clean up any stale temp dir from a previous failed attempt
-                if temp_dest.exists():
-                    shutil.rmtree(temp_dest)
-                shutil.copytree(site_packages, temp_dest)
+                copied = copy_tree_without_following_symlinks(
+                    site_packages,
+                    temp_dest,
+                )
+            except SandboxFileSafetyError as exc:
+                raise PackageInstallError(
+                    "Installed packages contained unsafe filesystem entries"
+                ) from exc
 
-                # Atomic rename into place. If dest already exists (another process
-                # beat us), this will fail on POSIX - that's fine, we just use theirs.
-                try:
-                    os.rename(temp_dest, dest)
-                    logger.info(
-                        "Packages cached",
-                        cache_key=cache_key,
-                        path=str(dest),
-                    )
-                except OSError:
-                    # Another process already created the cache - use theirs
-                    logger.debug(
-                        "Cache already exists (concurrent install), using existing",
-                        cache_key=cache_key,
-                    )
-            finally:
-                # Clean up temp dir if rename failed or succeeded
-                if temp_dest.exists():
-                    shutil.rmtree(temp_dest, ignore_errors=True)
-        else:
-            logger.warning(
-                "No packages were installed",
-                dependencies=dependencies,
-            )
+            if not copied:
+                logger.warning(
+                    "No packages were installed",
+                    dependencies=dependencies,
+                )
+                return
+
+            # Atomic rename into place. If another installer won the race, use
+            # the already-published cache tree.
+            try:
+                os.rename(temp_dest, dest)
+                logger.info(
+                    "Packages cached",
+                    cache_key=cache_key,
+                    path=str(dest),
+                )
+            except OSError:
+                logger.debug(
+                    "Cache already exists (concurrent install), using existing",
+                    cache_key=cache_key,
+                )
+        finally:
+            if temp_dest.exists():
+                shutil.rmtree(temp_dest, ignore_errors=True)
 
     async def _prepare_execution(
         self,

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -18,6 +18,8 @@ from tracecat.config import (
     TRACECAT__SANDBOX_DEFAULT_MEMORY_MB,
     TRACECAT__SANDBOX_DEFAULT_TIMEOUT,
     TRACECAT__SANDBOX_NSJAIL_PATH,
+    TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_BYTES,
+    TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_ENTRIES,
     TRACECAT__SANDBOX_ROOTFS_PATH,
 )
 from tracecat.logger import logger
@@ -260,6 +262,8 @@ class SandboxService:
                 copied = copy_tree_without_following_symlinks(
                     site_packages,
                     temp_dest,
+                    max_bytes=TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_BYTES,
+                    max_entries=TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_ENTRIES,
                 )
             except SandboxFileSafetyError as exc:
                 raise PackageInstallError(

--- a/tracecat/sandbox/types.py
+++ b/tracecat/sandbox/types.py
@@ -74,7 +74,10 @@ class SandboxResult:
     output: Any | None = None
     stdout: str = ""
     stderr: str = ""
-    error: str | None = None
+    # Action sandboxes report failures as ExecutorActionErrorInfo-shaped JSON
+    # objects that cross the sandbox boundary opaquely and are validated by the
+    # consumer (action_runner); python sandboxes report plain strings.
+    error: str | dict[str, Any] | None = None
     error_code: SandboxErrorCode | None = None
     exit_code: int | None = None
     execution_time_ms: float | None = None

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from tracecat.config import (
+    TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
     TRACECAT__SANDBOX_CACHE_DIR,
     TRACECAT__SANDBOX_DEFAULT_TIMEOUT,
     TRACECAT__SANDBOX_PYPI_EXTRA_INDEX_URLS,
@@ -26,8 +27,10 @@ from tracecat.logger import logger
 from tracecat.sandbox.exceptions import (
     PackageInstallError,
     SandboxExecutionError,
+    SandboxFileSafetyError,
     SandboxTimeoutError,
 )
+from tracecat.sandbox.file_io import read_json_object_beneath
 from tracecat.sandbox.types import SandboxResult
 from tracecat.sandbox.utils import pid_namespace_available, pid_namespace_probe_error
 
@@ -486,21 +489,36 @@ class UnsafePidExecutor:
             stdout = stdout_bytes.decode("utf-8", errors="replace")
             stderr = stderr_bytes.decode("utf-8", errors="replace")
 
-            result_path = work_dir / "result.json"
-            if result_path.exists():
-                try:
-                    result_data = json.loads(result_path.read_text())
-                    return SandboxResult(
-                        success=result_data.get("success", False),
-                        output=result_data.get("output"),
-                        stdout=result_data.get("stdout", stdout),
-                        stderr=result_data.get("stderr", stderr),
-                        error=result_data.get("error"),
-                        exit_code=process.returncode,
-                        execution_time_ms=execution_time_ms,
-                    )
-                except json.JSONDecodeError:
-                    logger.warning("Failed to parse result.json")
+            try:
+                result_data = read_json_object_beneath(
+                    work_dir,
+                    Path("result.json"),
+                    max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
+                )
+            except SandboxFileSafetyError as exc:
+                logger.warning(
+                    "Rejected unsafe PID executor result file",
+                    error=str(exc),
+                )
+                return SandboxResult(
+                    success=False,
+                    error="Execution produced an invalid result file",
+                    stdout=stdout,
+                    stderr=stderr[:500],
+                    exit_code=process.returncode,
+                    execution_time_ms=execution_time_ms,
+                )
+
+            if result_data is not None:
+                return SandboxResult(
+                    success=result_data.get("success", False),
+                    output=result_data.get("output"),
+                    stdout=result_data.get("stdout", stdout),
+                    stderr=result_data.get("stderr", stderr),
+                    error=result_data.get("error"),
+                    exit_code=process.returncode,
+                    execution_time_ms=execution_time_ms,
+                )
 
             return SandboxResult(
                 success=False,

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -27,10 +27,9 @@ from tracecat.logger import logger
 from tracecat.sandbox.exceptions import (
     PackageInstallError,
     SandboxExecutionError,
-    SandboxFileSafetyError,
     SandboxTimeoutError,
 )
-from tracecat.sandbox.file_io import read_json_object_beneath
+from tracecat.sandbox.result_envelope import decode_result_envelope
 from tracecat.sandbox.types import SandboxResult
 from tracecat.sandbox.utils import pid_namespace_available, pid_namespace_probe_error
 
@@ -489,36 +488,21 @@ class UnsafePidExecutor:
             stdout = stdout_bytes.decode("utf-8", errors="replace")
             stderr = stderr_bytes.decode("utf-8", errors="replace")
 
-            try:
-                result_data = read_json_object_beneath(
-                    work_dir,
-                    Path("result.json"),
-                    max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
-                )
-            except SandboxFileSafetyError as exc:
-                logger.warning(
-                    "Rejected unsafe PID executor result file",
-                    error=str(exc),
-                )
-                return SandboxResult(
-                    success=False,
-                    error="Execution produced an invalid result file",
-                    stdout=stdout,
-                    stderr=stderr[:500],
-                    exit_code=process.returncode,
-                    execution_time_ms=execution_time_ms,
-                )
-
-            if result_data is not None:
-                return SandboxResult(
-                    success=result_data.get("success", False),
-                    output=result_data.get("output"),
-                    stdout=result_data.get("stdout", stdout),
-                    stderr=result_data.get("stderr", stderr),
-                    error=result_data.get("error"),
-                    exit_code=process.returncode,
-                    execution_time_ms=execution_time_ms,
-                )
+            outcome = decode_result_envelope(
+                work_dir,
+                output_key="output",
+                stdout=stdout,
+                stderr=stderr,
+                stderr_limit=500,
+                invalid_result_error="Execution produced an invalid result file",
+                log_label="PID executor",
+                exit_code=process.returncode,
+                execution_time_ms=execution_time_ms,
+                max_bytes=TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES,
+                stream_source="envelope",
+            )
+            if outcome is not None:
+                return outcome.result
 
             return SandboxResult(
                 success=False,


### PR DESCRIPTION
## Summary

- run Claude Code as UID 1000 with a private writable runtime home
- demote native Bash commands and root/subagent stdio MCP servers to UID 1001 with zero capabilities and a separate private home
- keep `/work` as the only writable filesystem shared by both identities
- make Claude's built-in and MCP tool inventory explicit and fail closed
- retain native Write/Edit while denying paths that do not resolve beneath `/work`
- disable user/project settings and require strict runtime-owned MCP configuration

## Stack

- stacked on #3088
- tracks ENG-1552
- Landlock and SessionStore remain separate follow-up phases

## Verification

- 158 focused unit tests passed; one Linux-only test skipped on macOS
- Ruff check and format passed
- basedpyright passed with zero errors or warnings
- executor test image built successfully
- real Linux/nsjail UID test passed: Claude UID 1000 retains only `CAP_SETUID`; tool UID 1001 has no capabilities; private homes are mutually inaccessible; `/work` remains shared
- nsjail session smoke harness completed successfully

## Merge blocker

This PR is intentionally a draft. The required race exercise proved that PreToolUse path validation is not atomic with Anthropic's native Write/Edit execution: a concurrent UID 1001 process can replace a validated `/work` directory component with a pre-created symlink before UID 1000 performs the mutation, causing the operation to reach Claude's private home.

Do not merge until native mutation is made atomic with path enforcement or authoritative session state is moved outside Claude's writable home. Mount-wide `nosymfollow` is not included because it would disable legitimate symlink use throughout `/work`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates Claude from model-controlled tools by running Claude as UID 1000 with a private home and demoting Bash and stdio MCP processes to UID 1001 with no capabilities, sharing only /work. Tightens runtime to a fail-closed tool inventory and enforces safe filesystem writes per ENG-1552.

- **New Features**
  - nsjail UID/GID maps: Claude UID 1000 retains only CAP_SETUID; tools run as UID 1001 with zero caps; shared setgid /work (02770); tmpfs-backed private homes at /home/agent and /home/tools.
  - Trusted shim wraps Bash and stdio MCP servers: verifies identity, demotes to tool UID, clears all caps, preserves no_new_privs, and passes argv/env via a base64 payload; blocks env boundary overrides; tools get a private HOME/TMP and cannot read Claude state.
  - Fail-closed inventories: built-in tools limited to a known set; stdio MCP tools must be explicitly listed; PreToolUse denies MCP calls not in the runtime inventory; removes wildcard acceptance.
  - Safe native writes: Write/Edit paths are canonicalized under /work and reject traversal, null bytes, missing parents, and symlink escapes; Bash commands are executed via the trusted wrapper.
  - Runtime env hardening: Claude process uses private XDG dirs and TMP under /home/agent; only /work is shared; direct mode prepares the same dirs (without UID isolation) for parity.
  - nsjail config updates: explicit uidmap/gidmap, CAP_SETUID, strict tmpfs modes, mounts for /home/agent, /home/tools, and /work with correct ownership and permissions.

- **Dependencies**
  - Docker: install `uidmap`; create `tools` user (UID 1001) and subordinate UID range for `apiuser`; validate `newuidmap` and `/etc/subuid` at runtime.

<sup>Written for commit 863c0207e997098328c9e37e08817cfc943a0686. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

