### PR TITLE
feat(agent): expose catalog IDs for custom models in UI and API

### DIFF
--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -1143,16 +1143,48 @@ function CustomSourceModelRow({
           </p>
         ) : null}
       </div>
-      <Button
-        disabled={disabled}
-        onClick={() => {
-          void onToggle(model)
-        }}
-        size="sm"
-        variant={model.enabled ? "secondary" : "outline"}
-      >
-        {model.enabled ? "Disable" : "Enable"}
-      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            aria-label="Model actions"
+            disabled={disabled}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <MoreVertical className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onSelect={() => {
+              void onToggle(model)
+            }}
+          >
+            {model.enabled ? "Disable" : "Enable"}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={async () => {
+              try {
+                await navigator.clipboard.writeText(model.id)
+                toast({
+                  title: "Copied",
+                  description: `Catalog ID ${model.id} copied to clipboard.`,
+                })
+              } catch {
+                toast({
+                  title: "Copy failed",
+                  description:
+                    "Could not copy the catalog ID to your clipboard.",
+                  variant: "destructive",
+                })
+              }
+            }}
+          >
+            Copy catalog ID
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   )
 }

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from temporalio.client import WorkflowExecutionStatus
 
 from tracecat.agent import router as agent_router
+from tracecat.agent.catalog import router as agent_catalog_router
 from tracecat.auth.dependencies import (
     WorkspaceActorRouteRole,
     WorkspaceUserRouteRole,
@@ -555,6 +556,29 @@ def test_org_agent_routes_remain_user_only() -> None:
         agent_router.get_workspace_providers_status, include_extras=True
     )["role"]
     assert workspace_status_role == WorkspaceActorRouteRole
+
+
+def test_agent_catalog_read_routes_accept_org_actors() -> None:
+    endpoints = [
+        agent_catalog_router.list_catalog,
+        agent_catalog_router.get_catalog_entry,
+    ]
+
+    for endpoint in endpoints:
+        role = get_type_hints(endpoint, include_extras=True)["role"]
+        assert role == agent_catalog_router.OrgActorRole
+
+
+def test_agent_catalog_mutation_routes_remain_user_only() -> None:
+    endpoints = [
+        agent_catalog_router.create_catalog_entry,
+        agent_catalog_router.update_catalog_entry,
+        agent_catalog_router.delete_catalog_entry,
+    ]
+
+    for endpoint in endpoints:
+        role = get_type_hints(endpoint, include_extras=True)["role"]
+        assert role == agent_catalog_router.OrgUserRole
 
 
 def test_github_manifest_flow_routes_remain_user_only() -> None:

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import uuid
 from collections.abc import Awaitable, Callable, Sequence
-from typing import cast
+from typing import Any, cast
 
 import pytest
+from fastapi import HTTPException
 
+from tracecat.agent.catalog import router as agent_catalog_router
 from tracecat.agent.folders import router as agent_folder_router
 from tracecat.agent.preset import router as agent_preset_router
 from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
@@ -211,6 +214,81 @@ async def test_agent_folder_scope_guards(
     endpoint: AsyncEndpoint, required_scope: str
 ) -> None:
     await _assert_endpoint_requires_scope(endpoint, required_scope)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        agent_catalog_router.list_catalog,
