### PR TITLE
fix(mcp): drop force flag from sync_custom_registry tool

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -7070,10 +7070,12 @@ async def test_sync_custom_registry_requires_organization_context(monkeypatch):
 
 
 def test_sync_custom_registry_public_signature_drops_repo_selectors() -> None:
+    """Force-sync deletes the current registry version and is not MCP-reachable."""
     signature = inspect.signature(_tool(mcp_server.sync_custom_registry))
     assert "repository_id" not in signature.parameters
     assert "origin" not in signature.parameters
     assert "workspace_id" not in signature.parameters
+    assert "force" not in signature.parameters
     assert "org_id" in signature.parameters
 
 

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -4047,7 +4047,6 @@ async def list_actions(
 async def sync_custom_registry(
     org_id: uuid.UUID | None = None,
     target_commit_sha: str | None = None,
-    force: bool = False,
 ) -> CustomRegistrySyncResponse:
     """Sync the organization's custom action registry from its remote git repository.
 
@@ -4064,8 +4063,6 @@ async def sync_custom_registry(
             single-org callers or tokens scoped with organization_id/org:<id>.
         target_commit_sha: 40-character commit SHA to sync to. Defaults to
             the remote's HEAD when omitted.
-        force: Delete the repository's current registry version before
-            syncing, so the same commit can be re-synced from scratch.
 
     Returns JSON with `success`, `synced_at`, and a `results` array containing
     the per-repository `repository_id`, `origin`, `version`, `commit_sha`,
@@ -4102,7 +4099,6 @@ async def sync_custom_registry(
                     repo,
                     RegistryRepositorySync(
                         target_commit_sha=target_commit_sha,
-                        force=force,
                     ),
                 )
             except ScopeDeniedError:
@@ -4123,7 +4119,7 @@ async def sync_custom_registry(
                             synced_at=synced_at,
                             repository_id=repo.id,
                             origin=repo.origin,
-                            forced=force,
+                            forced=False,
                             error=str(exc),
                         )
                     ],
@@ -4141,7 +4137,7 @@ async def sync_custom_registry(
                         version=response.version,
                         commit_sha=response.commit_sha,
                         actions_count=response.actions_count,
-                        forced=force,
+                        forced=response.forced,
                     )
                 ],
             )


### PR DESCRIPTION
## Problem

The `sync_custom_registry` MCP tool forwarded a `force: bool` argument straight through to `RegistryReposService.sync_repository`. With `force=True`, that service **deletes the repository's current registry version** before syncing (`tracecat/registry/repositories/service.py:142-157`).

Force-sync is a lower-level break-glass operation intended for the HTTP API and the admin UI. It has no legitimate agent-driven use case, and having it in the tool's input schema both made it reachable by an agent and advertised its existence to the model.

MCP tool annotations (`destructiveHint` and friends) are advisory only — the spec requires clients to treat them as untrusted — so the input schema is the enforcement point.

## Change

Remove `force` from the agent-facing MCP surface:

- Drop the `force` parameter from the `sync_custom_registry` signature and docstring.
- Stop passing `force` into `RegistryRepositorySync`, so the schema default (`False`) applies.
- Report `forced` from the actual service result (`response.forced`) on success, and `False` on the failure path, rather than echoing the caller's argument.

`CustomRegistrySyncResult.forced` stays in the response contract — it still truthfully reports what the service did.

## Not changed

`force` remains fully available on every non-agent surface: the service API, the org router (`POST /registry/repositories/{id}/sync`), the admin API, and the "Force sync (delete existing)" action in the admin UI. This is an MCP-only narrowing.

## Review guide

The invariant is asserted in `test_sync_custom_registry_public_signature_drops_repo_selectors`, alongside the existing repo-selector assertions: `force` must not appear in the tool's public signature.

## Verification

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run basedpyright --warnings` on both changed files — 0 errors, 0 warnings
- `uv run pytest tests/unit/test_mcp_server.py -k sync_custom_registry` — 10 passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `force` flag from the MCP `sync_custom_registry` tool to prevent agent-triggered destructive force-syncs. The tool now always performs a safe sync and still reports whether the service forced a sync.

- **Bug Fixes**
  - Removed `force` from the tool’s signature and stopped passing it to `RegistryRepositorySync`.
  - `forced` in responses now reflects the service result; on errors it returns `forced: false`.
  - Added a test to assert `force` is not in the tool’s public signature; `force` remains available via non-agent APIs and the admin UI.

<sup>Written for commit 452f56433e07b86f1262a99df699b67bc626916f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

