### PR TITLE
fix(agent): preserve NUL session history

### DIFF
--- a/alembic/versions/864d277bedfa_add_raw_agent_session_line.py
+++ b/alembic/versions/864d277bedfa_add_raw_agent_session_line.py
@@ -1,0 +1,30 @@
+"""add raw agent session line
+
+Revision ID: 864d277bedfa
+Revises: c6a8d4f3b2e1
+Create Date: 2026-07-30 11:12:41.817803
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "864d277bedfa"
+down_revision: str | None = "c6a8d4f3b2e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_session_history",
+        sa.Column("raw_session_line", sa.LargeBinary(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_session_history", "raw_session_line")

--- a/alembic/versions/864d277bedfa_add_raw_agent_session_line.py
+++ b/alembic/versions/864d277bedfa_add_raw_agent_session_line.py
@@ -27,4 +27,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column("agent_session_history", "raw_session_line")
+    raise NotImplementedError(
+        "Downgrading would discard lossless agent session history. "
+        "Restore the database from a backup or snapshot before rolling back "
+        "the application."
+    )

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -30,6 +30,7 @@ from tracecat.artifacts.bindings import ArtifactSideEffect
 from tracecat.artifacts.schemas import CaseArtifact
 from tracecat.auth.types import Role
 from tracecat.cases.enums import CaseSeverity, CaseStatus
+from tracecat.db.models import AgentSessionHistory
 
 
 class _FakeStream:
@@ -65,6 +66,16 @@ class _FakeSessionContext:
 class _FakeArtifactPersistenceSession:
     def __init__(self, organization_id: UUID | None) -> None:
         self.scalar = AsyncMock(return_value=organization_id)
+
+
+class _FakeHistoryPersistenceSession:
+    def __init__(self) -> None:
+        self.entries: list[AgentSessionHistory] = []
+        self.commit = AsyncMock()
+
+    def add(self, entry: object) -> None:
+        assert isinstance(entry, AgentSessionHistory)
+        self.entries.append(entry)
 
 
 def _reader_for_envelopes(*envelopes: RuntimeEventEnvelope) -> asyncio.StreamReader:
@@ -222,6 +233,36 @@ def _make_handler() -> LoopbackHandler:
             workspace_id=UUID("00000000-0000-0000-0000-000000000002"),
         )
     )
+
+
+@pytest.mark.anyio
+async def test_persist_session_line_preserves_raw_nul_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _make_handler()
+    handler._sdk_session_id = "sdk-session"
+    session = _FakeHistoryPersistenceSession()
+    monkeypatch.setattr(
+        "tracecat.agent.executor.loopback.get_async_session_bypass_rls_context_manager",
+        lambda: _FakeSessionContext(session),
+    )
+    raw_line = (
+        r'{"type":"user","uuid":"line-uuid","message":{"role":"user",'
+        r'"content":"left\u0000right"}}'
+    )
+
+    await handler._persist_session_line("sdk-session", raw_line)
+
+    assert len(session.entries) == 1
+    [entry] = session.entries
+    assert entry.content["message"]["content"] == r"left\u0000right"
+    assert entry.raw_session_line == raw_line.encode()
+    assert entry.raw_session_line is not None
+    assert orjson.loads(entry.raw_session_line)["message"]["content"] == (
+        "left\x00right"
+    )
+    assert handler._persisted_line_uuids == {"line-uuid"}
+    session.commit.assert_awaited_once()
 
 
 def test_should_suppress_pending_approval_tool_result() -> None:

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -422,7 +422,7 @@ async def test_list_messages_sql_owns_active_run_visibility(
 
 
 @pytest.mark.anyio
-async def test_replace_interrupt_with_tool_results_replaces_legacy_interrupted_row(
+async def test_replace_interrupt_with_tool_results_preserves_nul_result(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
@@ -498,7 +498,7 @@ async def test_replace_interrupt_with_tool_results_replaces_legacy_interrupted_r
             ToolExecutionResult(
                 tool_call_id="call_123",
                 tool_name="core.http_request",
-                result={"status": "success"},
+                result="left\x00right",
                 is_error=False,
             )
         ],
@@ -516,7 +516,20 @@ async def test_replace_interrupt_with_tool_results_replaces_legacy_interrupted_r
     [tool_result] = tool_result_blocks
     assert tool_result["tool_use_id"] == "call_123"
     assert tool_result["is_error"] is False
-    assert orjson.loads(tool_result["content"]) == {"status": "success"}
+    assert tool_result["content"] == r"left\u0000right"
+
+    tool_result_entry = next(
+        entry
+        for entry in history
+        if any(
+            isinstance(block, dict) and block.get("type") == "tool_result"
+            for block in entry.content.get("message", {}).get("content", [])
+        )
+    )
+    assert tool_result_entry.raw_session_line is not None
+    raw_entry = orjson.loads(tool_result_entry.raw_session_line)
+    [raw_tool_result] = raw_entry["message"]["content"]
+    assert raw_tool_result["content"] == "left\x00right"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_history.py
+++ b/tests/unit/test_agent_session_history.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import orjson
+import pytest
+
+from tracecat.agent.session.history import (
+    decode_raw_session_line,
+    prepare_session_history,
+)
+
+
+def _contains_nul(value: object) -> bool:
+    match value:
+        case str() as text:
+            return "\x00" in text
+        case list() as items:
+            return any(_contains_nul(item) for item in items)
+        case Mapping() as mapping:
+            return any(
+                _contains_nul(key) or _contains_nul(item)
+                for key, item in mapping.items()
+            )
+        case _:
+            return False
+
+
+def test_prepare_session_history_preserves_exact_raw_nul_content() -> None:
+    raw_line = (
+        r'{"actual\u0000key":"left\u0000right",'
+        r'"actual\\u0000key":"literal\\u0000text"}'
+    )
+    content = orjson.loads(raw_line)
+
+    payload = prepare_session_history(content, raw_session_line=raw_line)
+
+    assert payload.raw_session_line is not None
+    assert payload.raw_session_line == raw_line.encode()
+    assert _contains_nul(payload.content) is False
+    assert len(payload.content) == 2
+
+    decoded, decoded_line = decode_raw_session_line(payload.raw_session_line)
+    assert decoded_line == raw_line
+    assert decoded == content
+    assert decoded["actual\x00key"] == "left\x00right"
+    assert decoded[r"actual\u0000key"] == r"literal\u0000text"
+
+
+def test_prepare_session_history_builds_raw_line_for_synthetic_content() -> None:
+    content = {
+        "type": "user",
+        "message": {"content": "left\x00right"},
+    }
+
+    payload = prepare_session_history(content)
+
+    assert payload.content["message"]["content"] == r"left\u0000right"
+    assert payload.raw_session_line is not None
+    assert orjson.loads(payload.raw_session_line) == content
+
+
+def test_prepare_session_history_keeps_safe_rows_jsonb_only() -> None:
+    content = {"type": "user", "message": {"content": "plain text"}}
+
+    payload = prepare_session_history(content)
+
+    assert payload.content == content
+    assert payload.raw_session_line is None
+
+
+def test_decode_raw_session_line_rejects_non_object_json() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        decode_raw_session_line(memoryview(b"[]"))

--- a/tests/unit/test_agent_session_history.py
+++ b/tests/unit/test_agent_session_history.py
@@ -40,11 +40,11 @@ def test_prepare_session_history_preserves_exact_raw_nul_content() -> None:
     assert _contains_nul(payload.content) is False
     assert len(payload.content) == 2
 
-    decoded, decoded_line = decode_raw_session_line(payload.raw_session_line)
-    assert decoded_line == raw_line
-    assert decoded == content
-    assert decoded["actual\x00key"] == "left\x00right"
-    assert decoded[r"actual\u0000key"] == r"literal\u0000text"
+    decoded = decode_raw_session_line(payload.raw_session_line)
+    assert decoded.raw_line == raw_line
+    assert decoded.content == content
+    assert decoded.content["actual\x00key"] == "left\x00right"
+    assert decoded.content[r"actual\u0000key"] == r"literal\u0000text"
 
 
 def test_prepare_session_history_builds_raw_line_for_synthetic_content() -> None:

--- a/tests/unit/test_agent_session_messages.py
+++ b/tests/unit/test_agent_session_messages.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import orjson
 import pytest
 
+from tracecat.agent.session.history import prepare_session_history
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.auth.types import Role
 from tracecat.chat.enums import MessageKind
@@ -158,6 +159,45 @@ async def test_load_session_history_omits_cancelled_marker_rows() -> None:
 
 
 @pytest.mark.anyio
+async def test_load_session_history_prefers_exact_raw_nul_content() -> None:
+    service, _ = _build_service()
+    session_id = uuid.uuid4()
+    sdk_session = SimpleNamespace(
+        id=session_id,
+        parent_session_id=None,
+        sdk_session_id="sdk-session-123",
+        curr_run_id=None,
+    )
+    raw_line = (
+        r'{"type":"user","uuid":"raw-uuid","message":{"role":"user",'
+        r'"content":["left\u0000right","literal\\u0000text"]}}'
+    )
+    payload = prepare_session_history(
+        orjson.loads(raw_line),
+        raw_session_line=raw_line,
+    )
+    entry = SimpleNamespace(
+        id=uuid.uuid4(),
+        kind=MessageKind.CHAT_MESSAGE.value,
+        content=payload.content,
+        raw_session_line=payload.raw_session_line,
+    )
+
+    service.get_session = AsyncMock(return_value=sdk_session)
+    service.session.execute = AsyncMock(return_value=_mock_scalar_result([entry]))
+
+    history = await service.load_session_history(session_id)
+
+    assert history is not None
+    assert history.sdk_session_data == raw_line
+    [actual_nul, literal_escape] = orjson.loads(history.sdk_session_data)["message"][
+        "content"
+    ]
+    assert actual_nul == "left\x00right"
+    assert literal_escape == r"literal\u0000text"
+
+
+@pytest.mark.anyio
 async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain() -> (
     None
 ):
@@ -172,6 +212,15 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
     tool_result_uuid = "tool-result-uuid"
     thinking_uuid = "thinking-uuid"
     answer_uuid = "answer-uuid"
+    answer_raw_line = (
+        r'{"type":"assistant","uuid":"answer-uuid",'
+        r'"parentUuid":"thinking-uuid","message":{"content":['
+        r'{"type":"text","text":"There are\u0000no cases."}]}}'
+    )
+    answer_payload = prepare_session_history(
+        orjson.loads(answer_raw_line),
+        raw_session_line=answer_raw_line,
+    )
     entries = [
         SimpleNamespace(
             kind=MessageKind.CHAT_MESSAGE.value,
@@ -238,14 +287,8 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
         ),
         SimpleNamespace(
             kind=MessageKind.CHAT_MESSAGE.value,
-            content={
-                "type": "assistant",
-                "uuid": answer_uuid,
-                "parentUuid": thinking_uuid,
-                "message": {
-                    "content": [{"type": "text", "text": "There are no cases."}]
-                },
-            },
+            content=answer_payload.content,
+            raw_session_line=answer_payload.raw_session_line,
         ),
     ]
 
@@ -259,6 +302,7 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
     lines = [orjson.loads(line) for line in history.sdk_session_data.splitlines()]
     assert [line["uuid"] for line in lines] == [tool_result_uuid, answer_uuid]
     assert lines[1]["parentUuid"] == tool_result_uuid
+    assert lines[1]["message"]["content"][0]["text"] == "There are\x00no cases."
     assert "Continue" not in history.sdk_session_data
 
 

--- a/tests/unit/test_agent_session_messages.py
+++ b/tests/unit/test_agent_session_messages.py
@@ -121,7 +121,9 @@ async def test_load_session_history_omits_cancelled_marker_rows() -> None:
     )
     entries = [
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.CHAT_MESSAGE.value,
+            raw_session_line=None,
             content={
                 "type": "user",
                 "uuid": "prompt-uuid",
@@ -129,7 +131,9 @@ async def test_load_session_history_omits_cancelled_marker_rows() -> None:
             },
         ),
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.CANCELLED.value,
+            raw_session_line=None,
             content={
                 "type": "cancelled",
                 "reason": "user_cancel",
@@ -137,7 +141,9 @@ async def test_load_session_history_omits_cancelled_marker_rows() -> None:
             },
         ),
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.CHAT_MESSAGE.value,
+            raw_session_line=None,
             content={
                 "type": "assistant",
                 "uuid": "answer-uuid",
@@ -223,7 +229,9 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
     )
     entries = [
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.CHAT_MESSAGE.value,
+            raw_session_line=None,
             content={
                 "type": "user",
                 "uuid": tool_result_uuid,
@@ -234,7 +242,9 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
             },
         ),
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.INTERNAL.value,
+            raw_session_line=None,
             content={
                 "type": "user",
                 "uuid": "meta-uuid",
@@ -252,7 +262,9 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
             },
         ),
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.INTERNAL.value,
+            raw_session_line=None,
             content={
                 "type": "assistant",
                 "uuid": "synthetic-uuid",
@@ -261,7 +273,9 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
             },
         ),
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.INTERNAL.value,
+            raw_session_line=None,
             content={
                 "type": "user",
                 "uuid": "prompt-uuid",
@@ -270,7 +284,9 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
             },
         ),
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.INTERNAL.value,
+            raw_session_line=None,
             content={
                 "type": "assistant",
                 "uuid": thinking_uuid,
@@ -286,6 +302,7 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
             },
         ),
         SimpleNamespace(
+            id=uuid.uuid4(),
             kind=MessageKind.CHAT_MESSAGE.value,
             content=answer_payload.content,
             raw_session_line=answer_payload.raw_session_line,

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -37,6 +37,7 @@ from tracecat.agent.common.stream_types import (
     ToolCallContent,
     UnifiedStreamEvent,
 )
+from tracecat.agent.session.history import prepare_session_history
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.stream.artifacts import artifact_stream_event
@@ -256,11 +257,6 @@ def _session_line_from_json(session_line: str) -> ClaudeSessionLine:
     if not isinstance(decoded, dict):
         raise ValueError("Claude session line must be a JSON object")
     return cast(ClaudeSessionLine, decoded)
-
-
-def _session_line_db_content(line: ClaudeSessionLine) -> dict[str, Any]:
-    """Return a SQLAlchemy JSONB payload for an already validated session line."""
-    return cast(dict[str, Any], line)
 
 
 class LoopbackHandler:
@@ -1034,7 +1030,7 @@ class LoopbackHandler:
     async def _persist_session_line(
         self, sdk_session_id: str, session_line: str, *, internal: bool = False
     ) -> None:
-        """Persist sanitized JSONL line from SDK session file.
+        """Persist an SDK JSONL line with a JSONB-safe projection.
 
         Writes to AgentSessionHistory only. The session_id in self.input
         is the AgentSession.id for new chats, so all writes go to the
@@ -1049,8 +1045,12 @@ class LoopbackHandler:
             session_line: Raw JSONL line from the SDK session file.
             internal: If True, this is internal state not shown in UI timeline.
         """
