### PR TITLE
perf(cases): defer case number allocation

### DIFF
--- a/alembic/versions/2792569cf359_defer_case_number_allocation.py
+++ b/alembic/versions/2792569cf359_defer_case_number_allocation.py
@@ -1,0 +1,180 @@
+"""Defer case-number allocation until the end of case creation.
+
+Revision ID: 2792569cf359
+Revises: 864d277bedfa
+Create Date: 2026-07-31 18:00:24.238167
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2792569cf359"
+down_revision: str | None = "864d277bedfa"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_CASE_NUMBER_CONSTRAINT = "uq_case_workspace_case_number"
+_REPLACEMENT_INDEX = "ix_case_workspace_case_number_replacement"
+
+
+def _create_replacement_index() -> None:
+    """Build a replacement index without blocking case writes."""
+    with op.get_context().autocommit_block():
+        # A failed migration can leave the concurrently-created index behind.
+        # Rebuild it so a retry never adopts an invalid partial index.
+        op.execute(f'DROP INDEX CONCURRENTLY IF EXISTS "{_REPLACEMENT_INDEX}"')
+        op.execute(
+            f"""
+            CREATE UNIQUE INDEX CONCURRENTLY "{_REPLACEMENT_INDEX}"
+            ON "case" (workspace_id, case_number)
+            """
+        )
+
+
+def _replace_case_number_constraint(*, deferred: bool) -> None:
+    _create_replacement_index()
+    op.drop_constraint(_CASE_NUMBER_CONSTRAINT, "case", type_="unique")
+    deferred_clause = " DEFERRABLE INITIALLY DEFERRED" if deferred else ""
+    op.execute(
+        f"""
+        ALTER TABLE "case"
+        ADD CONSTRAINT "{_CASE_NUMBER_CONSTRAINT}"
+        UNIQUE USING INDEX "{_REPLACEMENT_INDEX}"{deferred_clause}
+        """
+    )
+
+
+def _install_deferred_allocator() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION assign_workspace_case_number()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF NEW.case_number IS NULL THEN
+                -- Compatibility path for application versions that rely on the
+                -- trigger to allocate a number during INSERT.
+                UPDATE workspace
+                SET last_case_number = last_case_number + 1
+                WHERE id = NEW.workspace_id
+                RETURNING last_case_number INTO NEW.case_number;
+
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION
+                        'Workspace % not found while allocating case number',
+                        NEW.workspace_id;
+                END IF;
+            ELSIF NEW.case_number > 0 THEN
+                -- Preserve explicit-number imports without locking the workspace
+                -- row when the counter is already at or above the supplied value.
+                UPDATE workspace
+                SET last_case_number = NEW.case_number
+                WHERE id = NEW.workspace_id
+                  AND last_case_number < NEW.case_number;
+
+                IF NOT FOUND THEN
+                    PERFORM 1 FROM workspace WHERE id = NEW.workspace_id;
+                    IF NOT FOUND THEN
+                        RAISE EXCEPTION
+                            'Workspace % not found while allocating case number',
+                            NEW.workspace_id;
+                    END IF;
+                END IF;
+            ELSE
+                -- Non-positive numbers are transaction-local sentinels. Validate
+                -- the foreign workspace without taking its counter-row lock.
+                PERFORM 1 FROM workspace WHERE id = NEW.workspace_id;
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION
+                        'Workspace % not found while deferring case number allocation',
+                        NEW.workspace_id;
+                END IF;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION require_assigned_workspace_case_number()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM "case"
+                WHERE id = NEW.id
+                  AND case_number <= 0
+            ) THEN
+                RAISE EXCEPTION 'Case number must be assigned before commit'
+                    USING ERRCODE = '23514';
+            END IF;
+
+            RETURN NULL;
+        END;
+        $$;
+        """
+    )
+    op.execute('DROP TRIGGER IF EXISTS trg_case_require_assigned_number ON "case"')
+    op.execute(
+        """
+        CREATE CONSTRAINT TRIGGER trg_case_require_assigned_number
+        AFTER INSERT OR UPDATE OF case_number ON "case"
+        DEFERRABLE INITIALLY DEFERRED
+        FOR EACH ROW
+        WHEN (NEW.case_number <= 0)
+        EXECUTE FUNCTION require_assigned_workspace_case_number()
+        """
+    )
+
+
+def _install_immediate_allocator() -> None:
+    op.execute('DROP TRIGGER IF EXISTS trg_case_require_assigned_number ON "case"')
+    op.execute("DROP FUNCTION IF EXISTS require_assigned_workspace_case_number()")
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION assign_workspace_case_number()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF NEW.case_number IS NULL THEN
+                UPDATE workspace
+                SET last_case_number = last_case_number + 1
+                WHERE id = NEW.workspace_id
+                RETURNING last_case_number INTO NEW.case_number;
+            ELSE
+                UPDATE workspace
+                SET last_case_number = GREATEST(last_case_number, NEW.case_number)
+                WHERE id = NEW.workspace_id;
+            END IF;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION
+                    'Workspace % not found while allocating case number',
+                    NEW.workspace_id;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+
+def upgrade() -> None:
+    _replace_case_number_constraint(deferred=True)
+    _install_deferred_allocator()
+
+
+def downgrade() -> None:
+    _install_immediate_allocator()
+    _replace_case_number_constraint(deferred=False)

