### PR TITLE
fix(executor): terminate action process groups

### DIFF
--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -87,6 +87,13 @@ def temp_cache_dir():
 class TestActionRunner:
     """Tests for ActionRunner class."""
 
+    @pytest.fixture(autouse=True)
+    def mock_process_group_cleanup(self, monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+        """Keep subprocess unit tests focused on ActionRunner behavior."""
+        cleanup = AsyncMock()
+        monkeypatch.setattr(action_runner, "terminate_process_group", cleanup)
+        return cleanup
+
     @pytest.mark.anyio
     async def test_ensure_registry_environment_no_tarball(self, temp_cache_dir):
         """Test that an empty list is returned when no tarball URI provided."""
@@ -100,7 +107,11 @@ class TestActionRunner:
 
     @pytest.mark.anyio
     async def test_execute_action_timeout(
-        self, temp_cache_dir, mock_run_action_input, mock_role
+        self,
+        temp_cache_dir,
+        mock_run_action_input,
+        mock_role,
+        mock_process_group_cleanup: AsyncMock,
     ):
         """Test that action execution respects timeout."""
         runner = ActionRunner(cache_dir=temp_cache_dir)
@@ -140,7 +151,7 @@ class TestActionRunner:
 
             assert isinstance(result, ExecutorActionErrorInfo)
             assert result.type == "TimeoutError"
-            mock_proc.kill.assert_called_once()
+            mock_process_group_cleanup.assert_awaited_once_with(mock_proc)
 
     @pytest.mark.anyio
     async def test_execute_action_subprocess_crash(

--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -88,11 +88,28 @@ class TestActionRunner:
     """Tests for ActionRunner class."""
 
     @pytest.fixture(autouse=True)
-    def mock_process_group_cleanup(self, monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    def mock_process_group_communication(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> AsyncMock:
         """Keep subprocess unit tests focused on ActionRunner behavior."""
-        cleanup = AsyncMock()
-        monkeypatch.setattr(action_runner, "terminate_process_group", cleanup)
-        return cleanup
+
+        async def communicate(
+            process: asyncio.subprocess.Process,
+            *,
+            input: bytes | None = None,  # noqa: A002
+        ) -> tuple[bytes, bytes]:
+            stdout, stderr = await process.communicate(input=input)
+            assert stdout is not None
+            assert stderr is not None
+            return stdout, stderr
+
+        communication = AsyncMock(side_effect=communicate)
+        monkeypatch.setattr(
+            action_runner,
+            "communicate_and_terminate_process_group",
+            communication,
+        )
+        return communication
 
     @pytest.mark.anyio
     async def test_ensure_registry_environment_no_tarball(self, temp_cache_dir):
@@ -111,7 +128,7 @@ class TestActionRunner:
         temp_cache_dir,
         mock_run_action_input,
         mock_role,
-        mock_process_group_cleanup: AsyncMock,
+        mock_process_group_communication: AsyncMock,
     ):
         """Test that action execution respects timeout."""
         runner = ActionRunner(cache_dir=temp_cache_dir)
@@ -151,7 +168,7 @@ class TestActionRunner:
 
             assert isinstance(result, ExecutorActionErrorInfo)
             assert result.type == "TimeoutError"
-            mock_process_group_cleanup.assert_awaited_once_with(mock_proc)
+            mock_process_group_communication.assert_awaited_once()
 
     @pytest.mark.anyio
     async def test_execute_action_subprocess_crash(

--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -97,8 +97,12 @@ class TestActionRunner:
             process: asyncio.subprocess.Process,
             *,
             input: bytes | None = None,  # noqa: A002
+            timeout: float | None = None,
         ) -> tuple[bytes, bytes]:
-            stdout, stderr = await process.communicate(input=input)
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(input=input),
+                timeout=timeout,
+            )
             assert stdout is not None
             assert stderr is not None
             return stdout, stderr
@@ -106,7 +110,7 @@ class TestActionRunner:
         communication = AsyncMock(side_effect=communicate)
         monkeypatch.setattr(
             action_runner,
-            "communicate_and_terminate_process_group",
+            "communicate_process_group",
             communication,
         )
         return communication

--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -199,6 +199,45 @@ def main():
         assert result.success
         assert result.output == 42
 
+    @pytest.mark.parametrize("timeout_seconds", [0, -1])
+    @pytest.mark.anyio
+    async def test_execute_non_positive_timeout_reaps_subprocess(
+        self,
+        executor: UnsafePidExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+        timeout_seconds: int,
+    ) -> None:
+        real_create_subprocess_exec = asyncio.create_subprocess_exec
+        created_processes: list[asyncio.subprocess.Process] = []
+
+        async def pid_namespace_unavailable() -> bool:
+            return False
+
+        async def create_subprocess_exec(*args, **kwargs):
+            process = await real_create_subprocess_exec(*args, **kwargs)
+            created_processes.append(process)
+            return process
+
+        monkeypatch.setattr(
+            unsafe_pid_executor,
+            "pid_namespace_available",
+            pid_namespace_unavailable,
+        )
+        monkeypatch.setattr(
+            asyncio,
+            "create_subprocess_exec",
+            create_subprocess_exec,
+        )
+
+        with pytest.raises(SandboxTimeoutError):
+            await executor.execute(
+                script="def main(): return 42",
+                timeout_seconds=timeout_seconds,
+            )
+
+        assert len(created_processes) == 1
+        assert created_processes[0].returncode is not None
+
     @pytest.mark.anyio
     async def test_execute_kills_background_descendants_holding_output_pipes(
         self, executor: UnsafePidExecutor, tmp_path: Path

--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -61,8 +61,6 @@ def main(pid_file, wait):
     child = subprocess.Popen(
         [sys.executable, "-c", "import time; time.sleep(30)"],
         stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
     )
     Path(pid_file).write_text(str(child.pid))
     if wait:
@@ -202,13 +200,16 @@ def main():
         assert result.output == 42
 
     @pytest.mark.anyio
-    async def test_execute_kills_background_descendants_after_success(
+    async def test_execute_kills_background_descendants_holding_output_pipes(
         self, executor: UnsafePidExecutor, tmp_path: Path
     ) -> None:
         pid_file = tmp_path / "success-child.pid"
-        result = await executor.execute(
-            script=_background_process_script(),
-            inputs={"pid_file": str(pid_file), "wait": False},
+        result = await asyncio.wait_for(
+            executor.execute(
+                script=_background_process_script(),
+                inputs={"pid_file": str(pid_file), "wait": False},
+            ),
+            timeout=5,
         )
 
         assert result.success

--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -1,12 +1,67 @@
 """Tests for UnsafePidExecutor fallback mode."""
 
 import asyncio
+import contextlib
 import logging
+import os
+import signal
+from pathlib import Path
 
 import pytest
 
 from tracecat.sandbox import unsafe_pid_executor
+from tracecat.sandbox.exceptions import SandboxTimeoutError
 from tracecat.sandbox.unsafe_pid_executor import UnsafePidExecutor
+
+
+def _process_is_running(pid: int) -> bool:
+    """Return whether a process is alive, treating zombies as terminated."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+
+    stat_path = Path(f"/proc/{pid}/stat")
+    if stat_path.exists() and stat_path.read_text().split()[2] == "Z":
+        return False
+    return True
+
+
+async def _wait_for_file(path: Path) -> None:
+    for _ in range(200):
+        if path.exists():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"Timed out waiting for {path}")
+
+
+async def _wait_for_process_exit(pid: int) -> None:
+    for _ in range(200):
+        if not _process_is_running(pid):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"Process {pid} did not exit")
+
+
+def _background_process_script() -> str:
+    return """
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+def main(pid_file, wait):
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    Path(pid_file).write_text(str(child.pid))
+    if wait:
+        time.sleep(30)
+    return child.pid
+"""
 
 
 class TestUnsafePidExecutor:
@@ -121,6 +176,68 @@ def main():
         result = await executor.execute(script=script)
         assert result.success
         assert result.output == 42
+
+    @pytest.mark.anyio
+    async def test_execute_kills_background_descendants_after_success(
+        self, executor: UnsafePidExecutor, tmp_path: Path
+    ) -> None:
+        pid_file = tmp_path / "success-child.pid"
+        result = await executor.execute(
+            script=_background_process_script(),
+            inputs={"pid_file": str(pid_file), "wait": False},
+        )
+
+        assert result.success
+        child_pid = int(pid_file.read_text())
+        try:
+            await _wait_for_process_exit(child_pid)
+        finally:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(child_pid, signal.SIGKILL)
+
+    @pytest.mark.anyio
+    async def test_execute_kills_descendants_on_timeout(
+        self, executor: UnsafePidExecutor, tmp_path: Path
+    ) -> None:
+        pid_file = tmp_path / "timeout-child.pid"
+
+        with pytest.raises(SandboxTimeoutError):
+            await executor.execute(
+                script=_background_process_script(),
+                inputs={"pid_file": str(pid_file), "wait": True},
+                timeout_seconds=1,
+            )
+
+        child_pid = int(pid_file.read_text())
+        try:
+            await _wait_for_process_exit(child_pid)
+        finally:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(child_pid, signal.SIGKILL)
+
+    @pytest.mark.anyio
+    async def test_execute_kills_descendants_on_cancellation(
+        self, executor: UnsafePidExecutor, tmp_path: Path
+    ) -> None:
+        pid_file = tmp_path / "cancelled-child.pid"
+        execution = asyncio.create_task(
+            executor.execute(
+                script=_background_process_script(),
+                inputs={"pid_file": str(pid_file), "wait": True},
+                timeout_seconds=30,
+            )
+        )
+        await _wait_for_file(pid_file)
+        child_pid = int(pid_file.read_text())
+
+        execution.cancel()
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await execution
+            await _wait_for_process_exit(child_pid)
+        finally:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(child_pid, signal.SIGKILL)
 
     @pytest.mark.anyio
     async def test_execute_normalizes_non_json_leaf_values(

--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -22,7 +22,14 @@ def _process_is_running(pid: int) -> bool:
         return False
 
     stat_path = Path(f"/proc/{pid}/stat")
-    if stat_path.exists() and stat_path.read_text().split()[2] == "Z":
+    if not stat_path.exists():
+        return True
+    try:
+        stat_fields = stat_path.read_text().split()
+    except (FileNotFoundError, ProcessLookupError):
+        # The process can exit between the existence check and reading procfs.
+        return False
+    if len(stat_fields) < 3 or stat_fields[2] == "Z":
         return False
     return True
 
@@ -68,6 +75,23 @@ class TestUnsafePidExecutor:
     @pytest.fixture
     def executor(self, tmp_path) -> UnsafePidExecutor:
         return UnsafePidExecutor(cache_dir=str(tmp_path))
+
+    def test_process_probe_handles_procfs_exit_race(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def process_disappeared(
+            path: Path,
+            encoding: str | None = None,
+            errors: str | None = None,
+        ) -> str:
+            del path, encoding, errors
+            raise ProcessLookupError
+
+        monkeypatch.setattr(os, "kill", lambda *_: None)
+        monkeypatch.setattr(Path, "exists", lambda _: True)
+        monkeypatch.setattr(Path, "read_text", process_disappeared)
+
+        assert not _process_is_running(123)
 
     @pytest.mark.anyio
     async def test_build_execution_cmd_with_pid_namespace(

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -45,7 +45,7 @@ from tracecat.executor.secret_preprocessors import (
 from tracecat.logger import logger
 from tracecat.sandbox.executor import ActionSandboxConfig, NsjailExecutor
 from tracecat.sandbox.types import ResourceLimits
-from tracecat.sandbox.utils import terminate_process_group
+from tracecat.sandbox.utils import communicate_and_terminate_process_group
 from tracecat.secrets.common import apply_masks, apply_masks_object
 
 if TYPE_CHECKING:
@@ -469,34 +469,30 @@ class ActionRunner:
         )
 
         try:
-            try:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(input=input_json),
-                    timeout=timeout,
-                )
-                elapsed_ms = (time.monotonic() - start_time) * 1000
-                logger.info(
-                    "Subprocess execution completed",
-                    action=input.task.action,
-                    elapsed_ms=f"{elapsed_ms:.1f}",
-                    returncode=proc.returncode,
-                )
-            except TimeoutError:
-                logger.error(
-                    "Action execution timed out, killing subprocess",
-                    action=input.task.action,
-                    timeout=timeout,
-                )
-                return ExecutorActionErrorInfo(
-                    type="TimeoutError",
-                    message=f"Action execution timed out after {timeout}s",
-                    action_name=input.task.action,
-                    filename="<subprocess>",
-                    function="execute_action",
-                )
-        finally:
-            await terminate_process_group(proc)
-
+            stdout, stderr = await asyncio.wait_for(
+                communicate_and_terminate_process_group(proc, input=input_json),
+                timeout=timeout,
+            )
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+            logger.info(
+                "Subprocess execution completed",
+                action=input.task.action,
+                elapsed_ms=f"{elapsed_ms:.1f}",
+                returncode=proc.returncode,
+            )
+        except TimeoutError:
+            logger.error(
+                "Action execution timed out, killing subprocess",
+                action=input.task.action,
+                timeout=timeout,
+            )
+            return ExecutorActionErrorInfo(
+                type="TimeoutError",
+                message=f"Action execution timed out after {timeout}s",
+                action_name=input.task.action,
+                filename="<subprocess>",
+                function="execute_action",
+            )
         # Check for subprocess crash
         if proc.returncode != 0:
             stderr_text = apply_masks(

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -45,6 +45,7 @@ from tracecat.executor.secret_preprocessors import (
 from tracecat.logger import logger
 from tracecat.sandbox.executor import ActionSandboxConfig, NsjailExecutor
 from tracecat.sandbox.types import ResourceLimits
+from tracecat.sandbox.utils import terminate_process_group
 from tracecat.secrets.common import apply_masks, apply_masks_object
 
 if TYPE_CHECKING:
@@ -464,35 +465,37 @@ class ActionRunner:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            start_new_session=True,
         )
 
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=input_json),
-                timeout=timeout,
-            )
-            elapsed_ms = (time.monotonic() - start_time) * 1000
-            logger.info(
-                "Subprocess execution completed",
-                action=input.task.action,
-                elapsed_ms=f"{elapsed_ms:.1f}",
-                returncode=proc.returncode,
-            )
-        except TimeoutError:
-            logger.error(
-                "Action execution timed out, killing subprocess",
-                action=input.task.action,
-                timeout=timeout,
-            )
-            proc.kill()
-            await proc.wait()
-            return ExecutorActionErrorInfo(
-                type="TimeoutError",
-                message=f"Action execution timed out after {timeout}s",
-                action_name=input.task.action,
-                filename="<subprocess>",
-                function="execute_action",
-            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(input=input_json),
+                    timeout=timeout,
+                )
+                elapsed_ms = (time.monotonic() - start_time) * 1000
+                logger.info(
+                    "Subprocess execution completed",
+                    action=input.task.action,
+                    elapsed_ms=f"{elapsed_ms:.1f}",
+                    returncode=proc.returncode,
+                )
+            except TimeoutError:
+                logger.error(
+                    "Action execution timed out, killing subprocess",
+                    action=input.task.action,
+                    timeout=timeout,
+                )
+                return ExecutorActionErrorInfo(
+                    type="TimeoutError",
+                    message=f"Action execution timed out after {timeout}s",
+                    action_name=input.task.action,
+                    filename="<subprocess>",
+                    function="execute_action",
+                )
+        finally:
+            await terminate_process_group(proc)
 
         # Check for subprocess crash
         if proc.returncode != 0:

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -45,7 +45,7 @@ from tracecat.executor.secret_preprocessors import (
 from tracecat.logger import logger
 from tracecat.sandbox.executor import ActionSandboxConfig, NsjailExecutor
 from tracecat.sandbox.types import ResourceLimits
-from tracecat.sandbox.utils import communicate_and_terminate_process_group
+from tracecat.sandbox.utils import communicate_process_group
 from tracecat.secrets.common import apply_masks, apply_masks_object
 
 if TYPE_CHECKING:
@@ -469,8 +469,9 @@ class ActionRunner:
         )
 
         try:
-            stdout, stderr = await asyncio.wait_for(
-                communicate_and_terminate_process_group(proc, input=input_json),
+            stdout, stderr = await communicate_process_group(
+                proc,
+                input=input_json,
                 timeout=timeout,
             )
             elapsed_ms = (time.monotonic() - start_time) * 1000

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -29,7 +29,11 @@ from tracecat.sandbox.exceptions import (
     SandboxTimeoutError,
 )
 from tracecat.sandbox.types import SandboxResult
-from tracecat.sandbox.utils import pid_namespace_available, pid_namespace_probe_error
+from tracecat.sandbox.utils import (
+    pid_namespace_available,
+    pid_namespace_probe_error,
+    terminate_process_group,
+)
 
 module_logger = logging.getLogger(__name__)
 
@@ -469,18 +473,20 @@ class UnsafePidExecutor:
                 stderr=asyncio.subprocess.PIPE,
                 cwd=str(work_dir),
                 env=exec_env,
+                start_new_session=True,
             )
             try:
-                stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                    process.communicate(),
-                    timeout=timeout_seconds,
-                )
-            except TimeoutError as e:
-                process.kill()
-                await process.wait()
-                raise SandboxTimeoutError(
-                    f"Script execution timed out after {timeout_seconds}s"
-                ) from e
+                try:
+                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                        process.communicate(),
+                        timeout=timeout_seconds,
+                    )
+                except TimeoutError as e:
+                    raise SandboxTimeoutError(
+                        f"Script execution timed out after {timeout_seconds}s"
+                    ) from e
+            finally:
+                await terminate_process_group(process)
 
             execution_time_ms = (time.time() - start_time) * 1000
             stdout = stdout_bytes.decode("utf-8", errors="replace")

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -30,7 +30,7 @@ from tracecat.sandbox.exceptions import (
 )
 from tracecat.sandbox.types import SandboxResult
 from tracecat.sandbox.utils import (
-    communicate_and_terminate_process_group,
+    communicate_process_group,
     pid_namespace_available,
     pid_namespace_probe_error,
 )
@@ -476,8 +476,8 @@ class UnsafePidExecutor:
                 start_new_session=True,
             )
             try:
-                stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                    communicate_and_terminate_process_group(process),
+                stdout_bytes, stderr_bytes = await communicate_process_group(
+                    process,
                     timeout=timeout_seconds,
                 )
             except TimeoutError as e:

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -30,9 +30,9 @@ from tracecat.sandbox.exceptions import (
 )
 from tracecat.sandbox.types import SandboxResult
 from tracecat.sandbox.utils import (
+    communicate_and_terminate_process_group,
     pid_namespace_available,
     pid_namespace_probe_error,
-    terminate_process_group,
 )
 
 module_logger = logging.getLogger(__name__)
@@ -476,18 +476,14 @@ class UnsafePidExecutor:
                 start_new_session=True,
             )
             try:
-                try:
-                    stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                        process.communicate(),
-                        timeout=timeout_seconds,
-                    )
-                except TimeoutError as e:
-                    raise SandboxTimeoutError(
-                        f"Script execution timed out after {timeout_seconds}s"
-                    ) from e
-            finally:
-                await terminate_process_group(process)
-
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    communicate_and_terminate_process_group(process),
+                    timeout=timeout_seconds,
+                )
+            except TimeoutError as e:
+                raise SandboxTimeoutError(
+                    f"Script execution timed out after {timeout_seconds}s"
+                ) from e
             execution_time_ms = (time.time() - start_time) * 1000
             stdout = stdout_bytes.decode("utf-8", errors="replace")
             stderr = stderr_bytes.decode("utf-8", errors="replace")

--- a/tracecat/sandbox/utils.py
+++ b/tracecat/sandbox/utils.py
@@ -41,10 +41,11 @@ async def terminate_process_group(process: asyncio.subprocess.Process) -> None:
     await process.wait()
 
 
-async def communicate_and_terminate_process_group(
+async def communicate_process_group(
     process: asyncio.subprocess.Process,
     *,
     input: bytes | None = None,  # noqa: A002
+    timeout: float | None = None,
 ) -> tuple[bytes, bytes]:
     """Communicate with a process while containing its process group.
 
@@ -57,11 +58,12 @@ async def communicate_and_terminate_process_group(
     communicate_task = asyncio.create_task(process.communicate(input=input))
     group_terminated = False
     try:
-        while process.returncode is None:
-            await asyncio.sleep(_PROCESS_EXIT_POLL_INTERVAL_SECONDS)
-        await terminate_process_group(process)
-        group_terminated = True
-        stdout, stderr = await communicate_task
+        async with asyncio.timeout(timeout):
+            while process.returncode is None:
+                await asyncio.sleep(_PROCESS_EXIT_POLL_INTERVAL_SECONDS)
+            await terminate_process_group(process)
+            group_terminated = True
+            stdout, stderr = await communicate_task
     finally:
         if not group_terminated:
             await terminate_process_group(process)

--- a/tracecat/sandbox/utils.py
+++ b/tracecat/sandbox/utils.py
@@ -22,6 +22,7 @@ from tracecat.config import (
 
 _PID_NAMESPACE_AVAILABLE: bool | None = None
 _PID_NAMESPACE_PROBE_ERROR: str | None = None
+_PROCESS_EXIT_POLL_INTERVAL_SECONDS = 0.01
 
 
 async def terminate_process_group(process: asyncio.subprocess.Process) -> None:
@@ -38,6 +39,40 @@ async def terminate_process_group(process: asyncio.subprocess.Process) -> None:
         with suppress(ProcessLookupError):
             process.kill()
     await process.wait()
+
+
+async def communicate_and_terminate_process_group(
+    process: asyncio.subprocess.Process,
+    *,
+    input: bytes | None = None,  # noqa: A002
+) -> tuple[bytes, bytes]:
+    """Communicate with a process while containing its process group.
+
+    A background descendant can inherit the leader's output pipes, causing both
+    ``communicate()`` and asyncio's ``wait()`` to wait after the leader exits.
+    Polling ``returncode`` observes the leader exit independently, letting us
+    terminate the group immediately and close those pipes. Cancellation also
+    terminates the group before it propagates.
+    """
+    communicate_task = asyncio.create_task(process.communicate(input=input))
+    group_terminated = False
+    try:
+        while process.returncode is None:
+            await asyncio.sleep(_PROCESS_EXIT_POLL_INTERVAL_SECONDS)
+        await terminate_process_group(process)
+        group_terminated = True
+        stdout, stderr = await communicate_task
+    finally:
+        if not group_terminated:
+            await terminate_process_group(process)
+        if not communicate_task.done():
+            communicate_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await communicate_task
+
+    if stdout is None or stderr is None:
+        raise RuntimeError("Captured stdout and stderr are required")
+    return stdout, stderr
 
 
 def is_nsjail_available() -> bool:

--- a/tracecat/sandbox/utils.py
+++ b/tracecat/sandbox/utils.py
@@ -7,7 +7,9 @@ and agent runtime sandbox (tracecat/agent/sandbox/).
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
+import signal
 import subprocess
 from contextlib import suppress
 from pathlib import Path
@@ -20,6 +22,22 @@ from tracecat.config import (
 
 _PID_NAMESPACE_AVAILABLE: bool | None = None
 _PID_NAMESPACE_PROBE_ERROR: str | None = None
+
+
+async def terminate_process_group(process: asyncio.subprocess.Process) -> None:
+    """Kill and reap a subprocess session, including any surviving descendants.
+
+    The subprocess must have been started with ``start_new_session=True``, which
+    makes its PID the process-group ID. Calling this after normal completion is
+    intentional: a subprocess can exit while leaving background descendants
+    alive.
+    """
+    with suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGKILL)
+    if process.returncode is None:
+        with suppress(ProcessLookupError):
+            process.kill()
+    await process.wait()
 
 
 def is_nsjail_available() -> bool:


### PR DESCRIPTION
## Summary

- Start direct and unsafe action subprocesses in dedicated process sessions.
- Terminate and reap the subprocess group as soon as its leader exits, or on timeout or cancellation, before the registry-artifact lease can be released.
- Observe leader exit independently of stdout and stderr so a background descendant holding inherited pipes cannot delay cleanup.
- Share the process-group communication and cleanup logic between the direct action runner and unsafe PID executor.

This is the correctness prerequisite for #3139: active action processes must be gone before their registry-artifact lease is released and the cache entry becomes eligible for eviction.

## Scope

This contains ordinary descendants that remain in the action's process group. Deliberately detached sessions are outside the unsafe fallback's contract; full hostile-code isolation requires nsjail or PID-namespace support. Reaping orphaned grandchildren from a PID-1 worker is separate container-init hygiene because zombies cannot execute against or hold file descriptors into the leased artifact.

## Testing

- `uv run pytest tests/unit/test_registry_artifacts.py tests/unit/test_action_runner.py tests/unit/test_unsafe_pid_executor.py -q` (`58 passed`)
- Post-restack direct and unsafe PID regression suite (`31 passed`)
- Inherited-output-pipe regression repeated 20 times (`20 passed`)
- Ruff check and format clean on all changed Python files
- BasedPyright on all changed Python files (`0 errors, 0 warnings`)

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 68 | 11 |
| Tests | 215 | 2 |

## Related Issues

ENG-1568
