### PR TITLE
fix(integrations): calculate initial OAuth token expiry in UTC

### DIFF
--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1684,7 +1684,7 @@ class IntegrationService(BaseWorkspaceService):
         # Calculate expiration time if expires_in is provided
         expires_at = None
         if expires_in is not None:
-            expires_at = datetime.now() + timedelta(seconds=expires_in)
+            expires_at = datetime.now(UTC) + timedelta(seconds=expires_in)
 
         provider_impl = get_provider_class(provider_key)
         default_authorization = (


### PR DESCRIPTION
## Description

This PR fixes a critical correctness bug where newly created OAuth integrations (e.g., Slack, GitHub, Jira, etc.) are instantly marked as **"Reauthorization required"** (or fail to refresh when expired) when Tracecat is hosted on servers located in non-UTC time zones.

### The Problem
In `tracecat/integrations/service.py:1687` inside `store_integration`, the initial token expiration `expires_at` was calculated using naive local time:
```python
expires_at = datetime.now() + timedelta(seconds=expires_in)
```
When this naive datetime is written to a timezone-aware database column (`TIMESTAMP WITH TIME ZONE` in PostgreSQL), the SQLAlchemy/Postgres layer interprets the naive value as matching the database's current session timezone (usually **UTC** on standard Docker or Cloud DB deployments) without performing any offset translation.

#### Severe Consequences:
- **For Servers Behind UTC (Americas, UTC-4 to UTC-8):** 
  If New York is currently `10:30 AM` local time (`14:30 UTC`), a 1-hour token has its naive expiration calculated as `11:30 AM`. This gets stored in Postgres literally as `11:30 AM UTC`. 
  Because the real UTC time is `14:30 UTC`, **the token is treated as already expired by 3 hours the exact second it is stored.** The frontend instantly flags the connection as broken and prompts the user to re-authorize immediately.
- **For Servers Ahead of UTC (Asia/Pacific, UTC+5:30 to UTC+9):**
  The expiration is written hours in the future. The system assumes a 1-hour token is valid for 6–10 hours, failing to refresh it on time and leading to silent workflow failures with `401 Unauthorized` errors.

### The Solution
I change the calculation to use timezone-aware **UTC** datetime, which aligns with all subsequent refresh checks and comparisons in the codebase:
```python
expires_at = datetime.now(UTC) + timedelta(seconds=expires_in)
```

---

## Verification

### Live Database Reproduction
I spun up the local test cluster and forced the `api` timezone to `America/New_York` (EDT, UTC-4).
After triggering the buggy code flow, I queried Postgres:

```sql
SELECT id, provider_id, expires_at FROM oauth_integration;
```

#### Before the Fix (Buggy)
The naive `12:01:42` local expiration got saved as-is in UTC, placing it **3 hours in the past** relative to the true UTC time (`15:01:42`):
```
id                                   | provider_id | expires_at
-------------------------------------+-------------+---------------------------
cbd0edce-4efe-4e4a-91de-f42a2a312ced | github      | 2026-08-05 12:01:42+00:00  <-- Stored in the past!
```
*Evaluates to:* `is_expired: True` immediately upon database insert.

#### After the Fix (Corrected)
The timezone-aware expiration is calculated correctly relative to UTC:
```
id                                   | provider_id | expires_at
-------------------------------------+-------------+---------------------------
cbd0edce-4efe-4e4a-91de-f42a2a312ced | github      | 2026-08-05 16:01:42+00:00  <-- Stored correctly!
```
*Evaluates to:* `is_expired: False` as expected, with a correct 1-hour lifetime.

---

## Screenshots

<img width="1266" height="547" alt="Screenshot 2026-08-05 at 8 35 00 PM" src="https://github.com/user-attachments/assets/4af217f6-f9cf-4ecc-b9cf-ff1072d39e87" />


<img width="1058" height="754" alt="Screenshot 2026-08-05 at 8 40 02 PM" src="https://github.com/user-attachments/assets/05140a1d-18cd-4f6d-a92c-f41a9b968d1d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calculate initial OAuth token expiry in UTC to prevent immediate expiration or late refresh on non-UTC hosts. Sets `expires_at` using `datetime.now(UTC)` in `tracecat/integrations/service.py` to align with `TIMESTAMP WITH TIME ZONE` storage and refresh checks.

<sup>Written for commit 91a7e38e8840647625e6990eafb6bf0f2287b6df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

