### PR TITLE
docs: document Temporal history retention

### DIFF
--- a/docs/self-hosting/docker-compose.mdx
+++ b/docs/self-hosting/docker-compose.mdx
@@ -65,6 +65,40 @@ Make sure your `docker-compose.yml` and generated `.env` files are in the same d
 docker compose up
 ```
 
+## Configure Temporal workflow history retention
+
+A new Docker Compose installation retains closed Temporal workflow histories for 24 hours. Running workflows are not affected by this retention period.
+
+To use a different retention period for a new installation, create `docker-compose.override.yml` next to `docker-compose.yml`:
+
+```yaml
+services:
+  temporal:
+    environment:
+      DEFAULT_NAMESPACE_RETENTION: 720h # 30 days
+```
+
+Then start Tracecat with `docker compose up -d`. Temporal reads `DEFAULT_NAMESPACE_RETENTION` only when it creates the `default` namespace.
+
+If you already started Tracecat, update the existing namespace directly:
+
+```bash
+docker compose exec temporal \
+  temporal operator namespace update \
+  --namespace default \
+  --retention 720h
+```
+
+Verify the current retention period:
+
+```bash
+docker compose exec temporal \
+  temporal operator namespace describe \
+  --namespace default
+```
+
+Temporal deletes closed workflow histories after the configured period. This setting does not control workflow artifacts in object storage; configure those separately with `TRACECAT__WORKFLOW_ARTIFACT_RETENTION_DAYS`.
+
 ## Access Tracecat
 
 Once deployed, access your instance at:


### PR DESCRIPTION
## Summary
- Document the 24-hour default retention period for closed Temporal workflow histories in fresh Docker Compose installations.
- Show how to configure a different retention period for new installations.
- Show how to update and verify retention for an existing Temporal namespace.
- Distinguish Temporal history retention from workflow artifact retention in object storage.

## User impact
Self-hosted users can configure workflow history retention without recreating volumes or confusing it with artifact lifecycle settings.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Docs | 34 | 0 |

## Validation
- `npx --yes -p node@22 -p mint -c 'mint broken-links'` (passed before validation was stopped)
- Full visual preview was not completed per request.

## Screenshots
Not applicable; this is a configuration-only documentation change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document Temporal workflow history retention in self-hosted Docker Compose installs. Shows the 24-hour default, how to set `DEFAULT_NAMESPACE_RETENTION` for new installs, how to update and verify an existing namespace with `temporal operator`, and that this is separate from artifact retention (`TRACECAT__WORKFLOW_ARTIFACT_RETENTION_DAYS`).

<sup>Written for commit 1d1203401efc69d18ed9930c7efba29c693c071c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

