### PR TITLE
feat(ui): render agent mention chips in case comment viewer

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -3,25 +3,35 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   testEnvironment: "jsdom", // For React components
   transform: {
-    "^.+\\.tsx?$": [
+    // `.js`/`.mjs` are included because `marked` (pulled in by
+    // @tiptap/markdown) ships ESM only and has to be downleveled to CommonJS
+    // before Jest can require it. ts-jest only honours one set of options per
+    // run, so this must stay a single entry.
+    "^.+\\.m?[jt]sx?$": [
       "ts-jest",
       {
         tsconfig: {
           jsx: "react-jsx",
+          allowJs: true,
         },
       },
     ],
   },
   testPathIgnorePatterns: ["/node_modules/", "/.next/", "/tests/smoke/"],
-  transformIgnorePatterns: ["node_modules/(?!(yaml)/)"],
+  // The optional `.pnpm/` hop makes this work with pnpm's nested store layout,
+  // where every real package path contains `node_modules/.pnpm/<name>@<ver>/`.
+  transformIgnorePatterns: [
+    "node_modules/(?!(\\.pnpm/)?(yaml|marked|react-hotkeys-hook)([@/]|$))",
+  ],
   moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
-    "^lucide-react/dynamicIconImports$":
-      "<rootDir>/tests/mocks/lucide-dynamic-icon-imports.js",
-    // Mock CSS and other non-JS files
+    // Only the first matching pattern applies, so the asset mocks have to come
+    // before the `@/` alias: stylesheets are imported through it too.
     "\\.(css|less|scss|sass)$": "identity-obj-proxy",
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "jest-transform-stub",
+    "^@/(.*)$": "<rootDir>/src/$1",
+    "^lucide-react/dynamicIconImports$":
+      "<rootDir>/tests/mocks/lucide-dynamic-icon-imports.js",
     // Mock yaml module for Jest
     "^yaml$": "identity-obj-proxy",
   },

