### PR TITLE
perf(executor): share platform registry manifest cache

### DIFF
--- a/tests/unit/test_registry_resolver.py
+++ b/tests/unit/test_registry_resolver.py
@@ -1,5 +1,6 @@
 """Unit tests for registry resolver module."""
 
+import asyncio
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -100,6 +101,113 @@ class TestBuildImplIndex:
         assert impl.type == "template"
         assert impl.template_definition is not None
         assert impl.origin == "custom_registry"
+
+
+class TestManifestCache:
+    """Tests for cache scoping, coalescing, and retry behavior."""
+
+    @pytest.mark.anyio
+    async def test_platform_manifest_is_shared_across_organizations(self):
+        manifest = _make_manifest({})
+        entry = (manifest, {})
+
+        with patch.object(
+            registry_resolver,
+            "_load_manifest_entry",
+            new_callable=AsyncMock,
+            return_value=entry,
+        ) as mock_load:
+            first = await registry_resolver._get_manifest_entry(
+                "tracecat_registry", "v1", uuid.uuid4()
+            )
+            second = await registry_resolver._get_manifest_entry(
+                "tracecat_registry", "v1", uuid.uuid4()
+            )
+
+        assert first is second
+        mock_load.assert_awaited_once_with("tracecat_registry", "v1", None)
+
+    @pytest.mark.anyio
+    async def test_org_manifest_remains_scoped_to_organization(self):
+        manifest = _make_manifest({})
+        entry = (manifest, {})
+        first_org = uuid.uuid4()
+        second_org = uuid.uuid4()
+
+        with patch.object(
+            registry_resolver,
+            "_load_manifest_entry",
+            new_callable=AsyncMock,
+            return_value=entry,
+        ) as mock_load:
+            await registry_resolver._get_manifest_entry(
+                "custom_registry", "v1", first_org
+            )
+            await registry_resolver._get_manifest_entry(
+                "custom_registry", "v1", second_org
+            )
+
+        assert mock_load.await_count == 2
+        mock_load.assert_any_await("custom_registry", "v1", first_org)
+        mock_load.assert_any_await("custom_registry", "v1", second_org)
+
+    @pytest.mark.anyio
+    async def test_concurrent_platform_misses_are_coalesced(self):
+        manifest = _make_manifest({})
+        entry = (manifest, {})
+        load_started = asyncio.Event()
+        release_load = asyncio.Event()
+        load_count = 0
+
+        async def load_once(*_args: object) -> registry_resolver.ManifestCacheEntry:
+            nonlocal load_count
+            load_count += 1
+            load_started.set()
+            await release_load.wait()
+            return entry
+
+        organization_ids = [uuid.uuid4() for _ in range(20)]
+        with patch.object(
+            registry_resolver,
+            "_load_manifest_entry",
+            side_effect=load_once,
+        ):
+            tasks = [
+                asyncio.create_task(
+                    registry_resolver._get_manifest_entry(
+                        "tracecat_registry", "v1", organization_id
+                    )
+                )
+                for organization_id in organization_ids
+            ]
+            await load_started.wait()
+            release_load.set()
+            results = await asyncio.gather(*tasks)
+
+        assert load_count == 1
+        assert all(result is entry for result in results)
+
+    @pytest.mark.anyio
+    async def test_failed_manifest_load_can_retry(self):
+        manifest = _make_manifest({})
+        entry = (manifest, {})
+
+        with patch.object(
+            registry_resolver,
+            "_load_manifest_entry",
+            new_callable=AsyncMock,
+            side_effect=[RegistryError("temporary failure"), entry],
+        ) as mock_load:
+            with pytest.raises(RegistryError, match="temporary failure"):
+                await registry_resolver._get_manifest_entry(
+                    "tracecat_registry", "v1", uuid.uuid4()
+                )
+            result = await registry_resolver._get_manifest_entry(
+                "tracecat_registry", "v1", uuid.uuid4()
+            )
+
+        assert result is entry
+        assert mock_load.await_count == 2
 
 
 class TestResolveAction:

--- a/tests/unit/test_registry_resolver.py
+++ b/tests/unit/test_registry_resolver.py
@@ -109,7 +109,7 @@ class TestManifestCache:
     @pytest.mark.anyio
     async def test_platform_manifest_is_shared_across_organizations(self):
         manifest = _make_manifest({})
