### PR TITLE
feat(registry): add MISP security integration

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -1114,6 +1114,81 @@
       }
     },
     {
+      "slug": "misp-mcp",
+      "docs": "https://github.com/MISP/misp-mcp",
+      "connection_spec": {
+        "server_type": "stdio",
+        "auth_type": "CUSTOM",
+        "stdio_command": "uvx",
+        "stdio_args": [
+          "--with",
+          "mcp==1.28.1",
+          "--from",
+          "git+https://github.com/MISP/misp-mcp.git@745ce9ab4989a98b765ca4a5a99530926ea3d232",
+          "misp-mcp"
+        ],
+        "stdio_env": [
+          "MISP_URL",
+          "MISP_API_KEY",
+          "MISP_VERIFYCERT"
+        ],
+        "packages": [
+          {
+            "manager": "uvx",
+            "command": "uvx",
+            "args": [
+              "--with",
+              "mcp==1.28.1",
+              "--from",
+              "git+https://github.com/MISP/misp-mcp.git@745ce9ab4989a98b765ca4a5a99530926ea3d232",
+              "misp-mcp"
+            ],
+            "package": "git+https://github.com/MISP/misp-mcp.git@745ce9ab4989a98b765ca4a5a99530926ea3d232"
+          }
+        ],
+        "credentials": [
+          {
+            "key": "MISP_URL",
+            "label": "MISP URL",
+            "description": "Base URL of your MISP instance, including the http:// or https:// scheme.",
+            "required": true,
+            "secret": false,
+            "placeholder": "https://misp.example.com",
+            "type": "url",
+            "target": "stdio_env"
+          },
+          {
+            "key": "MISP_API_KEY",
+            "label": "MISP API Key",
+            "description": "API authentication key used to read threat intelligence from MISP.",
+            "required": true,
+            "secret": true,
+            "target": "stdio_env"
+          },
+          {
+            "key": "MISP_VERIFYCERT",
+            "label": "Verify TLS Certificate",
+            "description": "Whether to verify the MISP server TLS certificate. Use true unless the instance uses a private development certificate.",
+            "required": true,
+            "secret": false,
+            "placeholder": "true",
+            "target": "stdio_env"
+          }
+        ],
+        "_research": {
+          "confidence": "high",
+          "docker_only": false,
+          "notes": "Official first-party MISP MCP server from MISP/misp-mcp. The v0.1 release identifies itself as version 0.1.0 and is pinned to source commit 745ce9ab4989a98b765ca4a5a99530926ea3d232 because no misp-mcp distribution is published on PyPI. Its declared mcp[cli]>=1.0.0 dependency is not bounded above; the current unconstrained resolution fails at startup after the MCP SDK removed mcp.server.fastmcp. The uvx recipe therefore also pins mcp==1.28.1, which was verified with an MCP initialize/list-tools probe returning 14 read-only tools. Authentication uses MISP_URL and MISP_API_KEY. MISP_VERIFYCERT controls TLS certificate verification and is explicitly prefilled as true so an empty environment value cannot silently disable verification.",
+          "sources": [
+            "https://github.com/MISP/misp-mcp",
+            "https://github.com/MISP/misp-mcp/releases/tag/v0.1",
+            "https://github.com/MISP/misp-mcp/blob/v0.1/pyproject.toml",
+            "https://github.com/MISP/misp-mcp/blob/v0.1/README.md"
+          ]
+        }
+      }
+    },
+    {
       "slug": "microsoft-entra-id-mcp",
       "docs": "https://learn.microsoft.com/en-us/graph/mcp-server/overview",
       "connection_spec": {

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/attributes/get_attribute.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/attributes/get_attribute.yml
@@ -1,0 +1,34 @@
+type: action
+definition:
+  title: Get attribute
+  description: Retrieve a specific MISP indicator by its numeric attribute ID.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Attributes/operation/getAttributeById
+  namespace: tools.misp
+  name: get_attribute
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    attribute_id:
+      type: int
+      description: Numeric ID of the attribute to retrieve.
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/attributes/view/${{ FN.url_encode(str(inputs.attribute_id)) }}
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/attributes/search_attributes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/attributes/search_attributes.yml
@@ -1,0 +1,123 @@
+type: action
+definition:
+  title: Search attributes
+  description: Search individual MISP indicators across events for threat enrichment.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Attributes/operation/restSearchAttributes
+  namespace: tools.misp
+  name: search_attributes
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    value:
+      type: str | None
+      description: Indicator value such as an IP address, domain, URL, or hash.
+      default: null
+    type_attribute:
+      type: str | None
+      description: MISP attribute type such as ip-src, domain, url, md5, or sha256.
+      default: null
+    category:
+      type: str | None
+      description: MISP attribute category.
+      default: null
+    org:
+      type: str | None
+      description: Creator organisation name or ID.
+      default: null
+    tags:
+      type: list[str] | None
+      description: Attribute tags to include or exclude.
+      default: null
+    date_from:
+      type: str | None
+      description: Earliest event date in YYYY-MM-DD format.
+      default: null
+    date_to:
+      type: str | None
+      description: Latest event date in YYYY-MM-DD format.
+      default: null
+    eventid:
+      type: int | list[int] | None
+      description: Parent event ID or list of event IDs.
+      default: null
+    published:
+      type: bool | None
+      description: Filter by parent event publication state.
+      default: null
+    enforce_warninglist:
+      type: bool | None
+      description: Exclude attributes matching enabled warning lists.
+      default: null
+    to_ids:
+      type: bool | None
+      description: Filter attributes by their IDS flag.
+      default: null
+    include_event_uuid:
+      type: bool
+      description: Include the parent event UUID.
+      default: true
+    include_event_tags:
+      type: bool
+      description: Include parent event tags.
+      default: false
+    include_correlations:
+      type: bool
+      description: Include correlation data.
+      default: false
+    include_sightings:
+      type: bool
+      description: Include sighting data.
+      default: false
+    include_decay_score:
+      type: bool
+      description: Include indicator decay scores.
+      default: false
+    limit:
+      type: int
+      description: Maximum number of attributes to return.
+      default: 50
+    page:
+      type: int
+      description: Result page number.
+      default: 1
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/attributes/restSearch
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+          Content-Type: application/json
+        payload:
+          value: ${{ inputs.value }}
+          type: ${{ inputs.type_attribute }}
+          category: ${{ inputs.category }}
+          org: ${{ inputs.org }}
+          tags: ${{ inputs.tags }}
+          from: ${{ inputs.date_from }}
+          to: ${{ inputs.date_to }}
+          eventid: ${{ inputs.eventid }}
+          published: ${{ inputs.published }}
+          enforceWarninglist: ${{ inputs.enforce_warninglist }}
+          to_ids: ${{ inputs.to_ids }}
+          includeEventUuid: ${{ inputs.include_event_uuid }}
+          includeEventTags: ${{ inputs.include_event_tags }}
+          includeCorrelations: ${{ inputs.include_correlations }}
+          includeSightings: ${{ inputs.include_sightings }}
+          includeDecayScore: ${{ inputs.include_decay_score }}
+          limit: ${{ inputs.limit }}
+          page: ${{ inputs.page }}
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/events/get_event.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/events/get_event.yml
@@ -1,0 +1,63 @@
+type: action
+definition:
+  title: Get event
+  description: Retrieve a complete MISP event by ID, including its attributes, objects, tags, and metadata.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Events/operation/getEventById
+  namespace: tools.misp
+  name: get_event
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    event_id:
+      type: int
+      description: Numeric ID of the event to retrieve.
+    include_correlations:
+      type: bool
+      description: Include correlation data when supported by the MISP instance.
+      default: false
+    include_sightings:
+      type: bool
+      description: Include sighting data when supported by the MISP instance.
+      default: false
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: build_request
+      action: core.script.run_python
+      args:
+        inputs:
+          event_id: ${{ inputs.event_id }}
+          include_correlations: ${{ inputs.include_correlations }}
+          include_sightings: ${{ inputs.include_sightings }}
+        script: |
+          def main(event_id, include_correlations, include_sightings):
+              if include_correlations or include_sightings:
+                  return {
+                      "method": "POST",
+                      "payload": {
+                          "eventid": event_id,
+                          "includeCorrelations": include_correlations,
+                          "includeSightings": include_sightings,
+                          "limit": 1,
+                      },
+                  }
+              return {"method": "GET", "payload": None}
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}${{ "/events/restSearch" if inputs.include_correlations || inputs.include_sightings else "/events/view/" }}${{ "" if inputs.include_correlations || inputs.include_sightings else FN.url_encode(str(inputs.event_id)) }}
+        method: ${{ steps.build_request.result.method }}
+        payload: ${{ steps.build_request.result.payload }}
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/events/search_event_index.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/events/search_event_index.yml
@@ -1,0 +1,118 @@
+type: action
+definition:
+  title: Search event index
+  description: Browse and filter lightweight MISP event metadata without loading full attributes or objects.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Events/operation/searchEvents
+  namespace: tools.misp
+  name: search_event_index
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    eventinfo:
+      type: str | None
+      description: Text to match in the event information field.
+      default: null
+    tags:
+      type: list[str] | None
+      description: Event tags to include or exclude.
+      default: null
+    org:
+      type: str | None
+      description: Creator organisation name or ID.
+      default: null
+    date_from:
+      type: str | None
+      description: Earliest event date in YYYY-MM-DD format.
+      default: null
+    date_to:
+      type: str | None
+      description: Latest event date in YYYY-MM-DD format.
+      default: null
+    eventid:
+      type: str | None
+      description: Event ID filter.
+      default: null
+    threatlevel:
+      type: int | None
+      description: Threat level where 1 is high, 2 medium, 3 low, and 4 undefined.
+      default: null
+    published:
+      type: bool | None
+      description: Filter by event publication state.
+      default: null
+    analysis:
+      type: int | None
+      description: Analysis level where 0 is initial, 1 ongoing, and 2 complete.
+      default: null
+    timestamp:
+      type: str | None
+      description: Filter by last-modified timestamp or relative time.
+      default: null
+    publish_timestamp:
+      type: str | None
+      description: Filter by publication timestamp or relative time.
+      default: null
+    attribute:
+      type: str | None
+      description: Match events containing this attribute value.
+      default: null
+    minimal:
+      type: bool
+      description: Return the minimal event metadata shape.
+      default: false
+    sort:
+      type: str | None
+      description: Sort field such as id, date, or attribute_count.
+      default: null
+    desc:
+      type: bool | None
+      description: Sort descending when true or ascending when false.
+      default: null
+    limit:
+      type: int
+      description: Maximum number of events to return.
+      default: 25
+    page:
+      type: int
+      description: Result page number.
+      default: 1
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/events/index
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+          Content-Type: application/json
+        payload:
+          eventinfo: ${{ inputs.eventinfo }}
+          tags: ${{ inputs.tags }}
+          org: ${{ inputs.org }}
+          datefrom: ${{ inputs.date_from }}
+          dateuntil: ${{ inputs.date_to }}
+          eventid: ${{ inputs.eventid }}
+          threatlevel: ${{ inputs.threatlevel }}
+          published: ${{ inputs.published }}
+          analysis: ${{ inputs.analysis }}
+          timestamp: ${{ inputs.timestamp }}
+          publish_timestamp: ${{ inputs.publish_timestamp }}
+          attribute: ${{ inputs.attribute }}
+          minimal: ${{ inputs.minimal }}
+          sort: ${{ inputs.sort }}
+          direction: ${{ ("desc" if inputs.desc else "asc") if inputs.sort && inputs.desc != None else None }}
+          limit: ${{ inputs.limit }}
+          page: ${{ inputs.page }}
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/events/search_events.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/events/search_events.yml
@@ -1,0 +1,128 @@
+type: action
+definition:
+  title: Search events
+  description: Search MISP events by indicators, tags, dates, organisation, and publication state.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Events/operation/restSearchEvents
+  namespace: tools.misp
+  name: search_events
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    value:
+      type: str | None
+      description: Indicator value such as an IP address, domain, URL, or hash.
+      default: null
+    type_attribute:
+      type: str | None
+      description: MISP attribute type such as ip-src, domain, url, md5, or sha256.
+      default: null
+    category:
+      type: str | None
+      description: MISP attribute category.
+      default: null
+    org:
+      type: str | None
+      description: Creator organisation name or ID.
+      default: null
+    tags:
+      type: list[str] | None
+      description: Attribute tags to include or exclude.
+      default: null
+    event_tags:
+      type: list[str] | None
+      description: Event-level tags to include or exclude.
+      default: null
+    date_from:
+      type: str | None
+      description: Earliest event date in YYYY-MM-DD format.
+      default: null
+    date_to:
+      type: str | None
+      description: Latest event date in YYYY-MM-DD format.
+      default: null
+    eventid:
+      type: int | list[int] | None
+      description: Event ID or list of event IDs.
+      default: null
+    eventinfo:
+      type: str | None
+      description: Text to match in the event information field.
+      default: null
+    published:
+      type: bool | None
+      description: Filter by event publication state.
+      default: null
+    enforce_warninglist:
+      type: bool | None
+      description: Exclude attributes matching enabled warning lists.
+      default: null
+    to_ids:
+      type: bool | None
+      description: Filter attributes by their IDS flag.
+      default: null
+    include_correlations:
+      type: bool
+      description: Include correlation data.
+      default: false
+    include_sightings:
+      type: bool
+      description: Include sighting data.
+      default: false
+    metadata:
+      type: bool
+      description: Return event metadata without attributes or objects.
+      default: false
+    limit:
+      type: int
+      description: Maximum number of events to return.
+      default: 25
+    page:
+      type: int
+      description: Result page number.
+      default: 1
+    quick_filter:
+      type: str | None
+      description: Quick text search across event and attribute fields.
+      default: null
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/events/restSearch
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+          Content-Type: application/json
+        payload:
+          value: ${{ inputs.value }}
+          type: ${{ inputs.type_attribute }}
+          category: ${{ inputs.category }}
+          org: ${{ inputs.org }}
+          tags: ${{ inputs.tags }}
+          event_tags: ${{ inputs.event_tags }}
+          from: ${{ inputs.date_from }}
+          to: ${{ inputs.date_to }}
+          eventid: ${{ inputs.eventid }}
+          eventinfo: ${{ inputs.eventinfo }}
+          published: ${{ inputs.published }}
+          enforceWarninglist: ${{ inputs.enforce_warninglist }}
+          to_ids: ${{ inputs.to_ids }}
+          includeCorrelations: ${{ inputs.include_correlations }}
+          includeSightings: ${{ inputs.include_sightings }}
+          metadata: ${{ inputs.metadata }}
+          limit: ${{ inputs.limit }}
+          page: ${{ inputs.page }}
+          quickFilter: ${{ inputs.quick_filter }}
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/feeds/search_feeds.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/feeds/search_feeds.yml
@@ -1,0 +1,54 @@
+type: action
+definition:
+  title: Search feeds
+  description: List configured MISP feeds or search their cached threat intelligence for an indicator.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Feeds
+  namespace: tools.misp
+  name: search_feeds
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    value:
+      type: str | None
+      description: Indicator to search in cached feeds. Omit to list configured feeds.
+      default: null
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: build_request
+      action: core.script.run_python
+      args:
+        inputs:
+          value: ${{ inputs.value }}
+        script: |
+          def main(value):
+              if value:
+                  return {
+                      "method": "POST",
+                      "path": "/feeds/searchCaches",
+                      "payload": {"value": value},
+                  }
+              return {
+                  "method": "GET",
+                  "path": "/feeds/index",
+                  "payload": None,
+              }
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}${{ steps.build_request.result.path }}
+        method: ${{ steps.build_request.result.method }}
+        payload: ${{ steps.build_request.result.payload }}
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/galaxies/get_galaxy.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/galaxies/get_galaxy.yml
@@ -1,0 +1,40 @@
+type: action
+definition:
+  title: Get galaxy
+  description: Retrieve a MISP galaxy and optionally include all of its clusters.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Galaxies/operation/getGalaxyById
+  namespace: tools.misp
+  name: get_galaxy
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    galaxy_id:
+      type: int
+      description: Numeric ID of the galaxy to retrieve.
+    with_clusters:
+      type: bool
+      description: Include clusters associated with the galaxy.
+      default: true
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/galaxies/view/${{ FN.url_encode(str(inputs.galaxy_id)) }}
+        method: GET
+        params:
+          withCluster: ${{ inputs.with_clusters }}
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/galaxies/search_galaxies.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/galaxies/search_galaxies.yml
@@ -1,0 +1,42 @@
+type: action
+definition:
+  title: Search galaxies
+  description: Search MISP galaxies for threat actors, malware, tools, and ATT&CK knowledge bases.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Galaxies/operation/searchGalaxies
+  namespace: tools.misp
+  name: search_galaxies
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    value:
+      type: str
+      description: Text to match in galaxy names and descriptions.
+    with_clusters:
+      type: bool
+      description: Request cluster data with matching galaxies when supported.
+      default: false
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/galaxies
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+          Content-Type: application/json
+        payload:
+          value: ${{ inputs.value }}
+          withCluster: ${{ inputs.with_clusters }}
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/galaxies/search_galaxy_clusters.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/galaxies/search_galaxy_clusters.yml
@@ -1,0 +1,46 @@
+type: action
+definition:
+  title: Search galaxy clusters
+  description: Search threat actors, malware families, techniques, and other clusters within a MISP galaxy.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Galaxy-Clusters/operation/searchGalaxyClusters
+  namespace: tools.misp
+  name: search_galaxy_clusters
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    galaxy_id:
+      type: int
+      description: Numeric ID of the galaxy to search.
+    search_term:
+      type: str | None
+      description: Text to match in cluster names, descriptions, and synonyms.
+      default: null
+    context:
+      type: str | None
+      description: Optional MISP galaxy cluster context filter.
+      default: null
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/galaxy_clusters/index/${{ FN.url_encode(str(inputs.galaxy_id)) }}
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+          Content-Type: application/json
+        payload:
+          searchall: ${{ inputs.search_term }}
+          context: ${{ inputs.context || "all" }}
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/objects/get_object.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/objects/get_object.yml
@@ -1,0 +1,34 @@
+type: action
+definition:
+  title: Get object
+  description: Retrieve a specific MISP object and all of its grouped attributes.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Objects/operation/getObjectById
+  namespace: tools.misp
+  name: get_object
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    object_id:
+      type: int
+      description: Numeric ID of the object to retrieve.
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/objects/view/${{ FN.url_encode(str(inputs.object_id)) }}
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/objects/search_objects.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/objects/search_objects.yml
@@ -1,0 +1,88 @@
+type: action
+definition:
+  title: Search objects
+  description: Search MISP objects that group related indicators such as files, network connections, and emails.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Objects/operation/restSearchObjects
+  namespace: tools.misp
+  name: search_objects
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    value:
+      type: str | None
+      description: Value of an attribute contained in an object.
+      default: null
+    type_attribute:
+      type: str | None
+      description: Type of an attribute contained in an object.
+      default: null
+    category:
+      type: str | None
+      description: MISP attribute category.
+      default: null
+    org:
+      type: str | None
+      description: Creator organisation name or ID.
+      default: null
+    tags:
+      type: list[str] | None
+      description: Tags to include or exclude.
+      default: null
+    date_from:
+      type: str | None
+      description: Earliest event date in YYYY-MM-DD format.
+      default: null
+    date_to:
+      type: str | None
+      description: Latest event date in YYYY-MM-DD format.
+      default: null
+    eventid:
+      type: int | list[int] | None
+      description: Parent event ID or list of event IDs.
+      default: null
+    object_name:
+      type: str | None
+      description: Object template name such as file, ip-port, domain-ip, or email.
+      default: null
+    limit:
+      type: int
+      description: Maximum number of objects to return.
+      default: 25
+    page:
+      type: int
+      description: Result page number.
+      default: 1
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/objects/restSearch
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+          Content-Type: application/json
+        payload:
+          value: ${{ inputs.value }}
+          type: ${{ inputs.type_attribute }}
+          category: ${{ inputs.category }}
+          org: ${{ inputs.org }}
+          tags: ${{ inputs.tags }}
+          from: ${{ inputs.date_from }}
+          to: ${{ inputs.date_to }}
+          eventid: ${{ inputs.eventid }}
+          object_name: ${{ inputs.object_name }}
+          limit: ${{ inputs.limit }}
+          page: ${{ inputs.page }}
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/tags/search_tags.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/tags/search_tags.yml
@@ -1,0 +1,42 @@
+type: action
+definition:
+  title: Search tags
+  description: Search MISP tags by exact or partial tag name.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Tags/operation/searchTag
+  namespace: tools.misp
+  name: search_tags
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    tagname:
+      type: str
+      description: Exact or partial tag name, such as tlp:amber or a galaxy tag.
+    strict:
+      type: bool
+      description: Match the tag name exactly instead of matching synonyms and galaxy values.
+      default: false
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/tags/search
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+          Content-Type: application/json
+        payload:
+          tagname: ${{ inputs.tagname }}
+          strict_tagname: ${{ inputs.strict }}
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/taxonomies/get_taxonomy.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/taxonomies/get_taxonomy.yml
@@ -1,0 +1,34 @@
+type: action
+definition:
+  title: Get taxonomy
+  description: Retrieve a MISP taxonomy with its predicates and values.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Taxonomies/operation/getTaxonomyById
+  namespace: tools.misp
+  name: get_taxonomy
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    taxonomy_id:
+      type: int
+      description: Numeric ID of the taxonomy to retrieve.
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/taxonomies/view/${{ FN.url_encode(str(inputs.taxonomy_id)) }}
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+  returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/misp/taxonomies/list_taxonomies.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/misp/taxonomies/list_taxonomies.yml
@@ -1,0 +1,31 @@
+type: action
+definition:
+  title: List taxonomies
+  description: List MISP taxonomy vocabularies used to classify threat intelligence.
+  display_group: MISP
+  doc_url: https://www.misp-project.org/openapi/#tag/Taxonomies/operation/getTaxonomies
+  namespace: tools.misp
+  name: list_taxonomies
+  secrets:
+    - name: misp
+      keys: ["MISP_API_KEY"]
+  expects:
+    base_url:
+      type: str | None
+      description: MISP base URL. Falls back to VARS.misp.base_url.
+      default: null
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+  steps:
+    - ref: request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url || VARS.misp.base_url }}/taxonomies/index
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: ${{ SECRETS.misp.MISP_API_KEY }}
+          Accept: application/json
+  returns: ${{ steps.request.result.data }}

