### PR TITLE
fix(agent): enable deferred tool loading in the Claude runtime

### DIFF
--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -882,3 +882,133 @@ async def test_stop_closes_http_client_and_removes_socket(tmp_path: Path) -> Non
 
     assert socket_proxy._client is None
     assert not socket_path.exists()
+
+
+def _custom_provider_route() -> LLMRoute:
+    return LLMRoute(
+        base_url="https://customer-gateway.example",
+        model_provider="custom-model-provider",
+    )
+
+
+def test_direct_route_drops_anthropic_beta_header() -> None:
+    route = _custom_provider_route()
+    request = route.prepare_forward_request(
+        path="/v1/messages",
+        headers={
+            "Content-Type": "application/json",
+            "anthropic-beta": (
+                "claude-code-20250219,interleaved-thinking-2025-05-14,"
+                "advanced-tool-use-2025-11-20"
+            ),
+        },
+        body=b"{}",
+        data={},
+    )
+    assert "anthropic-beta" not in request.headers
+    assert request.headers["Content-Type"] == "application/json"
+
+
+def test_anthropic_route_preserves_beta_header() -> None:
+    route = LLMRoute(
+        base_url="https://customer-gateway.example",
+        model_provider="anthropic",
+    )
+    request = route.prepare_forward_request(
+        path="/v1/messages",
+        headers={"anthropic-beta": "advanced-tool-use-2025-11-20"},
+        body=b"{}",
+        data={},
+    )
+    assert request.headers["anthropic-beta"] == "advanced-tool-use-2025-11-20"
+
+
+def test_direct_route_forwards_tools_untouched() -> None:
+    # Tool defs flow raw, including tool-search fields like defer_loading —
+    # verified tolerated by LiteLLM and Ollama Anthropic-compat endpoints.
+    route = _custom_provider_route()
+    data = {
+        "model": "claude-4-6-sonnet",
+        "tools": [
+            {
+                "name": "mcp__tracecat-registry__core__cases__list_cases",
+                "description": "List cases",
+                "input_schema": {"type": "object"},
+                "defer_loading": True,
+            }
+        ],
+    }
+    request = route.prepare_forward_request(
+        path="/v1/messages",
+        headers={},
+        body=orjson.dumps(data),
+        data=data,
+    )
+    forwarded = orjson.loads(request.body)
+    assert forwarded["tools"] == data["tools"]
+
+
+def test_direct_route_forwards_messages_untouched() -> None:
+    # Message content is never rewritten — tool_reference blocks flow raw
+    # (verified tolerated by LiteLLM and Ollama Anthropic-compat endpoints).
+    route = _custom_provider_route()
+    data = {
+        "model": "claude-4-6-sonnet",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_01",
+                        "content": [
+                            {
+                                "type": "tool_reference",
+                                "tool_name": "mcp__tracecat-registry__core__cases__list_cases",
+                            },
+                            {"type": "text", "text": "1 result"},
+                        ],
+                    }
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+        ],
+    }
+    request = route.prepare_forward_request(
+        path="/v1/messages",
+        headers={},
+        body=orjson.dumps(data),
+        data=data,
+    )
+    forwarded = orjson.loads(request.body)
+    assert forwarded["messages"] == data["messages"]
+
+
+def test_anthropic_route_preserves_tool_reference_blocks_and_tool_fields() -> None:
+    route = LLMRoute(
+        base_url="https://customer-gateway.example",
+        model_provider="anthropic",
+    )
+    data = {
+        "model": "claude-direct",
+        "tools": [{"name": "t", "input_schema": {}, "defer_loading": True}],
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_01",
+                        "content": [{"type": "tool_reference", "tool_name": "t"}],
+                    }
+                ],
+            }
+        ],
+    }
+    request = route.prepare_forward_request(
+        path="/v1/messages",
+        headers={},
+        body=orjson.dumps(data),
+        data=data,
+    )
+    assert orjson.loads(request.body) == data

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -1224,22 +1224,15 @@ class TestClaudeAgentRuntimeRun:
         assert captured_options
         assert captured_options[0].env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "128000"
 
