### PR TITLE
feat(agents): template referencing for mcp integrations

### DIFF
--- a/docs/automations/integrations/mcp-integrations.mdx
+++ b/docs/automations/integrations/mcp-integrations.mdx
@@ -42,18 +42,14 @@ For a custom remote MCP server, first create a custom OAuth provider in [OAuth](
 
 ### Custom headers for remote MCP
 
-`Custom` authentication stores request headers as JSON.
+`Custom` authentication stores request headers as JSON. Header values support workspace secret and variable expressions.
 
 ```json
 {
-  "Authorization": "Bearer token123",
-  "X-API-Key": "abc123"
+  "Authorization": "ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}",
+  "X-Tenant": "${{ VARS.elastic_security.tenant }}"
 }
 ```
-
-<Info>
-Remote MCP custom header JSON does not resolve `${{ SECRETS.* }}` or `${{ VARS.* }}`. Header values are sent as literal strings.
-</Info>
 
 ## Stdio MCP
 
@@ -72,11 +68,7 @@ Tracecat resolves those expressions from the workflow default environment unless
 
 ## Secrets and variables in MCP configuration
 
-Expression support differs by MCP integration type:
-
-- `stdio` environment variables support `${{ SECRETS.* }}` and `${{ VARS.* }}`.
-- Remote MCP OAuth mode does not need secret expressions for the bearer token because Tracecat injects the OAuth token automatically.
-- Remote MCP custom header JSON does not currently resolve `${{ SECRETS.* }}` or `${{ VARS.* }}`.
+Both remote and `stdio` MCP integrations support template strings.
 
 ## Related pages
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -16022,6 +16022,10 @@ export const $MCPHttpServerConfig = {
       type: "string",
       title: "Id",
     },
+    environment: {
+      type: "string",
+      title: "Environment",
+    },
   },
   type: "object",
   required: ["name", "url"],