--- a/alembic/versions/2792569cf359_defer_case_number_allocation.py
+++ b/alembic/versions/2792569cf359_defer_case_number_allocation.py
@@ -176,5 +176,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    _install_immediate_allocator()
     _replace_case_number_constraint(deferred=False)
+    _install_immediate_allocator()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,21 +129,76 @@ def _install_case_number_allocator(conn: Any) -> None:
                     SET last_case_number = last_case_number + 1
                     WHERE id = NEW.workspace_id
                     RETURNING last_case_number INTO NEW.case_number;
-                ELSE
+                    IF NOT FOUND THEN
+                        RAISE EXCEPTION
+                            'Workspace % not found while allocating case number',
+                            NEW.workspace_id;
+                    END IF;
+                ELSIF NEW.case_number > 0 THEN
                     UPDATE workspace
-                    SET last_case_number = GREATEST(last_case_number, NEW.case_number)
-                    WHERE id = NEW.workspace_id;
-                END IF;
+                    SET last_case_number = NEW.case_number
+                    WHERE id = NEW.workspace_id
+                      AND last_case_number < NEW.case_number;
 
-                IF NOT FOUND THEN
-                    RAISE EXCEPTION
-                        'Workspace % not found while allocating case number',
-                        NEW.workspace_id;
+                    IF NOT FOUND THEN
+                        PERFORM 1 FROM workspace WHERE id = NEW.workspace_id;
+                        IF NOT FOUND THEN
+                            RAISE EXCEPTION
+                                'Workspace % not found while allocating case number',
+                                NEW.workspace_id;
+                        END IF;
+                    END IF;
+                ELSE
+                    PERFORM 1 FROM workspace WHERE id = NEW.workspace_id;
+                    IF NOT FOUND THEN
+                        RAISE EXCEPTION
+                            'Workspace % not found while deferring case number allocation',
+                            NEW.workspace_id;
+                    END IF;
                 END IF;
 
                 RETURN NEW;
             END;
             $$;
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE OR REPLACE FUNCTION require_assigned_workspace_case_number()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM "case"
+                    WHERE id = NEW.id
+                      AND case_number <= 0
+                ) THEN
+                    RAISE EXCEPTION 'Case number must be assigned before commit'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                RETURN NULL;
+            END;
+            $$;
+            """
+        )
+    )
+    conn.execute(
+        text('DROP TRIGGER IF EXISTS trg_case_require_assigned_number ON "case"')
+    )
+    conn.execute(
+        text(
+            """
+            CREATE CONSTRAINT TRIGGER trg_case_require_assigned_number
+            AFTER INSERT OR UPDATE OF case_number ON "case"
+            DEFERRABLE INITIALLY DEFERRED
+            FOR EACH ROW
+            WHEN (NEW.case_number <= 0)
+            EXECUTE FUNCTION require_assigned_workspace_case_number()
             """
         )
     )

--- a/tests/migration/test_deferred_case_number_allocation_migration.py
+++ b/tests/migration/test_deferred_case_number_allocation_migration.py
@@ -1,0 +1,370 @@
+"""Tests for deferred workspace case-number allocation."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.pool import NullPool
+
+from tests.database import TEST_DB_CONFIG
+
+MIGRATION_REVISION = "2792569cf359"
+PREVIOUS_REVISION = "864d277bedfa"
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "2792569cf359_defer_case_number_allocation.py"
+)
+
+
+def _run_alembic(db_url: str, *args: str) -> None:
+    env = os.environ.copy()
+    env["TRACECAT__DB_URI"] = db_url
+    result = subprocess.run(
+        ["uv", "run", "alembic", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Alembic command failed:\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+
+def _load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "deferred_case_number_allocation_migration",
+        MIGRATION_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load migration at {MIGRATION_PATH}")
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+@pytest.fixture(scope="function")
+def migration_db_url() -> Iterator[str]:
+    default_engine = create_engine(
+        TEST_DB_CONFIG.sys_url_sync,
+        isolation_level="AUTOCOMMIT",
+        poolclass=NullPool,
+    )
+    db_name = f"test_deferred_case_number_{uuid.uuid4().hex[:8]}"
+    termination_query = text(
+        f"""
+        SELECT pg_terminate_backend(pg_stat_activity.pid)
+        FROM pg_stat_activity
+        WHERE pg_stat_activity.datname = '{db_name}'
+          AND pid <> pg_backend_pid();
+        """
+    )
+
+    try:
+        with default_engine.connect() as conn:
+            conn.execute(termination_query)
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+
+        db_url = TEST_DB_CONFIG.test_url_sync.replace(
+            TEST_DB_CONFIG.test_db_name,
+            db_name,
+        )
+        _run_alembic(db_url, "upgrade", PREVIOUS_REVISION)
+        yield db_url
+    finally:
+        with default_engine.connect() as conn:
+            conn.execute(termination_query)
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        default_engine.dispose()
+
+
+def _insert_case(
+    conn: Connection,
+    *,
+    workspace_id: uuid.UUID,
+    case_number: int | None,
+) -> tuple[uuid.UUID, int]:
+    case_id = uuid.uuid4()
+    if case_number is None:
+        assigned_number = conn.execute(
+            text(
+                """
+                INSERT INTO "case" (
+                    id,
+                    workspace_id,
+                    summary,
+                    description,
+                    priority,
+                    severity,
+                    status
+                )
+                VALUES (
+                    :id,
+                    :workspace_id,
+                    'Migration case',
+                    'Migration case',
+                    'MEDIUM',
+                    'LOW',
+                    'NEW'
+                )
+                RETURNING case_number
+                """
+            ),
+            {"id": case_id, "workspace_id": workspace_id},
+        ).scalar_one()
+    else:
+        assigned_number = conn.execute(
+            text(
+                """
+                INSERT INTO "case" (
+                    id,
+                    workspace_id,
+                    case_number,
+                    summary,
+                    description,
+                    priority,
+                    severity,
+                    status
+                )
+                VALUES (
+                    :id,
+                    :workspace_id,
+                    :case_number,
+                    'Migration case',
+                    'Migration case',
+                    'MEDIUM',
+                    'LOW',
+                    'NEW'
+                )
+                RETURNING case_number
+                """
+            ),
+            {
+                "id": case_id,
+                "workspace_id": workspace_id,
+                "case_number": case_number,
+            },
+        ).scalar_one()
+    return case_id, assigned_number
+
+
+def _constraint_state(conn: Connection) -> tuple[bool, bool]:
+    row = conn.execute(
+        text(
+            """
+            SELECT condeferrable, condeferred
+            FROM pg_constraint
+            WHERE conrelid = '"case"'::regclass
+              AND conname = 'uq_case_workspace_case_number'
+            """
+        )
+    ).one()
+    return bool(row[0]), bool(row[1])
+
+
+def _guard_trigger_count(conn: Connection) -> int:
+    return conn.execute(
+        text(
+            """
+            SELECT count(*)
+            FROM pg_trigger
+            WHERE tgrelid = '"case"'::regclass
+              AND tgname = 'trg_case_require_assigned_number'
+              AND NOT tgisinternal
+            """
+        )
+    ).scalar_one()
+
+
+def _seed_workspace(db_url: str) -> uuid.UUID:
+    engine = create_engine(db_url, poolclass=NullPool)
+    organization_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO organization (id, name, slug, is_active)
+                    VALUES (:id, 'Migration test org', :slug, true)
+                    """
+                ),
+                {
+                    "id": organization_id,
+                    "slug": f"migration-test-{organization_id.hex[:8]}",
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO workspace (id, organization_id, name)
+                    VALUES (:id, :organization_id, 'Migration test workspace')
+                    """
+                ),
+                {"id": workspace_id, "organization_id": organization_id},
+            )
+            _, assigned_number = _insert_case(
+                conn,
+                workspace_id=workspace_id,
+                case_number=1,
+            )
+            assert assigned_number == 1
+    finally:
+        engine.dispose()
+    return workspace_id
+
+
+def test_deferred_allocator_upgrade_downgrade_and_reupgrade(
+    migration_db_url: str,
+) -> None:
+    workspace_id = _seed_workspace(migration_db_url)
+    _run_alembic(migration_db_url, "upgrade", MIGRATION_REVISION)
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+
+    try:
+        with engine.connect() as conn:
+            assert _constraint_state(conn) == (True, True)
+            assert _guard_trigger_count(conn) == 1
+
+        with engine.begin() as conn:
+            _, legacy_number = _insert_case(
+                conn,
+                workspace_id=workspace_id,
+                case_number=None,
+            )
+            assert legacy_number == 2
+
+        first = engine.connect()
+        second = engine.connect()
+        first_tx = first.begin()
+        second_tx = second.begin()
+        try:
+            first.execute(text("SET LOCAL lock_timeout = '1s'"))
+            second.execute(text("SET LOCAL lock_timeout = '1s'"))
+            first_case_id, first_pending_number = _insert_case(
+                first,
+                workspace_id=workspace_id,
+                case_number=0,
+            )
+            second_case_id, second_pending_number = _insert_case(
+                second,
+                workspace_id=workspace_id,
+                case_number=0,
+            )
+            assert first_pending_number == second_pending_number == 0
+
+            first_number = first.execute(
+                text(
+                    """
+                    UPDATE workspace
+                    SET last_case_number = last_case_number + 1
+                    WHERE id = :workspace_id
+                    RETURNING last_case_number
+                    """
+                ),
+                {"workspace_id": workspace_id},
+            ).scalar_one()
+            first.execute(
+                text('UPDATE "case" SET case_number = :number WHERE id = :id'),
+                {"number": first_number, "id": first_case_id},
+            )
+            first_tx.commit()
+
+            second_number = second.execute(
+                text(
+                    """
+                    UPDATE workspace
+                    SET last_case_number = last_case_number + 1
+                    WHERE id = :workspace_id
+                    RETURNING last_case_number
+                    """
+                ),
+                {"workspace_id": workspace_id},
+            ).scalar_one()
+            second.execute(
+                text('UPDATE "case" SET case_number = :number WHERE id = :id'),
+                {"number": second_number, "id": second_case_id},
+            )
+            second_tx.commit()
+        finally:
+            if first_tx.is_active:
+                first_tx.rollback()
+            if second_tx.is_active:
+                second_tx.rollback()
+            first.close()
+            second.close()
+
+        assert (first_number, second_number) == (3, 4)
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                _insert_case(conn, workspace_id=workspace_id, case_number=0)
+
+        _run_alembic(migration_db_url, "downgrade", PREVIOUS_REVISION)
+        with engine.connect() as conn:
+            assert _constraint_state(conn) == (False, False)
+            assert _guard_trigger_count(conn) == 0
+
+        with engine.begin() as conn:
+            _, downgraded_number = _insert_case(
+                conn,
+                workspace_id=workspace_id,
+                case_number=None,
+            )
+            assert downgraded_number == 5
+
+        _run_alembic(migration_db_url, "upgrade", MIGRATION_REVISION)
+        with engine.connect() as conn:
+            assert _constraint_state(conn) == (True, True)
+            assert _guard_trigger_count(conn) == 1
+
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                _insert_case(conn, workspace_id=workspace_id, case_number=0)
+    finally:
+        engine.dispose()
+
+
+def test_downgrade_replaces_constraint_before_disabling_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _load_migration()
+    allocator_installed = False
+
+    def fail_constraint_replacement(*, deferred: bool) -> None:
+        assert deferred is False
+        raise RuntimeError("Synthetic concurrent-index failure")
+
+    def install_immediate_allocator() -> None:
+        nonlocal allocator_installed
+        allocator_installed = True
+
+    monkeypatch.setattr(
+        migration,
+        "_replace_case_number_constraint",
+        fail_constraint_replacement,
+    )
+    monkeypatch.setattr(
+        migration,
+        "_install_immediate_allocator",
+        install_immediate_allocator,
+    )
+
+    with pytest.raises(RuntimeError, match="Synthetic concurrent-index failure"):
+        migration.downgrade()
+
+    assert allocator_installed is False

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -7,12 +7,18 @@ from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from sqlalchemy import select, text
+from sqlalchemy import delete, select, text
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import DBAPIError
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.orm import selectinload as sa_selectinload
+from sqlalchemy.pool import NullPool
 