-        # Parse and sanitize to prevent XSS from untrusted content (e.g., tool results)
+        # Parse once, preserving exact resume bytes if JSONB needs a safe projection.
         line_data = _session_line_from_json(session_line)
+        history_payload = prepare_session_history(
+            cast(dict[str, Any], line_data),
+            raw_session_line=session_line,
+        )
         if not internal and line_data.get("type") == "assistant":
             self._received_assistant_content = True
 
@@ -1104,7 +1104,8 @@ class LoopbackHandler:
             history_entry = AgentSessionHistory(
                 session_id=self.input.session_id,
                 workspace_id=self.input.workspace_id,
-                content=_session_line_db_content(line_data),
+                content=history_payload.content,
+                raw_session_line=history_payload.raw_session_line,
                 kind=kind,
                 curr_run_id=self.input.curr_run_id,
             )

--- a/tracecat/agent/session/history.py
+++ b/tracecat/agent/session/history.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass
-from typing import Any, NamedTuple, cast
+from typing import Any, cast
 
 import orjson
 
@@ -19,7 +19,8 @@ class PreparedSessionHistory:
     raw_session_line: bytes | None
 
 
-class SessionHistoryContent(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class SessionHistoryContent:
     """Decoded session history content and its exact raw JSONL line, if stored."""
 
     content: dict[str, Any]

--- a/tracecat/agent/session/history.py
+++ b/tracecat/agent/session/history.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 import orjson
 
@@ -17,6 +17,13 @@ class PreparedSessionHistory:
 
     content: dict[str, Any]
     raw_session_line: bytes | None
+
+
+class SessionHistoryContent(NamedTuple):
+    """Decoded session history content and its exact raw JSONL line, if stored."""
+
+    content: dict[str, Any]
+    raw_line: str | None
 
 
 def _jsonb_safe_key(key: object) -> tuple[object, bool]:
@@ -87,10 +94,13 @@ def prepare_session_history(
 
 def decode_raw_session_line(
     raw_session_line: bytes | bytearray | memoryview,
-) -> tuple[dict[str, Any], str]:
+) -> SessionHistoryContent:
     """Decode an exact JSONL row stored alongside its JSONB projection."""
     raw_line = bytes(raw_session_line).decode("utf-8")
     decoded = orjson.loads(raw_line)
     if not isinstance(decoded, dict):
         raise ValueError("Raw agent session line must be a JSON object")
-    return cast(dict[str, Any], decoded), raw_line
+    return SessionHistoryContent(
+        content=cast(dict[str, Any], decoded),
+        raw_line=raw_line,
+    )

--- a/tracecat/agent/session/history.py
+++ b/tracecat/agent/session/history.py
@@ -1,0 +1,96 @@
+"""Persistence helpers for agent session history payloads."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Any, cast
+
+import orjson
+
+_ENCODED_JSONB_KEY_PREFIX = "__tracecat_encoded_key_v1__:"
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedSessionHistory:
+    """Raw resume data and its PostgreSQL-safe JSONB projection."""
+
+    content: dict[str, Any]
+    raw_session_line: bytes | None
+
+
+def _jsonb_safe_key(key: object) -> tuple[object, bool]:
+    if not isinstance(key, str):
+        return key, False
+    if "\x00" not in key and not key.startswith(_ENCODED_JSONB_KEY_PREFIX):
+        return key, False
+
+    # Encoding the whole key avoids collisions with a literal "\\u0000" key.
+    # Keys already in our namespace are encoded too, keeping the mapping injective.
+    encoded = base64.urlsafe_b64encode(key.encode("utf-8")).decode("ascii")
+    return f"{_ENCODED_JSONB_KEY_PREFIX}{encoded}", True
+
+
+def _jsonb_safe_value(value: object) -> tuple[object, bool]:
+    match value:
+        case str() as text:
+            safe_text = text.replace("\x00", "\\u0000")
+            return safe_text, safe_text != text
+        case list() as items:
+            safe_items: list[object] = []
+            changed = False
+            for item in items:
+                safe_item, item_changed = _jsonb_safe_value(item)
+                safe_items.append(safe_item)
+                changed = changed or item_changed
+            return (safe_items if changed else items), changed
+        case dict() as mapping:
+            safe_mapping: dict[object, object] = {}
+            changed = False
+            for key, item in mapping.items():
+                safe_key, key_changed = _jsonb_safe_key(key)
+                safe_item, item_changed = _jsonb_safe_value(item)
+                safe_mapping[safe_key] = safe_item
+                changed = changed or key_changed or item_changed
+            return (safe_mapping if changed else mapping), changed
+        case _:
+            return value, False
+
+
+def prepare_session_history(
+    content: dict[str, Any],
+    *,
+    raw_session_line: str | bytes | None = None,
+) -> PreparedSessionHistory:
+    """Prepare exact resume bytes and a JSONB-safe history projection.
+
+    Raw bytes are retained only when the projection must change. Ordinary
+    session rows continue using the existing JSONB-only storage path.
+    """
+    safe_value, changed = _jsonb_safe_value(content)
+    safe_content = cast(dict[str, Any], safe_value)
+    if not changed:
+        return PreparedSessionHistory(content=safe_content, raw_session_line=None)
+
+    if isinstance(raw_session_line, str):
+        raw_bytes = raw_session_line.encode("utf-8")
+    elif raw_session_line is not None:
+        raw_bytes = raw_session_line
+    else:
+        raw_bytes = orjson.dumps(content)
+
+    return PreparedSessionHistory(
+        content=safe_content,
+        raw_session_line=raw_bytes,
+    )
+
+
+def decode_raw_session_line(
+    raw_session_line: bytes | bytearray | memoryview,
+) -> tuple[dict[str, Any], str]:
+    """Decode an exact JSONL row stored alongside its JSONB projection."""
+    raw_line = bytes(raw_session_line).decode("utf-8")
+    decoded = orjson.loads(raw_line)
+    if not isinstance(decoded, dict):
+        raise ValueError("Raw agent session line must be a JSON object")
+    return cast(dict[str, Any], decoded), raw_line

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -76,6 +76,10 @@ from tracecat.agent.runtime.claude_code.session_lines import (
 )
 from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.service import AgentManagementService
+from tracecat.agent.session.history import (
+    decode_raw_session_line,
+    prepare_session_history,
+)
 from tracecat.agent.session.schemas import (
     AgentSessionCancelResponse,
     AgentSessionCreate,
@@ -210,6 +214,33 @@ class SessionHistoryData:
     sdk_session_id: str
     sdk_session_data: str
     is_fork: bool = False  # If True, SDK should use fork_session=True
+
+
+def _session_history_content(
+    entry: AgentSessionHistory,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Load exact raw content when available, else clone the JSONB projection."""
+    raw_session_line = getattr(entry, "raw_session_line", None)
+    if isinstance(raw_session_line, (bytes, bytearray, memoryview)):
+        try:
+            return decode_raw_session_line(raw_session_line)
+        except (UnicodeDecodeError, ValueError) as exc:
+            logger.warning(
+                "Ignoring invalid raw agent session line",
+                session_history_id=getattr(entry, "id", None),
+                error=str(exc),
+            )
+    elif raw_session_line is not None:
+        logger.warning(
+            "Ignoring raw agent session line with invalid type",
+            session_history_id=getattr(entry, "id", None),
+            raw_type=type(raw_session_line).__name__,
+        )
+
+    content = orjson.loads(orjson.dumps(entry.content))
+    if not isinstance(content, dict):
+        return None, None
+    return cast(dict[str, Any], content), None
 
 
 class _ApprovalDecisionFields(NamedTuple):
@@ -1101,6 +1132,7 @@ class AgentSessionService(BaseWorkspaceService):
         }
         if interrupted_tool_call_ids:
             content["tool_call_ids"] = list(interrupted_tool_call_ids)