@@ -17000,6 +17004,10 @@ export const $MCPStdioServerConfig = {
     id: {
       type: "string",
       title: "Id",
+    },
+    environment: {
+      type: "string",
+      title: "Environment",
     },
     tools: {
       items: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4951,6 +4951,7 @@ export type MCPHttpServerConfig = {
   transport?: "http" | "sse"
   timeout?: number
   id?: string
+  environment?: string
 }
 
 export type transport = "http" | "sse"
@@ -5198,6 +5199,7 @@ export type MCPStdioServerConfig = {
   }
   timeout?: number
   id?: string
+  environment?: string
   tools?: Array<MCPServerToolSummary>
 }
 

--- a/frontend/src/components/editor/codemirror/code-editor.tsx
+++ b/frontend/src/components/editor/codemirror/code-editor.tsx
@@ -17,6 +17,7 @@ interface CodeEditorProps {
   readOnly?: boolean
   wrapLongLines?: boolean
   className?: string
+  additionalExtensions?: Extension[]
 }
 
 function getLanguageExtension(language: string): Extension | null {
@@ -40,6 +41,7 @@ export function CodeEditor({
   readOnly = false,
   wrapLongLines = false,
   className,
+  additionalExtensions = [],
 }: CodeEditorProps) {
   const { resolvedTheme } = useTheme()
   const codeMirrorTheme = resolvedTheme === "dark" ? "dark" : "light"
@@ -47,6 +49,7 @@ export function CodeEditor({
   const extensions = [
     ...(languageExtension ? [languageExtension] : []),
     ...(wrapLongLines ? [EditorView.lineWrapping] : []),
+    ...additionalExtensions,
   ]
 
   return (
@@ -54,6 +57,9 @@ export function CodeEditor({
       value={value}
       onChange={onChange}
       extensions={extensions}
+      basicSetup={
+        additionalExtensions.length > 0 ? { autocompletion: false } : undefined
+      }
       theme={codeMirrorTheme}
       readOnly={readOnly}
       className={cn(

--- a/frontend/src/components/editor/codemirror/common.tsx
+++ b/frontend/src/components/editor/codemirror/common.tsx
@@ -1185,6 +1185,11 @@ export const TEMPLATE_SUGGESTIONS = [
     info: "For each item in the array",
   },
 ]
+type TemplateSuggestion = (typeof TEMPLATE_SUGGESTIONS)[number]
+
+const WORKSPACE_MAPPING_TEMPLATE_SUGGESTIONS = TEMPLATE_SUGGESTIONS.filter(
+  (suggestion) => suggestion.label === "SECRETS" || suggestion.label === "VARS"
+)
 
 // Custom keymap for @ key to trigger completions
 export function createAtKeyCompletion() {
@@ -1229,9 +1234,9 @@ export function createExitEditModeKeyHandler() {
 }
 
 // Completion functions
-export function createMentionCompletion(): (
-  context: CompletionContext
-) => CompletionResult | null {
+export function createMentionCompletion(
+  suggestions: readonly TemplateSuggestion[] = TEMPLATE_SUGGESTIONS
+): (context: CompletionContext) => CompletionResult | null {
   return (context: CompletionContext): CompletionResult | null => {
     const word = context.matchBefore(/@\w*/)
     if (!word) return null
@@ -1244,7 +1249,7 @@ export function createMentionCompletion(): (
 
     return {
       from: word.from,
-      options: TEMPLATE_SUGGESTIONS.map((suggestion) => ({
+      options: suggestions.map((suggestion) => ({
         label: `@${suggestion.label}`,
         detail: suggestion.detail,
         info: suggestion.info,
@@ -2065,6 +2070,19 @@ export function createAutocomplete({
       createSecretsCompletion(workspaceId),
       createVarsCompletion(workspaceId),
       createEnvCompletion(),
+    ],
+  })
+}
+
+/**
+ * Create secret and variable completions for workspace configuration mappings.
+ */
+export function createWorkspaceMappingAutocomplete(workspaceId: string) {
+  return autocompletion({
+    override: [
+      createMentionCompletion(WORKSPACE_MAPPING_TEMPLATE_SUGGESTIONS),
+      createSecretsCompletion(workspaceId),
+      createVarsCompletion(workspaceId),
     ],
   })
 }

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { completionKeymap } from "@codemirror/autocomplete"
+import { keymap } from "@codemirror/view"
 import { zodResolver } from "@hookform/resolvers/zod"
 import {
   Check,
@@ -30,6 +32,12 @@ import type {
 } from "@/client/types.gen"
 import { useScopeCheck } from "@/components/auth/scope-guard"
 import { CodeEditor } from "@/components/editor/codemirror/code-editor"
+import {
+  createAtKeyCompletion,
+  createWorkspaceMappingAutocomplete,
+  templatePillTheme,
+} from "@/components/editor/codemirror/common"
+import { createSimpleTemplatePlugin } from "@/components/editor/codemirror/highlight-plugin"
 import { getMcpProviderIconId, ProviderIcon } from "@/components/icons"
 import {
   ALLOWED_COMMANDS,
@@ -408,6 +416,16 @@ export function MCPIntegrationDialog({
   catalogEntry?: PlatformMCPCatalogRead | null
 }) {
   const workspaceId = useWorkspaceId()
+  const mcpTemplateEditorExtensions = React.useMemo(
+    () => [
+      createWorkspaceMappingAutocomplete(workspaceId),
+      createAtKeyCompletion(),
+      keymap.of(completionKeymap),
+      createSimpleTemplatePlugin(workspaceId),
+      templatePillTheme,
+    ],
+    [workspaceId]
+  )
   const isEditMode = Boolean(mcpIntegrationId)
   const { connectMcpIntegration, connectMcpIntegrationIsPending } =
     useConnectMcpIntegration(workspaceId)
@@ -1479,6 +1497,9 @@ export function MCPIntegrationDialog({
                                 value={field.value || ""}
                                 onChange={field.onChange}
                                 language="json"
+                                additionalExtensions={
+                                  mcpTemplateEditorExtensions
+                                }
                                 className="font-mono text-xs [&_.cm-content]:text-xs [&_.cm-editor]:min-h-[80px]"
                               />
                             </FormControl>
@@ -1761,12 +1782,17 @@ export function MCPIntegrationDialog({
                                     value={field.value || ""}
                                     onChange={field.onChange}
                                     language="json"
+                                    additionalExtensions={
+                                      mcpTemplateEditorExtensions
+                                    }
                                     className="font-mono text-xs [&_.cm-content]:text-xs [&_.cm-editor]:min-h-[120px]"
                                   />
                                 </FormControl>
                                 <FormDescription className="text-xs">
                                   Authorization is set from OAuth and cannot be
-                                  overridden.
+                                  overridden. Type <code>@SECRETS</code> or{" "}
+                                  <code>@VARS</code> to insert a workspace
+                                  expression in another header value.
                                 </FormDescription>
                                 <FormMessage />
                               </FormItem>
@@ -1809,12 +1835,20 @@ export function MCPIntegrationDialog({
                               value={field.value || ""}
                               onChange={field.onChange}
                               language="json"
+                              additionalExtensions={mcpTemplateEditorExtensions}
                               className="font-mono text-xs [&_.cm-content]:text-xs [&_.cm-editor]:min-h-[120px]"
                             />
                           </FormControl>
                           <FormDescription className="text-xs">
-                            Enter headers as a JSON object, for example{" "}
-                            <code>{`{"Authorization":"Bearer token123"}`}</code>
+                            Enter headers as JSON. Type <code>@SECRETS</code> or{" "}
+                            <code>@VARS</code> to insert a workspace expression,
+                            such as{" "}
+                            <code>
+                              {
+                                '{"Authorization":"ApiKey ${{ SECRETS.elastic.API_KEY }}"}'
+                              }
+                            </code>
+                            .
                           </FormDescription>
                           <FormMessage />
                         </FormItem>

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -336,7 +336,8 @@ class AgentActivities:
                     for hydrated, integration_id in configs_with_integration_id:
                         try:
                             secrets = await svc.resolve_mcp_integration_secrets(
-                                integration_id
+                                integration_id,
+                                environment=hydrated.get("environment"),
                             )
                         except (ValueError, MCPSecretResolutionError):
                             secrets = None
@@ -389,12 +390,13 @@ class AgentActivities:
                             effective_tool_approvals[approval_key] = True
                     defs[tool_name] = tool_def
 
-                # JWT claims carry the source integration id when available so
-                # the trusted MCP server can re-resolve headers per call. For
-                # legacy in-flight payloads that don't carry ``id`` (recorded
-                # before the refs-only cutover), fall back to the pre-rollout
-                # inline shape — otherwise discovery would add ``mcp__*`` tools
-                # that the trusted server can't authorize at call time.
+                # JWT claims carry the source integration id and effective
+                # environment when available so the trusted MCP server can
+                # re-resolve the correct headers per call. For legacy in-flight
+                # payloads that don't carry ``id`` (recorded before the
+                # refs-only cutover), fall back to the pre-rollout inline shape
+                # — otherwise discovery would add ``mcp__*`` tools that the
+                # trusted server can't authorize at call time.
                 user_mcp_claims = []
                 for cfg in http_servers:
                     integration_id_str = cfg.get("id")
@@ -403,6 +405,7 @@ class AgentActivities:
                             UserMCPServerClaim(
                                 name=cfg["name"],
                                 id=uuid.UUID(integration_id_str),
+                                environment=cfg.get("environment"),
                             )
                         )
                         continue

--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -18,6 +18,7 @@ _BASE_CONFIG = ConfigDict(extra="ignore")
 class AgentActionArgs(BaseModel):
     model_config = _BASE_CONFIG
 
+    environment: str | None = None
     user_prompt: str
     model_name: str
     model_provider: str
@@ -79,6 +80,7 @@ class AgentActionArgs(BaseModel):
 class PresetAgentActionArgs(BaseModel):
     model_config = _BASE_CONFIG
 
+    environment: str | None = None
     preset: str
     preset_version: int | None = None
     user_prompt: str

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -51,9 +51,13 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.parsers import try_parse_json
     from tracecat.agent.preset.activities import (
         ResolveAgentPresetConfigActivityInput,
+        ResolveAgentPresetConfigWithEnvironmentActivityInput,
         ResolveAgentsConfigActivityInput,
+        ResolveAgentsConfigWithEnvironmentActivityInput,
         resolve_agent_preset_config_activity,
+        resolve_agent_preset_config_with_environment_activity,
         resolve_agents_config_activity,
+        resolve_agents_config_with_environment_activity,
         resolve_custom_model_provider_config_activity,
     )
     from tracecat.agent.preset.resolver import (
@@ -400,6 +404,8 @@ class AgentWorkflowArgs(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     role: Role
+    environment: str | None = None
+    """Effective DSL action environment for workspace-backed agent resources."""
     agent_args: RunAgentArgs
     # Session metadata
     title: str = Field(default="New Chat", description="Session title")
@@ -471,6 +477,7 @@ LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-histo
 PRESERVE_RESUMED_AGENT_BINDINGS_PATCH = (
     "durable-agent-preserve-resumed-agent-bindings-v1"
 )
+AGENT_ACTION_ENVIRONMENT_PATCH = "durable-agent-action-environment-v1"
 
 
 def _agents_config_from_binding(
@@ -599,24 +606,45 @@ class DurableAgentWorkflow:
 
     async def _build_config(self, args: AgentWorkflowArgs) -> AgentConfig:
         if args.agent_args.preset_slug:
-            activity_input = (
-                ResolveAgentPresetConfigActivityInput(
-                    role=self.role,
-                    preset_version_id=args.agent_preset_version_id,
+            use_action_environment = workflow.patched(AGENT_ACTION_ENVIRONMENT_PATCH)
+            if use_action_environment and args.environment is not None:
+                preset_config_payload = await workflow.execute_activity(
+                    resolve_agent_preset_config_with_environment_activity,
+                    (
+                        ResolveAgentPresetConfigWithEnvironmentActivityInput(
+                            role=self.role,
+                            preset_version_id=args.agent_preset_version_id,
+                            environment=args.environment,
+                        )
+                        if args.agent_preset_version_id is not None
+                        else ResolveAgentPresetConfigWithEnvironmentActivityInput(
+                            role=self.role,
+                            preset_slug=args.agent_args.preset_slug,
+                            preset_version=args.agent_args.preset_version,
+                            environment=args.environment,
+                        )
+                    ),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
                 )
-                if args.agent_preset_version_id is not None
-                else ResolveAgentPresetConfigActivityInput(
-                    role=self.role,
-                    preset_slug=args.agent_args.preset_slug,
-                    preset_version=args.agent_args.preset_version,
+            else:
+                preset_config_payload = await workflow.execute_activity(
+                    resolve_agent_preset_config_activity,
+                    (
+                        ResolveAgentPresetConfigActivityInput(
+                            role=self.role,
+                            preset_version_id=args.agent_preset_version_id,
+                        )
+                        if args.agent_preset_version_id is not None
+                        else ResolveAgentPresetConfigActivityInput(
+                            role=self.role,
+                            preset_slug=args.agent_args.preset_slug,
+                            preset_version=args.agent_args.preset_version,
+                        )
+                    ),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
                 )
-            )
-            preset_config_payload = await workflow.execute_activity(
-                resolve_agent_preset_config_activity,
-                activity_input,
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=RETRY_POLICIES["activity:fail_fast"],
-            )
             preset_config = agent_config_from_payload(preset_config_payload)
             # Apply overrides from the provided config (if any)
             # When using a preset, the 'config' in args acts as an override layer
@@ -660,6 +688,21 @@ class DurableAgentWorkflow:
             return ResolvedAgentsRuntimeConfig()
         if not agents_config.subagents:
             return ResolvedAgentsRuntimeConfig(enabled=True)
+        use_action_environment = workflow.patched(AGENT_ACTION_ENVIRONMENT_PATCH)
+        if use_action_environment and args.environment is not None:
+            return await workflow.execute_activity(
+                resolve_agents_config_with_environment_activity,
+                ResolveAgentsConfigWithEnvironmentActivityInput(
+                    role=self.role,
+                    agents=agents_config,
+                    parent_preset_id=args.agent_preset_id,
+                    parent_slug=args.agent_args.preset_slug,
+                    follow_latest_versions=follow_latest_versions,
+                    environment=args.environment,
+                ),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
         return await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(

--- a/tests/temporal/test_agent_config_workflow_boundary.py
+++ b/tests/temporal/test_agent_config_workflow_boundary.py
@@ -57,6 +57,7 @@ def _build_agent_config() -> TracecatAgentConfig:
                 "url": "http://host.docker.internal:8080",
                 "transport": "http",
                 "headers": {"Authorization": "Bearer secret123"},
+                "environment": "staging",
             }
         ],
         model_settings={"parallel_tool_calls": False},
@@ -113,6 +114,7 @@ class AgentConfigDecodeWorkflow:
                 "url": "http://host.docker.internal:8080",
                 "transport": "http",
                 "headers": {"Authorization": "Bearer secret123"},
+                "environment": "staging",
             }
         ]
         assert config.model_settings == {"parallel_tool_calls": False}
@@ -220,8 +222,9 @@ async def test_legacy_agent_config_payload_replays_as_agent_config_payload(
 # These pin that:
 #   * the legacy MCP server shape (no ``id``, inline ``headers``) recorded in
 #     pre-rollout workflow history still decodes,
-#   * the new ref shape (carrying ``id``, no ``headers``) round-trips through
-#     the workflow boundary so trusted callers can re-resolve secrets,
+#   * the new ref shape (carrying ``id`` and ``environment``, no ``headers``)
+#     round-trips through the workflow boundary so trusted callers can
+#     re-resolve secrets,
 #   * a payload containing a mix of the two shapes (and a stdio server)
 #     decodes intact.
 # ---------------------------------------------------------------------------
@@ -246,7 +249,7 @@ def _legacy_mcp_agent_config() -> TracecatAgentConfig:
 
 
 def _ref_mcp_agent_config() -> TracecatAgentConfig:
-    """Post-rollout config: ``id`` set, no ``headers``."""
+    """Post-rollout config: ``id`` and ``environment`` set, no ``headers``."""
     return TracecatAgentConfig(
         model_name="gpt-5.2",
         model_provider="openai",
@@ -257,6 +260,7 @@ def _ref_mcp_agent_config() -> TracecatAgentConfig:
                 "url": "http://host.docker.internal:8080",
                 "transport": "http",
                 "id": "11111111-1111-1111-1111-111111111111",
+                "environment": "staging",
             }
         ],
         retries=3,
@@ -277,13 +281,14 @@ def _mixed_mcp_agent_config() -> TracecatAgentConfig:
                 "transport": "http",
                 "headers": {"Authorization": "Bearer legacy"},
             },
-            # New http with id, no headers
+            # New http with id and environment, no headers
             {
                 "type": "http",
                 "name": "modern",
                 "url": "http://modern.local",
                 "transport": "http",
                 "id": "22222222-2222-2222-2222-222222222222",
+                "environment": "staging",
             },
             # Stdio with id
             {
@@ -292,6 +297,7 @@ def _mixed_mcp_agent_config() -> TracecatAgentConfig:
                 "command": "/usr/bin/echo",
                 "args": ["hello"],
                 "id": "33333333-3333-3333-3333-333333333333",
+                "environment": "production",
                 "tools": [
                     {
                         "name": "list_alerts",
@@ -396,7 +402,7 @@ async def test_legacy_mcp_payload_decodes_without_id(
 async def test_ref_mcp_payload_preserves_id_across_boundary(
     env: WorkflowEnvironment,
 ) -> None:
-    """New ref shape must round-trip with ``id`` intact and no headers added."""
+    """New ref shape preserves ``id`` and ``environment`` without adding headers."""
     task_queue = "test-ref-mcp-payload-decode"
     async with Worker(
         env.client,
@@ -419,6 +425,7 @@ async def test_ref_mcp_payload_preserves_id_across_boundary(
             "url": "http://host.docker.internal:8080",
             "transport": "http",
             "id": "11111111-1111-1111-1111-111111111111",
+            "environment": "staging",
         }
     ]
 
@@ -457,6 +464,7 @@ async def test_mixed_mcp_payload_decodes_intact(
             "url": "http://modern.local",
             "transport": "http",
             "id": "22222222-2222-2222-2222-222222222222",
+            "environment": "staging",
         },
         {
             "type": "stdio",
@@ -464,6 +472,7 @@ async def test_mixed_mcp_payload_decodes_intact(
             "command": "/usr/bin/echo",
             "args": ["hello"],
             "id": "33333333-3333-3333-3333-333333333333",
+            "environment": "production",
             "tools": [
                 {
                     "name": "list_alerts",

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -326,8 +326,11 @@ class TestBuildToolDefinitionsActivity:
             async def resolve_mcp_integration_secrets(
                 self,
                 mcp_integration_id: uuid.UUID,
+                *,
+                environment: str | None = None,
             ) -> dict[str, str]:
                 assert mcp_integration_id == integration_id
+                assert environment == "staging"
                 return {"authorization": "Bearer test-token"}
 
         class _PresetContext:
@@ -395,6 +398,7 @@ class TestBuildToolDefinitionsActivity:
                         "name": "Jira",
                         "url": "https://mcp.example.com/mcp",
                         "id": str(integration_id),
+                        "environment": "staging",
                     }
                 ],
             )
@@ -404,6 +408,7 @@ class TestBuildToolDefinitionsActivity:
         assert result.tool_approvals == {"mcp.Jira.getIssue": True}
         assert result.user_mcp_claims is not None
         assert result.user_mcp_claims[0].id == integration_id
+        assert result.user_mcp_claims[0].environment == "staging"
         assert entitlement_roles == [mock_role]
 
     @pytest.mark.anyio
@@ -468,7 +473,10 @@ class TestBuildToolDefinitionsActivity:
             async def resolve_mcp_integration_secrets(
                 self,
                 mcp_integration_id: uuid.UUID,
+                *,
+                environment: str | None = None,
             ) -> dict[str, str]:
+                _ = environment
                 return {}
 
         class _PresetContext:

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -109,8 +109,14 @@ async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
                 }
             ]
 
-        async def resolve_mcp_integration_secrets(self, resolved_integration_id):
+        async def resolve_mcp_integration_secrets(
+            self,
+            resolved_integration_id,
+            *,
+            environment=None,
+        ):
             assert resolved_integration_id == integration_id
+            assert environment == "staging"
             return {"Authorization": "Bearer secret"}
 
     monkeypatch.setattr(
@@ -142,7 +148,13 @@ async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
         {"key": "SEC-1"},
         _build_claims(
             allowed_actions=["mcp__Jira__getIssue"],
-            user_mcp_servers=[UserMCPServerClaim(name="Jira", id=integration_id)],
+            user_mcp_servers=[
+                UserMCPServerClaim(
+                    name="Jira",
+                    id=integration_id,
+                    environment="staging",
+                )
+            ],
         ),
     )
 
@@ -529,8 +541,14 @@ async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
                 }
             ]
 
-        async def resolve_mcp_integration_secrets(self, resolved_integration_id):
+        async def resolve_mcp_integration_secrets(
+            self,
+            resolved_integration_id,
+            *,
+            environment=None,
+        ):
             assert resolved_integration_id == integration_id
+            assert environment is None
             return {}
 
     discovered_config_names: list[list[str]] = []

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -4,15 +4,19 @@ import uuid
 from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from tracecat.agent.preset.activities import (
+    ResolveAgentPresetConfigWithEnvironmentActivityInput,
     ResolveAgentPresetVersionRefActivityInput,
     ResolveAgentsConfigActivityInput,
+    ResolveAgentsConfigWithEnvironmentActivityInput,
+    resolve_agent_preset_config_with_environment_activity,
     resolve_agent_preset_version_ref_activity,
     resolve_agents_config_activity,
+    resolve_agents_config_with_environment_activity,
     resolve_custom_model_provider_config_activity,
 )
 from tracecat.agent.preset.resolver import (
@@ -115,6 +119,46 @@ def test_resolve_agents_config_result_derives_session_binding() -> None:
     agents_binding = result.to_agents_binding()
     assert agents_binding.enabled is True
     assert agents_binding.subagents == [binding]
+
+
+@pytest.mark.anyio
+async def test_resolve_agent_preset_config_uses_action_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    config = AgentConfig(
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        retries=3,
+    )
+    with_preset_config = Mock(return_value=_AsyncContext(config))
+    service = SimpleNamespace(with_preset_config=with_preset_config)
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentManagementService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    result = await resolve_agent_preset_config_with_environment_activity(
+        ResolveAgentPresetConfigWithEnvironmentActivityInput(
+            role=role,
+            preset_slug="triage-agent",
+            environment="staging",
+        )
+    )
+
+    with_preset_config.assert_called_once_with(
+        preset_id=None,
+        slug="triage-agent",
+        preset_version_id=None,
+        preset_version=None,
+        environment="staging",
+    )
+    assert result.model_name == "gpt-4o-mini"
 
 
 @pytest.mark.anyio
@@ -227,6 +271,66 @@ async def test_resolve_agents_config_resolves_pinned_ref_by_version_id(
     service.use_latest_resource_versions.assert_awaited_once()
     assert result.subagents[0].binding.preset_version_id == preset_version_id
     assert result.subagents[0].binding.preset_version == 4
+
+
+@pytest.mark.anyio
+async def test_resolve_subagent_config_uses_action_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preset_id = uuid.uuid4()
+    preset_version_id = uuid.uuid4()
+    version = SimpleNamespace(
+        id=preset_version_id,
+        preset_id=preset_id,
+        version=4,
+        agents={"enabled": False},
+        tool_approvals={},
+    )
+    service = SimpleNamespace(
+        resolve_agent_preset_version=AsyncMock(return_value=version),
+        get_preset=AsyncMock(return_value=SimpleNamespace(description="Child preset")),
+        resolve_agent_preset_config=AsyncMock(
+            return_value=AgentConfig(
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                retries=3,
+            )
+        ),
+        use_latest_resource_versions=AsyncMock(return_value=False),
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    await resolve_agents_config_with_environment_activity(
+        ResolveAgentsConfigWithEnvironmentActivityInput(
+            role=role,
+            agents=AgentSubagentsConfig(
+                enabled=True,
+                subagents=[
+                    ResolvedAttachedSubagentRef(
+                        preset="analyst",
+                        preset_version=4,
+                        preset_id=preset_id,
+                        preset_version_id=preset_version_id,
+                    )
+                ],
+            ),
+            environment="staging",
+        )
+    )
+
+    service.resolve_agent_preset_config.assert_awaited_once_with(
+        preset_version_id=preset_version_id,
+        environment="staging",
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -19,6 +19,7 @@ from tracecat.agent.channels.schemas import (
     SlackChannelTokenConfig,
 )
 from tracecat.agent.channels.service import PENDING_SLACK_BOT_TOKEN, AgentChannelService
+from tracecat.agent.mcp.secret_resolution import TemplatedMappingResolutionError
 from tracecat.agent.preset.resolver import resolve_agents_config
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
@@ -277,6 +278,88 @@ async def registry_actions(
     return actions
 
 
+@pytest.mark.anyio
+async def test_resolve_stdio_env_resolves_secrets_variables_and_literals(
+    agent_preset_service: AgentPresetService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stdio env resolves workspace secrets, variables, and literals."""
+    suffix = uuid.uuid4().hex
+    secret_name = f"stdio_secret_{suffix}"
+    secret_value = f"stdio-secret-value-{suffix}"
+    variable_name = f"stdio_variable_{suffix}"
+    variable_value = f"stdio-variable-value-{suffix}"
+
+    async def get_action_secrets(**_: object) -> dict[str, dict[str, str]]:
+        return {secret_name: {"TOKEN": secret_value}}
+
+    async def get_workspace_variables(
+        *_: object, **__: object
+    ) -> dict[str, dict[str, str]]:
+        return {variable_name: {"host": variable_value}}
+
+    monkeypatch.setattr(
+        "tracecat.secrets.secrets_manager.get_action_secrets",
+        get_action_secrets,
+    )
+    monkeypatch.setattr(
+        "tracecat.executor.service.get_workspace_variables",
+        get_workspace_variables,
+    )
+    stdio_env = {
+        "TOKEN": f"${{{{ SECRETS.{secret_name}.TOKEN }}}}",
+        "HOST": f"prefix-${{{{ VARS.{variable_name}.host }}}}",
+        "LITERAL": "literal-value",
+    }
+
+    resolved = await agent_preset_service.resolve_stdio_env(
+        stdio_env=stdio_env,
+        mcp_integration_id=uuid.uuid4(),
+        mcp_integration_slug=f"stdio-template-{suffix}",
+    )
+
+    assert resolved == {
+        "TOKEN": secret_value,
+        "HOST": f"prefix-{variable_value}",
+        "LITERAL": "literal-value",
+    }
+
+
+@pytest.mark.anyio
+async def test_resolve_stdio_env_missing_reference_fails_closed(
+    agent_preset_service: AgentPresetService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unresolvable stdio env references raise instead of resolving to None."""
+    missing_secret_name = f"missing_stdio_secret_{uuid.uuid4().hex}"
+
+    async def get_action_secrets(**_: object) -> dict[str, dict[str, str]]:
+        return {}
+
+    async def get_workspace_variables(
+        *_: object, **__: object
+    ) -> dict[str, dict[str, str]]:
+        return {}
+
+    monkeypatch.setattr(
+        "tracecat.secrets.secrets_manager.get_action_secrets",
+        get_action_secrets,
+    )
+    monkeypatch.setattr(
+        "tracecat.executor.service.get_workspace_variables",
+        get_workspace_variables,
+    )
+
+    with pytest.raises(TemplatedMappingResolutionError) as exc_info:
+        await agent_preset_service.resolve_stdio_env(
+            stdio_env={"TOKEN": f"${{{{ SECRETS.{missing_secret_name}.TOKEN }}}}"},
+            mcp_integration_id=uuid.uuid4(),
+            mcp_integration_slug="stdio-missing-secret",
+        )
+
+    assert missing_secret_name in str(exc_info.value)
+
+
 @pytest.fixture
 def agent_preset_create_params() -> AgentPresetCreate:
     """Sample agent preset creation parameters."""
@@ -320,11 +403,11 @@ async def test_resolve_stdio_env_uses_explicit_environment(
         return {"tenant": {"id": "staging-tenant"}}
 
     monkeypatch.setattr(
-        "tracecat.agent.preset.service.secrets_manager.get_action_secrets",
+        "tracecat.secrets.secrets_manager.get_action_secrets",
         get_action_secrets,
     )
     monkeypatch.setattr(
-        "tracecat.agent.preset.service.get_workspace_variables",
+        "tracecat.executor.service.get_workspace_variables",
         get_workspace_variables,
     )
 

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -299,6 +299,54 @@ def agent_preset_create_params() -> AgentPresetCreate:
 
 
 @pytest.mark.anyio
+async def test_resolve_stdio_env_uses_explicit_environment(
+    agent_preset_service: AgentPresetService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_secret_environments: list[str | None] = []
+    requested_variable_environments: list[str | None] = []
+
+    async def get_action_secrets(
+        **kwargs: object,
+    ) -> dict[str, dict[str, str]]:
+        requested_secret_environments.append(cast(str | None, kwargs["environment"]))
+        return {"api": {"TOKEN": "staging-token"}}
+
+    async def get_workspace_variables(
+        *_: object,
+        **kwargs: object,
+    ) -> dict[str, dict[str, str]]:
+        requested_variable_environments.append(cast(str | None, kwargs["environment"]))
+        return {"tenant": {"id": "staging-tenant"}}
+
+    monkeypatch.setattr(
+        "tracecat.agent.preset.service.secrets_manager.get_action_secrets",
+        get_action_secrets,
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.service.get_workspace_variables",
+        get_workspace_variables,
+    )
+
+    resolved = await agent_preset_service.resolve_stdio_env(
+        stdio_env={
+            "TOKEN": "${{ SECRETS.api.TOKEN }}",
+            "TENANT": "${{ VARS.tenant.id }}",
+        },
+        mcp_integration_id=uuid.uuid4(),
+        mcp_integration_slug="environment-scoped-stdio",
+        environment="staging",
+    )
+
+    assert resolved == {
+        "TOKEN": "staging-token",
+        "TENANT": "staging-tenant",
+    }
+    assert requested_secret_environments == ["staging"]
+    assert requested_variable_environments == ["staging"]
+
+
+@pytest.mark.anyio
 class TestAgentPresetService:
     async def test_create_and_get_preset(
         self,

--- a/tests/unit/test_agent_tokens.py
+++ b/tests/unit/test_agent_tokens.py
@@ -90,8 +90,9 @@ def test_mcp_token_accepts_legacy_user_mcp_server_claim_shape(monkeypatch) -> No
 
 
 def test_mcp_token_round_trips_refs_only_user_mcp_server_claim(monkeypatch) -> None:
-    """New-shape claims (``name`` + ``id`` only) must round-trip cleanly so the
-    trusted server has the integration id it needs to re-resolve secrets.
+    """New-shape claims round-trip the id and non-secret resolution environment.
+
+    The trusted server needs both values to re-resolve the correct credentials.
     """
     workspace_id, organization_id, session_id = _setup_service_key(monkeypatch)
     integration_id = uuid.uuid4()
@@ -102,7 +103,13 @@ def test_mcp_token_round_trips_refs_only_user_mcp_server_claim(monkeypatch) -> N
         allowed_actions=["core.http_request"],
         session_id=session_id,
         registry_lock=_registry_lock(),
-        user_mcp_servers=[UserMCPServerClaim(name="modern-mcp", id=integration_id)],
+        user_mcp_servers=[
+            UserMCPServerClaim(
+                name="modern-mcp",
+                id=integration_id,
+                environment="staging",
+            )
+        ],
     )
 
     claims = verify_mcp_token(token)
@@ -110,6 +117,7 @@ def test_mcp_token_round_trips_refs_only_user_mcp_server_claim(monkeypatch) -> N
     ref = claims.user_mcp_servers[0]
     assert ref.name == "modern-mcp"
     assert ref.id == integration_id
+    assert ref.environment == "staging"
     # New-shape claims should not carry secret material.
     assert ref.url is None
     assert ref.headers == {}

--- a/tests/unit/test_build_agent_args.py
+++ b/tests/unit/test_build_agent_args.py
@@ -421,8 +421,44 @@ class TestBuildAgentArgsMcpResolution:
         ) as mock_resolve:
             result = await DSLActivities.build_agent_args_activity(input)
 
-        mock_resolve.assert_awaited_once_with([integration_id], role=role)
+        mock_resolve.assert_awaited_once_with(
+            [integration_id],
+            role=role,
+            environment="default",
+        )
         assert result.mcp_servers == [resolved]
+
+    @pytest.mark.anyio
+    async def test_mcp_resolution_uses_effective_task_environment(self, role: Role):
+        """MCP refs carry the action override used for later header resolution."""
+        integration_id = str(uuid.uuid4())
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "mcp_integrations": [integration_id],
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment="staging",
+            default_environment="default",
+        )
+
+        with patch(
+            "tracecat.dsl.action._resolve_mcp_integrations",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_resolve:
+            result = await DSLActivities.build_agent_args_activity(input)
+
+        mock_resolve.assert_awaited_once_with(
+            [integration_id],
+            role=role,
+            environment="staging",
+        )
+        assert result.environment == "staging"
 
     @pytest.mark.anyio
     async def test_mcp_integration_ids_not_present_on_result(self, role: Role):
@@ -522,7 +558,11 @@ class TestBuildAgentArgsMcpResolution:
         ) as mock_resolve:
             result = await DSLActivities.build_agent_args_activity(input)
 
-        mock_resolve.assert_awaited_once_with([id1, id2], role=role)
+        mock_resolve.assert_awaited_once_with(
+            [id1, id2],
+            role=role,
+            environment="default",
+        )
         assert result.mcp_servers == resolved
         assert len(result.mcp_servers) == 2  # type: ignore[arg-type]
 
@@ -671,10 +711,11 @@ class TestBuildPresetAgentArgsActivity:
             new_callable=AsyncMock,
             return_value={"prompts": {"default": "Analyze this alert"}},
         ) as mock_get_vars:
-            await DSLActivities.build_preset_agent_args_activity(input)
+            result = await DSLActivities.build_preset_agent_args_activity(input)
 
         mock_get_vars.assert_called_once_with(
             variable_exprs={"prompts"},
             environment="staging",
             role=role,
         )
+        assert result.environment == "staging"

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -100,6 +100,33 @@ async def test_get_action_secrets_passes_sets_to_auth_sandbox(mocker):
 
 
 @pytest.mark.anyio
+async def test_get_action_secrets_uses_explicit_environment(mocker):
+    """An explicit environment overrides the ambient workflow context."""
+    mock_sandbox = mocker.MagicMock()
+    mock_sandbox.secrets = {}
+    mock_sandbox.__aenter__.return_value = mock_sandbox
+    mock_sandbox.__aexit__.return_value = None
+
+    auth_sandbox_mock = mocker.patch(
+        "tracecat.secrets.secrets_manager.AuthSandbox",
+        return_value=mock_sandbox,
+    )
+    runtime_env_mock = mocker.patch(
+        "tracecat.secrets.secrets_manager.get_runtime_env",
+        return_value="default",
+    )
+
+    await secrets_manager.get_action_secrets(
+        secret_exprs={"api.TOKEN"},
+        action_secrets=set(),
+        environment="staging",
+    )
+
+    assert auth_sandbox_mock.call_args.kwargs["environment"] == "staging"
+    runtime_env_mock.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_get_action_secrets_skips_optional_oauth(mocker):
     """Ensure optional OAuth integrations do not raise when missing."""
 

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -2181,6 +2181,33 @@ class TestMCPIntegrationCRUD:
         assert retrieved.name == created.name
         assert retrieved.server_uri == created.server_uri
 
+    async def test_resolve_mcp_refs_carry_effective_environment(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Boundary-safe refs retain the environment needed at the trusted edge."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Environment-scoped ref",
+                server_uri="https://mcp.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        preset_service = AgentPresetService(
+            session=integration_service.session,
+            role=integration_service.role,
+        )
+
+        resolved = await preset_service.resolve_mcp_integration_refs(
+            [str(created.id)],
+            environment="staging",
+        )
+
+        assert resolved is not None
+        assert resolved[0].get("id") == str(created.id)
+        assert resolved[0].get("environment") == "staging"
+        assert "headers" not in resolved[0]
+
     async def test_resolve_oauth2_mcp_with_additional_headers(
         self,
         integration_service: IntegrationService,

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -11,12 +11,14 @@ This test suite covers MCP integration functionality including:
 import contextlib
 import socket
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
+import orjson
 import pytest
 from authlib.integrations.base_client.errors import OAuthError
 from pydantic import SecretStr, TypeAdapter, ValidationError
@@ -51,6 +53,7 @@ from tracecat.db.models import (
     Workspace,
 )
 from tracecat.exceptions import EntitlementRequired
+from tracecat.executor import service as executor_service_module
 from tracecat.integrations.catalog.loader import catalog_id_for_slug
 from tracecat.integrations.catalog.service import PlatformMCPCatalogService
 from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGrantType
@@ -94,6 +97,7 @@ from tracecat.integrations.service import (
     OAuthRefreshBusyError,
 )
 from tracecat.integrations.types import DCRResponse, OAuthServerMetadata
+from tracecat.secrets import secrets_manager as secrets_manager_module
 from tracecat.tiers import defaults as tier_defaults
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -101,6 +105,18 @@ pytestmark = pytest.mark.usefixtures("db")
 _MCP_CONNECTION_SPEC_ADAPTER: TypeAdapter[MCPConnectionSpec] = TypeAdapter(
     MCPConnectionSpec
 )
+
+
+@dataclass(frozen=True, slots=True)
+class MCPTemplateContext:
+    """Workspace secret and variable references for MCP resolution tests."""
+
+    secret_name: str
+    secret_key: str
+    secret_value: str
+    variable_name: str
+    variable_key: str
+    variable_value: str
 
 
 class _TestCatalogEntry(dict):
@@ -352,6 +368,65 @@ async def oauth_integration(
         expires_in=3600,
     )
     return integration
+
+
+@pytest.fixture
+def mcp_template_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> MCPTemplateContext:
+    """Create synthetic workspace values used by MCP header expressions."""
+    suffix = uuid.uuid4().hex
+    context = MCPTemplateContext(
+        secret_name=f"mcp_secret_{suffix}",
+        secret_key="API_KEY",
+        secret_value=f"secret-value-{suffix}",
+        variable_name=f"mcp_variable_{suffix}",
+        variable_key="tenant",
+        variable_value=f"tenant-{suffix}",
+    )
+
+    async def get_action_secrets(
+        *,
+        secret_exprs: set[str],
+        action_secrets: set[object],
+        environment: str | None = None,
+    ) -> dict[str, dict[str, str]]:
+        _ = action_secrets, environment
+        secret_prefix = f"{context.secret_name}."
+        if not any(ref.startswith(secret_prefix) for ref in secret_exprs):
+            return {}
+        return {
+            context.secret_name: {
+                context.secret_key: context.secret_value,
+            }
+        }
+
+    async def get_workspace_variables(
+        variable_exprs: set[str],
+        *,
+        environment: str | None = None,
+        role: Role | None = None,
+    ) -> dict[str, dict[str, str]]:
+        _ = environment, role
+        if context.variable_name not in variable_exprs:
+            return {}
+        return {
+            context.variable_name: {
+                context.variable_key: context.variable_value,
+            }
+        }
+
+    monkeypatch.setattr(
+        secrets_manager_module,
+        "get_action_secrets",
+        get_action_secrets,
+    )
+    monkeypatch.setattr(
+        executor_service_module,
+        "get_workspace_variables",
+        get_workspace_variables,
+    )
+    return context
 
 
 @pytest.mark.anyio
@@ -6298,6 +6373,138 @@ class TestMCPConnectionVerification:
 
         assert server_config.get("headers") == {"X-API-Key": "secret-key"}
 
+    async def test_resolve_http_config_custom_header_expressions(
+        self,
+        integration_service: IntegrationService,
+        mcp_template_context: MCPTemplateContext,
+    ) -> None:
+        """CUSTOM headers resolve secrets, variables, and mixed literals."""
+        secret_expr = (
+            "${{ SECRETS."
+            f"{mcp_template_context.secret_name}.{mcp_template_context.secret_key}"
+            " }}"
+        )
+        variable_expr = (
+            "${{ VARS."
+            f"{mcp_template_context.variable_name}.{mcp_template_context.variable_key}"
+            " }}"
+        )
+        configured_headers = {
+            "Authorization": f"ApiKey {secret_expr}",
+            "X-Tenant": f"tenant={variable_expr}",
+            "X-Literal": "literal-value",
+        }
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Templated Custom Auth MCP",
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr(orjson.dumps(configured_headers).decode()),
+            )
+        )
+
+        server_config = await integration_service.resolve_mcp_http_server_config(
+            mcp_integration
+        )
+
+        headers = server_config.get("headers")
+        assert headers is not None
+        assert headers == {
+            "Authorization": f"ApiKey {mcp_template_context.secret_value}",
+            "X-Tenant": f"tenant={mcp_template_context.variable_value}",
+            "X-Literal": "literal-value",
+        }
+        assert all("${{" not in value for value in headers.values())
+
+    async def test_resolve_http_config_uses_effective_environment(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Headers resolve secrets and variables from the action environment."""
+        suffix = uuid.uuid4().hex
+        secret_name = f"mcp_environment_secret_{suffix}"
+        variable_name = f"mcp_environment_variable_{suffix}"
+        values_by_environment = {
+            "default": "default-tenant",
+            "staging": "staging-tenant",
+        }
+        requested_secret_environments: list[str | None] = []
+        requested_variable_environments: list[str | None] = []
+
+        async def get_action_secrets(
+            *,
+            secret_exprs: set[str],
+            action_secrets: set[object],
+            environment: str | None = None,
+        ) -> dict[str, dict[str, str]]:
+            _ = action_secrets
+            requested_secret_environments.append(environment)
+            assert secret_exprs == {f"{secret_name}.TOKEN"}
+            assert environment is not None
+            return {
+                secret_name: {
+                    "TOKEN": f"{values_by_environment[environment]}-token",
+                }
+            }
+
+        async def get_workspace_variables(
+            variable_exprs: set[str],
+            *,
+            environment: str | None = None,
+            role: Role | None = None,
+        ) -> dict[str, dict[str, str]]:
+            _ = role
+            requested_variable_environments.append(environment)
+            assert variable_exprs == {variable_name}
+            assert environment is not None
+            return {
+                variable_name: {
+                    "tenant": values_by_environment[environment],
+                }
+            }
+
+        monkeypatch.setattr(
+            secrets_manager_module,
+            "get_action_secrets",
+            get_action_secrets,
+        )
+        monkeypatch.setattr(
+            executor_service_module,
+            "get_workspace_variables",
+            get_workspace_variables,
+        )
+
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Environment-scoped MCP",
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr(
+                    orjson.dumps(
+                        {
+                            "Authorization": (
+                                f"Bearer ${{{{ SECRETS.{secret_name}.TOKEN }}}}"
+                            ),
+                            "X-Tenant": f"${{{{ VARS.{variable_name}.tenant }}}}",
+                        }
+                    ).decode()
+                ),
+            )
+        )
+
+        server_config = await integration_service.resolve_mcp_http_server_config(
+            mcp_integration,
+            environment="staging",
+        )
+
+        assert server_config.get("headers") == {
+            "Authorization": "Bearer staging-tenant-token",
+            "X-Tenant": "staging-tenant",
+        }
+        assert requested_secret_environments == ["staging"]
+        assert requested_variable_environments == ["staging"]
+
     async def test_resolve_http_config_oauth2_drops_custom_authorization(
         self,
         integration_service: IntegrationService,
@@ -6325,6 +6532,207 @@ class TestMCPConnectionVerification:
         assert headers["Authorization"] == "Bearer test_access_token"
         assert "authorization" not in headers
         assert headers["X-Tenant"] == "t1"
+
+    async def test_resolve_http_config_oauth2_extra_header_expressions(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+        mcp_template_context: MCPTemplateContext,
+    ) -> None:
+        """OAuth extra headers resolve while OAuth Authorization remains authoritative."""
+        configured_headers = {
+            "authorization": "Bearer attacker",
+            "X-API-Key": (
+                "${{ SECRETS."
+                f"{mcp_template_context.secret_name}.{mcp_template_context.secret_key}"
+                " }}"
+            ),
+            "X-Tenant": (
+                "prefix-${{ VARS."
+                f"{mcp_template_context.variable_name}."
+                f"{mcp_template_context.variable_key}"
+                " }}"
+            ),
+        }
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Templated OAuth MCP",
+                server_uri="https://oauth.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+                custom_credentials=SecretStr(orjson.dumps(configured_headers).decode()),
+            )
+        )
+
+        server_config = await integration_service.resolve_mcp_http_server_config(
+            mcp_integration
+        )
+
+        headers = server_config.get("headers")
+        assert headers is not None
+        assert headers["Authorization"] == "Bearer test_access_token"
+        assert "authorization" not in headers
+        assert headers["X-API-Key"] == mcp_template_context.secret_value
+        assert headers["X-Tenant"] == (f"prefix-{mcp_template_context.variable_value}")
+        assert all("${{" not in value for value in headers.values())
+
+    async def test_oauth2_malformed_extra_headers_are_dropped(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """Malformed optional OAuth headers do not disable a valid OAuth token."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Malformed OAuth Headers MCP",
+                server_uri="https://oauth.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+        mcp_integration.encrypted_headers = integration_service._encrypt_token(
+            "{not-json"
+        )
+
+        server_config = await integration_service.resolve_mcp_http_server_config(
+            mcp_integration
+        )
+
+        assert server_config.get("headers") == {
+            "Authorization": "Bearer test_access_token"
+        }
+
+    async def test_oauth2_unresolvable_extra_header_fails_closed(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+        mcp_template_context: MCPTemplateContext,
+    ) -> None:
+        """Expression failures in optional OAuth headers are not warn-and-dropped."""
+        missing_secret_name = f"missing_oauth_header_{uuid.uuid4().hex}"
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Missing OAuth Header Secret MCP",
+                server_uri="https://oauth.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+                custom_credentials=SecretStr(
+                    orjson.dumps(
+                        {
+                            "X-API-Key": (
+                                f"${{{{ SECRETS.{missing_secret_name}.API_KEY }}}}"
+                            )
+                        }
+                    ).decode()
+                ),
+            )
+        )
+
+        with pytest.raises(MCPConfigurationError) as exc_info:
+            await integration_service.resolve_mcp_http_server_config(mcp_integration)
+
+        detail = str(exc_info.value)
+        assert missing_secret_name in detail
+        assert mcp_template_context.secret_value not in detail
+
+    async def test_missing_header_secret_fails_resolution_and_verification(
+        self,
+        integration_service: IntegrationService,
+        mcp_template_context: MCPTemplateContext,
+    ) -> None:
+        """Missing secret references fail closed without exposing secret values."""
+        missing_secret_name = f"missing_mcp_secret_{uuid.uuid4().hex}"
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Missing Secret MCP",
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr(
+                    orjson.dumps(
+                        {
+                            "Authorization": (
+                                "ApiKey ${{ SECRETS."
+                                f"{missing_secret_name}.API_KEY"
+                                " }}"
+                            )
+                        }
+                    ).decode()
+                ),
+            )
+        )
+
+        with pytest.raises(MCPConfigurationError) as exc_info:
+            await integration_service.resolve_mcp_http_server_config(mcp_integration)
+
+        detail = str(exc_info.value)
+        assert missing_secret_name in detail
+        assert mcp_template_context.secret_value not in detail
+
+        with pytest.raises(MCPConnectionVerificationError) as verify_exc_info:
+            await integration_service._probe_mcp_http_server(mcp_integration)
+
+        assert (
+            verify_exc_info.value.message
+            == "MCP integration is not configured correctly"
+        )
+        assert verify_exc_info.value.error is not None
+        assert missing_secret_name in verify_exc_info.value.error
+        assert mcp_template_context.secret_value not in verify_exc_info.value.error
+
+    async def test_unresolved_header_template_marker_fails_closed(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Malformed template markers are never sent as literal header values."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Malformed Template MCP",
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr(
+                    '{"Authorization": "ApiKey ${{ SECRETS.example.API_KEY"}'
+                ),
+            )
+        )
+
+        with pytest.raises(MCPConfigurationError) as exc_info:
+            await integration_service.resolve_mcp_http_server_config(mcp_integration)
+
+        assert "Authorization" in str(exc_info.value)
+
+    async def test_missing_header_secret_key_does_not_expose_values(
+        self,
+        integration_service: IntegrationService,
+        mcp_template_context: MCPTemplateContext,
+    ) -> None:
+        """Missing secret keys name the reference without exposing sibling values."""
+        missing_key = "MISSING_KEY"
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Missing Secret Key MCP",
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr(
+                    orjson.dumps(
+                        {
+                            "Authorization": (
+                                "${{ SECRETS."
+                                f"{mcp_template_context.secret_name}.{missing_key}"
+                                " }}"
+                            )
+                        }
+                    ).decode()
+                ),
+            )
+        )
+
+        with pytest.raises(MCPConfigurationError) as exc_info:
+            await integration_service.resolve_mcp_http_server_config(mcp_integration)
+
+        detail = str(exc_info.value)
+        assert mcp_template_context.secret_name in detail
+        assert missing_key in detail
+        assert mcp_template_context.secret_value not in detail
 
     async def test_resolve_http_config_translates_busy_oauth_refresh(
         self,

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -59,6 +59,10 @@ class MCPHttpServerConfig(TypedDict):
     resolved from. Set when produced by ``AgentPresetService`` resolvers so
     callers can re-resolve secrets per use without re-listing integrations."""
 
+    environment: NotRequired[str]
+    """Effective workflow/action environment for resolving workspace-backed
+    header templates at the trusted edge."""
+
 
 class MCPServerToolSummary(TypedDict):
     """Non-secret summary of a verified user MCP tool."""
@@ -84,6 +88,10 @@ class MCPStdioServerConfig(TypedDict):
     id: NotRequired[str]
     """Optional: UUID of the source ``mcp_integrations`` row this config was
     resolved from. See :class:`MCPHttpServerConfig.id`."""
+
+    environment: NotRequired[str]
+    """Effective workflow/action environment for resolving workspace-backed
+    process environment templates at the trusted edge."""
 
     tools: NotRequired[list[MCPServerToolSummary]]
     """Optional, non-secret tool summaries from the latest successful

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -1052,7 +1052,10 @@ async def _hydrate_stdio_env(
                         f"Stdio MCP server {cfg.get('name')!r} is missing a source integration id"
                     )
                 try:
-                    env = await svc.resolve_mcp_integration_secrets(uuid.UUID(cfg_id))
+                    env = await svc.resolve_mcp_integration_secrets(
+                        uuid.UUID(cfg_id),
+                        environment=cfg.get("environment"),
+                    )
                 except (ValueError, MCPSecretResolutionError):
                     env = None
                 result.append({**cfg, "env": env} if env else cfg)

--- a/tracecat/agent/mcp/secret_resolution.py
+++ b/tracecat/agent/mcp/secret_resolution.py
@@ -1,0 +1,155 @@
+"""Resolve workspace-backed template expressions in MCP string mappings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from tracecat.auth.types import Role
+from tracecat.dsl.common import create_default_execution_context
+from tracecat.exceptions import TracecatException, TracecatValidationError
+from tracecat.expressions.core import CollectedExprs
+from tracecat.expressions.eval import collect_expressions, eval_templated_object
+from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
+
+
+@dataclass(frozen=True, slots=True)
+class TemplatedMappingResolution:
+    """Resolved mapping plus non-sensitive reference counts for logging."""
+
+    mapping: dict[str, str]
+    secret_ref_count: int
+    var_ref_count: int
+
+
+class TemplatedMappingResolutionError(TracecatException):
+    """Raised when mapping resolution cannot safely produce strings."""
+
+
+def _template_target(
+    mapping: dict[str, str], *, resolve_keys: bool
+) -> dict[str, str] | list[str]:
+    return mapping if resolve_keys else list(mapping.values())
+
+
+def _template_reference_summary(collected: CollectedExprs) -> str:
+    references = [
+        *(f"SECRETS.{path}" for path in sorted(collected.secrets)),
+        *(f"VARS.{name}" for name in sorted(collected.variables)),
+    ]
+    return ", ".join(f"'{reference}'" for reference in references)
+
+
+def _template_value_keys(mapping: dict[str, str]) -> list[str]:
+    return sorted(key for key, value in mapping.items() if "${{" in value)
+
+
+def _resolution_error(
+    mapping: dict[str, str],
+    collected: CollectedExprs | None = None,
+) -> TemplatedMappingResolutionError:
+    if collected and (summary := _template_reference_summary(collected)):
+        return TemplatedMappingResolutionError(
+            f"Could not resolve template reference(s): {summary}"
+        )
+    keys = _template_value_keys(mapping)
+    if keys:
+        return TemplatedMappingResolutionError(
+            "Could not resolve template expression in mapping value(s): "
+            f"{', '.join(repr(key) for key in keys)}"
+        )
+    return TemplatedMappingResolutionError(
+        "Could not resolve template expression in mapping values"
+    )
+
+
+async def resolve_templated_mapping(
+    mapping: dict[str, str],
+    *,
+    role: Role,
+    environment: str | None = None,
+    resolve_keys: bool = True,
+) -> TemplatedMappingResolution:
+    """Resolve MCP mapping expressions at call time without persisting results.
+
+    Resolution fails closed: missing references, malformed expressions, and
+    unresolved template markers raise ``TemplatedMappingResolutionError``.
+    Workspace secrets and variables resolve in ``environment``; callers
+    without an action-specific environment use the workspace default.
+    ``resolve_keys=False`` preserves header names and resolves values only.
+    """
+    # Keep these service imports local: executor.service imports secrets_manager,
+    # which imports IntegrationService, and IntegrationService imports this module.
+    from tracecat.executor.service import get_workspace_variables
+    from tracecat.secrets import secrets_manager
+
+    effective_environment = (
+        environment if environment is not None else DEFAULT_SECRETS_ENVIRONMENT
+    )
+    target = _template_target(mapping, resolve_keys=resolve_keys)
+    try:
+        collected = collect_expressions(target)
+    except Exception as exc:
+        raise _resolution_error(mapping) from exc
+
+    if (
+        not collected.secrets
+        and not collected.variables
+        and not _template_value_keys(mapping)
+    ):
+        return TemplatedMappingResolution(
+            mapping=mapping,
+            secret_ref_count=0,
+            var_ref_count=0,
+        )
+
+    try:
+        secrets = await secrets_manager.get_action_secrets(
+            secret_exprs=collected.secrets,
+            action_secrets=set(),
+            environment=effective_environment,
+        )
+        vars_map = await get_workspace_variables(
+            variable_exprs=collected.variables,
+            environment=effective_environment,
+            role=role,
+        )
+
+        context = create_default_execution_context()
+        context["SECRETS"] = secrets
+        context["VARS"] = vars_map
+        resolved = eval_templated_object(target, operand=context, strict=True)
+    except Exception as exc:
+        raise _resolution_error(mapping, collected) from exc
+
+    if resolve_keys:
+        if not isinstance(resolved, dict):
+            raise TracecatValidationError(
+                "Resolved mapping must be a JSON object with string values"
+            )
+        resolved_mapping = resolved
+    else:
+        if not isinstance(resolved, list) or len(resolved) != len(mapping):
+            raise TracecatValidationError(
+                "Resolved mapping must preserve all string values"
+            )
+        resolved_mapping = dict(zip(mapping, resolved, strict=True))
+
+    non_string_keys = [
+        key for key, value in resolved_mapping.items() if not isinstance(value, str)
+    ]
+    if non_string_keys:
+        raise TemplatedMappingResolutionError(
+            "Resolved mapping values must be strings "
+            f"(invalid keys: {sorted(non_string_keys)})"
+        )
+
+    typed_mapping = cast(dict[str, str], resolved_mapping)
+    if _template_value_keys(typed_mapping):
+        raise _resolution_error(mapping, collected)
+
+    return TemplatedMappingResolution(
+        mapping=typed_mapping,
+        secret_ref_count=len(collected.secrets),
+        var_ref_count=len(collected.variables),
+    )

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -381,7 +381,10 @@ async def _resolve_user_mcp_config(
             metadata = refs[0]
             if not is_http_mcp_server(metadata):
                 raise ToolError(f"User MCP server '{ref.name}' is not an HTTP server")
-            secrets = await svc.resolve_mcp_integration_secrets(ref.id)
+            secrets = await svc.resolve_mcp_integration_secrets(
+                ref.id,
+                environment=ref.environment,
+            )
     except ToolError:
         raise
     except MCPSecretResolutionError as e:

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -41,6 +41,14 @@ class ResolveAgentPresetConfigActivityInput(BaseModel):
         return self
 
 
+class ResolveAgentPresetConfigWithEnvironmentActivityInput(
+    ResolveAgentPresetConfigActivityInput
+):
+    """Preset resolution input with an explicit action environment."""
+
+    environment: str
+
+
 class ResolveAgentPresetVersionRefActivityInput(BaseModel):
     role: Role
     preset_slug: str
@@ -60,9 +68,16 @@ class ResolveAgentsConfigActivityInput(BaseModel):
     follow_latest_versions: bool | None = None
 
 
-@activity.defn
-async def resolve_agent_preset_config_activity(
+class ResolveAgentsConfigWithEnvironmentActivityInput(ResolveAgentsConfigActivityInput):
+    """Subagent resolution input with an explicit action environment."""
+
+    environment: str
+
+
+async def _resolve_agent_preset_config(
     args: ResolveAgentPresetConfigActivityInput,
+    *,
+    environment: str | None,
 ) -> AgentConfigPayload:
     async with AgentManagementService.with_session(role=args.role) as service:
         async with service.with_preset_config(
@@ -70,8 +85,25 @@ async def resolve_agent_preset_config_activity(
             slug=args.preset_slug,
             preset_version_id=args.preset_version_id,
             preset_version=args.preset_version,
+            environment=environment,
         ) as config:
             return agent_config_to_payload(config)
+
+
+@activity.defn
+async def resolve_agent_preset_config_activity(
+    args: ResolveAgentPresetConfigActivityInput,
+) -> AgentConfigPayload:
+    """Resolve a preset for replayed runs that predate environment propagation."""
+    return await _resolve_agent_preset_config(args, environment=None)
+
+
+@activity.defn
+async def resolve_agent_preset_config_with_environment_activity(
+    args: ResolveAgentPresetConfigWithEnvironmentActivityInput,
+) -> AgentConfigPayload:
+    """Resolve a preset in the action's effective environment."""
+    return await _resolve_agent_preset_config(args, environment=args.environment)
 
 
 @activity.defn
@@ -93,6 +125,23 @@ async def resolve_agent_preset_version_ref_activity(
 async def resolve_agents_config_activity(
     args: ResolveAgentsConfigActivityInput,
 ) -> ResolvedAgentsRuntimeConfig:
+    """Resolve subagent configs for runs that predate environment propagation."""
+    return await _resolve_agents_config(args, environment=None)
+
+
+@activity.defn
+async def resolve_agents_config_with_environment_activity(
+    args: ResolveAgentsConfigWithEnvironmentActivityInput,
+) -> ResolvedAgentsRuntimeConfig:
+    """Resolve subagent configs in the action's effective environment."""
+    return await _resolve_agents_config(args, environment=args.environment)
+
+
+async def _resolve_agents_config(
+    args: ResolveAgentsConfigActivityInput,
+    *,
+    environment: str | None,
+) -> ResolvedAgentsRuntimeConfig:
     async with AgentPresetService.with_session(role=args.role) as service:
         follow_latest_versions = args.follow_latest_versions
         if follow_latest_versions is None:
@@ -104,6 +153,7 @@ async def resolve_agents_config_activity(
             parent_slug=args.parent_slug,
             include_runtime_config=True,
             follow_latest_versions=follow_latest_versions,
+            environment=environment,
         )
         return resolved.to_runtime_config()
 

--- a/tracecat/agent/preset/resolver.py
+++ b/tracecat/agent/preset/resolver.py
@@ -44,6 +44,7 @@ class AgentPresetResolutionService(Protocol):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        environment: str | None = None,
     ) -> Awaitable[AgentConfig]: ...
 
 
@@ -125,6 +126,7 @@ async def resolve_agents_config(
     parent_slug: str | None = None,
     include_runtime_config: bool = False,
     follow_latest_versions: bool = False,
+    environment: str | None = None,
 ) -> ResolvedAgentsConfigResult:
     """Resolve and validate preset-backed subagent refs."""
 
@@ -214,6 +216,7 @@ async def resolve_agents_config(
             preset = await service.get_preset(version.preset_id)
             child_config = await service.resolve_agent_preset_config(
                 preset_version_id=version.id,
+                environment=environment,
             )
             description = (
                 ref.description

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -22,6 +22,7 @@ from tracecat.agent.common.types import (
     MCPServerToolSummary,
     MCPStdioServerConfig,
 )
+from tracecat.agent.mcp.secret_resolution import resolve_templated_mapping
 from tracecat.agent.preset.resolver import resolve_agents_config
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
@@ -63,10 +64,7 @@ from tracecat.db.models import (
     SkillVersion,
 )
 from tracecat.db.soft_delete import with_deleted
-from tracecat.dsl.common import create_default_execution_context
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
-from tracecat.executor.service import get_workspace_variables
-from tracecat.expressions.eval import collect_expressions, eval_templated_object
 from tracecat.integrations.enums import MCPAuthType
 from tracecat.integrations.mcp_validation import (
     MCPConfigurationError,
@@ -83,7 +81,6 @@ from tracecat.pagination import (
     CursorPaginationParams,
 )
 from tracecat.registry.actions.service import RegistryActionsService
-from tracecat.secrets import secrets_manager
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.settings.schemas import VersionedResourceResolutionStrategy
 from tracecat.settings.service import get_versioned_resource_resolution_strategy
@@ -893,7 +890,8 @@ class AgentPresetService(BaseWorkspaceService):
             # Handle HTTP-type servers (default)
             try:
                 http_config = await integrations_service.resolve_mcp_http_server_config(
-                    mcp_integration
+                    mcp_integration,
+                    environment=environment,
                 )
             except MCPConfigurationError as e:
                 logger.warning(
@@ -1131,13 +1129,11 @@ class AgentPresetService(BaseWorkspaceService):
                 )
             except Exception as e:
                 logger.warning(
-                    "Stdio env resolution failed for MCP integration %r: %s",
-                    mcp_integration.name,
-                    str(e),
-                    extra={
-                        "workspace_id": str(self.workspace_id),
-                        "mcp_integration_id": str(mcp_integration.id),
-                    },
+                    "Stdio env resolution failed for MCP integration",
+                    mcp_integration_name=mcp_integration.name,
+                    error=str(e),
+                    workspace_id=str(self.workspace_id),
+                    mcp_integration_id=str(mcp_integration.id),
                 )
                 raise MCPSecretResolutionError(
                     "Stdio MCP integration env could not be resolved",
@@ -1149,17 +1145,16 @@ class AgentPresetService(BaseWorkspaceService):
         # HTTP server — resolve headers per auth type.
         try:
             server_config = await integrations_service.resolve_mcp_http_server_config(
-                mcp_integration
+                mcp_integration,
+                environment=environment,
             )
         except MCPConfigurationError as e:
             logger.warning(
-                "Failed to resolve secrets for HTTP MCP integration %r: %s",
-                mcp_integration.name,
-                str(e),
-                extra={
-                    "workspace_id": str(self.workspace_id),
-                    "mcp_integration_id": str(mcp_integration.id),
-                },
+                "Failed to resolve secrets for HTTP MCP integration",
+                mcp_integration_name=mcp_integration.name,
+                error=str(e),
+                workspace_id=str(self.workspace_id),
+                mcp_integration_id=str(mcp_integration.id),
             )
             if mcp_integration.auth_type in {MCPAuthType.OAUTH2, MCPAuthType.CUSTOM}:
                 raise MCPSecretResolutionError(
@@ -1179,52 +1174,24 @@ class AgentPresetService(BaseWorkspaceService):
         mcp_integration_slug: str,
         environment: str | None = None,
     ) -> dict[str, str]:
-        """Resolve template expressions in stdio_env using workspace secrets/vars."""
-        collected = collect_expressions(stdio_env)
-        if not collected.secrets and not collected.variables:
-            return stdio_env
-
-        secrets = await secrets_manager.get_action_secrets(
-            secret_exprs=collected.secrets,
-            action_secrets=set(),
-            environment=environment,
-        )
-        vars_map = await get_workspace_variables(
-            variable_exprs=collected.variables,
+        """Resolve stdio env expressions at call time without persisting values."""
+        resolution = await resolve_templated_mapping(
+            stdio_env,
             role=self.role,
             environment=environment,
         )
-
-        context = create_default_execution_context()
-        context["SECRETS"] = secrets
-        context["VARS"] = vars_map
-
-        resolved = eval_templated_object(stdio_env, operand=context)
-        if not isinstance(resolved, dict):
-            raise TracecatValidationError(
-                "Resolved stdio_env must be a JSON object with string values"
+        if resolution.secret_ref_count or resolution.var_ref_count:
+            logger.info(
+                "Resolved stdio_env template expressions",
+                workspace_id=str(self.workspace_id),
+                mcp_integration_id=str(mcp_integration_id),
+                mcp_integration_slug=mcp_integration_slug,
+                env_key_count=len(resolution.mapping),
+                secret_ref_count=resolution.secret_ref_count,
+                var_ref_count=resolution.var_ref_count,
             )
 
-        non_string_keys = [
-            key for key, value in resolved.items() if not isinstance(value, str)
-        ]
-        if non_string_keys:
-            raise TracecatValidationError(
-                "Resolved stdio_env values must be strings "
-                f"(invalid keys: {sorted(non_string_keys)})"
-            )
-
-        logger.info(
-            "Resolved stdio_env template expressions",
-            workspace_id=str(self.workspace_id),
-            mcp_integration_id=str(mcp_integration_id),
-            mcp_integration_slug=mcp_integration_slug,
-            env_key_count=len(resolved),
-            secret_ref_count=len(collected.secrets),
-            var_ref_count=len(collected.variables),
-        )
-
-        return cast(dict[str, str], resolved)
+        return resolution.mapping
 
     async def _normalize_and_validate_slug(
         self,

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -584,6 +584,7 @@ class AgentPresetService(BaseWorkspaceService):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        environment: str | None = None,
     ) -> AgentConfig:
         """Get an agent configuration from a preset by ID or slug with MCP integrations resolved."""
         version = await self.resolve_agent_preset_version(
@@ -592,7 +593,7 @@ class AgentPresetService(BaseWorkspaceService):
             preset_version_id=preset_version_id,
             preset_version=preset_version,
         )
-        return await self._version_to_agent_config(version)
+        return await self._version_to_agent_config(version, environment=environment)
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def resolve_agent_preset_version(
@@ -771,7 +772,10 @@ class AgentPresetService(BaseWorkspaceService):
             )
 
     async def resolve_mcp_integrations(
-        self, mcp_integrations: list[str] | None
+        self,
+        mcp_integrations: list[str] | None,
+        *,
+        environment: str | None = None,
     ) -> list[MCPServerConfig] | None:
         """Resolve MCP integrations into MCP server configs."""
         if not mcp_integrations:
@@ -834,6 +838,7 @@ class AgentPresetService(BaseWorkspaceService):
                             stdio_env=stdio_env,
                             mcp_integration_id=mcp_integration.id,
                             mcp_integration_slug=mcp_integration.slug,
+                            environment=environment,
                         )
                     except Exception as e:
                         logger.warning(
@@ -911,13 +916,17 @@ class AgentPresetService(BaseWorkspaceService):
         return mcp_servers
 
     async def resolve_mcp_integration_refs(
-        self, mcp_integrations: list[str] | None
+        self,
+        mcp_integrations: list[str] | None,
+        *,
+        environment: str | None = None,
     ) -> list[MCPServerConfig] | None:
         """Resolve MCP integration IDs into ``MCPServerConfig``s without secrets.
 
         Returns metadata only — ``headers`` and stdio ``env`` are intentionally
-        omitted. Each config carries its source ``id`` so trusted callers can
-        re-resolve secrets per use via :meth:`resolve_mcp_integration_secrets`.
+        omitted. Each config carries its source ``id`` and, when provided, the
+        effective ``environment`` so trusted callers can re-resolve secrets per
+        use via :meth:`resolve_mcp_integration_secrets`.
 
         Safe to serialize across Temporal boundaries.
 
@@ -1001,6 +1010,8 @@ class AgentPresetService(BaseWorkspaceService):
                     stdio_ref["args"] = mcp_integration.stdio_args
                 if mcp_integration.timeout is not None:
                     stdio_ref["timeout"] = mcp_integration.timeout
+                if environment is not None:
+                    stdio_ref["environment"] = environment
                 stored_tools = MCPToolSummary.validate_stored(
                     mcp_integration.tools,
                     mcp_integration_id=mcp_integration.id,
@@ -1036,6 +1047,8 @@ class AgentPresetService(BaseWorkspaceService):
             }
             if mcp_integration.timeout is not None:
                 http_ref["timeout"] = mcp_integration.timeout
+            if environment is not None:
+                http_ref["environment"] = environment
             refs.append(http_ref)
 
         if not refs:
@@ -1071,7 +1084,10 @@ class AgentPresetService(BaseWorkspaceService):
         return policies
 
     async def resolve_mcp_integration_secrets(
-        self, mcp_integration_id: uuid.UUID
+        self,
+        mcp_integration_id: uuid.UUID,
+        *,
+        environment: str | None = None,
     ) -> dict[str, str] | None:
         """Resolve the secret material for a single MCP integration.
 
@@ -1111,6 +1127,7 @@ class AgentPresetService(BaseWorkspaceService):
                     stdio_env=stdio_env,
                     mcp_integration_id=mcp_integration.id,
                     mcp_integration_slug=mcp_integration.slug,
+                    environment=environment,
                 )
             except Exception as e:
                 logger.warning(
@@ -1160,6 +1177,7 @@ class AgentPresetService(BaseWorkspaceService):
         stdio_env: dict[str, str],
         mcp_integration_id: uuid.UUID,
         mcp_integration_slug: str,
+        environment: str | None = None,
     ) -> dict[str, str]:
         """Resolve template expressions in stdio_env using workspace secrets/vars."""
         collected = collect_expressions(stdio_env)
@@ -1169,10 +1187,12 @@ class AgentPresetService(BaseWorkspaceService):
         secrets = await secrets_manager.get_action_secrets(
             secret_exprs=collected.secrets,
             action_secrets=set(),
+            environment=environment,
         )
         vars_map = await get_workspace_variables(
             variable_exprs=collected.variables,
             role=self.role,
+            environment=environment,
         )
 
         context = create_default_execution_context()
@@ -1903,14 +1923,20 @@ class AgentPresetService(BaseWorkspaceService):
         )
 
     async def _version_to_agent_config(
-        self, version: AgentPresetVersion
+        self,
+        version: AgentPresetVersion,
+        *,
+        environment: str | None = None,
     ) -> AgentConfig:
         use_latest_resource_versions = await self.use_latest_resource_versions()
         # Resolve refs only — no headers / stdio env. The resulting
         # AgentConfig is safe to cross Temporal boundaries. Trusted callers
         # (build_tool_definitions, trusted MCP server) re-resolve secrets
         # per use via resolve_mcp_integration_secrets.
-        mcp_servers = await self.resolve_mcp_integration_refs(version.mcp_integrations)
+        mcp_servers = await self.resolve_mcp_integration_refs(
+            version.mcp_integrations,
+            environment=environment,
+        )
         model_settings: dict[str, Any] = {}
         resolved_skills = await self.skills.get_resolved_skill_refs_for_preset_version(
             version.id,

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -1079,6 +1079,7 @@ class AgentManagementService(BaseOrgService):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        environment: str | None = None,
     ) -> AsyncIterator[AgentConfig]:
         """Yield an agent preset configuration with provider credentials loaded.
 
@@ -1103,6 +1104,7 @@ class AgentManagementService(BaseOrgService):
             slug=slug,
             preset_version_id=preset_version_id,
             preset_version=preset_version,
+            environment=environment,
         )
 
         credentials: dict[str, str] | None = None

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -56,8 +56,9 @@ class UserMCPServerClaim(BaseModel):
 
     The legacy ``url``/``transport``/``headers``/``timeout`` fields are
     kept here so in-flight JWTs and Temporal activity outputs serialized
-    before this change still validate on replay. New mint paths set only
-    ``(name, id)``; trusted-server code paths use ``id``.
+    before this change still validate on replay. New mint paths set
+    ``(name, id, environment)``; trusted-server code paths use the latter two
+    values to resolve credentials.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -67,6 +68,8 @@ class UserMCPServerClaim(BaseModel):
     id: uuid.UUID | None = None
     """UUID of the source ``mcp_integrations`` row. Required on new tokens;
     optional only to support replay of pre-rollout tokens that lack it."""
+    environment: str | None = None
+    """Effective workflow/action environment for trusted template resolution."""
 
     # --- Legacy fields kept for replay of in-flight tokens. ---
     # New mint paths leave these unset. Trusted server reads only (name, id).

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -30,8 +30,10 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.mcp.activities import persist_stdio_mcp_connection_activity
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_config_activity,
+        resolve_agent_preset_config_with_environment_activity,
         resolve_agent_preset_version_ref_activity,
         resolve_agents_config_activity,
+        resolve_agents_config_with_environment_activity,
         resolve_custom_model_provider_config_activity,
     )
     from tracecat.agent.session.activities import get_session_activities
@@ -82,8 +84,10 @@ def get_activities() -> list[Callable[..., object]]:
     activities.extend(agent_activities.get_activities())
     activities.extend(ApprovalManager.get_activities())
     activities.append(resolve_agent_preset_config_activity)
+    activities.append(resolve_agent_preset_config_with_environment_activity)
     activities.append(resolve_agent_preset_version_ref_activity)
     activities.append(resolve_agents_config_activity)
+    activities.append(resolve_agents_config_with_environment_activity)
     activities.append(resolve_custom_model_provider_config_activity)
     activities.append(persist_stdio_mcp_connection_activity)
     activities.extend(get_session_activities())

--- a/tracecat/agent/workflow_config.py
+++ b/tracecat/agent/workflow_config.py
@@ -37,6 +37,7 @@ def _mcp_server_to_payload(
                 env=server.get("env"),
                 timeout=server.get("timeout"),
                 id=server.get("id"),
+                environment=server.get("environment"),
                 tools=(
                     [MCPServerToolSummaryPayload.model_validate(tool) for tool in tools]
                     if (tools := server.get("tools")) is not None
@@ -55,6 +56,7 @@ def _mcp_server_to_payload(
                 transport=server.get("transport"),
                 timeout=server.get("timeout"),
                 id=server.get("id"),
+                environment=server.get("environment"),
             )
         case _:
             raise ValueError(f"Unsupported MCP server config: {server!r}")
@@ -76,6 +78,8 @@ def _mcp_server_from_payload(server: MCPServerConfigPayload) -> MCPServerConfig:
                 stdio_server["timeout"] = server.timeout
             if server.id is not None:
                 stdio_server["id"] = server.id
+            if server.environment is not None:
+                stdio_server["environment"] = server.environment
             if server.tools is not None:
                 tools: list[MCPServerToolSummary] = []
                 for tool in server.tools:
@@ -104,6 +108,8 @@ def _mcp_server_from_payload(server: MCPServerConfigPayload) -> MCPServerConfig:
                 http_server["timeout"] = server.timeout
             if server.id is not None:
                 http_server["id"] = server.id
+            if server.environment is not None:
+                http_server["environment"] = server.environment
             return http_server
 
 

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -46,6 +46,8 @@ class MCPHttpServerConfigPayload(BaseModel):
     """UUID of the source ``mcp_integrations`` row. Lets trusted callers
     re-resolve secrets per use without carrying them through workflow
     history."""
+    environment: str | None = Field(default=None)
+    """Effective environment used when resolving workspace-backed templates."""
 
 
 class MCPServerToolSummaryPayload(BaseModel):
@@ -74,6 +76,8 @@ class MCPStdioServerConfigPayload(BaseModel):
     id: str | None = Field(default=None)
     """UUID of the source ``mcp_integrations`` row. See
     :class:`MCPHttpServerConfigPayload.id`."""
+    environment: str | None = Field(default=None)
+    """Effective environment used when resolving workspace-backed templates."""
     tools: list[MCPServerToolSummaryPayload] | None = Field(default=None)
     """Latest verified stdio tool summaries. Non-secret and safe for workflow
     history."""

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -103,12 +103,18 @@ class _ThreadLocalRunner:
 
 
 async def _resolve_mcp_integrations(
-    mcp_integration_ids: list[str], *, role: Role
+    mcp_integration_ids: list[str],
+    *,
+    role: Role,
+    environment: str,
 ) -> list[MCPServerConfig]:
     try:
         async with AgentPresetService.with_session(role=role) as svc:
             await svc.load_selected_mcp_integrations(mcp_integration_ids)
-            servers = await svc.resolve_mcp_integration_refs(mcp_integration_ids)
+            servers = await svc.resolve_mcp_integration_refs(
+                mcp_integration_ids,
+                environment=environment,
+            )
     except (MCPValidationError, TracecatValidationError) as e:
         raise ApplicationError(str(e), non_retryable=True) from e
     return servers or []
@@ -711,10 +717,13 @@ class DSLActivities:
         evaled_args = await asyncio.to_thread(
             eval_templated_object, args, operand=materialized
         )
+        evaled_args["environment"] = environment
         mcp_integration_ids = evaled_args.pop("mcp_integrations", None)
         if mcp_integration_ids:
             evaled_args["mcp_servers"] = await _resolve_mcp_integrations(
-                mcp_integration_ids, role=input.role
+                mcp_integration_ids,
+                role=input.role,
+                environment=environment,
             )
         return AgentActionArgs(**evaled_args)
 
@@ -752,6 +761,7 @@ class DSLActivities:
         evaled_args = await asyncio.to_thread(
             eval_templated_object, args, operand=materialized
         )
+        evaled_args["environment"] = environment
         return PresetAgentActionArgs(**evaled_args)
 
     @staticmethod

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -972,6 +972,7 @@ class DSLWorkflow:
                     session_id = action_args.session_id or workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=action_args.user_prompt,
                             session_id=session_id,
@@ -1038,6 +1039,7 @@ class DSLWorkflow:
                     session_id = workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=action_args.user_prompt,
                             session_id=session_id,
@@ -1128,6 +1130,7 @@ class DSLWorkflow:
                     session_id = preset_action_args.session_id or workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=preset_action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=preset_action_args.user_prompt,
                             session_id=session_id,

--- a/tracecat/expressions/common.py
+++ b/tracecat/expressions/common.py
@@ -179,11 +179,15 @@ def eval_jsonpath(
         if strict:
             # We know that if this function is called, there was a templated field.
             # Therefore, it means the jsonpath was valid but there was no match.
-            logger.error("Jsonpath no match", expr=repr(expr), operand=operand)
+            logger.error(
+                "Jsonpath no match",
+                expr=repr(expr),
+                operand_type=type(operand).__name__,
+            )
             formatted_expr = _expr_with_context(expr, context_type)
             raise TracecatExpressionError(
                 f"Couldn't resolve expression {formatted_expr!r} in the context",
-                detail={"expression": formatted_expr, "operand": operand},
+                detail={"expression": formatted_expr},
             )
         # Return None instead of empty list
         return None

--- a/tracecat/expressions/core.py
+++ b/tracecat/expressions/core.py
@@ -14,7 +14,7 @@ from tracecat.expressions import patterns
 from tracecat.expressions.common import ExprContext, ExprOperand, ExprType
 from tracecat.expressions.parser.core import parser
 from tracecat.expressions.parser.evaluator import ExprEvaluator
-from tracecat.expressions.validator.validator import BaseExprValidator
+from tracecat.expressions.validator.base import BaseExprValidator
 from tracecat.logger import logger
 from tracecat.parse import traverse_expressions
 
@@ -31,11 +31,13 @@ class Expression:
         *,
         operand: ExprOperand[str] | None = None,
         visitor: Visitor[Token] | None = None,
+        strict: bool = False,
     ) -> None:
         self._expr = expression
         self._operand = operand
         self._parser = parser
         self._visitor = visitor
+        self._strict = strict
 
     def __str__(self) -> str:
         return self.__repr__()
@@ -72,7 +74,7 @@ class Expression:
             ) from e
 
         try:
-            visitor = ExprEvaluator(operand=self._operand)
+            visitor = ExprEvaluator(operand=self._operand, strict=self._strict)
             if parse_tree is None:
                 raise ValueError(f"Parser returned None for expression `{self._expr}`")
             return visitor.evaluate(parse_tree)
@@ -142,6 +144,7 @@ class TemplateExpression:
         template: str,
         operand: ExprOperand[str] | None = None,
         pattern: re.Pattern[str] = patterns.TEMPLATE_STRING,
+        strict: bool = False,
         **kwargs: Any,
     ) -> None:
         match = pattern.match(template)
@@ -154,7 +157,7 @@ class TemplateExpression:
             raise TracecatExpressionError(
                 f"Template expression {template!r} matched pattern but contained no expression. "
             )
-        self.expr = Expression(expr, operand=operand)
+        self.expr = Expression(expr, operand=operand, strict=strict)
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/tracecat/expressions/eval.py
+++ b/tracecat/expressions/eval.py
@@ -35,9 +35,11 @@ def _eval_templated_obj_rec[T: (str, list[Any], dict[str, Any])](
             return obj
 
 
-def _eval_expression_op(match: re.Match[str], operand: ExprOperand | None) -> str:
+def _eval_expression_op(
+    match: re.Match[str], operand: ExprOperand | None, *, strict: bool
+) -> str:
     expr = match.group("template")
-    result = TemplateExpression(expr, operand=operand).result()
+    result = TemplateExpression(expr, operand=operand, strict=strict).result()
     try:
         return str(result)
     except Exception as e:
@@ -49,9 +51,10 @@ def eval_templated_object(
     *,
     operand: ExprOperand | None = None,
     pattern: re.Pattern[str] = patterns.TEMPLATE_STRING,
+    strict: bool = False,
 ) -> Any:
     """Populate templated fields with actual values."""
-    evaluator = partial(_eval_expression_op, operand=operand)
+    evaluator = partial(_eval_expression_op, operand=operand, strict=strict)
 
     def operator(line: str) -> Any:
         """Evaluate the templated string.
@@ -68,7 +71,7 @@ def eval_templated_object(
             # Non-inline template
             # If the template expression isn't given a reolve type, its underlying
             # value is returned as is.
-            return TemplateExpression(line, operand=operand).result()
+            return TemplateExpression(line, operand=operand, strict=strict).result()
         # Inline template
         # If the template expression is inline, we evaluate the result
         # and attempt to cast each underlying value into a string.

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -29,6 +29,7 @@ from temporalio.service import RPCError, RPCStatusCode
 
 from tracecat import config
 from tracecat.agent.common.types import MCPHttpServerConfig
+from tracecat.agent.mcp import secret_resolution as mcp_secret_resolution
 from tracecat.agent.mcp.stdio_probe_types import (
     MCP_STDIO_PROBE_TIMEOUT_CAP,
     StdioMCPProbeResult,
@@ -3919,8 +3920,41 @@ class IntegrationService(BaseWorkspaceService):
             )
         return cast(dict[str, str], parsed)
 
+    async def _resolve_mcp_custom_header_templates(
+        self,
+        *,
+        mcp_integration: MCPIntegration,
+        custom_headers: dict[str, str],
+        environment: str | None = None,
+    ) -> dict[str, str]:
+        """Resolve custom header values at call time and fail closed."""
+        try:
+            resolution = await mcp_secret_resolution.resolve_templated_mapping(
+                custom_headers,
+                role=self.role,
+                environment=environment,
+                resolve_keys=False,
+            )
+        except mcp_secret_resolution.TemplatedMappingResolutionError as exc:
+            raise MCPConfigurationError(str(exc)) from exc
+
+        if resolution.secret_ref_count or resolution.var_ref_count:
+            self.logger.info(
+                "Resolved HTTP MCP header template expressions",
+                workspace_id=str(self.workspace_id),
+                mcp_integration_id=str(mcp_integration.id),
+                mcp_integration_slug=mcp_integration.slug,
+                header_key_count=len(resolution.mapping),
+                secret_ref_count=resolution.secret_ref_count,
+                var_ref_count=resolution.var_ref_count,
+            )
+        return resolution.mapping
+
     async def resolve_mcp_http_server_config(
-        self, mcp_integration: MCPIntegration
+        self,
+        mcp_integration: MCPIntegration,
+        *,
+        environment: str | None = None,
     ) -> MCPHttpServerConfig:
         """Resolve an HTTP MCP integration into a connectable server config.
 
@@ -3983,14 +4017,34 @@ class IntegrationService(BaseWorkspaceService):
                     # The OAuth Authorization header always wins.
                     if key.strip().casefold() == "authorization":
                         custom_headers.pop(key, None)
+                custom_headers = await self._resolve_mcp_custom_header_templates(
+                    mcp_integration=mcp_integration,
+                    custom_headers=custom_headers,
+                    environment=environment,
+                )
                 headers.update(custom_headers)
         elif mcp_integration.auth_type == MCPAuthType.CUSTOM:
-            headers.update(self._decrypt_mcp_custom_headers(mcp_integration))
+            custom_headers = self._decrypt_mcp_custom_headers(mcp_integration)
+            custom_headers = await self._resolve_mcp_custom_header_templates(
+                mcp_integration=mcp_integration,
+                custom_headers=custom_headers,
+                environment=environment,
+            )
+            headers.update(custom_headers)
         elif mcp_integration.auth_type == MCPAuthType.NONE:
             pass
         else:
             raise MCPConfigurationError(
                 f"Unsupported MCP auth type: {mcp_integration.auth_type}"
+            )
+
+        unresolved_header_names = [
+            name for name, value in headers.items() if "${{" in value
+        ]
+        if unresolved_header_names:
+            raise MCPConfigurationError(
+                "Unresolved template expression in HTTP MCP header(s): "
+                f"{', '.join(sorted(unresolved_header_names))}"
             )
 
         server_config: MCPHttpServerConfig = {

--- a/tracecat/secrets/secrets_manager.py
+++ b/tracecat/secrets/secrets_manager.py
@@ -133,6 +133,8 @@ def _inject_runtime_aws_external_id(secrets: dict[str, Any]) -> None:
 async def get_action_secrets(
     secret_exprs: builtins.set[str],
     action_secrets: builtins.set[RegistrySecretType],
+    *,
+    environment: str | None = None,
 ) -> dict[str, Any]:
     # Handle secrets from the task args
     args_secrets = secret_exprs
@@ -198,7 +200,7 @@ async def get_action_secrets(
     secrets: dict[str, Any] = {}
     async with AuthSandbox(
         secrets=all_basic_secrets,
-        environment=get_runtime_env(),
+        environment=environment if environment is not None else get_runtime_env(),
         optional_secrets=optional_basic_secrets,
     ) as sandbox:
         secrets |= sandbox.secrets.copy()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds environment-aware templating for MCP integrations. Remote header values and `stdio` env vars now resolve `${{ SECRETS.* }}` and `${{ VARS.* }}` at runtime with strict, fail‑closed behavior; OAuth Authorization stays authoritative.

- **New Features**
  - Resolve template expressions in remote MCP custom headers and OAuth extra headers; header names stay literal, user-supplied `authorization` is dropped when OAuth is used, and unresolved/malformed templates raise `MCPConfigurationError` instead of being sent.
  - Resolve template expressions in `stdio` MCP env values using a shared, strict resolver; missing or invalid references fail closed and literals are preserved.
  - New `resolve_templated_mapping` adds environment‑scoped resolution, value‑only mode for headers, reference counting, and sanitized errors; used by the MCP HTTP resolver and preset `stdio` env resolution. Extra guard rejects any header that still contains `${{ ... }}`.
  - Pass the effective environment through MCP HTTP server config so secrets/variables resolve for the correct action environment.
  - MCP dialog editors add workspace‑aware `@SECRETS`/`@VARS` autocomplete with template pills; `CodeEditor` supports `additionalExtensions` and disables default completion when provided. Docs updated to reflect header value templating.

<sup>Written for commit 07b9fc8707ef791f621755a6c6e10c87d554ca51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

