### PR TITLE
fix(chat): workflow execution tools

### DIFF
--- a/frontend/src/components/chat/chat-tools-picker.test.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.test.tsx
@@ -104,8 +104,10 @@ describe("DEFAULT_CAPABILITY_GROUPS", () => {
         "core.workflow.execute",
         "core.workflow.get_authoring_context",
         "core.workflow.get_case_trigger",
+        "core.workflow.get_status",
         "core.workflow.get_webhook",
         "core.workflow.get_workflow",
+        "core.workflow.list_executions",
         "core.workflow.publish",
         "core.workflow.run",
         "core.workflow.update_case_trigger",
@@ -121,7 +123,9 @@ describe("DEFAULT_CAPABILITY_GROUPS", () => {
     expect(workflows?.tools).toContain("core.workflow.execute")
     expect(workflows?.tools).toContain("core.workflow.publish")
     expect(workflows?.tools).toContain("core.workflow.run")
-    expect(workflows?.tools.length).toBe(11)
+    expect(workflows?.tools).toContain("core.workflow.list_executions")
+    expect(workflows?.tools).toContain("core.workflow.get_status")
+    expect(workflows?.tools.length).toBe(13)
   })
 })
 

--- a/frontend/src/components/chat/chat-tools-picker.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.tsx
@@ -135,6 +135,8 @@ export const DEFAULT_CAPABILITY_GROUPS: CapabilityGroup[] = [
       "core.workflow.publish",
       "core.workflow.run",
       "core.workflow.execute",
+      "core.workflow.list_executions",
+      "core.workflow.get_status",
     ],
   },
   {

--- a/packages/tracecat-registry/tracecat_registry/_internal/models.py
+++ b/packages/tracecat-registry/tracecat_registry/_internal/models.py
@@ -57,6 +57,13 @@ SecretName = Annotated[str, StringConstraints(pattern=r"[a-z0-9_]+")]
 SecretKey = Annotated[str, StringConstraints(pattern=r"[a-zA-Z0-9_]+")]
 """Validator for a secret key. e.g. 'access_key_id'"""
 
+# Keep in sync with tracecat.identifiers.workflow.WF_EXEC_ID_SCHEMA_PATTERN
+# (parity pinned by tests/registry/test_workflow_sdk.py).
+WF_EXEC_ID_PATTERN = r"(wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/]((exec_[0-9a-zA-Z]+|exec-[\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))"
+
+WorkflowExecutionID = Annotated[str, StringConstraints(pattern=WF_EXEC_ID_PATTERN)]
+"""Validator for a workflow execution ID. e.g. 'wf_.../exec_...'"""
+
 
 class RegistrySecret(BaseModel):
     type: Literal["custom"] = Field(default="custom", frozen=True)

--- a/packages/tracecat-registry/tracecat_registry/core/workflow.py
+++ b/packages/tracecat-registry/tracecat_registry/core/workflow.py
@@ -10,7 +10,8 @@ from typing import Annotated, Any, Literal
 
 from typing_extensions import Doc
 
-from tracecat_registry import ActionIsInterfaceError, ctx, registry
+from tracecat_registry import ActionIsInterfaceError, ctx, registry, types
+from tracecat_registry._internal.models import WorkflowExecutionID
 from tracecat_registry.context import get_context
 from tracecat_registry.sdk.workflows import (
     JsonPatchOperation,
@@ -472,28 +473,75 @@ async def run(
 
 @registry.register(
     namespace="core.workflow",
-    description="Get the status of a workflow execution.",
+    description=(
+        "Get the status of a workflow execution. With `include_events=true`, "
+        "also returns a per-action event timeline (status, timing, results, "
+        "and errors) for debugging a run. Find execution IDs with "
+        "`list_executions`."
+    ),
     default_title="Get workflow status",
     display_group="Workflows",
 )
 async def get_status(
     *,
     wf_exec_id: Annotated[
-        str,
-        Doc("The workflow execution ID to check."),
+        WorkflowExecutionID,
+        Doc(
+            "The workflow execution ID to check (`wf_.../exec_...`), as "
+            "returned by `run` or `list_executions`."
+        ),
     ],
-) -> dict[str, Any]:
+    include_events: Annotated[
+        bool,
+        Doc("When true, also return the per-action event timeline."),
+    ] = False,
+) -> types.WorkflowExecutionStatusRead:
     """Get the status of a workflow execution.
 
     Returns:
         dict containing:
-            - wf_exec_id: Execution ID
+            - workflow_execution_id: Execution ID
             - status: RUNNING, COMPLETED, FAILED, CANCELED, TERMINATED, TIMED_OUT
             - start_time: When execution started (ISO format or None)
             - close_time: When execution completed (ISO format or None)
             - result: Workflow result (if completed successfully)
+            - with ``include_events=true``: ``trigger_type``, ``execution_type``,
+              ``history_length``, and ``events``
 
     Raises:
         RuntimeError: If no context is available.
     """
-    return await ctx.workflows.aio.get_status(wf_exec_id)
+    return await ctx.workflows.aio.get_status(wf_exec_id, include_events=include_events)
+
+
+@registry.register(
+    namespace="core.workflow",
+    description=(
+        "List a workflow's recent executions (run history), newest first. Use "
+        "this to see which runs succeeded or failed and to find execution IDs "
+        "for `get_execution`."
+    ),
+    default_title="List workflow executions",
+    display_group="Workflows",
+)
+async def list_executions(
+    *,
+    workflow_id: Annotated[
+        str,
+        Doc("The workflow ID to list executions for (short `wf_...` or full)."),
+    ],
+    limit: Annotated[
+        int,
+        Doc("Maximum number of executions to return (clamped to 1-100)."),
+    ] = 20,
+    cursor: Annotated[
+        str | None,
+        Doc("The `next_cursor` from a previous page. Omit for the first page."),
+    ] = None,
+) -> types.WorkflowExecutionPageRead:
+    """List recent executions for a workflow with cursor pagination."""
+    return await ctx.workflows.aio.list_executions(
+        workflow_id=workflow_id,
+        limit=limit,
+        cursor=cursor,
+    )

--- a/packages/tracecat-registry/tracecat_registry/core/workflow.py
+++ b/packages/tracecat-registry/tracecat_registry/core/workflow.py
@@ -519,7 +519,7 @@ async def get_status(
     description=(
         "List a workflow's recent executions (run history), newest first. Use "
         "this to see which runs succeeded or failed and to find execution IDs "
-        "for `get_execution`."
+        "for `get_status`."
     ),
     default_title="List workflow executions",
     display_group="Workflows",

--- a/packages/tracecat-registry/tracecat_registry/ctx.pyi
+++ b/packages/tracecat-registry/tracecat_registry/ctx.pyi
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from tracecat_registry import types
 from tracecat_registry import types as registry_types
+from tracecat_registry._internal.models import WorkflowExecutionID
 from tracecat_registry.sdk.agents import AgentConfig, CursorPage, RankableItem
 from tracecat_registry.sdk.client import TracecatClient
 from tracecat_registry.sdk.types import CasePriority, CaseSeverity, CaseStatus, Unset
@@ -1228,8 +1229,10 @@ class _WorkflowsAsync:
     ) -> dict[str, Any]: ...
     async def get_status(
         self,
-        workflow_execution_id: str,
-    ) -> dict[str, Any]: ...
+        workflow_execution_id: WorkflowExecutionID,
+        *,
+        include_events: bool = ...,
+    ) -> types.WorkflowExecutionStatusRead: ...
     async def create_workflow(
         self,
         *,
@@ -1293,6 +1296,13 @@ class _WorkflowsAsync:
         use_draft: bool = ...,
         version: int | None = ...,
     ) -> dict[str, Any]: ...
+    async def list_executions(
+        self,
+        *,
+        workflow_id: str,
+        limit: int = ...,
+        cursor: str | None = ...,
+    ) -> types.WorkflowExecutionPageRead: ...
 
 class _Workflows:
     @property
@@ -1311,8 +1321,10 @@ class _Workflows:
     ) -> dict[str, Any]: ...
     def get_status(
         self,
-        workflow_execution_id: str,
-    ) -> dict[str, Any]: ...
+        workflow_execution_id: WorkflowExecutionID,
+        *,
+        include_events: bool = ...,
+    ) -> types.WorkflowExecutionStatusRead: ...
     def create_workflow(
         self,
         *,
@@ -1376,6 +1388,13 @@ class _Workflows:
         use_draft: bool = ...,
         version: int | None = ...,
     ) -> dict[str, Any]: ...