+from tests.database import TEST_DB_CONFIG
 from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.service import AuditService
 from tracecat.auth.types import Role
@@ -47,7 +53,7 @@ from tracecat.cases.service import (
     CasesService,
 )
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.db.models import Case, CaseComment, Workspace
+from tracecat.db.models import Case, CaseComment, Organization, Workspace
 from tracecat.exceptions import (
     TracecatAuthorizationError,
     TracecatConflictError,
@@ -486,18 +492,29 @@ class TestCasesService:
 
     async def test_slow_related_writes_do_not_hold_case_number_counter_lock(
         self,
-        cases_service: CasesService,
-        session: AsyncSession,
-        svc_role: Role,
     ) -> None:
         """A stalled case should not block another case before final allocation."""
-        await cases_service.fields._ensure_schema_ready()
-        await cases_service.session.commit()
-        assert session.bind is not None
-        session_factory = async_sessionmaker(bind=session.bind, expire_on_commit=False)
+        organization_id = uuid.uuid4()
+        workspace_id = uuid.uuid4()
+        role = Role(
+            type="service",
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+            service_id="tracecat-service",
+            scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-service"],
+        )
+        concurrent_engine = create_async_engine(
+            TEST_DB_CONFIG.test_url,
+            poolclass=NullPool,
+        )
+        session_factory = async_sessionmaker(
+            bind=concurrent_engine,
+            expire_on_commit=False,
+        )
         slow_write_started = asyncio.Event()
         release_slow_write = asyncio.Event()
         original_upsert = CaseFieldsService.upsert_field_values
+        backend_pids: set[int] = set()
 
         async def pause_slow_case(
             fields_service: CaseFieldsService,
@@ -511,9 +528,14 @@ class TestCasesService:
 
         async def create_case(summary: str) -> int:
             async with session_factory() as concurrent_session:
+                backend_pid = await concurrent_session.scalar(
+                    text("SELECT pg_backend_pid()")
+                )
+                assert backend_pid is not None
+                backend_pids.add(backend_pid)
                 service = CasesService(
                     session=concurrent_session,
-                    role=svc_role.model_copy(deep=True),
+                    role=role.model_copy(deep=True),
                 )
                 case = await service.create_case(
                     CaseCreate(
@@ -526,29 +548,65 @@ class TestCasesService:
                 )
                 return case.case_number
 
-        with (
-            patch.object(
-                CaseFieldsService,
-                "_ensure_schema_ready",
-                new=AsyncMock(return_value=None),
-            ),
-            patch.object(
-                CaseFieldsService,
-                "upsert_field_values",
-                new=pause_slow_case,
-            ),
-        ):
-            slow_task = asyncio.create_task(create_case("Slow case"))
-            try:
+        slow_task: asyncio.Task[int] | None = None
+        try:
+            async with session_factory() as seed_session:
+                seed_session.add_all(
+                    [
+                        Organization(
+                            id=organization_id,
+                            name="Case contention test organization",
+                            slug=f"case-contention-{organization_id.hex[:8]}",
+                            is_active=True,
+                        ),
+                        Workspace(
+                            id=workspace_id,
+                            name=f"case-contention-{workspace_id.hex[:8]}",
+                            organization_id=organization_id,
+                        ),
+                    ]
+                )
+                await seed_session.commit()
+                seed_service = CasesService(session=seed_session, role=role)
+                await seed_service.fields._ensure_schema_ready()
+                await seed_session.commit()
+
+            with (
+                patch.object(
+                    CaseFieldsService,
+                    "_ensure_schema_ready",
+                    new=AsyncMock(return_value=None),
+                ),
+                patch.object(
+                    CaseFieldsService,
+                    "upsert_field_values",
+                    new=pause_slow_case,
+                ),
+            ):
+                slow_task = asyncio.create_task(create_case("Slow case"))
                 await asyncio.wait_for(slow_write_started.wait(), timeout=5)
                 fast_case_number = await asyncio.wait_for(
                     create_case("Fast case"), timeout=5
                 )
-            finally:
                 release_slow_write.set()
+                slow_case_number = await asyncio.wait_for(slow_task, timeout=5)
+        finally:
+            release_slow_write.set()
+            if slow_task is not None:
+                if not slow_task.done():
+                    slow_task.cancel()
+                await asyncio.gather(slow_task, return_exceptions=True)
+            async with session_factory() as cleanup_session:
+                await cleanup_session.execute(
+                    delete(Workspace).where(Workspace.id == workspace_id)
+                )
+                await cleanup_session.execute(
+                    delete(Organization).where(Organization.id == organization_id)
+                )
+                await cleanup_session.commit()
+            await concurrent_engine.dispose()
 
-            slow_case_number = await asyncio.wait_for(slow_task, timeout=5)
-
+        assert len(backend_pids) == 2
         assert fast_case_number == 1
         assert slow_case_number == 2
 

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -436,7 +436,7 @@ class TestCasesService:
         svc_role: Role,
         svc_workspace: Workspace,
     ) -> None:
-        """Concurrent creates should serialize on the workspace counter row."""
+        """Concurrent creates should allocate unique workspace-local numbers."""
         await cases_service.fields._ensure_schema_ready()
         await cases_service.session.commit()
         assert session.bind is not None
@@ -483,6 +483,140 @@ class TestCasesService:
                 )
             ).scalars()
             assert sorted(stored_case_numbers.all()) == [1, 2, 3, 4, 5]
