### PR TITLE
feat(agents): retry agent turn once on infra failure

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -1336,7 +1336,7 @@ class DurableAgentWorkflow:
                         seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
                     ),
                     heartbeat_timeout=timedelta(seconds=60),
-                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                    retry_policy=RETRY_POLICIES["activity:agent_turn"],
                 )
             else:
                 activity_handle = workflow.start_activity(
@@ -1348,7 +1348,7 @@ class DurableAgentWorkflow:
                         seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
                     ),
                     heartbeat_timeout=timedelta(seconds=60),
-                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                    retry_policy=RETRY_POLICIES["activity:agent_turn"],
                 )
                 # ActivityHandle is an asyncio.Task subclass, so .done() is
                 # valid. Neither wait_condition nor the handle poll emits

--- a/tests/unit/test_retry_policies.py
+++ b/tests/unit/test_retry_policies.py
@@ -1,0 +1,12 @@
+from tracecat.dsl.common import NON_RETRYABLE_ERROR_TYPES, RETRY_POLICIES
+
+
+def test_agent_turn_retry_policy() -> None:
+    policy = RETRY_POLICIES["activity:agent_turn"]
+
+    assert policy.maximum_attempts == 2
+    assert policy.non_retryable_error_types is NON_RETRYABLE_ERROR_TYPES
+
+
+def test_fail_fast_retry_policy_remains_single_attempt() -> None:
+    assert RETRY_POLICIES["activity:fail_fast"].maximum_attempts == 1

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -1430,6 +1430,12 @@ RETRY_POLICIES = {
         maximum_attempts=1,
         non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
     ),
+    "activity:agent_turn": RetryPolicy(
+        # One retry for infrastructure failures (worker loss, heartbeat timeout).
+        # Application errors are excluded via NON_RETRYABLE_ERROR_TYPES.
+        maximum_attempts=2,
+        non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
+    ),
     "activity:fail_slow": RetryPolicy(maximum_attempts=6),
     "workflow:fail_fast": RetryPolicy(
         # XXX: Do not set max attempts to 0, it will default to unlimited


### PR DESCRIPTION
## Why

When the agent-executor pod was OOM-killed on 2026-07-27, all ten in-flight `run_agent_activity` executions heartbeat-timed-out with `RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED` and every affected `DurableAgentWorkflow` (and parent workflow) failed — even though a replacement worker was polling **47 seconds before** the first timeout fired. One retry would very likely have recovered all ten sessions.

## What

A dedicated `activity:agent_turn` retry policy (`maximum_attempts=2`, same `NON_RETRYABLE_ERROR_TYPES` list) applied at both `run_agent_activity` call sites in `DurableAgentWorkflow`. Application/validation errors still fail on the first attempt — only infrastructure failures (heartbeat timeout, worker loss, timeouts) get the second attempt. The shared `activity:fail_fast` policy and its ~17 other call sites in the DSL and EE workflows are unchanged, with a regression test pinning both policies.

## ⚠️ Known limitation: the turn is not idempotent

Reviewed in depth before shipping; retries trade certain failure for rare duplication artifacts:

- **Existing-session retry**: attempt 2 rehydrates the session from the DB (including attempt 1's partially persisted lines) and re-submits the same user prompt — persisted history can show the prompt twice, with attempt 1's partial transcript followed by attempt 2's full response. A tool side effect that completed before its result was persisted can be **executed again**.
- **First-turn retry**: attempt 2's input still carries `sdk_session_id=None`, so it starts an independent SDK session; the Tracecat session history then contains both attempts' transcripts chronologically merged.
- Line-UUID dedup is attempt-local (`LoopbackHandler._persisted_line_uuids` starts empty per attempt; no DB uniqueness constraint on the content UUID), so it does not protect across attempts — though the resumed-file offset means attempt 1's exact lines are normally not re-emitted.
- A user watching the live stream sees attempt 1 stall, then attempt 2 restart output in the same turn.

Rationale for shipping anyway: the retry only fires on worker loss (rare, infra-caused), and the status quo is guaranteed failure of the session and its parent workflow. Follow-ups that would close the gap: reload session state at activity start for retries (mirror the approval-resume path), hydrate the SDK session ID on first-turn retries, and cross-attempt line dedup.

## Testing

- `tests/unit/test_retry_policies.py`: pins `activity:agent_turn` (attempts=2, non-retryable list identity) and `activity:fail_fast` (attempts=1); accessing the exact key guards the runtime-KeyError failure mode.
- Audit: no existing test pinned the old agent-turn policy.
- `ruff`, `basedpyright --warnings`, pytest on touched files: clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-time retry for agent turns to recover from infra failures like worker loss or heartbeat timeouts. This reduces failed sessions and parent workflows when a worker restarts mid-turn.

- New Features
  - Added `activity:agent_turn` retry policy in `tracecat.dsl.common` (`maximum_attempts=2`, shares `NON_RETRYABLE_ERROR_TYPES` so app errors still fail fast).
  - Applied the policy to both `run_agent_activity` call sites in `DurableAgentWorkflow`; `activity:fail_fast` and other call sites remain unchanged.
  - Added `tests/unit/test_retry_policies.py` to pin both policies.
  - Limitation: retries are not idempotent and can occasionally duplicate persisted lines or re-run side effects.

<sup>Written for commit dfa2ec624f922b9dcdcf9193cccd4c8efbe7a2b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

