### PR TITLE
feat(cases): parse and persist case comment mentions

### DIFF
--- a/alembic/versions/c20c04c7d2a9_add_case_comment_mention.py
+++ b/alembic/versions/c20c04c7d2a9_add_case_comment_mention.py
@@ -1,0 +1,102 @@
+"""add case_comment_mention
+
+Revision ID: c20c04c7d2a9
+Revises: 2792569cf359
+Create Date: 2026-08-07 14:29:53.887198
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_workspace_table_rls,
+    enable_workspace_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "c20c04c7d2a9"
+down_revision: str | None = "2792569cf359"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "case_comment_mention",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("case_id", sa.UUID(), nullable=False),
+        sa.Column("comment_id", sa.UUID(), nullable=False),
+        sa.Column("target_type", sa.String(length=32), nullable=False),
+        sa.Column("target_id", sa.UUID(), nullable=False),
+        sa.Column("label", sa.String(length=255), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["case.id"],
+            name=op.f("fk_case_comment_mention_case_id_case"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["comment_id"],
+            ["case_comment.id"],
+            name=op.f("fk_case_comment_mention_comment_id_case_comment"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_case_comment_mention_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_case_comment_mention")),
+        sa.UniqueConstraint(
+            "comment_id",
+            "target_type",
+            "target_id",
+            name=op.f("uq_case_comment_mention_comment_id_target_type_target_id"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_case_comment_mention_case_id"),
+        "case_comment_mention",
+        ["case_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_case_comment_mention_comment_id"),
+        "case_comment_mention",
+        ["comment_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_case_comment_mention_id"), "case_comment_mention", ["id"], unique=True
+    )
+    op.execute(enable_workspace_table_rls("case_comment_mention"))
+
+
+def downgrade() -> None:
+    op.execute(disable_workspace_table_rls("case_comment_mention"))
+    op.drop_index(op.f("ix_case_comment_mention_id"), table_name="case_comment_mention")
+    op.drop_index(
+        op.f("ix_case_comment_mention_comment_id"), table_name="case_comment_mention"
+    )
+    op.drop_index(
+        op.f("ix_case_comment_mention_case_id"), table_name="case_comment_mention"
+    )
+    op.drop_table("case_comment_mention")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6483,8 +6483,7 @@ export const $CaseCommentMentionRead = {
       title: "Id",
     },
     target_type: {
-      type: "string",
-      title: "Target Type",
+      $ref: "#/components/schemas/MentionTargetType",
     },
     target_id: {
       type: "string",
@@ -17407,6 +17406,18 @@ export const $MCPVerificationStatusRead = {
   required: ["status"],
   title: "MCPVerificationStatusRead",
   description: "Response model for saved MCP verification status.",
+} as const
+
+export const $MentionTargetType = {
+  type: "string",
+  enum: ["agent"],
+  title: "MentionTargetType",
+  description: `Polymorphic target kind for a parsed case-comment mention.
+
+Only \`\`AGENT\`\` is supported today. The finite set lives here (rather than
+as a bare \`\`str\`\` checked at runtime) so every mention-aware call site —
+the parser, persistence, and API read schema — shares one exhaustive,
+type-checked domain of valid target kinds.`,
 } as const
 
 export const $MessageKind = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6475,6 +6475,37 @@ export const $CaseCommentDeleteMode = {
   enum: ["soft", "hard"],
 } as const
 
+export const $CaseCommentMentionRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    target_type: {
+      type: "string",
+      title: "Target Type",
+    },
+    target_id: {
+      type: "string",
+      format: "uuid",
+      title: "Target Id",
+    },
+    label: {
+      type: "string",
+      title: "Label",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+  },
+  type: "object",
+  required: ["id", "target_type", "target_id", "label", "created_at"],
+  title: "CaseCommentMentionRead",
+} as const
+
 export const $CaseCommentRead = {
   properties: {
     id: {
@@ -6556,6 +6587,13 @@ export const $CaseCommentRead = {
       type: "boolean",
       title: "Is Deleted",
       default: false,
+    },
+    mentions: {
+      items: {
+        $ref: "#/components/schemas/CaseCommentMentionRead",
+      },
+      type: "array",
+      title: "Mentions",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1687,6 +1687,14 @@ export type CaseCommentCreate = {
 
 export type CaseCommentDeleteMode = "soft" | "hard"
 
+export type CaseCommentMentionRead = {
+  id: string
+  target_type: string
+  target_id: string
+  label: string
+  created_at: string
+}
+
 export type CaseCommentRead = {
   id: string
   created_at: string
@@ -1698,6 +1706,7 @@ export type CaseCommentRead = {
   last_edited_at?: string | null
   deleted_at?: string | null
   is_deleted?: boolean
+  mentions?: Array<CaseCommentMentionRead>
 }
 
 export type CaseCommentThreadRead = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1689,7 +1689,7 @@ export type CaseCommentDeleteMode = "soft" | "hard"
 
 export type CaseCommentMentionRead = {
   id: string
-  target_type: string
+  target_type: MentionTargetType
   target_id: string
   label: string
   created_at: string
@@ -5323,6 +5323,16 @@ export type status5 =
   | "succeeded"
   | "failed"
   | "superseded"
+
+/**
+ * Polymorphic target kind for a parsed case-comment mention.
+ *
+ * Only ``AGENT`` is supported today. The finite set lives here (rather than
+ * as a bare ``str`` checked at runtime) so every mention-aware call site —
+ * the parser, persistence, and API read schema — shares one exhaustive,
+ * type-checked domain of valid target kinds.
+ */
+export type MentionTargetType = "agent"
 
 /**
  * The type/kind of message stored in the chat.

--- a/tests/unit/test_case_comment_mentions.py
+++ b/tests/unit/test_case_comment_mentions.py
@@ -4,9 +4,20 @@ import pytest
 
 from tracecat.cases.mentions import MentionToken, parse_mentions
 
+SINGLE_MENTION_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000001")
+UNKNOWN_TARGET_TYPE_ID = uuid.UUID("00000000-0000-4000-8000-000000000002")
+UNTERMINATED_TOKEN_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000003")
+MISSING_BRACKET_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000004")
+WRONG_SCHEME_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000005")
+DUPLICATE_MENTION_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000006")
+FIRST_DISTINCT_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000007")
+SECOND_DISTINCT_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000008")
+ADJACENT_TEXT_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000009")
+UNICODE_LABEL_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000010")
+
 
 def test_parse_single_valid_mention() -> None:
-    target_id = uuid.uuid4()
+    target_id = SINGLE_MENTION_TARGET_ID
 
     assert parse_mentions(f"[@Response agent](mention://agent/{target_id})") == [
         MentionToken(
@@ -21,10 +32,10 @@ def test_parse_single_valid_mention() -> None:
     "content",
     [
         "[@Agent](mention://agent/not-a-uuid)",
-        f"[@User](mention://user/{uuid.uuid4()})",
-        f"[@Agent](mention://agent/{uuid.uuid4()}",
-        f"[@Agent(mention://agent/{uuid.uuid4()})",
-        f"[@Agent](mentions://agent/{uuid.uuid4()})",
+        f"[@User](mention://user/{UNKNOWN_TARGET_TYPE_ID})",
+        f"[@Agent](mention://agent/{UNTERMINATED_TOKEN_TARGET_ID}",
+        f"[@Agent(mention://agent/{MISSING_BRACKET_TARGET_ID})",
+        f"[@Agent](mentions://agent/{WRONG_SCHEME_TARGET_ID})",
     ],
 )
 def test_parse_skips_malformed_mentions(content: str) -> None:
@@ -32,7 +43,7 @@ def test_parse_skips_malformed_mentions(content: str) -> None:
 
 
 def test_parse_preserves_duplicate_mentions() -> None:
-    target_id = uuid.uuid4()
+    target_id = DUPLICATE_MENTION_TARGET_ID
     content = (
         f"[@First label](mention://agent/{target_id}) "
         f"[@Second label](mention://agent/{target_id})"
@@ -45,8 +56,8 @@ def test_parse_preserves_duplicate_mentions() -> None:
 
 
 def test_parse_multiple_distinct_mentions() -> None:
-    first_target_id = uuid.uuid4()
-    second_target_id = uuid.uuid4()
+    first_target_id = FIRST_DISTINCT_TARGET_ID
+    second_target_id = SECOND_DISTINCT_TARGET_ID
     content = (
         f"[@First](mention://agent/{first_target_id}) and "
         f"[@Second](mention://agent/{second_target_id})"
@@ -67,7 +78,7 @@ def test_parse_multiple_distinct_mentions() -> None:
 
 
 def test_parse_mention_adjacent_to_surrounding_text() -> None:
-    target_id = uuid.uuid4()
+    target_id = ADJACENT_TEXT_TARGET_ID
 
     assert parse_mentions(f"before[@Agent](mention://agent/{target_id})after") == [
         MentionToken(target_type="agent", target_id=target_id, label="Agent")
@@ -75,7 +86,7 @@ def test_parse_mention_adjacent_to_surrounding_text() -> None:
 
 
 def test_parse_preserves_unicode_label() -> None:
-    target_id = uuid.uuid4()
+    target_id = UNICODE_LABEL_TARGET_ID
     label = "响应者 🚨 агент"
 
     assert parse_mentions(f"[@{label}](mention://agent/{target_id})") == [

--- a/tests/unit/test_case_comment_mentions.py
+++ b/tests/unit/test_case_comment_mentions.py
@@ -2,6 +2,7 @@ import uuid
 
 import pytest
 
+from tracecat.cases.enums import MentionTargetType
 from tracecat.cases.mentions import MentionToken, parse_mentions
 
 SINGLE_MENTION_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000001")
@@ -14,6 +15,8 @@ FIRST_DISTINCT_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000007")
 SECOND_DISTINCT_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000008")
 ADJACENT_TEXT_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000009")
 UNICODE_LABEL_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000010")
+MAX_LENGTH_LABEL_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000011")
+OVERLONG_LABEL_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000012")
 
 
 def test_parse_single_valid_mention() -> None:
@@ -21,7 +24,7 @@ def test_parse_single_valid_mention() -> None:
 
     assert parse_mentions(f"[@Response agent](mention://agent/{target_id})") == [
         MentionToken(
-            target_type="agent",
+            target_type=MentionTargetType.AGENT,
             target_id=target_id,
             label="Response agent",
         )
@@ -50,8 +53,16 @@ def test_parse_preserves_duplicate_mentions() -> None:
     )
 
     assert parse_mentions(content) == [
-        MentionToken(target_type="agent", target_id=target_id, label="First label"),
-        MentionToken(target_type="agent", target_id=target_id, label="Second label"),
+        MentionToken(
+            target_type=MentionTargetType.AGENT,
+            target_id=target_id,
+            label="First label",
+        ),
+        MentionToken(
+            target_type=MentionTargetType.AGENT,
+            target_id=target_id,
+            label="Second label",
+        ),
     ]
 
 
@@ -65,12 +76,12 @@ def test_parse_multiple_distinct_mentions() -> None:
 
     assert parse_mentions(content) == [
         MentionToken(
-            target_type="agent",
+            target_type=MentionTargetType.AGENT,
             target_id=first_target_id,
             label="First",
         ),
         MentionToken(
-            target_type="agent",
+            target_type=MentionTargetType.AGENT,
             target_id=second_target_id,
             label="Second",
         ),
@@ -81,7 +92,9 @@ def test_parse_mention_adjacent_to_surrounding_text() -> None:
     target_id = ADJACENT_TEXT_TARGET_ID
 
     assert parse_mentions(f"before[@Agent](mention://agent/{target_id})after") == [
-        MentionToken(target_type="agent", target_id=target_id, label="Agent")
+        MentionToken(
+            target_type=MentionTargetType.AGENT, target_id=target_id, label="Agent"
+        )
     ]
 
 
@@ -90,5 +103,25 @@ def test_parse_preserves_unicode_label() -> None:
     label = "响应者 🚨 агент"
 
     assert parse_mentions(f"[@{label}](mention://agent/{target_id})") == [
-        MentionToken(target_type="agent", target_id=target_id, label=label)
+        MentionToken(
+            target_type=MentionTargetType.AGENT, target_id=target_id, label=label
+        )
     ]
+
+
+def test_parse_accepts_label_at_max_length() -> None:
+    target_id = MAX_LENGTH_LABEL_TARGET_ID
+    label = "a" * 255
+
+    assert parse_mentions(f"[@{label}](mention://agent/{target_id})") == [
+        MentionToken(
+            target_type=MentionTargetType.AGENT, target_id=target_id, label=label
+        )
+    ]
+
+
+def test_parse_skips_overlong_label() -> None:
+    target_id = OVERLONG_LABEL_TARGET_ID
+    label = "a" * 256
+
+    assert parse_mentions(f"[@{label}](mention://agent/{target_id})") == []

--- a/tests/unit/test_case_comment_mentions.py
+++ b/tests/unit/test_case_comment_mentions.py
@@ -1,0 +1,83 @@
+import uuid
+
+import pytest
+
+from tracecat.cases.mentions import MentionToken, parse_mentions
+
+
+def test_parse_single_valid_mention() -> None:
+    target_id = uuid.uuid4()
+
+    assert parse_mentions(f"[@Response agent](mention://agent/{target_id})") == [
+        MentionToken(
+            target_type="agent",
+            target_id=target_id,
+            label="Response agent",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "[@Agent](mention://agent/not-a-uuid)",
+        f"[@User](mention://user/{uuid.uuid4()})",
+        f"[@Agent](mention://agent/{uuid.uuid4()}",
+        f"[@Agent(mention://agent/{uuid.uuid4()})",
+        f"[@Agent](mentions://agent/{uuid.uuid4()})",
+    ],
+)
+def test_parse_skips_malformed_mentions(content: str) -> None:
+    assert parse_mentions(content) == []
+
+
+def test_parse_preserves_duplicate_mentions() -> None:
+    target_id = uuid.uuid4()
+    content = (
+        f"[@First label](mention://agent/{target_id}) "
+        f"[@Second label](mention://agent/{target_id})"
+    )
+
+    assert parse_mentions(content) == [
+        MentionToken(target_type="agent", target_id=target_id, label="First label"),
+        MentionToken(target_type="agent", target_id=target_id, label="Second label"),
+    ]
+
+
+def test_parse_multiple_distinct_mentions() -> None:
+    first_target_id = uuid.uuid4()
+    second_target_id = uuid.uuid4()
+    content = (
+        f"[@First](mention://agent/{first_target_id}) and "
+        f"[@Second](mention://agent/{second_target_id})"
+    )
+
+    assert parse_mentions(content) == [
+        MentionToken(
+            target_type="agent",
+            target_id=first_target_id,
+            label="First",
+        ),
+        MentionToken(
+            target_type="agent",
+            target_id=second_target_id,
+            label="Second",
+        ),
+    ]
+
+
+def test_parse_mention_adjacent_to_surrounding_text() -> None:
+    target_id = uuid.uuid4()
+
+    assert parse_mentions(f"before[@Agent](mention://agent/{target_id})after") == [
+        MentionToken(target_type="agent", target_id=target_id, label="Agent")
+    ]
+
+
+def test_parse_preserves_unicode_label() -> None:
+    target_id = uuid.uuid4()
+    label = "响应者 🚨 агент"
+
+    assert parse_mentions(f"[@{label}](mention://agent/{target_id})") == [
+        MentionToken(target_type="agent", target_id=target_id, label=label)
+    ]

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -27,7 +27,14 @@ from tracecat.cases.schemas import (
     CaseCreate,
 )
 from tracecat.cases.service import CaseCommentsService, CasesService
-from tracecat.db.models import Case, CaseComment, CaseEvent, Workflow
+from tracecat.db.models import (
+    AgentPreset,
+    Case,
+    CaseComment,
+    CaseCommentMention,
+    CaseEvent,
+    Workflow,
+)
 from tracecat.exceptions import (
     EntitlementRequired,
     ScopeDeniedError,
@@ -67,6 +74,43 @@ async def _load_case_events(
         .order_by(CaseEvent.created_at, CaseEvent.surrogate_id)
     )
     return list(result.scalars().all())
+
+
+async def _load_comment_mentions(
+    session: AsyncSession,
+    comment_id: uuid.UUID,
+) -> list[CaseCommentMention]:
+    result = await session.execute(
+        select(CaseCommentMention)
+        .where(CaseCommentMention.comment_id == comment_id)
+        .order_by(CaseCommentMention.created_at, CaseCommentMention.surrogate_id)
+    )
+    return list(result.scalars().all())
+
+
+async def _create_agent_preset(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    *,
+    name: str,
+    deleted_at: datetime | None = None,
+) -> AgentPreset:
+    preset = AgentPreset(
+        workspace_id=workspace_id,
+        name=name,
+        slug=f"case-comment-mention-{uuid.uuid4().hex}",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        deleted_at=deleted_at,
+    )
+    session.add(preset)
+    await session.commit()
+    await session.refresh(preset)
+    return preset
+
+
+def _mention_token(label: str, target_id: uuid.UUID) -> str:
+    return f"[@{label}](mention://agent/{target_id})"
 
 
 @pytest.fixture
@@ -222,6 +266,209 @@ class TestCaseCommentsService:
         assert retrieved_comment.content == comment_create_params.content
         assert retrieved_comment.parent_id == comment_create_params.parent_id
         assert retrieved_comment.user_id == case_comments_service.role.user_id
+
+    async def test_create_comment_persists_valid_agent_mention(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Response agent",
+        )
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(content=_mention_token("Response agent", preset.id)),
+        )
+
+        mentions = await _load_comment_mentions(session, comment.id)
+        assert len(mentions) == 1
+        mention = mentions[0]
+        assert mention.case_id == test_case.id
+        assert mention.comment_id == comment.id
+        assert mention.target_type == "agent"
+        assert mention.target_id == preset.id
+        assert mention.label == "Response agent"
+
+        serialized_comment = next(
+            item
+            for item in await case_comments_service.list_comments(test_case)
+            if item.id == comment.id
+        )
+        assert len(serialized_comment.mentions) == 1
+        assert serialized_comment.mentions[0].target_id == preset.id
+        assert serialized_comment.mentions[0].label == "Response agent"
+
+        threads = await case_comments_service.list_comment_threads(test_case)
+        assert len(threads) == 1
+        assert threads[0].comment.mentions[0].target_id == preset.id
+
+        thread = await case_comments_service.get_comment_thread(comment.id)
+        assert thread is not None
+        assert thread.comment.mentions[0].target_id == preset.id
+
+    async def test_create_comment_deduplicates_agent_mentions(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Deduplicated agent",
+        )
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(
+                content=" ".join(
+                    [
+                        _mention_token("First label", preset.id),
+                        _mention_token("Second label", preset.id),
+                    ]
+                )
+            ),
+        )
+
+        mentions = await _load_comment_mentions(session, comment.id)
+        assert len(mentions) == 1
+        assert mentions[0].target_id == preset.id
+        assert mentions[0].label == "First label"
+
+    async def test_create_comment_persists_multiple_agent_mentions(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        first_preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="First agent",
+        )
+        second_preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Second agent",
+        )
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(
+                content=" ".join(
+                    [
+                        _mention_token("First agent", first_preset.id),
+                        _mention_token("Second agent", second_preset.id),
+                    ]
+                )
+            ),
+        )
+
+        mentions = await _load_comment_mentions(session, comment.id)
+        assert {(mention.target_id, mention.label) for mention in mentions} == {
+            (first_preset.id, "First agent"),
+            (second_preset.id, "Second agent"),
+        }
+
+    async def test_create_comment_skips_missing_and_deleted_agent_mentions(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        deleted_preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Deleted agent",
+            deleted_at=datetime.now(UTC),
+        )
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(
+                content=" ".join(
+                    [
+                        _mention_token("Missing agent", uuid.uuid4()),
+                        _mention_token("Deleted agent", deleted_preset.id),
+                    ]
+                )
+            ),
+        )
+
+        assert await _load_comment_mentions(session, comment.id) == []
+
+    async def test_update_comment_does_not_change_mentions(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        original_preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Original agent",
+        )
+        replacement_preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Replacement agent",
+        )
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(
+                content=_mention_token("Original agent", original_preset.id)
+            ),
+        )
+        before = [
+            (
+                mention.id,
+                mention.target_type,
+                mention.target_id,
+                mention.label,
+                mention.created_at,
+            )
+            for mention in await _load_comment_mentions(session, comment.id)
+        ]
+
+        await case_comments_service.update_comment(
+            comment,
+            CaseCommentUpdate(
+                content=_mention_token("Replacement agent", replacement_preset.id)
+            ),
+        )
+
+        after = [
+            (
+                mention.id,
+                mention.target_type,
+                mention.target_id,
+                mention.label,
+                mention.created_at,
+            )
+            for mention in await _load_comment_mentions(session, comment.id)
+        ]
+        assert after == before
+
+    async def test_delete_comment_cascades_to_mentions(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Temporary agent",
+        )
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(content=_mention_token("Temporary agent", preset.id)),
+        )
+        assert len(await _load_comment_mentions(session, comment.id)) == 1
+
+        await case_comments_service.delete_comment(comment)
+
+        assert await _load_comment_mentions(session, comment.id) == []
 
     async def test_create_workflow_backed_comment(
         self,
@@ -1048,9 +1295,17 @@ class TestCaseCommentsService:
     ) -> None:
         """Top-level comments with replies are soft deleted and rendered as tombstones."""
         existing_audit_count = len(audit_event_calls)
+        preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Tombstoned comment agent",
+        )
         parent = await case_comments_service.create_comment(
             test_case,
-            CaseCommentCreate(content="Parent", parent_id=None),
+            CaseCommentCreate(
+                content=_mention_token("Tombstoned comment agent", preset.id),
+                parent_id=None,
+            ),
         )
         await case_comments_service.create_comment(
             test_case,
@@ -1068,6 +1323,7 @@ class TestCaseCommentsService:
         assert threads[0].comment.id == parent.id
         assert threads[0].comment.is_deleted is True
         assert threads[0].comment.content == "Comment deleted"
+        assert threads[0].comment.mentions[0].target_id == preset.id
 
         case_events = await _load_case_events(session, test_case.id)
         assert case_events[-1].type == CaseEventType.COMMENT_DELETED

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -19,6 +19,7 @@ from tracecat.cases.enums import (
     CasePriority,
     CaseSeverity,
     CaseStatus,
+    MentionTargetType,
 )
 from tracecat.cases.schemas import (
     CaseCommentCreate,
@@ -290,7 +291,7 @@ class TestCaseCommentsService:
         mention = mentions[0]
         assert mention.case_id == test_case.id
         assert mention.comment_id == comment.id
-        assert mention.target_type == "agent"
+        assert mention.target_type == MentionTargetType.AGENT
         assert mention.target_id == preset.id
         assert mention.label == "Response agent"
 
@@ -395,6 +396,31 @@ class TestCaseCommentsService:
                     ]
                 )
             ),
+        )
+
+        assert await _load_comment_mentions(session, comment.id) == []
+
+    async def test_create_comment_skips_overlong_label_mention(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        """An otherwise-valid mention with a label over the column width is inert.
+
+        The label column is `String(255)`; a longer label must not reach the
+        database (which would fail the whole comment insert) and must not
+        raise from `create_comment`.
+        """
+        preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Overlong label agent",
+        )
+        overlong_label = "a" * 256
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(content=_mention_token(overlong_label, preset.id)),
         )
 
         assert await _load_comment_mentions(session, comment.id) == []

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -43,6 +43,8 @@ from tracecat.exceptions import (
 )
 from tracecat.identifiers.workflow import WorkflowUUID
 
+MISSING_AGENT_TARGET_ID = uuid.UUID("00000000-0000-4000-8000-000000000099")
+
 pytestmark = pytest.mark.usefixtures("db")
 
 
@@ -98,7 +100,7 @@ async def _create_agent_preset(
     preset = AgentPreset(
         workspace_id=workspace_id,
         name=name,
-        slug=f"case-comment-mention-{uuid.uuid4().hex}",
+        slug=f"case-comment-mention-{name.lower().replace(' ', '-')}",
         model_name="gpt-4o-mini",
         model_provider="openai",
         deleted_at=deleted_at,
@@ -388,7 +390,7 @@ class TestCaseCommentsService:
             CaseCommentCreate(
                 content=" ".join(
                     [
-                        _mention_token("Missing agent", uuid.uuid4()),
+                        _mention_token("Missing agent", MISSING_AGENT_TARGET_ID),
                         _mention_token("Deleted agent", deleted_preset.id),
                     ]
                 )

--- a/tracecat/cases/enums.py
+++ b/tracecat/cases/enums.py
@@ -125,3 +125,15 @@ class CaseFieldReadType(StrEnum):
     SELECT = "SELECT"
     MULTI_SELECT = "MULTI_SELECT"
     UUID = "UUID"
+
+
+class MentionTargetType(StrEnum):
+    """Polymorphic target kind for a parsed case-comment mention.
+
+    Only ``AGENT`` is supported today. The finite set lives here (rather than
+    as a bare ``str`` checked at runtime) so every mention-aware call site —
+    the parser, persistence, and API read schema — shares one exhaustive,
+    type-checked domain of valid target kinds.
+    """
+
+    AGENT = "agent"

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -648,7 +648,7 @@ async def create_comment(
         comment = await comments_svc.create_comment(case, params)
     except (TracecatAuthorizationError, TracecatValidationError) as exc:
         _raise_comment_http_error(exc)
-    return comments_svc.serialize_comment(comment)
+    return await comments_svc.serialize_comment_with_mentions(comment)
 
 
 @router.patch(
@@ -682,7 +682,7 @@ async def update_comment(
         updated_comment = await comments_svc.update_comment(comment, params)
     except (TracecatAuthorizationError, TracecatValidationError) as exc:
         _raise_comment_http_error(exc)
-    return comments_svc.serialize_comment(updated_comment)
+    return await comments_svc.serialize_comment_with_mentions(updated_comment)
 
 
 # Separate router for comment operations that don't require case_id in path
@@ -715,7 +715,7 @@ async def update_comment_by_id(
         updated_comment = await comments_svc.update_comment(comment, params)
     except (TracecatAuthorizationError, TracecatValidationError) as exc:
         _raise_comment_http_error(exc)
-    return comments_svc.serialize_comment(updated_comment)
+    return await comments_svc.serialize_comment_with_mentions(updated_comment)
 
 
 @comments_router.get(

--- a/tracecat/cases/mentions.py
+++ b/tracecat/cases/mentions.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class MentionToken:
+    """A parsed case-comment mention target."""
+
+    target_type: str
+    target_id: uuid.UUID
+    label: str
+
+
+_KNOWN_TARGET_TYPES = frozenset({"agent"})
+
+_MENTION_PATTERN = re.compile(
+    r"\[@(?P<label>[^\]]+)\]\(mention://(?P<target_type>[a-z]+)/(?P<target_id>[^)]+)\)"
+)
+
+
+def parse_mentions(content: str) -> list[MentionToken]:
+    """Parse mention tokens from comment content.
+
+    Malformed tokens (bad UUID, unknown target type, or broken syntax) are
+    skipped silently. This is the only function in the application that should
+    understand the mention token encoding.
+    """
+    tokens: list[MentionToken] = []
+    for match in _MENTION_PATTERN.finditer(content):
+        target_type = match.group("target_type")
+        if target_type not in _KNOWN_TARGET_TYPES:
+            continue
+        try:
+            target_id = uuid.UUID(match.group("target_id"))
+        except ValueError:
+            continue
+        tokens.append(
+            MentionToken(
+                target_type=target_type,
+                target_id=target_id,
+                label=match.group("label"),
+            )
+        )
+    return tokens

--- a/tracecat/cases/mentions.py
+++ b/tracecat/cases/mentions.py
@@ -4,17 +4,23 @@ import re
 import uuid
 from dataclasses import dataclass
 
+from tracecat.cases.enums import MentionTargetType
+
+# Must match the `label` column width on `CaseCommentMention`
+# (`tracecat/db/models.py`, `String(255)`). A label longer than this cannot be
+# persisted, so an overlong label is treated as a malformed token and skipped,
+# consistent with the other malformed-token handling below.
+_MAX_LABEL_LENGTH = 255
+
 
 @dataclass(frozen=True, slots=True)
 class MentionToken:
     """A parsed case-comment mention target."""
 
-    target_type: str
+    target_type: MentionTargetType
     target_id: uuid.UUID
     label: str
 
-
-_KNOWN_TARGET_TYPES = frozenset({"agent"})
 
 _MENTION_PATTERN = re.compile(
     r"\[@(?P<label>[^\]]+)\]\(mention://(?P<target_type>[a-z]+)/(?P<target_id>[^)]+)\)"
@@ -24,24 +30,28 @@ _MENTION_PATTERN = re.compile(
 def parse_mentions(content: str) -> list[MentionToken]:
     """Parse mention tokens from comment content.
 