+
+    async def test_slow_related_writes_do_not_hold_case_number_counter_lock(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+        svc_role: Role,
+    ) -> None:
+        """A stalled case should not block another case before final allocation."""
+        await cases_service.fields._ensure_schema_ready()
+        await cases_service.session.commit()
+        assert session.bind is not None
+        session_factory = async_sessionmaker(bind=session.bind, expire_on_commit=False)
+        slow_write_started = asyncio.Event()
+        release_slow_write = asyncio.Event()
+        original_upsert = CaseFieldsService.upsert_field_values
+
+        async def pause_slow_case(
+            fields_service: CaseFieldsService,
+            case: Case,
+            fields: dict[str, Any],
+        ) -> dict[str, Any]:
+            if case.summary == "Slow case":
+                slow_write_started.set()
+                await release_slow_write.wait()
+            return await original_upsert(fields_service, case, fields)
+
+        async def create_case(summary: str) -> int:
+            async with session_factory() as concurrent_session:
+                service = CasesService(
+                    session=concurrent_session,
+                    role=svc_role.model_copy(deep=True),
+                )
+                case = await service.create_case(
+                    CaseCreate(
+                        summary=summary,
+                        description=summary,
+                        status=CaseStatus.NEW,
+                        priority=CasePriority.MEDIUM,
+                        severity=CaseSeverity.LOW,
+                    )
+                )
+                return case.case_number
+
+        with (
+            patch.object(
+                CaseFieldsService,
+                "_ensure_schema_ready",
+                new=AsyncMock(return_value=None),
+            ),
+            patch.object(
+                CaseFieldsService,
+                "upsert_field_values",
+                new=pause_slow_case,
+            ),
+        ):
+            slow_task = asyncio.create_task(create_case("Slow case"))
+            try:
+                await asyncio.wait_for(slow_write_started.wait(), timeout=5)
+                fast_case_number = await asyncio.wait_for(
+                    create_case("Fast case"), timeout=5
+                )
+            finally:
+                release_slow_write.set()
+
+            slow_case_number = await asyncio.wait_for(slow_task, timeout=5)
+
+        assert fast_case_number == 1
+        assert slow_case_number == 2
+
+    async def test_failed_case_creation_rolls_back_allocated_number(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+    ) -> None:
+        """The counter remains gapless when failure occurs after allocation."""
+        workspace_id = cases_service.workspace_id
+        original_assign = cases_service._assign_next_case_number
+
+        async def fail_after_counter_update(case: Case) -> None:
+            await original_assign(case)
+            raise RuntimeError("Synthetic failure after case-number allocation")
+
+        with (
+            patch.object(
+                cases_service,
+                "_assign_next_case_number",
+                new=fail_after_counter_update,
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await cases_service.create_case(
+                CaseCreate(
+                    summary="Failed case",
+                    description="Failed case",
+                    status=CaseStatus.NEW,
+                    priority=CasePriority.MEDIUM,
+                    severity=CaseSeverity.LOW,
+                )
+            )
+
+        workspace = await session.scalar(
+            select(Workspace).where(Workspace.id == workspace_id)
+        )
+        assert workspace is not None
+        assert workspace.last_case_number == 0
+        stored_cases = (
+            await session.execute(select(Case).where(Case.workspace_id == workspace_id))
+        ).scalars()
+        assert stored_cases.all() == []
+
+    async def test_pending_case_number_cannot_be_committed(
+        self,
+        session: AsyncSession,
+        svc_workspace: Workspace,
+    ) -> None:
+        """The deferred database invariant rejects a persisted sentinel."""
+        session.add(
+            Case(
+                workspace_id=svc_workspace.id,
+                case_number=0,
+                summary="Pending case",
+                description="Pending case",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+
+        await session.flush()
+        # The session fixture wraps each test in an outer transaction, so force
+        # deferred triggers to run instead of relying on session.commit().
+        with pytest.raises(DBAPIError):
+            await session.execute(text("SET CONSTRAINTS ALL IMMEDIATE"))
+        await session.rollback()
 
     async def test_list_cases_with_limit(
         self, cases_service: CasesService, case_create_params: CaseCreate

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -106,6 +106,7 @@ from tracecat.db.models import (
     CaseTask,
     User,
     Workflow,
+    Workspace,
     WorkspaceSyncResourceMapping,
 )
 from tracecat.db.session_events import AfterCommitQueue
@@ -212,6 +213,7 @@ def _enum_sort_rank(value: Any, ordered_values: Sequence[str]) -> int:
 CASE_VIEW_EVENT_DEDUP_WINDOW = timedelta(minutes=5)
 CASE_BATCH_LOCK_TIMEOUT = "5s"
 CASE_BATCH_LOCK_NOT_AVAILABLE_SQLSTATE = "55P03"
+PENDING_CASE_NUMBER = 0
 
 
 class CasesService(BaseWorkspaceService):
@@ -851,6 +853,19 @@ class CasesService(BaseWorkspaceService):
 
         return case
 
+    async def _assign_next_case_number(self, case: Case) -> None:
+        """Assign the next gapless number at the end of case creation."""
+        next_case_number = await self.session.scalar(
+            sa.update(Workspace)
+            .where(Workspace.id == self.workspace_id)
+            .values(last_case_number=Workspace.last_case_number + 1)
+            .returning(Workspace.last_case_number)
+        )
+        if next_case_number is None:
+            raise TracecatNotFoundError("Workspace not found")
+        case.case_number = next_case_number
+        await self.session.flush()
+
     @require_scope("case:create")
     @audit_log(resource_type="case", action="create")
     async def create_case(self, params: CaseCreate) -> Case:
@@ -864,6 +879,9 @@ class CasesService(BaseWorkspaceService):
             now = datetime.now(UTC)
             case = Case(
                 workspace_id=self.workspace_id,
+                # The trigger recognizes zero as a transaction-local sentinel. The
+                # real number is allocated after all potentially slow related writes.
+                case_number=PENDING_CASE_NUMBER,
                 summary=params.summary,
                 description=params.description,
                 priority=params.priority,
@@ -876,7 +894,8 @@ class CasesService(BaseWorkspaceService):
             )
 
             self.session.add(case)
-            await self.session.flush()  # Generate case ID
+            # Generate the case ID without locking the workspace counter.
+            await self.session.flush()
 
             # Always create the fields row to ensure defaults are applied
             # Pass empty dict if no fields provided to trigger default value application
@@ -896,6 +915,12 @@ class CasesService(BaseWorkspaceService):
                     params.dropdown_values,
                     commit=False,
                 )
+
+            # Flush all related writes before entering the gapless counter's short
+            # critical section. The counter update and case-number assignment remain
+            # in this transaction, so a failed commit rolls both back together.
+            await self.session.flush()
+            await self._assign_next_case_number(case)
 
             # Commit once to persist case, fields, and event atomically
             await self.session.commit()

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2282,6 +2282,8 @@ class Case(WorkspaceModel):
             "workspace_id",
             "case_number",
             name="uq_case_workspace_case_number",
+            deferrable=True,
+            initially="DEFERRED",
         ),
         Index("ix_case_cursor_pagination", "workspace_id", "created_at", "id"),
     )
@@ -2297,7 +2299,7 @@ class Case(WorkspaceModel):
         Integer,
         server_default=FetchedValue(),
         nullable=False,
-        doc="Server-generated workspace-scoped case number for human readable IDs like CASE-1234",
+        doc="Workspace-scoped case number for human-readable IDs like CASE-1234",
     )
     summary: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(String(5000), nullable=False)


### PR DESCRIPTION
## Summary

- insert in-flight cases with a transaction-local sentinel that does not lock the workspace counter
- allocate and assign the real workspace case number only after field, event, and dropdown writes have flushed
- make workspace case-number uniqueness deferred so concurrent sentinels can coexist
- enforce at commit that no sentinel can persist
- retain the legacy trigger path for older application versions that insert without an explicit case number
- build the replacement unique index concurrently during migration

## Root cause

The existing `BEFORE INSERT` trigger incremented `workspace.last_case_number`. PostgreSQL held that row lock until the complete case transaction committed, so field, event, and dropdown work extended the critical section and made concurrent case inserts wait.

## Impact

The counter lock is held only across the final number assignment and commit. Numbering remains gapless on rollback, related case writes remain atomic, and rolling deployments remain compatible with older application versions.

## Validation

- `TRACECAT__DB_ENCRYPTION_KEY=<synthetic-test-key> uv run pytest tests/unit/test_cases_service.py -q` — 55 passed
- `uv run pytest tests/migration/test_deferred_case_number_allocation_migration.py -q` — 2 passed
- migration upgrade, downgrade, and re-upgrade completed successfully
- `uv run ruff check` and `uv run ruff format --check` on changed files
- targeted `uv run basedpyright` — 0 diagnostics
- full signed-commit hooks, including repository Python typechecking

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 29 | 2 |
| Tests | 629 | 12 |
| Migration | 180 | 0 |

## Tracking

[ENG-1575](https://linear.app/tracecat/issue/ENG-1575/perfdb-investigate-slow-registry-lookups-and-case-inserts)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers workspace case-number allocation to commit time using a `case_number=0` sentinel to remove counter-row contention. Adds a deferred DB guard and trigger-side checks to keep numbering gapless and safe while staying compatible with older app versions. Addresses ENG-1575.

- **Refactors**
  - Insert with a sentinel; assign the real number at the end via `_assign_next_case_number`.
  - Hardened trigger behavior: keep legacy `NULL` path, accept explicit `case_number > 0` imports without locking, and validate workspace existence.
  - New tests cover concurrency without lock contention, rollback gaplessness, and guard enforcement.

- **Migration**
  - Replace the unique index concurrently and make it `DEFERRABLE INITIALLY DEFERRED`.
  - Install `assign_workspace_case_number()` and the `require_assigned_workspace_case_number()` constraint trigger to reject persisted sentinels.
  - Downgrade restores immediate allocation and a non-deferred constraint; ordering ensures the constraint is replaced before disabling the guard.

<sup>Written for commit fe2da1ac0edfb5d3b76a001fe03a1c94cbb6b78e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
