### PR TITLE
fix(ui): keep settings modal content within dialog width

### DIFF
--- a/frontend/src/components/settings/settings-modal.tsx
+++ b/frontend/src/components/settings/settings-modal.tsx
@@ -204,7 +204,11 @@ function SettingsModalContent() {
         <DialogDescription className="sr-only">
           Manage your account and workspace settings
         </DialogDescription>
-        <div className="flex h-full">
+        {/* `min-w-0` keeps this grid item from flooring the dialog's implicit
+            grid track at its own min-content width. Without it, unbreakable
+            tokens in the git-sync diff preview widen the track past the
+            dialog's max-width and get clipped by `overflow-hidden`. */}
+        <div className="flex h-full min-w-0">
           {/* Left nav panel */}
           <div className="flex w-[200px] shrink-0 flex-col border-r">
             <div className="flex flex-col gap-1 p-3">


### PR DESCRIPTION
## Problem

In the settings modal (Git sync → pull preview), the resource diff review list overflows the dialog horizontally: diff rows and hunk headers run under the modal's right edge, the content pane's right padding disappears, and the per-row "Viewed" checkbox controls are pushed off-screen. Earlier `min-w-0` additions on the inner diff components did not fix it.

## Root cause

shadcn's `DialogContent` renders as CSS grid, and the settings modal's sole child `<div className="flex h-full">` was a grid item with the default `min-width: auto`, so the implicit grid column track is floored at the item's min-content width. The diff text uses `break-words` (`overflow-wrap: break-word`), which wraps visually but per spec does **not** reduce min-content width — long unbreakable tokens in diffed YAML (workflow IDs, URLs) propagate a large min-content width up through the flex chain into the grid item, blowing the track past the dialog's `max-w-[1080px]`. `overflow-hidden` on `DialogContent` then clips everything at the modal edge. The `min-w-0`s on inner components sit below this boundary and cannot stop it.

## Fix

Add `min-w-0` to the grid-item wrapper in `settings-modal.tsx` so the track can no longer be floored by content min-content width.

Verified empirically in Chrome with a standalone repro of the exact class chain (1080px dialog): the grid item measured 1599px before the fix and 1078px after, with the right padding and "Viewed" controls back inside the dialog and no horizontal scroll in the diff box (`scrollWidth == offsetWidth`); long tokens wrap correctly without needing `overflow-wrap: anywhere`.

Other `DialogContent` usages were swept; none render wide unbreakable mono content, so they are left unchanged.

## Verification

- `pnpm -C frontend exec biome check --write .` — clean, no fixes applied
- `pnpm -C frontend run typecheck` — clean

## LOC breakdown

| Category | + | - |
|---|---|---|
| Logic | 5 | 1 |