+    def list_executions(
+        self,
+        *,
+        workflow_id: str,
+        limit: int = ...,
+        cursor: str | None = ...,
+    ) -> types.WorkflowExecutionPageRead: ...
 
 agents: _Agents
 cases: _Cases

--- a/packages/tracecat-registry/tracecat_registry/sdk/workflows.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/workflows.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from tracecat_registry import types
+from tracecat_registry._internal.models import WorkflowExecutionID
 from tracecat_registry.sdk.types import UNSET, Unset, is_set
 
 if TYPE_CHECKING:
@@ -482,11 +484,21 @@ class WorkflowsClient:
             poll_interval=poll_interval,
         )
 
-    async def get_status(self, workflow_execution_id: str) -> dict[str, Any]:
+    async def get_status(
+        self,
+        workflow_execution_id: WorkflowExecutionID,
+        *,
+        include_events: bool = False,
+    ) -> types.WorkflowExecutionStatusRead:
         """Get the status of a workflow execution.
 
         Args:
-            workflow_execution_id: The workflow execution ID.
+            workflow_execution_id: The workflow execution ID (``wf_.../exec_...``).
+            include_events: When true, populate ``trigger_type``,
+                ``execution_type``, ``history_length``, and ``events`` (per-action
+                status, timing, results, and errors); otherwise those fields are
+                null. Oversized action results are returned as a truncated string
+                in ``result_truncated``.
 
         Returns:
             dict containing:
@@ -495,13 +507,51 @@ class WorkflowsClient:
                 - start_time: When execution started (ISO format or None)
                 - close_time: When execution completed (ISO format or None)
                 - result: Workflow result (if completed successfully)
+                - the event-timeline fields above when ``include_events=True``
 
         Raises:
             TracecatNotFoundError: If execution not found.
             TracecatAPIError: For other API errors.
         """
         # Server uses {execution_id:path} to handle '/' in the ID
+        if include_events:
+            return await self._client.get(
+                f"/workflows/executions/{workflow_execution_id}",
+                params={"include_events": True},
+            )
         return await self._client.get(f"/workflows/executions/{workflow_execution_id}")