+        history_payload = prepare_session_history(content)
         # Tag with the active run id like other mid-turn rows so the marker
         # stays hidden from DB reloads until terminal cleanup reveals it
         # together with the rest of the turn.
@@ -1108,7 +1140,8 @@ class AgentSessionService(BaseWorkspaceService):
             AgentSessionHistory(
                 session_id=session_id,
                 workspace_id=self.workspace_id,
-                content=content,
+                content=history_payload.content,
+                raw_session_line=history_payload.raw_session_line,
                 kind=MessageKind.CANCELLED.value,
                 curr_run_id=curr_run_id
                 if curr_run_id is not None
@@ -1160,8 +1193,8 @@ class AgentSessionService(BaseWorkspaceService):
         For forked sessions (with parent_session_id), loads the parent's history
         and sets is_fork=True so the runtime uses fork_session=True with the SDK.
 
-        The sdk_session_id is stored on the AgentSession model (not in the
-        JSONL content) to keep the history entries pristine for SDK resume.
+        The sdk_session_id is stored on the AgentSession model. Rows that need
+        a JSONB-safe projection retain exact JSONL bytes for SDK resume.
 
         Args:
             session_id: The session UUID.
@@ -1233,8 +1266,8 @@ class AgentSessionService(BaseWorkspaceService):
         internal_uuids: set[str] = set()
         last_visible_uuid: str | None = None
         for entry in history_entries:
-            content = orjson.loads(orjson.dumps(entry.content))
-            if not isinstance(content, dict):
+            content, raw_line = _session_history_content(entry)
+            if content is None:
                 continue
 
             line_uuid = session_line_uuid(content)
@@ -1260,12 +1293,17 @@ class AgentSessionService(BaseWorkspaceService):
                 and last_visible_uuid is not None
             ):
                 content["parentUuid"] = last_visible_uuid
