### PR TITLE
fix(auth): mark session cookie Secure when public API uses HTTPS

### DIFF
--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import uuid
 
@@ -5,6 +6,7 @@ import pytest
 from httpx import AsyncClient
 
 from tracecat import config
+from tracecat.auth import users as users_mod
 from tracecat.auth.types import Role
 from tracecat.clients import AuthenticatedAPIClient, AuthenticatedServiceClient
 from tracecat.contexts import ctx_role
@@ -188,3 +190,24 @@ async def test_authenticated_api_client_init_with_role(mock_user_id, mock_org_id
         assert "x-tracecat-role-user-id" not in client.headers
         assert uuid.UUID(client.headers["x-tracecat-role-workspace-id"]) == mock_org_id
         assert client.base_url == config.TRACECAT__API_URL
+
+
+@pytest.mark.parametrize(
+    ("public_api_url", "expected"),
+    [
+        # Browser-facing URL terminates TLS at the load balancer, so the session
+        # cookie must be marked Secure regardless of the internal API URL scheme.
+        ("https://tracecat.example.com/api", True),
+        ("http://localhost/api", False),
+    ],
+)
+def test_cookie_secure_derived_from_public_api_url(
+    monkeypatch, public_api_url, expected
+):
+    monkeypatch.setattr(config, "TRACECAT__PUBLIC_API_URL", public_api_url)
+    reloaded = importlib.reload(users_mod)
+    assert reloaded.cookie_transport.cookie_secure is expected
+    # Ensure the internal API URL never gates the Secure flag on its own.
+    monkeypatch.setattr(config, "TRACECAT__API_URL", "http://api-service:8000")
+    reloaded = importlib.reload(users_mod)
+    assert reloaded.cookie_transport.cookie_secure is expected

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -692,7 +692,7 @@ def _get_cookie_name() -> str:
 cookie_transport = CookieTransport(
     cookie_name=_get_cookie_name(),
     cookie_max_age=config.SESSION_EXPIRE_TIME_SECONDS,
-    cookie_secure=config.TRACECAT__API_URL.startswith("https"),
+    cookie_secure=config.TRACECAT__PUBLIC_API_URL.startswith("https"),
 )
 
 


### PR DESCRIPTION
## Summary

The auth session cookie's `Secure` flag was derived from `TRACECAT__API_URL`, the **internal** API URL that deployments set to plain HTTP (e.g. `http://api-service:8000` in the Fargate module at `deployments/fargate/modules/ecs/locals.tf:19`). This caused the session cookie to be sent **without** the `Secure` attribute even when the public API is served over HTTPS, so it could be transmitted over plaintext HTTP (CWE-614).

This PR derives the flag from `TRACECAT__PUBLIC_API_URL` instead — the browser-facing URL that already determines the cookie name (`tracecat/auth/users.py`), and which production sets to `https://<domain>/api`.

## Changes

- `tracecat/auth/users.py`: base `cookie_secure` on `TRACECAT__PUBLIC_API_URL` scheme
- `tests/unit/test_auth.py`: regression test covering both https/http public URLs, and asserting the internal API URL never gates the flag

## Verification

- `uv run pytest tests/unit/test_auth.py` — 9 passed (2 new)
- `uv run ruff check`, `uv run ruff format --check` — clean
- `uv run basedpyright --warnings --threads 4` — 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the auth session cookie as Secure when the public API is served over HTTPS, preventing it from being sent over plaintext HTTP.

- **Bug Fixes**
  - Derive `cookie_secure` from `TRACECAT__PUBLIC_API_URL` in `tracecat/auth/users.py` (not `TRACECAT__API_URL`).
  - Add regression tests to cover HTTPS/HTTP public URLs and ensure the internal API URL never gates the flag.

<sup>Written for commit 40b84ab5d97490cff4608286224c5b0e17c36b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