-        entry = (manifest, {})
+        entry = registry_resolver.ManifestCacheEntry(manifest=manifest, impl_index={})
 
         with patch.object(
             registry_resolver,
@@ -130,7 +130,7 @@ class TestManifestCache:
     @pytest.mark.anyio
     async def test_org_manifest_remains_scoped_to_organization(self):
         manifest = _make_manifest({})
-        entry = (manifest, {})
+        entry = registry_resolver.ManifestCacheEntry(manifest=manifest, impl_index={})
         first_org = uuid.uuid4()
         second_org = uuid.uuid4()
 
@@ -154,7 +154,7 @@ class TestManifestCache:
     @pytest.mark.anyio
     async def test_concurrent_platform_misses_are_coalesced(self):
         manifest = _make_manifest({})
-        entry = (manifest, {})
+        entry = registry_resolver.ManifestCacheEntry(manifest=manifest, impl_index={})
         load_started = asyncio.Event()
         release_load = asyncio.Event()
         load_count = 0
@@ -190,7 +190,7 @@ class TestManifestCache:
     @pytest.mark.anyio
     async def test_failed_manifest_load_can_retry(self):
         manifest = _make_manifest({})
-        entry = (manifest, {})
+        entry = registry_resolver.ManifestCacheEntry(manifest=manifest, impl_index={})
 
         with patch.object(
             registry_resolver,
@@ -238,7 +238,10 @@ class TestResolveAction:
             registry_resolver,
             "_get_manifest_entry",
             new_callable=AsyncMock,
-            return_value=(manifest, impl_index),
+            return_value=registry_resolver.ManifestCacheEntry(
+                manifest=manifest,
+                impl_index=impl_index,
+            ),
         ):
             action_impl = await registry_resolver.resolve_action(
                 "core.transform.reshape",
@@ -340,7 +343,10 @@ class TestPrefetchLock:
                 registry_resolver,
                 "_get_manifest_entry",
                 new_callable=AsyncMock,
-                return_value=(manifest, {}),
+                return_value=registry_resolver.ManifestCacheEntry(
+                    manifest=manifest,
+                    impl_index={},
+                ),
             ) as mock_get_manifest_entry,
         ):
             await registry_resolver.prefetch_lock(lock, organization_id=uuid.uuid4())
@@ -372,7 +378,10 @@ class TestPrefetchLock:
                 registry_resolver,
                 "_get_manifest_entry",
                 new_callable=AsyncMock,
-                return_value=(manifest, {}),
+                return_value=registry_resolver.ManifestCacheEntry(
+                    manifest=manifest,
+                    impl_index={},
+                ),
             ) as mock_get_manifest_entry,
         ):
             await registry_resolver.prefetch_lock(lock, organization_id=organization_id)
@@ -449,7 +458,10 @@ class TestPrefetchLock:
                 registry_resolver,
                 "_get_manifest_entry",
                 new_callable=AsyncMock,
-                return_value=(manifest, {}),
+                return_value=registry_resolver.ManifestCacheEntry(
+                    manifest=manifest,
+                    impl_index={},
+                ),
             ) as mock_get_manifest_entry,
         ):
             await registry_resolver.prefetch_lock(lock, organization_id=uuid.uuid4())
@@ -493,7 +505,10 @@ class TestCollectActionSecretsFromManifest:
             registry_resolver,
             "_get_manifest_entry",
             new_callable=AsyncMock,