+                raw_line = None
 
             if line_uuid is not None:
                 included_uuids.add(line_uuid)
                 last_visible_uuid = line_uuid
 
-            line = orjson.dumps(content).decode("utf-8")
+            line = (
+                raw_line
+                if raw_line is not None
+                else orjson.dumps(content).decode("utf-8")
+            )
             lines.append(line)
 
         if not lines:
@@ -3174,6 +3212,7 @@ class AgentSessionService(BaseWorkspaceService):
                 ],
             },
         }
+        history_payload = prepare_session_history(entry_content)
 
         # Tag the inserted tool_result with the active run id so the mid-turn
         # filter hides it alongside its (also active-run-tagged) assistant
@@ -3185,7 +3224,8 @@ class AgentSessionService(BaseWorkspaceService):
             AgentSessionHistory(
                 session_id=session_id,
                 workspace_id=self.workspace_id,
-                content=entry_content,
+                content=history_payload.content,
+                raw_session_line=history_payload.raw_session_line,
                 kind=MessageKind.CHAT_MESSAGE.value,
                 curr_run_id=session.curr_run_id,
             )

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -77,6 +77,7 @@ from tracecat.agent.runtime.claude_code.session_lines import (
 from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.session.history import (
+    SessionHistoryContent,
     decode_raw_session_line,
     prepare_session_history,
 )
@@ -218,7 +219,7 @@ class SessionHistoryData:
 
 def _session_history_content(
     entry: AgentSessionHistory,
-) -> tuple[dict[str, Any] | None, str | None]:
+) -> SessionHistoryContent | None:
     """Load exact raw content when available, else clone the JSONB projection."""
     raw_session_line = entry.raw_session_line
     if isinstance(raw_session_line, (bytes, bytearray, memoryview)):