+
+    async def list_executions(
+        self,
+        *,
+        workflow_id: str,
+        limit: int = 20,
+        cursor: str | None = None,
+    ) -> types.WorkflowExecutionPageRead:
+        """List recent executions for a workflow, newest first.
+
+        Args:
+            workflow_id: Workflow UUID (short ``wf_...`` or full format).
+            limit: Maximum number of executions to return (clamped to 1-100).
+            cursor: Opaque ``next_cursor`` from a previous page.
+
+        Returns:
+            dict with ``items`` (each with ``id``, ``run_id``, ``status``,
+            ``start_time``, ``close_time``, ``trigger_type``,
+            ``execution_type``), plus ``next_cursor``, ``prev_cursor``,
+            ``has_more``, and ``has_previous``.
+
+        Raises:
+            TracecatNotFoundError: If the workflow does not exist.
+            TracecatAPIError: For other API errors.
+        """
+        params: dict[str, Any] = {"limit": limit}
+        if cursor is not None:
+            params["cursor"] = cursor
+        return await self._client.get(
+            f"/workflows/{workflow_id}/executions",
+            params=params,
+        )
 
     async def _poll_until_complete(
         self,

--- a/packages/tracecat-registry/tracecat_registry/types.py
+++ b/packages/tracecat-registry/tracecat_registry/types.py
@@ -723,3 +723,70 @@ class AgentPresetRead(TypedDict):
     current_version_id: UUID | None
     created_at: datetime
     updated_at: datetime
+
+
+# ============================================================================
+# Workflow Execution Types
+# ============================================================================
+
+
+class WorkflowExecutionSummaryRead(TypedDict):
+    """Summary of a single workflow execution."""
+
+    id: str
+    run_id: str
+    status: str | None
+    start_time: str
+    close_time: str | None
+    trigger_type: str | None
+    execution_type: str | None
+
+
+class WorkflowExecutionPageRead(TypedDict):
+    """Cursor-paginated page of workflow execution summaries."""
+
+    items: list[WorkflowExecutionSummaryRead]
+    next_cursor: str | None
+    prev_cursor: str | None
+    has_more: bool
+    has_previous: bool
+
+
+class WorkflowExecutionEventErrorRead(TypedDict):
+    """Action-level error in a workflow execution event."""
+
+    message: str
+    cause: Any | None
+
+
+class WorkflowExecutionEventRead(TypedDict):
+    """Compact per-action event in a workflow execution timeline."""
+
+    action_ref: str | None
+    action_name: str | None
+    status: str
+    schedule_time: str
+    start_time: str | None
+    close_time: str | None
+    error: WorkflowExecutionEventErrorRead | None
+    result: Any | None
+    result_truncated: str | None
+
+
+class WorkflowExecutionStatusRead(TypedDict):
+    """Status of a workflow execution.
+
+    The event-timeline fields are non-null only when requested with
+    ``include_events=True``.
+    """
+
+    workflow_execution_id: str
+    status: str
+    start_time: str | None
+    close_time: str | None
+    result: Any | None
+    error: str | None
+    trigger_type: str | None
+    execution_type: str | None
+    history_length: int | None
+    events: list[WorkflowExecutionEventRead] | None

--- a/tests/registry/test_workflow_sdk.py
+++ b/tests/registry/test_workflow_sdk.py
@@ -175,6 +175,74 @@ class TestWorkflowsClientGetStatus:
         )
 
 