-    def test_disables_experimental_betas_when_subagent_uses_passthrough(
+    def test_enables_tool_search(
         self,
         sample_init_payload: RuntimeInitPayload,
     ) -> None:
-        child = SandboxSubagentConfig(
-            alias="analyst",
-            description="Use for enrichment analysis.",
-            prompt="Analyze enrichment data.",
-            config=sample_init_payload.config.model_copy(update={"passthrough": True}),
-            mcp_auth_token="child-mcp-token",
-        )
-        payload = replace(sample_init_payload, subagents=[child])
+        # Always on: the CLI would otherwise disable deferred tool loading
+        # because the socket bridge is not a first-party Anthropic host.
+        env = ClaudeAgentRuntime._sdk_env(sample_init_payload)
 
-        env = ClaudeAgentRuntime._sdk_env(payload)
-
-        assert env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "1"
+        assert env["ENABLE_TOOL_SEARCH"] == "true"
 
     @pytest.mark.anyio
     async def test_agents_toggle_adds_agent_tool_without_custom_subagents(

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -1462,10 +1462,12 @@ class ClaudeAgentRuntime:
             env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = (
                 CUSTOM_MODEL_PROVIDER_AUTO_COMPACT_WINDOW
             )
-        if payload.config.passthrough or any(
-            subagent.config.passthrough for subagent in payload.subagents
-        ):
-            env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] = "1"
+        # The CLI disables tool search (deferred tool loading) for
+        # non-first-party base URLs — ours is always the socket bridge — unless
+        # explicitly enabled. Every leg terminates at the managed LiteLLM or an
+        # Anthropic-compatible passthrough gateway; both tolerate its wire
+        # artifacts (defer_loading, tool_reference; verified on LiteLLM 1.89).
+        env["ENABLE_TOOL_SEARCH"] = "true"
         return env
 
     def _build_options(

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -77,6 +77,19 @@ _ANTHROPIC_ONLY_FIELDS = (
 )
 
 
+# Beta headers are opt-ins the model never sees; headerless requests are the
+# vanilla-client default, so the header is dropped for non-Anthropic upstreams.
+# Bodies are forwarded untouched apart from the Anthropic-only top-level fields
+# above (tool_search wire artifacts like defer_loading/tool_reference are
+# tolerated by Anthropic-compatible gateways — verified against LiteLLM and
+# Ollama).
+def _drop_anthropic_beta_header(headers: dict[str, str]) -> dict[str, str]:
+    """Remove the anthropic-beta header for non-Anthropic upstreams."""
+    return {
+        key: value for key, value in headers.items() if key.lower() != "anthropic-beta"
+    }
+
+
 def _format_timeout_duration(seconds: float) -> str:
     if seconds >= 60 and seconds % 60 == 0:
         minutes = seconds / 60
@@ -209,11 +222,14 @@ class LLMRoute:
         excluded_headers = {"host", "connection", "transfer-encoding"}
         if self.is_direct:
             excluded_headers.add("authorization")
-        return {
+        forwarded = {
             key: value
             for key, value in headers.items()
             if key.lower() not in excluded_headers
         }
+        if self._applies_provider_cleanup:
+            forwarded = _drop_anthropic_beta_header(forwarded)
+        return forwarded
 
     def forward_body_and_headers(
         self,
@@ -254,12 +270,17 @@ class LLMRoute:
         headers["Content-Length"] = str(len(body))
         return body, headers
 
+    @property
+    def _applies_provider_cleanup(self) -> bool:
+        """Whether this route rewrites requests down to the whitelisted surface."""
+        return self.local_provider_cleanup and self.model_provider != "anthropic"
+
     def _forward_data(self, data: dict[str, Any]) -> dict[str, Any] | None:
         """Return rewritten request JSON, or None when the original can pass through."""
         forward_data = dict(data)
         if self.upstream_model_name is not None:
             forward_data["model"] = self.upstream_model_name
-        if self.local_provider_cleanup and self.model_provider != "anthropic":
+        if self._applies_provider_cleanup:
             for field_name in _ANTHROPIC_ONLY_FIELDS:
                 forward_data.pop(field_name, None)
         return forward_data if forward_data != data else None


### PR DESCRIPTION
 ### Root cause (reproduced locally)
  Eager tool loading sends every MCP schema on every request — a ~90-tool preset
  produces a 150KB+ first request (~84k tokens at scale). Under the 128k
  `CLAUDE_CODE_AUTO_COMPACT_WINDOW` clamp the autocompact threshold is ~95k
  tokens, so the context floor sits at/above the threshold and every query start
  re-compacts and re-invokes — an unrecoverable loop ending only at the sandbox
  timeout. Reproduced deterministically by shrinking the window; loop signature
  matches the affected production sessions.

  ### Fix verification (wire captures)
  | Build | First request | MCP schemas sent |
  |---|---|---|
  | eager (before) | 152KB | 91/91 |
  | deferred (after) | 34KB | 0/91 + 4.8KB name list |

  The CLI loads schemas on demand via its client-side `ToolSearch` tool
  (captures show the next request containing exactly the loaded tool).
  `ENABLE_TOOL_SEARCH=true` is required — the CLI disables tool search for
  non-first-party base URLs (our socket bridge); A/B confirmed all schemas ship
  eagerly without it. The only wire artifacts are `defer_loading: true` on
`ENABLE_TOOL_SEARCH=true` is required — the CLI disables tool search for
non-first-party base URLs (our socket bridge); A/B confirmed all schemas ship
eagerly without it. The only wire artifacts are `defer_loading: true` on
loaded tool defs and `tool_reference` blocks in tool results.

### Gateway compatibility (raw artifacts, no rewriting)
Probed `/v1/messages` with realistic tool-search payloads:

| Upstream | Result |
|---|---|
| LiteLLM 1.89.1 (managed pin) → Ollama | 200, parsed + translated |
| LiteLLM 1.9x → Bedrock (Converse) | 200 |
| Ollama Anthropic-compat endpoint | 200 (incl. full beta header set) |

`anthropic-beta` headers are dropped at the socket proxy for non-Anthropic
direct routes; A/B runs with/without the header were behaviorally identical
(thinking comes from the `thinking` body param, not the header).

### End-to-end runs (live models, full agent loop)
All completed with deferred loading active, one `StructuredOutput`, zero
compaction events:
1. Passthrough → LiteLLM → Bedrock: model discovered and loaded `list_cases`
   via `ToolSearch`, executed it, emitted structured output.
2. Passthrough → Ollama (local 20B): called the deferred tool directly off the
   name list; valid structured output.
3. Managed → LiteLLM 1.89.1 → Anthropic: same flow through the managed
   gateway path.
Tip: Open the Command Palette (Cmd+Shift+P) and run "Shell Command: Install 'code' command in PATH" to enable IDE integration