### PR TITLE
fix(agents): preserve MCP action environments

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -16508,6 +16508,10 @@ export const $MCPHttpServerConfig = {
       type: "string",
       title: "Id",
     },
+    environment: {
+      type: "string",
+      title: "Environment",
+    },
   },
   type: "object",
   required: ["name", "url"],
@@ -17486,6 +17490,10 @@ export const $MCPStdioServerConfig = {
     id: {
       type: "string",
       title: "Id",
+    },
+    environment: {
+      type: "string",
+      title: "Environment",
     },
     tools: {
       items: {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -16022,6 +16022,10 @@ export const $MCPHttpServerConfig = {
       type: "string",
       title: "Id",
     },
+    environment: {
+      type: "string",
+      title: "Environment",
+    },
   },
   type: "object",
   required: ["name", "url"],
@@ -17000,6 +17004,10 @@ export const $MCPStdioServerConfig = {
     id: {
       type: "string",
       title: "Id",
+    },
+    environment: {
+      type: "string",
+      title: "Environment",
     },
     tools: {
       items: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4951,6 +4951,7 @@ export type MCPHttpServerConfig = {
   transport?: "http" | "sse"
   timeout?: number
   id?: string
+  environment?: string
 }
 
 export type transport = "http" | "sse"
@@ -5198,6 +5199,7 @@ export type MCPStdioServerConfig = {
   }
   timeout?: number
   id?: string
+  environment?: string
   tools?: Array<MCPServerToolSummary>
 }
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -5093,6 +5093,7 @@ export type MCPHttpServerConfig = {
   transport?: "http" | "sse"
   timeout?: number
   id?: string
+  environment?: string
 }
 
 export type transport = "http" | "sse"
@@ -5340,6 +5341,7 @@ export type MCPStdioServerConfig = {
   }
   timeout?: number
   id?: string
+  environment?: string
   tools?: Array<MCPServerToolSummary>
 }
 

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -336,7 +336,8 @@ class AgentActivities:
                     for hydrated, integration_id in configs_with_integration_id:
                         try:
                             secrets = await svc.resolve_mcp_integration_secrets(
-                                integration_id
+                                integration_id,
+                                environment=hydrated.get("environment"),
                             )
                         except (ValueError, MCPSecretResolutionError):
                             secrets = None
@@ -389,12 +390,13 @@ class AgentActivities:
                             effective_tool_approvals[approval_key] = True
                     defs[tool_name] = tool_def
 
-                # JWT claims carry the source integration id when available so
-                # the trusted MCP server can re-resolve headers per call. For
-                # legacy in-flight payloads that don't carry ``id`` (recorded
-                # before the refs-only cutover), fall back to the pre-rollout
-                # inline shape — otherwise discovery would add ``mcp__*`` tools
-                # that the trusted server can't authorize at call time.
+                # JWT claims carry the source integration id and effective
+                # environment when available so the trusted MCP server can
+                # re-resolve the correct headers per call. For legacy in-flight
+                # payloads that don't carry ``id`` (recorded before the
+                # refs-only cutover), fall back to the pre-rollout inline shape
+                # — otherwise discovery would add ``mcp__*`` tools that the
+                # trusted server can't authorize at call time.
                 user_mcp_claims = []
                 for cfg in http_servers:
                     integration_id_str = cfg.get("id")
@@ -403,6 +405,7 @@ class AgentActivities:
                             UserMCPServerClaim(
                                 name=cfg["name"],
                                 id=uuid.UUID(integration_id_str),
+                                environment=cfg.get("environment"),
                             )
                         )
                         continue

--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -18,6 +18,7 @@ _BASE_CONFIG = ConfigDict(extra="ignore")
 class AgentActionArgs(BaseModel):
     model_config = _BASE_CONFIG
 
+    environment: str | None = None
     user_prompt: str
     model_name: str
     model_provider: str
@@ -79,6 +80,7 @@ class AgentActionArgs(BaseModel):
 class PresetAgentActionArgs(BaseModel):
     model_config = _BASE_CONFIG
 
+    environment: str | None = None
     preset: str
     preset_version: int | None = None
     user_prompt: str

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -51,9 +51,13 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.parsers import try_parse_json
     from tracecat.agent.preset.activities import (
         ResolveAgentPresetConfigActivityInput,
+        ResolveAgentPresetConfigWithEnvironmentActivityInput,
         ResolveAgentsConfigActivityInput,
+        ResolveAgentsConfigWithEnvironmentActivityInput,
         resolve_agent_preset_config_activity,
+        resolve_agent_preset_config_with_environment_activity,
         resolve_agents_config_activity,
+        resolve_agents_config_with_environment_activity,
         resolve_custom_model_provider_config_activity,
     )
     from tracecat.agent.preset.resolver import (
@@ -400,6 +404,8 @@ class AgentWorkflowArgs(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     role: Role
+    environment: str | None = None
+    """Effective DSL action environment for workspace-backed agent resources."""
     agent_args: RunAgentArgs
     # Session metadata
     title: str = Field(default="New Chat", description="Session title")
@@ -471,6 +477,7 @@ LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-histo
 PRESERVE_RESUMED_AGENT_BINDINGS_PATCH = (
     "durable-agent-preserve-resumed-agent-bindings-v1"
 )
+AGENT_ACTION_ENVIRONMENT_PATCH = "durable-agent-action-environment-v1"
 
 
 def _agents_config_from_binding(
@@ -599,24 +606,45 @@ class DurableAgentWorkflow:
 
     async def _build_config(self, args: AgentWorkflowArgs) -> AgentConfig:
         if args.agent_args.preset_slug:
-            activity_input = (
-                ResolveAgentPresetConfigActivityInput(
-                    role=self.role,
-                    preset_version_id=args.agent_preset_version_id,
+            use_action_environment = workflow.patched(AGENT_ACTION_ENVIRONMENT_PATCH)
+            if use_action_environment and args.environment is not None:
+                preset_config_payload = await workflow.execute_activity(
+                    resolve_agent_preset_config_with_environment_activity,
+                    (
+                        ResolveAgentPresetConfigWithEnvironmentActivityInput(
+                            role=self.role,
+                            preset_version_id=args.agent_preset_version_id,
+                            environment=args.environment,
+                        )
+                        if args.agent_preset_version_id is not None
+                        else ResolveAgentPresetConfigWithEnvironmentActivityInput(
+                            role=self.role,
+                            preset_slug=args.agent_args.preset_slug,
+                            preset_version=args.agent_args.preset_version,
+                            environment=args.environment,
+                        )
+                    ),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
                 )
-                if args.agent_preset_version_id is not None
-                else ResolveAgentPresetConfigActivityInput(
-                    role=self.role,
-                    preset_slug=args.agent_args.preset_slug,
-                    preset_version=args.agent_args.preset_version,
+            else:
+                preset_config_payload = await workflow.execute_activity(
+                    resolve_agent_preset_config_activity,
+                    (
+                        ResolveAgentPresetConfigActivityInput(
+                            role=self.role,
+                            preset_version_id=args.agent_preset_version_id,
+                        )
+                        if args.agent_preset_version_id is not None
+                        else ResolveAgentPresetConfigActivityInput(
+                            role=self.role,
+                            preset_slug=args.agent_args.preset_slug,
+                            preset_version=args.agent_args.preset_version,
+                        )
+                    ),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
                 )
-            )
-            preset_config_payload = await workflow.execute_activity(
-                resolve_agent_preset_config_activity,
-                activity_input,
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=RETRY_POLICIES["activity:fail_fast"],
-            )
             preset_config = agent_config_from_payload(preset_config_payload)
             # Apply overrides from the provided config (if any)
             # When using a preset, the 'config' in args acts as an override layer
@@ -660,6 +688,21 @@ class DurableAgentWorkflow:
             return ResolvedAgentsRuntimeConfig()
         if not agents_config.subagents:
             return ResolvedAgentsRuntimeConfig(enabled=True)
+        use_action_environment = workflow.patched(AGENT_ACTION_ENVIRONMENT_PATCH)
+        if use_action_environment and args.environment is not None:
+            return await workflow.execute_activity(
+                resolve_agents_config_with_environment_activity,
+                ResolveAgentsConfigWithEnvironmentActivityInput(
+                    role=self.role,
+                    agents=agents_config,
+                    parent_preset_id=args.agent_preset_id,
+                    parent_slug=args.agent_args.preset_slug,
+                    follow_latest_versions=follow_latest_versions,
+                    environment=args.environment,
+                ),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
         return await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(

--- a/tests/temporal/test_agent_config_workflow_boundary.py
+++ b/tests/temporal/test_agent_config_workflow_boundary.py
@@ -57,6 +57,7 @@ def _build_agent_config() -> TracecatAgentConfig:
                 "url": "http://host.docker.internal:8080",
                 "transport": "http",
                 "headers": {"Authorization": "Bearer secret123"},
+                "environment": "staging",
             }
         ],
         model_settings={"parallel_tool_calls": False},
@@ -113,6 +114,7 @@ class AgentConfigDecodeWorkflow:
                 "url": "http://host.docker.internal:8080",
                 "transport": "http",
                 "headers": {"Authorization": "Bearer secret123"},
+                "environment": "staging",
             }
         ]
         assert config.model_settings == {"parallel_tool_calls": False}
@@ -220,8 +222,9 @@ async def test_legacy_agent_config_payload_replays_as_agent_config_payload(
 # These pin that:
 #   * the legacy MCP server shape (no ``id``, inline ``headers``) recorded in
 #     pre-rollout workflow history still decodes,
-#   * the new ref shape (carrying ``id``, no ``headers``) round-trips through
-#     the workflow boundary so trusted callers can re-resolve secrets,
+#   * the new ref shape (carrying ``id`` and ``environment``, no ``headers``)
+#     round-trips through the workflow boundary so trusted callers can
+#     re-resolve secrets,
 #   * a payload containing a mix of the two shapes (and a stdio server)
 #     decodes intact.
 # ---------------------------------------------------------------------------
@@ -246,7 +249,7 @@ def _legacy_mcp_agent_config() -> TracecatAgentConfig:
 
 
 def _ref_mcp_agent_config() -> TracecatAgentConfig:
-    """Post-rollout config: ``id`` set, no ``headers``."""
+    """Post-rollout config: ``id`` and ``environment`` set, no ``headers``."""
     return TracecatAgentConfig(
         model_name="gpt-5.2",
         model_provider="openai",
@@ -257,6 +260,7 @@ def _ref_mcp_agent_config() -> TracecatAgentConfig:
                 "url": "http://host.docker.internal:8080",
                 "transport": "http",
                 "id": "11111111-1111-1111-1111-111111111111",
+                "environment": "staging",
             }
         ],
         retries=3,
@@ -277,13 +281,14 @@ def _mixed_mcp_agent_config() -> TracecatAgentConfig:
                 "transport": "http",
                 "headers": {"Authorization": "Bearer legacy"},
             },
-            # New http with id, no headers
+            # New http with id and environment, no headers
             {
                 "type": "http",
                 "name": "modern",
                 "url": "http://modern.local",
                 "transport": "http",
                 "id": "22222222-2222-2222-2222-222222222222",
+                "environment": "staging",
             },
             # Stdio with id
             {
@@ -292,6 +297,7 @@ def _mixed_mcp_agent_config() -> TracecatAgentConfig:
                 "command": "/usr/bin/echo",
                 "args": ["hello"],
                 "id": "33333333-3333-3333-3333-333333333333",
+                "environment": "production",
                 "tools": [
                     {
                         "name": "list_alerts",
@@ -396,7 +402,7 @@ async def test_legacy_mcp_payload_decodes_without_id(
 async def test_ref_mcp_payload_preserves_id_across_boundary(
     env: WorkflowEnvironment,
 ) -> None:
-    """New ref shape must round-trip with ``id`` intact and no headers added."""
+    """New ref shape preserves ``id`` and ``environment`` without adding headers."""
     task_queue = "test-ref-mcp-payload-decode"
     async with Worker(
         env.client,
@@ -419,6 +425,7 @@ async def test_ref_mcp_payload_preserves_id_across_boundary(
             "url": "http://host.docker.internal:8080",
             "transport": "http",
             "id": "11111111-1111-1111-1111-111111111111",
+            "environment": "staging",
         }
     ]
 
@@ -457,6 +464,7 @@ async def test_mixed_mcp_payload_decodes_intact(
             "url": "http://modern.local",
             "transport": "http",
             "id": "22222222-2222-2222-2222-222222222222",
+            "environment": "staging",
         },
         {
             "type": "stdio",
@@ -464,6 +472,7 @@ async def test_mixed_mcp_payload_decodes_intact(
             "command": "/usr/bin/echo",
             "args": ["hello"],
             "id": "33333333-3333-3333-3333-333333333333",
+            "environment": "production",
             "tools": [
                 {
                     "name": "list_alerts",

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -351,8 +351,11 @@ class TestBuildToolDefinitionsActivity:
             async def resolve_mcp_integration_secrets(
                 self,
                 mcp_integration_id: uuid.UUID,
+                *,
+                environment: str | None = None,
             ) -> dict[str, str]:
                 assert mcp_integration_id == integration_id
+                assert environment == "staging"
                 return {"authorization": "Bearer test-token"}
 
         class _PresetContext:
@@ -420,6 +423,7 @@ class TestBuildToolDefinitionsActivity:
                         "name": "Jira",
                         "url": "https://mcp.example.com/mcp",
                         "id": str(integration_id),
+                        "environment": "staging",
                     }
                 ],
             )
@@ -429,6 +433,7 @@ class TestBuildToolDefinitionsActivity:
         assert result.tool_approvals == {"mcp.Jira.getIssue": True}
         assert result.user_mcp_claims is not None
         assert result.user_mcp_claims[0].id == integration_id
+        assert result.user_mcp_claims[0].environment == "staging"
         assert entitlement_roles == [mock_role]
 
     @pytest.mark.anyio
@@ -493,7 +498,10 @@ class TestBuildToolDefinitionsActivity:
             async def resolve_mcp_integration_secrets(
                 self,
                 mcp_integration_id: uuid.UUID,
+                *,
+                environment: str | None = None,
             ) -> dict[str, str]:
+                _ = environment
                 return {}
 
         class _PresetContext:

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -326,8 +326,11 @@ class TestBuildToolDefinitionsActivity:
             async def resolve_mcp_integration_secrets(
                 self,
                 mcp_integration_id: uuid.UUID,
+                *,
+                environment: str | None = None,
             ) -> dict[str, str]:
                 assert mcp_integration_id == integration_id
+                assert environment == "staging"
                 return {"authorization": "Bearer test-token"}
 
         class _PresetContext:
@@ -395,6 +398,7 @@ class TestBuildToolDefinitionsActivity:
                         "name": "Jira",
                         "url": "https://mcp.example.com/mcp",
                         "id": str(integration_id),
+                        "environment": "staging",
                     }
                 ],
             )
@@ -404,6 +408,7 @@ class TestBuildToolDefinitionsActivity:
         assert result.tool_approvals == {"mcp.Jira.getIssue": True}
         assert result.user_mcp_claims is not None
         assert result.user_mcp_claims[0].id == integration_id
+        assert result.user_mcp_claims[0].environment == "staging"
         assert entitlement_roles == [mock_role]
 
     @pytest.mark.anyio
@@ -468,7 +473,10 @@ class TestBuildToolDefinitionsActivity:
             async def resolve_mcp_integration_secrets(
                 self,
                 mcp_integration_id: uuid.UUID,
+                *,
+                environment: str | None = None,
             ) -> dict[str, str]:
+                _ = environment
                 return {}
 
         class _PresetContext:

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -130,8 +130,14 @@ async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
                 }
             ]
 
-        async def resolve_mcp_integration_secrets(self, resolved_integration_id):
+        async def resolve_mcp_integration_secrets(
+            self,
+            resolved_integration_id,
+            *,
+            environment=None,
+        ):
             assert resolved_integration_id == integration_id
+            assert environment == "staging"
             return {"Authorization": "Bearer secret"}
 
     monkeypatch.setattr(
@@ -163,7 +169,13 @@ async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
         {"key": "SEC-1"},
         _build_claims(
             allowed_actions=["mcp__Jira__getIssue"],
-            user_mcp_servers=[UserMCPServerClaim(name="Jira", id=integration_id)],
+            user_mcp_servers=[
+                UserMCPServerClaim(
+                    name="Jira",
+                    id=integration_id,
+                    environment="staging",
+                )
+            ],
         ),
     )
 
@@ -550,8 +562,14 @@ async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
                 }
             ]
 
-        async def resolve_mcp_integration_secrets(self, resolved_integration_id):
+        async def resolve_mcp_integration_secrets(
+            self,
+            resolved_integration_id,
+            *,
+            environment=None,
+        ):
             assert resolved_integration_id == integration_id
+            assert environment is None
             return {}
 
     discovered_config_names: list[list[str]] = []

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -109,8 +109,14 @@ async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
                 }
             ]
 