+class TestWorkflowsClientListExecutions:
+    """Tests for WorkflowsClient.list_executions()."""
+
+    @pytest.mark.anyio
+    async def test_list_executions_defaults_omit_cursor(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """Test list_executions hits the workflow executions route."""
+        mock_tracecat_client.get.return_value = {
+            "items": [],
+            "next_cursor": None,
+            "prev_cursor": None,
+            "has_more": False,
+            "has_previous": False,
+        }
+
+        result = await workflows_client.list_executions(workflow_id="wf_abc")
+
+        assert result["items"] == []
+        mock_tracecat_client.get.assert_called_once_with(
+            "/workflows/wf_abc/executions",
+            params={"limit": 20},
+        )
+
+    @pytest.mark.anyio
+    async def test_list_executions_passes_limit_and_cursor(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """Test list_executions forwards pagination params."""
+        mock_tracecat_client.get.return_value = {"items": []}
+
+        await workflows_client.list_executions(
+            workflow_id="wf_abc", limit=5, cursor="opaque-cursor"
+        )
+
+        mock_tracecat_client.get.assert_called_once_with(
+            "/workflows/wf_abc/executions",
+            params={"limit": 5, "cursor": "opaque-cursor"},
+        )
+
+
+class TestWorkflowsClientGetStatusWithEvents:
+    """Tests for WorkflowsClient.get_status(include_events=True)."""
+
+    @pytest.mark.anyio
+    async def test_get_status_requests_events(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """Test include_events hits the status route with the events param."""
+        mock_tracecat_client.get.return_value = {
+            "workflow_execution_id": "wf-00000000000000000000000000000123/exec-456",
+            "status": "COMPLETED",
+            "history_length": 12,
+            "events": [],
+        }
+
+        result = await workflows_client.get_status(
+            "wf-00000000000000000000000000000123/exec-456",
+            include_events=True,
+        )
+
+        assert result.get("history_length") == 12
+        mock_tracecat_client.get.assert_called_once_with(
+            "/workflows/executions/wf-00000000000000000000000000000123/exec-456",
+            params={"include_events": True},
+        )
+
+
 class TestWorkflowsClientCreate:
     """Tests for WorkflowsClient.create_workflow()."""
 
@@ -423,3 +491,15 @@ class TestDefaultConstants:
     def test_default_max_wait_time(self):
         """Test default max wait time is 5 minutes."""
         assert DEFAULT_MAX_WAIT_TIME == 300.0
+
+
+class TestWorkflowExecutionIDPattern:
+    """Pin the registry's execution ID pattern to the tracecat source of truth."""
+
+    def test_pattern_matches_tracecat_schema_pattern(self):
+        """The registry copy must stay byte-identical to WF_EXEC_ID_SCHEMA_PATTERN."""
+        from tracecat_registry._internal.models import WF_EXEC_ID_PATTERN
+
+        from tracecat.identifiers.workflow import WF_EXEC_ID_SCHEMA_PATTERN
+
+        assert WF_EXEC_ID_PATTERN == WF_EXEC_ID_SCHEMA_PATTERN

--- a/tests/unit/api/test_api_workflow_execution_path_ids.py
+++ b/tests/unit/api/test_api_workflow_execution_path_ids.py
@@ -252,6 +252,238 @@ async def test_internal_get_execution_status_unwraps_nested_failure_cause(
     assert "Activity task failed" not in payload["error"]
 
 
+@pytest.mark.anyio
+async def test_internal_get_execution_status_leaves_event_fields_null_by_default(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Without include_events the event fields are null (unset, not empty)."""
+    wf_exec_id = "wf_abc/exec_def"
+
+    mock_execution = Mock()
+    mock_execution.status = WorkflowExecutionStatus.RUNNING
+    mock_execution.start_time = datetime(2024, 1, 1, tzinfo=UTC)
+    mock_execution.close_time = None
+
+    mock_svc = AsyncMock()
+    mock_svc.get_execution.return_value = mock_execution
+
+    with patch.object(
+        internal_executions_router.WorkflowExecutionsService,
+        "connect",
+        AsyncMock(return_value=mock_svc),
+    ):
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{wf_exec_id}"
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["events"] is None
+    assert payload["history_length"] is None
+    mock_svc.list_workflow_execution_events_compact.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_internal_get_execution_status_includes_events_when_requested(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """include_events populates the shared status envelope's event fields."""
+    wf_exec_id = "wf_abc/exec_def"
+
+    mock_execution = Mock()
+    mock_execution.id = wf_exec_id
+    mock_execution.status = WorkflowExecutionStatus.RUNNING
+    mock_execution.start_time = datetime(2024, 1, 1, tzinfo=UTC)
+    mock_execution.close_time = None
+    mock_execution.history_length = 7
+    mock_execution.typed_search_attributes = {}
+
+    mock_event = Mock()
+    mock_event.action_ref = "start"
+    mock_event.action_name = "core.noop"
+    mock_event.status = "COMPLETED"
+    mock_event.schedule_time = datetime(2024, 1, 1, tzinfo=UTC)
+    mock_event.start_time = datetime(2024, 1, 1, tzinfo=UTC)
+    mock_event.close_time = None
+    mock_event.action_error = None
+    mock_event.action_result = {"ok": True}
+
+    mock_svc = AsyncMock()
+    mock_svc.get_execution.return_value = mock_execution
+    mock_svc.list_workflow_execution_events_compact.return_value = [mock_event]
+
+    with patch.object(
+        internal_executions_router.WorkflowExecutionsService,
+        "connect",
+        AsyncMock(return_value=mock_svc),
+    ):
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{wf_exec_id}",
+            params={"include_events": "true"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["status"] == "RUNNING"
+    assert payload["history_length"] == 7
+    assert payload["events"] == [
+        {
+            "action_ref": "start",
+            "action_name": "core.noop",
+            "status": "COMPLETED",
+            "schedule_time": "2024-01-01 00:00:00+00:00",
+            "start_time": "2024-01-01 00:00:00+00:00",
+            "close_time": None,
+            "error": None,
+            "result": {"ok": True},
+            "result_truncated": None,
+        }
+    ]
+    mock_svc.list_workflow_execution_events_compact.assert_awaited_once_with(wf_exec_id)
+
+
+@pytest.mark.anyio
+async def test_internal_get_execution_status_truncates_large_event_result(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Oversized action results are truncated to 2000 chars plus an ellipsis."""
+    wf_exec_id = "wf_abc/exec_big"
+
+    mock_execution = Mock()
+    mock_execution.id = wf_exec_id
+    mock_execution.status = WorkflowExecutionStatus.RUNNING
+    mock_execution.start_time = datetime(2024, 1, 1, tzinfo=UTC)
+    mock_execution.close_time = None
+    mock_execution.history_length = 3
+    mock_execution.typed_search_attributes = {}
+
+    mock_event = Mock()
+    mock_event.action_ref = "big"
+    mock_event.action_name = "core.noop"
+    mock_event.status = "COMPLETED"
+    mock_event.schedule_time = datetime(2024, 1, 1, tzinfo=UTC)
+    mock_event.start_time = None
+    mock_event.close_time = None
+    mock_event.action_error = None
+    mock_event.action_result = "x" * 5000
+
+    mock_svc = AsyncMock()
+    mock_svc.get_execution.return_value = mock_execution
+    mock_svc.list_workflow_execution_events_compact.return_value = [mock_event]
+
+    with patch.object(
+        internal_executions_router.WorkflowExecutionsService,
+        "connect",
+        AsyncMock(return_value=mock_svc),
+    ):
+        response = action_gateway_client.get(
+            f"/internal/workflows/executions/{wf_exec_id}",
+            params={"include_events": "true"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    event = response.json()["events"][0]
+    assert event["result"] is None
+    assert event["result_truncated"] is not None
+    assert len(event["result_truncated"]) == 2003
+    assert event["result_truncated"].endswith("...")
+
+
+# --- Internal Router: GET /{workflow_id}/executions ---
+
+
+@pytest.mark.anyio
+async def test_internal_list_workflow_executions_returns_summaries(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """The list route returns cursor-paginated execution summaries."""
+    workflow_id = "wf_4itKqkgCZrLhgYiq5L211X"
+
+    mock_execution = Mock()
+    mock_execution.id = f"{workflow_id}/exec_abc"
+    mock_execution.run_id = "run_123"
+    mock_execution.status = WorkflowExecutionStatus.COMPLETED
+    mock_execution.start_time = datetime(2024, 1, 1, tzinfo=UTC)
+    mock_execution.close_time = datetime(2024, 1, 1, 0, 5, tzinfo=UTC)
+    mock_execution.typed_search_attributes = {}
+
+    mock_page = Mock()
+    mock_page.items = [mock_execution]
+    mock_page.next_cursor = "next"
+    mock_page.prev_cursor = None
+    mock_page.has_more = True
+    mock_page.has_previous = False
+
+    mock_svc = AsyncMock()
+    mock_svc.list_executions_paginated.return_value = mock_page
+
+    with patch.object(
+        internal_executions_router.WorkflowExecutionsService,
+        "connect",
+        AsyncMock(return_value=mock_svc),
+    ):
+        response = action_gateway_client.get(
+            f"/internal/workflows/{workflow_id}/executions"
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["next_cursor"] == "next"
+    assert payload["has_more"] is True
+    assert payload["items"] == [
+        {
+            "id": f"{workflow_id}/exec_abc",
+            "run_id": "run_123",
+            "status": "COMPLETED",
+            "start_time": "2024-01-01 00:00:00+00:00",
+            "close_time": "2024-01-01 00:05:00+00:00",
+            "trigger_type": "manual",
+            "execution_type": "published",
+        }
+    ]
+    pagination = mock_svc.list_executions_paginated.await_args.kwargs["pagination"]
+    assert pagination.limit == 20
+    assert pagination.cursor is None
+
+
+@pytest.mark.anyio
+async def test_internal_list_workflow_executions_clamps_limit(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Requested limits are clamped into the 1-100 range."""
+    workflow_id = "wf_4itKqkgCZrLhgYiq5L211X"
+
+    mock_page = Mock()
+    mock_page.items = []
+    mock_page.next_cursor = None
+    mock_page.prev_cursor = None
+    mock_page.has_more = False
+    mock_page.has_previous = False
+
+    mock_svc = AsyncMock()
+    mock_svc.list_executions_paginated.return_value = mock_page
+
+    with patch.object(
+        internal_executions_router.WorkflowExecutionsService,
+        "connect",
+        AsyncMock(return_value=mock_svc),
+    ):
+        response = action_gateway_client.get(
+            f"/internal/workflows/{workflow_id}/executions",
+            params={"limit": 5000, "cursor": "opaque"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    pagination = mock_svc.list_executions_paginated.await_args.kwargs["pagination"]
+    assert pagination.limit == 100
+    assert pagination.cursor == "opaque"
+
+
 # --- Internal Router: POST /executions ---
 
 

--- a/tests/unit/test_chat_tools.py
+++ b/tests/unit/test_chat_tools.py
@@ -61,6 +61,8 @@ def test_workspace_chat_default_tools_include_authoring_actions() -> None:
         "core.workflow.publish",
         "core.workflow.run",
         "core.workflow.execute",
+        "core.workflow.list_executions",
+        "core.workflow.get_status",
     ]
 
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -22,6 +22,7 @@ from mcp.types import CallToolRequestParams
 from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from temporalio.client import WorkflowExecutionStatus
 from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
 import tracecat.mcp.auth as mcp_auth
@@ -7930,7 +7931,7 @@ async def test_list_workflow_executions_forwards_prev_cursor(
                     SimpleNamespace(
                         id="wf_example/exec_123",
                         run_id="run-123",
-                        status=1,
+                        status=WorkflowExecutionStatus.RUNNING,
                         start_time=start_time,
                         close_time=None,
                         typed_search_attributes=None,

--- a/tracecat/chat/tools.py
+++ b/tracecat/chat/tools.py
@@ -45,6 +45,8 @@ WORKSPACE_CHAT_BASE_DEFAULT_TOOLS = [
     "core.workflow.publish",
     "core.workflow.run",
     "core.workflow.execute",
+    "core.workflow.list_executions",
+    "core.workflow.get_status",
 ]
 
 WORKSPACE_CHAT_DEFAULT_TOOLS = [

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -47,7 +47,6 @@ from redis.asyncio import Redis as AsyncRedis
 from slugify import slugify
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
-from temporalio.client import WorkflowExecutionStatus
 
 from tracecat import config
 from tracecat.agent.access.service import AgentModelAccessService
@@ -152,11 +151,7 @@ from tracecat.db.models import (
     Workflow,
     WorkflowDefinition,
 )
-from tracecat.dsl.common import (
-    DSLInput,
-    get_execution_type_from_search_attr,
-    get_trigger_type_from_search_attr,
-)
+from tracecat.dsl.common import DSLInput
 from tracecat.dsl.validation import (
     format_input_schema_validation_error,
     normalize_trigger_inputs,
@@ -258,7 +253,15 @@ from tracecat.workflow.case_triggers.schemas import (
     CaseTriggerUpdate,
 )
 from tracecat.workflow.case_triggers.service import CaseTriggersService
+from tracecat.workflow.executions.schemas import (
+    WorkflowExecutionDetailResponse,
+    WorkflowExecutionSummaryResponse,
+)
 from tracecat.workflow.executions.service import WorkflowExecutionsService
+from tracecat.workflow.executions.shaping import (
+    build_execution_events,
+    build_execution_summary,
+)
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.draft import (
     WorkflowEditError,
@@ -974,46 +977,6 @@ class ActionCatalogResponse(BaseModel):
     workspace_id: uuid.UUID
     total_actions: int
     namespaces: dict[str, ActionCatalogNamespace]
-
-
-class WorkflowExecutionSummaryResponse(BaseModel):
-    """Workflow execution summary."""
-
-    id: WorkflowExecutionID
-    run_id: uuid.UUID | str
-    status: str | None = None
-    start_time: str
-    close_time: str | None = None
-    trigger_type: str | None = None
-    execution_type: str | None = None
-
-
-class WorkflowExecutionEventError(BaseModel):
-    """Action-level workflow execution error payload."""
-
-    message: str
-    cause: Any | None = None
-
-
-class WorkflowExecutionEventResponse(BaseModel):
-    """Compact workflow execution event payload."""
-
-    action_ref: str | None = None
-    action_name: str | None = None
-    status: str
-    schedule_time: str
-    start_time: str | None = None
-    close_time: str | None = None
-    error: WorkflowExecutionEventError | None = None
-    result: Any | None = None
-    result_truncated: str | None = None
-
-
-class WorkflowExecutionDetailResponse(WorkflowExecutionSummaryResponse):
-    """Detailed workflow execution response."""
-
-    history_length: int
-    events: list[WorkflowExecutionEventResponse] = Field(default_factory=list)
 
 
 class WorkflowRunStartedResponse(BaseModel):
@@ -3073,22 +3036,6 @@ def _case_field_payload(
     )
 
 
-def _format_temporal_status(status: Any) -> str | None:
-    """Return a stable workflow status string for MCP responses."""
-    if status is None:
-        return None
-    if isinstance(status, WorkflowExecutionStatus):
-        return status.name
-    if isinstance(status, int):
-        try:
-            return WorkflowExecutionStatus(status).name
-        except ValueError:
-            return str(status)
-    if hasattr(status, "name"):
-        return str(status.name)
-    return str(status)
-
-
 def _parse_sql_type_arg(raw_value: str, field_name: str = "type") -> SqlType:
     """Parse an uppercase SqlType string argument."""
     try:
@@ -4661,32 +4608,7 @@ async def list_workflow_executions(
             pagination=CursorPaginationParams(limit=limit, cursor=cursor),
             workflow_id=workflow_id,
         )
-        items: list[WorkflowExecutionSummaryResponse] = []
-        for execution in executions.items:
-            trigger_type = None
-            execution_type = None
-            try:
-                trigger_type = get_trigger_type_from_search_attr(
-                    execution.typed_search_attributes, execution.id
-                )
-                execution_type = get_execution_type_from_search_attr(
-                    execution.typed_search_attributes
-                )
-            except Exception:
-                pass
-            items.append(
-                WorkflowExecutionSummaryResponse(
-                    id=execution.id,
-                    run_id=execution.run_id,
-                    status=_format_temporal_status(execution.status),
-                    start_time=str(execution.start_time),
-                    close_time=(
-                        str(execution.close_time) if execution.close_time else None
-                    ),
-                    trigger_type=str(trigger_type) if trigger_type else None,
-                    execution_type=str(execution_type) if execution_type else None,
-                )
-            )
+        items = [build_execution_summary(execution) for execution in executions.items]
         return MCPPaginatedResponse[WorkflowExecutionSummaryResponse](
             items=items,
             next_cursor=executions.next_cursor,
@@ -4742,59 +4664,16 @@ async def get_workflow_execution(
         if execution is None:
             raise ToolError(f"Execution {execution_id} not found")
 
-        trigger_type = None
-        execution_type = None
-        try:
-            trigger_type = get_trigger_type_from_search_attr(
-                execution.typed_search_attributes, execution.id
-            )
-            execution_type = get_execution_type_from_search_attr(
-                execution.typed_search_attributes
-            )
-        except Exception:
-            pass
-
         # Get compact event history for action-level details
         compact_events = await exec_service.list_workflow_execution_events_compact(
             execution_id
         )
 
-        events_payload: list[WorkflowExecutionEventResponse] = []
-        for event in compact_events:
-            event_data = WorkflowExecutionEventResponse(
-                action_ref=event.action_ref,
-                action_name=event.action_name,
-                status=str(event.status),
-                schedule_time=str(event.schedule_time),
-                start_time=str(event.start_time) if event.start_time else None,
-                close_time=str(event.close_time) if event.close_time else None,
-            )
-            if event.action_error is not None:
-                event_data.error = WorkflowExecutionEventError(
-                    message=event.action_error.message,
-                    cause=event.action_error.cause,
-                )
-            if event.action_result is not None:
-                try:
-                    result_str = json.dumps(event.action_result, default=str)
-                    if len(result_str) > 2000:
-                        event_data.result_truncated = result_str[:2000] + "..."
-                    else:
-                        event_data.result = event.action_result
-                except (TypeError, ValueError):
-                    event_data.result = str(event.action_result)[:2000]
-            events_payload.append(event_data)
-
+        summary = build_execution_summary(execution)
         return WorkflowExecutionDetailResponse(
-            id=execution.id,
-            run_id=execution.run_id,
-            status=_format_temporal_status(execution.status),
-            start_time=str(execution.start_time),
-            close_time=str(execution.close_time) if execution.close_time else None,
-            trigger_type=str(trigger_type) if trigger_type else None,
-            execution_type=str(execution_type) if execution_type else None,
+            **summary.model_dump(),
             history_length=execution.history_length,
-            events=events_payload,
+            events=build_execution_events(compact_events),
         )
     except ToolError:
         raise

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -52,6 +52,7 @@ from tracecat.mcp.schemas import (
     WorkflowEditDocument,
     WorkflowEditResponse,
 )
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.webhooks import service as webhook_service
 from tracecat.webhooks.schemas import WebhookRead, WebhookUpdate
@@ -61,7 +62,17 @@ from tracecat.workflow.case_triggers.schemas import (
 )
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.executions.enums import TriggerType
+from tracecat.workflow.executions.schemas import (
+    WorkflowExecutionEventResponse,
+    WorkflowExecutionSummaryResponse,
+)
 from tracecat.workflow.executions.service import WorkflowExecutionsService
+from tracecat.workflow.executions.shaping import (
+    build_execution_events,
+    build_execution_summary,
+    extract_execution_types,
+    format_temporal_status,
+)
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.draft import (
     WorkflowEditError,
@@ -161,7 +172,7 @@ class InternalWorkflowExecuteResponse(BaseModel):
 
 
 class InternalWorkflowStatusResponse(BaseModel):
-    """Response for workflow execution status."""
+    """SDK workflow execution status, optionally including the event timeline."""
 
     workflow_execution_id: WorkflowExecutionID = Field(
         ..., description="Workflow execution ID"
@@ -181,6 +192,23 @@ class InternalWorkflowStatusResponse(BaseModel):
     )
     error: str | None = Field(
         default=None, description="Error message (if workflow failed)"
+    )
+    trigger_type: str | None = Field(
+        default=None, description="How the execution was triggered"
+    )
+    execution_type: str | None = Field(
+        default=None, description="Execution type (e.g. workflow, subflow)"
+    )
+    history_length: int | None = Field(
+        default=None, description="Number of events in the Temporal history"
+    )
+    events: list[WorkflowExecutionEventResponse] | None = Field(
+        default=None,
+        description=(
+            "Compact per-action event timeline (status, timing, errors). "
+            "None when not requested with include_events; [] when the run "
+            "has no action events."
+        ),
     )
 
 
@@ -705,6 +733,41 @@ async def update_case_trigger(
         raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
+@router.get("/{workflow_id}/executions", status_code=HTTP_200_OK)
+@require_scope("workflow:read")
+async def list_workflow_executions(
+    *,
+    role: ExecutorWorkspaceRole,
+    workflow_id: AnyWorkflowIDPath,
+    limit: int = 20,
+    cursor: str | None = None,
+) -> CursorPaginatedResponse[WorkflowExecutionSummaryResponse]:
+    """List recent executions for a workflow, newest first.
+
+    Mirrors the MCP ``list_workflow_executions`` tool so the workflows SDK can
+    read run history and find execution IDs for ``get_status``. The 1-100 clamp
+    matches the MCP tool's LLM-friendly bounds, not the app's wider ones.
+    ``total_estimate`` is always null (not computed for this endpoint).
+    """
+    clamped_limit = max(1, min(limit, 100))
+    exec_service = await WorkflowExecutionsService.connect(role=role)
+    try:
+        page = await exec_service.list_executions_paginated(
+            pagination=CursorPaginationParams(limit=clamped_limit, cursor=cursor),
+            workflow_id=workflow_id,
+        )
+    except ValueError as e:
+        # Malformed cursor is a caller error, not a server fault.
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return CursorPaginatedResponse(
+        items=[build_execution_summary(execution) for execution in page.items],
+        next_cursor=page.next_cursor,
+        prev_cursor=page.prev_cursor,
+        has_more=page.has_more,
+        has_previous=page.has_previous,
+    )
+
+
 @router.post("/authoring-context", status_code=HTTP_200_OK)
 @require_scope("workflow:read")
 async def get_authoring_context(
@@ -903,10 +966,17 @@ async def get_execution_status(
     *,
     role: ExecutorWorkspaceRole,
     execution_id: WorkflowExecutionID,
+    include_events: bool = False,
 ) -> InternalWorkflowStatusResponse:
     """Get the status of a workflow execution.
 
     Returns the current status, timing information, and result (if completed).
+    With ``include_events=true``, also returns the trigger/execution type and a
+    compact per-action event timeline for debugging a run; without it those
+    fields are null (never silently dropped).
+
+    ``{execution_id:path}`` is greedy (execution IDs contain a ``/``), so new
+    behavior here must be a query param, not a sibling route.
     """
     try:
         exec_service = await WorkflowExecutionsService.connect(role=role)
@@ -918,21 +988,7 @@ async def get_execution_status(
                 detail=f"Workflow execution '{execution_id}' not found",
             )
 
-        # Map Temporal status to string
-        status_map = {
-            WorkflowExecutionStatus.RUNNING: "RUNNING",
-            WorkflowExecutionStatus.COMPLETED: "COMPLETED",
-            WorkflowExecutionStatus.FAILED: "FAILED",
-            WorkflowExecutionStatus.CANCELED: "CANCELED",
-            WorkflowExecutionStatus.TERMINATED: "TERMINATED",
-            WorkflowExecutionStatus.CONTINUED_AS_NEW: "CONTINUED_AS_NEW",
-            WorkflowExecutionStatus.TIMED_OUT: "TIMED_OUT",
-        }
-        status = (
-            status_map.get(execution.status, "UNKNOWN")
-            if execution.status
-            else "UNKNOWN"
-        )
+        status = format_temporal_status(execution.status) or "UNKNOWN"
 
         # Get result or error based on status
         result = None
@@ -954,6 +1010,20 @@ async def get_execution_status(
                     error=str(e),
                 )
 
+        if not include_events:
+            return InternalWorkflowStatusResponse(
+                workflow_execution_id=execution_id,
+                status=status,
+                start_time=execution.start_time,
+                close_time=execution.close_time,
+                result=result,
+                error=error,
+            )
+
+        trigger_type, execution_type = extract_execution_types(execution)
+        compact_events = await exec_service.list_workflow_execution_events_compact(
+            execution_id
+        )
         return InternalWorkflowStatusResponse(
             workflow_execution_id=execution_id,
             status=status,
@@ -961,6 +1031,10 @@ async def get_execution_status(
             close_time=execution.close_time,
             result=result,
             error=error,
+            trigger_type=trigger_type,
+            execution_type=execution_type,
+            history_length=execution.history_length,
+            events=build_execution_events(compact_events),
         )
 
     except RPCError as e:

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import uuid
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import (
@@ -1179,3 +1180,43 @@ class WorkflowExecutionBulkResetResponse(BaseModel):
 
 class ReceiveInteractionResponse(BaseModel):
     message: str
+
+
+class WorkflowExecutionSummaryResponse(BaseModel):
+    """Canonical execution summary projection shared by MCP and internal surfaces."""
+
+    id: WorkflowExecutionID
+    run_id: uuid.UUID | str
+    status: str | None = None
+    start_time: str
+    close_time: str | None = None
+    trigger_type: str | None = None
+    execution_type: str | None = None
+
+
+class WorkflowExecutionEventError(BaseModel):
+    """Action-level workflow execution error payload."""
+
+    message: str
+    cause: Any | None = None
+
+
+class WorkflowExecutionEventResponse(BaseModel):
+    """Canonical compact execution event projection."""
+
+    action_ref: str | None = None
+    action_name: str | None = None
+    status: str
+    schedule_time: str
+    start_time: str | None = None
+    close_time: str | None = None
+    error: WorkflowExecutionEventError | None = None
+    result: Any | None = None
+    result_truncated: str | None = None
+
+
+class WorkflowExecutionDetailResponse(WorkflowExecutionSummaryResponse):
+    """Canonical execution detail projection: summary plus the event timeline."""
+
+    history_length: int
+    events: list[WorkflowExecutionEventResponse] = Field(default_factory=list)

--- a/tracecat/workflow/executions/shaping.py
+++ b/tracecat/workflow/executions/shaping.py
@@ -1,0 +1,119 @@
+"""Shared workflow-execution shaping helpers for MCP tools and internal routers.
+
+Builds the canonical summary/event projections defined in
+``tracecat.workflow.executions.schemas`` from Temporal execution descriptions
+and compact event histories. The event and summary shaping is shared verbatim;
+the surrounding detail envelopes intentionally differ per transport (the MCP
+tool returns the canonical detail projection, while the internal SDK route
+wraps the same events in its legacy status envelope).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
+
+from tracecat.dsl.common import (
+    get_execution_type_from_search_attr,
+    get_trigger_type_from_search_attr,
+)
+from tracecat.workflow.executions.schemas import (
+    WorkflowExecutionEventCompact,
+    WorkflowExecutionEventError,
+    WorkflowExecutionEventResponse,
+    WorkflowExecutionSummaryResponse,
+)
+
+# Action results larger than this are returned as a truncated string instead of
+# the raw value, to keep tool payloads within model context budgets.
+MAX_EVENT_RESULT_CHARS = 2000
+
+
+def format_temporal_status(status: WorkflowExecutionStatus | None) -> str | None:
+    """Return a stable workflow status string for tool responses."""
+    return status.name if status else None
+
+
+def extract_execution_types(
+    execution: WorkflowExecution,
+) -> tuple[str | None, str | None]:
+    """Return ``(trigger_type, execution_type)`` from an execution's search attributes.
+
+    Search attributes are best-effort metadata: a missing or malformed attribute
+    must not fail the whole listing, so extraction failures yield ``(None, None)``.
+    """
+    try:
+        trigger_type = get_trigger_type_from_search_attr(
+            execution.typed_search_attributes, execution.id
+        )
+        execution_type = get_execution_type_from_search_attr(
+            execution.typed_search_attributes
+        )
+    except Exception:
+        return None, None
+    return (
+        str(trigger_type) if trigger_type else None,
+        str(execution_type) if execution_type else None,
+    )
+
+
+def build_execution_summary(
+    execution: WorkflowExecution,
+) -> WorkflowExecutionSummaryResponse:
+    """Shape a Temporal execution into the canonical summary projection."""
+    trigger_type, execution_type = extract_execution_types(execution)
+    return WorkflowExecutionSummaryResponse(
+        id=execution.id,
+        run_id=execution.run_id,
+        status=format_temporal_status(execution.status),
+        start_time=str(execution.start_time),
+        close_time=str(execution.close_time) if execution.close_time else None,
+        trigger_type=trigger_type,
+        execution_type=execution_type,
+    )
+
+
+def build_execution_event(
+    event: WorkflowExecutionEventCompact[Any, Any, Any],
+) -> WorkflowExecutionEventResponse:
+    """Shape a compact execution event, truncating oversized action results."""
+    # The status route excludes unset fields recursively. Set every canonical
+    # event key explicitly so nullable event fields remain present on the wire.
+    event_data = WorkflowExecutionEventResponse(
+        action_ref=event.action_ref,
+        action_name=event.action_name,
+        status=str(event.status),
+        schedule_time=str(event.schedule_time),
+        start_time=str(event.start_time) if event.start_time else None,
+        close_time=str(event.close_time) if event.close_time else None,
+        error=None,
+        result=None,
+        result_truncated=None,
+    )
+    if event.action_error is not None:
+        event_data.error = WorkflowExecutionEventError(
+            message=event.action_error.message,
+            cause=event.action_error.cause,
+        )
+    if event.action_result is not None:
+        try:
+            result_str = json.dumps(event.action_result, default=str)
+            if len(result_str) > MAX_EVENT_RESULT_CHARS:
+                event_data.result_truncated = (
+                    result_str[:MAX_EVENT_RESULT_CHARS] + "..."
+                )
+            else:
+                event_data.result = event.action_result
+        except (TypeError, ValueError):
+            event_data.result = str(event.action_result)[:MAX_EVENT_RESULT_CHARS]
+    return event_data
+
+
+def build_execution_events(
+    events: Iterable[WorkflowExecutionEventCompact[Any, Any, Any]],
+) -> list[WorkflowExecutionEventResponse]:
+    """Shape a compact event history into the tool-facing event timeline."""
+    return [build_execution_event(event) for event in events]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds workflow execution tools to workspace chat and SDK: new `core.workflow.list_executions` and an enhanced `core.workflow.get_status` (optional per-action event timeline). Unifies execution response shaping across MCP and internal APIs, with stricter execution ID validation.

- New Features
  - Chat default tools now include `core.workflow.list_executions` and `core.workflow.get_status`.
  - SDK: `ctx.workflows.get_status(wf_exec_id, include_events)` returns `WorkflowExecutionStatusRead`; `ctx.workflows.list_executions(workflow_id, limit, cursor)` returns `WorkflowExecutionPageRead` (cursor pagination, limit clamped to 1–100).
  - API: `/workflows/{workflow_id}/executions` (cursor pagination) and `/workflows/executions/{wf_exec_id}?include_events=true`.

- Refactors
  - Extracted shared shapers to `tracecat/workflow/executions/shaping.py` and canonical schemas to `tracecat/workflow/executions/schemas.py`; MCP server now uses these.
  - Added `WorkflowExecutionID` validator (pattern pinned to source-of-truth) and updated stubs/types; event fields are null unless `include_events=true`, oversized action results are truncated.
  - Tightened tests for event timelines, pagination (including limit clamping), truncation, and ID format.

<sup>Written for commit 0afda407b316aa323853b2251440e0f850e5e184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

