### PR TITLE
fix(ui): calibrate notification banners for dark mode

### DIFF
--- a/frontend/src/components/notifications.tsx
+++ b/frontend/src/components/notifications.tsx
@@ -57,12 +57,12 @@ const notificationVariants = cva(
     variants: {
       variant: {
         success:
-          "bg-green-500/15 border-green-500/50 text-green-600 dark:border-green-500 [&>svg]:text-green-500",
-        info: "bg-cyan-500/15 border-cyan-500/50 text-cyan-600 dark:border-cyan-500 [&>svg]:text-cyan-500",
+          "border-green-500/50 bg-green-500/15 text-green-700 dark:border-green-500/50 dark:bg-green-950/40 dark:text-green-300 [&>svg]:text-green-600 dark:[&>svg]:text-green-400",
+        info: "border-cyan-500/50 bg-cyan-500/15 text-cyan-700 dark:border-cyan-500/50 dark:bg-cyan-950/40 dark:text-cyan-300 [&>svg]:text-cyan-600 dark:[&>svg]:text-cyan-400",
         warning:
-          "bg-yellow-500/10 border-yellow-500/50 text-yellow-600 dark:border-yellow-500 [&>svg]:text-yellow-500",
+          "border-yellow-500/50 bg-yellow-500/10 text-yellow-700 dark:border-yellow-500/50 dark:bg-yellow-950/40 dark:text-yellow-300 [&>svg]:text-yellow-600 dark:[&>svg]:text-yellow-400",
         error:
-          "bg-destructive/10 border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          "border-destructive/50 bg-destructive/10 text-destructive dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300 [&>svg]:text-destructive dark:[&>svg]:text-red-400",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -10,9 +10,9 @@ const alertVariants = cva(
       variant: {
         default: "bg-background text-foreground",
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          "border-destructive/50 bg-destructive/5 text-destructive dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300 [&>svg]:text-destructive dark:[&>svg]:text-red-400",
         warning:
-          "border-amber-400 bg-amber-50 text-amber-600 dark:border-amber-400 dark:bg-amber-950 dark:text-amber-600 [&>svg]:text-amber-600 dark:[&>svg]:text-amber-600",
+          "border-amber-400 bg-amber-50 text-amber-700 dark:border-amber-500/50 dark:bg-amber-950/40 dark:text-amber-300 [&>svg]:text-amber-600 dark:[&>svg]:text-amber-400",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/workspace-sync/pull-tab.tsx
+++ b/frontend/src/components/workspace-sync/pull-tab.tsx
@@ -11,6 +11,7 @@ import {
 import { useEffect, useState } from "react"
 import type { GitCommitInfo, PullResult, VcsProvider } from "@/client"
 import { CommitSelector } from "@/components/registry/commit-selector"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -254,10 +255,13 @@ export function WorkspaceSyncPullTab({
  */
 function SyncWarning({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-700">
-      <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
-      <span>{children}</span>
-    </div>
+    <Alert
+      variant="warning"
+      className="rounded-md px-3 py-2 text-[11px] [&>svg]:left-3 [&>svg]:top-2.5 [&>svg~*]:pl-5"
+    >
+      <AlertTriangleIcon className="size-3.5" />
+      <AlertDescription className="text-[11px]">{children}</AlertDescription>
+    </Alert>
   )
 }
 


### PR DESCRIPTION
## Summary

- calibrate the shared success, info, warning, and error notification variants for dark mode
- give warning and destructive alerts appropriately muted dark surfaces and readable foregrounds
- replace the workspace-sync Pull warning's custom bright markup with the shared `Alert` primitive

## Root cause

The affected banners retained light-mode surfaces or foregrounds in dark mode. Some variants only changed their border, leaving a high-luminance callout against the dark application shell.

## Impact

Status callouts keep their semantic color and contrast without appearing as bright light-mode panels. The workspace-sync warning now inherits future Alert variant improvements instead of maintaining a separate color recipe.

## Validation

- `pnpm -C frontend exec biome check src/components/ui/alert.tsx src/components/notifications.tsx src/components/workspace-sync/pull-tab.tsx`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`
- `git diff --check`
- live local-cluster dark-mode QA covering the workspace-sync Pull warning, an info notification, and a destructive alert
- browser console checked with no warnings or errors; cluster services remained healthy


## Screenshots

### Before
<img width="1098" height="742" alt="image" src="https://github.com/user-attachments/assets/5368fb0d-fbe7-407e-b8ae-b4d5b55b306b" />

### After
Fresh dark-mode receipts from the local cluster:


<img width="1313" height="741" alt="01-success-notification-ui-only" src="https://github.com/user-attachments/assets/11a6adce-ab76-4d3c-92a2-3db558aa2d1c" />
<img width="1313" height="741" alt="02-workspace-sync-warning-ui-only" src="https://github.com/user-attachments/assets/7f56d21b-e14d-483e-bc48-774215e92cc1" />
<img width="1313" height="741" alt="03-info-notification-ui-only" src="https://github.com/user-attachments/assets/17a87825-8362-4492-a54f-3c1148e57341" />
<img width="1313" height="741" alt="04-destructive-alert-ui-only" src="https://github.com/user-attachments/assets/7c693311-c32e-4bab-88be-5127ab16e9a0" />
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calibrates notification banners and `Alert` variants for dark mode so callouts keep contrast without bright light panels. Replaces the workspace‑sync Pull warning’s custom banner with the shared `Alert`.

- **Bug Fixes**
  - Dark-mode styles for success/info/warning/error notifications: muted surfaces, matching borders, readable text and icon colors.
  - `Alert` warning and destructive variants now use softer dark surfaces with corrected text/icon colors.
  - Workspace-sync Pull warning now uses `Alert` + `AlertDescription` with consistent icon spacing.

<sup>Written for commit a0cdd30cbfb548d48ed77b5ae0bf5e410e18338b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

