### PR TITLE
fix(ui): render workspace sync toast as external link

### DIFF
--- a/frontend/src/components/workspace-sync/push-tab.tsx
+++ b/frontend/src/components/workspace-sync/push-tab.tsx
@@ -1,17 +1,24 @@
 "use client"
 
-import { ArrowUpIcon, GitPullRequestIcon, Loader2Icon } from "lucide-react"
+import {
+  ArrowUpIcon,
+  ExternalLinkIcon,
+  GitPullRequestIcon,
+  Loader2Icon,
+} from "lucide-react"
 import { useEffect, useState } from "react"
 import type { GitBranchInfo, VcsProvider } from "@/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { ToastAction } from "@/components/ui/toast"
 import { toast } from "@/components/ui/use-toast"
 import {
   useWorkspaceSyncBranchTarget,
   WorkspaceSyncBranchSelector,
 } from "@/components/workspace-sync/branch-target-selector"
 import {
+  getReviewRequestAbbreviation,
   getReviewRequestLabel,
   getWorkspaceSyncPushButtonLabel,
   getWorkspaceSyncPushOutcome,
@@ -130,8 +137,23 @@ export function WorkspaceSyncPushTab({
         title: result.commit.pr_url
           ? `${reviewRequestTitle} ready`
           : "Workspace config pushed",
-        description:
-          result.commit.pr_url ?? result.commit.sha ?? result.commit.message,
+        description: result.commit.message ?? result.commit.sha ?? undefined,
+        action: result.commit.pr_url ? (
+          <ToastAction
+            asChild
+            altText={`Open ${getReviewRequestLabel(provider)}`}
+            className="gap-1.5"
+          >
+            <a
+              href={result.commit.pr_url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View {getReviewRequestAbbreviation(provider)}
+              <ExternalLinkIcon className="size-3.5" />
+            </a>
+          </ToastAction>
+        ) : undefined,
       })
     } catch (error) {
       toast({

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -14,6 +14,8 @@ import type {
   WorkspaceSyncExportPreview,
 } from "@/client"
 import { WorkspaceSyncSettings } from "@/components/settings/workspace-sync-settings"
+import { Toast, ToastProvider, ToastViewport } from "@/components/ui/toast"
+import { toast } from "@/components/ui/use-toast"
 import {
   useRepositoryBranches,
   useRepositoryCommits,
@@ -39,6 +41,10 @@ jest.mock("@/hooks/use-workspace-sync", () => ({
   useWorkflowSync: jest.fn(),
   useWorkspaceSyncExport: jest.fn(),
   useWorkspaceSyncExportPreview: jest.fn(),
+}))
+
+jest.mock("@/components/ui/use-toast", () => ({
+  toast: jest.fn(),
 }))
 
 beforeAll(() => {
@@ -523,6 +529,61 @@ describe("WorkspaceSyncSettings", () => {
     expect(
       screen.getByText("workflows/root/definition.yml")
     ).toBeInTheDocument()
+  })
+
+  it("renders the workspace push review request as an external link", async () => {
+    const user = userEvent.setup()
+    const prUrl = "https://github.com/test-org/repo-a/pull/42"
+    const connectedWorkspace = setupHooks({
+      gitRepoUrl: repositories[0].git_url,
+      branches: [{ name: "main", is_default: true }],
+    })
+    mockExportWorkspace.mockResolvedValue({
+      commit: {
+        status: "committed",
+        sha: "a".repeat(40),
+        ref: "sync/workspace-test",
+        base_ref: "main",
+        pr_url: prUrl,
+        message: "Export workspace config",
+      },
+      files: ["tracecat.json"],
+    })
+
+    render(<WorkspaceSyncSettings workspace={connectedWorkspace} />)
+
+    await user.click(screen.getByRole("button", { name: "Push & open PR" }))
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Pull request ready",
+          description: "Export workspace config",
+          action: expect.anything(),
+        })
+      )
+    })
+
+    const toastOptions = jest.mocked(toast).mock.calls[0][0]
+    render(
+      <ToastProvider>
+        <Toast open>{toastOptions.action}</Toast>
+        <ToastViewport />
+      </ToastProvider>
+    )
+
+    expect(screen.getByRole("link", { name: "View PR" })).toHaveAttribute(
+      "href",
+      prUrl
+    )
+    expect(screen.getByRole("link", { name: "View PR" })).toHaveAttribute(
+      "target",
+      "_blank"
+    )
+    expect(screen.getByRole("link", { name: "View PR" })).toHaveAttribute(
+      "rel",
+      "noopener noreferrer"
+    )
   })
 
   it("keeps pull actions available after previewing changes", async () => {


### PR DESCRIPTION
## Summary

- render the Workspace Sync Push review-request action as a semantic external link
- open the generated PR or MR in a new tab with safe `rel` attributes and an external-link icon
- keep the commit message in the toast description and cover the link semantics with a focused regression test

## Root cause

The push-success toast placed `commit.pr_url` directly in its description. The shared toaster renders descriptions as plain content, so the URL appeared as text instead of an actionable external link.

## Impact

Users can now open the generated GitHub pull request or GitLab merge request directly from the Workspace Sync Push toast. The link is also exposed correctly to assistive technology.

## Validation

- `pnpm -C frontend test --runInBand workspace-sync-settings.test.tsx`
- `pnpm -C frontend exec biome check --write src/components/workspace-sync/push-tab.tsx tests/workspace-sync-settings.test.tsx`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the Workspace Sync Push toast with a real external link so users can open the created PR/MR in a new tab. Fixes the plain-text URL issue and improves accessibility.

- **Bug Fixes**
  - Use `ToastAction` with an anchor for `commit.pr_url`, labeled with provider abbreviation and an external-link icon.
  - Open in a new tab with `target="_blank"` and `rel="noopener noreferrer"`.
  - Keep the commit message in the toast description; title shows “<PR/MR> ready” when available.
  - Add a focused test to verify link label, href, target, and rel.

<sup>Written for commit cc9809d1a0630b0e3585228456eed4bd1e829881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