-            return_value=(manifest, impl_index),
+            return_value=registry_resolver.ManifestCacheEntry(
+                manifest=manifest,
+                impl_index=impl_index,
+            ),
         ):
             secrets = await registry_resolver.collect_action_secrets_from_manifest(
                 "tools.api.call",

--- a/tests/unit/test_rls_failure_repros.py
+++ b/tests/unit/test_rls_failure_repros.py
@@ -28,7 +28,7 @@ from tracecat.db import rls as rls_module
 from tracecat.db.engine import get_async_session
 from tracecat.db.rls import set_rls_context, set_rls_context_from_role
 from tracecat.dsl.worker import get_activities as get_worker_activities
-from tracecat.executor.registry_resolver import _get_manifest_entry
+from tracecat.executor.registry_resolver import _load_manifest_entry
 from tracecat.executor.service import get_registry_artifacts_for_lock
 from tracecat.integrations.router import oauth_callback
 from tracecat.integrations.service import IntegrationService
@@ -630,5 +630,5 @@ def test_registry_artifact_lookup_uses_bypass_session_manager() -> None:
 
 
 def test_registry_manifest_lookup_uses_bypass_session_manager() -> None:
-    source = inspect.getsource(_get_manifest_entry)
+    source = inspect.getsource(_load_manifest_entry)
     assert "get_async_session_bypass_rls_context_manager" in source

--- a/tracecat/executor/registry_resolver.py
+++ b/tracecat/executor/registry_resolver.py
@@ -39,7 +39,7 @@ from tracecat.tiers.enums import Entitlement
 
 PLATFORM_MANIFEST_CACHE_SIZE = 8
 ORG_MANIFEST_CACHE_SIZE = 32
-MANIFEST_CACHE_TTL_SECONDS = 3600
+MANIFEST_CACHE_TTL_SECONDS = 60
 
 type ManifestCacheEntry = tuple[
     RegistryVersionManifest,

--- a/tracecat/executor/registry_resolver.py
+++ b/tracecat/executor/registry_resolver.py
@@ -6,6 +6,8 @@ Provides O(1) action resolution using registry locks with action-level bindings.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass
 
 from aiocache import Cache, cached
 from async_lru import alru_cache
@@ -41,10 +43,13 @@ PLATFORM_MANIFEST_CACHE_SIZE = 8
 ORG_MANIFEST_CACHE_SIZE = 32
 MANIFEST_CACHE_TTL_SECONDS = 60
 
-type ManifestCacheEntry = tuple[
-    RegistryVersionManifest,
-    dict[str, ActionImplementation],
-]
+
+@dataclass(frozen=True, slots=True)
+class ManifestCacheEntry:
+    """Cached registry manifest and its action implementation index."""
+
+    manifest: RegistryVersionManifest
+    impl_index: Mapping[str, ActionImplementation]
 
 
 def _build_impl_index(
@@ -156,7 +161,7 @@ async def _load_manifest_entry(
             num_actions=len(impl_index),
         )
 
-        return (manifest, impl_index)
+        return ManifestCacheEntry(manifest=manifest, impl_index=impl_index)
 
 
 @alru_cache(
@@ -301,15 +306,15 @@ async def resolve_action(
     version = lock.origins[origin]
 
     # Get from cache (or fetch if miss)
-    _, impl_index = await _get_manifest_entry(origin, version, organization_id)
+    entry = await _get_manifest_entry(origin, version, organization_id)
 
-    if action_name not in impl_index:
+    if action_name not in entry.impl_index:
         raise RegistryError(
             f"Action '{action_name}' not found in manifest for "
             f"origin={origin!r}, version={version!r}"
         )
 
-    return impl_index[action_name]
+    return entry.impl_index[action_name]
 
 
 async def resolve_manifest_action(
@@ -326,8 +331,8 @@ async def resolve_manifest_action(
     if version is None:
         raise RegistryError(f"Origin '{origin}' not found in registry_lock")
 
-    manifest, _ = await _get_manifest_entry(origin, version, organization_id)
-    manifest_action = manifest.actions.get(action_name)
+    entry = await _get_manifest_entry(origin, version, organization_id)
+    manifest_action = entry.manifest.actions.get(action_name)
     if manifest_action is None:
         raise RegistryError(
             f"Action '{action_name}' not found in manifest for "
@@ -363,9 +368,9 @@ async def collect_action_secrets_from_manifest(
         raise RegistryError(f"Origin '{origin}' not found in registry_lock")
 
     # Get from cache (or fetch if miss)
-    manifest, _ = await _get_manifest_entry(origin, version, organization_id)
+    entry = await _get_manifest_entry(origin, version, organization_id)
 
-    manifest_action = manifest.actions.get(action_name)
+    manifest_action = entry.manifest.actions.get(action_name)
     if manifest_action is None:
         raise RegistryError(
             f"Action '{action_name}' not found in manifest for "
@@ -412,14 +417,14 @@ async def _collect_secrets_recursive(
 
             # Get from cache (will be a cache hit if prefetch was called)
             try:
-                step_manifest, _ = await _get_manifest_entry(
+                entry = await _get_manifest_entry(
                     step_origin, step_version, organization_id
                 )
             except RegistryError:
                 # Step manifest not available - skip
                 continue
 
-            step_manifest_action = step_manifest.actions.get(step_action_name)
+            step_manifest_action = entry.manifest.actions.get(step_action_name)
             if step_manifest_action is None:
                 continue
 

--- a/tracecat/executor/registry_resolver.py
+++ b/tracecat/executor/registry_resolver.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 
 from aiocache import Cache, cached
+from async_lru import alru_cache
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_registry import RegistrySecretType
@@ -35,6 +36,15 @@ from tracecat.registry.versions.schemas import (
 )
 from tracecat.tiers.access import is_org_entitled
 from tracecat.tiers.enums import Entitlement
+
+PLATFORM_MANIFEST_CACHE_SIZE = 8
+ORG_MANIFEST_CACHE_SIZE = 32
+MANIFEST_CACHE_TTL_SECONDS = 3600
+
+type ManifestCacheEntry = tuple[
+    RegistryVersionManifest,
+    dict[str, ActionImplementation],
+]
 
 
 def _build_impl_index(
@@ -76,7 +86,7 @@ async def _fetch_manifest(
     session: AsyncSession,
     origin: str,
     version: str,
-    organization_id: OrganizationID,
+    organization_id: OrganizationID | None,
 ) -> RegistryVersionManifest:
     """Fetch manifest from database for a specific origin and version.
 
@@ -110,6 +120,8 @@ async def _fetch_manifest(
 
     # Add org filter only for org-scoped tables
     if not is_platform:
+        if organization_id is None:
+            raise ValueError("organization_id is required for org registry manifests")
         statement = statement.where(
             RegistryRepository.organization_id == organization_id,
             RegistryVersion.organization_id == organization_id,
@@ -127,30 +139,12 @@ async def _fetch_manifest(
     return RegistryVersionManifest.model_validate(manifest_dict)
 
 
-def _manifest_key_builder(
-    fn: object,
+async def _load_manifest_entry(
     origin: str,
     version: str,
-    organization_id: OrganizationID,
-) -> str:
-    """Build cache key for manifest entries."""
-    return f"manifest:{organization_id}:{origin}:{version}"
-
-
-@cached(
-    ttl=60,
-    cache=Cache.MEMORY,
-    key_builder=_manifest_key_builder,
-)
-async def _get_manifest_entry(
-    origin: str,
-    version: str,
-    organization_id: OrganizationID,
-) -> tuple[RegistryVersionManifest, dict[str, ActionImplementation]]:
-    """Fetch manifest and build impl index (cached with TTL).
-
-    This function handles its own DB session and caching via aiocache.
-    """
+    organization_id: OrganizationID | None,
+) -> ManifestCacheEntry:
+    """Fetch one immutable manifest and build its action implementation index."""
     async with get_async_session_bypass_rls_context_manager() as session:
         manifest = await _fetch_manifest(session, origin, version, organization_id)
         impl_index = _build_impl_index(manifest, origin)
@@ -163,6 +157,42 @@ async def _get_manifest_entry(
         )
 
         return (manifest, impl_index)
+
+
+@alru_cache(
+    maxsize=PLATFORM_MANIFEST_CACHE_SIZE,
+    ttl=MANIFEST_CACHE_TTL_SECONDS,
+)
+async def _get_platform_manifest_entry(
+    origin: str,
+    version: str,
+) -> ManifestCacheEntry:
+    """Load a platform manifest shared by every organization in this process."""
+    return await _load_manifest_entry(origin, version, None)
+
+
+@alru_cache(
+    maxsize=ORG_MANIFEST_CACHE_SIZE,
+    ttl=MANIFEST_CACHE_TTL_SECONDS,
+)
+async def _get_org_manifest_entry(
+    origin: str,
+    version: str,
+    organization_id: OrganizationID,
+) -> ManifestCacheEntry:
+    """Load an organization-scoped manifest for this process."""
+    return await _load_manifest_entry(origin, version, organization_id)
+
+
+async def _get_manifest_entry(
+    origin: str,
+    version: str,
+    organization_id: OrganizationID,
+) -> ManifestCacheEntry:
+    """Route manifest loads through the correctly scoped single-flight cache."""
+    if origin == DEFAULT_REGISTRY_ORIGIN:
+        return await _get_platform_manifest_entry(origin, version)
+    return await _get_org_manifest_entry(origin, version, organization_id)
 
 
 def _custom_registry_entitlement_key_builder(
@@ -214,7 +244,7 @@ async def prefetch_lock(lock: RegistryLock, organization_id: OrganizationID) -> 
     """Prefetch all manifests for a registry lock into cache.
 
     Call this once at the start of action execution to warm the cache.
-    Uses aiocache with TTL - no session needed (managed internally).
+    Uses bounded process-local async LRU caches; no caller session is needed.
     """
     await _require_custom_registry_entitlement_if_needed(lock, organization_id)
 
@@ -240,7 +270,7 @@ async def resolve_action(
     """Resolve action implementation from registry lock.
 
     O(1) lookup using action-level bindings in the lock.
-    Uses aiocache - returns cached value on hit, fetches on miss.
+    Returns the process-local cached value on hit and fetches on miss.
 
     Args:
         action_name: Full action name (e.g., "core.transform.reshape")
@@ -400,5 +430,6 @@ async def _collect_secrets_recursive(
 
 async def clear_cache() -> None:
     """Clear the manifest cache. Useful for testing."""
-    await _get_manifest_entry.cache.clear()  # pyright: ignore[reportAttributeAccessIssue]
+    _get_platform_manifest_entry.cache_clear()
+    _get_org_manifest_entry.cache_clear()
     await _has_custom_registry_entitlement.cache.clear()  # pyright: ignore[reportAttributeAccessIssue]


### PR DESCRIPTION
## Summary

- share immutable platform registry manifests across organizations within each executor process
- keep custom registry manifests scoped by organization
- replace the unbounded cache behavior with bounded async LRU caches, a 60-second TTL, and concurrent-miss coalescing
- preserve retry behavior after a failed load and explicit test cache clearing

## Root cause

The prior cache key always included the organization ID and expired after 60 seconds. Platform manifests are organization-independent, so each organization and process repeatedly fetched and decoded the same large manifest. Concurrent misses could also duplicate the work.

## Impact

Platform manifest reads are reused across organizations, concurrent callers share one in-flight load, and memory remains bounded. Custom registry isolation is unchanged.

## Validation

- `uv run pytest --confcutdir=tests/unit tests/unit/test_registry_resolver.py tests/unit/test_rls_failure_repros.py::test_registry_manifest_lookup_uses_bypass_session_manager -q` — 18 passed
- `uv run ruff check tracecat/executor/registry_resolver.py`
- `uv run ruff format --check tracecat/executor/registry_resolver.py`
- `uv run basedpyright tracecat/executor/registry_resolver.py` — 0 diagnostics
- full signed-commit hooks, including OpenAPI client generation and repository Python typechecking

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 57 | 26 |
| Tests | 110 | 2 |

## Tracking

[ENG-1575](https://linear.app/tracecat/issue/ENG-1575/perfdb-investigate-slow-registry-lookups-and-case-inserts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share platform registry manifests across organizations within each executor process to reduce duplicate loads and bound memory. Addresses ENG-1575 by consolidating platform manifest fetches and coalescing concurrent misses.

- **Refactors**
  - Use process-local async LRU caches via `async_lru` for manifests; replace `aiocache` TTL cache for manifest lookups.
  - Share platform manifests across orgs; keep custom registry manifests scoped per org.
  - Bounded caches: platform size 8, org size 32, 60-second TTL; single-flight on concurrent misses.
  - Introduce `ManifestCacheEntry` dataclass; extract `_load_manifest_entry` and route via `_get_platform_manifest_entry` / `_get_org_manifest_entry`; preserve retry after failures and support explicit test cache clearing.

<sup>Written for commit 521a8fe2b5afb216fa6603b98ded158d997741cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

