### PR TITLE
fix(integrations): unblock catalog MCP OAuth setup

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
@@ -216,6 +216,25 @@ function requiresCatalogConfig(entry: PlatformMCPCatalogRead) {
   return catalogConnectionSpecs(entry).some((spec) => spec.requires_config)
 }
 
+/**
+ * Connection option one-click Connect uses for a catalog entry.
+ *
+ * The request carries no connection fields, so the backend cannot infer the
+ * recipe; naming the option the card offered avoids falling back to a catalog
+ * default that may not be the one shown. Undefined for bare-spec rows, where
+ * the default is unambiguous.
+ */
+function catalogConnectOptionId(entry: PlatformMCPCatalogRead) {
+  const options = entry.connection_options ?? []
+  if (options.length < 2) {
+    return undefined
+  }
+  const connectable = options.filter(
+    (option) => !option.connection_spec.requires_config
+  )
+  return connectable.length === 1 ? connectable[0].id : undefined
+}
+
 function isCatalogEntryConnectable(entry: PlatformMCPCatalogRead) {
   return Boolean(
     entry.connection_spec ||
@@ -318,6 +337,9 @@ export default function McpServersPage() {
       await mcpIntegrationsConnectPlatformMcpCatalog({
         workspaceId,
         catalogSlug: entry.slug,
+        requestBody: {
+          connection_option_id: catalogConnectOptionId(entry),
+        },
       }),
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: catalogQueryKey })

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -15559,6 +15559,30 @@ export const $MCPAuthType = {
   description: "Authentication type for MCP integrations.",
 } as const
 
+export const $MCPCatalogConnectRequest = {
+  properties: {
+    connection_option_id: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 80,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Connection Option Id",
+      description: "Platform MCP catalog connection option to connect",
+    },
+  },
+  type: "object",
+  title: "MCPCatalogConnectRequest",
+  description: `Request for one-click connecting a platform MCP catalog entry.
+
+Carries no connection fields, so the recipe cannot be inferred from the
+payload; the caller names the connection option it offered.`,
+} as const
+
 export const $MCPCatalogConnectResponse = {
   properties: {
     status: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -11797,6 +11797,7 @@ export const mcpIntegrationsListPlatformMcpCatalog = (
  * @param data The data for the request.
  * @param data.catalogSlug
  * @param data.workspaceId
+ * @param data.requestBody
  * @returns MCPCatalogConnectResponse Successful Response
  * @throws ApiError
  */
@@ -11810,6 +11811,8 @@ export const mcpIntegrationsConnectPlatformMcpCatalog = (
       catalog_slug: data.catalogSlug,
       workspace_id: data.workspaceId,
     },
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4798,6 +4798,19 @@ export type JoinStrategy = "any" | "all"
 export type MCPAuthType = "OAUTH2" | "CUSTOM" | "NONE"
 
 /**
+ * Request for one-click connecting a platform MCP catalog entry.
+ *
+ * Carries no connection fields, so the recipe cannot be inferred from the
+ * payload; the caller names the connection option it offered.
+ */
+export type MCPCatalogConnectRequest = {
+  /**
+   * Platform MCP catalog connection option to connect
+   */
+  connection_option_id?: string | null
+}
+
+/**
  * Response for connecting a platform MCP catalog entry.
  */
 export type MCPCatalogConnectResponse = {
@@ -13447,6 +13460,7 @@ export type McpIntegrationsListPlatformMcpCatalogResponse =
 
 export type McpIntegrationsConnectPlatformMcpCatalogData = {
   catalogSlug: string
+  requestBody?: MCPCatalogConnectRequest | null
   workspaceId: string
 }
 

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -13,13 +13,7 @@ import {
 } from "lucide-react"
 import React, { useState } from "react"
 import { type Resolver, useFieldArray, useForm } from "react-hook-form"
-import {
-  integrationsGetIntegration,
-  mcpIntegrationsConnectPlatformMcpCatalog,
-  providersCreateCustomProvider,
-} from "@/client/services.gen"
 import type {
-  MCPCatalogConnectResponse,
   MCPConnectionSpec,
   MCPHttpIntegrationCreate,
   MCPIntegrationRead,
@@ -40,7 +34,6 @@ import {
   MCP_INTEGRATION_FORM_DEFAULTS,
   type MCPIntegrationFormValues,
   missingRequiredOAuthClientCredentials,
-  normalizeOAuthClientKey,
   SERVER_TYPES,
   urlTypedStdioEnvKeys,
 } from "@/components/integrations/mcp-integration-schema"
@@ -125,27 +118,58 @@ function optionIcon(
   return spec?.server_type === "stdio" ? Server : Globe2
 }
 
+/**
+ * Whether a catalog HTTP recipe delegates its server URI to the user.
+ *
+ * Mirrors the backend resolver: a recipe declaring a `server_uri`-targeted
+ * credential (or shipping no URI) accepts any user URI.
+ */
+function serverUriIsUserSupplied(spec: MCPConnectionSpec) {
+  if (spec.server_type !== "http") {
+    return false
+  }
+  if (
+    (spec.credentials ?? []).some(
+      (credential) => credential.target === "server_uri"
+    )
+  ) {
+    return true
+  }
+  return !spec.server_uri
+}
+
+/**
+ * Best-effort catalog option id for a stored integration.
+ *
+ * The option id is not persisted, so edit mode re-derives it with the same
+ * rules the backend resolver applies; an ambiguous row resolves to "" and lets
+ * the backend bind it.
+ */
 function catalogOptionIdForIntegration(
   entry: PlatformMCPCatalogRead | null | undefined,
   integration: MCPIntegrationRead
 ) {
   const options = entry?.connection_options ?? []
-  const match = options.find((option) => {
+  const matches = options.filter((option) => {
     const spec = option.connection_spec
     if (!spec || spec.server_type !== integration.server_type) {
       return false
     }
-    if (spec.server_type === "http") {
-      return (
-        spec.auth_type === integration.auth_type &&
-        (!integration.server_uri ||
-          !("server_uri" in spec) ||
-          spec.server_uri === integration.server_uri)
-      )
+    if (spec.server_type !== "http") {
+      return true
     }
-    return true
+    if (spec.auth_type !== integration.auth_type) {
+      return false
+    }
+    if (!integration.server_uri || serverUriIsUserSupplied(spec)) {
+      return true
+    }
+    return spec.server_uri === integration.server_uri
   })
-  return match?.id ?? ""
+  if (matches.length !== 1) {
+    return ""
+  }
+  return matches[0].id
 }
 
 function catalogSpecForOption(
@@ -173,47 +197,6 @@ function hasOAuthClientConfig(spec: MCPConnectionSpec | null | undefined) {
       (credential) => credential.target === "oauth_client"
     )
   )
-}
-
-function isClientSecretKey(key: string) {
-  const normalized = normalizeOAuthClientKey(key)
-  return (
-    normalized === "client_secret" ||
-    normalized === "oauth_client_secret" ||
-    normalized.endsWith("_client_secret")
-  )
-}
-
-function isClientIdKey(key: string) {
-  const normalized = normalizeOAuthClientKey(key)
-  return (
-    normalized === "client_id" ||
-    normalized === "oauth_client_id" ||
-    normalized.endsWith("_client_id")
-  )
-}
-
-function readOAuthClientCredentials(value: string) {
-  const parsed = JSON.parse(value) as Record<string, string>
-  const entries = Object.entries(parsed)
-  const clientIdEntry =
-    entries.find(([key]) => isClientIdKey(key)) ??
-    entries.find(([key]) => !isClientSecretKey(key))
-  const clientSecretEntry = entries.find(([key]) => isClientSecretKey(key))
-  const clientId = clientIdEntry?.[1]?.trim() ?? ""
-  const clientSecret = clientSecretEntry?.[1]?.trim() ?? ""
-  if (!clientId) {
-    throw new Error("OAuth client ID is required")
-  }
-  return { clientId, clientSecret: clientSecret || undefined }
-}
-
-function catalogMcpProviderId(
-  entry: PlatformMCPCatalogRead,
-  optionId: string | null | undefined
-) {
-  const suffix = optionId ? `-${optionId}` : ""
-  return `custom_mcp_${entry.slug}${suffix}`.replace(/[^a-zA-Z0-9_]+/g, "_")
 }
 
 function CatalogEntrySummary({
@@ -809,7 +792,7 @@ export function MCPIntegrationDialog({
           await createMcpIntegration(params)
           hookHandledError = false
         } else {
-          let params: MCPHttpIntegrationCreate = {
+          const params: MCPHttpIntegrationCreate = {
             ...createBaseParams,
             server_type: "http",
             server_uri: values.server_uri?.trim() ?? "",
@@ -858,59 +841,12 @@ export function MCPIntegrationDialog({
               return
             }
             setCatalogOAuthClientIsPending(true)
-            // Without advertised endpoints, the backend does dynamic registration
-            // from the pasted credentials; otherwise create the OAuth client here.
-            let result: MCPCatalogConnectResponse
-            if (
-              !spec.oauth_authorization_endpoint ||
-              !spec.oauth_token_endpoint
-            ) {
-              hookHandledError = true
-              result = await connectMcpIntegration({
-                ...params,
-                custom_credentials: oauthClientCredentials,
-              })
-              hookHandledError = false
-            } else {
-              const { clientId, clientSecret } = readOAuthClientCredentials(
-                oauthClientCredentials
-              )
-              const provider = await providersCreateCustomProvider({
-                workspaceId,
-                requestBody: {
-                  provider_id: catalogMcpProviderId(
-                    catalogEntry,
-                    values.connection_option_id
-                  ),
-                  name: `${values.name} OAuth`,
-                  description:
-                    values.description?.trim() ||
-                    `OAuth client for ${values.name}`,
-                  grant_type: "authorization_code",
-                  authorization_endpoint: spec.oauth_authorization_endpoint,
-                  token_endpoint: spec.oauth_token_endpoint,
-                  scopes: spec.scopes ?? [],
-                  client_id: clientId,
-                  client_secret: clientSecret,
-                },
-              })
-              const oauthIntegration = await integrationsGetIntegration({
-                workspaceId,
-                providerId: provider.id,
-                grantType: "authorization_code",
-              })
-              params = {
-                ...params,
-                oauth_integration_id: oauthIntegration.id,
-              }
-              hookHandledError = true
-              await createMcpIntegration(params)
-              hookHandledError = false
-              result = await mcpIntegrationsConnectPlatformMcpCatalog({
-                workspaceId,
-                catalogSlug: catalogEntry.slug,
-              })
-            }
+            hookHandledError = true
+            const result = await connectMcpIntegration({
+              ...params,
+              custom_credentials: oauthClientCredentials,
+            })
+            hookHandledError = false
             if (result.auth_url) {
               window.location.href = result.auth_url
               return

--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -160,6 +160,14 @@
         "server_uri": "https://mcp.your-env-here.scanner.dev/v1/mcp",
         "credentials": [
           {
+            "key": "your-env-here",
+            "label": "Scanner environment",
+            "description": "Your Scanner environment slug, found in Scanner Settings under API URL, e.g. acme-prod. The MCP endpoint is https://mcp.<your-env-here>.scanner.dev/v1/mcp.",
+            "required": true,
+            "secret": false,
+            "target": "server_uri"
+          },
+          {
             "key": "Authorization",
             "label": "Scanner API key (Authorization header)",
             "description": "Scanner API key sent as the Authorization header in the form 'Bearer <api-key>'. The key needs Read and Query permissions on the indexes you want to investigate, or team-level IndexReadAny and IndexQueryAny permissions.",

--- a/tests/unit/test_mcp_catalog_resolver.py
+++ b/tests/unit/test_mcp_catalog_resolver.py
@@ -1,0 +1,234 @@
+"""Tests binding MCP connection requests to shipped catalog recipes."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tracecat.integrations.catalog.loader import (
+    get_platform_mcp_catalog_entry_by_slug,
+)
+from tracecat.integrations.catalog.resolver import (
+    CatalogConnectionError,
+    resolve_available_catalog_entry,
+    resolve_catalog_connection,
+)
+from tracecat.integrations.catalog.types import PlatformMCPCatalogEntry
+from tracecat.integrations.enums import MCPAuthType
+from tracecat.integrations.schemas import (
+    MCPConnectionOption,
+    MCPHTTPCustomConnectionSpec,
+)
+
+
+def _entry(slug: str) -> PlatformMCPCatalogEntry:
+    entry = get_platform_mcp_catalog_entry_by_slug(slug, include_private=True)
+    assert entry is not None, f"catalog entry {slug} not found"
+    return entry
+
+
+# Shipped recipe shapes: fixed vendor URI, null URI with a server_uri
+# credential, templated URI with documented path variants, and explicit
+# multi-option rows. Each regressed under exact-URI matching before.
+REAL_CATALOG_CONNECTIONS = [
+    pytest.param(
+        "slack-mcp",
+        None,
+        MCPAuthType.OAUTH2,
+        "https://mcp.slack.com/mcp",
+        id="slack-fixed-vendor-uri",
+    ),
+    pytest.param(
+        "sumo-logic-mcp",
+        None,
+        MCPAuthType.CUSTOM,
+        "https://api.us2.sumologic.com/mcp",
+        id="sumo-logic-null-recipe-uri",
+    ),
+    pytest.param(
+        "snowflake-mcp",
+        None,
+        MCPAuthType.CUSTOM,
+        "https://acme-prod.snowflakecomputing.com/api/v2/databases/db/schemas/core/mcp-servers/main",
+        id="snowflake-null-recipe-uri",
+    ),
+    pytest.param(
+        "ansible-mcp",
+        None,
+        MCPAuthType.CUSTOM,
+        "https://aap.example.com:8448",
+        id="ansible-null-recipe-uri",
+    ),
+    pytest.param(
+        "scanner-mcp",
+        None,
+        MCPAuthType.CUSTOM,
+        "https://mcp.acme-prod.scanner.dev/v1/mcp",
+        id="scanner-user-environment",
+    ),
+    pytest.param(
+        "elastic-mcp",
+        None,
+        MCPAuthType.CUSTOM,
+        "https://my-deployment.kb.us-central1.gcp.cloud.es.io/s/security/api/agent_builder/mcp",
+        id="elastic-custom-space-path",
+    ),
+    pytest.param(
+        "databricks-mcp",
+        None,
+        MCPAuthType.OAUTH2,
+        "https://dbc-1234abcd.cloud.databricks.com/api/2.0/mcp/genie",
+        id="databricks-documented-path-variant",
+    ),
+    pytest.param(
+        "freshservice-mcp",
+        "remote-oauth",
+        MCPAuthType.OAUTH2,
+        "https://acme.freshservice.com/mcp",
+        id="freshservice-oauth-option",
+    ),
+    pytest.param(
+        "freshservice-mcp",
+        "api-key",
+        MCPAuthType.CUSTOM,
+        "https://acme.freshservice.com/mcp",
+        id="freshservice-api-key-option",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("slug", "expected_option_id", "auth_type", "server_uri"), REAL_CATALOG_CONNECTIONS
+)
+def test_shipped_recipes_resolve(
+    slug: str,
+    expected_option_id: str | None,
+    auth_type: MCPAuthType,
+    server_uri: str,
+) -> None:
+    resolved = resolve_catalog_connection(
+        _entry(slug),
+        server_type="http",
+        auth_type=auth_type,
+        server_uri=server_uri,
+    )
+    assert resolved.spec.server_type == "http"
+    assert resolved.spec.auth_type == auth_type
+    if expected_option_id is not None:
+        assert resolved.option_id == expected_option_id
+
+
+def test_bare_spec_rows_get_a_stable_generated_option_id() -> None:
+    resolved = resolve_catalog_connection(
+        _entry("slack-mcp"),
+        server_type="http",
+        auth_type=MCPAuthType.OAUTH2,
+        server_uri="https://mcp.slack.com/mcp",
+    )
+    assert resolved.option_id == "http-oauth2"
+
+
+def test_fixed_vendor_uri_rejects_other_hosts() -> None:
+    with pytest.raises(CatalogConnectionError, match="server URI must be"):
+        resolve_catalog_connection(
+            _entry("slack-mcp"),
+            server_type="http",
+            auth_type=MCPAuthType.OAUTH2,
+            server_uri="https://mcp.evil.example/mcp",
+        )
+
+
+def test_fixed_vendor_uri_rejects_other_auth() -> None:
+    with pytest.raises(CatalogConnectionError, match="authentication"):
+        resolve_catalog_connection(
+            _entry("slack-mcp"),
+            server_type="http",
+            auth_type=MCPAuthType.CUSTOM,
+            server_uri="https://mcp.slack.com/mcp",
+        )
+
+
+def test_user_supplied_uri_rejects_embedded_credentials() -> None:
+    with pytest.raises(CatalogConnectionError, match="embed credentials"):
+        resolve_catalog_connection(
+            _entry("sumo-logic-mcp"),
+            server_type="http",
+            auth_type=MCPAuthType.CUSTOM,
+            server_uri="https://user:pass@api.us2.sumologic.com/mcp",
+        )
+
+
+def test_mixed_transport_row_disambiguates_by_server_type() -> None:
+    """Panther ships both a remote HTTP option and a stdio package option."""
+    entry = _entry("panther-mcp")
+    http_resolved = resolve_catalog_connection(
+        entry,
+        server_type="http",
+        auth_type=MCPAuthType.OAUTH2,
+        server_uri="https://api.acme.runpanther.net/mcp",
+    )
+    assert http_resolved.spec.server_type == "http"
+    stdio_resolved = resolve_catalog_connection(entry, server_type="stdio")
+    assert stdio_resolved.spec.server_type == "stdio"
+
+
+def test_http_request_requires_auth_and_uri() -> None:
+    with pytest.raises(CatalogConnectionError, match="required for http"):
+        resolve_catalog_connection(_entry("slack-mcp"), server_type="http")
+
+
+def test_ambiguous_recipes_are_rejected_rather_than_guessed() -> None:
+    """No shipped entry has same-shape recipes; a future one must not resolve."""
+
+    def _option(option_id: str) -> MCPConnectionOption:
+        return MCPConnectionOption(
+            id=option_id,
+            label=option_id,
+            connection_spec=MCPHTTPCustomConnectionSpec(server_uri=""),
+        )
+
+    entry = PlatformMCPCatalogEntry(
+        id=uuid.uuid4(),
+        slug="ambiguous-mcp",
+        name="Ambiguous",
+        description="Two equivalent HTTP options",
+        category="test",
+        status="available",
+        sort_key="0000:ambiguous",
+        connection_options=[_option("first"), _option("second")],
+    )
+    with pytest.raises(CatalogConnectionError, match="multiple connection options"):
+        resolve_catalog_connection(
+            entry,
+            server_type="http",
+            auth_type=MCPAuthType.CUSTOM,
+            server_uri="https://mcp.example.com/mcp",
+        )
+
+
+def test_row_without_options_is_not_connectable() -> None:
+    entry = PlatformMCPCatalogEntry(
+        id=uuid.uuid4(),
+        slug="display-only-mcp",
+        name="Display Only",
+        description="No connect recipes",
+        category="test",
+        status="available",
+        sort_key="0000:display",
+    )
+    with pytest.raises(CatalogConnectionError, match="not connectable"):
+        resolve_catalog_connection(
+            entry,
+            server_type="http",
+            auth_type=MCPAuthType.NONE,
+            server_uri="https://mcp.example.com/mcp",
+        )
+
+
+def test_resolve_available_catalog_entry_guards() -> None:
+    assert resolve_available_catalog_entry("slack-mcp").slug == "slack-mcp"
+    with pytest.raises(CatalogConnectionError, match="not found"):
+        resolve_available_catalog_entry("no-such-mcp")
+    with pytest.raises(CatalogConnectionError, match="not available"):
+        resolve_available_catalog_entry("splunk-mcp")

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -13,6 +13,7 @@ import socket
 import uuid
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -28,6 +29,7 @@ from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 from temporalio.exceptions import TerminatedError
 from temporalio.service import RPCError, RPCStatusCode
 
+import tracecat.integrations.catalog.resolver as catalog_resolver_module
 import tracecat.integrations.catalog.service as catalog_service_module
 import tracecat.integrations.router as integration_router_module
 import tracecat.integrations.service as integration_service_module
@@ -52,7 +54,12 @@ from tracecat.db.models import (
 )
 from tracecat.exceptions import EntitlementRequired
 from tracecat.integrations.catalog.loader import catalog_id_for_slug
+from tracecat.integrations.catalog.resolver import (
+    ResolvedCatalogConnection,
+    connect_options,
+)
 from tracecat.integrations.catalog.service import PlatformMCPCatalogService
+from tracecat.integrations.catalog.types import PlatformMCPCatalogEntry
 from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGrantType
 from tracecat.integrations.mcp_validation import (
     MCPConfigurationError,
@@ -177,6 +184,11 @@ def _install_catalog_entry(
         _get_entry_by_slug,
     )
     monkeypatch.setattr(
+        catalog_resolver_module,
+        "get_platform_mcp_catalog_entry_by_slug",
+        _get_entry_by_slug,
+    )
+    monkeypatch.setattr(
         integration_service_module,
         "get_platform_mcp_catalog_entries",
         _entries,
@@ -185,6 +197,17 @@ def _install_catalog_entry(
         catalog_service_module,
         "get_platform_mcp_catalog_entries",
         _entries,
+    )
+
+
+def _resolved_catalog(
+    spec: MCPConnectionSpec, *, slug: str = "test-mcp", name: str = "Test MCP"
+) -> ResolvedCatalogConnection:
+    """Wrap a bare spec into the catalog binding the service threads through."""
+    entry = _catalog_entry(slug=slug, name=name, description=name, connection_spec=spec)
+    return ResolvedCatalogConnection(
+        entry=cast(PlatformMCPCatalogEntry, entry),
+        option=connect_options(cast(PlatformMCPCatalogEntry, entry))[0],
     )
 
 
@@ -496,6 +519,90 @@ class TestMCPIntegrationCRUD:
         assert first.server_type == "http"
         assert first.server_uri == "https://mcp.example.com/mcp"
         assert first.auth_type == MCPAuthType.NONE
+
+    async def test_connect_platform_mcp_catalog_honors_requested_option(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The caller's option wins over the catalog's declared default."""
+        remote_spec = {
+            "kind": "http_none",
+            "server_type": "http",
+            "auth_type": "NONE",
+            "requires_config": False,
+            "config_fields": [],
+            "credentials": [],
+            "server_uri": "https://mcp.example.com/mcp",
+        }
+        catalog = _catalog_entry(
+            slug="two-transport-mcp",
+            name="Two Transport MCP",
+            description="Remote default with a local stdio option",
+            connection_spec=remote_spec,
+            connection_options=[
+                {
+                    "id": "remote-http",
+                    "label": "Remote",
+                    "connection_spec": remote_spec,
+                },
+                {
+                    "id": "local-stdio",
+                    "label": "Local",
+                    "connection_spec": {
+                        "kind": "stdio_none",
+                        "server_type": "stdio",
+                        "auth_type": "NONE",
+                        "requires_config": False,
+                        "config_fields": [],
+                        "credentials": [],
+                        "stdio_command": "uvx",
+                        "stdio_args": ["two-transport-mcp"],
+                        "stdio_env": [],
+                        "packages": [],
+                    },
+                },
+            ],
+            sort_key="0000:two-transport-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        result = await integration_service.connect_platform_mcp_catalog(
+            catalog_slug=catalog.slug, connection_option_id="local-stdio"
+        )
+
+        created = result.mcp_integration
+        assert created is not None
+        assert created.server_type == "stdio"
+        assert created.stdio_command == "uvx"
+
+    async def test_connect_platform_mcp_catalog_rejects_unknown_option(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An option the catalog no longer ships must not silently fall back."""
+        catalog = _catalog_entry(
+            slug="single-option-mcp",
+            name="Single Option MCP",
+            description="Bare spec catalog row",
+            connection_spec={
+                "kind": "http_none",
+                "server_type": "http",
+                "auth_type": "NONE",
+                "requires_config": False,
+                "config_fields": [],
+                "credentials": [],
+                "server_uri": "https://mcp.example.com/mcp",
+            },
+            sort_key="0000:single-option-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        with pytest.raises(ValueError, match="does not exist"):
+            await integration_service.connect_platform_mcp_catalog(
+                catalog_slug=catalog.slug, connection_option_id="gone"
+            )
 
     async def test_platform_mcp_catalog_redacts_locked_rows_without_entitlement(
         self,
@@ -970,7 +1077,7 @@ class TestMCPIntegrationCRUD:
         )
         _install_catalog_entry(monkeypatch, catalog)
 
-        with pytest.raises(ValueError, match="does not match any connection option"):
+        with pytest.raises(ValueError, match="connection option uses OAUTH2"):
             await integration_service.create_mcp_integration(
                 params=MCPHttpIntegrationCreate(
                     name=catalog.name,
@@ -1035,6 +1142,84 @@ class TestMCPIntegrationCRUD:
 
         assert created.catalog_slug == catalog.slug
         assert created.auth_type == MCPAuthType.CUSTOM
+
+    async def test_metadata_edit_survives_catalog_recipe_drift(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A drifted recipe must not block edits that leave the connection alone."""
+        spec = {
+            "kind": "http_custom",
+            "server_type": "http",
+            "auth_type": "CUSTOM",
+            "requires_config": False,
+            "config_fields": [],
+            "credentials": [],
+            "server_uri": "https://mcp.example.com/mcp",
+        }
+        catalog = _catalog_entry(
+            slug="drifting-mcp",
+            name="Drifting MCP",
+            description="Catalog row whose recipe changes after create",
+            connection_spec=spec,
+            sort_key="0003:drifting-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name=catalog.name,
+                description=catalog.description,
+                catalog_slug=catalog.slug,
+                server_uri="https://mcp.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr('{"Authorization": "Bearer test-token"}'),
+            )
+        )
+
+        # The vendor moves its endpoint; the stored row now matches no recipe.
+        _install_catalog_entry(
+            monkeypatch,
+            _catalog_entry(
+                slug="drifting-mcp",
+                name="Drifting MCP",
+                description="Catalog row whose recipe changes after create",
+                connection_spec={
+                    **spec,
+                    "server_uri": "https://mcp.example.com/v2/mcp",
+                },
+                sort_key="0003:drifting-mcp",
+            ),
+        )
+
+        # The dialog always resubmits every HTTP field, so an unchanged
+        # connection must still save.
+        renamed = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(
+                name="Renamed MCP",
+                server_type="http",
+                server_uri="https://mcp.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+            ),
+            verify_connection=False,
+        )
+        assert renamed is not None
+        assert renamed.name == "Renamed MCP"
+        assert renamed.server_uri == "https://mcp.example.com/mcp"
+
+        # Actually moving the connection still revalidates against the catalog.
+        with pytest.raises(ValueError, match="server URI must be"):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=created.id,
+                params=MCPIntegrationUpdate(
+                    server_type="http",
+                    server_uri="https://attacker.example/mcp",
+                    auth_type=MCPAuthType.CUSTOM,
+                ),
+                verify_connection=False,
+            )
 
     async def test_create_mcp_integration_rejects_coming_soon_catalog_row(
         self,
@@ -3231,8 +3416,173 @@ class TestMCPIntegrationAuthTypeSwapping:
         assert updated is not None
         assert updated.auth_type == MCPAuthType.CUSTOM
         assert updated.encrypted_headers is not None
-        # OAuth integration ID should still be set but not used
+        # Leaving OAuth must drop the grant so it can't be reused on a new URI.
+        assert updated.oauth_integration_id is None
+
+    async def test_oauth_to_custom_to_oauth_cannot_retain_grant_on_new_uri(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """Two-step auth transitions must not redirect a live token to a new host."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Test MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+
+        # Step one: leave OAuth and move the URI, omitting oauth_integration_id.
+        moved = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(
+                server_type="http",
+                server_uri="https://attacker.example/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr('{"Authorization": "Bearer token"}'),
+            ),
+        )
+        assert moved is not None
+        assert moved.oauth_integration_id is None
+
+        # Step two: back to OAuth without naming a grant must not resurrect one.
+        with pytest.raises(ValueError, match="oauth_integration_id is required"):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=created.id,
+                params=MCPIntegrationUpdate(
+                    server_type="http",
+                    server_uri="https://attacker.example/mcp",
+                    auth_type=MCPAuthType.OAUTH2,
+                ),
+            )
+
+    async def test_oauth_uri_change_requires_reauthorization(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """A retained grant may not follow the server URI to a new host."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Test MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+
+        with pytest.raises(ValueError, match="reauthorizing"):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=created.id,
+                params=MCPIntegrationUpdate(
+                    server_type="http",
+                    server_uri="https://attacker.example/mcp",
+                ),
+            )
+
+    async def test_oauth_uri_change_rejected_when_grant_is_named(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """The edit form resubmits the stored grant; that must not unlock the URI.
+
+        Verification runs against the merged config before persistence, so a
+        grant paired with a new URI would reach the new host even if the write
+        were later rolled back.
+        """
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Test MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+
+        with pytest.raises(ValueError, match="reauthorizing"):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=created.id,
+                params=MCPIntegrationUpdate(
+                    server_type="http",
+                    server_uri="https://attacker.example/mcp",
+                    auth_type=MCPAuthType.OAUTH2,
+                    oauth_integration_id=oauth_integration.id,
+                ),
+            )
+
+    async def test_oauth_metadata_edit_allowed_when_grant_is_named(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """The same resubmitted-grant payload still permits benign edits."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Test MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+
+        updated = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(
+                name="Renamed MCP",
+                server_type="http",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            ),
+        )
+
+        assert updated is not None
+        assert updated.name == "Renamed MCP"
         assert updated.oauth_integration_id == oauth_integration.id
+
+    async def test_non_oauth_target_drops_explicitly_named_grant(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """A grant named on a non-OAuth update must not survive to be reused.
+
+        Otherwise a caller launders the URI change through CUSTOM: step one
+        moves the URI while resubmitting the grant, step two switches back to
+        OAUTH2 omitting it. The URI guard sees no change on step two, so the
+        grant's bearer token reaches the new host.
+        """
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Test MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+
+        laundered = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(
+                server_type="http",
+                server_uri="https://attacker.example/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr('{"Authorization": "Bearer x"}'),
+                oauth_integration_id=oauth_integration.id,
+            ),
+        )
+
+        assert laundered is not None
+        assert laundered.oauth_integration_id is None
+
+        with pytest.raises(ValueError, match="oauth_integration_id is required"):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=created.id,
+                params=MCPIntegrationUpdate(auth_type=MCPAuthType.OAUTH2),
+            )
 
     async def test_switch_from_custom_to_none(
         self,
@@ -5320,7 +5670,7 @@ class TestMCPProviderOAuth:
                     server_uri="https://mcp.example.com/mcp",
                     auth_type=MCPAuthType.OAUTH2,
                 ),
-                catalog_spec=catalog_spec,
+                resolved_catalog=_resolved_catalog(catalog_spec),
             )
 
         assert captured_hosts == [frozenset({"app.example.com"})]
@@ -6060,7 +6410,7 @@ class TestMCPProviderOAuth:
                 server_uri="https://mcp.example.test/mcp",
                 auth_type=MCPAuthType.OAUTH2,
             ),
-            catalog_spec=catalog_spec,
+            resolved_catalog=_resolved_catalog(catalog_spec),
         )
 
         assert result.oauth_connect is not None
@@ -6142,7 +6492,7 @@ class TestMCPProviderOAuth:
                 server_uri="https://mcp.example.test/mcp",
                 auth_type=MCPAuthType.OAUTH2,
             ),
-            catalog_spec=catalog_spec,
+            resolved_catalog=_resolved_catalog(catalog_spec),
         )
         assert connect_result.oauth_connect is not None
         assert connect_result.mcp_integration is not None
@@ -6173,6 +6523,64 @@ class TestMCPProviderOAuth:
             urlparse(reconnect_result.oauth_connect.auth_url).query
         )
         assert "offline_access" in reconnect_query["scope"][0].split()
+
+    async def test_catalog_pinned_endpoints_skip_discovery(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Rows pin endpoints because their server advertises no usable metadata."""
+        await _seed_service_user(session, integration_service)
+
+        async def fail_discover(**kwargs: object) -> None:
+            raise AssertionError(f"discovery must not run for pinned rows: {kwargs}")
+
+        monkeypatch.setattr(
+            integration_service, "_discover_mcp_oauth_endpoints", fail_discover
+        )
+
+        catalog_spec = _MCP_CONNECTION_SPEC_ADAPTER.validate_python(
+            {
+                "kind": "http_oauth2",
+                "server_type": "http",
+                "auth_type": "OAUTH2",
+                "requires_config": False,
+                "config_fields": [],
+                "credentials": [
+                    {
+                        "key": "client_id",
+                        "label": "Client ID",
+                        "description": "OAuth client id",
+                        "required": True,
+                        "secret": False,
+                        "type": "string",
+                        "target": "oauth_client",
+                    }
+                ],
+                "server_uri": "https://mcp.example.test/mcp",
+                "scopes": ["read"],
+                "oauth_authorization_endpoint": "https://auth.example.test/oauth/authorize",
+                "oauth_token_endpoint": "https://auth.example.test/oauth/token",
+            }
+        )
+
+        result = await integration_service.connect_mcp_oauth_discovery(
+            params=MCPHttpIntegrationCreate(
+                name="Pinned Endpoint MCP",
+                server_uri="https://mcp.example.test/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                custom_credentials=SecretStr(
+                    '{"client_id": "pinned-client", "client_secret": "pinned-secret"}'
+                ),
+            ),
+            resolved_catalog=_resolved_catalog(catalog_spec),
+        )
+
+        assert result.oauth_connect is not None
+        parsed = urlparse(result.oauth_connect.auth_url)
+        assert parsed.hostname == "auth.example.test"
+        assert parsed.path == "/oauth/authorize"
 
     async def test_reconnect_emits_connect_log(
         self,

--- a/tracecat/integrations/catalog/resolver.py
+++ b/tracecat/integrations/catalog/resolver.py
@@ -1,0 +1,168 @@
+"""Bind MCP connection requests to platform catalog connect recipes.
+
+The platform catalog is repo-owned data; a workspace request references it by
+``catalog_slug``. This module owns the binding between such a request and the
+one connect recipe it targets, so service code never re-infers recipe identity
+from transport/auth/URI heuristics.
+
+The server URI policy is credential-driven. A recipe that declares a
+``target: "server_uri"`` credential (or ships no URI at all) delegates the
+URI to the user; a recipe with a bare literal URI is a fixed vendor endpoint
+and must match exactly. The exact match is a security boundary: a trusted
+catalog row must not be bound to an arbitrary host that would then receive
+its tokens over the MCP transport.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from tracecat.integrations.catalog.loader import (
+    get_platform_mcp_catalog_entry_by_slug,
+)
+from tracecat.integrations.catalog.types import PlatformMCPCatalogEntry
+from tracecat.integrations.enums import MCPAuthType
+from tracecat.integrations.schemas import (
+    MCPConnectionOption,
+    MCPConnectionSpec,
+    MCPHTTPCustomConnectionSpec,
+    MCPHTTPNoneConnectionSpec,
+    MCPHTTPOAuth2ConnectionSpec,
+)
+from tracecat.integrations.types import MCPServerType
+
+MCPHTTPConnectionSpec = (
+    MCPHTTPOAuth2ConnectionSpec
+    | MCPHTTPCustomConnectionSpec
+    | MCPHTTPNoneConnectionSpec
+)
+
+
+class CatalogConnectionError(ValueError):
+    """Requested connection does not bind to a catalog connect recipe."""
+
+
+@dataclass(slots=True, frozen=True)
+class ResolvedCatalogConnection:
+    """One catalog connect recipe a request has been bound to."""
+
+    entry: PlatformMCPCatalogEntry
+    option: MCPConnectionOption
+
+    @property
+    def option_id(self) -> str:
+        return self.option.id
+
+    @property
+    def spec(self) -> MCPConnectionSpec:
+        return self.option.connection_spec
+
+
+def server_uri_is_user_supplied(spec: MCPHTTPConnectionSpec) -> bool:
+    """Whether the recipe delegates the server URI to the user."""
+    if any(cred.target == "server_uri" for cred in spec.credentials):
+        return True
+    return not spec.server_uri
+
+
+def resolve_available_catalog_entry(slug: str) -> PlatformMCPCatalogEntry:
+    """Return the available catalog entry for ``slug`` or raise."""
+    entry = get_platform_mcp_catalog_entry_by_slug(slug, include_private=True)
+    if entry is None:
+        raise CatalogConnectionError("Platform MCP catalog row not found")
+    if entry.status != "available":
+        raise CatalogConnectionError(f"{entry.name} is not available to connect")
+    return entry
+
+
+def resolve_catalog_connection(
+    entry: PlatformMCPCatalogEntry,
+    *,
+    server_type: MCPServerType,
+    auth_type: MCPAuthType | None = None,
+    server_uri: str | None = None,
+) -> ResolvedCatalogConnection:
+    """Bind a requested connection to one of ``entry``'s connect recipes.
+
+    The request must satisfy exactly one recipe; ambiguity is an error rather
+    than a guess.
+    """
+    options = connect_options(entry)
+    if not options:
+        raise CatalogConnectionError(f"{entry.name} is not connectable yet")
+
+    mismatches = {
+        option.id: _spec_mismatch(
+            option.connection_spec,
+            server_type=server_type,
+            auth_type=auth_type,
+            server_uri=server_uri,
+        )
+        for option in options
+    }
+    matches = [option for option in options if mismatches[option.id] is None]
+    if not matches:
+        # A single-recipe row can report precisely what failed; multi-recipe
+        # rows fall back to the generic message rather than guessing intent.
+        if len(options) == 1:
+            raise CatalogConnectionError(f"{entry.name}: {mismatches[options[0].id]}")
+        raise CatalogConnectionError(
+            f"Requested server and auth configuration does not match any "
+            f"connection option for {entry.name}"
+        )
+    if len(matches) > 1:
+        raise CatalogConnectionError(
+            f"Requested configuration matches multiple connection options for "
+            f"{entry.name}"
+        )
+    return ResolvedCatalogConnection(entry=entry, option=matches[0])
+
+
+def connect_options(entry: PlatformMCPCatalogEntry) -> list[MCPConnectionOption]:
+    """Connect recipes on ``entry``, normalizing a bare ``connection_spec`` row."""
+    if entry.connection_options:
+        return entry.connection_options
+    spec = entry.connection_spec
+    if spec is None:
+        return []
+    return [
+        MCPConnectionOption(
+            id=f"{spec.server_type}-{spec.auth_type.lower()}",
+            label=spec.server_type.upper(),
+            docs_url=entry.docs_url,
+            connection_spec=spec,
+        )
+    ]
+
+
+def _spec_mismatch(
+    spec: MCPConnectionSpec,
+    *,
+    server_type: MCPServerType,
+    auth_type: MCPAuthType | None,
+    server_uri: str | None,
+) -> str | None:
+    """Reason the request does not satisfy ``spec``, or ``None`` if it does."""
+    if spec.server_type != server_type:
+        return f"connection option is a {spec.server_type} server"
+    if spec.server_type == "stdio":
+        # Stdio requests carry no auth discriminator; credentials ride in
+        # stdio_env and are validated separately against the catalog.
+        return None
+    if auth_type is None or not server_uri:
+        return "server URI and auth type are required for http connections"
+    if spec.auth_type != auth_type:
+        return f"connection option uses {spec.auth_type} authentication"
+    return _server_uri_mismatch(spec, server_uri=server_uri)
+
+
+def _server_uri_mismatch(spec: MCPHTTPConnectionSpec, *, server_uri: str) -> str | None:
+    if server_uri_is_user_supplied(spec):
+        parsed = urlparse(server_uri)
+        if parsed.username is not None or parsed.password is not None:
+            return "server URI must not embed credentials"
+        return None
+    if server_uri != spec.server_uri:
+        return f"server URI must be {spec.server_uri}"
+    return None

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -42,6 +42,7 @@ from tracecat.integrations.schemas import (
     IntegrationReadMinimal,
     IntegrationTestConnectionResponse,
     IntegrationUpdate,
+    MCPCatalogConnectRequest,
     MCPCatalogConnectResponse,
     MCPCatalogConnectStatus,
     MCPHttpIntegrationCreate,
@@ -1083,6 +1084,7 @@ async def connect_platform_mcp_catalog(
     role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     catalog_slug: str,
+    params: Annotated[MCPCatalogConnectRequest | None, Body()] = None,
 ) -> MCPCatalogConnectResponse:
     """Create or return a workspace MCP integration from catalog defaults."""
     if role.workspace_id is None:
@@ -1094,7 +1096,8 @@ async def connect_platform_mcp_catalog(
     svc = IntegrationService(session, role=role)
     try:
         connect_result = await svc.connect_platform_mcp_catalog(
-            catalog_slug=catalog_slug
+            catalog_slug=catalog_slug,
+            connection_option_id=params.connection_option_id if params else None,
         )
     except Exception as exc:
         _raise_mcp_connect_http_error(exc)

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -1003,6 +1003,20 @@ class MCPIntegrationTestConnectionResponse(BaseModel):
     error: str | None = None
 
 
+class MCPCatalogConnectRequest(BaseModel):
+    """Request for one-click connecting a platform MCP catalog entry.
+
+    Carries no connection fields, so the recipe cannot be inferred from the
+    payload; the caller names the connection option it offered.
+    """
+
+    connection_option_id: str | None = Field(
+        default=None,
+        max_length=80,
+        description="Platform MCP catalog connection option to connect",
+    )
+
+
 class MCPCatalogConnectResponse(BaseModel):
     """Response for connecting a platform MCP catalog entry."""
 

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -59,6 +59,13 @@ from tracecat.integrations.catalog.loader import (
     get_platform_mcp_catalog_entry_by_provider_id,
     get_platform_mcp_catalog_entry_by_slug,
 )
+from tracecat.integrations.catalog.resolver import (
+    CatalogConnectionError,
+    ResolvedCatalogConnection,
+    connect_options,
+    resolve_available_catalog_entry,
+    resolve_catalog_connection,
+)
 from tracecat.integrations.catalog.types import PlatformMCPCatalogEntry
 from tracecat.integrations.enums import (
     IntegrationStatus,
@@ -739,6 +746,39 @@ class IntegrationService(BaseWorkspaceService):
         urls.append(f"{base_url}/.well-known/oauth-authorization-server")
         return urls
 
+    @classmethod
+    def _catalog_pinned_oauth_endpoints(
+        cls,
+        catalog_spec: MCPConnectionSpec,
+        *,
+        server_uri: str,
+        oauth_resource: str | None,
+        allowed_endpoint_hosts: frozenset[str],
+    ) -> MCPOAuthDiscoveryEndpoints | None:
+        """Use a catalog row's pinned OAuth endpoints instead of discovery.
+
+        Rows pin endpoints precisely when the MCP server does not advertise
+        usable RFC 8414 metadata, so discovery would fail. DCR is unavailable
+        on this path; such rows supply OAuth client credentials.
+        """
+        if not isinstance(catalog_spec, MCPHTTPOAuth2ConnectionSpec):
+            return None
+        authorization_endpoint = catalog_spec.oauth_authorization_endpoint
+        token_endpoint = catalog_spec.oauth_token_endpoint
+        if not authorization_endpoint or not token_endpoint:
+            return None
+        return MCPOAuthDiscoveryEndpoints(
+            authorization_endpoint=cls._validate_mcp_oauth_endpoint(
+                authorization_endpoint, allowed_hosts=allowed_endpoint_hosts
+            ),
+            token_endpoint=cls._validate_mcp_oauth_endpoint(
+                token_endpoint, allowed_hosts=allowed_endpoint_hosts
+            ),
+            token_methods=[],
+            registration_endpoint=None,
+            resource=cls._mcp_resource_uri(oauth_resource or server_uri),
+        )
+
     @staticmethod
     def _validate_mcp_oauth_endpoint(
         endpoint: str,
@@ -1195,24 +1235,24 @@ class IntegrationService(BaseWorkspaceService):
         self,
         *,
         params: MCPHttpIntegrationCreate,
-        catalog_spec: MCPConnectionSpec | None = None,
+        resolved_catalog: ResolvedCatalogConnection | None = None,
         existing_mcp_integration: MCPIntegration | None = None,
     ) -> PlatformMCPCatalogConnectResult:
         if params.server_type != "http" or params.auth_type != MCPAuthType.OAUTH2:
             raise ValueError("MCP OAuth discovery requires an HTTP OAuth MCP server")
+        # Resolve the catalog binding once per request and thread it onward.
+        if resolved_catalog is None:
+            resolved_catalog = self._resolve_catalog_connection_for_create(params)
         if params.oauth_integration_id is not None:
             return PlatformMCPCatalogConnectResult(
-                mcp_integration=await self.create_mcp_integration(params=params),
+                mcp_integration=await self.create_mcp_integration(
+                    params=params, resolved_catalog=resolved_catalog
+                ),
                 created=True,
             )
 
+        catalog_spec = resolved_catalog.spec if resolved_catalog else None
         scopes: list[str] | None = None
-        if catalog_spec is None and params.catalog_slug:
-            catalog = get_platform_mcp_catalog_entry_by_slug(
-                params.catalog_slug, include_private=True
-            )
-            if catalog is not None:
-                catalog_spec = self._catalog_connection_spec(catalog)
         allowed_endpoint_hosts: frozenset[str] = frozenset()
         oauth_resource: str | None = None
         if catalog_spec is not None:
@@ -1232,7 +1272,28 @@ class IntegrationService(BaseWorkspaceService):
                 if endpoint and (hostname := urlparse(endpoint).hostname)
             )
 
-        if oauth_resource is not None:
+        registration = self._mcp_oauth_client_registration_from_credentials(
+            params=params,
+            catalog_spec=catalog_spec,
+        )
+        # Captured before DCR reassigns ``registration`` below.
+        needs_dcr = registration is None
+        # Catalog-pinned endpoints replace discovery only when registration is
+        # not needed: the catalog never pins a registration endpoint, so a DCR
+        # flow must still discover one even on a pinned row.
+        pinned_endpoints = (
+            self._catalog_pinned_oauth_endpoints(
+                catalog_spec,
+                server_uri=params.server_uri,
+                oauth_resource=oauth_resource,
+                allowed_endpoint_hosts=allowed_endpoint_hosts,
+            )
+            if catalog_spec is not None and not needs_dcr
+            else None
+        )
+        if pinned_endpoints is not None:
+            endpoints = pinned_endpoints
+        elif oauth_resource is not None:
             endpoints = await self._discover_mcp_oauth_endpoints(
                 server_uri=params.server_uri,
                 oauth_resource=oauth_resource,
@@ -1260,11 +1321,6 @@ class IntegrationService(BaseWorkspaceService):
         )
         # Prefer user-supplied OAuth client credentials; otherwise fall back to
         # dynamic client registration (DCR) against the discovered endpoint.
-        registration = self._mcp_oauth_client_registration_from_credentials(
-            params=params,
-            catalog_spec=catalog_spec,
-        )
-        used_byo_credentials = registration is not None
         if registration is None:
             if not endpoints.registration_endpoint:
                 raise ValueError(
@@ -1310,11 +1366,14 @@ class IntegrationService(BaseWorkspaceService):
             overrides: dict[str, object] = {
                 "oauth_integration_id": oauth_integration.id
             }
-            # Credentials already consumed into the OAuth client; don't persist them.
-            if used_byo_credentials:
+            # BYO credentials were consumed into the OAuth client; don't
+            # persist them on the MCP row.
+            if not needs_dcr:
                 overrides["custom_credentials"] = None
             create_params = params.model_copy(update=overrides)
-            mcp_integration = await self.create_mcp_integration(params=create_params)
+            mcp_integration = await self.create_mcp_integration(
+                params=create_params, resolved_catalog=resolved_catalog
+            )
         oauth_connect = await self._start_custom_mcp_oauth_authorization(
             integration=oauth_integration,
             server_uri=mcp_integration.server_uri or params.server_uri,
@@ -2644,60 +2703,51 @@ class IntegrationService(BaseWorkspaceService):
         result = await self.session.execute(statement)
         return result.scalars().first() is not None
 
-    async def _resolve_create_platform_mcp_catalog(
-        self, *, params: MCPIntegrationCreate
-    ) -> PlatformMCPCatalogEntry | None:
-        """Resolve the catalog row for catalog-backed create payloads."""
-        if params.catalog_slug is None:
-            return None
-
-        catalog_entry = get_platform_mcp_catalog_entry_by_slug(
-            params.catalog_slug,
-            include_private=True,
-        )
-        if catalog_entry is None:
-            raise ValueError("Platform MCP catalog row not found")
-        if catalog_entry.status != "available":
-            raise ValueError(f"{catalog_entry.name} is not available to connect")
-        matched_spec = self._match_catalog_connection_spec(
-            params=params, catalog_entry=catalog_entry
-        )
-        if matched_spec is None:
-            raise ValueError(
-                f"Requested server and auth configuration does not match any "
-                f"connection option for {catalog_entry.name}"
+    @staticmethod
+    def _resolve_catalog_connection_for_update(
+        *,
+        catalog_slug: str,
+        server_type: MCPServerType,
+        auth_type: MCPAuthType | None = None,
+        server_uri: str | None = None,
+    ) -> ResolvedCatalogConnection:
+        """Rebind a changed connection on a catalog-backed row to its recipe."""
+        entry = resolve_available_catalog_entry(catalog_slug)
+        try:
+            return resolve_catalog_connection(
+                entry,
+                server_type=server_type,
+                auth_type=auth_type,
+                server_uri=server_uri,
             )
-        self._validate_catalog_url_credentials(params=params, spec=matched_spec)
-
-        await self.require_entitlement(Entitlement.AGENT_ADDONS)
-        return catalog_entry
+        except CatalogConnectionError as exc:
+            raise CatalogConnectionError(
+                f"{exc} Disconnect and reconnect this server to pick a "
+                f"currently supported {entry.name} connection option."
+            ) from exc
 
     @staticmethod
-    def _match_catalog_connection_spec(
-        *,
+    def _resolve_catalog_connection_for_create(
         params: MCPIntegrationCreate,
-        catalog_entry: PlatformMCPCatalogEntry,
-    ) -> MCPConnectionSpec | None:
-        """Return the catalog connect recipe the create params bind to, if any.
-
-        Guards against binding an arbitrary payload to a platform catalog row
-        (e.g. an auth-less row spoofing an OAuth-only connector as connected).
-        HTTP params must match a spec's server and auth type; stdio create
-        params carry no auth type (credentials ride in ``stdio_env``), so any
-        stdio spec the row offers is accepted.
-        """
-        specs: list[MCPConnectionSpec] = []
-        if catalog_entry.connection_spec is not None:
-            specs.append(catalog_entry.connection_spec)
-        specs.extend(
-            option.connection_spec for option in catalog_entry.connection_options or []
+    ) -> ResolvedCatalogConnection | None:
+        """Bind catalog-backed create params to one catalog connect recipe."""
+        if params.catalog_slug is None:
+            return None
+        entry = resolve_available_catalog_entry(params.catalog_slug)
+        return resolve_catalog_connection(
+            entry,
+            server_type=params.server_type,
+            auth_type=(
+                params.auth_type
+                if isinstance(params, MCPHttpIntegrationCreate)
+                else None
+            ),
+            server_uri=(
+                params.server_uri
+                if isinstance(params, MCPHttpIntegrationCreate)
+                else None
+            ),
         )
-        for spec in specs:
-            if spec.server_type != params.server_type:
-                continue
-            if params.server_type == "stdio" or spec.auth_type == params.auth_type:
-                return spec
-        return None
 
     @staticmethod
     def _validate_catalog_url_credentials(
@@ -2752,22 +2802,35 @@ class IntegrationService(BaseWorkspaceService):
         )
         if catalog_entry is None:
             return
-        specs: list[MCPConnectionSpec] = []
+        specs: list[MCPConnectionSpec] = [
+            option.connection_spec for option in catalog_entry.connection_options or []
+        ]
         if catalog_entry.connection_spec is not None:
             specs.append(catalog_entry.connection_spec)
-        specs.extend(
-            option.connection_spec for option in catalog_entry.connection_options or []
-        )
         url_keys = self._stdio_env_url_keys(specs)
         if url_keys:
             validate_url_credential_values(stdio_env, url_keys)
 
     @require_scope("integration:create", "integration:read")
     async def create_mcp_integration(
-        self, *, params: MCPIntegrationCreate
+        self,
+        *,
+        params: MCPIntegrationCreate,
+        resolved_catalog: ResolvedCatalogConnection | None = None,
     ) -> MCPIntegration:
-        """Create a new MCP integration."""
-        catalog_row = await self._resolve_create_platform_mcp_catalog(params=params)
+        """Create a new MCP integration.
+
+        ``resolved_catalog`` lets a caller that already bound the request to a
+        catalog recipe pass it through, so one request resolves the catalog once.
+        """
+        if resolved_catalog is None:
+            resolved_catalog = self._resolve_catalog_connection_for_create(params)
+        if resolved_catalog is not None:
+            self._validate_catalog_url_credentials(
+                params=params, spec=resolved_catalog.spec
+            )
+            await self.require_entitlement(Entitlement.AGENT_ADDONS)
+        catalog_row = resolved_catalog.entry if resolved_catalog else None
         slug = await self._generate_mcp_integration_slug(
             name=params.name,
             requested_slug=catalog_row.slug if catalog_row else None,
@@ -2938,21 +3001,23 @@ class IntegrationService(BaseWorkspaceService):
 
     @require_scope("integration:create", "integration:read")
     async def connect_platform_mcp_catalog(
-        self, *, catalog_slug: str
+        self, *, catalog_slug: str, connection_option_id: str | None = None
     ) -> PlatformMCPCatalogConnectResult:
         """Create or return the workspace MCP row for a catalog entry.
 
         Runtime catalog recipes are the primary path. Provider-backed OAuth is
         retained as an exception/legacy fallback for rows without a generic
         connection spec.
+
+        This request carries no connection fields, so the recipe cannot be
+        inferred: the caller names the option it offered, else the catalog's
+        declared default applies.
         """
-        catalog = get_platform_mcp_catalog_entry_by_slug(
-            catalog_slug, include_private=True
+        catalog = resolve_available_catalog_entry(catalog_slug)
+        connection = self._resolve_catalog_connect_option(
+            catalog, connection_option_id=connection_option_id
         )
-        if catalog is None:
-            raise ValueError("Platform MCP catalog row not found")
-        if catalog.status != "available":
-            raise ValueError(f"{catalog.name} is not available to connect")
+        spec = connection.spec if connection else None
 
         existing = await self._get_mcp_integration_by_catalog(catalog)
         if existing is not None:
@@ -2970,7 +3035,6 @@ class IntegrationService(BaseWorkspaceService):
                     mcp_integration=existing
                 ):
                     return custom_connect
-                spec = self._catalog_connection_spec(catalog)
                 if spec and spec.server_type == "http" and existing.server_uri:
                     return await self.connect_mcp_oauth_discovery(
                         params=MCPHttpIntegrationCreate(
@@ -2982,7 +3046,7 @@ class IntegrationService(BaseWorkspaceService):
                             server_uri=existing.server_uri,
                             auth_type=MCPAuthType.OAUTH2,
                         ),
-                        catalog_spec=spec,
+                        resolved_catalog=connection,
                         existing_mcp_integration=existing,
                     )
                 if provider_connect := await self._start_catalog_provider_oauth(
@@ -2994,8 +3058,12 @@ class IntegrationService(BaseWorkspaceService):
 
         await self.require_entitlement(Entitlement.AGENT_ADDONS)
 
-        spec = self._catalog_connection_spec(catalog)
-        if spec and spec.server_type == "http" and spec.auth_type == MCPAuthType.OAUTH2:
+        if (
+            connection is not None
+            and spec is not None
+            and spec.server_type == "http"
+            and spec.auth_type == MCPAuthType.OAUTH2
+        ):
             if self._catalog_requires_user_config(spec):
                 raise ValueError(
                     f"{catalog.name} requires configuration before connect"
@@ -3010,13 +3078,15 @@ class IntegrationService(BaseWorkspaceService):
                     server_uri=spec.server_uri,
                     auth_type=MCPAuthType.OAUTH2,
                 ),
-                catalog_spec=spec,
+                resolved_catalog=connection,
             )
 
-        if spec is not None:
+        if connection is not None and spec is not None:
             params = self._catalog_connect_create_params(catalog=catalog, spec=spec)
             return PlatformMCPCatalogConnectResult(
-                mcp_integration=await self.create_mcp_integration(params=params),
+                mcp_integration=await self.create_mcp_integration(
+                    params=params, resolved_catalog=connection
+                ),
                 created=True,
             )
 
@@ -3071,7 +3141,8 @@ class IntegrationService(BaseWorkspaceService):
         # slug AND its server config matches the catalog recipe, then heal it
         # in place. The recipe check prevents a coincidentally same-named custom
         # integration from being hijacked as a platform row.
-        spec = self._catalog_connection_spec(catalog)
+        connection = self._resolve_catalog_connect_option(catalog)
+        spec = connection.spec if connection else None
         if spec is not None:
             legacy = (
                 (
@@ -3103,12 +3174,13 @@ class IntegrationService(BaseWorkspaceService):
         provider_id = catalog.provider_id
         if not provider_id:
             return None
-        provider_impl = get_provider_class(
+        mcp_provider_impl = get_provider_class(
             ProviderKey(id=provider_id, grant_type=OAuthGrantType.AUTHORIZATION_CODE)
         )
-        if provider_impl is None or not issubclass(provider_impl, MCPAuthProvider):
+        if mcp_provider_impl is None or not issubclass(
+            mcp_provider_impl, MCPAuthProvider
+        ):
             return None
-        mcp_provider_impl = cast(type[MCPAuthProvider], provider_impl)
         statement = (
             select(MCPIntegration)
             .join(
@@ -3138,11 +3210,40 @@ class IntegrationService(BaseWorkspaceService):
         )
 
     @staticmethod
-    def _catalog_connection_spec(
+    def _resolve_catalog_connect_option(
         catalog: PlatformMCPCatalogEntry,
-    ) -> MCPConnectionSpec | None:
-        """Return the validated runtime catalog connection spec."""
-        return catalog.connection_spec
+        *,
+        connection_option_id: str | None = None,
+    ) -> ResolvedCatalogConnection | None:
+        """Bind a catalog row to the recipe one-click Connect uses.
+
+        The request carries no connection fields, so the recipe is either the
+        option the caller names or the catalog's declared default.
+        """
+        options = connect_options(catalog)
+        if connection_option_id:
+            option = next(
+                (option for option in options if option.id == connection_option_id),
+                None,
+            )
+            if option is None:
+                raise CatalogConnectionError(
+                    f"Connection option {connection_option_id!r} does not exist "
+                    f"for {catalog.name}"
+                )
+            return ResolvedCatalogConnection(entry=catalog, option=option)
+
+        default_option = next(
+            (
+                option
+                for option in options
+                if option.connection_spec == catalog.connection_spec
+            ),
+            None,
+        )
+        if default_option is None:
+            return None
+        return ResolvedCatalogConnection(entry=catalog, option=default_option)
 
     @classmethod
     def _catalog_mcp_oauth_resource(cls, catalog_slug: str | None) -> str | None:
@@ -3154,10 +3255,9 @@ class IntegrationService(BaseWorkspaceService):
         )
         if catalog is None:
             return None
-        spec = cls._catalog_connection_spec(catalog)
-        if not isinstance(spec, MCPHTTPOAuth2ConnectionSpec):
+        if not isinstance(catalog.connection_spec, MCPHTTPOAuth2ConnectionSpec):
             return None
-        return spec.oauth_resource
+        return catalog.connection_spec.oauth_resource
 
     @staticmethod
     def _catalog_requires_user_config(spec: MCPConnectionSpec) -> bool:
@@ -4089,6 +4189,7 @@ class IntegrationService(BaseWorkspaceService):
         # Match the persistence semantics below: null is treated as omitted,
         # while an empty object explicitly clears the stored environment.
         stdio_env_was_provided = params.stdio_env is not None
+        target_oauth_integration_id = mcp_integration.oauth_integration_id
 
         if target_server_type == "http":
             target_server_uri = params.server_uri or mcp_integration.server_uri
@@ -4104,12 +4205,47 @@ class IntegrationService(BaseWorkspaceService):
             else:
                 target_auth_type = mcp_integration.auth_type
 
-            if oauth_integration_id_was_provided:
-                target_oauth_integration_id = params.oauth_integration_id
-            elif server_type_changed:
+            if target_auth_type != MCPAuthType.OAUTH2 or server_type_changed:
+                # Auth type decides, not field presence: a grant named on a
+                # non-OAuth update would otherwise persist and be reused when
+                # the row switches back to OAUTH2, by which point the URI guard
+                # below sees no change and lets its token reach the new host.
                 target_oauth_integration_id = None
+            elif oauth_integration_id_was_provided:
+                target_oauth_integration_id = params.oauth_integration_id
             else:
                 target_oauth_integration_id = mcp_integration.oauth_integration_id
+
+            # A grant is bound to the URI it was authorized for, so no OAuth
+            # target may carry one to a different URI -- including a grant the
+            # request names explicitly, which is what the edit form resubmits.
+            # Verification below runs before persistence, so an unauthorized
+            # pairing must be rejected here rather than rolled back after the
+            # token has already been sent.
+            if (
+                target_auth_type == MCPAuthType.OAUTH2
+                and target_oauth_integration_id is not None
+                and target_server_uri != mcp_integration.server_uri
+            ):
+                raise ValueError(
+                    "Changing the server URI of an OAuth MCP server requires "
+                    "reauthorizing. Reconnect the server to authorize the new URI."
+                )
+
+            connection_changed = (
+                target_server_uri != mcp_integration.server_uri
+                or target_auth_type != mcp_integration.auth_type
+                or target_oauth_integration_id != mcp_integration.oauth_integration_id
+            )
+            # Only revalidate against the catalog when the connection itself
+            # moved; a drifted recipe must never block a rename or timeout edit.
+            if connection_changed and mcp_integration.catalog_slug:
+                self._resolve_catalog_connection_for_update(
+                    catalog_slug=mcp_integration.catalog_slug,
+                    server_type="http",
+                    auth_type=target_auth_type,
+                    server_uri=target_server_uri,
+                )
 
             # Validate OAuth integration if auth_type is, or remains, oauth2.
             if target_auth_type == MCPAuthType.OAUTH2 and target_oauth_integration_id:
@@ -4224,12 +4360,12 @@ class IntegrationService(BaseWorkspaceService):
                 mcp_integration.oauth_integration_id = None
                 mcp_integration.encrypted_headers = None
 
-        if target_server_type == "http" and params.server_uri is not None:
-            mcp_integration.server_uri = params.server_uri.strip()
-        if target_server_type == "http" and params.auth_type is not None:
-            mcp_integration.auth_type = params.auth_type
-        if target_server_type == "http" and oauth_integration_id_was_provided:
-            mcp_integration.oauth_integration_id = params.oauth_integration_id
+        if target_server_type == "http":
+            if params.server_uri is not None:
+                mcp_integration.server_uri = params.server_uri.strip()
+            if params.auth_type is not None:
+                mcp_integration.auth_type = params.auth_type
+            mcp_integration.oauth_integration_id = target_oauth_integration_id
 
         # Update stdio-type server fields
         if target_server_type == "stdio" and params.stdio_command is not None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unblocks MCP catalog OAuth setup by moving OAuth discovery/registration to the backend and strictly binding requests to a single catalog recipe. Adds one‑click Connect support with `connection_option_id` for predictable option selection and safer updates.

- **Bug Fixes**
  - Catalog resolver picks one recipe by server type, auth, and URI policy; rejects embedded creds, ambiguous matches, and off‑vendor hosts; supports stdio and adds stable option ids for bare-spec rows.
  - OAuth: uses catalog‑pinned endpoints when present (skips discovery); otherwise discovers with host allowlists; accepts BYO client creds and falls back to DCR.
  - Updates: changing an OAuth server URI requires reauth; leaving OAuth clears the grant; a grant can’t be reused or laundered across auth changes; only revalidates against the catalog when the connection changes (metadata edits allowed if recipes drift).
  - One‑click Connect binds via `connection_option_id` or the catalog default; rejects unknown option ids. Frontend passes the option id from catalog cards and removes client‑side provider creation/OAuth parsing, using backend discovery via `connectMcpIntegration`.

<sup>Written for commit 49ecc92ddb440b7e238d8fb221ea00ff5d254564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