@@ -239,8 +240,11 @@ def _session_history_content(
 
     content = orjson.loads(orjson.dumps(entry.content))
     if not isinstance(content, dict):
-        return None, None
-    return cast(dict[str, Any], content), None
+        return None
+    return SessionHistoryContent(
+        content=cast(dict[str, Any], content),
+        raw_line=None,
+    )
 
 
 class _ApprovalDecisionFields(NamedTuple):
@@ -1266,9 +1270,11 @@ class AgentSessionService(BaseWorkspaceService):
         internal_uuids: set[str] = set()
         last_visible_uuid: str | None = None
         for entry in history_entries:
-            content, raw_line = _session_history_content(entry)
-            if content is None:
+            history_content = _session_history_content(entry)
+            if history_content is None:
                 continue
+            content = history_content.content
+            raw_line = history_content.raw_line
 
             line_uuid = session_line_uuid(content)
             if entry.kind == MessageKind.INTERNAL.value:

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -220,20 +220,20 @@ def _session_history_content(
     entry: AgentSessionHistory,
 ) -> tuple[dict[str, Any] | None, str | None]:
     """Load exact raw content when available, else clone the JSONB projection."""
-    raw_session_line = getattr(entry, "raw_session_line", None)
+    raw_session_line = entry.raw_session_line
     if isinstance(raw_session_line, (bytes, bytearray, memoryview)):
         try:
             return decode_raw_session_line(raw_session_line)
         except (UnicodeDecodeError, ValueError) as exc:
             logger.warning(
                 "Ignoring invalid raw agent session line",
-                session_history_id=getattr(entry, "id", None),
+                session_history_id=entry.id,
                 error=str(exc),
             )
     elif raw_session_line is not None:
         logger.warning(
             "Ignoring raw agent session line with invalid type",
-            session_history_id=getattr(entry, "id", None),
+            session_history_id=entry.id,
             raw_type=type(raw_session_line).__name__,
         )
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3015,6 +3015,11 @@ class AgentSessionHistory(WorkspaceModel):
         nullable=False,
         doc="Harness-specific message content",
     )
