### PR TITLE
test(benchmark): add postgres scatter load-test scaffolding

### DIFF
--- a/docker-compose.loadtest.yml
+++ b/docker-compose.loadtest.yml
@@ -1,0 +1,136 @@
+# PostgreSQL scatter load-test override.
+#
+# Layer this on top of a profile compose file, e.g.
+#
+#   ./scripts/cluster up -d --loadtest
+#   docker compose -f docker-compose.dev.yml -f docker-compose.loadtest.yml config
+#
+# Scope: this override constrains ONLY `postgres_db`, the application database
+# under test. Temporal persistence runs on the separate `temporal_postgres_db`
+# service and is deliberately left unconstrained so Temporal scheduling
+# pressure is not coupled to the database under test. Verify at runtime that
+# Temporal still points at `temporal_postgres_db`.
+#
+# See scripts/benchmark/postgres-scatter-load-test-plan.md.
+
+services:
+  # === Database under test ===================================================
+  # Controlled test settings. These are NOT a claim that the container
+  # resembles a named RDS instance class.
+  postgres_db:
+    cpus: "1.0"
+    mem_limit: 1g
+    memswap_limit: 1g
+    pids_limit: 256
+    command:
+      - postgres
+      - -c
+      - max_connections=50
+      - -c
+      - shared_buffers=128MB
+
+  # === Connection budget =====================================================
+  #
+  # PLACEHOLDER VALUES. Finalize these after the phase 0/1 baseline
+  # measurement, then record the measured numbers in the run artifacts.
+  #
+  # The plan's invariant is:
+  #
+  #   C_budget     = max_connections - C_admin_reserve - C_nonload_baseline
+  #   C_configured = sum(replicas[i] * processes_per_replica[i]
+  #                      * (pool_size[i] + max_overflow[i]))
+  #   Required: C_configured <= C_budget
+  #
+  # We set a pool ceiling on EVERY database-capable service below, so
+  # C_nonload_baseline is zero by construction: every long-lived application
+  # connection is already inside C_configured. That avoids double-counting the
+  # idle connections of the non-load services against the same budget.
+  #
+  # Reserve arithmetic against max_connections=50:
+  #
+  #   superuser_reserved_connections (PostgreSQL built-in)          3
+  #   operator + metric-collector sessions (psql, pg_stat_activity) 3
+  #   `migrations` container burst (alembic, sync psycopg engine)   2
+  #   ------------------------------------------------------------ --
+  #   C_admin_reserve (INCLUSIVE of the built-in reserve)           8
+  #   C_budget = 50 - 8 - 0                                        42
+  #
+  # CAVEAT: the built-in `superuser_reserved_connections` only withholds slots
+  # from NON-superuser roles. The dev stack connects as `postgres`, which is a
+  # superuser, so those 3 slots are not actually protected today. Either point
+  # TRACECAT__POSTGRES_USER at a non-superuser role for the run, or treat the
+  # reserve as advisory and confirm it during the runtime checks.
+  #
+  # Per-service allocation. Every dev-profile service below is 1 replica
+  # running 1 process that can create the shared async SQLAlchemy engine
+  # (`api` runs a single uvicorn process with no --workers; the rest are single
+  # `python -m ...` processes). Verify this inventory at runtime before phase 2
+  # — in particular whether executor sandbox worker subprocesses
+  # (TRACECAT__EXECUTOR_WORKER_POOL_SIZE) create their own engine, which would
+  # multiply the executor row.
+  #
+  #   service          pool  overflow  ceiling  rationale
+  #   api                 8         4       12  submissions + fixed-interval
+  #                                             polling; every poll does auth +
+  #                                             membership queries, so this is
+  #                                             the hottest path
+  #   worker              6         3        9  DSL workflow worker
+  #   executor            6         3        9  runs core.table.insert_row(s)
+  #   mcp                 2         1        3  idle during the load test
+  #   litellm             2         1        3  idle during the load test
+  #   agent-executor      2         1        3  idle during the load test
+  #   ------------------------------------------
+  #   C_configured                          39  <= C_budget (42)   OK
+  #
+  # Executor capacity budget:
+  #
+  #   C_executor = executor_replicas * max_concurrent_activities_per_replica
+  #              = 1 * 8 = 8
+  #
+  # 8 is chosen to sit one below the executor's own 9-connection ceiling, on
+  # the assumption that a table-insert activity holds at most one session at a
+  # time, leaving one connection for registry/bookkeeping queries. Confirm that
+  # assumption from pg_stat_activity before trusting it.
+  #
+  # TRACECAT__DB_POOL_TIMEOUT is set here so pool exhaustion fails within a
+  # known bound rather than waiting indefinitely. It is honored by
+  # `tracecat/db/engine.py`, which passes `pool_timeout` to
+  # `create_async_engine`; re-confirm that during the phase 2 runtime checks
+  # before attributing any unbounded wait to something else.
+
+  api:
+    environment:
+      TRACECAT__DB_POOL_SIZE: ${TRACECAT__LOADTEST_API_DB_POOL_SIZE:-8}
+      TRACECAT__DB_MAX_OVERFLOW: ${TRACECAT__LOADTEST_API_DB_MAX_OVERFLOW:-4}
+      TRACECAT__DB_POOL_TIMEOUT: ${TRACECAT__LOADTEST_DB_POOL_TIMEOUT:-10}
+
+  worker:
+    environment:
+      TRACECAT__DB_POOL_SIZE: ${TRACECAT__LOADTEST_WORKER_DB_POOL_SIZE:-6}
+      TRACECAT__DB_MAX_OVERFLOW: ${TRACECAT__LOADTEST_WORKER_DB_MAX_OVERFLOW:-3}
+      TRACECAT__DB_POOL_TIMEOUT: ${TRACECAT__LOADTEST_DB_POOL_TIMEOUT:-10}
+
+  executor:
+    environment:
+      TRACECAT__DB_POOL_SIZE: ${TRACECAT__LOADTEST_EXECUTOR_DB_POOL_SIZE:-6}
+      TRACECAT__DB_MAX_OVERFLOW: ${TRACECAT__LOADTEST_EXECUTOR_DB_MAX_OVERFLOW:-3}
+      TRACECAT__DB_POOL_TIMEOUT: ${TRACECAT__LOADTEST_DB_POOL_TIMEOUT:-10}
+      TRACECAT__EXECUTOR_MAX_CONCURRENT_ACTIVITIES: ${TRACECAT__LOADTEST_EXECUTOR_MAX_CONCURRENT_ACTIVITIES:-8}
+
+  mcp:
+    environment:
+      TRACECAT__DB_POOL_SIZE: ${TRACECAT__LOADTEST_MCP_DB_POOL_SIZE:-2}
+      TRACECAT__DB_MAX_OVERFLOW: ${TRACECAT__LOADTEST_MCP_DB_MAX_OVERFLOW:-1}
+      TRACECAT__DB_POOL_TIMEOUT: ${TRACECAT__LOADTEST_DB_POOL_TIMEOUT:-10}
+
+  litellm:
+    environment:
+      TRACECAT__DB_POOL_SIZE: ${TRACECAT__LOADTEST_LITELLM_DB_POOL_SIZE:-2}
+      TRACECAT__DB_MAX_OVERFLOW: ${TRACECAT__LOADTEST_LITELLM_DB_MAX_OVERFLOW:-1}
+      TRACECAT__DB_POOL_TIMEOUT: ${TRACECAT__LOADTEST_DB_POOL_TIMEOUT:-10}
+
+  agent-executor:
+    environment:
+      TRACECAT__DB_POOL_SIZE: ${TRACECAT__LOADTEST_AGENT_EXECUTOR_DB_POOL_SIZE:-2}
+      TRACECAT__DB_MAX_OVERFLOW: ${TRACECAT__LOADTEST_AGENT_EXECUTOR_DB_MAX_OVERFLOW:-1}
+      TRACECAT__DB_POOL_TIMEOUT: ${TRACECAT__LOADTEST_DB_POOL_TIMEOUT:-10}

--- a/scripts/benchmark/scatter_load/__init__.py
+++ b/scripts/benchmark/scatter_load/__init__.py
@@ -1,0 +1,11 @@
+"""Scaffolding for the PostgreSQL scatter load test.
+
+Modules:
+    models      Typed scenario, result, and artifact models.
+    client      Minimal async client for the public Tracecat API.
+    fixtures    Synthetic table and workflow fixtures plus idempotent setup.
+    runner      Asynchronous API load runner.
+    collector   PostgreSQL activity and environment metric collector.
+
+See scripts/benchmark/postgres-scatter-load-test-plan.md.
+"""

