### PR TITLE
fix(integrations): stop forwarding inbound auth to user MCP servers

### DIFF
--- a/tests/unit/test_agent_mcp_user_client.py
+++ b/tests/unit/test_agent_mcp_user_client.py
@@ -1,5 +1,6 @@
+import httpx
 import pytest
-from fastmcp.client.transports import StreamableHttpTransport
+from fastmcp.client.transports import SSETransport, StreamableHttpTransport
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
 from tracecat.agent.mcp.user_client import UserMCPClient, _create_transport
@@ -124,3 +125,95 @@ def test_create_transport_lowercased_headers_survive_inbound_merge() -> None:
     assert merged.get("authorization") == "Bearer notion-real"
     auth_keys = [k for k in merged if k.lower() == "authorization"]
     assert auth_keys == ["authorization"]
+
+
+# Regression: lowercasing only wins fastmcp's `inbound | self.headers` union
+# when our own credential is an Authorization header. Servers authenticating
+# via non-Authorization headers (e.g. Wiz client-credentials sends
+# Wiz-Client-Id/Secret) never collide, so the inbound Tracecat session JWT
+# reached the third-party server and Wiz rejected the request with a 401.
+# _create_transport now installs a client factory that strips the forwarded
+# token unless our configured headers deliberately set Authorization.
+
+WIZ_CLIENT_CREDENTIALS = {
+    "Wiz-Client-Id": "svc-account-id",
+    "Wiz-Client-Secret": "svc-account-secret",
+    "Wiz-DataCenter": "us1",
+    "X-Wiz-MCP-Mode": "gateway",
+}
+
+
+def _outbound_headers(
+    configured: dict[str, str] | None,
+    inbound: dict[str, str],
+) -> httpx.Headers:
+    """Return the headers httpx receives after fastmcp's merge and our factory."""
+    transport = _create_transport(
+        url="https://mcp.example.com/mcp",
+        transport_type="http",
+        headers=configured,
+        timeout=None,
+    )
+    assert isinstance(transport, StreamableHttpTransport)
+    factory = transport.httpx_client_factory
+    assert factory is not None
+    # fastmcp http.py: get_http_headers(include={"authorization"}) | self.headers
+    merged = inbound | transport.headers
+    client = factory(headers=merged, timeout=None, auth=None)
+    return client.headers
+
+
+def test_create_transport_strips_forwarded_auth_for_non_authorization_credentials() -> (
+    None
+):
+    """A server authenticating via custom headers must not receive our JWT."""
+    headers = _outbound_headers(
+        dict(WIZ_CLIENT_CREDENTIALS),
+        {"authorization": "Bearer tracecat-session-jwt"},
+    )
+
+    assert "authorization" not in headers
+    assert headers["wiz-client-id"] == "svc-account-id"
+    assert headers["wiz-client-secret"] == "svc-account-secret"
+    assert headers["wiz-datacenter"] == "us1"
+    assert headers["x-wiz-mcp-mode"] == "gateway"
+
+
+def test_create_transport_strips_forwarded_auth_when_no_credentials_configured() -> (
+    None
+):
+    """Servers configured with no auth must not receive an Authorization header."""
+    headers = _outbound_headers(None, {"authorization": "Bearer tracecat-session-jwt"})
+
+    # Not merely emptied: the header must be absent, since httpx transmits
+    # empty-valued headers rather than dropping them.
+    assert "authorization" not in headers
+
+
+def test_create_transport_preserves_configured_authorization_credential() -> None:
+    """OAuth-backed servers must still receive their own bearer token."""
+    headers = _outbound_headers(
+        {"Authorization": "Bearer wiz-oauth-token"},
+        {"authorization": "Bearer tracecat-session-jwt"},
+    )
+
+    assert headers["authorization"] == "Bearer wiz-oauth-token"
+
+
+def test_sse_transport_also_strips_forwarded_auth() -> None:
+    """The leak is transport-independent; fastmcp merges in the shared base."""
+    transport = _create_transport(
+        url="https://mcp.example.com/sse",
+        transport_type="sse",
+        headers=dict(WIZ_CLIENT_CREDENTIALS),
+        timeout=None,
+    )
+    assert isinstance(transport, SSETransport)
+    factory = transport.httpx_client_factory
+    assert factory is not None
+
+    merged = {"authorization": "Bearer tracecat-session-jwt"} | transport.headers
+    client = factory(headers=merged, timeout=None, auth=None)
+
+    assert "authorization" not in client.headers
+    assert client.headers["wiz-client-id"] == "svc-account-id"

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -16,6 +16,7 @@ import httpx
 from fastmcp import Client
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
 from mcp import McpError
+from mcp.shared._httpx_utils import McpHttpClientFactory
 from tenacity import (
     AsyncRetrying,
     retry_if_exception,
@@ -40,6 +41,34 @@ class UserMCPDiscoveryResult:
     failed_servers: dict[str, str]
 
 
+def _drop_forwarded_authorization(
+    configured: dict[str, str] | None,
+) -> McpHttpClientFactory:
+    """Build a client factory that strips fastmcp's forwarded inbound auth."""
+    keeps_authorization = configured is not None and "authorization" in configured
+
+    def factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+        **kwargs: Any,
+    ) -> httpx.AsyncClient:
+        merged = dict(headers or {})
+        if not keeps_authorization:
+            merged.pop("authorization", None)
+        if timeout is None:
+            timeout = httpx.Timeout(30.0, read=300.0)
+        kwargs.setdefault("follow_redirects", True)
+        return httpx.AsyncClient(
+            headers=merged,
+            timeout=timeout,
+            auth=auth,
+            **kwargs,
+        )
+
+    return factory
+
+
 def _create_transport(
     url: str,
     transport_type: Literal["http", "sse"],
@@ -52,10 +81,23 @@ def _create_transport(
     # producing duplicate Authorization headers with different casing.
     if headers is not None:
         headers = {name.lower(): value for name, value in headers.items()}
+    # Lowercasing alone only wins the merge when our credential is itself an
+    # Authorization header; strip the forwarded token in every other case.
+    httpx_client_factory = _drop_forwarded_authorization(headers)
     if transport_type == "sse":
-        return SSETransport(url=url, headers=headers, sse_read_timeout=timeout)
+        return SSETransport(
+            url=url,
+            headers=headers,
+            sse_read_timeout=timeout,
+            httpx_client_factory=httpx_client_factory,
+        )
     # Default to HTTP (Streamable HTTP transport)
-    return StreamableHttpTransport(url=url, headers=headers, sse_read_timeout=timeout)
+    return StreamableHttpTransport(
+        url=url,
+        headers=headers,
+        sse_read_timeout=timeout,
+        httpx_client_factory=httpx_client_factory,
+    )
 
 
 async def list_remote_mcp_tools(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop forwarding inbound Authorization to user MCP servers to prevent leaking the Tracecat session JWT. We now only send `authorization` when it’s explicitly configured in server credentials; applies to both `http` and `sse` transports.

- **Bug Fixes**
  - Added an `httpx` client factory that strips forwarded `authorization` unless the configured headers include `authorization`.
  - Wired the factory into `SSETransport` and `StreamableHttpTransport` via `httpx_client_factory`; kept header names lowercased.
  - Added regression tests for non-Authorization credential flows, no-credential cases, preserving configured Authorization, and SSE transport.

<sup>Written for commit 93a5b31ccb3a8cc0dca51cb50ee8fc9e9b1d728b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

