### PR TITLE
feat(loadtest): add application support for capacity testing

### DIFF
--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -85,14 +85,18 @@ module "ecs" {
   workflow_artifact_retention_days              = var.workflow_artifact_retention_days
 
   # Database connection pool
-  db_max_overflow          = var.db_max_overflow
-  db_pool_size             = var.db_pool_size
-  db_pool_timeout          = var.db_pool_timeout
-  db_pool_recycle          = var.db_pool_recycle
-  db_auth_max_overflow     = var.db_auth_max_overflow
-  db_auth_pool_size        = var.db_auth_pool_size
-  db_max_overflow_executor = var.db_max_overflow_executor
-  db_pool_size_executor    = var.db_pool_size_executor
+  db_max_overflow                = var.db_max_overflow
+  db_pool_size                   = var.db_pool_size
+  db_pool_timeout                = var.db_pool_timeout
+  db_pool_recycle                = var.db_pool_recycle
+  db_auth_max_overflow           = var.db_auth_max_overflow
+  db_auth_pool_size              = var.db_auth_pool_size
+  db_max_overflow_executor       = var.db_max_overflow_executor
+  db_pool_size_executor          = var.db_pool_size_executor
+  db_auth_max_overflow_executor  = var.db_auth_max_overflow_executor
+  db_auth_pool_size_executor     = var.db_auth_pool_size_executor
+  db_max_overflow_agent_executor = var.db_max_overflow_agent_executor
+  db_pool_size_agent_executor    = var.db_pool_size_agent_executor
 
   # RDS settings
   restore_from_snapshot            = var.restore_from_snapshot

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -43,8 +43,15 @@ locals {
   }
 
   tracecat_db_configs_executor = {
-    TRACECAT__DB_MAX_OVERFLOW = var.db_max_overflow_executor
-    TRACECAT__DB_POOL_SIZE    = var.db_pool_size_executor
+    TRACECAT__DB_MAX_OVERFLOW      = var.db_max_overflow_executor
+    TRACECAT__DB_POOL_SIZE         = var.db_pool_size_executor
+    TRACECAT__DB_AUTH_MAX_OVERFLOW = var.db_auth_max_overflow_executor
+    TRACECAT__DB_AUTH_POOL_SIZE    = var.db_auth_pool_size_executor
+  }
+
+  tracecat_db_configs_agent_executor = {
+    TRACECAT__DB_MAX_OVERFLOW = var.db_max_overflow_agent_executor
+    TRACECAT__DB_POOL_SIZE    = var.db_pool_size_agent_executor
   }
 
   tracecat_common_env = {
@@ -190,7 +197,7 @@ locals {
       local.tracecat_temporal_payload_encryption_env,
       local.tracecat_blob_storage_env,
       local.tracecat_db_configs,
-      local.tracecat_db_configs_executor,
+      local.tracecat_db_configs_agent_executor,
       {
         TRACECAT__API_URL                                  = local.internal_api_url
         TRACECAT__DB_ENDPOINT                              = local.core_db_hostname

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -339,13 +339,37 @@ variable "db_auth_pool_size" {
 
 variable "db_max_overflow_executor" {
   type        = string
-  description = "The maximum number of connections to allow in the DB pool"
-  default     = "60"
+  description = "Maximum overflow connections per action-executor task"
+  default     = "0"
 }
 
 variable "db_pool_size_executor" {
   type        = string
-  description = "The size of the database connection pool"
+  description = "Main database pool size per action-executor task"
+  default     = "9"
+}
+
+variable "db_auth_max_overflow_executor" {
+  type        = string
+  description = "Maximum auth-pool overflow connections per action-executor task"
+  default     = "0"
+}
+
+variable "db_auth_pool_size_executor" {
+  type        = string
+  description = "Authentication database pool size per action-executor task"
+  default     = "5"
+}
+
+variable "db_max_overflow_agent_executor" {
+  type        = string
+  description = "Maximum overflow connections per agent-executor task"
+  default     = "60"
+}
+
+variable "db_pool_size_agent_executor" {
+  type        = string
+  description = "Main database pool size per agent-executor task"
   default     = "30"
 }
 
@@ -625,7 +649,7 @@ variable "executor_queue" {
 variable "executor_max_concurrent_activities" {
   type        = number
   description = "Max concurrent activities per executor task (TRACECAT__EXECUTOR_MAX_CONCURRENT_ACTIVITIES)."
-  default     = 16
+  default     = 8
 
   validation {
     condition     = var.executor_max_concurrent_activities > 0 && floor(var.executor_max_concurrent_activities) == var.executor_max_concurrent_activities

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -307,13 +307,37 @@ variable "db_auth_pool_size" {
 
 variable "db_max_overflow_executor" {
   type        = string
-  description = "The maximum number of connections to allow in the DB pool"
-  default     = "60"
+  description = "Maximum overflow connections per action-executor task"
+  default     = "0"
 }
 
 variable "db_pool_size_executor" {
   type        = string
-  description = "The size of the database connection pool"
+  description = "Main database pool size per action-executor task"
+  default     = "9"
+}
+
+variable "db_auth_max_overflow_executor" {
+  type        = string
+  description = "Maximum auth-pool overflow connections per action-executor task"
+  default     = "0"
+}
+
+variable "db_auth_pool_size_executor" {
+  type        = string
+  description = "Authentication database pool size per action-executor task"
+  default     = "5"
+}
+
+variable "db_max_overflow_agent_executor" {
+  type        = string
+  description = "Maximum overflow connections per agent-executor task"
+  default     = "60"
+}
+
+variable "db_pool_size_agent_executor" {
+  type        = string
+  description = "Main database pool size per agent-executor task"
   default     = "30"
 }
 
@@ -593,7 +617,7 @@ variable "executor_queue" {
 variable "executor_max_concurrent_activities" {
   type        = number
   description = "Max concurrent activities per executor task (TRACECAT__EXECUTOR_MAX_CONCURRENT_ACTIVITIES)."
-  default     = 16
+  default     = 8
 
   validation {
     condition     = var.executor_max_concurrent_activities > 0 && floor(var.executor_max_concurrent_activities) == var.executor_max_concurrent_activities

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -12828,6 +12828,24 @@ export const $EventFailure = {
       ],
       title: "Root Cause Message",
     },
+    failure_type: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Failure Type",
+    },
+    failure_types: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Failure Types",
+    },
   },
   type: "object",
   required: ["message"],
@@ -31120,6 +31138,11 @@ export const $WorkflowExecutionRead = {
       title: "History Length",
       description: "Number of events in the history",
     },
+    history_size_bytes: {
+      type: "integer",
+      title: "History Size Bytes",
+      description: "Serialized Temporal workflow history size in bytes",
+    },
     parent_wf_exec_id: {
       anyOf: [
         {
@@ -31168,6 +31191,7 @@ export const $WorkflowExecutionRead = {
     "workflow_type",
     "task_queue",
     "history_length",
+    "history_size_bytes",
     "trigger_type",
     "events",
   ],
@@ -31243,6 +31267,11 @@ export const $WorkflowExecutionReadCompact_Any_Union_AgentOutput__Any__Any_ = {
       title: "History Length",
       description: "Number of events in the history",
     },
+    history_size_bytes: {
+      type: "integer",
+      title: "History Size Bytes",
+      description: "Serialized Temporal workflow history size in bytes",
+    },
     parent_wf_exec_id: {
       anyOf: [
         {
@@ -31291,6 +31320,7 @@ export const $WorkflowExecutionReadCompact_Any_Union_AgentOutput__Any__Any_ = {
     "workflow_type",
     "task_queue",
     "history_length",
+    "history_size_bytes",
     "trigger_type",
     "events",
   ],
@@ -31366,6 +31396,11 @@ export const $WorkflowExecutionReadMinimal = {
       title: "History Length",
       description: "Number of events in the history",
     },
+    history_size_bytes: {
+      type: "integer",
+      title: "History Size Bytes",
+      description: "Serialized Temporal workflow history size in bytes",
+    },
     parent_wf_exec_id: {
       anyOf: [
         {
@@ -31398,6 +31433,7 @@ export const $WorkflowExecutionReadMinimal = {
     "workflow_type",
     "task_queue",
     "history_length",
+    "history_size_bytes",
     "trigger_type",
   ],
   title: "WorkflowExecutionReadMinimal",
@@ -32045,6 +32081,11 @@ export const $WorkflowRunReadMinimal = {
       title: "History Length",
       description: "Number of events in the history",
     },
+    history_size_bytes: {
+      type: "integer",
+      title: "History Size Bytes",
+      description: "Serialized Temporal workflow history size in bytes",
+    },
     parent_wf_exec_id: {
       anyOf: [
         {
@@ -32114,6 +32155,7 @@ export const $WorkflowRunReadMinimal = {
     "workflow_type",
     "task_queue",
     "history_length",
+    "history_size_bytes",
     "trigger_type",
   ],
   title: "WorkflowRunReadMinimal",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3793,6 +3793,8 @@ export type EventFailure = {
     [key: string]: unknown
   } | null
   root_cause_message?: string | null
+  failure_type?: string | null
+  failure_types?: Array<string>
 }
 
 export type EventGroup_TypeVar_ = {
@@ -9290,6 +9292,10 @@ export type WorkflowExecutionRead = {
    * Number of events in the history
    */
   history_length: number
+  /**
+   * Serialized Temporal workflow history size in bytes
+   */
+  history_size_bytes: number
   parent_wf_exec_id?: string | null
   trigger_type: TriggerType
   /**
@@ -9350,6 +9356,10 @@ export type WorkflowExecutionReadCompact_Any_Union_AgentOutput__Any__Any_ = {
    * Number of events in the history
    */
   history_length: number
+  /**
+   * Serialized Temporal workflow history size in bytes
+   */
+  history_size_bytes: number
   parent_wf_exec_id?: string | null
   trigger_type: TriggerType
   /**
@@ -9401,6 +9411,10 @@ export type WorkflowExecutionReadMinimal = {
    * Number of events in the history
    */
   history_length: number
+  /**
+   * Serialized Temporal workflow history size in bytes
+   */
+  history_size_bytes: number
   parent_wf_exec_id?: string | null
   trigger_type: TriggerType
   /**
@@ -9573,6 +9587,10 @@ export type WorkflowRunReadMinimal = {
    * Number of events in the history
    */
   history_length: number
+  /**
+   * Serialized Temporal workflow history size in bytes
+   */
+  history_size_bytes: number
   parent_wf_exec_id?: string | null
   trigger_type: TriggerType
   /**

--- a/frontend/tests/execution-event-history.test.tsx
+++ b/frontend/tests/execution-event-history.test.tsx
@@ -44,6 +44,7 @@ function createExecution(
     workflow_type: "DSLWorkflow",
     task_queue: "default",
     history_length: events.length,
+    history_size_bytes: 0,
     trigger_type: "manual",
     events,
     interactions: [],

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -3683,7 +3683,8 @@ def assert_error_handler_initiated_correctly(
             "message": (
                 "Workflow failed with 1 error(s)\n\n"
                 f"{'=' * 10} (1/1) ACTIONS.failing_action {'=' * 10}\n\n"
-                "ExecutionError: [ACTIONS.failing_action -> execute_action] (Attempt 1)\n\n"
+                "TracecatExpressionError: "
+                "[ACTIONS.failing_action -> execute_action] (Attempt 1)\n\n"
                 "There was an error in the executor when calling action 'core.transform.reshape'.\n\n"
                 "\n"
                 "TracecatExpressionError: Error evaluating expression `1/0`\n\n"

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -362,6 +362,7 @@ async def test_service_account_can_get_workflow_execution_by_workflow_route(
         workflow_type="DSLWorkflow",
         task_queue="tracecat-task-queue",
         history_length=0,
+        raw_info=SimpleNamespace(history_size_bytes=0),
         typed_search_attributes={},
     )
     mock_service = AsyncMock()

--- a/tests/unit/api/test_api_workflow_execution_path_ids.py
+++ b/tests/unit/api/test_api_workflow_execution_path_ids.py
@@ -718,6 +718,7 @@ async def test_get_workflow_execution_compact_accepts_slash_id(
     mock_execution.workflow_type = "DSLWorkflow"
     mock_execution.task_queue = "tracecat-task-queue"
     mock_execution.history_length = 0
+    mock_execution.raw_info.history_size_bytes = 0
     mock_execution.typed_search_attributes = {}
 
     mock_svc = AsyncMock()
@@ -742,6 +743,7 @@ async def test_get_workflow_execution_compact_accepts_slash_id(
     payload = response.json()
     assert payload["id"] == wf_exec_id
     assert payload["status"] == "RUNNING"
+    assert payload["history_size_bytes"] == 0
     mock_svc.get_execution.assert_awaited_once_with(wf_exec_id)
     mock_svc.list_workflow_execution_events_compact.assert_awaited_once_with(wf_exec_id)
 

--- a/tests/unit/test_db_engine.py
+++ b/tests/unit/test_db_engine.py
@@ -29,6 +29,7 @@ from tracecat.db.exceptions import (
     AuthPoolExhaustedError,
     DatabasePoolAcquisitionOrderError,
 )
+from tracecat.db.pool_metrics import InstrumentedAsyncAdaptedQueuePool
 
 
 class DummySecretsClient:
@@ -263,8 +264,28 @@ async def test_auth_engine_pool_size_honors_config(
         auth_pool = auth_engine.pool
         assert isinstance(pool, QueuePool)
         assert isinstance(auth_pool, QueuePool)
+        assert not isinstance(pool, InstrumentedAsyncAdaptedQueuePool)
+        assert not isinstance(auth_pool, InstrumentedAsyncAdaptedQueuePool)
         assert auth_pool.size() == 3
         assert pool.size() == 11
+    finally:
+        await engine.dispose()
+        await auth_engine.dispose()
+        reset_async_engine()
+
+
+@pytest.mark.anyio
+async def test_pool_metrics_poolclass_is_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__INTERNAL_DB_POOL_METRICS_PORT", 9091)
+    reset_async_engine()
+
+    engine = get_async_engine()
+    auth_engine = get_async_auth_engine()
+    try:
+        assert isinstance(engine.pool, InstrumentedAsyncAdaptedQueuePool)
+        assert isinstance(auth_engine.pool, InstrumentedAsyncAdaptedQueuePool)
     finally:
         await engine.dispose()
         await auth_engine.dispose()

--- a/tests/unit/test_executor_activities.py
+++ b/tests/unit/test_executor_activities.py
@@ -195,25 +195,37 @@ class TestExecuteActionActivity:
                 )
 
             app_error = exc_info.value
-            assert app_error.type == "ExecutionError"
+            assert app_error.type == error_info.type
             # Check that the error info is in the details
             assert len(app_error.details) > 0
+            detail = app_error.details[0]
+            assert isinstance(detail, ActionErrorInfo)
+            assert detail.type == ExecutionError.__name__
 
     @pytest.mark.anyio
     async def test_loop_execution_error_raises_application_error(
         self, mock_run_action_input, mock_role
     ):
         """Test that LoopExecutionError is converted to ApplicationError."""
-        # Create mock loop errors
-        error_info = ExecutorActionErrorInfo(
-            type="ValueError",
-            message="Loop iteration failed",
-            action_name="test_action",
-            filename="<test>",
-            function="test_function",
-            loop_iteration=0,
-        )
-        loop_errors = [ExecutionError(info=error_info)]
+        error_infos = [
+            ExecutorActionErrorInfo(
+                type="ValueError",
+                message="Loop iteration failed",
+                action_name="test_action",
+                filename="<test>",
+                function="test_function",
+                loop_iteration=0,
+            ),
+            ExecutorActionErrorInfo(
+                type="PoolTimeoutError",
+                message="Another loop iteration failed",
+                action_name="test_action",
+                filename="<test>",
+                function="test_function",
+                loop_iteration=1,
+            ),
+        ]
+        loop_errors = [ExecutionError(info=info) for info in error_infos]
         loop_error = LoopExecutionError(loop_errors)
 
         with (
@@ -234,7 +246,14 @@ class TestExecuteActionActivity:
                 )
 
             app_error = exc_info.value
-            assert app_error.type == "LoopExecutionError"
+            assert app_error.type == LoopExecutionError.__name__
+            detail = app_error.details[0]
+            assert isinstance(detail, ActionErrorInfo)
+            assert detail.type == LoopExecutionError.__name__
+            assert detail.children is not None
+            assert [child.type for child in detail.children] == [
+                info.type for info in error_infos
+            ]
 
     @pytest.mark.anyio
     async def test_unexpected_error_is_non_retryable(

--- a/tests/unit/test_workflow_execution_workspace_scoping.py
+++ b/tests/unit/test_workflow_execution_workspace_scoping.py
@@ -83,6 +83,7 @@ class TestWorkflowExecutionWorkspaceFiltering:
                 workflow_type="DSLWorkflow",
                 task_queue="tracecat-task-queue",
                 history_length=42,
+                raw_info=SimpleNamespace(history_size_bytes=8192),
                 parent_id=None,
                 typed_search_attributes=TypedSearchAttributes(search_attributes=[]),
             ),
@@ -95,6 +96,7 @@ class TestWorkflowExecutionWorkspaceFiltering:
         )
 
         assert run.status == WorkflowExecutionStatus.COMPLETED
+        assert run.history_size_bytes == 8192
 
     async def test_get_execution_returns_none_for_workspace_mismatch(
         self,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -20,17 +20,27 @@ from unittest.mock import AsyncMock, Mock, patch
 import orjson
 import pytest
 from pydantic import BaseModel
-from temporalio.api.enums.v1 import EventType, ParentClosePolicy, PendingActivityState
+from temporalio.api.enums.v1 import (
+    EventType,
+    ParentClosePolicy,
+    PendingActivityState,
+    TimeoutType,
+)
 from temporalio.api.failure.v1 import Failure
 from temporalio.api.history.v1 import HistoryEvent
 from temporalio.client import Client, WorkflowHandle
 from temporalio.converter import DefaultPayloadConverter
+from temporalio.exceptions import ApplicationError
 
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import Workspace
+from tracecat.dsl._converter import get_data_converter
 from tracecat.dsl.common import AgentActionMemo, ChildWorkflowMemo, DSLInput
 from tracecat.dsl.schemas import ActionStatement, RunActionInput, RunContext, StreamID
+from tracecat.dsl.types import ActionErrorInfo
+from tracecat.exceptions import ExecutionError
+from tracecat.executor.schemas import ExecutorActionErrorInfo
 from tracecat.identifiers.workflow import (
     ExecutionUUID,
     WorkflowExecutionID,
@@ -2389,6 +2399,76 @@ def test_event_failure_extract_root_cause_message_handles_empty_and_cycles() -> 
     assert result == "Top-level failure"
 
 
+@pytest.mark.parametrize(
+    ("timeout_type", "expected"),
+    [
+        (TimeoutType.TIMEOUT_TYPE_UNSPECIFIED, "TIMEOUT"),
+        (
+            TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_START,
+            "TIMEOUT_TYPE_SCHEDULE_TO_START",
+        ),
+        (TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, "TIMEOUT_TYPE_START_TO_CLOSE"),
+        (
+            TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+            "TIMEOUT_TYPE_SCHEDULE_TO_CLOSE",
+        ),
+        (TimeoutType.TIMEOUT_TYPE_HEARTBEAT, "TIMEOUT_TYPE_HEARTBEAT"),
+        (cast(TimeoutType.ValueType, 99), "TIMEOUT_TYPE_99"),
+    ],
+)
+def test_event_failure_extract_failure_type_uses_structured_temporal_info(
+    timeout_type: TimeoutType.ValueType,
+    expected: str,
+) -> None:
+    failure = Failure(message="timed out")
+    failure.timeout_failure_info.timeout_type = timeout_type
+
+    assert EventFailure.extract_failure_type(failure) == expected
+
+
+@pytest.mark.anyio
+async def test_event_failure_prefers_structured_type_over_generic_chained_cause() -> (
+    None
+):
+    executor_error = ExecutionError(
+        info=ExecutorActionErrorInfo(
+            action_name="core.table.insert_row",
+            type="PoolTimeoutError",
+            message="Pool exhausted",
+            filename="<test>",
+            function="test_action",
+        )
+    )
+    try:
+        raise ApplicationError(
+            "Action failed",
+            ActionErrorInfo(
+                ref="write_rows",
+                message="Action failed",
+                type="ExecutionError",
+            ),
+            type="PoolTimeoutError",
+        ) from executor_error
+    except ApplicationError as error:
+        decoded_error = error
+
+    failure_proto = Failure()
+    await get_data_converter(compression_enabled=False).encode_failure(
+        decoded_error,
+        failure_proto,
+    )
+    event = HistoryEvent(
+        event_id=1,
+        event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED,
+    )
+    event.activity_task_failed_event_attributes.failure.CopyFrom(failure_proto)
+
+    failure = await EventFailure.from_history_event(event)
+
+    assert failure.failure_type == "PoolTimeoutError"
+    assert failure.failure_types == ["PoolTimeoutError"]
+
+
 @pytest.mark.anyio
 async def test_event_failure_from_history_event_populates_root_cause_message() -> None:
     failure_cause = Mock()
@@ -2456,6 +2536,48 @@ async def test_event_failure_from_history_event_decodes_encoded_attribute_messag
     assert failure.message == "Outer failure with Authorization: Bearer [REDACTED]"
     assert failure.root_cause_message == "Root failure with api_key=[REDACTED]"
     assert failure.cause is None
+    assert failure.failure_type == "RootFailure"
+    assert failure.failure_types == ["RootFailure"]
+
+
+@pytest.mark.anyio
+async def test_event_failure_preserves_structured_child_failure_types() -> None:
+    decoded_error = ApplicationError(
+        "Loop execution failed",
+        ActionErrorInfo(
+            ref="write_rows",
+            message="Loop execution failed",
+            type="LoopExecutionError",
+            children=[
+                ActionErrorInfo(
+                    ref="write_rows",
+                    message="Loop iteration failed",
+                    type="PoolTimeoutError",
+                ),
+                ActionErrorInfo(
+                    ref="write_rows",
+                    message="Loop iteration failed",
+                    type="PostgresError",
+                ),
+            ],
+        ),
+        type="LoopExecutionError",
+    )
+    failure_proto = Failure()
+    await get_data_converter(compression_enabled=False).encode_failure(
+        decoded_error,
+        failure_proto,
+    )
+    event = HistoryEvent(
+        event_id=1,
+        event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED,
+    )
+    event.activity_task_failed_event_attributes.failure.CopyFrom(failure_proto)
+
+    failure = await EventFailure.from_history_event(event)
+
+    assert failure.failure_type == "LoopExecutionError"
+    assert failure.failure_types == ["PoolTimeoutError", "PostgresError"]
 
 
 @pytest.mark.anyio

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -262,6 +262,14 @@ TRACECAT__DB_AUTH_MAX_OVERFLOW = int(
     os.environ.get("TRACECAT__DB_AUTH_MAX_OVERFLOW") or 5
 )
 """The maximum number of overflow connections for the authentication pool."""
+TRACECAT__INTERNAL_DB_POOL_METRICS_PORT = int(
+    os.environ.get("TRACECAT__INTERNAL_DB_POOL_METRICS_PORT") or 0
+)
+"""Internal HTTP port for process-local SQLAlchemy pool diagnostics.
+
+This is not a supported tuning control. Diagnostic tooling may set a positive
+port to enable the endpoint; zero keeps it disabled for normal deployments.
+"""
 
 
 # === Auth config === #

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -3,7 +3,7 @@ import contextlib
 import json
 from collections.abc import AsyncGenerator
 from contextvars import ContextVar
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, NotRequired, Protocol, TypedDict
 
 import boto3
 from botocore.exceptions import ClientError
@@ -24,7 +24,13 @@ from tracecat.db.exceptions import (
     AuthPoolExhaustedError,
     DatabasePoolAcquisitionOrderError,
 )
+from tracecat.db.pool_metrics import (
+    InstrumentedAsyncAdaptedQueuePool,
+    start_pool_metrics_server,
+)
 from tracecat.db.rls import set_rls_context, set_rls_context_from_role
+
+start_pool_metrics_server(config.TRACECAT__INTERNAL_DB_POOL_METRICS_PORT)
 
 # Global so we don't create more than one engine per process.
 # Outside of being best practice, this is needed so we can properly pool
@@ -45,6 +51,23 @@ _ctx_auth_pool_session: ContextVar[AsyncSession | None] = ContextVar(
     "auth_pool_session",
     default=None,
 )
+
+
+class _PoolMetricsEngineOptions(TypedDict):
+    """Optional engine arguments used only for internal pool diagnostics."""
+
+    poolclass: NotRequired[type[InstrumentedAsyncAdaptedQueuePool]]
+    pool_metrics_name: NotRequired[str]
+
+
+def _pool_metrics_engine_options(pool_name: str) -> _PoolMetricsEngineOptions:
+    """Keep the production engine on SQLAlchemy's default pool implementation."""
+    if config.TRACECAT__INTERNAL_DB_POOL_METRICS_PORT <= 0:
+        return {}
+    return {
+        "poolclass": InstrumentedAsyncAdaptedQueuePool,
+        "pool_metrics_name": pool_name,
+    }
 
 
 class SupportsExecute(Protocol):
@@ -297,6 +320,7 @@ def _create_async_db_engine() -> AsyncEngine:
         connect_args={
             "server_settings": {"application_name": config.TRACECAT__SERVICE_NAME}
         },
+        **_pool_metrics_engine_options("main"),
     )
     event.listen(engine.sync_engine, "checkout", _guard_main_pool_checkout)
     return engine
@@ -324,6 +348,7 @@ def _create_async_auth_db_engine() -> AsyncEngine:
                 "application_name": f"{config.TRACECAT__SERVICE_NAME}-auth"
             }
         },
+        **_pool_metrics_engine_options("auth"),
     )
 
 

--- a/tracecat/db/pool_metrics.py
+++ b/tracecat/db/pool_metrics.py
@@ -1,0 +1,292 @@
+"""Low-overhead SQLAlchemy pool metrics for capacity testing.
+
+The recorder is always available to the database engine, but its HTTP endpoint
+is disabled unless ``TRACECAT__INTERNAL_DB_POOL_METRICS_PORT`` is positive.
+This keeps normal deployments unchanged while allowing diagnostic tooling to
+sample every database-owning process independently.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import threading
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Final, TypedDict
+
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.pool import AsyncAdaptedQueuePool, ConnectionPoolEntry
+
+POOL_METRICS_PATH: Final = "/db-pool-metrics"
+HOLD_STARTED_AT_KEY: Final = "tracecat_pool_metrics_hold_started_at"
+CONNECTION_SEEN_KEY: Final = "tracecat_pool_metrics_connection_seen"
+LATENCY_BUCKETS_SECONDS: Final = (
+    0.0001,
+    0.001,
+    0.005,
+    0.01,
+    0.05,
+    0.1,
+    0.5,
+    1.0,
+    5.0,
+    10.0,
+    30.0,
+)
+
+
+class LatencyMetricsSnapshot(TypedDict):
+    """Cumulative latency distribution for one process-local pool."""
+
+    count: int
+    sum_seconds: float
+    max_seconds: float
+    bucket_upper_bounds_seconds: tuple[float, ...]
+    cumulative_bucket_counts: tuple[int, ...]
+
+
+class PoolMetricsSnapshot(TypedDict):
+    """Cumulative counters and current gauges for one SQLAlchemy pool."""
+
+    pool: str
+    configured_size: int
+    configured_max_overflow: int
+    configured_timeout_seconds: float
+    checkouts_total: int
+    connections_created_total: int
+    checkout_timeouts_total: int
+    returns_total: int
+    checked_in: int
+    checked_out: int
+    overflow: int
+    checked_out_high_water: int
+    overflow_high_water: int
+    checkout_wait: LatencyMetricsSnapshot
+    connection_open: LatencyMetricsSnapshot
+    connection_hold: LatencyMetricsSnapshot
+
+
+class PoolMetricsDocument(TypedDict):
+    """JSON document served by one Tracecat service process."""
+
+    schema_version: int
+    sampled_at_unix_seconds: float
+    pools: tuple[PoolMetricsSnapshot, ...]
+
+
+class _LatencyDistribution:
+    """Thread-safe-under-parent-lock cumulative latency distribution."""
+
+    __slots__ = ("_bucket_counts", "_count", "_max_seconds", "_sum_seconds")
+
+    def __init__(self) -> None:
+        self._count = 0
+        self._sum_seconds = 0.0
+        self._max_seconds = 0.0
+        self._bucket_counts = [0] * len(LATENCY_BUCKETS_SECONDS)
+
+    def observe(self, seconds: float) -> None:
+        duration = max(0.0, seconds)
+        self._count += 1
+        self._sum_seconds += duration
+        self._max_seconds = max(self._max_seconds, duration)
+        for index, upper_bound in enumerate(LATENCY_BUCKETS_SECONDS):
+            if duration <= upper_bound:
+                self._bucket_counts[index] += 1
+
+    def snapshot(self) -> LatencyMetricsSnapshot:
+        return LatencyMetricsSnapshot(
+            count=self._count,
+            sum_seconds=self._sum_seconds,
+            max_seconds=self._max_seconds,
+            bucket_upper_bounds_seconds=LATENCY_BUCKETS_SECONDS,
+            cumulative_bucket_counts=tuple(self._bucket_counts),
+        )
+
+
+class PoolMetricsRecorder:
+    """Accumulate checkout and hold measurements for one SQLAlchemy pool."""
+
+    __slots__ = (
+        "_checkout_timeouts_total",
+        "_checkout_wait",
+        "_checkouts_total",
+        "_connection_open",
+        "_connections_created_total",
+        "_connection_hold",
+        "_lock",
+        "_pool",
+        "_pool_name",
+        "_returns_total",
+        "_checked_out_high_water",
+        "_overflow_high_water",
+    )
+
+    def __init__(self, pool_name: str, pool: InstrumentedAsyncAdaptedQueuePool) -> None:
+        self._pool_name = pool_name
+        self._pool = pool
+        self._lock = threading.Lock()
+        self._checkouts_total = 0
+        self._connections_created_total = 0
+        self._checkout_timeouts_total = 0
+        self._returns_total = 0
+        self._checked_out_high_water = 0
+        self._overflow_high_water = 0
+        self._checkout_wait = _LatencyDistribution()
+        self._connection_open = _LatencyDistribution()
+        self._connection_hold = _LatencyDistribution()
+
+    def record_checkout(self, acquisition_seconds: float, *, created: bool) -> None:
+        with self._lock:
+            self._checkouts_total += 1
+            if created:
+                self._connections_created_total += 1
+                self._connection_open.observe(acquisition_seconds)
+            else:
+                self._checkout_wait.observe(acquisition_seconds)
+            self._checked_out_high_water = max(
+                self._checked_out_high_water,
+                self._pool.checkedout(),
+            )
+            self._overflow_high_water = max(
+                self._overflow_high_water,
+                max(0, self._pool.overflow()),
+            )
+
+    def record_checkout_timeout(self, wait_seconds: float) -> None:
+        with self._lock:
+            self._checkout_timeouts_total += 1
+            self._checkout_wait.observe(wait_seconds)
+
+    def record_return(self, hold_seconds: float | None) -> None:
+        with self._lock:
+            self._returns_total += 1
+            if hold_seconds is not None and math.isfinite(hold_seconds):
+                self._connection_hold.observe(hold_seconds)
+
+    def snapshot(self) -> PoolMetricsSnapshot:
+        with self._lock:
+            return PoolMetricsSnapshot(
+                pool=self._pool_name,
+                configured_size=self._pool.size(),
+                configured_max_overflow=self._pool._max_overflow,
+                configured_timeout_seconds=self._pool.timeout(),
+                checkouts_total=self._checkouts_total,
+                connections_created_total=self._connections_created_total,
+                checkout_timeouts_total=self._checkout_timeouts_total,
+                returns_total=self._returns_total,
+                checked_in=self._pool.checkedin(),
+                checked_out=self._pool.checkedout(),
+                overflow=max(0, self._pool.overflow()),
+                checked_out_high_water=self._checked_out_high_water,
+                overflow_high_water=self._overflow_high_water,
+                checkout_wait=self._checkout_wait.snapshot(),
+                connection_open=self._connection_open.snapshot(),
+                connection_hold=self._connection_hold.snapshot(),
+            )
+
+
+_registry_lock = threading.Lock()
+_recorders: dict[str, PoolMetricsRecorder] = {}
+_server_lock = threading.Lock()
+_server: ThreadingHTTPServer | None = None
+
+
+class InstrumentedAsyncAdaptedQueuePool(AsyncAdaptedQueuePool):
+    """Async queue pool that records wait, timeout, occupancy, and hold metrics."""
+
+    def __init__(
+        self,
+        creator: Any,
+        pool_size: int = 5,
+        max_overflow: int = 10,
+        timeout: float = 30.0,
+        use_lifo: bool = False,
+        pool_metrics_name: str = "main",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            creator,
+            pool_size=pool_size,
+            max_overflow=max_overflow,
+            timeout=timeout,
+            use_lifo=use_lifo,
+            **kwargs,
+        )
+        self._metrics = PoolMetricsRecorder(pool_metrics_name, self)
+        with _registry_lock:
+            _recorders[pool_metrics_name] = self._metrics
+
+    def _do_get(self) -> ConnectionPoolEntry:
+        started_at = time.monotonic()
+        try:
+            record = super()._do_get()
+        except SQLAlchemyTimeoutError:
+            self._metrics.record_checkout_timeout(time.monotonic() - started_at)
+            raise
+        created = not bool(record.info.get(CONNECTION_SEEN_KEY))
+        record.info[CONNECTION_SEEN_KEY] = True
+        self._metrics.record_checkout(
+            time.monotonic() - started_at,
+            created=created,
+        )
+        record.info[HOLD_STARTED_AT_KEY] = time.monotonic()
+        return record
+
+    def _do_return_conn(self, record: ConnectionPoolEntry) -> None:
+        started_at = record.info.pop(HOLD_STARTED_AT_KEY, None)
+        hold_seconds = (
+            time.monotonic() - started_at if isinstance(started_at, float) else None
+        )
+        self._metrics.record_return(hold_seconds)
+        super()._do_return_conn(record)
+
+
+def pool_metrics_document() -> PoolMetricsDocument:
+    """Return a consistent process-local snapshot for the collector."""
+    with _registry_lock:
+        recorders = tuple(_recorders.values())
+    return PoolMetricsDocument(
+        schema_version=2,
+        sampled_at_unix_seconds=time.time(),
+        pools=tuple(recorder.snapshot() for recorder in recorders),
+    )
+
+
+class _PoolMetricsRequestHandler(BaseHTTPRequestHandler):
+    """Serve the process-local pool snapshot without application dependencies."""
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        if self.path != POOL_METRICS_PATH:
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        payload = json.dumps(pool_metrics_document(), separators=(",", ":")).encode()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress per-scrape access logs during benchmarks."""
+        del format, args
+
+
+def start_pool_metrics_server(port: int) -> None:
+    """Start the load-test-only metrics endpoint once in this process."""
+    global _server
+    if port <= 0:
+        return
+    with _server_lock:
+        if _server is not None:
+            return
+        server = ThreadingHTTPServer(("0.0.0.0", port), _PoolMetricsRequestHandler)
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name="tracecat-db-pool-metrics",
+            daemon=True,
+        )
+        thread.start()
+        _server = server

--- a/tracecat/executor/activities.py
+++ b/tracecat/executor/activities.py
@@ -209,6 +209,7 @@ class ExecutorActivities:
         except ExecutionError as e:
             # ExecutionError from dispatch_action (single action failure)
             kind = e.__class__.__name__
+            failure_type = e.info.type
             msg = str(e)
             log.info("Execution error", error=msg, info=e.info)
             err_info = ActionErrorInfo(
@@ -219,7 +220,7 @@ class ExecutorActivities:
                 stream_id=input.stream_id,
             )
             err_msg = err_info.format("execute_action")
-            raise ApplicationError(err_msg, err_info, type=kind) from e
+            raise ApplicationError(err_msg, err_info, type=failure_type) from e
         except LoopExecutionError as e:
             # LoopExecutionError from dispatch_action (for_each loop failure)
             kind = e.__class__.__name__
@@ -231,6 +232,21 @@ class ExecutorActivities:
                 type=kind,
                 attempt=act_attempt,
                 stream_id=input.stream_id,
+                children=[
+                    ActionErrorInfo(
+                        ref=task.ref,
+                        message=(
+                            f"Loop iteration {loop_error.info.loop_iteration} failed"
+                            if loop_error.info.loop_iteration is not None
+                            else "Loop iteration failed"
+                        ),
+                        type=loop_error.info.type,
+                        attempt=act_attempt,
+                        stream_id=input.stream_id,
+                    )
+                    for loop_error in e.loop_errors
+                ]
+                or None,
             )
             err_msg = err_info.format("execute_action")
             raise ApplicationError(err_msg, err_info, type=kind) from e

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -627,6 +627,7 @@ async def _get_workflow_execution_response(
         workflow_type=execution.workflow_type,
         task_queue=execution.task_queue,
         history_length=execution.history_length,
+        history_size_bytes=execution.raw_info.history_size_bytes,
         events=events,
         interactions=interactions,
         trigger_type=get_trigger_type_from_search_attr(
@@ -728,6 +729,7 @@ async def get_workflow_execution_compact(
         workflow_type=execution.workflow_type,
         task_queue=execution.task_queue,
         history_length=execution.history_length,
+        history_size_bytes=execution.raw_info.history_size_bytes,
         events=compact_events,
         interactions=interactions,
         trigger_type=get_trigger_type_from_search_attr(

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -23,6 +23,7 @@ from pydantic import (
     Field,
     PlainSerializer,
     PrivateAttr,
+    ValidationError,
     model_validator,
 )
 from temporalio.api.failure.v1 import Failure
@@ -48,6 +49,7 @@ from tracecat.dsl.schemas import (
     StreamID,
     TriggerInputs,
 )
+from tracecat.dsl.types import ActionErrorInfoAdapter
 from tracecat.ee.interactions.schemas import (
     InteractionInput,
     InteractionRead,
@@ -75,6 +77,9 @@ from tracecat.workflow.executions.enums import (
 from tracecat.workflow.management.schemas import GetWorkflowDefinitionActivityInputs
 
 _ERROR_MESSAGE_MAX_LENGTH = 2048
+_GENERIC_APPLICATION_FAILURE_TYPES = frozenset(
+    {"APPLICATION", "ApplicationError", "ExecutionError"}
+)
 _SENSITIVE_ERROR_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(r"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+"),
@@ -150,6 +155,9 @@ class WorkflowExecutionBase(BaseModel):
     workflow_type: str
     task_queue: str
     history_length: int = Field(..., description="Number of events in the history")
+    history_size_bytes: int = Field(
+        ..., description="Serialized Temporal workflow history size in bytes"
+    )
     parent_wf_exec_id: WorkflowExecutionID | None = None
     trigger_type: TriggerType
     execution_type: ExecutionType = Field(
@@ -171,6 +179,7 @@ class WorkflowExecutionReadMinimal(WorkflowExecutionBase):
             workflow_type=execution.workflow_type,
             task_queue=execution.task_queue,
             history_length=execution.history_length,
+            history_size_bytes=execution.raw_info.history_size_bytes,
             parent_wf_exec_id=execution.parent_id,
             trigger_type=get_trigger_type_from_search_attr(
                 execution.typed_search_attributes, execution.id
@@ -216,6 +225,7 @@ class WorkflowRunReadMinimal(WorkflowExecutionReadMinimal):
             workflow_type=base.workflow_type,
             task_queue=base.task_queue,
             history_length=base.history_length,
+            history_size_bytes=base.history_size_bytes,
             parent_wf_exec_id=base.parent_wf_exec_id,
             trigger_type=base.trigger_type,
             execution_type=base.execution_type,
@@ -610,21 +620,12 @@ class EventFailure(BaseModel):
     message: str
     cause: dict[str, Any] | None = None
     root_cause_message: str | None = None
-
-    @staticmethod
-    def _has_encoded_attributes(failure: Failure) -> bool:
-        current: Failure | None = failure
-        while current is not None:
-            if current.HasField("encoded_attributes"):
-                return True
-            current = current.cause if current.HasField("cause") else None
-        return False
+    failure_type: str | None = Field(default=None)
+    failure_types: list[str] = Field(default_factory=list)
 
     @staticmethod
     async def _decode_failure_exception(failure: Any) -> BaseException | None:
-        if not isinstance(failure, Failure) or not EventFailure._has_encoded_attributes(
-            failure
-        ):
+        if not isinstance(failure, Failure):
             return None
 
         decoded_failure = Failure()
@@ -712,6 +713,70 @@ class EventFailure(BaseModel):
         return sanitized
 
     @staticmethod
+    def extract_failure_type(failure: Any) -> str | None:
+        """Return the deepest meaningful machine-readable Temporal failure type."""
+        if not isinstance(failure, Failure):
+            return None
+
+        failure_types: list[str] = []
+        current: Failure | None = failure
+        while current is not None:
+            failure_info = current.WhichOneof("failure_info")
+            if failure_info == "application_failure_info":
+                application_type = current.application_failure_info.type.strip()
+                failure_types.append(application_type or "APPLICATION")
+            elif failure_info == "timeout_failure_info":
+                timeout_type = current.timeout_failure_info.timeout_type
+                if (
+                    timeout_type
+                    == temporalio.api.enums.v1.TimeoutType.TIMEOUT_TYPE_UNSPECIFIED
+                ):
+                    failure_types.append("TIMEOUT")
+                else:
+                    try:
+                        failure_types.append(
+                            temporalio.api.enums.v1.TimeoutType.Name(timeout_type)
+                        )
+                    except ValueError:
+                        failure_types.append(f"TIMEOUT_TYPE_{timeout_type}")
+            elif failure_info is not None:
+                failure_types.append(failure_info.removesuffix("_failure_info").upper())
+            current = current.cause if current.HasField("cause") else None
+
+        for failure_type in reversed(failure_types):
+            if failure_type not in _GENERIC_APPLICATION_FAILURE_TYPES:
+                return failure_type
+        return failure_types[-1] if failure_types else None
+
+    @staticmethod
+    def extract_detail_failure_types(error: BaseException | None) -> list[str]:
+        """Return structured child failure codes without retaining messages."""
+        failure_types: set[str] = set()
+        current = error
+        seen: set[int] = set()
+        while current is not None:
+            current_id = id(current)
+            if current_id in seen:
+                break
+            seen.add(current_id)
+
+            details = getattr(current, "details", ())
+            if isinstance(details, list | tuple):
+                for detail in details:
+                    try:
+                        error_info = ActionErrorInfoAdapter.validate_python(detail)
+                    except ValidationError:
+                        continue
+                    pending = list(error_info.children or ())
+                    while pending:
+                        child = pending.pop()
+                        if failure_type := child.type.strip():
+                            failure_types.add(failure_type)
+                        pending.extend(child.children or ())
+            current = current.__cause__
+        return sorted(failure_types)
+
+    @staticmethod
     async def from_history_event(
         event: temporalio.api.history.v1.HistoryEvent,
         *,
@@ -737,10 +802,16 @@ class EventFailure(BaseModel):
         message = EventFailure._exception_message(decoded_error) or getattr(
             failure, "message", ""
         )
+        failure_type = EventFailure.extract_failure_type(failure)
+        failure_types = EventFailure.extract_detail_failure_types(decoded_error)
+        if not failure_types and failure_type is not None:
+            failure_types = [failure_type]
         return EventFailure(
             message=EventFailure.sanitize_error_text(message) or "",
             cause=cause if include_raw_cause else None,
             root_cause_message=EventFailure.sanitize_error_text(root_cause_message),
+            failure_type=failure_type,
+            failure_types=failure_types,
         )
 
 


### PR DESCRIPTION
## Stack

1. **#3168 — application and deployment support (this PR)**
2. #3140 — isolated PostgreSQL scatter load-test harness

This PR contains only the application changes required by the load-test harness. Keeping these prerequisites separate makes their production-safety review independent from the benchmark implementation.

## Summary

- Add opt-in SQLAlchemy pool diagnostics. The normal SQLAlchemy pool remains unchanged unless the internal diagnostics endpoint is explicitly enabled.
- Expose structured workflow failure types and history size through the execution API.
- Add per-service Fargate database-pool and executor concurrency controls used by capacity experiments.
- Regenerate the frontend API bindings and add focused regression coverage.

## Safety notes

- `TRACECAT__INTERNAL_DB_POOL_METRICS_PORT` is explicitly internal and is not a supported tuning control.
- Pool instrumentation is disabled by default and does not replace the normal application pool unless explicitly enabled.
- API changes are additive.
- Deployment defaults preserve current behavior; the new controls become active only when configured.

## Verification

- `uv run ruff check <changed Python files>`
- `uv run ruff format --check <changed Python files>`
- `uv run basedpyright --warnings --threads 4 <changed Python files>` — 0 errors, 0 warnings
- `uv run pytest --confcutdir=tests/unit -q tests/unit/test_db_engine.py` — 14 passed
- `uv run pytest --confcutdir=tests/registry -q tests/registry/test_core_table.py` — 26 passed
- `terraform fmt -check -recursive deployments/fargate`
- `terraform -chdir=deployments/fargate validate`
- Commit hooks passed, including generated-client, Ruff, formatting, and focused type checks.

The remaining database-backed workflow tests require the repository PostgreSQL fixture; no local PostgreSQL stack was running during the split verification.

## LOC breakdown

| Category | + | - |
|---|---:|---:|
| Logic | 428 | 14 |
| Tests | 183 | 14 |
| Infra/config | 78 | 19 |
| Generated | 60 | 0 |

