### PR TITLE
fix(audit): ensure valid payloads and resource attribution

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5483,7 +5483,7 @@ export const $AuditSettingsUpdate = {
       ],
       title: "Audit Webhook Custom Payload",
       description:
-        "Custom JSON payload merged into streamed audit event payloads. Custom keys override default audit event keys.",
+        "Custom JSON fields merged into streamed audit event payloads. Canonical audit event fields take precedence; conflicting custom keys are ignored.",
     },
     audit_webhook_payload_attribute: {
       anyOf: [
@@ -18953,7 +18953,7 @@ export const $PlatformAuditSettingsUpdate = {
       ],
       title: "Audit Webhook Custom Payload",
       description:
-        "Custom JSON payload merged into streamed audit event payloads. Custom keys override default audit event keys.",
+        "Custom JSON fields merged into streamed audit event payloads. Canonical audit event fields take precedence; conflicting custom keys are ignored.",
     },
     audit_webhook_payload_attribute: {
       anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1372,7 +1372,7 @@ export type AuditSettingsUpdate = {
     [key: string]: string
   } | null
   /**
-   * Custom JSON payload merged into streamed audit event payloads. Custom keys override default audit event keys.
+   * Custom JSON fields merged into streamed audit event payloads. Canonical audit event fields take precedence; conflicting custom keys are ignored.
    */
   audit_webhook_custom_payload?: {
     [key: string]: unknown
@@ -5713,7 +5713,7 @@ export type PlatformAuditSettingsUpdate = {
     [key: string]: string
   } | null
   /**
-   * Custom JSON payload merged into streamed audit event payloads. Custom keys override default audit event keys.
+   * Custom JSON fields merged into streamed audit event payloads. Canonical audit event fields take precedence; conflicting custom keys are ignored.
    */
   audit_webhook_custom_payload?: {
     [key: string]: unknown

--- a/packages/tracecat-ee/tracecat_ee/admin/settings/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/settings/service.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.audit.logger import audit_log
+from tracecat.audit.service import clear_audit_setting_cache
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import PlatformRole
 from tracecat.db.models import PlatformSetting
@@ -146,6 +147,7 @@ class AdminSettingsService(BasePlatformService):
         for key, value in params.model_dump(exclude_unset=True).items():
             await self._upsert_setting(key, value)
         await self.session.commit()
+        clear_audit_setting_cache()
         return await self.get_audit_settings()
 
     async def get_registry_settings(self) -> PlatformRegistrySettingsRead:

--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -245,7 +245,7 @@ class RBACService(BaseOrgService):
             await self._set_role_scopes(role.id, scope_ids)
 
         await self.session.commit()
-        await self.session.refresh(role, ["scopes"])
+        await self.session.refresh(role, ["updated_at", "scopes"])
         return role
 
     @require_scope("org:rbac:delete")
@@ -397,7 +397,7 @@ class RBACService(BaseOrgService):
             group.description = description
 
         await self.session.commit()
-        await self.session.refresh(group, ["members"])
+        await self.session.refresh(group, ["updated_at", "members"])
         return group
 
     @require_scope("org:rbac:delete")

--- a/tests/unit/test_admin_settings_service.py
+++ b/tests/unit/test_admin_settings_service.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import orjson
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.admin.settings import service as admin_settings_service_module
 from tracecat_ee.admin.settings.schemas import PlatformAuditSettingsUpdate
 from tracecat_ee.admin.settings.service import AdminSettingsService
 
@@ -52,8 +53,15 @@ async def test_platform_audit_settings_default_to_disconnected(
 async def test_platform_audit_settings_encrypt_sensitive_values(
     session: AsyncSession,
     platform_role: PlatformRole,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = AdminSettingsService(session, platform_role)
+    clear_audit_cache = MagicMock()
+    monkeypatch.setattr(
+        admin_settings_service_module,
+        "clear_audit_setting_cache",
+        clear_audit_cache,
+    )
     custom_headers = {"Authorization": "Bearer secret"}
     custom_payload = {"source": "tracecat-platform"}
 
@@ -72,6 +80,7 @@ async def test_platform_audit_settings_encrypt_sensitive_values(
     assert settings.audit_webhook_custom_payload == custom_payload
     assert settings.audit_webhook_payload_attribute == "event"
     assert settings.audit_webhook_verify_ssl is False
+    clear_audit_cache.assert_called_once_with()
 
     rows = (await session.execute(select(PlatformSetting))).scalars().all()
     settings_by_key = {setting.key: setting for setting in rows}

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -59,9 +59,9 @@ def audit_service(role: Role) -> AuditService:
 @pytest.fixture(autouse=True)
 def clear_audit_setting_cache() -> Iterator[None]:
     """Isolate the module-level audit-setting TTL cache between tests."""
-    audit_service_module._get_audit_setting_cached.cache_clear()
+    audit_service_module.clear_audit_setting_cache()
     yield
-    audit_service_module._get_audit_setting_cached.cache_clear()
+    audit_service_module.clear_audit_setting_cache()
 
 
 class _AuditedService(BaseService):
@@ -881,7 +881,7 @@ async def test_audit_setting_cache_clear_restores_fresh_reads(
     assert await audit_service._get_webhook_url() == "https://first.example.com/audit"
     assert await audit_service._get_webhook_url() == "https://first.example.com/audit"
 
-    audit_service_module._get_audit_setting_cached.cache_clear()
+    audit_service_module.clear_audit_setting_cache()
 
     assert await audit_service._get_webhook_url() == "https://second.example.com/audit"
     assert fetch.await_count == 2
@@ -900,7 +900,14 @@ async def test_post_event_uses_custom_payload_headers_and_verify_ssl(
     monkeypatch.setattr(
         audit_service,
         "_get_custom_payload",
-        AsyncMock(return_value={"resource_type": "organization", "custom": "yes"}),
+        AsyncMock(
+            return_value={
+                "resource_type": "organization",
+                "resource_id": "not-a-uuid",
+                "status": "INVALID_STATUS",
+                "custom": "yes",
+            }
+        ),
     )
     monkeypatch.setattr(
         audit_service,
@@ -947,7 +954,9 @@ async def test_post_event_uses_custom_payload_headers_and_verify_ssl(
     assert args[0] == webhook_url
     assert kwargs["headers"] == {"X-Custom-Header": "custom-value"}
     assert kwargs["json"]["custom"] == "yes"
-    assert kwargs["json"]["resource_type"] == "organization"
+    assert kwargs["json"]["resource_type"] == "workflow"
+    assert kwargs["json"]["resource_id"] == str(event.resource_id)
+    assert kwargs["json"]["status"] == "SUCCESS"
     assert kwargs["json"]["actor_label"] == "user@example.com"
 
 
@@ -1638,6 +1647,37 @@ async def test_audit_log_explicit_invitation_id_overrides_result_id(
 
     resource_ids = [call["resource_id"] for call in create_event_calls]
     assert resource_ids == [invitation_id, invitation_id]
+
+
+@pytest.mark.anyio
+async def test_audit_log_extracts_id_from_keyword_object(role: Role) -> None:
+    resource_id = uuid.uuid4()
+
+    class MockService:
+        def __init__(self):
+            self.session = AsyncMock()
+
+        @audit_log(resource_type="organization_secret", action="update")
+        async def update_secret(self, *, secret: SimpleNamespace) -> None:
+            return None
+
+    service = MockService()
+    token = ctx_role.set(role)
+    create_event_calls: list[dict[str, object]] = []
+
+    async def mock_create_event(*args, **kwargs):
+        create_event_calls.append(kwargs)
+
+    try:
+        with patch.object(AuditService, "create_event", side_effect=mock_create_event):
+            await service.update_secret(secret=SimpleNamespace(id=resource_id))
+    finally:
+        ctx_role.reset(token)
+
+    assert [call["resource_id"] for call in create_event_calls] == [
+        resource_id,
+        resource_id,
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_control_plane_audit.py
+++ b/tests/unit/test_control_plane_audit.py
@@ -422,6 +422,11 @@ async def _schedule(mp: pytest.MonkeyPatch, role: Role, action: str):
     if action == "create":
         mp.setattr(
             service,
+            "_require_published_workflow",
+            AsyncMock(),
+        )
+        mp.setattr(
+            service,
             "_create_schedule_impl",
             AsyncMock(return_value=SimpleNamespace(id=schedule_id)),
         )
@@ -475,6 +480,7 @@ async def _case_upsert(mp: pytest.MonkeyPatch, role: Role):
 async def _case_update(mp: pytest.MonkeyPatch, role: Role):
     trigger_id = uuid.uuid4()
     service = CaseTriggersService(cast(Any, _session()), role=role)
+    cast(AsyncMock, service.session.scalar).return_value = trigger_id
     mp.setattr(service, "require_entitlement", AsyncMock())
     mp.setattr(
         service,
@@ -485,7 +491,11 @@ async def _case_update(mp: pytest.MonkeyPatch, role: Role):
         WorkflowUUID.new_uuid4(), CaseTriggerUpdate(status="online")
     )
     return _pair(
-        "case_trigger", "update", None, trigger_id, {"changed_fields": ["status"]}
+        "case_trigger",
+        "update",
+        trigger_id,
+        trigger_id,
+        {"changed_fields": ["status"]},
     )
 
 

--- a/tests/unit/test_organization_settings.py
+++ b/tests/unit/test_organization_settings.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import MagicMock
 
 import orjson
 import pytest
@@ -11,6 +12,7 @@ from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.db.models import OrganizationDomain
 from tracecat.organization.domains import normalize_domain
+from tracecat.settings import service as settings_service_module
 from tracecat.settings.constants import SENSITIVE_SETTINGS_KEYS
 from tracecat.settings.router import (
     check_other_auth_enabled,
@@ -229,15 +231,23 @@ async def test_update_git_settings(
 @pytest.mark.anyio
 async def test_update_audit_settings(
     settings_service_with_defaults: SettingsService,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ensure audit webhook updates persist."""
     service = settings_service_with_defaults
+    clear_audit_cache = MagicMock()
+    monkeypatch.setattr(
+        settings_service_module,
+        "clear_audit_setting_cache",
+        clear_audit_cache,
+    )
     await service.update_audit_settings(
         AuditSettingsUpdate(audit_webhook_url="https://example.com/audit")
     )
     settings = await service.list_org_settings(keys={"audit_webhook_url"})
     settings_dict = {setting.key: service.get_value(setting) for setting in settings}
     assert settings_dict["audit_webhook_url"] == "https://example.com/audit"
+    clear_audit_cache.assert_called_once_with()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -238,6 +238,7 @@ class TestRBACServiceRoles:
         )
         assert updated.name == "Updated Name"
         assert updated.description == "New description"
+        assert updated.updated_at >= updated.created_at
 
     async def test_delete_role(
         self,
@@ -295,6 +296,25 @@ class TestRBACServiceGroups:
         assert group.name == "Engineering Team"
         assert group.organization_id == org.id
         assert group.created_by == role.user_id
+
+    async def test_update_group(
+        self,
+        session: AsyncSession,
+        role: Role,
+    ):
+        """Updated groups expose server-generated timestamps without lazy IO."""
+        service = RBACService(session, role=role)
+        group = await service.create_group(name="Original Group")
+
+        updated = await service.update_group(
+            group.id,
+            name="Updated Group",
+            description="New description",
+        )
+
+        assert updated.name == "Updated Group"
+        assert updated.description == "New description"
+        assert updated.updated_at >= updated.created_at
 
     async def test_add_member_to_group(
         self,

--- a/tests/unit/test_workflow_schedules_service.py
+++ b/tests/unit/test_workflow_schedules_service.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.service import AuditService
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import EDITOR_SCOPES
 from tracecat.db.models import Schedule, Workflow
-from tracecat.exceptions import ScopeDeniedError
+from tracecat.exceptions import ScopeDeniedError, TracecatNotFoundError
 from tracecat.identifiers import WorkspaceID
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.schedules import bridge
@@ -79,6 +82,43 @@ async def test_create_schedule_acquires_workflow_lock(
     assert schedule.workflow_id == workflow.id
     assert schedule.status == "offline"
     assert locked_workflow_ids == [WorkflowUUID.new(workflow.id)]
+
+
+@pytest.mark.anyio
+async def test_create_schedule_unpublished_workflow_emits_failure(
+    session: AsyncSession, svc_role, monkeypatch
+):
+    workflow = Workflow(
+        title="Unpublished Schedule",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.commit()
+
+    create_event = AsyncMock()
+    monkeypatch.setattr(AuditService, "create_event", create_event)
+    service = WorkflowSchedulesService(session, role=svc_role)
+
+    with pytest.raises(
+        TracecatNotFoundError,
+        match="Workflow must be saved before creating a schedule",
+    ):
+        await service.create_schedule(
+            ScheduleCreate(
+                workflow_id=WorkflowUUID.new(workflow.id),
+                every=timedelta(hours=1),
+                inputs={},
+                status="offline",
+                timeout=0,
+            )
+        )
+
+    assert [call.kwargs["status"] for call in create_event.await_args_list] == [
+        AuditEventStatus.ATTEMPT,
+        AuditEventStatus.FAILURE,
+    ]
 
 
 @pytest.mark.anyio

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -346,6 +346,7 @@ def _extract_resource_id(
     2. The first positional argument with an ``attr`` attribute.
     3. The bound function argument named ``attr``.
     4. The keyword argument named ``attr``.
+    5. The first keyword argument object with an ``attr`` attribute.
 
     Args:
         args: Positional arguments passed to the decorated function.
@@ -377,6 +378,11 @@ def _extract_resource_id(
             raw = bound_arguments.get(attr)
         if raw is None and attr in kwargs:
             raw = kwargs.get(attr)
+        if raw is None:
+            for argument in kwargs.values():
+                if hasattr(argument, attr):
+                    raw = getattr(argument, attr)
+                    break
 
     if raw is None:
         return None

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -231,6 +231,11 @@ async def _get_audit_setting_cached(
     return await get_setting(key, role=role, session=None, default=default)
 
 
+def clear_audit_setting_cache() -> None:
+    """Make committed audit setting changes visible to the next event."""
+    _get_audit_setting_cached.cache_clear()
+
+
 class AuditService(BaseService):
     """Stream user-driven events to an audit webhook if configured.
 
@@ -397,7 +402,9 @@ class AuditService(BaseService):
         payload_attribute = await self._get_payload_attribute()
         event_payload = payload.model_dump(mode="json")
         if custom_payload:
-            event_payload = {**event_payload, **custom_payload}
+            # Custom fields may enrich an event but cannot replace the canonical
+            # audit contract with invalid or misleading values.
+            event_payload = {**custom_payload, **event_payload}
         request_payload: dict[str, Any]
         if payload_attribute:
             request_payload = {payload_attribute: event_payload}

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -253,7 +253,7 @@ class SecretsService(BaseOrgService):
 
     @require_scope("secret:create")
     @audit_log(resource_type="secret", action="create")
-    async def create_secret(self, params: SecretCreate) -> None:
+    async def create_secret(self, params: SecretCreate) -> Secret:
         """Create a workspace secret."""
         workspace_id = self._require_workspace_id()
         if params.type == SecretType.SSH_KEY:
@@ -273,6 +273,7 @@ class SecretsService(BaseOrgService):
         )
         self.session.add(secret)
         await self.session.commit()
+        return secret
 
     @require_scope("secret:update")
     @audit_log(resource_type="secret", action="update")
@@ -384,7 +385,7 @@ class SecretsService(BaseOrgService):
         await self._create_org_secret(params)
 
     @audit_log(resource_type="organization_secret", action="create")
-    async def _create_org_secret(self, params: SecretCreate) -> None:
+    async def _create_org_secret(self, params: SecretCreate) -> OrganizationSecret:
         """Create an organization secret for callers with their own access gate."""
         if params.type == SecretType.SSH_KEY:
             validate_ssh_key_values(params.keys)
@@ -403,6 +404,7 @@ class SecretsService(BaseOrgService):
         )
         self.session.add(secret)
         await self.session.commit()
+        return secret
 
     @require_scope("org:secret:update")
     async def update_org_secret(

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -166,8 +166,9 @@ class AuditSettingsUpdate(BaseSettingsGroup):
     audit_webhook_custom_payload: dict[str, Any] | None = Field(
         default=None,
         description=(
-            "Custom JSON payload merged into streamed audit event payloads. "
-            "Custom keys override default audit event keys."
+            "Custom JSON fields merged into streamed audit event payloads. "
+            "Canonical audit event fields take precedence; conflicting custom "
+            "keys are ignored."
         ),
     )
     audit_webhook_payload_attribute: str | None = Field(

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.api.common import get_default_organization_id
 from tracecat.audit.logger import audit_log
+from tracecat.audit.service import clear_audit_setting_cache
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
@@ -43,6 +44,7 @@ from tracecat.settings.schemas import (
 VERSIONED_RESOURCE_RESOLUTION_STRATEGY_SETTING = (
     "app_versioned_resource_resolution_strategy"
 )
+AUDIT_SETTINGS_KEYS = AuditSettingsUpdate.keys()
 
 
 def _deserialize_setting_value(
@@ -215,6 +217,8 @@ class SettingsService(BaseOrgService):
         """Create a new organization setting."""
         setting = await self._create_org_setting(params)
         await self.session.commit()
+        if params.key in AUDIT_SETTINGS_KEYS:
+            clear_audit_setting_cache()
         return setting
 
     async def _update_setting(
@@ -259,6 +263,8 @@ class SettingsService(BaseOrgService):
         updated_setting = await self._update_setting(setting, params)
         self.session.add(updated_setting)
         await self.session.commit()
+        if setting.key in AUDIT_SETTINGS_KEYS:
+            clear_audit_setting_cache()
         await self.session.refresh(updated_setting)
         return updated_setting
 
@@ -273,6 +279,8 @@ class SettingsService(BaseOrgService):
             return
         await self.session.delete(setting)
         await self.session.commit()
+        if setting.key in AUDIT_SETTINGS_KEYS:
+            clear_audit_setting_cache()
 
     # Grouped settings
 
@@ -314,8 +322,9 @@ class SettingsService(BaseOrgService):
     @require_scope("org:settings:update")
     @audit_log(resource_type="organization_setting", action="update")
     async def update_audit_settings(self, params: AuditSettingsUpdate) -> None:
-        audit_settings = await self.list_org_settings(keys=AuditSettingsUpdate.keys())
+        audit_settings = await self.list_org_settings(keys=AUDIT_SETTINGS_KEYS)
         await self._update_grouped_settings(audit_settings, params)
+        clear_audit_setting_cache()
 
     @require_scope("org:settings:update")
     @audit_log(resource_type="organization_setting", action="update")

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -1,5 +1,5 @@
 import os
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import Any
 
 import orjson
@@ -44,7 +44,7 @@ from tracecat.settings.schemas import (
 VERSIONED_RESOURCE_RESOLUTION_STRATEGY_SETTING = (
     "app_versioned_resource_resolution_strategy"
 )
-AUDIT_SETTINGS_KEYS = AuditSettingsUpdate.keys()
+AUDIT_SETTINGS_KEYS = frozenset(AuditSettingsUpdate.keys())
 
 
 def _deserialize_setting_value(
@@ -141,7 +141,7 @@ class SettingsService(BaseOrgService):
     async def list_org_settings(
         self,
         *,
-        keys: set[str] | None = None,
+        keys: Collection[str] | None = None,
         value_type: str | None = None,
         is_encrypted: bool | None = None,
         limit: int | None = None,

--- a/tracecat/workflow/case_triggers/service.py
+++ b/tracecat/workflow/case_triggers/service.py
@@ -34,7 +34,7 @@ class CaseTriggersService(BaseWorkspaceService):
             return AuditEventDetails(emit=False)
         return AuditEventDetails(data={"changed_fields": sorted(params.model_dump())})
 
-    def _case_trigger_update_audit_details(
+    async def _case_trigger_update_audit_details(
         self,
         workflow_id: WorkflowID,
         params: CaseTriggerUpdate,
@@ -44,8 +44,16 @@ class CaseTriggersService(BaseWorkspaceService):
     ) -> AuditEventDetails:
         if commit is False:
             return AuditEventDetails(emit=False)
+        workflow_uuid = WorkflowUUID.new(workflow_id)
+        trigger_id = await self.session.scalar(
+            select(CaseTrigger.id).where(
+                CaseTrigger.workspace_id == self.workspace_id,
+                CaseTrigger.workflow_id == workflow_uuid,
+            )
+        )
         return AuditEventDetails(
-            data={"changed_fields": sorted(params.model_fields_set)}
+            resource_id=trigger_id,
+            data={"changed_fields": sorted(params.model_fields_set)},
         )
 
     async def _lock_workflow(self, workflow_id: WorkflowID) -> None:

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -845,7 +845,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
         await self.session.commit()
 
     @require_scope("workflow:create")
-    @audit_log(resource_type="workflow", action="create")
+    @audit_log(resource_type="workflow", action="create", resource_id_attr="id")
     async def create_workflow(self, params: WorkflowCreate) -> Workflow:
         """Create a new workflow."""
         now = datetime.now().strftime("%b %d, %Y, %H:%M:%S")

--- a/tracecat/workflow/schedules/router.py
+++ b/tracecat/workflow/schedules/router.py
@@ -6,9 +6,8 @@ from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import Schedule
 from tracecat.exceptions import TracecatNotFoundError, TracecatServiceError
-from tracecat.identifiers.workflow import OptionalAnyWorkflowIDQuery, WorkflowUUID
+from tracecat.identifiers.workflow import OptionalAnyWorkflowIDQuery
 from tracecat.logger import logger
-from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.schedules.dependencies import AnyScheduleIDPath
 from tracecat.workflow.schedules.schemas import (
     ScheduleCreate,
@@ -42,21 +41,14 @@ async def create_schedule(
 ) -> ScheduleRead:
     """Create a schedule for a workflow."""
     service = WorkflowSchedulesService(session, role=role)
-    workflow_svc = WorkflowsManagementService(session, role=role)
-    workflow = await workflow_svc.get_workflow(WorkflowUUID.new(params.workflow_id))
-    if not workflow:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Workflow not found. Please check the workflow ID and try again.k",
-        )
-    if not workflow.version:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Workflow must be saved before creating a schedule.",
-        )
     try:
         schedule = await service.create_schedule(params)
         return ScheduleRead.model_validate(schedule)
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
     except TracecatServiceError as e:
         logger.error("Error creating schedule", error=e)
         raise HTTPException(

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -65,6 +65,25 @@ class WorkflowSchedulesService(BaseWorkspaceService):
         if await self.session.scalar(stmt) is None:
             raise TracecatNotFoundError(f"Workflow {workflow_id} not found")
 
+    async def _require_published_workflow(
+        self, workflow_id: AnyWorkflowID | uuid.UUID
+    ) -> None:
+        """Validate the external create precondition inside the audit boundary."""
+        workflow_uuid = WorkflowUUID.new(workflow_id)
+        stmt = select(Workflow).where(
+            Workflow.workspace_id == self.workspace_id,
+            Workflow.id == workflow_uuid,
+        )
+        workflow = await self.session.scalar(stmt)
+        if workflow is None:
+            raise TracecatNotFoundError(
+                "Workflow not found. Please check the workflow ID and try again."
+            )
+        if workflow.version is None:
+            raise TracecatNotFoundError(
+                "Workflow must be saved before creating a schedule."
+            )
+
     async def list_schedules(
         self, workflow_id: WorkflowID | None = None
     ) -> list[Schedule]:
@@ -117,6 +136,8 @@ class WorkflowSchedulesService(BaseWorkspaceService):
             If there is an error creating the schedule.
 
         """
+        if commit:
+            await self._require_published_workflow(params.workflow_id)
         return await self._create_schedule_impl(params, commit=commit)
 
     async def _create_schedule_impl(

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -218,7 +218,11 @@ class WorkspaceService(BaseOrgService):
         return workspace
 
     @require_scope("workspace:delete")
-    @audit_log(resource_type="workspace", action="delete")
+    @audit_log(
+        resource_type="workspace",
+        action="delete",
+        resource_id_attr="workspace_id",
+    )
     async def delete_workspace(self, workspace_id: WorkspaceID) -> None:
         """Delete a workspace."""
         all_workspaces = await self.admin_list_workspaces()
@@ -566,7 +570,11 @@ class WorkspaceService(BaseOrgService):
         return membership
 
     @require_scope("workspace:member:remove")
-    @audit_log(resource_type="workspace_invitation", action="revoke")
+    @audit_log(
+        resource_type="workspace_invitation",
+        action="revoke",
+        resource_id_attr="invitation_id",
+    )
     async def revoke_invitation(
         self,
         workspace_id: WorkspaceID,


### PR DESCRIPTION
## Why
The existing audit coverage established the main emission paths. Followup end-to-end QA surfaced a few edge cases where delivered events could be incomplete or use stale configuration.

This PR ensures:
- Canonical fields cannot be overwritten by custom payloads.
- Resource IDs are included across different service signatures.
- Rejected schedule operations emit ATTEMPT and FAILURE.
- Invalidate audit-setting caching correctly


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure audit events always use canonical fields and correct resource IDs, and make audit webhook changes take effect immediately. Move schedule checks into the service so ATTEMPT/FAILURE are accurate and 404s are clear.

- **Bug Fixes**
  - Ignore conflicting custom payload keys so event fields win (resource_type, resource_id, status).
  - Attribute resources correctly across paths (keyword-arg objects; case trigger updates; explicit `resource_id_attr` for workflow create, workspace delete, and invitation revoke).
  - Clear the audit-setting TTL cache on platform/org setting changes via `clear_audit_setting_cache` so the next event uses new webhook config; use an immutable audit-setting key set.
  - Validate workflow existence and published state inside the schedules service; map errors to 404 and emit ATTEMPT then FAILURE.
  - Refresh `updated_at` on role and group updates to return fresh timestamps.

<sup>Written for commit 13f1803e08dbe0d86216a9b788962a51d0308387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



