### PR TITLE
docs: prefer frozen slotted dataclass over NamedTuple

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,12 @@ just gen-functions
   dictionary semantics are required, prefer `TypedDict`. Any unavoidable
   untyped-dictionary exception must include a clear nearby explanation of why
   the typed alternatives are unsuitable.
+- Prefer `@dataclass(frozen=True, slots=True)` over `NamedTuple` for immutable
+  structured values. It is smaller and blocks positional/iteration access, so
+  fields stay named. Measured on this repo's CPython 3.12.8 (shallow instance
+  size): `NamedTuple` 56 bytes, `@dataclass(frozen=True, slots=True)` 48 bytes,
+  plain dataclass 344 bytes including `__dict__`. Use `NamedTuple` only when
+  tuple unpacking or tuple compatibility is actually required.
 - Never branch on exception or error-message strings to choose behavior, status
   codes, or retry policy. Use explicit exception types, machine-readable error
   codes in exception details, or structured error objects instead.


### PR DESCRIPTION
Adds a repo-wide rule preferring `@dataclass(frozen=True, slots=True)` over `NamedTuple` for immutable structured values.

Measured on this repo's CPython 3.12.8 (shallow instance size):

| Type | Shallow instance size |
| --- | --- |
| `NamedTuple` | 56 bytes |
| `@dataclass(frozen=True, slots=True)` | 48 bytes |
| Regular dataclass | 344 bytes including `__dict__` |

Beyond the size difference, the slotted frozen dataclass blocks positional and iteration access, so fields stay named at every call site. `NamedTuple` stays acceptable where tuple unpacking or tuple compatibility is actually required.

Docs only — no code paths change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented a repo-wide rule to prefer `@dataclass(frozen=True, slots=True)` over `NamedTuple` for immutable structured values to reduce instance size and keep field access named. Use `NamedTuple` only when tuple behavior is required; docs-only change.

<sup>Written for commit d1f2c60bf7d7532d5763dfc58849649188f1f3de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

