### PR TITLE
feat(cases) ENG-1597: add team scoped agent session reads

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3613,6 +3613,12 @@ export const $AgentSessionRead = {
       ],
       title: "Created By",
     },
+    is_readonly: {
+      type: "boolean",
+      title: "Is Readonly",
+      description: "Whether the requesting actor can modify this session",
+      default: false,
+    },
     entity_type: {
       $ref: "#/components/schemas/AgentSessionEntity",
     },
@@ -3806,6 +3812,12 @@ export const $AgentSessionReadVercel = {
         },
       ],
       title: "Created By",
+    },
+    is_readonly: {
+      type: "boolean",
+      title: "Is Readonly",
+      description: "Whether the requesting actor can modify this session",
+      default: false,
     },
     entity_type: {
       $ref: "#/components/schemas/AgentSessionEntity",
@@ -4008,6 +4020,12 @@ export const $AgentSessionReadWithMessages = {
         },
       ],
       title: "Created By",
+    },
+    is_readonly: {
+      type: "boolean",
+      title: "Is Readonly",
+      description: "Whether the requesting actor can modify this session",
+      default: false,
     },
     entity_type: {
       $ref: "#/components/schemas/AgentSessionEntity",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -6609,6 +6609,7 @@ export const agentSessionsCreateSession = (
  * @param data.workspaceId
  * @param data.entityType Filter by entity type
  * @param data.entityId Filter by entity ID
+ * @param data.createdBy Filter by session creator. Omit to list the entire workspace.
  * @param data.excludeEntityTypes Entity types to exclude from results
  * @param data.parentSessionId Filter by parent session ID (for finding forked sessions)
  * @param data.limit Maximum number of sessions to return
@@ -6627,6 +6628,7 @@ export const agentSessionsListSessions = (
     query: {
       entity_type: data.entityType,
       entity_id: data.entityId,
+      created_by: data.createdBy,
       exclude_entity_types: data.excludeEntityTypes,
       parent_session_id: data.parentSessionId,
       limit: data.limit,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -884,6 +884,10 @@ export type AgentSessionRead = {
   workspace_id: string
   title: string
   created_by: string | null
+  /**
+   * Whether the requesting actor can modify this session
+   */
+  is_readonly?: boolean
   entity_type: AgentSessionEntity
   entity_id: string
   channel_context: {
@@ -911,6 +915,10 @@ export type AgentSessionReadVercel = {
   workspace_id: string
   title: string
   created_by: string | null
+  /**
+   * Whether the requesting actor can modify this session
+   */
+  is_readonly?: boolean
   entity_type: AgentSessionEntity
   entity_id: string
   channel_context: {
@@ -942,6 +950,10 @@ export type AgentSessionReadWithMessages = {
   workspace_id: string
   title: string
   created_by: string | null
+  /**
+   * Whether the requesting actor can modify this session
+   */
+  is_readonly?: boolean
   entity_type: AgentSessionEntity
   entity_id: string
   channel_context: {
@@ -11740,6 +11752,10 @@ export type AgentSessionsCreateSessionData = {
 export type AgentSessionsCreateSessionResponse = AgentSessionRead
 
 export type AgentSessionsListSessionsData = {
+  /**
+   * Filter by session creator. Omit to list the entire workspace.
+   */
+  createdBy?: string | null
   /**
    * Filter by entity ID
    */

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -69,7 +69,10 @@ import { AgentPresetVersionSelect } from "@/components/agents/agent-preset-versi
 import { AgentPresetVersionsPanel } from "@/components/agents/agent-preset-versions-panel"
 import { SlackChannelPanel } from "@/components/agents/external-channels/slack-channel-panel"
 import { ActionSelect } from "@/components/chat/action-select"
-import { ChatHistoryDropdown } from "@/components/chat/chat-history-dropdown"
+import {
+  ChatHistoryDropdown,
+  type ChatHistoryScope,
+} from "@/components/chat/chat-history-dropdown"
 import { ChatSessionPane } from "@/components/chat/chat-session-pane"
 import { CodeEditor } from "@/components/editor/codemirror/code-editor"
 import { getIcon, getMcpProviderIconId, ProviderIcon } from "@/components/icons"
@@ -149,6 +152,7 @@ import {
   useDeleteAgentPreset,
   useUpdateAgentPreset,
 } from "@/hooks/use-agent-presets"
+import { useAuth } from "@/hooks/use-auth"
 import {
   useCreateChat,
   useGetChatVercel,
@@ -792,13 +796,16 @@ function AgentPresetChatPane({
   enabledModelOptions: EnabledModelOption[]
   enabledModelsLoaded: boolean
 }) {
+  const { user } = useAuth()
   const [selectedChatId, setSelectedChatId] = useState<string | null>(null)
+  const [historyScope, setHistoryScope] = useState<ChatHistoryScope>("team")
 
   const { chats, chatsLoading, chatsError, refetchChats } = useListChats(
     {
       workspaceId,
       entityType: "agent_preset",
       entityId: preset?.id,
+      createdBy: historyScope === "mine" ? user?.id : undefined,
     },
     { enabled: Boolean(preset && workspaceId) }
   )
@@ -807,8 +814,14 @@ function AgentPresetChatPane({
     setSelectedChatId(null)
   }, [preset?.id])
 
-  const latestChatId = chats?.[0]?.id
+  const latestChatId =
+    chats?.find((candidate) => !candidate.is_readonly)?.id ?? chats?.[0]?.id
   const activeChatId = selectedChatId ?? latestChatId
+
+  const handleHistoryScopeChange = (nextScope: ChatHistoryScope) => {
+    setHistoryScope(nextScope)
+    setSelectedChatId(null)
+  }
 
   const { createChat, createChatPending } = useCreateChat(workspaceId)
   const { updateChat, isUpdating } = useUpdateChat(workspaceId)
@@ -893,7 +906,7 @@ function AgentPresetChatPane({
   }
 
   const handlePresetVersionChange = async (nextVersionId: string | null) => {
-    if (!activeChatId) {
+    if (!activeChatId || chat?.is_readonly) {
       return
     }
 
@@ -944,7 +957,12 @@ function AgentPresetChatPane({
       )
     }
 
-    if (enabledModelsLoaded && !selectedModel && !hasLegacyModelConfig) {
+    if (
+      enabledModelsLoaded &&
+      !selectedModel &&
+      !hasLegacyModelConfig &&
+      !chat?.is_readonly
+    ) {
       return (
         <div className="flex h-full flex-col items-center justify-center px-4">
           <div className="flex max-w-xs flex-col items-center gap-2 text-center text-xs text-muted-foreground">
@@ -973,7 +991,13 @@ function AgentPresetChatPane({
       )
     }
 
-    if (!activeChatId || chatLoading || chatsLoading || !chat || !modelInfo) {
+    if (
+      !activeChatId ||
+      chatLoading ||
+      chatsLoading ||
+      !chat ||
+      (!modelInfo && !chat.is_readonly)
+    ) {
       return (
         <div className="flex h-full items-center justify-center">
           <CenteredSpinner />
@@ -1004,7 +1028,7 @@ function AgentPresetChatPane({
         entityId={preset.id}
         className="flex-1 min-h-0"
         placeholder={`Talk to ${preset.name}...`}
-        modelInfo={modelInfo}
+        modelInfo={modelInfo ?? undefined}
         toolsEnabled={false}
       />
     )
@@ -1021,7 +1045,7 @@ function AgentPresetChatPane({
             selectedVersionId={chat?.agent_preset_version_id ?? null}
             currentVersionId={preset.current_version_id ?? null}
             onSelect={handlePresetVersionChange}
-            disabled={!activeChatId || !chat || isUpdating}
+            disabled={!activeChatId || !chat || chat.is_readonly || isUpdating}
             triggerClassName="h-8 w-[10.5rem] text-xs"
           />
           <div className="flex items-center gap-1">
@@ -1031,6 +1055,9 @@ function AgentPresetChatPane({
               error={chatsError}
               selectedChatId={activeChatId ?? undefined}
               onSelectChat={(chatId) => setSelectedChatId(chatId)}
+              workspaceId={workspaceId}
+              scope={historyScope}
+              onScopeChange={handleHistoryScopeChange}
               align="end"
             />
             <Button
@@ -3534,8 +3561,10 @@ function AgentPresetBuilderChatPane({
   workspaceId: string
   builderPrompt?: string
 }) {
+  const { user } = useAuth()
   const presetId = preset?.id
   const [selectedChatId, setSelectedChatId] = useState<string | null>(null)
+  const [historyScope, setHistoryScope] = useState<ChatHistoryScope>("team")
   const [pendingBuilderPrompt, setPendingBuilderPrompt] = useState<
     string | undefined
   >(builderPrompt?.trim() ? builderPrompt.trim() : undefined)
@@ -3552,6 +3581,7 @@ function AgentPresetBuilderChatPane({
       workspaceId,
       entityType: "agent_preset_builder",
       entityId: presetId ?? undefined,
+      createdBy: historyScope === "mine" ? user?.id : undefined,
     },
     { enabled: Boolean(presetId && workspaceId) }
   )
@@ -3566,8 +3596,14 @@ function AgentPresetBuilderChatPane({
     )
   }, [builderPrompt, presetId])
 
-  const latestChatId = chats?.[0]?.id
+  const latestChatId =
+    chats?.find((candidate) => !candidate.is_readonly)?.id ?? chats?.[0]?.id
   const activeChatId = selectedChatId ?? latestChatId
+
+  const handleHistoryScopeChange = (nextScope: ChatHistoryScope) => {
+    setHistoryScope(nextScope)
+    setSelectedChatId(null)
+  }
 
   const { createChat, createChatPending } = useCreateChat(workspaceId)
   const { chat, chatLoading, chatError } = useGetChatVercel({
@@ -3632,7 +3668,7 @@ function AgentPresetBuilderChatPane({
       )
     }
 
-    if (!chatReady || !modelInfo) {
+    if ((!chatReady || !modelInfo) && !chat?.is_readonly) {
       return (
         <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center text-xs text-muted-foreground">
           <AlertCircle className="size-5 text-amber-500" />
@@ -3687,7 +3723,12 @@ function AgentPresetBuilderChatPane({
       )
     }
 
-    if (chatLoading || chatsLoading || !chat || !modelInfo) {
+    if (
+      chatLoading ||
+      chatsLoading ||
+      !chat ||
+      (!modelInfo && !chat.is_readonly)
+    ) {
       return (
         <div className="flex h-full items-center justify-center">
           <CenteredSpinner />
@@ -3718,7 +3759,7 @@ function AgentPresetBuilderChatPane({
         entityId={presetId}
         className="flex-1 min-h-0"
         placeholder={`Talk to the builder assistant about your agent's prompt, tools, and approval rules...`}
-        modelInfo={modelInfo}
+        modelInfo={modelInfo ?? undefined}
         toolsEnabled={false}
         pendingMessage={pendingBuilderPrompt}
         onPendingMessageSent={() => setPendingBuilderPrompt(undefined)}
@@ -3737,6 +3778,9 @@ function AgentPresetBuilderChatPane({
               error={chatsError}
               selectedChatId={activeChatId ?? undefined}
               onSelectChat={(chatId) => setSelectedChatId(chatId)}
+              workspaceId={workspaceId}
+              scope={historyScope}
+              onScopeChange={handleHistoryScopeChange}
               align="end"
             />
             <Button

--- a/frontend/src/components/chat/chat-history-dropdown.tsx
+++ b/frontend/src/components/chat/chat-history-dropdown.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 
 import type { AgentSessionsListSessionsResponse } from "@/client"
 import { ChatLastErrorIndicator } from "@/components/chat/chat-last-error-indicator"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Command,
@@ -20,6 +21,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { ToggleTabs } from "@/components/ui/toggle-tabs"
+import { useWorkspaceMembers } from "@/hooks/use-workspace"
+import { getDisplayName } from "@/lib/auth"
+
+export type ChatHistoryScope = "team" | "mine"
 
 interface ChatHistoryDropdownProps {
   chats: AgentSessionsListSessionsResponse | undefined
@@ -27,6 +33,9 @@ interface ChatHistoryDropdownProps {
   error: unknown
   selectedChatId: string | undefined
   onSelectChat: (chatId: string) => void
+  workspaceId: string
+  scope: ChatHistoryScope
+  onScopeChange: (scope: ChatHistoryScope) => void
   align?: "start" | "center" | "end"
 }
 
@@ -36,9 +45,21 @@ export function ChatHistoryDropdown({
   error,
   selectedChatId,
   onSelectChat,
+  workspaceId,
+  scope,
+  onScopeChange,
   align = "start",
 }: ChatHistoryDropdownProps) {
   const [open, setOpen] = useState(false)
+  const { members } = useWorkspaceMembers(workspaceId, { enabled: open })
+
+  function creatorLabel(createdBy: string | null): string {
+    if (!createdBy) {
+      return "System"
+    }
+    const member = members?.find((candidate) => candidate.user_id === createdBy)
+    return member ? getDisplayName(member) : "Teammate"
+  }
 
   const handleSelect = (chatId: string) => {
     onSelectChat(chatId)
@@ -48,7 +69,7 @@ export function ChatHistoryDropdown({
   // Hide the selector entirely when there is no chat history — an empty
   // dropdown is just noise. Still render while loading or on error so those
   // states aren't silently swallowed.
-  if (!isLoading && !error && (chats?.length ?? 0) === 0) {
+  if (!isLoading && !error && (chats?.length ?? 0) === 0 && scope === "team") {
     return null
   }
 
@@ -67,6 +88,19 @@ export function ChatHistoryDropdown({
         </Button>
       </PopoverTrigger>
       <PopoverContent align={align} className="w-64 p-0">
+        <div className="flex items-center justify-between border-b px-3 py-2">
+          <span className="text-xs text-muted-foreground">Show chats</span>
+          <ToggleTabs<ChatHistoryScope>
+            value={scope}
+            onValueChange={onScopeChange}
+            size="sm"
+            showTooltips={false}
+            options={[
+              { value: "team", content: "Team" },
+              { value: "mine", content: "Mine" },
+            ]}
+          />
+        </div>
         {isLoading ? (
           <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -87,7 +121,9 @@ export function ChatHistoryDropdown({
                 return 1
               }
 
-              return `${chat.title} ${chat.id}`
+              const createdBy =
+                "created_by" in chat ? chat.created_by : chat.user_id
+              return `${chat.title} ${chat.id} ${creatorLabel(createdBy)}`
                 .toLowerCase()
                 .includes(normalizedSearch)
                 ? 1
@@ -99,7 +135,9 @@ export function ChatHistoryDropdown({
               className="h-8 text-xs"
             />
             <CommandList className="max-h-64 overflow-y-auto">
-              <CommandEmpty className="text-xs">No chats found.</CommandEmpty>
+              <CommandEmpty className="m-1 rounded-sm bg-muted/40 px-3 py-4 text-center text-xs text-muted-foreground">
+                No chats found.
+              </CommandEmpty>
               <CommandGroup>
                 {chats?.map((chat) => (
                   <CommandItem
@@ -114,8 +152,20 @@ export function ChatHistoryDropdown({
                           {chat.title}
                         </span>
                         <ChatLastErrorIndicator session={chat} />
+                        {chat.is_readonly ? (
+                          <Badge
+                            variant="outline"
+                            className="shrink-0 px-1.5 py-0 text-[10px] font-normal text-muted-foreground"
+                          >
+                            Read only
+                          </Badge>
+                        ) : null}
                       </div>
                       <span className="text-xs text-muted-foreground">
+                        {creatorLabel(
+                          "created_by" in chat ? chat.created_by : chat.user_id
+                        )}{" "}
+                        ·{" "}
                         {formatDistanceToNow(new Date(chat.created_at), {
                           addSuffix: true,
                         })}

--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -20,6 +20,7 @@ import {
   PromptInputTools,
 } from "@/components/ai-elements/prompt-input"
 import { ChatEmptyHero } from "@/components/chat/chat-empty-hero"
+import type { ChatHistoryScope } from "@/components/chat/chat-history-dropdown"
 import { ChatHistoryDropdown } from "@/components/chat/chat-history-dropdown"
 import { ChatSessionPane } from "@/components/chat/chat-session-pane"
 import { NoMessages } from "@/components/chat/messages"
@@ -36,6 +37,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Tooltip,
@@ -44,6 +46,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
+import { useAuth } from "@/hooks/use-auth"
 import {
   parseChatError,
   useCreateChat,
@@ -111,6 +114,7 @@ export function ChatInterface({
 }: ChatInterfaceProps) {
   const workspaceId = useWorkspaceId()
   const queryClient = useQueryClient()
+  const { user } = useAuth()
   const { hasEntitlement } = useEntitlements()
   const agentAddonsEnabled = hasEntitlement("agent_addons")
   const [selectedChatId, setSelectedChatId] = useState<string | undefined>(
@@ -121,6 +125,7 @@ export function ChatInterface({
   const [isDraftChat, setIsDraftChat] = useState(false)
   const [pendingFirstMessage, setPendingFirstMessage] =
     useState<PendingFirstMessage | null>(null)
+  const [historyScope, setHistoryScope] = useState<ChatHistoryScope>("team")
 
   // Keep local selection aligned when a parent-driven chatId changes.
   useEffect(() => {
@@ -134,6 +139,7 @@ export function ChatInterface({
     workspaceId: workspaceId,
     entityType,
     entityId,
+    createdBy: historyScope === "mine" ? user?.id : undefined,
   })
 
   // Create chat mutation
@@ -217,8 +223,10 @@ export function ChatInterface({
       !inWorkspaceChat &&
       !(entityType === "case" && isDraftChat)
     ) {
-      // Select first existing chat
-      const firstChatId = chats[0].id
+      // Prefer the current user's latest writable chat before falling back to
+      // the newest teammate session.
+      const firstChatId =
+        chats.find((candidate) => !candidate.is_readonly)?.id ?? chats[0].id
       setSelectedChatId(firstChatId)
       onChatSelect?.(firstChatId)
     } else if (
@@ -333,6 +341,13 @@ export function ChatInterface({
     onChatSelect?.(chatId)
   }
 
+  const handleHistoryScopeChange = (nextScope: ChatHistoryScope) => {
+    setHistoryScope(nextScope)
+    if (nextScope === "mine" && chat?.is_readonly) {
+      setSelectedChatId(undefined)
+    }
+  }
+
   // Show loading while chats are loading or being auto-created
   if (
     chatsLoading ||
@@ -398,7 +413,18 @@ export function ChatInterface({
               error={chatsError}
               selectedChatId={selectedChatId}
               onSelectChat={handleSelectChat}
+              workspaceId={workspaceId}
+              scope={historyScope}
+              onScopeChange={handleHistoryScopeChange}
             />
+            {chat?.is_readonly ? (
+              <Badge
+                variant="outline"
+                className="px-1.5 py-0 text-[10px] font-normal text-muted-foreground"
+              >
+                Read only
+              </Badge>
+            ) : null}
           </div>
 
           {/* Right-side actions */}
@@ -595,7 +621,7 @@ function ChatBody({
   }
 
   // Render active chat session when ready
-  if (!chatReady || !modelInfo) {
+  if ((!chatReady || !modelInfo) && !chat?.is_readonly) {
     // Render configuration required state
     if (surface === "workspace-chat") {
       return (
@@ -644,7 +670,7 @@ function ChatBody({
         entityId={entityId}
         placeholder={placeholder}
         className="flex-1 min-h-0"
-        modelInfo={modelInfo}
+        modelInfo={modelInfo ?? undefined}
         toolsEnabled={toolsEnabled}
         agentAddonsEnabled={agentAddonsEnabled}
         mcpEnabled={mcpEnabled}
@@ -677,7 +703,7 @@ function ChatBody({
       entityId={entityId}
       placeholder={placeholder}
       className="flex-1 min-h-0"
-      modelInfo={modelInfo}
+      modelInfo={modelInfo ?? undefined}
       toolsEnabled={toolsEnabled}
       agentAddonsEnabled={agentAddonsEnabled}
       mcpEnabled={mcpEnabled}

--- a/frontend/src/components/chat/chat-list.tsx
+++ b/frontend/src/components/chat/chat-list.tsx
@@ -4,6 +4,7 @@ import { MessageCircle, Plus } from "lucide-react"
 import { useState } from "react"
 import { $AgentSessionEntity, type AgentSessionEntity } from "@/client"
 import { ChatLastErrorIndicator } from "@/components/chat/chat-last-error-indicator"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -132,6 +133,14 @@ export function ChatList({
                     <div className="flex items-center gap-1.5">
                       <p className="font-medium truncate">{chat.title}</p>
                       <ChatLastErrorIndicator session={chat} />
+                      {chat.is_readonly ? (
+                        <Badge
+                          variant="outline"
+                          className="px-1.5 py-0 text-[10px] font-normal text-muted-foreground"
+                        >
+                          Read only
+                        </Badge>
+                      ) : null}
                     </div>
                     <p className="text-xs text-muted-foreground">
                       {new Date(chat.created_at).toLocaleString()}

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -265,7 +265,7 @@ export interface ChatSessionPaneProps {
   onData?: ChatOnDataCallback<UIMessage>
   /** Called whenever the underlying chat transport status changes. */
   onStatusChange?: (status: ChatStatus) => void
-  modelInfo: ModelInfo
+  modelInfo?: ModelInfo
   toolsEnabled?: boolean
   agentAddonsEnabled?: boolean
   mcpEnabled?: boolean
@@ -381,6 +381,10 @@ export function ChatSessionPane({
 
   // Check if this is a legacy read-only session
   const isReadonly = chat ? "is_readonly" in chat && chat.is_readonly : false
+  const readonlyDescription =
+    chat && "user_id" in chat
+      ? "This legacy conversation is read-only."
+      : "This conversation belongs to a teammate."
 
   const uiMessages = useMemo(
     () => (chat?.messages || []).map(toUIMessage),
@@ -464,7 +468,7 @@ export function ChatSessionPane({
 
   // Send pending message on mount (used after forking)
   useEffect(() => {
-    if (!pendingMessage || isReadonly || !chat) return
+    if (!pendingMessage || isReadonly || !chat || !modelInfo) return
 
     const messageKey = `${chat.id}:${pendingMessage}`
     if (pendingMessageSentRef.current === messageKey) return
@@ -477,6 +481,7 @@ export function ChatSessionPane({
     pendingMessage,
     isReadonly,
     chat,
+    modelInfo,
     clearError,
     sendMessage,
     onPendingMessageSent,
@@ -518,7 +523,7 @@ export function ChatSessionPane({
   }, [isGeneratingTurn])
 
   const handleStop = useCallback(async () => {
-    if (!chat?.id || cancelRequested) return
+    if (!chat?.id || cancelRequested || isReadonly) return
     setCancelRequested(true)
     try {
       await cancelChatTurn({ chatId: chat.id })
@@ -529,7 +534,7 @@ export function ChatSessionPane({
         description: parseChatError(error),
       })
     }
-  }, [cancelChatTurn, cancelRequested, chat?.id])
+  }, [cancelChatTurn, cancelRequested, chat?.id, isReadonly])
   const isInputDisabledRef = useRef(isInputDisabled)
   isInputDisabledRef.current = isInputDisabled
   const wasInputDisabledRef = useRef(isInputDisabled)
@@ -591,7 +596,7 @@ export function ChatSessionPane({
 
   const handleSubmitApprovals = useCallback(
     async (decisionPayload: ApprovalDecision[]) => {
-      if (!decisionPayload.length) return
+      if (isReadonly || !decisionPayload.length) return
       try {
         clearError()
         await sendMessage(makeContinueMessage(decisionPayload))
@@ -606,7 +611,7 @@ export function ChatSessionPane({
         throw error
       }
     },
-    [clearError, sendMessage]
+    [clearError, isReadonly, sendMessage]
   )
 
   useEffect(() => {
@@ -1158,7 +1163,7 @@ export function ChatSessionPane({
   const handleSubmit = async (message: PromptInputMessage) => {
     const hasText = Boolean(message.text?.trim())
 
-    if (!hasText) {
+    if (!hasText || isReadonly || !modelInfo) {
       return
     }
 
@@ -1212,6 +1217,14 @@ export function ChatSessionPane({
 
   const promptComposer = (
     <div ref={promptInputContainerRef} className={promptCenterClass}>
+      {isReadonly ? (
+        <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+          <Badge variant="outline" className="px-1.5 py-0 font-normal">
+            Read only
+          </Badge>
+          {readonlyDescription}
+        </div>
+      ) : null}
       {mentionEnabled && toolMention && (
         <div className="absolute inset-x-0 bottom-full z-30 mb-2">
           <div className="overflow-hidden rounded-md border bg-popover shadow-md">
@@ -1290,7 +1303,7 @@ export function ChatSessionPane({
             onBlur={handleInputBlur}
             placeholder={
               isReadonly
-                ? "This is a legacy session (read-only)"
+                ? readonlyDescription
                 : (inputDisabled || isOptimisticBeforeSendPending) &&
                     inputDisabledPlaceholder
                   ? inputDisabledPlaceholder
@@ -1324,15 +1337,16 @@ export function ChatSessionPane({
                 mcpIntegrationsHref={`/workspaces/${workspaceId}/mcp-servers`}
               />
             )}
-            {!isReadonly ? (
+            {!isReadonly && modelInfo ? (
               <PromptModelIndicator modelInfo={modelInfo} />
             ) : null}
           </PromptInputTools>
           <PromptInputSubmit
             disabled={
-              isGeneratingTurn
+              isReadonly ||
+              (isGeneratingTurn
                 ? isCancellingChatTurn || cancelRequested
-                : isInputDisabled || !input.trim()
+                : isInputDisabled || !input.trim())
             }
             onStop={() => void handleStop()}
             status={status}
@@ -1426,33 +1440,37 @@ export function ChatSessionPane({
                         isLastMessage={isLastMessage}
                         turnCancelled={cancelledTurnMessageIds.has(id)}
                         interruptedToolCallIds={interruptedToolCallIds}
-                        onSubmitApprovals={handleSubmitApprovals}
+                        onSubmitApprovals={
+                          isReadonly ? undefined : handleSubmitApprovals
+                        }
                       />
                     ))}
-                    {role === "assistant" && !isWaitingForResponse && (
-                      // Render response actions for assistant messages and reveal them on hover for older messages.
-                      <Actions
-                        className={cn(
-                          "mt-4",
-                          // Apply a smooth transition so the actions fade in and out gracefully.
-                          "transition-opacity duration-200 ease-out",
-                          // Hide actions by default for non-last messages and reveal them when the message group is hovered.
-                          !isLastMessage &&
-                            "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100"
-                        )}
-                      >
-                        {isLastMessage && (
-                          <Action
-                            size="sm"
-                            onClick={() => regenerate()}
-                            label="Retry"
-                            tooltip="Retry"
-                          >
-                            <RefreshCcwIcon className="size-3" />
-                          </Action>
-                        )}
-                      </Actions>
-                    )}
+                    {role === "assistant" &&
+                      !isWaitingForResponse &&
+                      !isReadonly && (
+                        // Render response actions for assistant messages and reveal them on hover for older messages.
+                        <Actions
+                          className={cn(
+                            "mt-4",
+                            // Apply a smooth transition so the actions fade in and out gracefully.
+                            "transition-opacity duration-200 ease-out",
+                            // Hide actions by default for non-last messages and reveal them when the message group is hovered.
+                            !isLastMessage &&
+                              "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100"
+                          )}
+                        >
+                          {isLastMessage && (
+                            <Action
+                              size="sm"
+                              onClick={() => regenerate()}
+                              label="Retry"
+                              tooltip="Retry"
+                            >
+                              <RefreshCcwIcon className="size-3" />
+                            </Action>
+                          )}
+                        </Actions>
+                      )}
                   </div>
                 )
               })}

--- a/frontend/src/components/inbox/inbox-chat.tsx
+++ b/frontend/src/components/inbox/inbox-chat.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { agentSessionsListSessions } from "@/client"
+import { useAuth } from "@/hooks/use-auth"
 import type { InboxSessionItem } from "@/lib/agents"
 import { useWorkspaceId } from "@/providers/workspace-id"
 import { InboxDetail } from "./inbox-detail"
@@ -12,6 +13,7 @@ interface InboxChatProps {
 
 export function InboxChat({ session }: InboxChatProps) {
   const workspaceId = useWorkspaceId()
+  const { user } = useAuth()
 
   // Track the forked session ID and pending message
   const [forkedState, setForkedState] = useState<{
@@ -33,6 +35,7 @@ export function InboxChat({ session }: InboxChatProps) {
         const childSessions = await agentSessionsListSessions({
           workspaceId,
           parentSessionId: session.id,
+          createdBy: user?.id,
           limit: 1,
         })
         // Only update state if this effect hasn't been superseded
@@ -60,7 +63,7 @@ export function InboxChat({ session }: InboxChatProps) {
     return () => {
       isCurrent = false
     }
-  }, [session?.id, workspaceId])
+  }, [session?.id, user?.id, workspaceId])
 
   const activeForkedState =
     forkedState?.parentSessionId === session.id ? forkedState : null

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -224,11 +224,13 @@ export function useListChats(
     workspaceId,
     entityType,
     entityId,
+    createdBy,
     limit = 50,
   }: {
     workspaceId: string
     entityType?: AgentSessionEntity
     entityId?: string
+    createdBy?: string
     limit?: number
   },
   options?: { enabled?: boolean }
@@ -247,12 +249,13 @@ export function useListChats(
     error: chatsError,
     refetch,
   } = useQuery<AgentSessionsListSessionsResponse, ApiError>({
-    queryKey: ["chats", workspaceId, entityType, entityId, limit],
+    queryKey: ["chats", workspaceId, entityType, entityId, createdBy, limit],
     queryFn: () =>
       agentSessionsListSessions({
         workspaceId,
         entityType: entityType || null,
         entityId: entityId || null,
+        createdBy: createdBy || null,
         limit,
       }),
     enabled: options?.enabled ?? true,
@@ -573,7 +576,7 @@ export function useVercelChat({
   chatId?: string
   workspaceId: string
   messages: UIMessage[]
-  modelInfo: ModelInfo
+  modelInfo?: ModelInfo
   onData?: ChatOnDataCallback<UIMessage>
   /**
    * Reconnect to the live event stream on mount. Defaults to true. Set to

--- a/frontend/tests/chat-history-dropdown.test.tsx
+++ b/frontend/tests/chat-history-dropdown.test.tsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react"
 import type { AgentSessionsListSessionsResponse } from "@/client"
 import { ChatHistoryDropdown } from "@/components/chat/chat-history-dropdown"
 
+jest.mock("@/hooks/use-workspace", () => ({
+  useWorkspaceMembers: () => ({ members: [] }),
+}))
+
 describe("ChatHistoryDropdown", () => {
   beforeAll(() => {
     global.ResizeObserver = class ResizeObserver {
@@ -41,6 +45,9 @@ describe("ChatHistoryDropdown", () => {
         error={null}
         selectedChatId="chat-1"
         onSelectChat={onSelectChat}
+        workspaceId="workspace-1"
+        scope="team"
+        onScopeChange={jest.fn()}
       />
     )
 

--- a/frontend/tests/use-chat.test.tsx
+++ b/frontend/tests/use-chat.test.tsx
@@ -105,7 +105,7 @@ describe("useUpdateChat", () => {
       createSessionReadVercel()
     )
     queryClient.setQueryData(
-      ["chats", "workspace-1", "case", "case-1", 50],
+      ["chats", "workspace-1", "case", "case-1", undefined, 50],
       [createSessionRead()]
     )
 
@@ -145,6 +145,7 @@ describe("useUpdateChat", () => {
         "workspace-1",
         "case",
         "case-1",
+        undefined,
         50,
       ])?.[0]?.tools
     ).toEqual(["core.cases.list_cases"])
@@ -177,7 +178,7 @@ describe("useUpdateChat", () => {
       })
     )
     queryClient.setQueryData(
-      ["chats", "workspace-1", "case", "case-1", 50],
+      ["chats", "workspace-1", "case", "case-1", undefined, 50],
       [
         createSessionRead({
           agent_preset_id: "preset-old",
@@ -231,6 +232,7 @@ describe("useUpdateChat", () => {
         "workspace-1",
         "case",
         "case-1",
+        undefined,
         50,
       ])?.[0]
     ).toMatchObject({

--- a/tests/unit/test_agent_internal_tools.py
+++ b/tests/unit/test_agent_internal_tools.py
@@ -102,6 +102,78 @@ def test_evaluate_configuration_accepts_configured_oauth_integration():
 
 
 @pytest.mark.anyio
+async def test_list_sessions_defaults_to_all_workspace_creators(monkeypatch):
+    preset_id = uuid.uuid4()
+    claims = _build_claims(preset_id)
+    captured: dict[str, object] = {}
+
+    async def _list_sessions(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    service = SimpleNamespace(list_sessions=_list_sessions)
+    monkeypatch.setattr(
+        "tracecat.agent.session.service.AgentSessionService.with_session",
+        lambda role: _AsyncContext(service),
+    )
+
+    result = await internal_tools.list_sessions({}, claims)
+
+    assert result == {"sessions": []}
+    assert captured["created_by"] is None
+    assert captured["entity_id"] == preset_id
+
+
+@pytest.mark.anyio
+async def test_list_sessions_accepts_creator_filter(monkeypatch):
+    preset_id = uuid.uuid4()
+    creator_id = uuid.uuid4()
+    claims = _build_claims(preset_id)
+    captured: dict[str, object] = {}
+
+    async def _list_sessions(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    service = SimpleNamespace(list_sessions=_list_sessions)
+    monkeypatch.setattr(
+        "tracecat.agent.session.service.AgentSessionService.with_session",
+        lambda role: _AsyncContext(service),
+    )
+
+    await internal_tools.list_sessions({"created_by": str(creator_id)}, claims)
+
+    assert captured["created_by"] == creator_id
+
+
+@pytest.mark.anyio
+async def test_get_session_rejects_non_preset_entity(monkeypatch):
+    preset_id = uuid.uuid4()
+    claims = _build_claims(preset_id)
+    service = SimpleNamespace(
+        get_session=lambda _session_id: None,
+    )
+
+    async def _get_session(_session_id):
+        return SimpleNamespace(
+            entity_type="agent_preset_builder",
+            entity_id=preset_id,
+        )
+
+    service.get_session = _get_session
+    monkeypatch.setattr(
+        "tracecat.agent.session.service.AgentSessionService.with_session",
+        lambda role: _AsyncContext(service),
+    )
+
+    with pytest.raises(internal_tools.InternalToolError, match="not found"):
+        await internal_tools.get_session(
+            {"session_id": str(uuid.uuid4())},
+            claims,
+        )
+
+
+@pytest.mark.anyio
 async def test_list_available_tools_includes_configuration_fields(monkeypatch):
     preset_id = uuid.uuid4()
     claims = _build_claims(preset_id)

--- a/tests/unit/test_agent_session_list_sessions.py
+++ b/tests/unit/test_agent_session_list_sessions.py
@@ -108,8 +108,30 @@ async def test_list_sessions_filter_created_by_none_excludes_legacy_chats() -> N
     executed_stmt = session.execute.await_args.args[0]
     assert "agent_session.created_by IS NULL" in str(executed_stmt)
     assert results == [
-        AgentSessionRead.model_validate(session_row, from_attributes=True)
+        AgentSessionRead.model_validate(session_row, from_attributes=True).model_copy(
+            update={"is_readonly": True}
+        )
     ]
+
+
+@pytest.mark.anyio
+async def test_list_sessions_marks_teammate_sessions_read_only() -> None:
+    service, session, role = _build_service()
+    assert role.workspace_id is not None
+    teammate_session = _agent_session_row(
+        workspace_id=role.workspace_id,
+        user_id=uuid.uuid4(),
+        parent_session_id=uuid.uuid4(),
+    )
+    session.execute.return_value = _mock_scalar_result([teammate_session])
+
+    results = await service.list_sessions(
+        parent_session_id=teammate_session.parent_session_id,
+        limit=1,
+    )
+
+    assert len(results) == 1
+    assert results[0].is_readonly is True
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -26,10 +26,12 @@ from tracecat.agent.session.router import (
     remove_session_artifact,
     send_message,
     stream_session_events,
+    update_session,
 )
 from tracecat.agent.session.schemas import (
     AgentSessionCancelRequest,
     AgentSessionForkRequest,
+    AgentSessionUpdate,
 )
 from tracecat.agent.session.types import AgentSessionEntity, TurnLifecycle
 from tracecat.artifacts.schemas import CaseArtifact
@@ -125,7 +127,7 @@ async def _deny_workspace_chat_entitlement(**kwargs: Any) -> None:
 
 
 @pytest.mark.anyio
-async def test_list_sessions_service_account_filters_null_created_by() -> None:
+async def test_list_sessions_service_account_defaults_to_workspace_sessions() -> None:
     workspace_id = uuid.uuid4()
     role = _service_account_role(workspace_id)
     fake_svc = SimpleNamespace(list_sessions=AsyncMock(return_value=[]))
@@ -139,6 +141,7 @@ async def test_list_sessions_service_account_filters_null_created_by() -> None:
             session=AsyncMock(),
             entity_type=None,
             entity_id=None,
+            created_by=None,
             exclude_entity_types=None,
             parent_session_id=None,
             limit=100,
@@ -147,7 +150,6 @@ async def test_list_sessions_service_account_filters_null_created_by() -> None:
     assert response == []
     fake_svc.list_sessions.assert_awaited_once_with(
         created_by=None,
-        filter_created_by_none=True,
         entity_type=None,
         entity_id=None,
         exclude_entity_types=[AgentSessionEntity.WORKSPACE_CHAT],
@@ -157,7 +159,7 @@ async def test_list_sessions_service_account_filters_null_created_by() -> None:
 
 
 @pytest.mark.anyio
-async def test_list_sessions_user_filters_by_user_id() -> None:
+async def test_list_sessions_user_filters_by_explicit_user_id() -> None:
     workspace_id = uuid.uuid4()
     user_id = uuid.uuid4()
     role = Role(
@@ -179,6 +181,7 @@ async def test_list_sessions_user_filters_by_user_id() -> None:
             session=AsyncMock(),
             entity_type=None,
             entity_id=None,
+            created_by=user_id,
             exclude_entity_types=None,
             parent_session_id=None,
             limit=100,
@@ -187,13 +190,92 @@ async def test_list_sessions_user_filters_by_user_id() -> None:
     assert response == []
     fake_svc.list_sessions.assert_awaited_once_with(
         created_by=user_id,
-        filter_created_by_none=False,
         entity_type=None,
         entity_id=None,
         exclude_entity_types=[AgentSessionEntity.WORKSPACE_CHAT],
         parent_session_id=None,
         limit=100,
     )
+
+
+@pytest.mark.anyio
+async def test_list_sessions_user_defaults_to_workspace_sessions() -> None:
+    workspace_id = uuid.uuid4()
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        user_id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:read"}),
+    )
+    fake_svc = SimpleNamespace(list_sessions=AsyncMock(return_value=[]))
+
+    with patch(
+        "tracecat.agent.session.router.AgentSessionService", return_value=fake_svc
+    ):
+        raw_list_sessions = cast(Any, list_sessions).__wrapped__
+        response = await raw_list_sessions(
+            role=role,
+            session=AsyncMock(),
+            entity_type=None,
+            entity_id=None,
+            created_by=None,
+            exclude_entity_types=None,
+            parent_session_id=None,
+            limit=100,
+        )
+
+    assert response == []
+    fake_svc.list_sessions.assert_awaited_once_with(
+        created_by=None,
+        entity_type=None,
+        entity_id=None,
+        exclude_entity_types=[AgentSessionEntity.WORKSPACE_CHAT],
+        parent_session_id=None,
+        limit=100,
+    )
+
+
+@pytest.mark.anyio
+async def test_update_session_rejects_teammate_session() -> None:
+    workspace_id = uuid.uuid4()
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        user_id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+    session_stub = _agent_session_stub(
+        workspace_id=workspace_id,
+        created_by=uuid.uuid4(),
+    )
+    fake_svc = SimpleNamespace(
+        is_legacy_session=AsyncMock(return_value=False),
+        get_session=AsyncMock(return_value=session_stub),
+        update_session=AsyncMock(),
+    )
+
+    with patch(
+        "tracecat.agent.session.router.AgentSessionService", return_value=fake_svc
+    ):
+        raw_update_session = cast(Any, update_session).__wrapped__
+        with pytest.raises(HTTPException) as exc_info:
+            await raw_update_session(
+                session_id=session_stub.id,
+                params=AgentSessionUpdate(title="Nope"),
+                role=role,
+                session=AsyncMock(),
+            )
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.detail == {
+        "code": "session_read_only",
+        "message": "Teammate sessions are read-only.",
+    }
+    fake_svc.update_session.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -1005,7 +1087,9 @@ async def test_send_message_maps_conflicting_decision_to_409() -> None:
     fake_svc = SimpleNamespace(
         session=Mock(),
         is_legacy_session=AsyncMock(return_value=False),
-        validate_turn_request=AsyncMock(return_value=SimpleNamespace(curr_run_id=None)),
+        validate_turn_request=AsyncMock(
+            return_value=SimpleNamespace(curr_run_id=None, created_by=None)
+        ),
         run_turn=AsyncMock(
             side_effect=TracecatConflictError(
                 "Approval decision conflicts with a decision already recorded"
@@ -1038,6 +1122,57 @@ async def test_send_message_maps_conflicting_decision_to_409() -> None:
 
     assert exc_info.value.status_code == 409
     assert "already recorded" in str(exc_info.value.detail)
+
+
+@pytest.mark.anyio
+async def test_send_message_rejects_teammate_session() -> None:
+    session_id = uuid.uuid4()
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        user_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+    request = ContinueRunRequest(
+        decisions=[ApprovalDecision(tool_call_id="tool_call_123", action="deny")],
+        source="inbox",
+    )
+    fake_svc = SimpleNamespace(
+        session=Mock(),
+        is_legacy_session=AsyncMock(return_value=False),
+        validate_turn_request=AsyncMock(
+            return_value=SimpleNamespace(
+                curr_run_id=None,
+                created_by=uuid.uuid4(),
+            )
+        ),
+        run_turn=AsyncMock(),
+    )
+
+    with patch(
+        "tracecat.agent.session.router.AgentSessionService.with_session",
+        return_value=_AsyncContext(fake_svc),
+    ):
+        raw_send_message = cast(Any, send_message).__wrapped__
+        with pytest.raises(HTTPException) as exc_info:
+            await raw_send_message(
+                session_id=session_id,
+                request=request,
+                role=role,
+                http_request=cast(
+                    Any,
+                    SimpleNamespace(is_disconnected=AsyncMock(return_value=False)),
+                ),
+            )
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.detail == {
+        "code": "session_read_only",
+        "message": "Teammate sessions are read-only.",
+    }
+    fake_svc.run_turn.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/mcp/internal_tools.py
+++ b/tracecat/agent/mcp/internal_tools.py
@@ -397,7 +397,7 @@ async def update_preset(args: dict[str, Any], claims: MCPTokenClaims) -> dict[st
 
 
 async def list_sessions(args: dict[str, Any], claims: MCPTokenClaims) -> dict[str, Any]:
-    """List agent sessions where this agent preset is being used by end users."""
+    """List workspace sessions where this agent preset is used."""
     from tracecat.agent.session.service import AgentSessionService
 
     preset_id = _get_preset_id(claims.internal_tool_context)
@@ -408,14 +408,24 @@ async def list_sessions(args: dict[str, Any], claims: MCPTokenClaims) -> dict[st
     if not isinstance(limit, int) or limit < 1 or limit > 100:
         limit = 50
 
+    created_by: uuid.UUID | None = None
+    if created_by_value := args.get("created_by"):
+        if isinstance(created_by_value, uuid.UUID):
+            created_by = created_by_value
+        elif isinstance(created_by_value, str):
+            try:
+                created_by = uuid.UUID(created_by_value)
+            except ValueError as e:
+                raise InternalToolError(
+                    f"Invalid created_by format: {created_by_value}"
+                ) from e
+        else:
+            raise InternalToolError(f"Invalid created_by format: {created_by_value}")
+
     try:
         async with AgentSessionService.with_session(role=role) as service:
-            if service.role.user_id is None:
-                raise InternalToolError(
-                    "Unable to list sessions: authentication required."
-                )
             sessions = await service.list_sessions(
-                created_by=service.role.user_id,
+                created_by=created_by,
                 entity_type=AgentSessionEntity.AGENT_PRESET,
                 entity_id=preset_id,
                 limit=limit,
@@ -455,7 +465,12 @@ async def get_session(args: dict[str, Any], claims: MCPTokenClaims) -> dict[str,
     try:
         async with AgentSessionService.with_session(role=role) as service:
             session = await service.get_session(session_id)
-            if not session or str(session.entity_id) != str(preset_id):
+            if (
+                not session
+                or AgentSessionEntity(session.entity_type)
+                is not AgentSessionEntity.AGENT_PRESET
+                or session.entity_id != preset_id
+            ):
                 raise InternalToolError(f"Session {session_id} not found.")
 
             messages = await service.list_messages(session.id)
@@ -529,6 +544,10 @@ class _ListSessionsParams(BaseModel):
         ge=config.TRACECAT__LIMIT_MIN,
         le=config.TRACECAT__LIMIT_CURSOR_MAX,
     )
+    created_by: uuid.UUID | None = Field(
+        default=None,
+        description="Filter by session creator. Omit to list the entire workspace.",
+    )
 
 
 class _GetSessionParams(BaseModel):
@@ -576,7 +595,10 @@ def get_builder_internal_tool_definitions() -> dict[str, MCPToolDefinition]:
         ),
         "internal.builder.list_sessions": MCPToolDefinition(
             name="internal.builder.list_sessions",
-            description="List agent sessions where this agent preset is being used by end users.",
+            description=(
+                "List workspace agent sessions where this preset is being used. "
+                "Returns all teammates by default; optionally filter by creator."
+            ),
             parameters_json_schema=_ListSessionsParams.model_json_schema(),
         ),
         "internal.builder.get_session": MCPToolDefinition(

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -48,6 +48,7 @@ from tracecat.chat.schemas import (
     ContinueRunRequest,
 )
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.db.models import AgentSession
 from tracecat.exceptions import (
     EntitlementRequired,
     TracecatConflictError,
@@ -90,7 +91,7 @@ def _bubble_id(session_id: uuid.UUID, curr_run_id: uuid.UUID | None) -> str | No
 
 def _require_session_write_access(
     role: WorkspaceActorRouteRole,
-    agent_session: Any,
+    agent_session: AgentSession,
 ) -> None:
     """Reject writes to sessions owned by another workspace actor."""
     if not is_session_readonly(role, agent_session.created_by):

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -27,7 +27,11 @@ from tracecat.agent.session.schemas import (
     AgentSessionUpdate,
 )
 from tracecat.agent.session.service import AgentSessionService
-from tracecat.agent.session.types import AgentSessionEntity, TurnLifecycle
+from tracecat.agent.session.types import (
+    AgentSessionEntity,
+    TurnLifecycle,
+    is_session_readonly,
+)
 from tracecat.agent.stream.artifacts import artifact_stream_event
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.stream.events import StreamFormat
@@ -84,6 +88,22 @@ def _bubble_id(session_id: uuid.UUID, curr_run_id: uuid.UUID | None) -> str | No
     return f"{session_id}:{curr_run_id}" if curr_run_id else None
 
 
+def _require_session_write_access(
+    role: WorkspaceActorRouteRole,
+    agent_session: Any,
+) -> None:
+    """Reject writes to sessions owned by another workspace actor."""
+    if not is_session_readonly(role, agent_session.created_by):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "session_read_only",
+            "message": "Teammate sessions are read-only.",
+        },
+    )
+
+
 async def _require_workspace_chat_entitlement_for_session_tree(
     *,
     svc: AgentSessionService,
@@ -138,6 +158,10 @@ async def list_sessions(
         None, description="Filter by entity type"
     ),
     entity_id: uuid.UUID | None = Query(None, description="Filter by entity ID"),
+    created_by: uuid.UUID | None = Query(
+        None,
+        description="Filter by session creator. Omit to list the entire workspace.",
+    ),
     exclude_entity_types: list[AgentSessionEntity] | None = Query(
         None, description="Entity types to exclude from results"
     ),
@@ -169,8 +193,7 @@ async def list_sessions(
         ]
     svc = AgentSessionService(session, role)
     return await svc.list_sessions(
-        created_by=role.user_id,
-        filter_created_by_none=role.type == "service_account",
+        created_by=created_by,
         entity_type=entity_type,
         entity_id=entity_id,
         exclude_entity_types=exclude_entity_types,
@@ -208,6 +231,7 @@ async def get_session(
             workspace_id=agent_session.workspace_id,
             title=agent_session.title,
             created_by=agent_session.created_by,
+            is_readonly=is_session_readonly(role, agent_session.created_by),
             entity_type=AgentSessionEntity(agent_session.entity_type),
             entity_id=agent_session.entity_id,
             channel_context=agent_session.channel_context,
@@ -291,6 +315,7 @@ async def get_session_vercel(
             workspace_id=agent_session.workspace_id,
             title=agent_session.title,
             created_by=agent_session.created_by,
+            is_readonly=is_session_readonly(role, agent_session.created_by),
             entity_type=AgentSessionEntity(agent_session.entity_type),
             entity_id=agent_session.entity_id,
             channel_context=agent_session.channel_context,
@@ -368,6 +393,8 @@ async def update_session(
             detail="Session not found",
         )
 
+    _require_session_write_access(role, agent_session)
+
     await require_workspace_chat_entitlement_for_entity(
         session=session,
         role=role,
@@ -400,6 +427,7 @@ async def remove_session_artifact(
         agent_session = await svc.get_session(session_id)
         if agent_session is None:
             raise TracecatNotFoundError(f"Session {session_id} not found")
+        _require_session_write_access(role, agent_session)
         await require_workspace_chat_entitlement_for_entity(
             session=session,
             role=role,
@@ -442,6 +470,8 @@ async def delete_session(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Session not found",
         )
+
+    _require_session_write_access(role, agent_session)
 
     await require_workspace_chat_entitlement_for_entity(
         session=session,
@@ -489,6 +519,7 @@ async def send_message(
                 session_id=session_id,
                 request=request,
             )
+            _require_session_write_access(role, agent_session)
             await _require_workspace_chat_entitlement_for_session_tree(
                 svc=svc,
                 session=svc.session,
@@ -621,6 +652,8 @@ async def send_message(
             detail=str(e),
         ) from e
     except EntitlementRequired:
+        raise
+    except HTTPException:
         raise
     except Exception as e:
         logger.error(
@@ -772,6 +805,7 @@ async def fork_session(
             raise TracecatNotFoundError(
                 f"Parent session with ID {session_id} not found"
             )
+        _require_session_write_access(role, parent_session)
         await _require_workspace_chat_entitlement_for_session_tree(
             svc=svc,
             session=session,
@@ -810,6 +844,7 @@ async def cancel_session(
         agent_session = await svc.get_session(session_id)
         if agent_session is None:
             raise TracecatNotFoundError(f"Session with ID {session_id} not found")
+        _require_session_write_access(role, agent_session)
         await _require_workspace_chat_entitlement_for_session_tree(
             svc=svc,
             session=session,

--- a/tracecat/agent/session/schemas.py
+++ b/tracecat/agent/session/schemas.py
@@ -123,6 +123,10 @@ class AgentSessionRead(BaseModel):
     # Metadata
     title: str
     created_by: uuid.UUID | None
+    is_readonly: bool = Field(
+        default=False,
+        description="Whether the requesting actor can modify this session",
+    )
     entity_type: AgentSessionEntity
     entity_id: uuid.UUID
     channel_context: dict[str, Any] | None

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -92,6 +92,7 @@ from tracecat.agent.session.types import (
     AgentSessionEntity,
     TurnLifecycle,
     TurnLifecycleResult,
+    is_session_readonly,
 )
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.subagents import (
@@ -914,7 +915,14 @@ class AgentSessionService(BaseWorkspaceService):
         items: list[AgentSessionRead | ChatReadMinimal] = []
 
         for s in sessions:
-            items.append(AgentSessionRead.model_validate(s, from_attributes=True))
+            session_read = AgentSessionRead.model_validate(s, from_attributes=True)
+            items.append(
+                session_read.model_copy(
+                    update={
+                        "is_readonly": is_session_readonly(self.role, s.created_by),
+                    }
+                )
+            )
 
         for c in legacy_chats:
             # ChatReadMinimal has is_readonly=True by default

--- a/tracecat/agent/session/types.py
+++ b/tracecat/agent/session/types.py
@@ -4,6 +4,23 @@ import uuid
 from enum import StrEnum
 from typing import NamedTuple
 
+from tracecat.auth.types import Role
+from tracecat.identifiers import UserID
+
+
+def is_session_readonly(role: Role, created_by: UserID | None) -> bool:
+    """Return whether an actor may modify a session with this creator.
+
+    User-backed actors can only modify sessions they created. Service accounts
+    own sessions without a user creator. Unbound internal services remain
+    writable so background execution is not blocked.
+    """
+    if role.type == "service_account":
+        return created_by is not None
+    if role.user_id is not None:
+        return created_by != role.user_id
+    return False
+
 
 class TurnLifecycle(StrEnum):
     """In-memory reconnect decision derived live from Temporal.


### PR DESCRIPTION
## Summary

Make agent session history visible across the workspace by default while preserving creator-only write access.

Users can browse teammate conversations from case chats and agent preset surfaces, but teammate sessions are clearly marked read-only and cannot be mutated. Both the REST API and builder MCP tool support an optional `created_by` filter for narrowing results to one user.

## Screen recording

https://github.com/user-attachments/assets/f7aff513-c2b7-4750-91d3-8dd98e74e23c


## Behavior changes

- Omitting `created_by` now returns sessions from the entire workspace.
- Passing `created_by=<user_id>` filters sessions to that creator.
- Session responses include actor-relative `is_readonly` metadata.
- User-owned sessions remain writable.
- Teammate and legacy sessions are read-only.
- Service accounts can only modify sessions without a user creator.
- Workspace chat exclusions and existing entitlement checks remain unchanged.

## Implementation

### Backend and API

- Add the optional `created_by` query parameter to `GET /agent/sessions`.
- Centralize ownership checks with `is_session_readonly`.
- Return `is_readonly` from list, detail, and Vercel session endpoints.
- Reject teammate-session mutations with HTTP `403` and the structured error code `session_read_only`.
- Apply the write guard to:
  - update and delete
  - message send/continue
  - fork and cancel
  - artifact removal
- Preserve HTTP exceptions from the streaming message endpoint instead of converting ownership failures into `500` responses.

### MCP

- Change `internal.builder.list_sessions` to return all workspace users by default.
- Add an optional `created_by` UUID filter to the tool schema.
- Validate `created_by` inputs before calling the session service.
- Harden `get_session` so builder MCP access only resolves sessions bound to the expected agent preset and entity type.

### Frontend

- Add a `Team` / `Mine` scope toggle to chat-history dropdowns.
- Default all supported chat surfaces to `Team`.
- Show session creator names and `Read only` badges for teammate sessions.
- Prefer the current user’s latest writable session during automatic selection.
- Allow read-only transcripts to render without a configured model.
- Disable or remove mutation controls for read-only sessions, including:
  - composer submission
  - stop and retry
  - approval decisions
  - tool and preset changes
  - pending-message submission
- Keep inbox child-session lookup scoped to the current user.
- Polish the empty search state for consistency with chat result rows.
- Regenerate the TypeScript API client for the new query parameter and response field.

## Reviewer guide

1. Start with `tracecat/agent/session/types.py` for the ownership rules.
2. Review `tracecat/agent/session/router.py` for API defaults and mutation enforcement.
3. Review `tracecat/agent/mcp/internal_tools.py` for MCP parity and preset isolation.
4. Review `frontend/src/components/chat/chat-history-dropdown.tsx` and `chat-session-pane.tsx` for scope selection and read-only UX.
5. Tests in `tests/unit/test_agent_session_router.py` cover the key API defaults and write-denial path.

## Verification

- `43` focused backend tests passed.
- Ruff lint and format checks passed.
- Basedpyright passed with no errors or warnings.
- Frontend TypeScript check passed.
- Biome passed.
- `git diff --check` passed.
- Manual QA against the local seeded workspace verified:
  - team sessions load by default
  - `Mine` sends the creator filter and only shows the current user’s sessions
  - teammate creator labels and read-only badges render
  - teammate transcripts remain visible
  - composer, submit, tools, presets, retry, and approval actions are unavailable
  - API requests with and without `created_by` return successfully

## Risk and compatibility

- This intentionally broadens unfiltered session-list responses from actor-owned sessions to workspace-wide sessions.
- Write authorization is enforced server-side across mutation endpoints; the disabled UI is not the security boundary.
- The API response change is additive.
- No database migration is required.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 309 | 70 |
| Tests | 246 | 8 |
| Generated client | 36 | 0 |
| **Total** | **591** | **78** |