--- a/tests/registry/test_misp_templates.py
+++ b/tests/registry/test_misp_templates.py
@@ -1,0 +1,306 @@
+"""Contract tests for the agent-oriented MISP enrichment actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tracecat_registry import RegistrySecret
+
+from tracecat.dsl.schemas import TemplateExecutionContext
+from tracecat.expressions.eval import eval_templated_object
+from tracecat.registry.actions.schemas import TemplateAction
+
+TEMPLATE_ROOT = Path(
+    "packages/tracecat-registry/tracecat_registry/templates/tools/misp"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogEntry:
+    name: str
+    method: str
+    endpoint: str
+
+    @property
+    def action(self) -> str:
+        return f"tools.misp.{self.name}"
+
+
+CATALOG = (
+    CatalogEntry("search_events", "POST", "/events/restSearch"),
+    CatalogEntry("search_attributes", "POST", "/attributes/restSearch"),
+    CatalogEntry("search_objects", "POST", "/objects/restSearch"),
+    CatalogEntry("search_event_index", "POST", "/events/index"),
+    CatalogEntry("get_attribute", "GET", "/attributes/view/"),
+    CatalogEntry("get_object", "GET", "/objects/view/"),
+    CatalogEntry("search_tags", "POST", "/tags/search"),
+    CatalogEntry("list_taxonomies", "GET", "/taxonomies/index"),
+    CatalogEntry("get_taxonomy", "GET", "/taxonomies/view/"),
+    CatalogEntry("search_galaxies", "POST", "/galaxies"),
+    CatalogEntry("get_galaxy", "GET", "/galaxies/view/"),
+    CatalogEntry(
+        "search_galaxy_clusters",
+        "POST",
+        "/galaxy_clusters/index/",
+    ),
+)
+
+APPROVED_ACTION_NAMES = frozenset(
+    "search_events search_attributes search_objects search_event_index "
+    "get_event get_attribute get_object search_tags list_taxonomies get_taxonomy "
+    "search_galaxies get_galaxy search_galaxy_clusters search_feeds".split()
+)
+
+
+@pytest.fixture(scope="module")
+def templates() -> dict[str, tuple[TemplateAction, Path]]:
+    loaded: dict[str, tuple[TemplateAction, Path]] = {}
+    for path in sorted(TEMPLATE_ROOT.rglob("*.yml")):
+        template = TemplateAction.from_yaml(path)
+        action = template.definition.action
+        if action in loaded:
+            pytest.fail(f"Duplicate action in {loaded[action][1]} and {path}")
+        loaded[action] = (template, path)
+    return loaded
+
+
+def http_step(template: TemplateAction):
+    return next(
+        step for step in template.definition.steps if step.action == "core.http_request"
+    )
+
+
+def execute_script(template: TemplateAction, ref: str, **inputs: Any) -> Any:
+    step = next(step for step in template.definition.steps if step.ref == ref)
+    namespace: dict[str, Any] = {}
+    exec(step.args["script"], namespace)  # noqa: S102
+    return namespace["main"](**inputs)
+
+
+def test_catalog_matches_official_mcp_surface(
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    expected = {f"tools.misp.{name}" for name in APPROVED_ACTION_NAMES}
+    assert len(expected) == 14
+    assert set(templates) == expected
+
+
+@pytest.mark.parametrize("entry", CATALOG, ids=lambda entry: entry.action)
+def test_action_method_and_endpoint(
+    entry: CatalogEntry,
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    template, _ = templates[entry.action]
+    definition = template.definition
+    request = http_step(template)
+
+    assert definition.namespace == "tools.misp"
+    assert definition.name == entry.name
+    assert definition.display_group == "MISP"
+    assert definition.doc_url is not None
+    assert definition.doc_url.startswith("https://www.misp-project.org/")
+    assert request.args["method"] == entry.method
+    assert entry.endpoint in request.args["url"]
+
+
+def test_common_connection_contract(
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    for action, (template, _) in templates.items():
+        definition = template.definition
+        assert definition.secrets is not None
+        assert len(definition.secrets) == 1
+        secret = definition.secrets[0]
+        assert isinstance(secret, RegistrySecret), action
+        assert secret.name == "misp", action
+        assert secret.keys == ["MISP_API_KEY"], action
+
+        assert definition.expects["base_url"].type == "str | None", action
+        assert definition.expects["base_url"].default is None, action
+        assert definition.expects["verify_ssl"].type == "bool", action
+        assert definition.expects["verify_ssl"].default is True, action
+        assert "payload" not in definition.expects, action
+        assert "params" not in definition.expects, action
+
+        request = http_step(template)
+        assert request.args["verify_ssl"] == "${{ inputs.verify_ssl }}", action
+        assert request.args["headers"]["Authorization"] == (
+            "${{ SECRETS.misp.MISP_API_KEY }}"
+        ), action
+        assert "inputs.base_url || VARS.misp.base_url" in request.args["url"], action
+        assert definition.returns == "${{ steps.request.result.data }}", action
+
+
+def test_catalog_contains_only_read_only_enrichment_paths(
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    forbidden_path_fragments = (
+        "/add",
+        "/delete",
+        "/edit",
+        "/publish",
+        "/unpublish",
+        "/enable",
+        "/disable",
+        "/update",
+        "/servers",
+        "/users",
+        "/auth",
+        "/admin",
+        "/sharing_groups",
+        "/sightings",
+    )
+    for action, (template, path) in templates.items():
+        source = path.read_text()
+        assert not any(fragment in source for fragment in forbidden_path_fragments), (
+            action
+        )
+        method = http_step(template).args["method"]
+        assert method in {"GET", "POST", "${{ steps.build_request.result.method }}"}
+
+
+@pytest.mark.parametrize(
+    ("action", "identifier", "path"),
+    (
+        ("tools.misp.get_event", "event_id", "/events/view/42"),
+        ("tools.misp.get_attribute", "attribute_id", "/attributes/view/42"),
+        ("tools.misp.get_object", "object_id", "/objects/view/42"),
+        ("tools.misp.get_taxonomy", "taxonomy_id", "/taxonomies/view/42"),
+        ("tools.misp.get_galaxy", "galaxy_id", "/galaxies/view/42"),
+        (
+            "tools.misp.search_galaxy_clusters",
+            "galaxy_id",
+            "/galaxy_clusters/index/42",
+        ),
+    ),
+)
+def test_numeric_identifiers_are_encoded_as_strings(
+    action: str,
+    identifier: str,
+    path: str,
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    template, _ = templates[action]
+    inputs = {
+        identifier: 42,
+        "base_url": "https://misp.example.com",
+        "include_correlations": False,
+        "include_sightings": False,
+    }
+    context = TemplateExecutionContext(inputs=inputs, steps={})
+
+    url = eval_templated_object(http_step(template).args["url"], operand=context)
+
+    assert url == f"https://misp.example.com{path}"
+
+
+def test_search_feeds_matches_official_list_or_search_behavior(
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    template, _ = templates["tools.misp.search_feeds"]
+
+    assert execute_script(template, "build_request", value=None) == {
+        "method": "GET",
+        "path": "/feeds/index",
+        "payload": None,
+    }
+    assert execute_script(template, "build_request", value="example.test") == {
+        "method": "POST",
+        "path": "/feeds/searchCaches",
+        "payload": {"value": "example.test"},
+    }
+
+
+def test_get_event_matches_official_direct_or_enriched_behavior(
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    template, path = templates["tools.misp.get_event"]
+
+    assert execute_script(
+        template,
+        "build_request",
+        event_id=42,
+        include_correlations=False,
+        include_sightings=False,
+    ) == {"method": "GET", "payload": None}
+    assert execute_script(
+        template,
+        "build_request",
+        event_id=42,
+        include_correlations=True,
+        include_sightings=False,
+    ) == {
+        "method": "POST",
+        "payload": {
+            "eventid": 42,
+            "includeCorrelations": True,
+            "includeSightings": False,
+            "limit": 1,
+        },
+    }
+    source = path.read_text()
+    assert "/events/view/" in source
+    assert "/events/restSearch" in source
+
+
+@pytest.mark.parametrize(
+    "action",
+    ("tools.misp.get_event", "tools.misp.search_feeds"),
+)
+def test_dual_method_actions_leave_content_type_to_http_client(
+    action: str,
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    template, _ = templates[action]
+
+    assert "Content-Type" not in http_step(template).args["headers"]
+
+
+@pytest.mark.parametrize(
+    ("sort", "desc", "expected"),
+    (
+        ("date", None, None),
+        ("date", False, "asc"),
+        ("date", True, "desc"),
+        (None, True, None),
+    ),
+)
+def test_event_index_preserves_optional_sort_direction(
+    sort: str | None,
+    desc: bool | None,
+    expected: str | None,
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    template, _ = templates["tools.misp.search_event_index"]
+    context = TemplateExecutionContext(
+        inputs={"sort": sort, "desc": desc},
+        steps={},
+    )
+    direction = http_step(template).args["payload"]["direction"]
+
+    assert eval_templated_object(direction, operand=context) == expected
+
+
+def test_search_defaults_are_bounded_and_agent_friendly(
+    templates: dict[str, tuple[TemplateAction, Path]],
+) -> None:
+    expected_limits = {
+        "tools.misp.search_events": 25,
+        "tools.misp.search_attributes": 50,
+        "tools.misp.search_objects": 25,
+        "tools.misp.search_event_index": 25,
+    }
+    for action, limit in expected_limits.items():
+        definition = templates[action][0].definition
+        assert definition.expects["limit"].default == limit
+        assert definition.expects["page"].default == 1
+
+    assert (
+        templates["tools.misp.search_galaxy_clusters"][0]
+        .definition.expects["context"]
+        .default
+        is None
+    )

--- a/tracecat/integrations/catalog/mcp_catalog.json
+++ b/tracecat/integrations/catalog/mcp_catalog.json
@@ -156,6 +156,13 @@
       "icon": "https://cdn.simpleicons.org/virustotal"
     },
     {
+      "slug": "misp-mcp",
+      "name": "MISP",
+      "description": "Search events, indicators, objects, tags, galaxies, and feeds in MISP",
+      "category": "Threat Intelligence",
+      "icon": "https://raw.githubusercontent.com/MISP/MISP/2.5/INSTALL/logos/misp-logo.svg"
+    },
+    {
       "slug": "microsoft-entra-id-mcp",
       "name": "Microsoft Entra ID",
       "description": "Query users, groups, and access policies through Microsoft Graph",


### PR DESCRIPTION
## Summary

- Add exactly 14 read-only MISP enrichment actions matching the official `MISP/misp-mcp` tool surface: event, attribute, object, tag, taxonomy, galaxy, galaxy-cluster, and feed search/retrieval.
- Expose descriptive typed inputs with `MISP_API_KEY`, `${{ inputs.base_url || VARS.misp.base_url }}`, and `verify_ssl: true` across every action.
- Add public and private catalog entries for the official MCP server, pinned to source commit `745ce9ab4989a98b765ca4a5a99530926ea3d232` and runtime dependency `mcp==1.28.1`, with the official MISP SVG logo.

## Scope

This integration is intentionally limited to threat enrichment that an AI agent can use during security investigations. It excludes mutation, publishing, sighting creation, feed management, server synchronization, sharing-group management, and user or server administration.

No generator, vendored OpenAPI snapshot, operation manifest, or integration script is included. Deterministic workflows outside the agent enrichment surface can use `core.http_request` directly.

## Validation

- Focused registry and catalog-loader tests: 48 passed
- Deterministic registry prebuild: 761 actions loaded, 0 errors
- Pinned MCP initialize, `tools/list`, and schema-parity probe: exactly 14 matching tools
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`: 0 errors, 0 warnings
- Signed pre-commit hooks: passed

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 877 | 0 |
| Tests | 306 | 0 |
| Infra/config | 82 | 0 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a MISP security integration with 14 read-only enrichment actions and a pinned `MISP/misp-mcp` MCP server, letting users search events, indicators, objects, tags, galaxies, feeds, and taxonomies without custom HTTP. Consistent auth and base URL handling support self-hosted MISP.

- **New Features**
  - 14 actions: events (get, restSearch, index), attributes (get, restSearch), objects (get, restSearch), tags, galaxies (search, get), galaxy clusters, feeds, and taxonomies (list, get).
  - Standardized inputs: `MISP_API_KEY`, `base_url` with `VARS.misp.base_url` fallback, and `verify_ssl`.
  - MCP catalog: add public and private entries for `misp-mcp` (stdio via `uvx`), pin `mcp==1.28.1` and commit `745ce9ab4989a98b765ca4a5a99530926ea3d232`; use `MISP_URL`, `MISP_API_KEY`, `MISP_VERIFYCERT`; includes MISP icon.
  - Contract tests cover endpoints, auth, numeric ID encoding, safe read-only surface, pagination defaults, and feed/event behavior toggles.

- **Migration**
  - Set `VARS.misp.base_url` or pass `base_url`.
  - Store `MISP_API_KEY` in the `misp` secret.
  - Toggle `verify_ssl` for self-signed TLS.
  - For MCP, provide `MISP_URL`, `MISP_API_KEY`, and `MISP_VERIFYCERT`.

<sup>Written for commit 395b5d0e7d137f7bccbbf9926183e5b8085c2f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
