### PR TITLE
perf(cases): avoid unused relationship loads in case metrics

### DIFF
--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import event, inspect, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.cases.durations import (
@@ -24,7 +24,7 @@ from tracecat.cases.enums import CaseEventType, CasePriority, CaseSeverity, Case
 from tracecat.cases.schemas import CaseCreate, CaseUpdate
 from tracecat.cases.service import CasesService
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.db.models import CaseDuration, CaseEvent
+from tracecat.db.models import Case, CaseDuration, CaseEvent
 from tracecat.db.models import CaseDurationDefinition as CaseDurationDefinitionDB
 from tracecat.tags.schemas import TagCreate
 
@@ -82,6 +82,125 @@ def make_case_create(
             "priority": priority,
             "severity": severity,
         }
+    )
+
+
+def test_duration_relationships_require_explicit_loading() -> None:
+    definition_relationships = inspect(CaseDurationDefinitionDB).relationships
+    duration_relationships = inspect(CaseDuration).relationships
+    case_relationships = inspect(Case).relationships
+
+    assert definition_relationships.case_durations.lazy == "raise"
+    assert definition_relationships.case_durations.passive_deletes is True
+    assert duration_relationships.case.lazy == "raise"
+    assert duration_relationships.definition.lazy == "raise"
+    assert case_relationships.durations.lazy == "raise"
+    assert case_relationships.durations.passive_deletes is True
+
+
+@pytest.mark.anyio
+async def test_list_definitions_does_not_load_persisted_duration_graph(
+    session: AsyncSession,
+    svc_role,
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    definition = await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="No implicit graph",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CREATED,
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CLOSED,
+            ),
+        )
+    )
+    case = await cases_service.create_case(make_case_create())
+    session.add(
+        CaseDuration(
+            workspace_id=case.workspace_id,
+            case_id=case.id,
+            definition_id=definition.id,
+            started_at=datetime.now(UTC) - timedelta(minutes=5),
+            ended_at=datetime.now(UTC),
+            duration=timedelta(minutes=5),
+        )
+    )
+    await session.commit()
+    session.expunge_all()
+
+    loaded_cases: list[uuid.UUID] = []
+    loaded_durations: list[uuid.UUID] = []
+
+    def record_case_load(entity: Case, _context: object) -> None:
+        loaded_cases.append(entity.id)
+
+    def record_duration_load(entity: CaseDuration, _context: object) -> None:
+        loaded_durations.append(entity.id)
+
+    event.listen(Case, "load", record_case_load)
+    event.listen(CaseDuration, "load", record_duration_load)
+    try:
+        definitions = await definition_service.list_definitions()
+    finally:
+        event.remove(Case, "load", record_case_load)
+        event.remove(CaseDuration, "load", record_duration_load)
+
+    assert [item.id for item in definitions] == [definition.id]
+    assert loaded_durations == []
+    assert loaded_cases == []
+
+
+@pytest.mark.anyio
+async def test_delete_definition_uses_database_duration_cascade_without_loading(
+    session: AsyncSession,
+    svc_role,
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    definition = await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="Passive duration cascade",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CREATED,
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CLOSED,
+            ),
+        )
+    )
+    case = await cases_service.create_case(make_case_create())
+    duration = CaseDuration(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        definition_id=definition.id,
+        started_at=datetime.now(UTC) - timedelta(minutes=5),
+        ended_at=datetime.now(UTC),
+        duration=timedelta(minutes=5),
+    )
+    session.add(duration)
+    await session.commit()
+    duration_id = duration.id
+    session.expunge_all()
+
+    loaded_durations: list[uuid.UUID] = []
+
+    def record_duration_load(entity: CaseDuration, _context: object) -> None:
+        loaded_durations.append(entity.id)
+
+    event.listen(CaseDuration, "load", record_duration_load)
+    try:
+        await definition_service.delete_definition(definition.id)
+    finally:
+        event.remove(CaseDuration, "load", record_duration_load)
+
+    assert loaded_durations == []
+    assert (
+        await session.scalar(
+            select(CaseDuration.id).where(CaseDuration.id == duration_id)
+        )
+        is None
     )
 
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2170,7 +2170,8 @@ class CaseDurationDefinition(WorkspaceModel):
         "CaseDuration",
         back_populates="definition",
         cascade="all, delete",
-        lazy="selectin",
+        lazy="raise",
+        passive_deletes=True,
     )
 
 
@@ -2224,12 +2225,12 @@ class CaseDuration(WorkspaceModel):
     case: Mapped[Case] = relationship(
         "Case",
         back_populates="durations",
-        lazy="selectin",
+        lazy="raise",
     )
     definition: Mapped[CaseDurationDefinition] = relationship(
         "CaseDurationDefinition",
         back_populates="case_durations",
-        lazy="selectin",
+        lazy="raise",
     )
 
 
@@ -2338,7 +2339,8 @@ class Case(WorkspaceModel):
         "CaseDuration",
         back_populates="case",
         cascade="all, delete-orphan",
-        lazy="selectin",
+        lazy="raise",
+        passive_deletes=True,
     )
     attachments: Mapped[list[CaseAttachment]] = relationship(
         "CaseAttachment",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop implicit loading of case duration relationships to cut query overhead in case metrics and definition APIs. Relationships now require explicit loading and use database cascades for deletes.

- **Refactors**
  - Switched `lazy="selectin"` to `lazy="raise"` for `CaseDuration.case`, `CaseDuration.definition`, `CaseDurationDefinition.case_durations`, and `Case.durations`; enabled `passive_deletes=True` where cascades apply.
  - Added tests to confirm no case/duration graph loads during `list_definitions` and that `delete_definition` relies on DB cascades without loading related rows.

<sup>Written for commit d2f04063bf75bc50075c6e30a2fe7df9d9d33ca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Customer-shaped 30-request benchmark:

| | Before | After |
|---|---:|---:|
| p50 | 4.81s | 0.58s |
| Case loads | 75,030 | 30 |
| Duration loads | 75,000 | 0 |
| Connection occupancy | 132.5s | 7.9s |