+    raw_session_line: Mapped[bytes | None] = mapped_column(
+        LargeBinary,
+        nullable=True,
+        doc="Exact JSONL bytes retained when content requires a JSONB-safe projection",
+    )
     kind: Mapped[str] = mapped_column(
         String(50),
         nullable=False,


### PR DESCRIPTION
## Summary

- Preserve the exact Claude session JSONL bytes in a nullable `BYTEA` sidecar whenever PostgreSQL needs a sanitized JSONB projection.
- Prepare the projection before the first insert instead of detecting a failed transaction and retrying.
- Hydrate SDK resume data from the raw sidecar while keeping JSONB as the UI/query representation.
- Apply the same persistence boundary to loopback lines, cancellation markers, and post-approval tool results.

Supersedes #2768.

## Root cause

PostgreSQL JSONB cannot represent Unicode NUL. The current #2768 head waits for that insert to fail, rolls back, then replaces NUL with the literal `backslash + u0000` sequence. That makes an actual NUL indistinguishable from a pre-existing literal escape during resume, can collapse object keys, and does not protect the approval-result writer.

## Impact

- Affected rows keep an exact resume source while exposing a PostgreSQL-safe projection to existing readers.
- NUL-bearing keys use a namespaced base64 representation in the projection, avoiding collisions with literal `backslash + u0000` keys.
- Ordinary rows remain JSONB-only, so the raw sidecar adds storage only when projection is necessary.
- The migration is additive and nullable; it requires no backfill.
- Database downgrade fails closed because dropping the sidecar after affected writes would destroy information. Operators must restore a backup or snapshot before rolling back the application.

## Verification

- `uv run pytest -q tests/unit/test_agent_session_history.py tests/unit/test_agent_executor_loopback.py tests/unit/test_agent_session_messages.py tests/unit/test_agent_session_approval_sink.py` — 75 passed
- Focused `uv run ruff check` and `uv run ruff format --check` — passed
- Focused `uv run basedpyright` — 0 errors, 0 warnings
- Exercised Alembic upgrade and verified downgrade raises before changing schema, leaving the database at head
- Commit hooks passed, including Ruff, Python type checking, generated-client verification, and secret scanning