-        async def resolve_mcp_integration_secrets(self, resolved_integration_id):
+        async def resolve_mcp_integration_secrets(
+            self,
+            resolved_integration_id,
+            *,
+            environment=None,
+        ):
             assert resolved_integration_id == integration_id
+            assert environment == "staging"
             return {"Authorization": "Bearer secret"}
 
     monkeypatch.setattr(
@@ -142,7 +148,13 @@ async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
         {"key": "SEC-1"},
         _build_claims(
             allowed_actions=["mcp__Jira__getIssue"],
-            user_mcp_servers=[UserMCPServerClaim(name="Jira", id=integration_id)],
+            user_mcp_servers=[
+                UserMCPServerClaim(
+                    name="Jira",
+                    id=integration_id,
+                    environment="staging",
+                )
+            ],
         ),
     )
 
@@ -529,8 +541,14 @@ async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
                 }
             ]
 
-        async def resolve_mcp_integration_secrets(self, resolved_integration_id):
+        async def resolve_mcp_integration_secrets(
+            self,
+            resolved_integration_id,
+            *,
+            environment=None,
+        ):
             assert resolved_integration_id == integration_id
+            assert environment is None
             return {}
 
     discovered_config_names: list[list[str]] = []

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -4,15 +4,19 @@ import uuid
 from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from tracecat.agent.preset.activities import (
+    ResolveAgentPresetConfigWithEnvironmentActivityInput,
     ResolveAgentPresetVersionRefActivityInput,
     ResolveAgentsConfigActivityInput,
+    ResolveAgentsConfigWithEnvironmentActivityInput,
+    resolve_agent_preset_config_with_environment_activity,
     resolve_agent_preset_version_ref_activity,
     resolve_agents_config_activity,
+    resolve_agents_config_with_environment_activity,
     resolve_custom_model_provider_config_activity,
 )
 from tracecat.agent.preset.resolver import (
@@ -115,6 +119,46 @@ def test_resolve_agents_config_result_derives_session_binding() -> None:
     agents_binding = result.to_agents_binding()
     assert agents_binding.enabled is True
     assert agents_binding.subagents == [binding]
+
+
+@pytest.mark.anyio
+async def test_resolve_agent_preset_config_uses_action_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    config = AgentConfig(
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        retries=3,
+    )
+    with_preset_config = Mock(return_value=_AsyncContext(config))
+    service = SimpleNamespace(with_preset_config=with_preset_config)
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentManagementService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    result = await resolve_agent_preset_config_with_environment_activity(
+        ResolveAgentPresetConfigWithEnvironmentActivityInput(
+            role=role,
+            preset_slug="triage-agent",
+            environment="staging",
+        )
+    )
+
+    with_preset_config.assert_called_once_with(
+        preset_id=None,
+        slug="triage-agent",
+        preset_version_id=None,
+        preset_version=None,
+        environment="staging",
+    )
+    assert result.model_name == "gpt-4o-mini"
 
 
 @pytest.mark.anyio
@@ -227,6 +271,66 @@ async def test_resolve_agents_config_resolves_pinned_ref_by_version_id(
     service.use_latest_resource_versions.assert_awaited_once()
     assert result.subagents[0].binding.preset_version_id == preset_version_id
     assert result.subagents[0].binding.preset_version == 4
+
+
+@pytest.mark.anyio
+async def test_resolve_subagent_config_uses_action_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preset_id = uuid.uuid4()
+    preset_version_id = uuid.uuid4()
+    version = SimpleNamespace(
+        id=preset_version_id,
+        preset_id=preset_id,
+        version=4,
+        agents={"enabled": False},
+        tool_approvals={},
+    )
+    service = SimpleNamespace(
+        resolve_agent_preset_version=AsyncMock(return_value=version),
+        get_preset=AsyncMock(return_value=SimpleNamespace(description="Child preset")),
+        resolve_agent_preset_config=AsyncMock(
+            return_value=AgentConfig(
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                retries=3,
+            )
+        ),
+        use_latest_resource_versions=AsyncMock(return_value=False),
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    await resolve_agents_config_with_environment_activity(
+        ResolveAgentsConfigWithEnvironmentActivityInput(
+            role=role,
+            agents=AgentSubagentsConfig(
+                enabled=True,
+                subagents=[
+                    ResolvedAttachedSubagentRef(
+                        preset="analyst",
+                        preset_version=4,
+                        preset_id=preset_id,
+                        preset_version_id=preset_version_id,
+                    )
+                ],
+            ),
+            environment="staging",
+        )
+    )
+
+    service.resolve_agent_preset_config.assert_awaited_once_with(
+        preset_version_id=preset_version_id,
+        environment="staging",
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -299,6 +299,54 @@ def agent_preset_create_params() -> AgentPresetCreate:
 
 
 @pytest.mark.anyio
+async def test_resolve_stdio_env_uses_explicit_environment(
+    agent_preset_service: AgentPresetService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_secret_environments: list[str | None] = []
+    requested_variable_environments: list[str | None] = []
+
+    async def get_action_secrets(
+        **kwargs: object,
+    ) -> dict[str, dict[str, str]]:
+        requested_secret_environments.append(cast(str | None, kwargs["environment"]))
+        return {"api": {"TOKEN": "staging-token"}}
+
+    async def get_workspace_variables(
+        *_: object,
+        **kwargs: object,
+    ) -> dict[str, dict[str, str]]:
+        requested_variable_environments.append(cast(str | None, kwargs["environment"]))
+        return {"tenant": {"id": "staging-tenant"}}
+
+    monkeypatch.setattr(
+        "tracecat.agent.preset.service.secrets_manager.get_action_secrets",
+        get_action_secrets,
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.service.get_workspace_variables",
+        get_workspace_variables,
+    )
+
+    resolved = await agent_preset_service.resolve_stdio_env(
+        stdio_env={
+            "TOKEN": "${{ SECRETS.api.TOKEN }}",
+            "TENANT": "${{ VARS.tenant.id }}",
+        },
+        mcp_integration_id=uuid.uuid4(),
+        mcp_integration_slug="environment-scoped-stdio",
+        environment="staging",
+    )
+
+    assert resolved == {
+        "TOKEN": "staging-token",
+        "TENANT": "staging-tenant",
+    }
+    assert requested_secret_environments == ["staging"]
+    assert requested_variable_environments == ["staging"]
+
+
+@pytest.mark.anyio
 class TestAgentPresetService:
     async def test_create_and_get_preset(
         self,

--- a/tests/unit/test_agent_tokens.py
+++ b/tests/unit/test_agent_tokens.py
@@ -90,8 +90,9 @@ def test_mcp_token_accepts_legacy_user_mcp_server_claim_shape(monkeypatch) -> No
 
 
 def test_mcp_token_round_trips_refs_only_user_mcp_server_claim(monkeypatch) -> None:
-    """New-shape claims (``name`` + ``id`` only) must round-trip cleanly so the
-    trusted server has the integration id it needs to re-resolve secrets.
+    """New-shape claims round-trip the id and non-secret resolution environment.
+
+    The trusted server needs both values to re-resolve the correct credentials.
     """
     workspace_id, organization_id, session_id = _setup_service_key(monkeypatch)
     integration_id = uuid.uuid4()
@@ -102,7 +103,13 @@ def test_mcp_token_round_trips_refs_only_user_mcp_server_claim(monkeypatch) -> N
         allowed_actions=["core.http_request"],
         session_id=session_id,
         registry_lock=_registry_lock(),
-        user_mcp_servers=[UserMCPServerClaim(name="modern-mcp", id=integration_id)],
+        user_mcp_servers=[
+            UserMCPServerClaim(
+                name="modern-mcp",
+                id=integration_id,
+                environment="staging",
+            )
+        ],
     )
 
     claims = verify_mcp_token(token)
@@ -110,6 +117,7 @@ def test_mcp_token_round_trips_refs_only_user_mcp_server_claim(monkeypatch) -> N
     ref = claims.user_mcp_servers[0]
     assert ref.name == "modern-mcp"
     assert ref.id == integration_id
+    assert ref.environment == "staging"
     # New-shape claims should not carry secret material.
     assert ref.url is None
     assert ref.headers == {}

--- a/tests/unit/test_build_agent_args.py
+++ b/tests/unit/test_build_agent_args.py
@@ -421,8 +421,44 @@ class TestBuildAgentArgsMcpResolution:
         ) as mock_resolve:
             result = await DSLActivities.build_agent_args_activity(input)
 
-        mock_resolve.assert_awaited_once_with([integration_id], role=role)
+        mock_resolve.assert_awaited_once_with(
+            [integration_id],
+            role=role,
+            environment="default",
+        )
         assert result.mcp_servers == [resolved]
+
+    @pytest.mark.anyio
+    async def test_mcp_resolution_uses_effective_task_environment(self, role: Role):
+        """MCP refs carry the action override used for later header resolution."""
+        integration_id = str(uuid.uuid4())
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "mcp_integrations": [integration_id],
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment="staging",
+            default_environment="default",
+        )
+
+        with patch(
+            "tracecat.dsl.action._resolve_mcp_integrations",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_resolve:
+            result = await DSLActivities.build_agent_args_activity(input)
+
+        mock_resolve.assert_awaited_once_with(
+            [integration_id],
+            role=role,
+            environment="staging",
+        )
+        assert result.environment == "staging"
 
     @pytest.mark.anyio
     async def test_mcp_integration_ids_not_present_on_result(self, role: Role):
@@ -522,7 +558,11 @@ class TestBuildAgentArgsMcpResolution:
         ) as mock_resolve:
             result = await DSLActivities.build_agent_args_activity(input)
 
-        mock_resolve.assert_awaited_once_with([id1, id2], role=role)
+        mock_resolve.assert_awaited_once_with(
+            [id1, id2],
+            role=role,
+            environment="default",
+        )
         assert result.mcp_servers == resolved
         assert len(result.mcp_servers) == 2  # type: ignore[arg-type]
 
@@ -671,10 +711,11 @@ class TestBuildPresetAgentArgsActivity:
             new_callable=AsyncMock,
             return_value={"prompts": {"default": "Analyze this alert"}},
         ) as mock_get_vars:
-            await DSLActivities.build_preset_agent_args_activity(input)
+            result = await DSLActivities.build_preset_agent_args_activity(input)
 
         mock_get_vars.assert_called_once_with(
             variable_exprs={"prompts"},
             environment="staging",
             role=role,
         )
+        assert result.environment == "staging"

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -117,6 +117,33 @@ async def test_get_action_secrets_passes_sets_to_auth_sandbox(mocker):
 
 
 @pytest.mark.anyio
+async def test_get_action_secrets_uses_explicit_environment(mocker):
+    """An explicit environment overrides the ambient workflow context."""
+    mock_sandbox = mocker.MagicMock()
+    mock_sandbox.secrets = {}
+    mock_sandbox.__aenter__.return_value = mock_sandbox
+    mock_sandbox.__aexit__.return_value = None
+
+    auth_sandbox_mock = mocker.patch(
+        "tracecat.secrets.secrets_manager.AuthSandbox",
+        return_value=mock_sandbox,
+    )
+    runtime_env_mock = mocker.patch(
+        "tracecat.secrets.secrets_manager.get_runtime_env",
+        return_value="default",
+    )
+
+    await secrets_manager.get_action_secrets(
+        secret_exprs={"api.TOKEN"},
+        action_secrets=set(),
+        environment="staging",
+    )
+
+    assert auth_sandbox_mock.call_args.kwargs["environment"] == "staging"
+    runtime_env_mock.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_get_action_secrets_skips_optional_oauth(mocker):
     """Ensure optional OAuth integrations do not raise when missing."""
 

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -100,6 +100,33 @@ async def test_get_action_secrets_passes_sets_to_auth_sandbox(mocker):
 
 
 @pytest.mark.anyio
+async def test_get_action_secrets_uses_explicit_environment(mocker):
+    """An explicit environment overrides the ambient workflow context."""
+    mock_sandbox = mocker.MagicMock()
+    mock_sandbox.secrets = {}
+    mock_sandbox.__aenter__.return_value = mock_sandbox
+    mock_sandbox.__aexit__.return_value = None
+
+    auth_sandbox_mock = mocker.patch(
+        "tracecat.secrets.secrets_manager.AuthSandbox",
+        return_value=mock_sandbox,
+    )
+    runtime_env_mock = mocker.patch(
+        "tracecat.secrets.secrets_manager.get_runtime_env",
+        return_value="default",
+    )
+
+    await secrets_manager.get_action_secrets(
+        secret_exprs={"api.TOKEN"},
+        action_secrets=set(),
+        environment="staging",
+    )
+
+    assert auth_sandbox_mock.call_args.kwargs["environment"] == "staging"
+    runtime_env_mock.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_get_action_secrets_skips_optional_oauth(mocker):
     """Ensure optional OAuth integrations do not raise when missing."""
 

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -2181,6 +2181,33 @@ class TestMCPIntegrationCRUD:
         assert retrieved.name == created.name
         assert retrieved.server_uri == created.server_uri
 
+    async def test_resolve_mcp_refs_carry_effective_environment(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Boundary-safe refs retain the environment needed at the trusted edge."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Environment-scoped ref",
+                server_uri="https://mcp.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        preset_service = AgentPresetService(
+            session=integration_service.session,
+            role=integration_service.role,
+        )
+
+        resolved = await preset_service.resolve_mcp_integration_refs(
+            [str(created.id)],
+            environment="staging",
+        )
+
+        assert resolved is not None
+        assert resolved[0].get("id") == str(created.id)
+        assert resolved[0].get("environment") == "staging"
+        assert "headers" not in resolved[0]
+
     async def test_resolve_oauth2_mcp_with_additional_headers(
         self,
         integration_service: IntegrationService,

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -2366,6 +2366,33 @@ class TestMCPIntegrationCRUD:
         assert retrieved.name == created.name
         assert retrieved.server_uri == created.server_uri
 
+    async def test_resolve_mcp_refs_carry_effective_environment(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Boundary-safe refs retain the environment needed at the trusted edge."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Environment-scoped ref",
+                server_uri="https://mcp.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        preset_service = AgentPresetService(
+            session=integration_service.session,
+            role=integration_service.role,
+        )
+
+        resolved = await preset_service.resolve_mcp_integration_refs(
+            [str(created.id)],
+            environment="staging",
+        )
+
+        assert resolved is not None
+        assert resolved[0].get("id") == str(created.id)
+        assert resolved[0].get("environment") == "staging"
+        assert "headers" not in resolved[0]
+
     async def test_resolve_oauth2_mcp_with_additional_headers(
         self,
         integration_service: IntegrationService,

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -59,6 +59,10 @@ class MCPHttpServerConfig(TypedDict):
     resolved from. Set when produced by ``AgentPresetService`` resolvers so
     callers can re-resolve secrets per use without re-listing integrations."""
 
+    environment: NotRequired[str]
+    """Effective workflow/action environment for resolving workspace-backed
+    header templates at the trusted edge."""
+
 
 class MCPServerToolSummary(TypedDict):
     """Non-secret summary of a verified user MCP tool."""
@@ -84,6 +88,10 @@ class MCPStdioServerConfig(TypedDict):
     id: NotRequired[str]
     """Optional: UUID of the source ``mcp_integrations`` row this config was
     resolved from. See :class:`MCPHttpServerConfig.id`."""
+
+    environment: NotRequired[str]
+    """Effective workflow/action environment for resolving workspace-backed
+    process environment templates at the trusted edge."""
 
     tools: NotRequired[list[MCPServerToolSummary]]
     """Optional, non-secret tool summaries from the latest successful

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -1068,7 +1068,10 @@ async def _hydrate_stdio_env(
                         f"Stdio MCP server {cfg.get('name')!r} is missing a source integration id"
                     )
                 try:
-                    env = await svc.resolve_mcp_integration_secrets(uuid.UUID(cfg_id))
+                    env = await svc.resolve_mcp_integration_secrets(
+                        uuid.UUID(cfg_id),
+                        environment=cfg.get("environment"),
+                    )
                 except (ValueError, MCPSecretResolutionError):
                     env = None
                 result.append({**cfg, "env": env} if env else cfg)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -1052,7 +1052,10 @@ async def _hydrate_stdio_env(
                         f"Stdio MCP server {cfg.get('name')!r} is missing a source integration id"
                     )
                 try:
-                    env = await svc.resolve_mcp_integration_secrets(uuid.UUID(cfg_id))
+                    env = await svc.resolve_mcp_integration_secrets(
+                        uuid.UUID(cfg_id),
+                        environment=cfg.get("environment"),
+                    )
                 except (ValueError, MCPSecretResolutionError):
                     env = None
                 result.append({**cfg, "env": env} if env else cfg)

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -381,7 +381,10 @@ async def _resolve_user_mcp_config(
             metadata = refs[0]
             if not is_http_mcp_server(metadata):
                 raise ToolError(f"User MCP server '{ref.name}' is not an HTTP server")
-            secrets = await svc.resolve_mcp_integration_secrets(ref.id)
+            secrets = await svc.resolve_mcp_integration_secrets(
+                ref.id,
+                environment=ref.environment,
+            )
     except ToolError:
         raise
     except MCPSecretResolutionError as e:

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -41,6 +41,14 @@ class ResolveAgentPresetConfigActivityInput(BaseModel):
         return self
 
 
+class ResolveAgentPresetConfigWithEnvironmentActivityInput(
+    ResolveAgentPresetConfigActivityInput
+):
+    """Preset resolution input with an explicit action environment."""
+
+    environment: str
+
+
 class ResolveAgentPresetVersionRefActivityInput(BaseModel):
     role: Role
     preset_slug: str
@@ -60,9 +68,16 @@ class ResolveAgentsConfigActivityInput(BaseModel):
     follow_latest_versions: bool | None = None
 
 
-@activity.defn
-async def resolve_agent_preset_config_activity(
+class ResolveAgentsConfigWithEnvironmentActivityInput(ResolveAgentsConfigActivityInput):
+    """Subagent resolution input with an explicit action environment."""
+
+    environment: str
+
+
+async def _resolve_agent_preset_config(
     args: ResolveAgentPresetConfigActivityInput,
+    *,
+    environment: str | None,
 ) -> AgentConfigPayload:
     async with AgentManagementService.with_session(role=args.role) as service:
         async with service.with_preset_config(
@@ -70,8 +85,25 @@ async def resolve_agent_preset_config_activity(
             slug=args.preset_slug,
             preset_version_id=args.preset_version_id,
             preset_version=args.preset_version,
+            environment=environment,
         ) as config:
             return agent_config_to_payload(config)
+
+
+@activity.defn
+async def resolve_agent_preset_config_activity(
+    args: ResolveAgentPresetConfigActivityInput,
+) -> AgentConfigPayload:
+    """Resolve a preset for replayed runs that predate environment propagation."""
+    return await _resolve_agent_preset_config(args, environment=None)
+
+
+@activity.defn
+async def resolve_agent_preset_config_with_environment_activity(
+    args: ResolveAgentPresetConfigWithEnvironmentActivityInput,
+) -> AgentConfigPayload:
+    """Resolve a preset in the action's effective environment."""
+    return await _resolve_agent_preset_config(args, environment=args.environment)
 
 
 @activity.defn
@@ -93,6 +125,23 @@ async def resolve_agent_preset_version_ref_activity(
 async def resolve_agents_config_activity(
     args: ResolveAgentsConfigActivityInput,
 ) -> ResolvedAgentsRuntimeConfig:
+    """Resolve subagent configs for runs that predate environment propagation."""
+    return await _resolve_agents_config(args, environment=None)
+
+
+@activity.defn
+async def resolve_agents_config_with_environment_activity(
+    args: ResolveAgentsConfigWithEnvironmentActivityInput,
+) -> ResolvedAgentsRuntimeConfig:
+    """Resolve subagent configs in the action's effective environment."""
+    return await _resolve_agents_config(args, environment=args.environment)
+
+
+async def _resolve_agents_config(
+    args: ResolveAgentsConfigActivityInput,
+    *,
+    environment: str | None,
+) -> ResolvedAgentsRuntimeConfig:
     async with AgentPresetService.with_session(role=args.role) as service:
         follow_latest_versions = args.follow_latest_versions
         if follow_latest_versions is None:
@@ -104,6 +153,7 @@ async def resolve_agents_config_activity(
             parent_slug=args.parent_slug,
             include_runtime_config=True,
             follow_latest_versions=follow_latest_versions,
+            environment=environment,
         )
         return resolved.to_runtime_config()
 

--- a/tracecat/agent/preset/resolver.py
+++ b/tracecat/agent/preset/resolver.py
@@ -44,6 +44,7 @@ class AgentPresetResolutionService(Protocol):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        environment: str | None = None,
     ) -> Awaitable[AgentConfig]: ...
 
 
@@ -125,6 +126,7 @@ async def resolve_agents_config(
     parent_slug: str | None = None,
     include_runtime_config: bool = False,
     follow_latest_versions: bool = False,
+    environment: str | None = None,
 ) -> ResolvedAgentsConfigResult:
     """Resolve and validate preset-backed subagent refs."""
 
@@ -214,6 +216,7 @@ async def resolve_agents_config(
             preset = await service.get_preset(version.preset_id)
             child_config = await service.resolve_agent_preset_config(
                 preset_version_id=version.id,
+                environment=environment,
             )
             description = (
                 ref.description

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -584,6 +584,7 @@ class AgentPresetService(BaseWorkspaceService):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        environment: str | None = None,
     ) -> AgentConfig:
         """Get an agent configuration from a preset by ID or slug with MCP integrations resolved."""
         version = await self.resolve_agent_preset_version(
@@ -592,7 +593,7 @@ class AgentPresetService(BaseWorkspaceService):
             preset_version_id=preset_version_id,
             preset_version=preset_version,
         )
-        return await self._version_to_agent_config(version)
+        return await self._version_to_agent_config(version, environment=environment)
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def resolve_agent_preset_version(
@@ -771,7 +772,10 @@ class AgentPresetService(BaseWorkspaceService):
             )
 
     async def resolve_mcp_integrations(
-        self, mcp_integrations: list[str] | None
+        self,
+        mcp_integrations: list[str] | None,
+        *,
+        environment: str | None = None,
     ) -> list[MCPServerConfig] | None:
         """Resolve MCP integrations into MCP server configs."""
         if not mcp_integrations:
@@ -834,6 +838,7 @@ class AgentPresetService(BaseWorkspaceService):
                             stdio_env=stdio_env,
                             mcp_integration_id=mcp_integration.id,
                             mcp_integration_slug=mcp_integration.slug,
+                            environment=environment,
                         )
                     except Exception as e:
                         logger.warning(
@@ -911,13 +916,17 @@ class AgentPresetService(BaseWorkspaceService):
         return mcp_servers
 
     async def resolve_mcp_integration_refs(
-        self, mcp_integrations: list[str] | None
+        self,
+        mcp_integrations: list[str] | None,
+        *,
+        environment: str | None = None,
     ) -> list[MCPServerConfig] | None:
         """Resolve MCP integration IDs into ``MCPServerConfig``s without secrets.
 
         Returns metadata only — ``headers`` and stdio ``env`` are intentionally
-        omitted. Each config carries its source ``id`` so trusted callers can
-        re-resolve secrets per use via :meth:`resolve_mcp_integration_secrets`.
+        omitted. Each config carries its source ``id`` and, when provided, the
+        effective ``environment`` so trusted callers can re-resolve secrets per
+        use via :meth:`resolve_mcp_integration_secrets`.
 
         Safe to serialize across Temporal boundaries.
 
@@ -1001,6 +1010,8 @@ class AgentPresetService(BaseWorkspaceService):
                     stdio_ref["args"] = mcp_integration.stdio_args
                 if mcp_integration.timeout is not None:
                     stdio_ref["timeout"] = mcp_integration.timeout
+                if environment is not None:
+                    stdio_ref["environment"] = environment
                 stored_tools = MCPToolSummary.validate_stored(
                     mcp_integration.tools,
                     mcp_integration_id=mcp_integration.id,
@@ -1036,6 +1047,8 @@ class AgentPresetService(BaseWorkspaceService):
             }
             if mcp_integration.timeout is not None:
                 http_ref["timeout"] = mcp_integration.timeout
+            if environment is not None:
+                http_ref["environment"] = environment
             refs.append(http_ref)
 
         if not refs:
@@ -1071,7 +1084,10 @@ class AgentPresetService(BaseWorkspaceService):
         return policies
 
     async def resolve_mcp_integration_secrets(
-        self, mcp_integration_id: uuid.UUID
+        self,
+        mcp_integration_id: uuid.UUID,
+        *,
+        environment: str | None = None,
     ) -> dict[str, str] | None:
         """Resolve the secret material for a single MCP integration.
 
@@ -1111,6 +1127,7 @@ class AgentPresetService(BaseWorkspaceService):
                     stdio_env=stdio_env,
                     mcp_integration_id=mcp_integration.id,
                     mcp_integration_slug=mcp_integration.slug,
+                    environment=environment,
                 )
             except Exception as e:
                 logger.warning(
@@ -1160,6 +1177,7 @@ class AgentPresetService(BaseWorkspaceService):
         stdio_env: dict[str, str],
         mcp_integration_id: uuid.UUID,
         mcp_integration_slug: str,
+        environment: str | None = None,
     ) -> dict[str, str]:
         """Resolve template expressions in stdio_env using workspace secrets/vars."""
         collected = collect_expressions(stdio_env)
@@ -1169,10 +1187,12 @@ class AgentPresetService(BaseWorkspaceService):
         secrets = await secrets_manager.get_action_secrets(
             secret_exprs=collected.secrets,
             action_secrets=set(),
+            environment=environment,
         )
         vars_map = await get_workspace_variables(
             variable_exprs=collected.variables,
             role=self.role,
+            environment=environment,
         )
 
         context = create_default_execution_context()
@@ -1903,14 +1923,20 @@ class AgentPresetService(BaseWorkspaceService):
         )
 
     async def _version_to_agent_config(
-        self, version: AgentPresetVersion
+        self,
+        version: AgentPresetVersion,
+        *,
+        environment: str | None = None,
     ) -> AgentConfig:
         use_latest_resource_versions = await self.use_latest_resource_versions()
         # Resolve refs only — no headers / stdio env. The resulting
         # AgentConfig is safe to cross Temporal boundaries. Trusted callers
         # (build_tool_definitions, trusted MCP server) re-resolve secrets
         # per use via resolve_mcp_integration_secrets.
-        mcp_servers = await self.resolve_mcp_integration_refs(version.mcp_integrations)
+        mcp_servers = await self.resolve_mcp_integration_refs(
+            version.mcp_integrations,
+            environment=environment,
+        )
         model_settings: dict[str, Any] = {}
         resolved_skills = await self.skills.get_resolved_skill_refs_for_preset_version(
             version.id,

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -586,6 +586,7 @@ class AgentPresetService(BaseWorkspaceService):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        environment: str | None = None,
     ) -> AgentConfig:
         """Get an agent configuration from a preset by ID or slug with MCP integrations resolved."""
         version = await self.resolve_agent_preset_version(
@@ -594,7 +595,7 @@ class AgentPresetService(BaseWorkspaceService):
             preset_version_id=preset_version_id,
             preset_version=preset_version,
         )
-        return await self._version_to_agent_config(version)
+        return await self._version_to_agent_config(version, environment=environment)
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def resolve_agent_preset_version(
@@ -816,7 +817,10 @@ class AgentPresetService(BaseWorkspaceService):
         }
 
     async def resolve_mcp_integrations(
-        self, mcp_integrations: list[str] | None
+        self,
+        mcp_integrations: list[str] | None,
+        *,
+        environment: str | None = None,
     ) -> list[MCPServerConfig] | None:
         """Resolve MCP integrations into MCP server configs."""
         if not mcp_integrations:
@@ -884,6 +888,7 @@ class AgentPresetService(BaseWorkspaceService):
                             stdio_env=stdio_env,
                             mcp_integration_id=mcp_integration.id,
                             mcp_integration_slug=mcp_integration.slug,
+                            environment=environment,
                         )
                     except Exception as e:
                         logger.warning(
@@ -967,13 +972,17 @@ class AgentPresetService(BaseWorkspaceService):
         return mcp_servers
 
     async def resolve_mcp_integration_refs(
-        self, mcp_integrations: list[str] | None
+        self,
+        mcp_integrations: list[str] | None,
+        *,
+        environment: str | None = None,
     ) -> list[MCPServerConfig] | None:
         """Resolve MCP integration IDs into ``MCPServerConfig``s without secrets.
 
         Returns metadata only — ``headers`` and stdio ``env`` are intentionally
-        omitted. Each config carries its source ``id`` so trusted callers can
-        re-resolve secrets per use via :meth:`resolve_mcp_integration_secrets`.
+        omitted. Each config carries its source ``id`` and, when provided, the
+        effective ``environment`` so trusted callers can re-resolve secrets per
+        use via :meth:`resolve_mcp_integration_secrets`.
 
         Safe to serialize across Temporal boundaries.
 
@@ -1063,6 +1072,8 @@ class AgentPresetService(BaseWorkspaceService):
                     stdio_ref["args"] = stdio_args
                 if mcp_integration.timeout is not None:
                     stdio_ref["timeout"] = mcp_integration.timeout
+                if environment is not None:
+                    stdio_ref["environment"] = environment
                 stored_tools = MCPToolSummary.validate_stored(
                     mcp_integration.tools,
                     mcp_integration_id=mcp_integration.id,
@@ -1098,6 +1109,8 @@ class AgentPresetService(BaseWorkspaceService):
             }
             if mcp_integration.timeout is not None:
                 http_ref["timeout"] = mcp_integration.timeout
+            if environment is not None:
+                http_ref["environment"] = environment
             refs.append(http_ref)
 
         if not refs:
@@ -1133,7 +1146,10 @@ class AgentPresetService(BaseWorkspaceService):
         return policies
 
     async def resolve_mcp_integration_secrets(
-        self, mcp_integration_id: uuid.UUID
+        self,
+        mcp_integration_id: uuid.UUID,
+        *,
+        environment: str | None = None,
     ) -> dict[str, str] | None:
         """Resolve the secret material for a single MCP integration.
 
@@ -1173,6 +1189,7 @@ class AgentPresetService(BaseWorkspaceService):
                     stdio_env=stdio_env,
                     mcp_integration_id=mcp_integration.id,
                     mcp_integration_slug=mcp_integration.slug,
+                    environment=environment,
                 )
             except Exception as e:
                 logger.warning(
@@ -1222,6 +1239,7 @@ class AgentPresetService(BaseWorkspaceService):
         stdio_env: dict[str, str],
         mcp_integration_id: uuid.UUID,
         mcp_integration_slug: str,
+        environment: str | None = None,
     ) -> dict[str, str]:
         """Resolve template expressions in stdio_env using workspace secrets/vars."""
         collected = collect_expressions(stdio_env)
@@ -1231,10 +1249,12 @@ class AgentPresetService(BaseWorkspaceService):
         secrets = await secrets_manager.get_action_secrets(
             secret_exprs=collected.secrets,
             action_secrets=set(),
+            environment=environment,
         )
         vars_map = await get_workspace_variables(
             variable_exprs=collected.variables,
             role=self.role,
+            environment=environment,
         )
 
         context = create_default_execution_context()
@@ -1965,14 +1985,20 @@ class AgentPresetService(BaseWorkspaceService):
         )
 
     async def _version_to_agent_config(
-        self, version: AgentPresetVersion
+        self,
+        version: AgentPresetVersion,
+        *,
+        environment: str | None = None,
     ) -> AgentConfig:
         use_latest_resource_versions = await self.use_latest_resource_versions()
         # Resolve refs only — no headers / stdio env. The resulting
         # AgentConfig is safe to cross Temporal boundaries. Trusted callers
         # (build_tool_definitions, trusted MCP server) re-resolve secrets
         # per use via resolve_mcp_integration_secrets.
-        mcp_servers = await self.resolve_mcp_integration_refs(version.mcp_integrations)
+        mcp_servers = await self.resolve_mcp_integration_refs(
+            version.mcp_integrations,
+            environment=environment,
+        )
         model_settings: dict[str, Any] = {}
         resolved_skills = await self.skills.get_resolved_skill_refs_for_preset_version(
             version.id,

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -1079,6 +1079,7 @@ class AgentManagementService(BaseOrgService):
         slug: str | None = None,
         preset_version_id: uuid.UUID | None = None,
         preset_version: int | None = None,
+        environment: str | None = None,
     ) -> AsyncIterator[AgentConfig]:
         """Yield an agent preset configuration with provider credentials loaded.
 
@@ -1103,6 +1104,7 @@ class AgentManagementService(BaseOrgService):
             slug=slug,
             preset_version_id=preset_version_id,
             preset_version=preset_version,
+            environment=environment,
         )
 
         credentials: dict[str, str] | None = None

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -56,8 +56,9 @@ class UserMCPServerClaim(BaseModel):
 
     The legacy ``url``/``transport``/``headers``/``timeout`` fields are
     kept here so in-flight JWTs and Temporal activity outputs serialized
-    before this change still validate on replay. New mint paths set only
-    ``(name, id)``; trusted-server code paths use ``id``.
+    before this change still validate on replay. New mint paths set
+    ``(name, id, environment)``; trusted-server code paths use the latter two
+    values to resolve credentials.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -67,6 +68,8 @@ class UserMCPServerClaim(BaseModel):
     id: uuid.UUID | None = None
     """UUID of the source ``mcp_integrations`` row. Required on new tokens;
     optional only to support replay of pre-rollout tokens that lack it."""
+    environment: str | None = None
+    """Effective workflow/action environment for trusted template resolution."""
 
     # --- Legacy fields kept for replay of in-flight tokens. ---
     # New mint paths leave these unset. Trusted server reads only (name, id).

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -30,8 +30,10 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.mcp.activities import persist_stdio_mcp_connection_activity
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_config_activity,
+        resolve_agent_preset_config_with_environment_activity,
         resolve_agent_preset_version_ref_activity,
         resolve_agents_config_activity,
+        resolve_agents_config_with_environment_activity,
         resolve_custom_model_provider_config_activity,
     )
     from tracecat.agent.session.activities import get_session_activities
@@ -89,8 +91,10 @@ def get_activities() -> list[Callable[..., object]]:
     activities.extend(agent_activities.get_activities())
     activities.extend(ApprovalManager.get_activities())
     activities.append(resolve_agent_preset_config_activity)
+    activities.append(resolve_agent_preset_config_with_environment_activity)
     activities.append(resolve_agent_preset_version_ref_activity)
     activities.append(resolve_agents_config_activity)
+    activities.append(resolve_agents_config_with_environment_activity)
     activities.append(resolve_custom_model_provider_config_activity)
     activities.append(persist_stdio_mcp_connection_activity)
     activities.extend(get_session_activities())

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -30,8 +30,10 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.mcp.activities import persist_stdio_mcp_connection_activity
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_config_activity,
+        resolve_agent_preset_config_with_environment_activity,
         resolve_agent_preset_version_ref_activity,
         resolve_agents_config_activity,
+        resolve_agents_config_with_environment_activity,
         resolve_custom_model_provider_config_activity,
     )
     from tracecat.agent.session.activities import get_session_activities
@@ -82,8 +84,10 @@ def get_activities() -> list[Callable[..., object]]:
     activities.extend(agent_activities.get_activities())
     activities.extend(ApprovalManager.get_activities())
     activities.append(resolve_agent_preset_config_activity)
+    activities.append(resolve_agent_preset_config_with_environment_activity)
     activities.append(resolve_agent_preset_version_ref_activity)
     activities.append(resolve_agents_config_activity)
+    activities.append(resolve_agents_config_with_environment_activity)
     activities.append(resolve_custom_model_provider_config_activity)
     activities.append(persist_stdio_mcp_connection_activity)
     activities.extend(get_session_activities())

--- a/tracecat/agent/workflow_config.py
+++ b/tracecat/agent/workflow_config.py
@@ -37,6 +37,7 @@ def _mcp_server_to_payload(
                 env=server.get("env"),
                 timeout=server.get("timeout"),
                 id=server.get("id"),
+                environment=server.get("environment"),
                 tools=(
                     [MCPServerToolSummaryPayload.model_validate(tool) for tool in tools]
                     if (tools := server.get("tools")) is not None
@@ -55,6 +56,7 @@ def _mcp_server_to_payload(
                 transport=server.get("transport"),
                 timeout=server.get("timeout"),
                 id=server.get("id"),
+                environment=server.get("environment"),
             )
         case _:
             raise ValueError(f"Unsupported MCP server config: {server!r}")
@@ -76,6 +78,8 @@ def _mcp_server_from_payload(server: MCPServerConfigPayload) -> MCPServerConfig:
                 stdio_server["timeout"] = server.timeout
             if server.id is not None:
                 stdio_server["id"] = server.id
+            if server.environment is not None:
+                stdio_server["environment"] = server.environment
             if server.tools is not None:
                 tools: list[MCPServerToolSummary] = []
                 for tool in server.tools:
@@ -104,6 +108,8 @@ def _mcp_server_from_payload(server: MCPServerConfigPayload) -> MCPServerConfig:
                 http_server["timeout"] = server.timeout
             if server.id is not None:
                 http_server["id"] = server.id
+            if server.environment is not None:
+                http_server["environment"] = server.environment
             return http_server
 
 

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -46,6 +46,8 @@ class MCPHttpServerConfigPayload(BaseModel):
     """UUID of the source ``mcp_integrations`` row. Lets trusted callers
     re-resolve secrets per use without carrying them through workflow
     history."""
+    environment: str | None = Field(default=None)
+    """Effective environment used when resolving workspace-backed templates."""
 
 
 class MCPServerToolSummaryPayload(BaseModel):
@@ -74,6 +76,8 @@ class MCPStdioServerConfigPayload(BaseModel):
     id: str | None = Field(default=None)
     """UUID of the source ``mcp_integrations`` row. See
     :class:`MCPHttpServerConfigPayload.id`."""
+    environment: str | None = Field(default=None)
+    """Effective environment used when resolving workspace-backed templates."""
     tools: list[MCPServerToolSummaryPayload] | None = Field(default=None)
     """Latest verified stdio tool summaries. Non-secret and safe for workflow
     history."""

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -103,12 +103,18 @@ class _ThreadLocalRunner:
 
 
 async def _resolve_mcp_integrations(
-    mcp_integration_ids: list[str], *, role: Role
+    mcp_integration_ids: list[str],
+    *,
+    role: Role,
+    environment: str,
 ) -> list[MCPServerConfig]:
     try:
         async with AgentPresetService.with_session(role=role) as svc:
             await svc.load_selected_mcp_integrations(mcp_integration_ids)
-            servers = await svc.resolve_mcp_integration_refs(mcp_integration_ids)
+            servers = await svc.resolve_mcp_integration_refs(
+                mcp_integration_ids,
+                environment=environment,
+            )
     except (MCPValidationError, TracecatValidationError) as e:
         raise ApplicationError(str(e), non_retryable=True) from e
     return servers or []
@@ -711,10 +717,13 @@ class DSLActivities:
         evaled_args = await asyncio.to_thread(
             eval_templated_object, args, operand=materialized
         )
+        evaled_args["environment"] = environment
         mcp_integration_ids = evaled_args.pop("mcp_integrations", None)
         if mcp_integration_ids:
             evaled_args["mcp_servers"] = await _resolve_mcp_integrations(
-                mcp_integration_ids, role=input.role
+                mcp_integration_ids,
+                role=input.role,
+                environment=environment,
             )
         return AgentActionArgs(**evaled_args)
 
@@ -752,6 +761,7 @@ class DSLActivities:
         evaled_args = await asyncio.to_thread(
             eval_templated_object, args, operand=materialized
         )
+        evaled_args["environment"] = environment
         return PresetAgentActionArgs(**evaled_args)
 
     @staticmethod

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -977,6 +977,7 @@ class DSLWorkflow:
                     session_id = action_args.session_id or workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=action_args.user_prompt,
                             session_id=session_id,
@@ -1043,6 +1044,7 @@ class DSLWorkflow:
                     session_id = workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=action_args.user_prompt,
                             session_id=session_id,
@@ -1133,6 +1135,7 @@ class DSLWorkflow:
                     session_id = preset_action_args.session_id or workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=preset_action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=preset_action_args.user_prompt,
                             session_id=session_id,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -972,6 +972,7 @@ class DSLWorkflow:
                     session_id = action_args.session_id or workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=action_args.user_prompt,
                             session_id=session_id,
@@ -1038,6 +1039,7 @@ class DSLWorkflow:
                     session_id = workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=action_args.user_prompt,
                             session_id=session_id,
@@ -1128,6 +1130,7 @@ class DSLWorkflow:
                     session_id = preset_action_args.session_id or workflow.uuid4()
                     arg = AgentWorkflowArgs(
                         role=self.role,
+                        environment=preset_action_args.environment,
                         agent_args=RunAgentArgs(
                             user_prompt=preset_action_args.user_prompt,
                             session_id=session_id,

--- a/tracecat/secrets/secrets_manager.py
+++ b/tracecat/secrets/secrets_manager.py
@@ -133,6 +133,8 @@ def _inject_runtime_aws_external_id(secrets: dict[str, Any]) -> None:
 async def get_action_secrets(
     secret_exprs: builtins.set[str],
     action_secrets: builtins.set[RegistrySecretType],
+    *,
+    environment: str | None = None,
 ) -> dict[str, Any]:
     # Handle secrets from the task args
     args_secrets = secret_exprs
@@ -198,7 +200,7 @@ async def get_action_secrets(
     secrets: dict[str, Any] = {}
     async with AuthSandbox(
         secrets=all_basic_secrets,
-        environment=get_runtime_env(),
+        environment=environment if environment is not None else get_runtime_env(),
         optional_secrets=optional_basic_secrets,
     ) as sandbox:
         secrets |= sandbox.secrets.copy()


### PR DESCRIPTION
## Summary by cubic
Preserves the action environment for MCP integrations end to end so secrets and stdio env resolve in the correct environment at the trusted edge. Adds `environment` to MCP configs and user MCP JWT claims, and propagates it through DSL actions, workflows, activities, and preset resolvers while keeping legacy payloads compatible.

- **Bug Fixes**
  - Propagated environment from DSL actions into `AgentWorkflowArgs`, preset/agent activities, and subagent resolution; guarded by the `durable-agent-action-environment-v1` patch for safe replay.
  - Added `environment` to MCP HTTP/STDIO server configs (backend payloads, workflow schemas, and frontend `schemas.gen.ts`/`types.gen.ts`) and ensured it round-trips across the workflow boundary.
  - Extended `UserMCPServerClaim` with `environment`; the trusted MCP server now passes it to `resolve_mcp_integration_secrets` for correct per-environment credentials.
  - Preset resolvers now accept and use `environment` when resolving MCP refs and stdio env; ref outputs include only `id` and `environment` (no secrets), with legacy inline/headers still supported on replay.
  - `get_action_secrets` honors an explicit `environment`, overriding the ambient runtime env for accurate per-action secret resolution.

<sup>Written for commit 81a30411beff4490b6e8a571911fa9657730194b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