-    Malformed tokens (bad UUID, unknown target type, or broken syntax) are
-    skipped silently. This is the only function in the application that should
-    understand the mention token encoding.
+    Malformed tokens (bad UUID, unknown target type, overlong label, or
+    broken syntax) are skipped silently. This is the only function in the
+    application that should understand the mention token encoding.
     """
     tokens: list[MentionToken] = []
     for match in _MENTION_PATTERN.finditer(content):
-        target_type = match.group("target_type")
-        if target_type not in _KNOWN_TARGET_TYPES:
+        try:
+            target_type = MentionTargetType(match.group("target_type"))
+        except ValueError:
             continue
         try:
             target_id = uuid.UUID(match.group("target_id"))
         except ValueError:
             continue
+        label = match.group("label")
+        if len(label) > _MAX_LABEL_LENGTH:
+            continue
         tokens.append(
             MentionToken(
                 target_type=target_type,
                 target_id=target_id,
-                label=match.group("label"),
+                label=label,
             )
         )
     return tokens

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -290,6 +290,14 @@ class CaseCommentWorkflowRead(Schema):
     status: CaseCommentWorkflowStatus
 
 
+class CaseCommentMentionRead(Schema):
+    id: uuid.UUID
+    target_type: str
+    target_id: uuid.UUID
+    label: str
+    created_at: datetime
+
+
 class CaseCommentRead(Schema):
     id: uuid.UUID
     created_at: datetime
@@ -301,6 +309,7 @@ class CaseCommentRead(Schema):
     last_edited_at: datetime | None = None
     deleted_at: datetime | None = None
     is_deleted: bool = Field(default=False)
+    mentions: list[CaseCommentMentionRead] = Field(default_factory=list)
 
 
 class CaseCommentThreadRead(Schema):

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -23,6 +23,7 @@ from tracecat.cases.enums import (
     CaseSeverity,
     CaseStatus,
     CaseTaskStatus,
+    MentionTargetType,
 )
 from tracecat.cases.rows.schemas import CaseTableRowRead
 from tracecat.cases.tags.schemas import CaseTagRead
@@ -292,7 +293,7 @@ class CaseCommentWorkflowRead(Schema):
 
 class CaseCommentMentionRead(Schema):
     id: uuid.UUID
-    target_type: str
+    target_type: MentionTargetType
     target_id: uuid.UUID
     label: str
     created_at: datetime

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -42,8 +42,9 @@ from tracecat.cases.enums import (
     CaseSeverity,
     CaseStatus,
     CaseTaskStatus,
+    MentionTargetType,
 )
-from tracecat.cases.mentions import parse_mentions
+from tracecat.cases.mentions import MentionToken, parse_mentions
 from tracecat.cases.schemas import (
     AssigneeChangedEvent,
     CaseBatchItemResult,
@@ -2494,8 +2495,8 @@ class CaseCommentsService(BaseWorkspaceService):
         content: str,
     ) -> None:
         """Persist live, workspace-local mention targets for a new comment."""
-        unique_tokens = []
-        seen_targets: set[tuple[str, uuid.UUID]] = set()
+        unique_tokens: list[MentionToken] = []
+        seen_targets: set[tuple[MentionTargetType, uuid.UUID]] = set()
         for token in parse_mentions(content):
             target_key = (token.target_type, token.target_id)
             if target_key in seen_targets:
@@ -2503,8 +2504,10 @@ class CaseCommentsService(BaseWorkspaceService):
             seen_targets.add(target_key)
             unique_tokens.append(token)
 
-        agent_ids = {
-            token.target_id for token in unique_tokens if token.target_type == "agent"
+        agent_ids: set[uuid.UUID] = {
+            token.target_id
+            for token in unique_tokens
+            if token.target_type == MentionTargetType.AGENT
         }
         if not agent_ids:
             return
@@ -2516,9 +2519,12 @@ class CaseCommentsService(BaseWorkspaceService):
                 AgentPreset.deleted_at.is_(None),
             )
         )
-        live_agent_ids = set(result.scalars().all())
+        live_agent_ids: set[uuid.UUID] = set(result.scalars().all())
         for token in unique_tokens:
-            if token.target_type != "agent" or token.target_id not in live_agent_ids:
+            if (
+                token.target_type != MentionTargetType.AGENT
+                or token.target_id not in live_agent_ids
+            ):
                 continue
             self.session.add(
                 CaseCommentMention(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -43,11 +43,13 @@ from tracecat.cases.enums import (
     CaseStatus,
     CaseTaskStatus,
 )
+from tracecat.cases.mentions import parse_mentions
 from tracecat.cases.schemas import (
     AssigneeChangedEvent,
     CaseBatchItemResult,
     CaseBatchResponse,
     CaseCommentCreate,
+    CaseCommentMentionRead,
     CaseCommentRead,
     CaseCommentThreadRead,
     CaseCommentUpdate,
@@ -95,8 +97,10 @@ from tracecat.contexts import ctx_run
 from tracecat.custom_fields import CustomFieldsService
 from tracecat.custom_fields.schemas import CustomFieldUpdate
 from tracecat.db.models import (
+    AgentPreset,
     Case,
     CaseComment,
+    CaseCommentMention,
     CaseDropdownDefinition,
     CaseDropdownOption,
     CaseDropdownValue,
@@ -2251,6 +2255,7 @@ class CaseCommentsService(BaseWorkspaceService):
         comment: CaseComment,
         *,
         user: User | None = None,
+        mentions: list[CaseCommentMention] | None = None,
     ) -> CaseCommentRead:
         """Serialize a comment for API responses with tombstone semantics."""
         comment_data = CaseCommentRead.model_validate(comment, from_attributes=True)
@@ -2258,10 +2263,53 @@ class CaseCommentsService(BaseWorkspaceService):
         comment_data.user = (
             UserRead.model_validate(user, from_attributes=True) if user else None
         )
+        comment_data.mentions = [
+            CaseCommentMentionRead.model_validate(mention, from_attributes=True)
+            for mention in mentions or []
+        ]
         if comment.deleted_at is not None:
             comment_data.content = _COMMENT_TOMBSTONE_CONTENT
             comment_data.is_deleted = True
         return comment_data
+
+    async def _list_mentions_for_comments(
+        self,
+        comment_ids: Sequence[uuid.UUID],
+    ) -> dict[uuid.UUID, list[CaseCommentMention]]:
+        """Batch-load mention records grouped by comment ID."""
+        if not comment_ids:
+            return {}
+
+        statement = (
+            select(CaseCommentMention)
+            .where(
+                CaseCommentMention.workspace_id == self.workspace_id,
+                CaseCommentMention.comment_id.in_(comment_ids),
+            )
+            .order_by(
+                CaseCommentMention.created_at,
+                CaseCommentMention.surrogate_id,
+            )
+        )
+        result = await self.session.execute(statement)
+        mentions_by_comment_id: dict[uuid.UUID, list[CaseCommentMention]] = {}
+        for mention in result.scalars().all():
+            mentions_by_comment_id.setdefault(mention.comment_id, []).append(mention)
+        return mentions_by_comment_id
+
+    async def serialize_comment_with_mentions(
+        self,
+        comment: CaseComment,
+        *,
+        user: User | None = None,
+    ) -> CaseCommentRead:
+        """Serialize one comment after loading its persisted mentions."""
+        mentions_by_comment_id = await self._list_mentions_for_comments([comment.id])
+        return self.serialize_comment(
+            comment,
+            user=user,
+            mentions=mentions_by_comment_id.get(comment.id),
+        )
 
     async def _list_comment_rows(
         self,
@@ -2292,17 +2340,34 @@ class CaseCommentsService(BaseWorkspaceService):
     async def list_comments(self, case: Case) -> list[CaseCommentRead]:
         """List all comments for a case as a flat compatibility view."""
         rows = await self._list_comment_rows(case_id=case.id)
-        return [self.serialize_comment(comment, user=user) for comment, user in rows]
+        mentions_by_comment_id = await self._list_mentions_for_comments(
+            [comment.id for comment, _ in rows]
+        )
+        return [
+            self.serialize_comment(
+                comment,
+                user=user,
+                mentions=mentions_by_comment_id.get(comment.id),
+            )
+            for comment, user in rows
+        ]
 
     async def list_comment_threads(self, case: Case) -> list[CaseCommentThreadRead]:
         """List comments grouped by top-level thread."""
         await self._require_replies_entitlement()
         rows = await self._list_comment_rows(case_id=case.id)
+        mentions_by_comment_id = await self._list_mentions_for_comments(
+            [comment.id for comment, _ in rows]
+        )
         threads_by_id: dict[uuid.UUID, CaseCommentThreadRead] = {}
         ordered_threads: list[CaseCommentThreadRead] = []
 
         for comment, user in rows:
-            serialized = self.serialize_comment(comment, user=user)
+            serialized = self.serialize_comment(
+                comment,
+                user=user,
+                mentions=mentions_by_comment_id.get(comment.id),
+            )
             if comment.parent_id is None:
                 if (thread := threads_by_id.get(comment.id)) is not None:
                     if thread.comment.parent_id is not None:
@@ -2357,12 +2422,20 @@ class CaseCommentsService(BaseWorkspaceService):
         if not rows:
             return None
 
+        mentions_by_comment_id = await self._list_mentions_for_comments(
+            [row_comment.id for row_comment, _ in rows]
+        )
+
         thread_comment: CaseCommentRead | None = None
         replies: list[CaseCommentRead] = []
         last_activity_at: datetime | None = None
 
         for row_comment, user in rows:
-            serialized = self.serialize_comment(row_comment, user=user)
+            serialized = self.serialize_comment(
+                row_comment,
+                user=user,
+                mentions=mentions_by_comment_id.get(row_comment.id),
+            )
             if row_comment.id == thread_root_id:
                 thread_comment = serialized
             else:
@@ -2413,6 +2486,50 @@ class CaseCommentsService(BaseWorkspaceService):
         )
         result = await self.session.execute(statement)
         return bool(result.scalar())
+
+    async def _persist_comment_mentions(
+        self,
+        *,
+        comment: CaseComment,
+        content: str,
+    ) -> None:
+        """Persist live, workspace-local mention targets for a new comment."""
+        unique_tokens = []
+        seen_targets: set[tuple[str, uuid.UUID]] = set()
+        for token in parse_mentions(content):
+            target_key = (token.target_type, token.target_id)
+            if target_key in seen_targets:
+                continue
+            seen_targets.add(target_key)
+            unique_tokens.append(token)
+
+        agent_ids = {
+            token.target_id for token in unique_tokens if token.target_type == "agent"
+        }
+        if not agent_ids:
+            return
+
+        result = await self.session.execute(
+            select(AgentPreset.id).where(
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentPreset.id.in_(agent_ids),
+                AgentPreset.deleted_at.is_(None),
+            )
+        )
+        live_agent_ids = set(result.scalars().all())
+        for token in unique_tokens:
+            if token.target_type != "agent" or token.target_id not in live_agent_ids:
+                continue
+            self.session.add(
+                CaseCommentMention(
+                    workspace_id=self.workspace_id,
+                    case_id=comment.case_id,
+                    comment_id=comment.id,
+                    target_type=token.target_type,
+                    target_id=token.target_id,
+                    label=token.label,
+                )
+            )
 
     @require_scope("case:update")
     async def create_comment(
@@ -2475,6 +2592,9 @@ class CaseCommentsService(BaseWorkspaceService):
             )
 
             self.session.add(comment)
+            await self._persist_comment_mentions(
+                comment=comment, content=params.content
+            )
             db_event = await CaseEventsService(
                 session=self.session, role=self.role
             ).create_event(

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2479,6 +2479,52 @@ class CaseComment(WorkspaceModel):
         return self.deleted_at is not None
 
 
+class CaseCommentMention(WorkspaceModel):
+    """A parsed @mention target extracted from a case comment.
+
+    Immutable event-record semantics: rows are written once at comment
+    creation time and never mutated by comment edits.
+    """
+
+    __tablename__ = "case_comment_mention"
+    __table_args__ = (UniqueConstraint("comment_id", "target_type", "target_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    case_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("case.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    comment_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("case_comment.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    target_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        doc='Polymorphic target kind, e.g. "agent". Currently only "agent" is supported.',
+    )
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        nullable=False,
+        doc="Polymorphic target identifier; no FK since target_type varies.",
+    )
+    label: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        doc="Display label snapshot captured at write time.",
+    )
+
+
 class CaseEvent(WorkspaceModel):
     """A activity record for a case.
 

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -24,6 +24,7 @@ INITIAL_WORKSPACE_SCOPED_TABLES = (
     "tables",
     "case",
     "case_comment",
+    "case_comment_mention",
     "case_event",
     "case_task",
     "case_tag",


### PR DESCRIPTION
## Summary

Implements the "fact half" of the agent-comment-mentions feature: parses `@mention` tokens out of case comment content and persists them as immutable rows at comment-creation time. A later task (ENG-1603) will add dispatch/notification/gating logic on top of these persisted facts — none of that is included here.

- New `case_comment_mention` table (`tracecat/db/models.py`), registered in the RLS-managed workspace table list (`tracecat/db/tenant_rls.py`).
- New pure parser module `tracecat/cases/mentions.py` for the token syntax `[@<label>](mention://agent/<uuid>)`. **This is the only place in the codebase that understands the token encoding** — it is intentionally quarantined there because the encoding is pending team review and must stay swappable.
- `CaseCommentsService.create_comment` parses mentions, deduplicates by `(target_type, target_id)`, batch-validates `agent` targets against live (non-soft-deleted) `AgentPreset` rows in the workspace, and inserts mention rows in the same transaction as the comment. Unknown target types and unresolved/soft-deleted agent targets are inert (no row, no error).
- `update_comment` is untouched — mentions are create-only, immutable event records; edits never add/remove/update mention rows.
- `CaseCommentRead` gains a `mentions: list[CaseCommentMentionRead]` field, populated via a batched (not per-comment) query across `list_comments`, `list_comment_threads`, `get_comment_thread`, and the internal router's comment create/update responses.

## Migration

Autogenerated with `uv run alembic revision --autogenerate` against the local dev database, then hand-tuned: stripped unrelated schema drift picked up by autogenerate, and added the `enable_workspace_table_rls` / `disable_workspace_table_rls` calls (matching the pattern used by other workspace-scoped table migrations) since RLS enablement isn't captured by autogenerate. Verified with a full upgrade/downgrade/upgrade round-trip against the dev database, and confirmed a follow-up autogenerate produces no further diff for this table.

## Test plan

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4` — 0 errors, 0 warnings
- `uv run pytest tests/unit -k "mention or comment" -x` — 81 passed
- `uv run pytest tests/unit -k "mention or comment" -n 2` — 81 passed, stable distributed collection
- `pnpm -C frontend exec biome check --write .`
- `pnpm -C frontend run typecheck`
- Manual: `alembic upgrade head` / `downgrade -1` / `upgrade head` round-trip against the local dev database; confirmed RLS policy present via `pg_class.relrowsecurity` and `\d case_comment_mention`.

New/extended coverage:
- `tests/unit/test_case_comment_mentions.py`: parser tests (valid token, malformed variants, duplicate tokens preserved, multiple distinct targets, token adjacent to surrounding text, unicode labels). All test inputs use hardcoded, named UUID constants (no `uuid.uuid4()`) so distributed (pytest-xdist) collection is deterministic.
- `tests/unit/test_case_comments_service.py`: valid mention persistence (incl. batched hydration across list/thread/tombstone reads), dedupe, multiple targets, inert-on-unknown/soft-deleted target, immutability across edits, and FK cascade on hard comment delete. Uses a deterministic per-preset slug and a hardcoded unresolved-target UUID constant instead of `uuid.uuid4()`.

## LOC breakdown

| Category | + | - |
|---|---|---|
| Logic | 229 | 6 |
| Tests | 354 | 2 |
| Generated | 149 | 0 |

Closes ENG-1602
https://linear.app/tracecat/issue/ENG-1602