--- a/frontend/src/components/cases/case-description-editor.test.tsx
+++ b/frontend/src/components/cases/case-description-editor.test.tsx
@@ -86,6 +86,17 @@ describe("CaseCommentViewer mentions", () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
+  it("resolves an uppercase uuid href against the lowercase preset id", async () => {
+    renderViewer(
+      `Please review [@Stale Label](mention://agent/${PRESET_ID.toUpperCase()}).`
+    )
+
+    const chip = await screen.findByTestId("mention-chip")
+    expect(chip).toHaveTextContent("@Triage Agent")
+    expect(chip).toHaveAttribute("data-state", "resolved")
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
   it("leaves a malformed mention href as a plain link", async () => {
     const { container } = renderViewer(
       "Ping [@Nobody](mention://agent/not-a-uuid) please."

--- a/frontend/src/components/cases/case-description-editor.test.tsx
+++ b/frontend/src/components/cases/case-description-editor.test.tsx
@@ -1,0 +1,128 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import type { AgentPresetReadMinimal } from "@/client"
+import { CaseCommentViewer } from "@/components/cases/case-description-editor"
+import { useAgentPresets } from "@/hooks/use-agent-presets"
+import { WorkspaceIdProvider } from "@/providers/workspace-id"
+
+jest.mock("@/hooks/use-agent-presets", () => ({
+  useAgentPresets: jest.fn(),
+}))
+
+const mockUseAgentPresets = useAgentPresets as jest.MockedFunction<
+  typeof useAgentPresets
+>
+
+const WORKSPACE_ID = "1f8d0f19-4b9c-4f7a-9c3f-2f4b6d8e0a12"
+const PRESET_ID = "0f9d9f4c-1c2b-4f3a-9a1e-2b7c8d9e0f11"
+
+const preset: AgentPresetReadMinimal = {
+  id: PRESET_ID,
+  workspace_id: WORKSPACE_ID,
+  name: "Triage Agent",
+  slug: "triage-agent",
+  description: null,
+  model_provider: "openai",
+  model_name: "gpt-4o",
+  created_at: "2024-01-01T00:00:00.000Z",
+  updated_at: "2024-01-01T00:00:00.000Z",
+}
+
+function renderViewer(content: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <WorkspaceIdProvider workspaceId={WORKSPACE_ID}>
+        <CaseCommentViewer content={content} workspaceId={WORKSPACE_ID} />
+      </WorkspaceIdProvider>
+    </QueryClientProvider>
+  )
+}
+
+let consoleErrorSpy: jest.SpyInstance
+
+beforeAll(() => {
+  // jsdom does not implement matchMedia, which `useIsMobile` calls on mount.
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }),
+  })
+})
+
+beforeEach(() => {
+  mockUseAgentPresets.mockReturnValue({
+    presets: [preset],
+    presetsIsLoading: false,
+    presetsError: null,
+    refetchPresets: jest.fn(),
+  } as unknown as ReturnType<typeof useAgentPresets>)
+  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+  mockUseAgentPresets.mockReset()
+})
+
+describe("CaseCommentViewer mentions", () => {
+  it("renders a valid agent mention as a chip showing the resolved name", async () => {
+    renderViewer(`Please review [@Stale Label](mention://agent/${PRESET_ID}).`)
+
+    const chip = await screen.findByTestId("mention-chip")
+    expect(chip).toHaveTextContent("@Triage Agent")
+    expect(chip).toHaveAttribute("data-state", "resolved")
+    expect(screen.queryByText("@Stale Label")).not.toBeInTheDocument()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it("leaves a malformed mention href as a plain link", async () => {
+    const { container } = renderViewer(
+      "Ping [@Nobody](mention://agent/not-a-uuid) please."
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector("a")).not.toBeNull()
+    })
+    const anchor = container.querySelector("a")
+    expect(anchor?.textContent).toBe("@Nobody")
+    expect(screen.queryByTestId("mention-chip")).not.toBeInTheDocument()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it("leaves an unknown mention segment as a plain link", async () => {
+    const { container } = renderViewer(
+      `Ping [@Someone](mention://user/${PRESET_ID}) please.`
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector("a")).not.toBeNull()
+    })
+    expect(container.querySelector("a")?.textContent).toBe("@Someone")
+    expect(screen.queryByTestId("mention-chip")).not.toBeInTheDocument()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it("does not affect ordinary links", async () => {
+    const { container } = renderViewer(
+      `See [Docs](https://example.test/docs) and [@Stale](mention://agent/${PRESET_ID}).`
+    )
+
+    await screen.findByTestId("mention-chip")
+    const anchors = Array.from(container.querySelectorAll("a"))
+    expect(anchors).toHaveLength(1)
+    expect(anchors[0]).toHaveAttribute("href", "https://example.test/docs")
+    expect(anchors[0]?.textContent).toBe("Docs")
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/cases/case-description-editor.tsx
+++ b/frontend/src/components/cases/case-description-editor.tsx
@@ -102,6 +102,10 @@ export function CaseDescriptionEditor({
   )
 }
 
+/**
+ * Read-only renderer for a case comment. `mention://` links render as inline
+ * mention chips here; the comment composer keeps them as editable markdown.
+ */
 export function CaseCommentViewer({
   content,
   className,
@@ -121,6 +125,7 @@ export function CaseCommentViewer({
         className="case-comment-viewer"
         enableImages={Boolean(workspaceId)}
         imageWorkspaceId={workspaceId ?? null}
+        enableMentions
       />
     </div>
   )

--- a/frontend/src/components/tiptap-node/mention-node/mention-node.test.tsx
+++ b/frontend/src/components/tiptap-node/mention-node/mention-node.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from "@testing-library/react"
+import type { AgentPresetReadMinimal } from "@/client"
+import {
+  AgentMentionChip,
+  MentionChip,
+} from "@/components/tiptap-node/mention-node/mention-node"
+import { useAgentPresets } from "@/hooks/use-agent-presets"
+
+jest.mock("@/hooks/use-agent-presets", () => ({
+  useAgentPresets: jest.fn(),
+}))
+
+const mockUseAgentPresets = useAgentPresets as jest.MockedFunction<
+  typeof useAgentPresets
+>
+
+const PRESET_ID = "0f9d9f4c-1c2b-4f3a-9a1e-2b7c8d9e0f11"
+
+function agentPreset(
+  overrides: Partial<AgentPresetReadMinimal> = {}
+): AgentPresetReadMinimal {
+  return {
+    id: PRESET_ID,
+    workspace_id: "workspace-1",
+    name: "Current Name",
+    slug: "current-name",
+    description: null,
+    model_provider: "openai",
+    model_name: "gpt-4o",
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function mockPresets({
+  presets,
+  presetsIsLoading = false,
+  presetsError = null,
+}: {
+  presets: AgentPresetReadMinimal[] | undefined
+  presetsIsLoading?: boolean
+  presetsError?: ReturnType<typeof useAgentPresets>["presetsError"]
+}) {
+  mockUseAgentPresets.mockReturnValue({
+    presets,
+    presetsIsLoading,
+    presetsError,
+    refetchPresets: jest.fn(),
+  } as unknown as ReturnType<typeof useAgentPresets>)
+}
+
+beforeEach(() => {
+  mockUseAgentPresets.mockReset()
+})
+
+describe("MentionChip", () => {
+  it("marks the unavailable treatment with a stable data-state hook", () => {
+    render(
+      <MentionChip
+        label="@Someone"
+        state="unavailable"
+        title="Agent preset unavailable"
+      />
+    )
+
+    const chip = screen.getByTestId("mention-chip")
+    expect(chip).toHaveAttribute("data-state", "unavailable")
+    expect(chip).toHaveAttribute("title", "Agent preset unavailable")
+    expect(chip.className).toContain("border-dashed")
+  })
+
+  it("uses the normal treatment for resolved and loading chips", () => {
+    const { rerender } = render(
+      <MentionChip label="@Someone" state="loading" />
+    )
+    expect(screen.getByTestId("mention-chip").className).not.toContain(
+      "border-dashed"
+    )
+
+    rerender(<MentionChip label="@Someone" state="resolved" />)
+    expect(screen.getByTestId("mention-chip").className).not.toContain(
+      "border-dashed"
+    )
+  })
+})
+
+describe("AgentMentionChip", () => {
+  it("renders the resolved preset name and drops a stale embedded label", () => {
+    mockPresets({ presets: [agentPreset({ name: "Current Name" })] })
+
+    render(<AgentMentionChip presetId={PRESET_ID} label="@Stale Label" />)
+
+    const chip = screen.getByTestId("mention-chip")
+    expect(chip).toHaveTextContent("@Current Name")
+    expect(chip).toHaveAttribute("data-state", "resolved")
+    expect(screen.queryByText("@Stale Label")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the embedded label with the unavailable treatment for an unknown preset", () => {
+    mockPresets({ presets: [agentPreset({ id: "some-other-id" })] })
+
+    render(<AgentMentionChip presetId={PRESET_ID} label="@Deleted Agent" />)
+
+    const chip = screen.getByTestId("mention-chip")
+    expect(chip).toHaveTextContent("@Deleted Agent")
+    expect(chip).toHaveAttribute("data-state", "unavailable")
+    expect(chip).toHaveAttribute("title", "Agent preset unavailable")
+  })
+
+  it("treats a failed preset query as unavailable", () => {
+    mockPresets({
+      presets: undefined,
+      presetsError: {
+        status: 500,
+        body: { detail: "boom" },
+      } as unknown as ReturnType<typeof useAgentPresets>["presetsError"],
+    })
+
+    render(<AgentMentionChip presetId={PRESET_ID} label="@Some Agent" />)
+
+    expect(screen.getByTestId("mention-chip")).toHaveAttribute(
+      "data-state",
+      "unavailable"
+    )
+  })
+
+  it("renders the embedded label without the unavailable treatment while loading", () => {
+    mockPresets({ presets: undefined, presetsIsLoading: true })
+
+    render(<AgentMentionChip presetId={PRESET_ID} label="@Some Agent" />)
+
+    const chip = screen.getByTestId("mention-chip")
+    expect(chip).toHaveTextContent("@Some Agent")
+    expect(chip).toHaveAttribute("data-state", "loading")
+    expect(chip).not.toHaveAttribute("title")
+  })
+
+  it("stays in the loading treatment while presets are still undefined", () => {
+    mockPresets({ presets: undefined, presetsIsLoading: false })
+
+    render(<AgentMentionChip presetId={PRESET_ID} label="@Some Agent" />)
+
+    expect(screen.getByTestId("mention-chip")).toHaveAttribute(
+      "data-state",
+      "loading"
+    )
+  })
+})

--- a/frontend/src/components/tiptap-node/mention-node/mention-node.tsx
+++ b/frontend/src/components/tiptap-node/mention-node/mention-node.tsx
@@ -1,0 +1,225 @@
+"use client"
+
+import {
+  mergeAttributes,
+  Node,
+  type NodeViewProps,
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+} from "@tiptap/react"
+import { useAgentPresets } from "@/hooks/use-agent-presets"
+import { type MentionTarget, parseMentionHref } from "@/lib/mentions"
+import { cn } from "@/lib/utils"
+import { useOptionalWorkspaceId } from "@/providers/workspace-id"
+
+/**
+ * Resolution state of a mention chip.
+ *
+ * - `resolved`: the target was found and the chip shows its current name.
+ * - `loading`: the target directory has not arrived yet; the chip shows the
+ *   authored label in the normal treatment so nothing flashes.
+ * - `unavailable`: the target does not exist (deleted, or a hand-typed id).
+ */
+export type MentionChipState = "resolved" | "loading" | "unavailable"
+
+function mentionChipClassName(state: MentionChipState): string {
+  switch (state) {
+    case "unavailable":
+      return "border-dashed border-border/70 bg-muted/30 text-muted-foreground"
+    default:
+      return "border-border bg-muted text-foreground"
+  }
+}
+
+/**
+ * Presentational, inert mention chip. Exported separately from the node so it
+ * can be tested without an editor.
+ */
+export function MentionChip({
+  label,
+  state,
+  title,
+}: {
+  /** Text rendered inside the chip, including its leading `@`. */
+  label: string
+  state: MentionChipState
+  /** Optional native tooltip, used to explain the unavailable state. */
+  title?: string
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-baseline rounded-md border px-1.5 align-baseline text-xs font-medium",
+        mentionChipClassName(state)
+      )}
+      data-state={state}
+      data-testid="mention-chip"
+      title={title}
+    >
+      {label}
+    </span>
+  )
+}
+
+/**
+ * Chip for `mention://agent/<preset id>`.
+ *
+ * The name always comes from the preset resolved by id, never from the label
+ * embedded in the markdown: labels can be hand-typed to disagree with the id
+ * and go stale when a preset is renamed.
+ */
+export function AgentMentionChip({
+  presetId,
+  label,
+}: {
+  /** Preset id taken from the mention href; the only trusted identifier. */
+  presetId: string
+  /** Label authored in the markdown, used only until the id resolves. */
+  label: string
+}) {
+  const workspaceId = useOptionalWorkspaceId()
+  const { presets, presetsIsLoading, presetsError } =
+    useAgentPresets(workspaceId)
+
+  const preset = presets?.find((candidate) => candidate.id === presetId)
+  if (preset) {
+    return <MentionChip label={`@${preset.name}`} state="resolved" />
+  }
+
+  if (!presetsError && (presetsIsLoading || presets === undefined)) {
+    return <MentionChip label={label} state="loading" />
+  }
+
+  return (
+    <MentionChip
+      label={label}
+      state="unavailable"
+      title="Agent preset unavailable"
+    />
+  )
+}
+
+function MentionTargetChip({
+  target,
+  label,
+}: {
+  target: MentionTarget
+  label: string
+}) {
+  switch (target.type) {
+    case "agent":
+      return <AgentMentionChip presetId={target.presetId} label={label} />
+  }
+}
+
+function MentionNodeView({ node }: NodeViewProps) {
+  const href = typeof node.attrs.href === "string" ? node.attrs.href : null
+  const label = typeof node.attrs.label === "string" ? node.attrs.label : ""
+  const target = parseMentionHref(href)
+
+  // Unreachable in practice: the node is only ever created for hrefs that
+  // already parsed. Kept so a malformed href can never render as a chip.
+  if (!target) {
+    return (
+      <NodeViewWrapper as="span" className="mention">
+        <a href={href ?? undefined}>{label}</a>
+      </NodeViewWrapper>
+    )
+  }
+
+  return (
+    <NodeViewWrapper as="span" className="mention">
+      <MentionTargetChip target={target} label={label} />
+    </NodeViewWrapper>
+  )
+}
+
+/**
+ * Inline atom node that takes over `mention://` links so they render as chips
+ * instead of anchors.
+ *
+ * Interception happens on the already-parsed href in both content pipelines:
+ * the markdown `link` token (how case comments are loaded) and the `a[href]`
+ * HTML parse rule (inline HTML and `setContent` with HTML). Hrefs that are not
+ * well-formed mentions are handed back to the Link mark untouched.
+ */
+export const Mention = Node.create({
+  name: "mention",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+  // Extension priority also decides markdown handler registration order, and
+  // this node has to be registered before the Link mark to claim `link` tokens.
+  priority: 1100,
+
+  addAttributes() {
+    return {
+      href: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("href"),
+      },
+      label: {
+        default: "",
+        parseHTML: (element) => element.textContent ?? "",
+        // Rendered as the anchor's text content, not as an attribute.
+        renderHTML: () => ({}),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "a[href]",
+        // ProseMirror sorts node and mark parse rules into one list and tries
+        // marks first at equal priority, so this rule needs to outrank the Link
+        // mark's default of 50. Extension priority does not reach parse rules.
+        priority: 1000,
+        getAttrs: (element) => {
+          const href = element.getAttribute("href")
+          if (!parseMentionHref(href)) {
+            // Not a mention: fall through to the Link mark.
+            return false
+          }
+          return { href, label: element.textContent ?? "" }
+        },
+      },
+    ]
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const label = typeof node.attrs.label === "string" ? node.attrs.label : ""
+    return ["a", mergeAttributes(HTMLAttributes), label]
+  },
+
+  renderText({ node }) {
+    return typeof node.attrs.label === "string" ? node.attrs.label : ""
+  },
+
+  markdownTokenName: "link",
+
+  parseMarkdown(token, helpers) {
+    const href = typeof token.href === "string" ? token.href : null
+    if (parseMentionHref(href)) {
+      return helpers.createNode("mention", { href, label: token.text ?? "" })
+    }
+    // Ordinary link: reproduce the Link mark's own markdown handling, because
+    // only the first registered handler for a token type is consulted. Keep
+    // this in step with `@tiptap/extension-link`'s `parseMarkdown`.
+    return helpers.applyMark("link", helpers.parseInline(token.tokens ?? []), {
+      href: token.href,
+      title: token.title || null,
+    })
+  },
+
+  renderMarkdown(node) {
+    const label = typeof node.attrs?.label === "string" ? node.attrs.label : ""
+    const href = typeof node.attrs?.href === "string" ? node.attrs.href : ""
+    return `[${label}](${href})`
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MentionNodeView)
+  },
+})

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -27,6 +27,7 @@ import { HorizontalRule } from "@/components/tiptap-node/horizontal-rule-node/ho
 import { AttachmentImage } from "@/components/tiptap-node/image-node/attachment-image-node"
 // --- Tiptap Node ---
 import { ImageUploadNode } from "@/components/tiptap-node/image-upload-node/image-upload-node-extension"
+import { Mention } from "@/components/tiptap-node/mention-node/mention-node"
 import { MermaidCodeBlock } from "@/components/tiptap-node/mermaid-code-block-node/mermaid-code-block-node"
 // --- UI Primitives ---
 import { Button, ButtonGroup } from "@/components/tiptap-ui-primitive/button"
@@ -523,6 +524,12 @@ export interface SimpleEditorProps {
    * `attachment://<caseId>/<attachmentId>`). Required to enable paste/drop.
    */
   onImageUpload?: (file: File) => Promise<string>
+  /**
+   * Render `mention://` links as inline mention chips. Intended for read-only
+   * viewers; editable surfaces keep the raw markdown link so it stays editable.
+   * @default false
+   */
+  enableMentions?: boolean
 }
 
 export function SimpleEditor({
@@ -544,6 +551,7 @@ export function SimpleEditor({
   enableImages = false,
   imageWorkspaceId = null,
   onImageUpload,
+  enableMentions = false,
 }: SimpleEditorProps) {
   const isMobile = useIsMobile()
   const { height } = useWindowSize()
@@ -561,6 +569,10 @@ export function SimpleEditor({
 
   const extensions = React.useMemo(
     () => [
+      // Must stay ahead of StarterKit: the markdown manager registers handlers
+      // in extension order and consults only the first one per token type, so
+      // Mention has to claim `link` tokens before StarterKit's Link mark does.
+      ...(enableMentions ? [Mention] : []),
       StarterKit.configure({
         horizontalRule: false,
         codeBlock: false,
@@ -611,7 +623,7 @@ export function SimpleEditor({
         },
       }),
     ],
-    [renderMermaidWhenBlurred, enableImages, imageWorkspaceId]
+    [renderMermaidWhenBlurred, enableImages, imageWorkspaceId, enableMentions]
   )
 
   const editor = useEditor({

--- a/frontend/src/lib/mentions.test.ts
+++ b/frontend/src/lib/mentions.test.ts
@@ -1,0 +1,60 @@
+import { parseMentionHref } from "@/lib/mentions"
+
+const PRESET_ID = "0f9d9f4c-1c2b-4f3a-9a1e-2b7c8d9e0f11"
+
+describe("parseMentionHref", () => {
+  it("parses an agent mention", () => {
+    expect(parseMentionHref(`mention://agent/${PRESET_ID}`)).toEqual({
+      type: "agent",
+      presetId: PRESET_ID,
+    })
+  })
+
+  it("accepts uppercase uuids and preserves the original casing", () => {
+    const upper = PRESET_ID.toUpperCase()
+    expect(parseMentionHref(`mention://agent/${upper}`)).toEqual({
+      type: "agent",
+      presetId: upper,
+    })
+  })
+
+  it.each([
+    ["a plain https url", `https://example.test/agent/${PRESET_ID}`],
+    ["a relative url", "/agents/some-preset"],
+    ["a non-uuid id", "mention://agent/not-a-uuid"],
+    ["a numeric id", "mention://agent/12345"],
+    ["an unknown segment", `mention://user/${PRESET_ID}`],
+    ["an unknown segment", `mention://foo/${PRESET_ID}`],
+    ["a missing id", "mention://agent"],
+    ["an empty id", "mention://agent/"],
+    ["extra segments", `mention://agent/${PRESET_ID}/extra`],
+    ["a missing segment", `mention://${PRESET_ID}`],
+    ["a scheme-only href", "mention://"],
+    ["a wrong scheme", `mentions://agent/${PRESET_ID}`],
+    ["an empty string", ""],
+  ])("returns null for %s", (_description, href) => {
+    expect(parseMentionHref(href)).toBeNull()
+  })
+
+  it("returns null for null and undefined", () => {
+    expect(parseMentionHref(null)).toBeNull()
+    expect(parseMentionHref(undefined)).toBeNull()
+  })
+
+  it("never throws on arbitrary input", () => {
+    const inputs = [
+      "mention:///",
+      "mention://///",
+      "mention://agent/%%%",
+      "mention://agent/../../etc/passwd",
+      "mention://AGENT/" + PRESET_ID,
+      "  mention://agent/" + PRESET_ID,
+      "\u0000",
+      "a".repeat(10_000),
+    ]
+    for (const input of inputs) {
+      expect(() => parseMentionHref(input)).not.toThrow()
+      expect(parseMentionHref(input)).toBeNull()
+    }
+  })
+})

--- a/frontend/src/lib/mentions.test.ts
+++ b/frontend/src/lib/mentions.test.ts
@@ -10,11 +10,20 @@ describe("parseMentionHref", () => {
     })
   })
 
-  it("accepts uppercase uuids and preserves the original casing", () => {
-    const upper = PRESET_ID.toUpperCase()
-    expect(parseMentionHref(`mention://agent/${upper}`)).toEqual({
+  it("accepts an uppercase uuid and lowercases it to match API ids", () => {
+    expect(
+      parseMentionHref(`mention://agent/${PRESET_ID.toUpperCase()}`)
+    ).toEqual({
       type: "agent",
-      presetId: upper,
+      presetId: PRESET_ID,
+    })
+  })
+
+  it("lowercases a mixed-case uuid", () => {
+    const mixed = "0F9d9F4c-1C2b-4f3A-9a1E-2b7C8d9E0f11"
+    expect(parseMentionHref(`mention://agent/${mixed}`)).toEqual({
+      type: "agent",
+      presetId: PRESET_ID,
     })
   })
 

--- a/frontend/src/lib/mentions.ts
+++ b/frontend/src/lib/mentions.ts
@@ -1,0 +1,52 @@
+/**
+ * Inline mentions are encoded in markdown as ordinary links with a
+ * `mention://` href, e.g. `[@Triage](mention://agent/<preset uuid>)`.
+ *
+ * The link label is authored text and is never trusted to identify the target;
+ * only the id in the href is. Renderers resolve the display name from the id.
+ */
+
+/**
+ * A well-formed `mention://` target.
+ *
+ * Discriminated on `type` so a future `mention://user/<uuid>` is one extra
+ * variant here and one extra `case` at every call site.
+ */
+export type MentionTarget = { type: "agent"; presetId: string }
+
+const MENTION_SCHEME = "mention://"
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Parse a `mention://` href into a typed target.
+ *
+ * Returns `null` for anything that is not exactly `mention://<segment>/<uuid>`
+ * with a known segment, so callers can fall back to rendering a plain link.
+ * Never throws.
+ */
+export function parseMentionHref(
+  href: string | null | undefined
+): MentionTarget | null {
+  if (!href || !href.startsWith(MENTION_SCHEME)) {
+    return null
+  }
+
+  const segments = href.slice(MENTION_SCHEME.length).split("/")
+  if (segments.length !== 2) {
+    return null
+  }
+
+  const [segment, id] = segments
+  if (!id || !UUID_PATTERN.test(id)) {
+    return null
+  }
+
+  switch (segment) {
+    case "agent":
+      return { type: "agent", presetId: id }
+    default:
+      return null
+  }
+}

--- a/frontend/src/lib/mentions.ts
+++ b/frontend/src/lib/mentions.ts
@@ -24,6 +24,7 @@ const UUID_PATTERN =
  *
  * Returns `null` for anything that is not exactly `mention://<segment>/<uuid>`
  * with a known segment, so callers can fall back to rendering a plain link.
+ * The id is lowercased so it compares directly against ids from the API.
  * Never throws.
  */
 export function parseMentionHref(
@@ -43,9 +44,14 @@ export function parseMentionHref(
     return null
   }
 
+  // Uuids are hex and case-insensitive, but the API only ever returns them
+  // lowercased. Normalize at this single parse boundary so every consumer can
+  // compare ids with `===` instead of case-folding at each lookup site.
+  const presetId = id.toLowerCase()
+
   switch (segment) {
     case "agent":
-      return { type: "agent", presetId: id }
+      return { type: "agent", presetId }
     default:
       return null
   }


### PR DESCRIPTION
## Summary

Case comments are plain markdown rendered through a read-only TipTap viewer, and agent mentions are encoded inline as ordinary markdown links: `[@Label](mention://agent/<preset_uuid>)`. Until now they rendered as plain links. This PR renders them as inert inline mention chips.

The displayed name always comes from the preset **resolved by id**, never from the label embedded in the markdown. That is deliberate: a hand-typed token can carry a label that disagrees with the id it points at, and presets get renamed after the comment is written. The embedded label is used only as a fallback when the id does not resolve, and is then given a visually distinct "unavailable" treatment (dashed border, muted foreground, `title="Agent preset unavailable"`).

Malformed hrefs (non-UUID id, unknown path segment, missing/extra segments) and every non-mention link are handed straight back to the Link mark and render exactly as they do today.

### How the interception works

`parseMentionHref` (`frontend/src/lib/mentions.ts`) parses a `mention://` href into a discriminated `MentionTarget` union, dispatched with a `switch` on the path segment, so a future `mention://user/<uuid>` is one extra variant and one extra `case`. It never throws.

A new inline atom node (`frontend/src/components/tiptap-node/mention-node/mention-node.tsx`) claims anchors whose href parses as a mention. No raw comment text is ever re-parsed, and `@tiptap/extension-mention` is not installed — this is href interception, not editor mention machinery.

Two things worth flagging for review:

1. **`@tiptap/markdown@3.7.1` does not route markdown through HTML.** It runs `marked`'s lexer and dispatches tokens to extension `parseMarkdown` handlers keyed by `markdownTokenName`; `parseHTML` rules are only consulted for literal HTML embedded in the markdown. So an `a[href]` parse rule alone never fires for a case comment. The node therefore intercepts on the already-parsed href in **both** pipelines: the markdown `link` token (how comments actually load) and the `a[href]` HTML rule (inline HTML and `setContent` with HTML). Because only the first registered handler per token type is consulted, the markdown handler reproduces `@tiptap/extension-link`'s own `parseMarkdown` verbatim (including `title`) for ordinary links.
2. **`Mention` must be registered before `StarterKit`.** `MarkdownManager` is built from the raw, declaration-ordered extension array rather than the priority-sorted one, so extension `priority` does not decide markdown handler order. There is a comment at the call site explaining this, and the integration test fails loudly if it regresses. Relatedly, TipTap does not propagate extension `priority` into ProseMirror parse rules, so the HTML rule carries its own `priority: 1000` to outrank the Link mark's default of 50.

`renderHTML` / `renderText` / `renderMarkdown` round-trip the node back to `[@Label](mention://agent/<id>)` unchanged.

## Rendering scope decision: read-only viewers only

Chips render **only where a consumer opts in**, via a new `enableMentions` prop on `SimpleEditor` (default `false`). `CaseCommentViewer` is the only consumer that sets it.

The alternative — chips everywhere a `mention://` link appears — was rejected because `SimpleEditor` is also the editable case description editor and comment composer. Swapping a link for an atom node in an editable surface would make the token uneditable in place: an author could no longer fix a typo in the label or retarget the mention without deleting the whole chip. Editable surfaces keep the raw markdown link, which stays selectable and editable; read-only viewers get the chip. This also keeps the blast radius of the change to exactly one call site.

## Styling

The chip reuses the existing badge/chip visual language (`inline-flex`, `rounded-md`, `border`, `px-1.5`, `text-xs font-medium`) with `align-baseline` and `items-baseline` so it does not disturb line height inside a comment paragraph or a thread reply. Colors are semantic tokens only (`bg-muted`, `text-foreground`, `border-border`, `text-muted-foreground`), so light and dark both work with no hardcoded values. The "unavailable" treatment reuses the dashed-border/muted language already used by `AttachmentImagePlaceholder`. No icon was added: the app has no consistent agent-preset icon (the sidebar uses `MousePointerClickIcon`, the canvas uses `BotIcon`), so inventing one here would have been the inconsistent choice.

Preset data loads async. While it is in flight the chip shows the embedded label in the normal treatment (no skeleton flash), then swaps to the resolved name.

## Test plan

Jest + Testing Library. Note the issue said vitest; this repo's frontend runner is Jest (`frontend/jest.config.cjs`, `pnpm -C frontend test` → `jest`).

- `frontend/src/lib/mentions.test.ts` — `parseMentionHref` across valid lower/uppercase UUIDs, https and relative urls, non-UUID and numeric ids, `mention://user/<uuid>`, `mention://foo/<uuid>`, missing/empty id, extra segments, missing segment, bare `mention://`, wrong scheme, empty string, `null`, `undefined`, plus a never-throws sweep over hostile inputs (path traversal, `%%%`, NUL, 10k chars, leading whitespace, uppercase segment).
- `frontend/src/components/tiptap-node/mention-node/mention-node.test.tsx` — chip states with the presets hook mocked. Resolved renders `@<current name>` and the stale label is asserted **absent**. Unknown id and query error both produce the unavailable treatment with `title`. Loading (and `presets === undefined`) renders the label with `data-state="loading"` and no `title`.
- `frontend/src/components/cases/case-description-editor.test.tsx` — real `CaseCommentViewer` over real markdown: a valid mention renders a chip with the resolved name and no stale label; `mention://agent/not-a-uuid` and `mention://user/<uuid>` both stay plain `<a>` elements with their original text and no chip; an ordinary `https://` link is the only anchor in the doc and keeps its href. Every case asserts `console.error` was never called.

Verification, all clean:

```
pnpm -C frontend exec biome check --write .   # 947 files, no fixes applied
pnpm -C frontend check                        # 947 files, no fixes applied
pnpm -C frontend run typecheck                # clean
pnpm -C frontend test                         # 101 suites, 581 tests passed
```

### `jest.config.cjs` changes

The integration test is the first test in the repo to mount `SimpleEditor`, which surfaced three latent config problems. All three are fixes, not workarounds, and the full suite passes with them:

- `marked` and `react-hotkeys-hook` (both ESM-only, reached transitively) now get transformed. The `transformIgnorePatterns` regex gained an optional `.pnpm/` hop — under pnpm every real package path contains a second `node_modules/` segment, so the previous pattern could never un-ignore anything.
- The `.ts/.tsx` and `.js/.mjs` transforms are merged into a single `ts-jest` entry. Two separate `ts-jest` entries make ts-jest apply one options set globally, which silently broke JSX compilation suite-wide.
- `moduleNameMapper` is reordered so the stylesheet mock precedes the `^@/(.*)$` alias. Only the first match applies, so `@/…/x.scss` imports were resolving to real `.scss` files.

No dependency or lockfile changes.

## Out of scope

Chips are inert in v1 — no click behavior, no navigation, no hover card. The comment composer and case description editor are behaviorally unchanged.

Closes ENG-1601
https://linear.app/tracecat/issue/ENG-1601

## LOC breakdown

| Category | + | - |
| --- | --- | --- |
| Logic | 295 | 1 |
| Tests | 337 | 0 |
| Infra/config | 16 | 6 |
| **Total** | **648** | **7** |