+        agent_catalog_router.get_catalog_entry,
+    ],
+)
+async def test_agent_catalog_read_scope_guards(endpoint: AsyncEndpoint) -> None:
+    await _assert_endpoint_requires_scope(endpoint, "agent:read")
+
+
+@pytest.mark.anyio
+async def test_agent_catalog_list_accepts_service_account_with_scope() -> None:
+    # Managed service-account key is authorized by its granted scopes.
+    endpoint = cast(AsyncEndpoint, agent_catalog_router.list_catalog)
+    organization_id = uuid.uuid4()
+    denied_role = Role(
+        type="service_account",
+        service_id="tracecat-api",
+        organization_id=organization_id,
+        service_account_id=uuid.uuid4(),
+        scopes=frozenset({"agent:create"}),
+    )
+    token = ctx_role.set(denied_role)
+    try:
+        with pytest.raises(ScopeDeniedError):
+            await endpoint()
+    finally:
+        ctx_role.reset(token)
+
+    allowed_role = Role(
+        type="service_account",
+        service_id="tracecat-api",
+        organization_id=organization_id,
+        service_account_id=uuid.uuid4(),
+        scopes=frozenset({"agent:read"}),
+    )
+    token = ctx_role.set(allowed_role)
+    try:
+        with pytest.raises(TypeError):
+            await endpoint()
+    finally:
+        ctx_role.reset(token)
+
+
+@pytest.mark.anyio
+async def test_agent_catalog_reads_reject_workspace_bound_service_accounts() -> None:
+    # A tc_ws_sk_ key resolves on org routes; it must not see the org-wide catalog.
+    workspace_id = uuid.uuid4()
+    bound_role = Role(
+        type="service_account",
+        service_id="tracecat-api",
+        organization_id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        bound_workspace_id=workspace_id,
+        service_account_id=uuid.uuid4(),
+        scopes=frozenset({"agent:read"}),
+    )
+    session = cast(Any, None)  # Guard raises before the session is touched
+    token = ctx_role.set(bound_role)
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await agent_catalog_router.list_catalog(role=bound_role, session=session)
+        assert exc_info.value.status_code == 403
+
+        with pytest.raises(HTTPException) as exc_info:
+            await agent_catalog_router.get_catalog_entry(
+                catalog_id=uuid.uuid4(), role=bound_role, session=session
+            )
+        assert exc_info.value.status_code == 403
+    finally:
+        ctx_role.reset(token)
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/catalog/router.py
+++ b/tracecat/agent/catalog/router.py
@@ -12,7 +12,11 @@ from tracecat.agent.catalog.schemas import (
     AgentCatalogUpdate,
 )
 from tracecat.agent.catalog.service import AgentCatalogService
-from tracecat.auth.dependencies import OrgUserRole, WorkspaceUserPathRole
+from tracecat.auth.dependencies import (
+    OrgActorRole,
+    OrgUserRole,
+    WorkspaceUserPathRole,
+)
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -27,7 +31,7 @@ router = APIRouter()
 )
 @require_scope("agent:read")
 async def list_catalog(
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     provider: str | None = Query(None),
     model_name: str | None = Query(None),
@@ -35,6 +39,9 @@ async def list_catalog(
     limit: int = Query(50, ge=1, le=100),
 ) -> AgentCatalogListResponse:
     """List catalog entries with optional filtering and pagination."""
+    # Workspace-bound keys must use the workspace-effective model view instead.
+    if role.type == "service_account" and role.bound_workspace_id is not None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
     service = AgentCatalogService(session=session)
     try:
         params = CursorPaginationParams(cursor=cursor, limit=limit)
@@ -59,11 +66,14 @@ async def list_catalog(
 @require_scope("agent:read")
 async def get_catalog_entry(
     catalog_id: UUID,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
 ) -> AgentCatalogRead:
     """Get a specific catalog entry."""
-    assert role.organization_id is not None  # OrgUserRole guarantees this
+    assert role.organization_id is not None  # OrgActorRole guarantees this
+    # Workspace-bound keys must use the workspace-effective model view instead.
+    if role.type == "service_account" and role.bound_workspace_id is not None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
     service = AgentCatalogService(session=session)
     try:
         row = await service.get_catalog_entry(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose catalog IDs for custom models in the UI. Allow org actors with `agent:read` to read the catalog; block workspace-bound service accounts; keep writes user-only.

- **New Features**
  - UI: Replaced the toggle button with an actions menu (Enable/Disable, Copy catalog ID) with success/failure toasts.
  - API/Auth: `list_catalog` and `get_catalog_entry` accept org actors under `agent:read`; workspace-bound service accounts return 403; create/update/delete remain user-only.
  - Tests: Added scope and role guard coverage, including org service accounts allowed on reads and workspace-bound keys denied.

<sup>Written for commit 45d23a240c22f4b1f568b6717206d8ebb03b2b71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

