### PR TITLE
docs: require LOC breakdown table in PR bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,18 @@ just gen-functions
   re-verify.
 - Keep auto-generated PR content from cubic unless the user explicitly asks to
   remove it.
+- Include a LOC breakdown in every PR body: categorize the diff's added and
+  removed lines by kind of change, e.g.:
+  - Logic: application/backend/frontend source code.
+  - Tests: `tests/`, `frontend/**/*.test.*`, fixtures.
+  - Infra/config: `docker-compose*.yml`, `deployments/`, `.github/`, `Dockerfile*`,
+    env files, `justfile`, tool configs.
+  - Docs: `docs/`, `*.md`.
+  - Generated: lockfiles (`uv.lock`, `pnpm-lock.yaml`), generated API clients,
+    migrations produced by autogenerate.
+  Compute counts from `git diff --numstat <base>...HEAD` and render as a small
+  Markdown table with one row per category and `+` / `-` columns. Omit empty
+  categories; use judgment for files that straddle categories.
 
 ## Services and logging
 


### PR DESCRIPTION
Adds a rule to the PR description guidelines in `AGENTS.md`: every PR body must include a LOC breakdown table that categorizes the diff's added and removed lines by kind of change (Logic, Tests, Infra/config, Docs, Generated), computed from `git diff --numstat <base>...HEAD`. Empty categories are omitted and judgment is allowed for files that straddle categories.

## LOC breakdown

| Category | + | - |
|---|---|---|
| Docs | 12 | 0 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a LOC breakdown table in all PR descriptions to categorize added and removed lines by type (Logic, Tests, Infra/config, Docs, Generated). Contributors compute counts with `git diff --numstat <base>...HEAD` and include a small Markdown table (omit empty categories) to make reviews faster and clearer.

<sup>Written for commit 835779a5c3ec41db6d96c28bd9cadc181e5887c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