--- a/scripts/benchmark/scatter_load/client.py
+++ b/scripts/benchmark/scatter_load/client.py
@@ -1,0 +1,329 @@
+"""Minimal typed async client for the public Tracecat API.
+
+Only the endpoints the scatter load test needs are wrapped. Everything goes
+through the public, workspace-scoped HTTP API - the runner never talks to
+Temporal or to PostgreSQL directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, Self, TypedDict
+
+import httpx
+
+DEFAULT_TIMEOUT: Final = httpx.Timeout(connect=10.0, read=60.0, write=30.0, pool=30.0)
+
+
+class ApiError(RuntimeError):
+    """A public API call returned an unexpected status code."""
+
+    def __init__(self, method: str, url: str, status_code: int, body: str) -> None:
+        super().__init__(f"{method} {url} -> {status_code}: {body[:500]}")
+        self.method = method
+        self.url = url
+        self.status_code = status_code
+        self.body = body
+
+
+class WorkspaceRef(TypedDict):
+    """The subset of a workspace listing entry that we consume."""
+
+    id: str
+    name: str
+
+
+class TableRef(TypedDict):
+    """The subset of a table listing entry that we consume."""
+
+    id: str
+    name: str
+
+
+class TableColumnRef(TypedDict):
+    """The subset of a table column read that we consume."""
+
+    id: str
+    name: str
+    is_index: bool
+
+
+class WorkflowRef(TypedDict):
+    """The subset of a workflow read that we consume."""
+
+    id: str
+    title: str
+
+
+class CommitResult(TypedDict):
+    """Outcome of POST /workflows/{id}/commit."""
+
+    status: str
+    errors: list[str]
+
+
+class SubmitResult(TypedDict):
+    """Outcome of POST /workflow-executions."""
+
+    status_code: int
+    wf_exec_id: str | None
+    detail: str | None
+
+
+def _as_str(value: object) -> str:
+    return value if isinstance(value, str) else str(value)
+
+
+def _as_bool(value: object) -> bool:
+    return value is True
+
+
+class TracecatClient:
+    """Async client scoped to one workspace of one local Tracecat cluster."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_key: str | None = None,
+        timeout: httpx.Timeout = DEFAULT_TIMEOUT,
+        max_connections: int = 200,
+    ) -> None:
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._client = httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            headers=headers,
+            timeout=timeout,
+            limits=httpx.Limits(
+                max_connections=max_connections,
+                max_keepalive_connections=max_connections,
+                keepalive_expiry=30.0,
+            ),
+            follow_redirects=True,
+        )
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    # -- plumbing ---------------------------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        expected: tuple[int, ...],
+        **kwargs: Any,
+    ) -> httpx.Response:
+        response = await self._client.request(method, url, **kwargs)
+        if response.status_code not in expected:
+            raise ApiError(method, url, response.status_code, response.text)
+        return response
+
+    @staticmethod
+    def _json_object(response: httpx.Response) -> dict[str, object]:
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ApiError(
+                response.request.method,
+                str(response.request.url),
+                response.status_code,
+                "expected a JSON object",
+            )
+        return payload
+
+    @staticmethod
+    def _json_array(response: httpx.Response) -> list[dict[str, object]]:
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise ApiError(
+                response.request.method,
+                str(response.request.url),
+                response.status_code,
+                "expected a JSON array",
+            )
+        return [item for item in payload if isinstance(item, dict)]
+
+    # -- auth -------------------------------------------------------------
+
+    async def login(self, email: str, password: str) -> None:
+        """Authenticate as a synthetic local user.
+
+        The API uses fastapi-users with a cookie transport and a database-backed
+        token strategy, so `POST /auth/login` takes an OAuth2 password form and
+        answers with a Set-Cookie header. httpx stores the cookie on the client
+        for every subsequent request.
+        """
+        await self._request(
+            "POST",
+            "/auth/login",
+            expected=(200, 204),
+            data={"username": email, "password": password},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    # -- workspaces -------------------------------------------------------
+
+    async def list_workspaces(self) -> list[WorkspaceRef]:
+        response = await self._request("GET", "/workspaces", expected=(200,))
+        return [
+            WorkspaceRef(id=_as_str(item.get("id")), name=_as_str(item.get("name")))
+            for item in self._json_array(response)
+        ]
+
+    async def create_workspace(self, name: str) -> WorkspaceRef:
+        response = await self._request(
+            "POST", "/workspaces", expected=(200, 201), json={"name": name}
+        )
+        payload = self._json_object(response)
+        return WorkspaceRef(
+            id=_as_str(payload.get("id")), name=_as_str(payload.get("name"))
+        )
+
+    # -- tables -----------------------------------------------------------
+
+    async def list_tables(self, workspace_id: str) -> list[TableRef]:
+        response = await self._request(
+            "GET", f"/workspaces/{workspace_id}/tables", expected=(200,)
+        )
+        return [
+            TableRef(id=_as_str(item.get("id")), name=_as_str(item.get("name")))
+            for item in self._json_array(response)
+        ]
+
+    async def create_table(
+        self, workspace_id: str, name: str, columns: list[dict[str, object]]
+    ) -> None:
+        """Create a table. The endpoint answers 201 with no body."""
+        await self._request(
+            "POST",
+            f"/workspaces/{workspace_id}/tables",
+            expected=(200, 201),
+            json={"name": name, "columns": columns},
+        )
+
+    async def get_table_columns(
+        self, workspace_id: str, table_id: str
+    ) -> list[TableColumnRef]:
+        response = await self._request(
+            "GET", f"/workspaces/{workspace_id}/tables/{table_id}", expected=(200,)
+        )
+        payload = self._json_object(response)
+        raw_columns = payload.get("columns")
+        if not isinstance(raw_columns, list):
+            return []
+        return [
+            TableColumnRef(
+                id=_as_str(column.get("id")),
+                name=_as_str(column.get("name")),
+                is_index=_as_bool(column.get("is_index")),
+            )
+            for column in raw_columns
+            if isinstance(column, dict)
+        ]
+
+    async def set_column_unique_index(
+        self, workspace_id: str, table_id: str, column_id: str
+    ) -> None:
+        await self._request(
+            "PATCH",
+            f"/workspaces/{workspace_id}/tables/{table_id}/columns/{column_id}",
+            expected=(200, 204),
+            json={"is_index": True},
+        )
+
+    # -- workflows --------------------------------------------------------
+
+    async def list_workflows(self, workspace_id: str) -> list[WorkflowRef]:
+        response = await self._request(
+            "GET", f"/workspaces/{workspace_id}/workflows", expected=(200,)
+        )
+        return [
+            WorkflowRef(id=_as_str(item.get("id")), title=_as_str(item.get("title")))
+            for item in self._json_array(response)
+        ]
+
+    async def create_workflow_from_yaml(
+        self, workspace_id: str, filename: str, content: bytes
+    ) -> WorkflowRef:
+        response = await self._request(
+            "POST",
+            f"/workspaces/{workspace_id}/workflows",
+            expected=(200, 201),
+            files={"file": (filename, content, "application/yaml")},
+        )
+        payload = self._json_object(response)
+        return WorkflowRef(
+            id=_as_str(payload.get("id")), title=_as_str(payload.get("title"))
+        )
+
+    async def commit_workflow(
+        self, workspace_id: str, workflow_id: str
+    ) -> CommitResult:
+        """Commit a workflow. Note the endpoint returns 200 even on failure."""
+        response = await self._request(
+            "POST",
+            f"/workspaces/{workspace_id}/workflows/{workflow_id}/commit",
+            expected=(200, 201),
+        )
+        payload = self._json_object(response)
+        raw_errors = payload.get("errors")
+        errors = (
+            [_as_str(item) for item in raw_errors]
+            if isinstance(raw_errors, list)
+            else []
+        )
+        return CommitResult(status=_as_str(payload.get("status")), errors=errors)
+
+    # -- workflow executions ----------------------------------------------
+
+    async def submit_execution(
+        self,
+        workspace_id: str,
+        workflow_id: str,
+        inputs: dict[str, object],
+    ) -> SubmitResult:
+        """Start a workflow through the public admission path.
+
+        Returns the raw status code instead of raising, so the runner can
+        classify admission rejections without inspecting exception text.
+        """
+        response = await self._client.post(
+            f"/workspaces/{workspace_id}/workflow-executions",
+            json={"workflow_id": workflow_id, "inputs": inputs},
+        )
+        if response.status_code not in (200, 201, 202):
+            return SubmitResult(
+                status_code=response.status_code,
+                wf_exec_id=None,
+                detail=response.text[:500],
+            )
+        payload = response.json()
+        wf_exec_id = (
+            _as_str(payload.get("wf_exec_id")) if isinstance(payload, dict) else None
+        )
+        return SubmitResult(
+            status_code=response.status_code, wf_exec_id=wf_exec_id, detail=None
+        )
+
+    async def get_execution_status(
+        self, workspace_id: str, wf_exec_id: str
+    ) -> str | None:
+        """Read one execution's status. Returns None if the API did not answer 200."""
+        response = await self._client.get(
+            f"/workspaces/{workspace_id}/workflow-executions/{wf_exec_id}"
+        )
+        if response.status_code != 200:
+            return None
+        payload = response.json()
+        if not isinstance(payload, dict):
+            return None
+        status = payload.get("status")
+        return _as_str(status) if status is not None else None

--- a/scripts/benchmark/scatter_load/collector.py
+++ b/scripts/benchmark/scatter_load/collector.py
@@ -1,0 +1,597 @@
+"""Metric collector for the PostgreSQL scatter load test.
+
+Samples PostgreSQL activity at >=1Hz and captures the surrounding evidence a
+run needs to be interpretable later: the resolved Compose model, effective
+container limits and OOM/restart state, effective PostgreSQL settings, service
+logs, fixture row correctness, and the Tracecat commit plus container image
+identifiers.
+
+Run it alongside the load runner, pointed at the same artifact directory:
+
+    uv run python -m scripts.benchmark.scatter_load.collector \\
+        --run-id scatter-abc123 \\
+        --compose-project tracecat-my-worktree-1 \\
+        --compose-file docker-compose.dev.yml \\
+        --compose-file docker-compose.loadtest.yml \\
+        --dsn postgresql://postgres:postgres@localhost:5432/postgres
+
+Stop it with SIGINT; it writes its manifest on the way out.
+
+See scripts/benchmark/postgres-scatter-load-test-plan.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import re
+import signal
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final
+
+import asyncpg
+
+from .models import (
+    CollectorConfig,
+    CollectorManifest,
+    ContainerState,
+    PgActivitySample,
+    RowCorrectness,
+)
+
+DEFAULT_ARTIFACT_ROOT: Final = "/tmp/tracecat-scatter-load"
+DEFAULT_DSN: Final = "postgresql://postgres:postgres@localhost:5432/postgres"
+DEFAULT_LOG_SERVICES: Final = ("api", "worker", "executor", "postgres_db")
+DEFAULT_TABLE_NAME: Final = "scatter_load_rows"
+IDENTIFIER_RE: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+ACTIVITY_SQL: Final = """
+SELECT
+    count(*)::int AS total,
+    count(*) FILTER (WHERE state = 'active')::int AS active,
+    count(*) FILTER (WHERE state = 'idle')::int AS idle,
+    count(*) FILTER (WHERE state = 'idle in transaction')::int AS idle_in_txn,
+    count(*) FILTER (
+        WHERE state = 'idle in transaction (aborted)'
+    )::int AS idle_in_txn_aborted,
+    count(*) FILTER (WHERE wait_event IS NOT NULL)::int AS waiting,
+    max(EXTRACT(EPOCH FROM (now() - xact_start)))::float8 AS longest_txn,
+    max(EXTRACT(EPOCH FROM (now() - query_start)))::float8 AS longest_query
+FROM pg_stat_activity
+WHERE backend_type = 'client backend'
+"""
+
+WAIT_EVENT_SQL: Final = """
+SELECT
+    coalesce(wait_event_type, 'none') || ':' || coalesce(wait_event, 'none') AS event,
+    count(*)::int AS sessions
+FROM pg_stat_activity
+WHERE backend_type = 'client backend'
+GROUP BY 1
+"""
+
+APPLICATION_NAME_SQL: Final = """
+SELECT
+    coalesce(nullif(application_name, ''), 'unknown') AS application_name,
+    count(*)::int AS sessions
+FROM pg_stat_activity
+WHERE backend_type = 'client backend'
+GROUP BY 1
+"""
+
+DATABASE_COUNTERS_SQL: Final = """
+SELECT
+    coalesce(sum(xact_commit), 0)::bigint AS xact_commit,
+    coalesce(sum(xact_rollback), 0)::bigint AS xact_rollback,
+    coalesce(sum(deadlocks), 0)::bigint AS deadlocks
+FROM pg_stat_database
+WHERE datname IS NOT NULL
+"""
+
+SETTINGS_SQL: Final = """
+SELECT name, setting, unit, source, boot_val
+FROM pg_settings
+WHERE name = ANY($1::text[])
+"""
+
+FIND_TABLE_SQL: Final = """
+SELECT table_schema
+FROM information_schema.tables
+WHERE table_name = $1 AND table_schema LIKE 'tables\\_%'
+ORDER BY table_schema
+"""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _run_command(args: list[str], *, timeout: float = 120.0) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, "", f"{type(exc).__name__}: {exc}"
+    return result.returncode, result.stdout, result.stderr
+
+
+def _as_int(value: object) -> int:
+    """Coerce a driver-typed scalar to int, treating NULL as zero."""
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    return int(str(value))
+
+
+def _quote_identifier(value: str) -> str:
+    """Validate then quote an SQL identifier.
+
+    Only identifiers matching a strict pattern are accepted, because schema and
+    table names have to be interpolated into DDL-shaped SQL that cannot use
+    bind parameters.
+    """
+    if not IDENTIFIER_RE.match(value):
+        raise ValueError(f"unsafe SQL identifier: {value!r}")
+    return f'"{value}"'
+
+
+class PgSampler:
+    """Holds one long-lived sampling connection plus a periodic slot probe."""
+
+    def __init__(self, dsn: str, settings_of_interest: tuple[str, ...]) -> None:
+        self._dsn = dsn
+        self._settings_of_interest = settings_of_interest
+        self._conn: asyncpg.Connection | None = None
+        self._prev_commit = 0
+        self._prev_rollback = 0
+        self._prev_deadlocks = 0
+        self._primed = False
+        self._connection_slot_errors = 0
+        self._max_connections = 0
+        self._superuser_reserved = 0
+
+    async def connect(self) -> None:
+        conn = await asyncpg.connect(
+            self._dsn, server_settings={"application_name": "scatter-load-collector"}
+        )
+        self._conn = conn
+        self._max_connections = _as_int(await conn.fetchval("SHOW max_connections"))
+        self._superuser_reserved = _as_int(
+            await conn.fetchval("SHOW superuser_reserved_connections")
+        )
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            await self._conn.close()
+            self._conn = None
+
+    async def probe_connection_slots(self) -> None:
+        """Open and close a throwaway connection to detect slot exhaustion.
+
+        Uses asyncpg's typed `TooManyConnectionsError` (SQLSTATE 53300) rather
+        than matching error text. This probe deliberately draws on the
+        administrative reserve: if it starts failing, the reserve is gone, which
+        is one of the plan's abort conditions.
+        """
+        try:
+            probe = await asyncpg.connect(
+                self._dsn,
+                server_settings={"application_name": "scatter-load-probe"},
+                timeout=5,
+            )
+        except asyncpg.exceptions.TooManyConnectionsError:
+            self._connection_slot_errors += 1
+            return
+        except (OSError, asyncpg.PostgresError, TimeoutError):
+            return
+        await probe.close()
+
+    async def sample(self) -> PgActivitySample:
+        conn = self._conn
+        if conn is None:
+            raise RuntimeError("sampler is not connected")
+
+        activity = await conn.fetchrow(ACTIVITY_SQL)
+        wait_rows = await conn.fetch(WAIT_EVENT_SQL)
+        app_rows = await conn.fetch(APPLICATION_NAME_SQL)
+        counters = await conn.fetchrow(DATABASE_COUNTERS_SQL)
+        if activity is None or counters is None:
+            raise RuntimeError("PostgreSQL returned no activity rows")
+
+        commit = int(counters["xact_commit"])
+        rollback = int(counters["xact_rollback"])
+        deadlocks = int(counters["deadlocks"])
+        if not self._primed:
+            self._prev_commit, self._prev_rollback, self._prev_deadlocks = (
+                commit,
+                rollback,
+                deadlocks,
+            )
+            self._primed = True
+
+        sample = PgActivitySample(
+            sampled_at=_utc_now_iso(),
+            monotonic=time.monotonic(),
+            max_connections=self._max_connections,
+            superuser_reserved_connections=self._superuser_reserved,
+            total_connections=int(activity["total"]),
+            active=int(activity["active"]),
+            idle=int(activity["idle"]),
+            idle_in_transaction=int(activity["idle_in_txn"]),
+            idle_in_transaction_aborted=int(activity["idle_in_txn_aborted"]),
+            waiting=int(activity["waiting"]),
+            wait_events={str(r["event"]): int(r["sessions"]) for r in wait_rows},
+            application_names={
+                str(r["application_name"]): int(r["sessions"]) for r in app_rows
+            },
+            longest_transaction_seconds=(
+                float(activity["longest_txn"])
+                if activity["longest_txn"] is not None
+                else None
+            ),
+            longest_query_seconds=(
+                float(activity["longest_query"])
+                if activity["longest_query"] is not None
+                else None
+            ),
+            xact_commit_delta=commit - self._prev_commit,
+            xact_rollback_delta=rollback - self._prev_rollback,
+            deadlocks_delta=deadlocks - self._prev_deadlocks,
+            connection_slot_errors=self._connection_slot_errors,
+        )
+        self._prev_commit, self._prev_rollback, self._prev_deadlocks = (
+            commit,
+            rollback,
+            deadlocks,
+        )
+        return sample
+
+    async def effective_settings(self) -> list[dict[str, str | None]]:
+        conn = self._conn
+        if conn is None:
+            raise RuntimeError("sampler is not connected")
+        rows = await conn.fetch(SETTINGS_SQL, list(self._settings_of_interest))
+        return [
+            {
+                "name": str(row["name"]),
+                "setting": str(row["setting"]),
+                "unit": str(row["unit"]) if row["unit"] is not None else None,
+                "source": str(row["source"]),
+                "boot_val": str(row["boot_val"])
+                if row["boot_val"] is not None
+                else None,
+            }
+            for row in rows
+        ]
+
+    async def row_correctness(
+        self, table_name: str, run_id: str | None
+    ) -> RowCorrectness | None:
+        conn = self._conn
+        if conn is None:
+            raise RuntimeError("sampler is not connected")
+        schema_name = await conn.fetchval(FIND_TABLE_SQL, table_name)
+        if schema_name is None:
+            return None
+
+        qualified = (
+            f"{_quote_identifier(str(schema_name))}.{_quote_identifier(table_name)}"
+        )
+        totals = await conn.fetchrow(
+            f"SELECT count(*)::bigint AS total, "  # noqa: S608 - identifiers validated
+            f"count(DISTINCT dedupe_key)::bigint AS distinct_keys FROM {qualified}"
+        )
+        per_run = await conn.fetchrow(
+            f"SELECT count(*)::bigint AS total, "  # noqa: S608 - identifiers validated
+            f"count(DISTINCT dedupe_key)::bigint AS distinct_keys "
+            f"FROM {qualified} WHERE run_id = $1",
+            run_id or "",
+        )
+        if totals is None or per_run is None:
+            return None
+
+        total_rows = int(totals["total"])
+        distinct_keys = int(totals["distinct_keys"])
+        return RowCorrectness(
+            schema_name=str(schema_name),
+            table_name=table_name,
+            total_rows=total_rows,
+            distinct_dedupe_keys=distinct_keys,
+            duplicate_dedupe_keys=total_rows - distinct_keys,
+            rows_for_run=int(per_run["total"]),
+            distinct_dedupe_keys_for_run=int(per_run["distinct_keys"]),
+        )
+
+
+def capture_compose_config(config: CollectorConfig, artifact_dir: Path) -> str | None:
+    """Write the fully resolved Compose model for the cluster under test."""
+    args = ["docker", "compose", "-p", config.compose_project]
+    for compose_file in config.compose_files:
+        args += ["-f", compose_file]
+    args.append("config")
+    code, stdout, stderr = _run_command(args)
+    target = artifact_dir / "compose_config.yml"
+    target.write_text(
+        stdout if code == 0 else f"# failed: {stderr}\n", encoding="utf-8"
+    )
+    return str(target)
+
+
+def capture_container_state(config: CollectorConfig, artifact_dir: Path) -> str | None:
+    """Record effective limits plus restart/OOM state and image identifiers."""
+    code, stdout, _ = _run_command(
+        [
+            "docker",
+            "ps",
+            "--all",
+            "--filter",
+            f"label=com.docker.compose.project={config.compose_project}",
+            "--format",
+            "{{.ID}}",
+        ]
+    )
+    states: list[ContainerState] = []
+    if code == 0:
+        for container_id in [line for line in stdout.splitlines() if line.strip()]:
+            inspect_code, inspect_out, _ = _run_command(
+                ["docker", "inspect", container_id]
+            )
+            if inspect_code != 0:
+                continue
+            parsed = json.loads(inspect_out)
+            if not isinstance(parsed, list) or not parsed:
+                continue
+            info = parsed[0]
+            state = info.get("State", {})
+            host_config = info.get("HostConfig", {})
+            labels = info.get("Config", {}).get("Labels", {})
+            states.append(
+                ContainerState(
+                    name=str(info.get("Name", "")).lstrip("/"),
+                    service=str(labels.get("com.docker.compose.service", "")),
+                    image=str(info.get("Config", {}).get("Image", "")),
+                    image_id=str(info.get("Image", "")),
+                    status=str(state.get("Status", "")),
+                    restart_count=int(info.get("RestartCount", 0)),
+                    oom_killed=bool(state.get("OOMKilled", False)),
+                    exit_code=state.get("ExitCode"),
+                    nano_cpus=host_config.get("NanoCpus"),
+                    memory_limit_bytes=host_config.get("Memory"),
+                    memory_swap_limit_bytes=host_config.get("MemorySwap"),
+                    pids_limit=host_config.get("PidsLimit"),
+                )
+            )
+    target = artifact_dir / "containers.json"
+    target.write_text(json.dumps(states, indent=2, default=str), encoding="utf-8")
+    return str(target)
+
+
+def capture_service_logs(config: CollectorConfig, artifact_dir: Path) -> dict[str, str]:
+    """Dump the tail of each service log."""
+    log_dir = artifact_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    written: dict[str, str] = {}
+    for service in config.log_services:
+        args = ["docker", "compose", "-p", config.compose_project]
+        for compose_file in config.compose_files:
+            args += ["-f", compose_file]
+        args += ["logs", "--no-color", "--tail", str(config.log_tail), service]
+        code, stdout, stderr = _run_command(args)
+        target = log_dir / f"{service}.log"
+        target.write_text(stdout if code == 0 else stderr, encoding="utf-8")
+        written[service] = str(target)
+    return written
+
+
+def capture_commit(repo_root: Path) -> tuple[str, bool]:
+    code, stdout, _ = _run_command(["git", "-C", str(repo_root), "rev-parse", "HEAD"])
+    commit = stdout.strip() if code == 0 else "unknown"
+    status_code, status_out, _ = _run_command(
+        ["git", "-C", str(repo_root), "status", "--porcelain"]
+    )
+    dirty = bool(status_out.strip()) if status_code == 0 else False
+    return commit, dirty
+
+
+class MetricCollector:
+    """Owns the sampling loop and the one-shot environment captures."""
+
+    def __init__(self, config: CollectorConfig) -> None:
+        self._config = config
+        self._artifact_dir = Path(config.artifact_dir)
+        self._sampler = PgSampler(config.dsn, config.settings_of_interest)
+        self._stop = asyncio.Event()
+        self._sample_count = 0
+
+    def request_stop(self) -> None:
+        self._stop.set()
+
+    async def _sample_loop(self, sink: Path) -> None:
+        probe_every = max(1, int(round(5.0 / self._config.sample_interval_seconds)))
+        with sink.open("a", encoding="utf-8") as handle:
+            deadline = (
+                time.monotonic() + self._config.duration_seconds
+                if self._config.duration_seconds is not None
+                else None
+            )
+            while not self._stop.is_set():
+                tick = time.monotonic()
+                try:
+                    sample = await self._sampler.sample()
+                except (asyncpg.PostgresError, OSError, RuntimeError) as exc:
+                    # Losing observability of the database is an abort condition.
+                    handle.write(
+                        json.dumps(
+                            {
+                                "sampled_at": _utc_now_iso(),
+                                "observability_failure": type(exc).__name__,
+                            }
+                        )
+                        + "\n"
+                    )
+                    handle.flush()
+                    return
+                handle.write(json.dumps(sample) + "\n")
+                handle.flush()
+                self._sample_count += 1
+
+                if self._sample_count % probe_every == 0:
+                    await self._sampler.probe_connection_slots()
+
+                if deadline is not None and time.monotonic() >= deadline:
+                    return
+                delay = self._config.sample_interval_seconds - (time.monotonic() - tick)
+                if delay > 0:
+                    with contextlib.suppress(TimeoutError):
+                        await asyncio.wait_for(self._stop.wait(), timeout=delay)
+
+    async def run(self, repo_root: Path) -> CollectorManifest:
+        self._artifact_dir.mkdir(parents=True, exist_ok=True)
+        started_at = _utc_now_iso()
+
+        artifacts: dict[str, str] = {}
+        compose_config = capture_compose_config(self._config, self._artifact_dir)
+        if compose_config:
+            artifacts["compose_config"] = compose_config
+
+        await self._sampler.connect()
+        try:
+            settings = await self._sampler.effective_settings()
+            settings_path = self._artifact_dir / "pg_settings.json"
+            settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+            artifacts["pg_settings"] = str(settings_path)
+
+            samples_path = self._artifact_dir / "pg_activity.jsonl"
+            artifacts["pg_activity"] = str(samples_path)
+            await self._sample_loop(samples_path)
+
+            correctness = await self._sampler.row_correctness(
+                self._config.table_name, self._config.run_id
+            )
+            if correctness is not None:
+                correctness_path = self._artifact_dir / "row_correctness.json"
+                correctness_path.write_text(
+                    json.dumps(correctness, indent=2), encoding="utf-8"
+                )
+                artifacts["row_correctness"] = str(correctness_path)
+        finally:
+            await self._sampler.close()
+
+        containers = capture_container_state(self._config, self._artifact_dir)
+        if containers:
+            artifacts["containers"] = containers
+        for service, path in capture_service_logs(
+            self._config, self._artifact_dir
+        ).items():
+            artifacts[f"log:{service}"] = path
+
+        # The runner writes these into the same directory by convention.
+        for name in ("scenario.json", "runner_results.jsonl", "summary.txt"):
+            candidate = self._artifact_dir / name
+            if candidate.exists():
+                artifacts[name] = str(candidate)
+
+        commit, dirty = capture_commit(repo_root)
+        manifest = CollectorManifest(
+            run_id=self._config.run_id,
+            artifact_dir=str(self._artifact_dir),
+            started_at=started_at,
+            finished_at=_utc_now_iso(),
+            sample_interval_seconds=self._config.sample_interval_seconds,
+            sample_count=self._sample_count,
+            tracecat_commit=commit,
+            tracecat_commit_dirty=dirty,
+            compose_project=self._config.compose_project,
+            artifacts=artifacts,
+        )
+        (self._artifact_dir / "manifest.json").write_text(
+            json.dumps(manifest, indent=2), encoding="utf-8"
+        )
+        return manifest
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scatter_load.collector",
+        description="PostgreSQL activity and environment collector for the scatter load test.",
+    )
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--artifact-root", default=DEFAULT_ARTIFACT_ROOT)
+    parser.add_argument("--dsn", default=DEFAULT_DSN)
+    parser.add_argument(
+        "--sample-interval-seconds",
+        type=float,
+        default=0.5,
+        help="Must be <= 1.0 to satisfy the plan's >=1Hz requirement.",
+    )
+    parser.add_argument("--compose-project", required=True)
+    parser.add_argument(
+        "--compose-file",
+        action="append",
+        default=None,
+        help="Repeatable. Should match the files `scripts/cluster` resolved.",
+    )
+    parser.add_argument(
+        "--log-service", action="append", default=None, help="Repeatable."
+    )
+    parser.add_argument("--log-tail", type=int, default=5000)
+    parser.add_argument("--table-name", default=DEFAULT_TABLE_NAME)
+    parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=None,
+        help="Stop sampling after this long. Omit to sample until SIGINT.",
+    )
+    return parser
+
+
+async def amain(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[3]
+
+    if args.sample_interval_seconds > 1.0:
+        print(
+            "--sample-interval-seconds must be <= 1.0 (>=1Hz)",
+            file=sys.stderr,
+        )
+        return 2
+
+    config = CollectorConfig(
+        run_id=args.run_id,
+        artifact_dir=str(Path(args.artifact_root) / args.run_id),
+        dsn=args.dsn,
+        sample_interval_seconds=args.sample_interval_seconds,
+        compose_project=args.compose_project,
+        compose_files=tuple(args.compose_file or ("docker-compose.dev.yml",)),
+        log_services=tuple(args.log_service or DEFAULT_LOG_SERVICES),
+        log_tail=args.log_tail,
+        table_name=args.table_name,
+        duration_seconds=args.duration_seconds,
+    )
+
+    collector = MetricCollector(config)
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(NotImplementedError):
+            loop.add_signal_handler(sig, collector.request_stop)
+
+    manifest = await collector.run(repo_root)
+    print(f"samples: {manifest['sample_count']}")
+    print(f"artifacts: {manifest['artifact_dir']}")
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(asyncio.run(amain(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/scatter_load/fixtures.py
+++ b/scripts/benchmark/scatter_load/fixtures.py
@@ -1,0 +1,175 @@
+"""Fixture definitions and idempotent setup for the scatter load test.
+
+Everything here goes through the public API. Setup is idempotent so it can be
+re-run between matrix cells without recreating the cluster or the database
+volume: existing tables and workflows are reused by name/title.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from .client import TracecatClient
+from .models import (
+    FixtureHandles,
+    TableColumnFixture,
+    TableFixture,
+    WorkflowFixture,
+    WritePath,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+TABLE_FIXTURE_PATH = FIXTURE_DIR / "table.json"
+
+WORKFLOW_FIXTURE_PATHS: dict[WritePath, Path] = {
+    WritePath.SCATTER: FIXTURE_DIR / "workflow_scatter_insert_row.yml",
+    WritePath.BULK: FIXTURE_DIR / "workflow_bulk_insert_rows.yml",
+}
+
+
+class FixtureError(RuntimeError):
+    """Fixture setup could not complete."""
+
+
+def load_table_fixture(path: Path = TABLE_FIXTURE_PATH) -> TableFixture:
+    """Load the synthetic table definition."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise FixtureError(f"{path} must contain a JSON object")
+    raw_columns = raw.get("columns")
+    if not isinstance(raw_columns, list):
+        raise FixtureError(f"{path} is missing a 'columns' array")
+    columns = tuple(
+        TableColumnFixture(
+            name=str(column["name"]),
+            type=str(column["type"]),
+            nullable=bool(column.get("nullable", True)),
+        )
+        for column in raw_columns
+        if isinstance(column, dict)
+    )
+    return TableFixture(
+        name=str(raw["name"]),
+        columns=columns,
+        unique_index_column=str(raw["unique_index_column"]),
+        unique_index_note=str(raw.get("unique_index_note", "")),
+    )
+
+
+def load_workflow_fixture(write_path: WritePath) -> WorkflowFixture:
+    """Load one fixture workflow and read its declared title."""
+    path = WORKFLOW_FIXTURE_PATHS[write_path]
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise FixtureError(f"{path} must contain a YAML mapping")
+    definition = raw.get("definition")
+    if not isinstance(definition, dict):
+        raise FixtureError(f"{path} is missing a 'definition' mapping")
+    title = definition.get("title")
+    if not isinstance(title, str):
+        raise FixtureError(f"{path} is missing 'definition.title'")
+    return WorkflowFixture(write_path=write_path, path=str(path), title=title)
+
+
+async def _ensure_table(
+    client: TracecatClient, workspace_id: str, fixture: TableFixture
+) -> tuple[str, str]:
+    """Create the fixture table if absent and ensure its unique index exists."""
+    tables = await client.list_tables(workspace_id)
+    table_id = next((t["id"] for t in tables if t["name"] == fixture.name), None)
+
+    if table_id is None:
+        await client.create_table(
+            workspace_id,
+            fixture.name,
+            [
+                {"name": c.name, "type": c.type, "nullable": c.nullable}
+                for c in fixture.columns
+            ],
+        )
+        tables = await client.list_tables(workspace_id)
+        table_id = next((t["id"] for t in tables if t["name"] == fixture.name), None)
+        if table_id is None:
+            raise FixtureError(f"table '{fixture.name}' was not created")
+
+    columns = await client.get_table_columns(workspace_id, table_id)
+    index_column = next(
+        (c for c in columns if c["name"] == fixture.unique_index_column), None
+    )
+    if index_column is None:
+        raise FixtureError(
+            f"table '{fixture.name}' has no column "
+            f"'{fixture.unique_index_column}' to index"
+        )
+    if not index_column["is_index"]:
+        await client.set_column_unique_index(workspace_id, table_id, index_column["id"])
+
+    return table_id, fixture.name
+
+
+async def _ensure_workflow(
+    client: TracecatClient, workspace_id: str, fixture: WorkflowFixture
+) -> str:
+    """Import the fixture workflow if absent, then commit it."""
+    workflows = await client.list_workflows(workspace_id)
+    workflow_id = next(
+        (w["id"] for w in workflows if w["title"] == fixture.title), None
+    )
+
+    if workflow_id is None:
+        path = Path(fixture.path)
+        created = await client.create_workflow_from_yaml(
+            workspace_id, path.name, path.read_bytes()
+        )
+        workflow_id = created["id"]
+
+    result = await client.commit_workflow(workspace_id, workflow_id)
+    if result["status"] != "success":
+        raise FixtureError(
+            f"commit failed for '{fixture.title}': {'; '.join(result['errors'])}"
+        )
+    return workflow_id
+
+
+async def ensure_fixtures(
+    client: TracecatClient,
+    workspace_id: str,
+    write_paths: tuple[WritePath, ...] = (WritePath.SCATTER, WritePath.BULK),
+) -> FixtureHandles:
+    """Create (or reuse) the fixture table and workflows, then commit them."""
+    table_fixture = load_table_fixture()
+    table_id, table_name = await _ensure_table(client, workspace_id, table_fixture)
+
+    workflow_ids: dict[WritePath, str] = {}
+    for write_path in write_paths:
+        workflow_fixture = load_workflow_fixture(write_path)
+        workflow_ids[write_path] = await _ensure_workflow(
+            client, workspace_id, workflow_fixture
+        )
+
+    return FixtureHandles(
+        workspace_id=workspace_id,
+        table_id=table_id,
+        table_name=table_name,
+        unique_index_column=table_fixture.unique_index_column,
+        workflow_ids=workflow_ids,
+    )
+
+
+async def resolve_workspace(
+    client: TracecatClient, workspace_id: str | None, workspace_name: str
+) -> str:
+    """Resolve the target workspace, creating it by name when necessary."""
+    if workspace_id:
+        return workspace_id
+
+    workspaces = await client.list_workspaces()
+    for workspace in workspaces:
+        if workspace["name"] == workspace_name:
+            return workspace["id"]
+
+    created = await client.create_workspace(workspace_name)
+    return created["id"]

--- a/scripts/benchmark/scatter_load/fixtures/table.json
+++ b/scripts/benchmark/scatter_load/fixtures/table.json
@@ -1,0 +1,32 @@
+{
+  "name": "scatter_load_rows",
+  "columns": [
+    {
+      "name": "run_id",
+      "type": "TEXT",
+      "nullable": false
+    },
+    {
+      "name": "workflow_seq",
+      "type": "INTEGER",
+      "nullable": false
+    },
+    {
+      "name": "branch_seq",
+      "type": "INTEGER",
+      "nullable": false
+    },
+    {
+      "name": "payload",
+      "type": "TEXT",
+      "nullable": true
+    },
+    {
+      "name": "dedupe_key",
+      "type": "TEXT",
+      "nullable": false
+    }
+  ],
+  "unique_index_column": "dedupe_key",
+  "unique_index_note": "The plan asks for a unique index on (run_id, workflow_seq, branch_seq). The public tables API can only create a SINGLE-column unique index, and at most one per table (see TablesService.create_unique_index). The `dedupe_key` column carries the composite key as '<run_id>:<workflow_seq>:<branch_seq>' so missing and duplicate writes stay measurable through supported endpoints."
+}

--- a/scripts/benchmark/scatter_load/fixtures/workflow_bulk_insert_rows.yml
+++ b/scripts/benchmark/scatter_load/fixtures/workflow_bulk_insert_rows.yml
@@ -1,0 +1,88 @@
+# Bulk control fixture for the PostgreSQL scatter load test.
+#
+# Writes exactly the same logical rows as workflow_scatter_insert_row.yml, but
+# through a single `core.table.insert_rows` action execution. This is the
+# phase 4 batching control.
+#
+# Row building happens in one `core.script.run_python` action rather than a
+# `for_each` reshape, because a `for_each` reshape would expand back into one
+# action execution per branch and destroy the "fewer action executions"
+# property this control exists to measure. The trade-off is that the control
+# pays for one sandboxed Python process; that cost is CPU-side, not
+# database-side, so it does not contaminate the database-time-per-logical-row
+# ratio that phase 4 records. Note it when reporting wall-clock numbers.
+#
+# External workflow definition format: POST as multipart/form-data to
+# `POST /workspaces/{workspace_id}/workflows`, then commit it.
+version: 1
+definition:
+  title: Scatter load - insert_rows bulk control
+  description: >-
+    Bulk control: the same logical rows as the scatter fixture, written by a
+    single core.table.insert_rows action execution.
+  entrypoint:
+    ref: build_rows
+    expects:
+      run_id:
+        type: str
+        description: Synthetic load-test run identifier.
+      workflow_seq:
+        type: int
+        description: Zero-based index of this workflow within the run.
+      branch_count:
+        type: int
+        description: Number of logical branches (rows) this workflow writes.
+      payload:
+        type: str
+        description: Synthetic payload body written to every row.
+  config:
+    environment: default
+    timeout: 0
+  actions:
+    - ref: build_rows
+      action: core.script.run_python
+      description: Build every row body in a single action execution.
+      args:
+        timeout_seconds: 60
+        inputs:
+          run_id: ${{ TRIGGER.run_id }}
+          workflow_seq: ${{ TRIGGER.workflow_seq }}
+          branch_count: ${{ TRIGGER.branch_count }}
+          payload: ${{ TRIGGER.payload }}
+        script: |
+          def main(run_id, workflow_seq, branch_count, payload):
+              return [
+                  {
+                      "run_id": run_id,
+                      "workflow_seq": workflow_seq,
+                      "branch_seq": branch_seq,
+                      "payload": payload,
+                      "dedupe_key": f"{run_id}:{workflow_seq}:{branch_seq}",
+                  }
+                  for branch_seq in range(branch_count)
+              ]
+      retry_policy:
+        max_attempts: 1
+    - ref: bulk_insert
+      action: core.table.insert_rows
+      description: One database round trip for every logical branch.
+      depends_on:
+        - build_rows
+      args:
+        table: scatter_load_rows
+        rows_data: ${{ ACTIONS.build_rows.result }}
+      retry_policy:
+        max_attempts: 1
+    - ref: gather
+      action: core.transform.reshape
+      description: Compact gather. Deliberately drops the row bodies.
+      depends_on:
+        - bulk_insert
+      args:
+        value:
+          run_id: ${{ TRIGGER.run_id }}
+          workflow_seq: ${{ TRIGGER.workflow_seq }}
+          branches_written: ${{ ACTIONS.bulk_insert.result }}
+      retry_policy:
+        max_attempts: 1
+  returns: ${{ ACTIONS.gather.result }}

--- a/scripts/benchmark/scatter_load/fixtures/workflow_scatter_insert_row.yml
+++ b/scripts/benchmark/scatter_load/fixtures/workflow_scatter_insert_row.yml
@@ -1,0 +1,66 @@
+# Adversarial scatter fixture for the PostgreSQL scatter load test.
+#
+# Fans out `core.table.insert_row` over FN.range(0, branch_count), so each
+# logical branch is its own action execution and its own database write. The
+# gather step returns only a compact count: the workflow's `returns` never
+# echoes the inserted payloads back into workflow history or into the polling
+# responses the load runner reads.
+#
+# `retry_policy.max_attempts: 1` keeps the characterization pass honest — the
+# first failure boundary is not hidden behind retries. Run the retry pass as a
+# separate sub-scenario with a modified copy.
+#
+# External workflow definition format: POST as multipart/form-data to
+# `POST /workspaces/{workspace_id}/workflows`, then commit it.
+version: 1
+definition:
+  title: Scatter load - insert_row fan-out
+  description: >-
+    Adversarial scatter: one core.table.insert_row action execution per logical
+    branch, gathered into a compact count.
+  entrypoint:
+    ref: insert_branches
+    expects:
+      run_id:
+        type: str
+        description: Synthetic load-test run identifier.
+      workflow_seq:
+        type: int
+        description: Zero-based index of this workflow within the run.
+      branch_count:
+        type: int
+        description: Number of logical branches (rows) this workflow writes.
+      payload:
+        type: str
+        description: Synthetic payload body written to every row.
+  config:
+    environment: default
+    timeout: 0
+  actions:
+    - ref: insert_branches
+      action: core.table.insert_row
+      description: One database write per logical branch.
+      for_each: ${{ for var.branch_seq in FN.range(0, TRIGGER.branch_count) }}
+      args:
+        table: scatter_load_rows
+        row_data:
+          run_id: ${{ TRIGGER.run_id }}
+          workflow_seq: ${{ TRIGGER.workflow_seq }}
+          branch_seq: ${{ var.branch_seq }}
+          payload: ${{ TRIGGER.payload }}
+          dedupe_key: ${{ TRIGGER.run_id }}:${{ TRIGGER.workflow_seq }}:${{ var.branch_seq }}
+      retry_policy:
+        max_attempts: 1
+    - ref: gather
+      action: core.transform.reshape
+      description: Compact gather. Deliberately drops the per-branch row bodies.
+      depends_on:
+        - insert_branches
+      args:
+        value:
+          run_id: ${{ TRIGGER.run_id }}
+          workflow_seq: ${{ TRIGGER.workflow_seq }}
+          branches_written: ${{ FN.length(ACTIONS.insert_branches.result) }}
+      retry_policy:
+        max_attempts: 1
+  returns: ${{ ACTIONS.gather.result }}

--- a/scripts/benchmark/scatter_load/models.py
+++ b/scripts/benchmark/scatter_load/models.py
@@ -1,0 +1,336 @@
+"""Typed models shared by the PostgreSQL scatter load-test runner and collector.
+
+See scripts/benchmark/postgres-scatter-load-test-plan.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Literal, TypedDict
+
+# Terminal Temporal workflow execution statuses. Anything not in this set is
+# still in flight. Mirrors WorkflowExecutionStatusLiteral in
+# tracecat/workflow/executions/enums.py.
+WorkflowExecutionStatus = Literal[
+    "RUNNING",
+    "COMPLETED",
+    "FAILED",
+    "CANCELED",
+    "TERMINATED",
+    "CONTINUED_AS_NEW",
+    "TIMED_OUT",
+]
+
+TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {
+        "COMPLETED",
+        "FAILED",
+        "CANCELED",
+        "TERMINATED",
+        "CONTINUED_AS_NEW",
+        "TIMED_OUT",
+    }
+)
+
+
+class WritePath(StrEnum):
+    """Which fixture workflow the scenario drives."""
+
+    SCATTER = "scatter"
+    """Adversarial: one core.table.insert_row action execution per branch."""
+
+    BULK = "bulk"
+    """Control: one core.table.insert_rows action execution per workflow."""
+
+
+class FailureMode(StrEnum):
+    """Primary failure classification from the load runner's vantage point.
+
+    The plan's full classification also includes modes the runner cannot see
+    (pool timeout, PostgreSQL connection-slot exhaustion, statement/lock
+    timeout, Temporal schedule-to-start delay, executor saturation, container
+    OOM). Those are attributed during analysis by correlating these records
+    with the collector's PostgreSQL samples and service logs.
+
+    Classification here is derived only from structured signals - the HTTP
+    status code of the submission and the terminal workflow status - never
+    from error-message text.
+    """
+
+    NONE = "none"
+    ADMISSION_REJECTED = "admission_rejected"
+    """Submission returned a non-2xx status."""
+
+    SUBMIT_TRANSPORT_ERROR = "submit_transport_error"
+    """Submission never produced an HTTP status (connect/read/pool error)."""
+
+    WORKFLOW_FAILED = "workflow_failed"
+    """Reached a terminal non-COMPLETED status."""
+
+    RUN_TIMEOUT = "run_timeout"
+    """Still non-terminal when the per-run timeout expired."""
+
+    POLL_TRANSPORT_ERROR = "poll_transport_error"
+    """Polling could not reach a terminal status because of transport errors."""
+
+    ABORTED = "aborted"
+    """Abort signal arrived before this execution reached a terminal status."""
+
+
+class Phase(StrEnum):
+    """Workload stage a submission belongs to."""
+
+    WARMUP = "warmup"
+    RAMP = "ramp"
+    SUSTAIN = "sustain"
+
+
+@dataclass(slots=True, frozen=True)
+class TableColumnFixture:
+    """One column of the synthetic fixture table."""
+
+    name: str
+    type: str
+    nullable: bool
+
+
+@dataclass(slots=True, frozen=True)
+class TableFixture:
+    """The synthetic fixture table definition loaded from fixtures/table.json."""
+
+    name: str
+    columns: tuple[TableColumnFixture, ...]
+    unique_index_column: str
+    unique_index_note: str
+
+
+@dataclass(slots=True, frozen=True)
+class WorkflowFixture:
+    """A fixture workflow definition file and the identifiers it resolved to."""
+
+    write_path: WritePath
+    path: str
+    title: str
+
+
+@dataclass(slots=True, frozen=True)
+class FixtureHandles:
+    """Identifiers produced by fixture setup, reused across matrix cells."""
+
+    workspace_id: str
+    table_id: str
+    table_name: str
+    unique_index_column: str
+    workflow_ids: dict[WritePath, str]
+
+
+@dataclass(slots=True, frozen=True)
+class AuthConfig:
+    """How the runner authenticates against the local API.
+
+    Exactly one of `password` (synthetic local user, fastapi-users cookie
+    session) or `api_key` (service-account bearer token) is used.
+    """
+
+    email: str
+    password: str | None
+    api_key: str | None
+
+
+@dataclass(slots=True, frozen=True)
+class ScenarioConfig:
+    """The exact scenario configuration, recorded verbatim in the artifacts.
+
+    `poll_interval_seconds` is deliberately part of the scenario config: the
+    plan requires it to be identical across all phases so the baseline
+    measurement absorbs the per-poll auth and membership query cost.
+    """
+
+    run_id: str
+    base_url: str
+    workspace_id: str
+    write_path: WritePath
+    workflow_count: int
+    branch_count: int
+    ramp_seconds: float
+    steady_state_seconds: float
+    payload_bytes: int
+    run_timeout_seconds: float
+    poll_interval_seconds: float
+    warmup: bool
+    submit_concurrency: int
+    max_connections: int
+    artifact_dir: str
+    tracecat_commit: str
+    started_at: str
+    auth_mode: Literal["password", "api_key"]
+    auth_email: str
+    abort_stops_polling: bool
+
+    @property
+    def expected_rows(self) -> int:
+        """Unique logical rows a fully successful run should produce."""
+        return self.workflow_count * self.branch_count
+
+
+@dataclass(slots=True)
+class ExecutionRecord:
+    """One workflow execution, from submission to terminal state."""
+
+    workflow_seq: int
+    phase: Phase
+    submitted_at: float
+    accepted_at: float | None = None
+    terminal_at: float | None = None
+    wf_exec_id: str | None = None
+    submit_status_code: int | None = None
+    terminal_status: str | None = None
+    failure_mode: FailureMode = FailureMode.NONE
+    poll_count: int = 0
+    detail: str | None = None
+    """Raw server detail, recorded for analysis only. Never branched on."""
+
+    @property
+    def accepted(self) -> bool:
+        return self.accepted_at is not None
+
+    @property
+    def latency_seconds(self) -> float | None:
+        if self.accepted_at is None or self.terminal_at is None:
+            return None
+        return self.terminal_at - self.accepted_at
+
+
+@dataclass(slots=True, frozen=True)
+class LatencySummary:
+    """Percentile summary for end-to-end workflow latency."""
+
+    count: int
+    p50: float | None
+    p95: float | None
+    p99: float | None
+    minimum: float | None
+    maximum: float | None
+
+
+@dataclass(slots=True, frozen=True)
+class RunSummary:
+    """Human- and machine-readable summary of one runner invocation."""
+
+    run_id: str
+    submitted: int
+    accepted: int
+    completed: int
+    failed: int
+    timed_out: int
+    aborted: int
+    failure_modes: dict[str, int]
+    submit_status_codes: dict[str, int]
+    wall_clock_seconds: float
+    throughput_workflows_per_second: float
+    latency: LatencySummary
+    expected_rows: int
+    first_failure_at: float | None
+    aborted_by_signal: bool
+
+
+class PgActivitySample(TypedDict):
+    """One >=1Hz sample derived from pg_stat_activity and pg_stat_database."""
+
+    sampled_at: str
+    monotonic: float
+    max_connections: int
+    superuser_reserved_connections: int
+    total_connections: int
+    active: int
+    idle: int
+    idle_in_transaction: int
+    idle_in_transaction_aborted: int
+    waiting: int
+    wait_events: dict[str, int]
+    application_names: dict[str, int]
+    longest_transaction_seconds: float | None
+    longest_query_seconds: float | None
+    xact_commit_delta: int
+    xact_rollback_delta: int
+    deadlocks_delta: int
+    connection_slot_errors: int
+
+
+class ContainerState(TypedDict):
+    """Docker inspect state for one container in the cluster under test."""
+
+    name: str
+    service: str
+    image: str
+    image_id: str
+    status: str
+    restart_count: int
+    oom_killed: bool
+    exit_code: int | None
+    nano_cpus: int | None
+    memory_limit_bytes: int | None
+    memory_swap_limit_bytes: int | None
+    pids_limit: int | None
+
+
+class RowCorrectness(TypedDict):
+    """Expected-versus-actual unique row accounting for the fixture table."""
+
+    schema_name: str
+    table_name: str
+    total_rows: int
+    distinct_dedupe_keys: int
+    duplicate_dedupe_keys: int
+    rows_for_run: int
+    distinct_dedupe_keys_for_run: int
+
+
+class CollectorManifest(TypedDict):
+    """Index of everything the collector wrote for a run."""
+
+    run_id: str
+    artifact_dir: str
+    started_at: str
+    finished_at: str
+    sample_interval_seconds: float
+    sample_count: int
+    tracecat_commit: str
+    tracecat_commit_dirty: bool
+    compose_project: str
+    artifacts: dict[str, str]
+
+
+@dataclass(slots=True, frozen=True)
+class CollectorConfig:
+    """Metric collector configuration."""
+
+    run_id: str
+    artifact_dir: str
+    dsn: str
+    sample_interval_seconds: float
+    compose_project: str
+    compose_files: tuple[str, ...]
+    log_services: tuple[str, ...]
+    log_tail: int
+    table_name: str
+    duration_seconds: float | None
+    settings_of_interest: tuple[str, ...] = field(
+        default=(
+            "max_connections",
+            "superuser_reserved_connections",
+            "shared_buffers",
+            "work_mem",
+            "maintenance_work_mem",
+            "effective_cache_size",
+            "max_worker_processes",
+            "autovacuum",
+            "autovacuum_naptime",
+            "statement_timeout",
+            "idle_in_transaction_session_timeout",
+            "lock_timeout",
+            "deadlock_timeout",
+            "server_version",
+        )
+    )

--- a/scripts/benchmark/scatter_load/runner.py
+++ b/scripts/benchmark/scatter_load/runner.py
@@ -1,0 +1,528 @@
+"""Asynchronous API load runner for the PostgreSQL scatter load test.
+
+Starts workflows through the public admission path
+(`POST /workspaces/{workspace_id}/workflow-executions`) and polls them to a
+terminal state at a fixed interval. It never calls Temporal directly and never
+deletes fixtures.
+
+Usage (from the repository root):
+
+    uv run python -m scripts.benchmark.scatter_load.runner \\
+        --base-url http://localhost:80/api \\
+        --workflow-count 8 --branch-count 64 \\
+        --ramp-seconds 30 --steady-state-seconds 120
+
+See scripts/benchmark/postgres-scatter-load-test-plan.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import dataclasses
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final
+
+import httpx
+
+from .client import ApiError, TracecatClient
+from .fixtures import ensure_fixtures, resolve_workspace
+from .models import (
+    TERMINAL_STATUSES,
+    AuthConfig,
+    ExecutionRecord,
+    FailureMode,
+    LatencySummary,
+    Phase,
+    RunSummary,
+    ScenarioConfig,
+    WritePath,
+)
+
+DEFAULT_ARTIFACT_ROOT: Final = "/tmp/tracecat-scatter-load"
+DEFAULT_BASE_URL: Final = "http://localhost:80/api"
+# Defaults match the synthetic users seeded by `scripts/cluster up -d`.
+DEFAULT_EMAIL: Final = "dev@tracecat.com"
+DEFAULT_PASSWORD: Final = "password1234"
+DEFAULT_WORKSPACE_NAME: Final = "scatter-load"
+WARMUP_BRANCH_COUNT: Final = 2
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _git_commit(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except OSError:
+        return "unknown"
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def _percentile(sorted_values: list[float], fraction: float) -> float | None:
+    if not sorted_values:
+        return None
+    index = min(len(sorted_values) - 1, int(round(fraction * (len(sorted_values) - 1))))
+    return sorted_values[index]
+
+
+def summarize_latency(values: list[float]) -> LatencySummary:
+    ordered = sorted(values)
+    return LatencySummary(
+        count=len(ordered),
+        p50=_percentile(ordered, 0.50),
+        p95=_percentile(ordered, 0.95),
+        p99=_percentile(ordered, 0.99),
+        minimum=ordered[0] if ordered else None,
+        maximum=ordered[-1] if ordered else None,
+    )
+
+
+class JsonLinesWriter:
+    """Append-only JSON Lines sink, flushed per record."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._handle = path.open("a", encoding="utf-8")
+        self._lock = asyncio.Lock()
+
+    async def write(self, kind: str, payload: dict[str, object]) -> None:
+        line = json.dumps({"kind": kind, **payload}, default=str)
+        async with self._lock:
+            self._handle.write(line + "\n")
+            self._handle.flush()
+
+    def close(self) -> None:
+        self._handle.close()
+
+
+class ScatterLoadRunner:
+    """Drives warm-up, ramp, sustain, and drain for one scenario."""
+
+    def __init__(
+        self,
+        client: TracecatClient,
+        scenario: ScenarioConfig,
+        workflow_id: str,
+        writer: JsonLinesWriter,
+    ) -> None:
+        self._client = client
+        self._scenario = scenario
+        self._workflow_id = workflow_id
+        self._writer = writer
+        self._abort = asyncio.Event()
+        self._records: list[ExecutionRecord] = []
+        self._records_lock = asyncio.Lock()
+        self._next_seq = 0
+        self._seq_lock = asyncio.Lock()
+        self._payload = "x" * scenario.payload_bytes
+        self._started_monotonic = 0.0
+        self._ramp_deadline = 0.0
+
+    @property
+    def aborted(self) -> bool:
+        return self._abort.is_set()
+
+    def request_abort(self) -> None:
+        """Stop submitting new work. Fixtures are never deleted."""
+        self._abort.set()
+
+    async def _claim_seq(self) -> int:
+        async with self._seq_lock:
+            seq = self._next_seq
+            self._next_seq += 1
+            return seq
+
+    async def _record(self, record: ExecutionRecord) -> None:
+        async with self._records_lock:
+            self._records.append(record)
+        await self._writer.write("execution", dataclasses.asdict(record))
+
+    async def _run_one(self, phase: Phase, branch_count: int) -> ExecutionRecord:
+        seq = await self._claim_seq()
+        record = ExecutionRecord(
+            workflow_seq=seq, phase=phase, submitted_at=time.monotonic()
+        )
+        inputs: dict[str, object] = {
+            "run_id": self._scenario.run_id,
+            "workflow_seq": seq,
+            "branch_count": branch_count,
+            "payload": self._payload,
+        }
+
+        try:
+            result = await self._client.submit_execution(
+                self._scenario.workspace_id, self._workflow_id, inputs
+            )
+        except httpx.HTTPError:
+            record.failure_mode = FailureMode.SUBMIT_TRANSPORT_ERROR
+            record.terminal_at = time.monotonic()
+            await self._record(record)
+            return record
+
+        record.submit_status_code = result["status_code"]
+        if result["wf_exec_id"] is None:
+            record.failure_mode = FailureMode.ADMISSION_REJECTED
+            record.detail = result["detail"]
+            record.terminal_at = time.monotonic()
+            await self._record(record)
+            return record
+
+        record.accepted_at = time.monotonic()
+        record.wf_exec_id = result["wf_exec_id"]
+        await self._poll_to_terminal(record)
+        await self._record(record)
+        return record
+
+    async def _poll_to_terminal(self, record: ExecutionRecord) -> None:
+        """Poll at the fixed scenario interval until terminal, timeout, or abort."""
+        wf_exec_id = record.wf_exec_id
+        if wf_exec_id is None:
+            return
+        deadline = record.submitted_at + self._scenario.run_timeout_seconds
+        transport_errors = 0
+
+        while True:
+            await asyncio.sleep(self._scenario.poll_interval_seconds)
+            record.poll_count += 1
+
+            try:
+                status = await self._client.get_execution_status(
+                    self._scenario.workspace_id, wf_exec_id
+                )
+            except httpx.HTTPError:
+                transport_errors += 1
+                status = None
+
+            if status is not None and status in TERMINAL_STATUSES:
+                record.terminal_at = time.monotonic()
+                record.terminal_status = status
+                if status != "COMPLETED":
+                    record.failure_mode = FailureMode.WORKFLOW_FAILED
+                return
+
+            now = time.monotonic()
+            if now >= deadline:
+                record.terminal_at = now
+                record.terminal_status = status
+                record.failure_mode = (
+                    FailureMode.POLL_TRANSPORT_ERROR
+                    if transport_errors and status is None
+                    else FailureMode.RUN_TIMEOUT
+                )
+                return
+
+            if self._abort.is_set() and self._scenario.abort_stops_polling:
+                record.terminal_at = now
+                record.terminal_status = status
+                record.failure_mode = FailureMode.ABORTED
+                return
+
+    async def _worker(self, stagger: float, sustain_deadline: float) -> None:
+        """One concurrency slot: ramp in, then keep the slot busy until the deadline."""
+        await asyncio.sleep(stagger)
+        while not self._abort.is_set():
+            phase = (
+                Phase.RAMP if time.monotonic() < self._ramp_deadline else Phase.SUSTAIN
+            )
+            await self._run_one(phase, self._scenario.branch_count)
+            if time.monotonic() >= sustain_deadline or self._abort.is_set():
+                return
+
+    async def run(self) -> RunSummary:
+        self._started_monotonic = time.monotonic()
+
+        if self._scenario.warmup and not self._abort.is_set():
+            await self._run_one(Phase.WARMUP, WARMUP_BRANCH_COUNT)
+
+        ramp_start = time.monotonic()
+        self._ramp_deadline = ramp_start + self._scenario.ramp_seconds
+        sustain_deadline = self._ramp_deadline + self._scenario.steady_state_seconds
+
+        slots = self._scenario.workflow_count
+        stagger_step = (
+            self._scenario.ramp_seconds / slots
+            if slots > 0 and self._scenario.ramp_seconds > 0
+            else 0.0
+        )
+        await asyncio.gather(
+            *(
+                self._worker(slot * stagger_step, sustain_deadline)
+                for slot in range(slots)
+            )
+        )
+
+        return self.summarize()
+
+    def summarize(self) -> RunSummary:
+        wall_clock = time.monotonic() - self._started_monotonic
+        load_records = [r for r in self._records if r.phase is not Phase.WARMUP]
+
+        failure_modes = Counter(r.failure_mode.value for r in load_records)
+        status_codes = Counter(
+            str(r.submit_status_code) if r.submit_status_code is not None else "none"
+            for r in load_records
+        )
+        completed = sum(1 for r in load_records if r.terminal_status == "COMPLETED")
+        latencies = [
+            r.latency_seconds
+            for r in load_records
+            if r.terminal_status == "COMPLETED" and r.latency_seconds is not None
+        ]
+        first_failure = min(
+            (
+                r.terminal_at
+                for r in load_records
+                if r.failure_mode is not FailureMode.NONE and r.terminal_at is not None
+            ),
+            default=None,
+        )
+
+        return RunSummary(
+            run_id=self._scenario.run_id,
+            submitted=len(load_records),
+            accepted=sum(1 for r in load_records if r.accepted),
+            completed=completed,
+            failed=failure_modes[FailureMode.WORKFLOW_FAILED.value],
+            timed_out=failure_modes[FailureMode.RUN_TIMEOUT.value],
+            aborted=failure_modes[FailureMode.ABORTED.value],
+            failure_modes=dict(failure_modes),
+            submit_status_codes=dict(status_codes),
+            wall_clock_seconds=wall_clock,
+            throughput_workflows_per_second=(
+                completed / wall_clock if wall_clock > 0 else 0.0
+            ),
+            latency=summarize_latency(latencies),
+            expected_rows=completed * self._scenario.branch_count,
+            first_failure_at=(
+                first_failure - self._started_monotonic
+                if first_failure is not None
+                else None
+            ),
+            aborted_by_signal=self._abort.is_set(),
+        )
+
+
+def render_summary(scenario: ScenarioConfig, summary: RunSummary) -> str:
+    latency = summary.latency
+
+    def fmt(value: float | None) -> str:
+        return f"{value:.3f}s" if value is not None else "n/a"
+
+    lines = [
+        "=== Tracecat PostgreSQL scatter load test ===",
+        f"run id                 {summary.run_id}",
+        f"write path             {scenario.write_path.value}",
+        f"workflows x branches   {scenario.workflow_count} x {scenario.branch_count}",
+        f"ramp / sustain         {scenario.ramp_seconds:.0f}s / "
+        f"{scenario.steady_state_seconds:.0f}s",
+        f"payload bytes          {scenario.payload_bytes}",
+        f"poll interval (fixed)  {scenario.poll_interval_seconds:.2f}s",
+        f"per-run timeout        {scenario.run_timeout_seconds:.0f}s",
+        "",
+        f"submitted              {summary.submitted}",
+        f"accepted               {summary.accepted}",
+        f"completed              {summary.completed}",
+        f"failed                 {summary.failed}",
+        f"timed out              {summary.timed_out}",
+        f"aborted                {summary.aborted}",
+        f"wall clock             {summary.wall_clock_seconds:.1f}s",
+        f"throughput             {summary.throughput_workflows_per_second:.3f} wf/s",
+        "",
+        f"latency p50/p95/p99    {fmt(latency.p50)} / {fmt(latency.p95)} / "
+        f"{fmt(latency.p99)}",
+        f"latency min/max        {fmt(latency.minimum)} / {fmt(latency.maximum)}",
+        "",
+        f"expected unique rows   {summary.expected_rows} "
+        f"(target {scenario.expected_rows} at full success)",
+        "  actual row counts are recorded by the metric collector, which holds the",
+        "  direct PostgreSQL connection.",
+        "",
+        f"first failure at       {fmt(summary.first_failure_at)}",
+        f"aborted by signal      {summary.aborted_by_signal}",
+        "",
+        "failure modes:",
+    ]
+    for mode, count in sorted(summary.failure_modes.items()):
+        lines.append(f"  {mode:<28} {count}")
+    lines.append("submit status codes:")
+    for code, count in sorted(summary.submit_status_codes.items()):
+        lines.append(f"  {code:<28} {count}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scatter_load.runner",
+        description="Asynchronous API load runner for the PostgreSQL scatter load test.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("TRACECAT_SCATTER_BASE_URL", DEFAULT_BASE_URL),
+    )
+    parser.add_argument(
+        "--email",
+        default=os.environ.get("TRACECAT_SCATTER_EMAIL", DEFAULT_EMAIL),
+    )
+    parser.add_argument(
+        "--password-env",
+        default="TRACECAT_SCATTER_PASSWORD",
+        help="Env var holding the synthetic user's password.",
+    )
+    parser.add_argument(
+        "--api-key-env",
+        default="TRACECAT_SCATTER_API_KEY",
+        help=(
+            "Env var holding a service-account API key. "
+            "Takes precedence over --password-env."
+        ),
+    )
+    parser.add_argument("--workspace-id", default=None)
+    parser.add_argument("--workspace-name", default=DEFAULT_WORKSPACE_NAME)
+    parser.add_argument(
+        "--write-path",
+        choices=[p.value for p in WritePath],
+        default=WritePath.SCATTER.value,
+    )
+    parser.add_argument("--workflow-count", type=int, default=1)
+    parser.add_argument("--branch-count", type=int, default=8)
+    parser.add_argument("--ramp-seconds", type=float, default=10.0)
+    parser.add_argument("--steady-state-seconds", type=float, default=60.0)
+    parser.add_argument("--payload-bytes", type=int, default=256)
+    parser.add_argument("--run-timeout-seconds", type=float, default=300.0)
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=1.0,
+        help="Fixed across every phase; recorded in the scenario config.",
+    )
+    parser.add_argument("--no-warmup", action="store_true")
+    parser.add_argument(
+        "--abort-stops-polling",
+        action="store_true",
+        help="On abort, also stop polling in-flight executions instead of draining them.",
+    )
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument("--artifact-root", default=DEFAULT_ARTIFACT_ROOT)
+    parser.add_argument(
+        "--max-connections",
+        type=int,
+        default=200,
+        help="HTTP connection pool size for the runner itself.",
+    )
+    return parser
+
+
+async def amain(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[3]
+
+    run_id = args.run_id or f"scatter-{uuid.uuid4().hex[:12]}"
+    artifact_dir = Path(args.artifact_root) / run_id
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    api_key = os.environ.get(args.api_key_env) or None
+    password = os.environ.get(args.password_env) or DEFAULT_PASSWORD
+    auth = AuthConfig(
+        email=args.email,
+        password=None if api_key else password,
+        api_key=api_key,
+    )
+
+    writer = JsonLinesWriter(artifact_dir / "runner_results.jsonl")
+    try:
+        async with TracecatClient(
+            args.base_url, api_key=auth.api_key, max_connections=args.max_connections
+        ) as client:
+            if auth.api_key is None:
+                if auth.password is None:
+                    print("No credential available", file=sys.stderr)
+                    return 2
+                await client.login(auth.email, auth.password)
+
+            workspace_id = await resolve_workspace(
+                client, args.workspace_id, args.workspace_name
+            )
+            write_path = WritePath(args.write_path)
+            handles = await ensure_fixtures(client, workspace_id, (write_path,))
+
+            scenario = ScenarioConfig(
+                run_id=run_id,
+                base_url=args.base_url,
+                workspace_id=workspace_id,
+                write_path=write_path,
+                workflow_count=args.workflow_count,
+                branch_count=args.branch_count,
+                ramp_seconds=args.ramp_seconds,
+                steady_state_seconds=args.steady_state_seconds,
+                payload_bytes=args.payload_bytes,
+                run_timeout_seconds=args.run_timeout_seconds,
+                poll_interval_seconds=args.poll_interval_seconds,
+                warmup=not args.no_warmup,
+                submit_concurrency=args.workflow_count,
+                max_connections=args.max_connections,
+                artifact_dir=str(artifact_dir),
+                tracecat_commit=_git_commit(repo_root),
+                started_at=_utc_now_iso(),
+                auth_mode="api_key" if auth.api_key else "password",
+                auth_email=auth.email,
+                abort_stops_polling=args.abort_stops_polling,
+            )
+
+            scenario_payload = dataclasses.asdict(scenario)
+            scenario_payload["table_name"] = handles.table_name
+            scenario_payload["unique_index_column"] = handles.unique_index_column
+            scenario_payload["workflow_id"] = handles.workflow_ids[write_path]
+            (artifact_dir / "scenario.json").write_text(
+                json.dumps(scenario_payload, indent=2, default=str), encoding="utf-8"
+            )
+            await writer.write("scenario", scenario_payload)
+
+            runner = ScatterLoadRunner(
+                client, scenario, handles.workflow_ids[write_path], writer
+            )
+
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                with contextlib.suppress(NotImplementedError):
+                    loop.add_signal_handler(sig, runner.request_abort)
+
+            summary = await runner.run()
+
+            await writer.write("summary", dataclasses.asdict(summary))
+            rendered = render_summary(scenario, summary)
+            (artifact_dir / "summary.txt").write_text(rendered + "\n", encoding="utf-8")
+            print(rendered)
+            print(f"\nartifacts: {artifact_dir}")
+            return 1 if summary.aborted_by_signal else 0
+    except ApiError as exc:
+        print(f"API error: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        writer.close()
+
+
+def main() -> None:
+    raise SystemExit(asyncio.run(amain(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -43,6 +43,10 @@ ENV_FILE="${REPO_ROOT}/.env"
 PROFILE="dev"
 CLUSTER_EE_MULTI_TENANT=""
 CLUSTER_USE_SANDBOX_COMPOSE=true
+# Extra compose files layered on top of the profile (and sandbox) files.
+# These never change the project name, ports, or volume names, so the
+# numbered-cluster isolation is preserved.
+CLUSTER_COMPOSE_OVERRIDES=()
 
 # Get worktree identifier for namespacing clusters
 # Returns "main" for the main worktree, or a sanitized branch/directory name for worktrees
@@ -373,6 +377,27 @@ get_compose_file() {
     esac
 }
 
+# Register an extra compose override file. Relative paths resolve against the
+# current directory first, then the repo root. The path is absolutized so later
+# `cd` calls inside this script cannot invalidate it.
+add_compose_override() {
+    local path=$1
+
+    if [[ ! -f "$path" && -f "${REPO_ROOT}/${path}" ]]; then
+        path="${REPO_ROOT}/${path}"
+    fi
+
+    if [[ ! -f "$path" ]]; then
+        echo "Error: compose override file not found: '$1'" >&2
+        exit 1
+    fi
+
+    local dir base
+    dir=$(cd "$(dirname "$path")" && pwd)
+    base=$(basename "$path")
+    CLUSTER_COMPOSE_OVERRIDES+=("${dir}/${base}")
+}
+
 usage() {
     cat <<EOF
 Usage: ./cluster [cluster_num] [-p profile] [tenant mode] <command> [args...]
@@ -400,6 +425,13 @@ Sandbox mode:
   --no-sandbox                    Disable nsjail sandboxing and sandbox
                                   compose privileges
 
+Compose overrides:
+  Layered after the profile and sandbox compose files. They do not change the
+  project name, ports, or volume names, so cluster isolation is preserved.
+  --loadtest                      Layer docker-compose.loadtest.yml
+                                  (constrained postgres_db + pool budget)
+  --compose-override <path>       Layer an arbitrary compose file (repeatable)
+
 Commands:
   up [args]     Start the cluster (e.g., up -d)
                 Reuses existing cluster for this worktree if one is running.
@@ -424,6 +456,8 @@ Commands:
   open          Open the cluster UI in the default browser
   ports         Show port mappings for the cluster
   list          List all running Tracecat clusters
+  compose-files Print the resolved compose files and project name, then exit
+                (dry run; does not touch Docker)
   nuke [opts]   Destroy cluster and optionally volumes/images
 
 Nuke options:
@@ -440,6 +474,9 @@ Examples:
   ./cluster --ee-multi-tenant false up -d
                                   Start cluster with explicit tenant mode
   ./cluster up -d --no-sandbox    Start cluster without nsjail sandboxing
+  ./cluster up -d --loadtest      Start cluster with the load-test override
+  ./cluster --compose-override ./docker-compose.loadtest.yml compose-files
+                                  Show the resolved compose file list
   ./cluster up -d --new          Force a new cluster on next available number
   ./cluster up -d --no-seed      Start cluster without creating dev tenant user
   ./cluster up -d --default-tier-entitlements none
@@ -689,6 +726,22 @@ while [[ $# -gt 0 ]]; do
             CLUSTER_USE_SANDBOX_COMPOSE=false
             shift
             ;;
+        --loadtest)
+            add_compose_override "${REPO_ROOT}/docker-compose.loadtest.yml"
+            shift
+            ;;
+        --compose-override)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --compose-override requires a compose file path" >&2
+                exit 1
+            fi
+            add_compose_override "$2"
+            shift 2
+            ;;
+        --compose-override=*)
+            add_compose_override "${1#*=}"
+            shift
+            ;;
         *)
             break
             ;;
@@ -764,6 +817,22 @@ while [[ $# -gt 0 ]]; do
             CLUSTER_USE_SANDBOX_COMPOSE=false
             shift
             ;;
+        --loadtest)
+            add_compose_override "${REPO_ROOT}/docker-compose.loadtest.yml"
+            shift
+            ;;
+        --compose-override)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --compose-override requires a compose file path" >&2
+                exit 1
+            fi
+            add_compose_override "$2"
+            shift 2
+            ;;
+        --compose-override=*)
+            add_compose_override "${1#*=}"
+            shift
+            ;;
         *)
             FILTERED_ARGS+=("$1")
             shift
@@ -815,6 +884,9 @@ if [[ "$AUTO_SELECT" == "true" ]]; then
                 CLUSTER_NUM=$(echo "$running" | select_cluster_interactive)
             fi
         fi
+    elif [[ "$COMMAND" == "compose-files" ]]; then
+        # Dry run: never require a running cluster.
+        CLUSTER_NUM=$(get_next_cluster_num)
     elif [[ "$COMMAND" == "nuke" ]]; then
         # For nuke, try to find any cluster (running or with leftover volumes)
         nuke_running=$(get_running_clusters)
@@ -849,6 +921,22 @@ COMPOSE_FILE=$(get_compose_file "$PROFILE")
 COMPOSE_FILES=(-f "$COMPOSE_FILE")
 if [[ "$CLUSTER_USE_SANDBOX_COMPOSE" == "true" ]]; then
     COMPOSE_FILES+=(-f "${REPO_ROOT}/docker-compose.sandbox.yml")
+fi
+for compose_override in ${CLUSTER_COMPOSE_OVERRIDES[@]+"${CLUSTER_COMPOSE_OVERRIDES[@]}"}; do
+    COMPOSE_FILES+=(-f "$compose_override")
+done
+
+# Handle 'compose-files' command - dry run that prints the resolved compose
+# invocation without touching Docker. Useful for verifying flag parsing.
+if [[ "$COMMAND" == "compose-files" ]]; then
+    echo "Project:  tracecat-${WORKTREE_ID}-${CLUSTER_NUM}"
+    echo "Profile:  ${PROFILE}"
+    echo "Compose files:"
+    for compose_arg in "${COMPOSE_FILES[@]}"; do
+        [[ "$compose_arg" == "-f" ]] && continue
+        echo "  ${compose_arg}"
+    done
+    exit 0
 fi
 
 # Handle 'ports' command


### PR DESCRIPTION
## What

Implements the test assets from the load-test plan one PR down this stack. No product code changes; nothing here runs in production.

- `docker-compose.loadtest.yml` — constrains **only** `postgres_db` (1 CPU, 1 GiB, `max_connections=50`, `shared_buffers=128MB`); `temporal_postgres_db` deliberately untouched. Sets placeholder pool ceilings on every DB-capable service with the budget arithmetic (`C_configured = 39 <= C_budget = 42`) documented inline.
- `scripts/cluster` — narrow `--loadtest` and `--compose-override <path>` flags plus a `compose-files` dry-run command. Numbered-project/port/volume isolation preserved; `shellcheck -x` clean.
- `scripts/benchmark/scatter_load/` — typed Python package: fixtures (synthetic table + adversarial `insert_row` scatter workflow + `insert_rows` bulk control), async API load runner (public API only, fixed recorded poll interval, JSONL + summary output, abort-safe), and a metric collector (≥1Hz `pg_stat_activity` sampling, container/cgroup state, logs, row-correctness audit, artifacts to `/tmp/tracecat-scatter-load/<run-id>/`).

## Key implementation decisions

- **`dedupe_key` column instead of a composite unique index** — the public tables API only supports single-column unique indexes; `<run_id>:<workflow_seq>:<branch_seq>` in one indexed text column gives the same missing/duplicate measurability.
- **Auth**: cookie session via `/auth/login` as the cluster-seeded user; a service-account API key takes precedence when provided.
- **Connection-slot detection** uses `asyncpg.exceptions.TooManyConnectionsError` (typed, no error-string matching); the probe deliberately draws from the admin reserve so its failure doubles as the reserve-consumed abort signal.

## Verification (static only — no cluster started, no load run)

- `docker compose -f docker-compose.dev.yml -f docker-compose.loadtest.yml config` exits 0; merged-model inspection confirms only `postgres_db` is constrained and Temporal still points at `temporal_postgres_db`.
- `shellcheck -x scripts/cluster` passes; flag parsing exercised via the `compose-files` dry-run, including the error path.
- Ruff + ruff format clean; basedpyright 0 errors (note: `pyproject.toml` excludes `scripts/` from pyright, so this was run with a mirrored config — CI does not typecheck these files).
- Both fixture YAMLs validate against the real `ExternalWorkflowDefinition`/`DSLInput` models, with templated expressions evaluated through `eval_templated_object`.

## Review guide

Risk concentrates in the `scripts/cluster` diff (must not break existing profiles) and `docker-compose.loadtest.yml`. The `scatter_load/` package is standalone tooling — reviewable for correctness but it cannot affect the product. Known open item: executor sandbox subprocesses creating their own engines would invalidate the 39-connection inventory; flagged in the compose file as a phase-2 runtime check.
