### PR TITLE
ci: pin ruff to pyproject version in lint workflow

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -35,13 +35,13 @@ jobs:
       - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
           src: "tracecat/ tests/ packages/ alembic/"
-          version: latest
+          version-file: "pyproject.toml"
           args: check --no-fix
 
       - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
           src: "tracecat/ tests/ packages/ alembic/"
-          version: latest
+          version-file: "pyproject.toml"
           args: format --diff
 
   pyright:


### PR DESCRIPTION
## What

Pin the ruff version in `lint-python.yml` to the repo's `pyproject.toml` pin (`ruff==0.15.0`) via `ruff-action`'s `version-file` input, replacing `version: latest`.

## Why

ruff 0.16.0 was released today and `version: latest` picked it up immediately, turning the `ruff` check red on every open PR with new violations (`I001`, `TRY201`, `UP035`, `RUF022`, `TRY004`, `BLE001`) in pre-existing `packages/tracecat-registry/` code that no PR touched. Verified locally:

- `uv run ruff check tracecat/ tests/ packages/ alembic/` (0.15.0, the pyproject pin) — passes
- `uvx ruff@0.16.0 check packages/tracecat-registry/` — fails with the same errors as CI

`version-file: "pyproject.toml"` keeps CI in lockstep with the dev/pre-commit pin, so future ruff upgrades happen deliberately via the `pyproject.toml` bump (with any new violations fixed in the same PR) instead of on ruff's release schedule.

## Notes

- First seen on PR #3120 (`ruff` job failing on files outside the diff).
- No workflow triggers, permissions, or environments changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `ruff` in `lint-python.yml` to the `pyproject.toml` version using `ruff-action`’s `version-file`, replacing `version: latest`, to prevent CI from breaking on new `ruff` releases. This keeps CI aligned with the dev/pre-commit pin and upgrades happen via the `pyproject.toml` bump.

<sup>Written for commit 5ebd77d5d3ea69c4dbe5a711314c7c860cc4718d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

