### PR TITLE
fix(engine): collapse S3 I/O onto one event loop

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ import aioboto3
 import pytest
 import redis
 import tracecat_registry.integrations.aws_boto3 as boto3_module
+import uvloop
 from minio import Minio
 from minio.error import S3Error
 from sqlalchemy import create_engine, select, text
@@ -43,6 +44,7 @@ from temporalio.worker import Worker
 
 from tests.database import TEST_DB_CONFIG
 from tracecat import config
+from tracecat.async_runtime import AppAsyncRuntime, use_app_async_runtime
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import (
     ADMIN_SCOPES,
@@ -71,6 +73,7 @@ from tracecat.logger import logger
 from tracecat.registry.repositories.schemas import RegistryRepositoryCreate
 from tracecat.registry.repositories.service import RegistryReposService
 from tracecat.secrets import secrets_manager
+from tracecat.storage.blob import close_storage_client_cache
 from tracecat.tiers import defaults as tier_defaults
 from tracecat.workspaces.service import WorkspaceService
 
@@ -1945,6 +1948,12 @@ async def test_worker_factory(
 ) -> AsyncGenerator[Callable[..., Worker], Any]:
     """Factory fixture to create workers with proper ThreadPoolExecutor cleanup."""
 
+    app_runtime = AppAsyncRuntime(
+        name="test-worker-app-io",
+        loop_factory=uvloop.new_event_loop,
+    )
+    app_runtime.start()
+
     def create_worker(
         client: Client,
         *,
@@ -1963,7 +1972,11 @@ async def test_worker_factory(
             activity_executor=threadpool,
         )
 
-    yield create_worker
+    try:
+        with use_app_async_runtime(app_runtime):
+            yield create_worker
+    finally:
+        await app_runtime.aclose(cleanup=close_storage_client_cache)
 
 
 @pytest.fixture(scope="function")

--- a/tests/temporal/test_worker_app_async_runtime_load.py
+++ b/tests/temporal/test_worker_app_async_runtime_load.py
@@ -1,0 +1,747 @@
+"""Release-gate load test for the worker-owned application I/O loop.
+
+The checked-in PR profile warms all 64 Temporal activity threads with one
+warm-up wave and three measured 2 MiB waves. Set
+``TRACECAT_TEST_APP_IO_SOAK_SECONDS=900`` to use 4 MiB payloads and extend the
+run to at least twenty measured waves for the pre-rollout soak profile. Set
+``TRACECAT_TEST_APP_IO_METRICS_PATH`` to retain the JSON metrics artifact.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import os
+import platform
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import orjson
+import pytest
+import uvloop
+from minio import Minio
+from minio.deleteobjects import DeleteObject
+from pydantic import BaseModel
+
+pytestmark = [
+    pytest.mark.temporal,
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.regression,
+    pytest.mark.skipif(
+        platform.system() != "Linux",
+        reason="The app I/O release gate requires Linux /proc metrics",
+    ),
+]
+
+from temporalio import activity, workflow
+from temporalio.client import Client
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from tracecat import config
+from tracecat.async_runtime import (
+    AppAsyncRuntime,
+    get_app_async_runtime,
+    run_sync,
+    use_app_async_runtime,
+)
+from tracecat.dsl.action import materialize_context_sync
+from tracecat.dsl.schemas import ExecutionContext
+from tracecat.expressions.eval import eval_templated_object
+from tracecat.storage import blob
+from tracecat.storage.backends.s3 import S3ObjectStorage
+from tracecat.storage.object import ExternalObject, ObjectRef
+from tracecat.storage.utils import clear_blob_cache, compute_sha256, serialize_object
+
+DEFAULT_CALLER_COUNT = 64
+DEFAULT_PAYLOAD_SIZE_BYTES = 2 * 1024 * 1024
+SOAK_PAYLOAD_SIZE_BYTES = 4 * 1024 * 1024
+DEFAULT_EXPRESSION_COUNT = 128
+DEFAULT_MEASURED_WAVES = 3
+SOAK_MINIMUM_WAVES = 20
+CANARY_POLL_SECONDS = 0.25
+CANARY_MAX_STALL_SECONDS = 1.5
+WAVE_TIMEOUT_SECONDS = 300
+RSS_PLATEAU_MIN_ALLOWANCE_BYTES = 32 * 1024 * 1024
+
+
+class _NestedPayload(BaseModel):
+    value: str
+
+
+class _LoadPayload(BaseModel):
+    caller_index: int
+    wave_index: int
+    nested: _NestedPayload
+
+
+class _RenderedPayload(BaseModel):
+    caller_index: int
+    wave_index: int
+    rendered: str
+    expressions: dict[str, int]
+
+
+class _MixedLoadActivityInput(BaseModel):
+    barrier_id: str
+    source: ExternalObject
+    output_key: str
+    expression_count: int
+
+
+class _MixedLoadActivityResult(BaseModel):
+    caller_index: int
+    wave_index: int
+    output_sha256: str
+    activity_thread_id: int
+    app_thread_id: int
+
+
+class _MixedLoadWorkflowInput(BaseModel):
+    activities: list[_MixedLoadActivityInput]
+
+
+class _WaveMetrics(BaseModel):
+    wave_index: int
+    measured: bool
+    rss_bytes: int
+    fd_count: int
+    thread_count: int
+    app_loop_thread_count: int
+    app_pending_submissions: int
+    storage_loop_count: int
+    entered_storage_client_count: int
+    canary_ticks: int
+
+
+class _LoadMetricsArtifact(BaseModel):
+    caller_count: int
+    payload_size_bytes: int
+    expression_count: int
+    measured_wave_target: int
+    soak_seconds: float
+    rss_before_load_bytes: int
+    peak_rss_bytes: int
+    max_canary_query_seconds: float
+    waves: list[_WaveMetrics]
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedSeedObject:
+    activity_input: _MixedLoadActivityInput
+    content: bytes
+
+
+_LOAD_BARRIERS: dict[str, threading.Barrier] = {}
+_LOAD_BARRIERS_LOCK = threading.RLock()
+
+
+def _register_load_barrier(barrier_id: str, caller_count: int) -> None:
+    with _LOAD_BARRIERS_LOCK:
+        _LOAD_BARRIERS[barrier_id] = threading.Barrier(caller_count)
+
+
+def _remove_load_barrier(barrier_id: str) -> None:
+    with _LOAD_BARRIERS_LOCK:
+        _LOAD_BARRIERS.pop(barrier_id, None)
+
+
+def _wait_for_load_barrier(barrier_id: str) -> None:
+    with _LOAD_BARRIERS_LOCK:
+        barrier = _LOAD_BARRIERS[barrier_id]
+    barrier.wait(timeout=60)
+
+
+@activity.defn
+def mixed_storage_cpu_load_activity(
+    input: _MixedLoadActivityInput,
+) -> _MixedLoadActivityResult:
+    """Exercise materialization, expressions, rendering, hashing, and S3."""
+    activity.heartbeat("waiting-for-wave")
+    _wait_for_load_barrier(input.barrier_id)
+    activity.heartbeat("wave-started")
+
+    activity_thread_id = threading.get_ident()
+    context = ExecutionContext(ACTIONS={}, TRIGGER=input.source)
+    materialized = materialize_context_sync(context)
+    trigger_value = materialized.get("TRIGGER")
+    if trigger_value is None:
+        raise ValueError("Materialized context did not contain trigger data")
+    trigger = _LoadPayload.model_validate(trigger_value)
+
+    expression_template = {
+        f"expression_{index}": "${{ TRIGGER.caller_index }}"
+        for index in range(input.expression_count)
+    }
+    rendered = _RenderedPayload.model_validate(
+        eval_templated_object(
+            {
+                "caller_index": "${{ TRIGGER.caller_index }}",
+                "wave_index": "${{ TRIGGER.wave_index }}",
+                "rendered": "payload:${{ TRIGGER.nested.value }}",
+                "expressions": expression_template,
+            },
+            operand=materialized,
+        )
+    )
+    if set(rendered.expressions.values()) != {trigger.caller_index}:
+        raise ValueError("Expression resolution returned an unexpected value")
+
+    # This intentionally stays in the synchronous activity thread. Only the
+    # upload/download coroutine crosses onto the app I/O loop.
+    output_bytes = serialize_object(rendered.model_dump())
+    output_sha256 = compute_sha256(output_bytes)
+    bucket = config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW
+    run_sync(
+        blob.upload_file(
+            content=output_bytes,
+            key=input.output_key,
+            bucket=bucket,
+            content_type="application/json",
+        )
+    )
+    activity.heartbeat("output-uploaded")
+
+    stored_output = ExternalObject(
+        ref=ObjectRef(
+            backend="s3",
+            bucket=bucket,
+            key=input.output_key,
+            size_bytes=len(output_bytes),
+            sha256=output_sha256,
+            content_type="application/json",
+            encoding="json",
+        ),
+        typename=_RenderedPayload.__name__,
+    )
+    retrieved = _RenderedPayload.model_validate(
+        S3ObjectStorage(bucket=bucket).retrieve_sync(stored_output)
+    )
+    if retrieved != rendered:
+        raise ValueError("Retrieved output did not match the rendered result")
+
+    runtime = get_app_async_runtime()
+    if runtime is None or runtime.thread_id is None:
+        raise RuntimeError("App async runtime is not healthy")
+    return _MixedLoadActivityResult(
+        caller_index=trigger.caller_index,
+        wave_index=trigger.wave_index,
+        output_sha256=output_sha256,
+        activity_thread_id=activity_thread_id,
+        app_thread_id=runtime.thread_id,
+    )
+
+
+@workflow.defn
+class MixedStorageCpuLoadWorkflow:
+    @workflow.run
+    async def run(
+        self, input: _MixedLoadWorkflowInput
+    ) -> list[_MixedLoadActivityResult]:
+        return await asyncio.gather(
+            *(
+                workflow.execute_activity(
+                    mixed_storage_cpu_load_activity,
+                    activity_input,
+                    start_to_close_timeout=timedelta(seconds=WAVE_TIMEOUT_SECONDS),
+                    heartbeat_timeout=timedelta(seconds=30),
+                )
+                for activity_input in input.activities
+            )
+        )
+
+
+@workflow.defn
+class TemporalLoopCanaryWorkflow:
+    def __init__(self) -> None:
+        self._ticks = 0
+        self._stopped = False
+
+    @workflow.run
+    async def run(self) -> int:
+        while not self._stopped:
+            await workflow.sleep(CANARY_POLL_SECONDS)
+            self._ticks += 1
+        return self._ticks
+
+    @workflow.signal
+    def stop(self) -> None:
+        self._stopped = True
+
+    @workflow.query
+    def progress(self) -> int:
+        return self._ticks
+
+
+def _linux_process_metrics() -> tuple[int, int, int]:
+    page_size = os.sysconf("SC_PAGE_SIZE")
+    resident_pages = int(Path("/proc/self/statm").read_text().split()[1])
+    rss_bytes = resident_pages * page_size
+    fd_count = len(list(Path("/proc/self/fd").iterdir()))
+    thread_count = len(list(Path("/proc/self/task").iterdir()))
+    return rss_bytes, fd_count, thread_count
+
+
+def _delete_test_objects(client: Minio, *, bucket: str, prefix: str) -> None:
+    object_names = [
+        item.object_name
+        for item in client.list_objects(bucket, prefix=prefix, recursive=True)
+        if item.object_name is not None
+    ]
+    objects = (DeleteObject(name) for name in object_names)
+    errors = list(client.remove_objects(bucket, objects))
+    if errors:
+        raise AssertionError(f"Failed to remove {len(errors)} load-test objects")
+
+
+def _load_profile() -> tuple[int, int, int, int, float]:
+    soak_seconds = float(os.environ.get("TRACECAT_TEST_APP_IO_SOAK_SECONDS") or 0)
+    caller_count = int(
+        os.environ.get("TRACECAT_TEST_APP_IO_CALLERS") or DEFAULT_CALLER_COUNT
+    )
+    payload_size_bytes = int(
+        os.environ.get("TRACECAT_TEST_APP_IO_PAYLOAD_BYTES")
+        or (SOAK_PAYLOAD_SIZE_BYTES if soak_seconds > 0 else DEFAULT_PAYLOAD_SIZE_BYTES)
+    )
+    expression_count = int(
+        os.environ.get("TRACECAT_TEST_APP_IO_EXPRESSIONS") or DEFAULT_EXPRESSION_COUNT
+    )
+    measured_waves = int(
+        os.environ.get("TRACECAT_TEST_APP_IO_MEASURED_WAVES") or DEFAULT_MEASURED_WAVES
+    )
+    if soak_seconds > 0:
+        measured_waves = max(measured_waves, SOAK_MINIMUM_WAVES)
+    if caller_count != DEFAULT_CALLER_COUNT and soak_seconds == 0:
+        raise ValueError("The checked-in PR profile must warm all 64 activity threads")
+    if not 100 <= expression_count <= 250:
+        raise ValueError("Expression count must stay between 100 and 250")
+    return (
+        caller_count,
+        payload_size_bytes,
+        expression_count,
+        measured_waves,
+        soak_seconds,
+    )
+
+
+async def _seed_wave(
+    *,
+    wave_index: int,
+    caller_count: int,
+    payload_size_bytes: int,
+    expression_count: int,
+    test_run_id: str,
+) -> list[_MixedLoadActivityInput]:
+    bucket = config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW
+    barrier_id = f"{test_run_id}-wave-{wave_index}"
+    prepared = await asyncio.to_thread(
+        _prepare_seed_wave,
+        wave_index=wave_index,
+        caller_count=caller_count,
+        payload_size_bytes=payload_size_bytes,
+        expression_count=expression_count,
+        test_run_id=test_run_id,
+        barrier_id=barrier_id,
+        bucket=bucket,
+    )
+    uploads: list[asyncio.Task[None]] = []
+    for seed_object in prepared:
+        uploads.append(
+            asyncio.create_task(
+                blob.upload_file(
+                    content=seed_object.content,
+                    key=seed_object.activity_input.source.ref.key,
+                    bucket=bucket,
+                    content_type="application/json",
+                )
+            )
+        )
+
+    await asyncio.gather(*uploads)
+    return [seed_object.activity_input for seed_object in prepared]
+
+
+def _prepare_seed_wave(
+    *,
+    wave_index: int,
+    caller_count: int,
+    payload_size_bytes: int,
+    expression_count: int,
+    test_run_id: str,
+    barrier_id: str,
+    bucket: str,
+) -> list[_PreparedSeedObject]:
+    """Build load payloads without blocking the Temporal worker loop."""
+    prepared: list[_PreparedSeedObject] = []
+    for caller_index in range(caller_count):
+        sentinel = f"{test_run_id}:{wave_index}:{caller_index}:"
+        padding_size = max(1, payload_size_bytes - len(sentinel))
+        payload = _LoadPayload(
+            caller_index=caller_index,
+            wave_index=wave_index,
+            nested=_NestedPayload(value=sentinel + ("x" * padding_size)),
+        )
+        content = serialize_object(payload.model_dump())
+        source_key = (
+            f"tests/app-io-load/{test_run_id}/wave-{wave_index}/"
+            f"source-{caller_index}.json"
+        )
+        prepared.append(
+            _PreparedSeedObject(
+                activity_input=_MixedLoadActivityInput(
+                    barrier_id=barrier_id,
+                    source=ExternalObject(
+                        ref=ObjectRef(
+                            backend="s3",
+                            bucket=bucket,
+                            key=source_key,
+                            size_bytes=len(content),
+                            sha256=compute_sha256(content),
+                            content_type="application/json",
+                            encoding="json",
+                        ),
+                        typename=_LoadPayload.__name__,
+                    ),
+                    output_key=(
+                        f"tests/app-io-load/{test_run_id}/wave-{wave_index}/"
+                        f"output-{caller_index}.json"
+                    ),
+                    expression_count=expression_count,
+                ),
+                content=content,
+            )
+        )
+    return prepared
+
+
+async def _monitor_canary(
+    handle: Any,
+    *,
+    stop: asyncio.Event,
+    query_durations: list[float],
+) -> None:
+    previous_ticks = -1
+    last_progress_at = time.monotonic()
+    while not stop.is_set():
+        query_started_at = time.monotonic()
+        ticks = await handle.query(TemporalLoopCanaryWorkflow.progress)
+        query_duration = time.monotonic() - query_started_at
+        query_durations.append(query_duration)
+        if query_duration >= CANARY_MAX_STALL_SECONDS:
+            raise AssertionError(
+                "Temporal workflow canary query approached the deadlock threshold"
+            )
+        if ticks > previous_ticks:
+            previous_ticks = ticks
+            last_progress_at = time.monotonic()
+        elif time.monotonic() - last_progress_at >= CANARY_MAX_STALL_SECONDS:
+            raise AssertionError(
+                "Temporal workflow canary stopped progressing during mixed load"
+            )
+        await asyncio.sleep(CANARY_POLL_SECONDS)
+
+
+async def _monitor_peak_rss(
+    samples: list[int],
+    *,
+    stop: asyncio.Event,
+) -> None:
+    while not stop.is_set():
+        samples.append(_linux_process_metrics()[0])
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=0.1)
+        except TimeoutError:
+            pass
+
+
+@pytest.mark.anyio
+async def test_worker_app_io_runtime_mixed_cpu_s3_load_plateaus(
+    temporal_client: Client,
+    minio_client: Minio,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warm 64 activity threads while one uvloop/client serves all S3 I/O."""
+    (
+        caller_count,
+        payload_size_bytes,
+        expression_count,
+        measured_wave_target,
+        soak_seconds,
+    ) = _load_profile()
+    access_key = (
+        os.environ.get("AWS_ACCESS_KEY_ID")
+        or os.environ.get("MINIO_ROOT_USER")
+        or "minio"
+    )
+    secret_key = (
+        os.environ.get("AWS_SECRET_ACCESS_KEY")
+        or os.environ.get("MINIO_ROOT_PASSWORD")
+        or "password"
+    )
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", access_key)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", secret_key)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    test_run_id = uuid.uuid4().hex
+    task_queue = f"app-io-load-{test_run_id}"
+    app_runtime = AppAsyncRuntime(
+        name="test-worker-app-io",
+        loop_factory=uvloop.new_event_loop,
+    )
+    app_runtime.start()
+    wave_metrics: list[_WaveMetrics] = []
+    canary_ticks = 0
+    canary_monitor_stop = asyncio.Event()
+    rss_monitor_stop = asyncio.Event()
+    rss_samples: list[int] = []
+    canary_query_durations: list[float] = []
+    rss_before_load_bytes = 0
+    metrics_path = Path(
+        os.environ.get("TRACECAT_TEST_APP_IO_METRICS_PATH")
+        or tmp_path / "app-io-load-metrics.json"
+    )
+
+    try:
+        with use_app_async_runtime(app_runtime):
+            await blob.close_storage_client_cache()
+            await clear_blob_cache()
+            with ThreadPoolExecutor(max_workers=caller_count) as activity_executor:
+                async with Worker(
+                    temporal_client,
+                    task_queue=task_queue,
+                    workflows=[
+                        MixedStorageCpuLoadWorkflow,
+                        TemporalLoopCanaryWorkflow,
+                    ],
+                    activities=[mixed_storage_cpu_load_activity],
+                    activity_executor=activity_executor,
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                    max_concurrent_activities=caller_count,
+                    max_concurrent_workflow_tasks=16,
+                    graceful_shutdown_timeout=timedelta(seconds=30),
+                ):
+                    canary_handle = await temporal_client.start_workflow(
+                        TemporalLoopCanaryWorkflow.run,
+                        id=f"app-io-canary-{test_run_id}",
+                        task_queue=task_queue,
+                    )
+                    canary_monitor = asyncio.create_task(
+                        _monitor_canary(
+                            canary_handle,
+                            stop=canary_monitor_stop,
+                            query_durations=canary_query_durations,
+                        )
+                    )
+                    rss_before_load_bytes = _linux_process_metrics()[0]
+                    rss_samples.append(rss_before_load_bytes)
+                    rss_monitor = asyncio.create_task(
+                        _monitor_peak_rss(rss_samples, stop=rss_monitor_stop)
+                    )
+                    measured_wave_count = 0
+                    wave_index = 0
+                    measured_started_at: float | None = None
+                    try:
+                        while True:
+                            measured = wave_index > 0
+                            if measured and measured_started_at is None:
+                                measured_started_at = time.monotonic()
+                            inputs = await _seed_wave(
+                                wave_index=wave_index,
+                                caller_count=caller_count,
+                                payload_size_bytes=payload_size_bytes,
+                                expression_count=expression_count,
+                                test_run_id=test_run_id,
+                            )
+                            barrier_id = inputs[0].barrier_id
+                            _register_load_barrier(barrier_id, caller_count)
+                            load_handle = await temporal_client.start_workflow(
+                                MixedStorageCpuLoadWorkflow.run,
+                                _MixedLoadWorkflowInput(activities=inputs),
+                                id=f"app-io-load-{test_run_id}-{wave_index}",
+                                task_queue=task_queue,
+                            )
+                            try:
+                                raw_results = await asyncio.wait_for(
+                                    load_handle.result(),
+                                    timeout=WAVE_TIMEOUT_SECONDS,
+                                )
+                            except BaseException:
+                                await load_handle.cancel()
+                                raise
+                            finally:
+                                _remove_load_barrier(barrier_id)
+
+                            results = [
+                                _MixedLoadActivityResult.model_validate(result)
+                                for result in raw_results
+                            ]
+                            assert len(results) == caller_count
+                            assert {result.caller_index for result in results} == set(
+                                range(caller_count)
+                            )
+                            assert {result.wave_index for result in results} == {
+                                wave_index
+                            }
+                            assert (
+                                len({result.output_sha256 for result in results})
+                                == caller_count
+                            )
+                            assert (
+                                len({result.activity_thread_id for result in results})
+                                == caller_count
+                            )
+                            assert {result.app_thread_id for result in results} == {
+                                app_runtime.thread_id
+                            }
+                            if canary_monitor.done():
+                                await canary_monitor
+
+                            # Force every wave through MinIO while excluding the
+                            # intentionally bounded 500 MiB byte cache from the
+                            # retained-RSS plateau signal under test.
+                            await clear_blob_cache()
+                            await asyncio.sleep(0.5)
+                            await asyncio.to_thread(gc.collect)
+                            rss_bytes, fd_count, thread_count = _linux_process_metrics()
+                            runtime_health = app_runtime.health
+                            storage_health = blob.storage_client_cache_health()
+                            ticks = await canary_handle.query(
+                                TemporalLoopCanaryWorkflow.progress
+                            )
+                            app_loop_thread_count = sum(
+                                thread.name == "test-worker-app-io"
+                                and thread.is_alive()
+                                for thread in threading.enumerate()
+                            )
+                            wave_metrics.append(
+                                _WaveMetrics(
+                                    wave_index=wave_index,
+                                    measured=measured,
+                                    rss_bytes=rss_bytes,
+                                    fd_count=fd_count,
+                                    thread_count=thread_count,
+                                    app_loop_thread_count=app_loop_thread_count,
+                                    app_pending_submissions=(
+                                        runtime_health.pending_submissions
+                                    ),
+                                    storage_loop_count=storage_health.loop_count,
+                                    entered_storage_client_count=(
+                                        storage_health.entered_client_count
+                                    ),
+                                    canary_ticks=ticks,
+                                )
+                            )
+                            assert runtime_health.pending_submissions == 0
+                            assert app_loop_thread_count == 1
+                            assert storage_health.loop_count == 1
+                            assert storage_health.entered_client_count == 1
+                            assert storage_health.active_user_count == 0
+
+                            if measured:
+                                measured_wave_count += 1
+                            wave_index += 1
+                            measured_elapsed = (
+                                time.monotonic() - measured_started_at
+                                if measured_started_at is not None
+                                else 0.0
+                            )
+                            if (
+                                measured_wave_count >= measured_wave_target
+                                and measured_elapsed >= soak_seconds
+                            ):
+                                break
+                    finally:
+                        canary_monitor_stop.set()
+                        rss_monitor_stop.set()
+                        await rss_monitor
+                        await canary_handle.signal(TemporalLoopCanaryWorkflow.stop)
+                        canary_ticks = await canary_handle.result()
+                        await canary_monitor
+    finally:
+        try:
+            try:
+                await app_runtime.aclose(cleanup=blob.close_storage_client_cache)
+            finally:
+                await clear_blob_cache()
+                await asyncio.to_thread(
+                    _delete_test_objects,
+                    minio_client,
+                    bucket=config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW,
+                    prefix=f"tests/app-io-load/{test_run_id}/",
+                )
+        finally:
+            metrics_path.parent.mkdir(parents=True, exist_ok=True)
+            metrics_path.write_bytes(
+                orjson.dumps(
+                    _LoadMetricsArtifact(
+                        caller_count=caller_count,
+                        payload_size_bytes=payload_size_bytes,
+                        expression_count=expression_count,
+                        measured_wave_target=measured_wave_target,
+                        soak_seconds=soak_seconds,
+                        rss_before_load_bytes=rss_before_load_bytes,
+                        peak_rss_bytes=max(rss_samples, default=0),
+                        max_canary_query_seconds=max(
+                            canary_query_durations,
+                            default=0.0,
+                        ),
+                        waves=wave_metrics,
+                    ).model_dump(),
+                    option=orjson.OPT_INDENT_2,
+                )
+            )
+
+    assert app_runtime.health.pending_submissions == 0
+    assert app_runtime.health.thread_alive is False
+    assert not any(
+        thread.name == "test-worker-app-io" and thread.is_alive()
+        for thread in threading.enumerate()
+    )
+    storage_health = blob.storage_client_cache_health()
+    assert storage_health.loop_count == 0
+    assert storage_health.entered_client_count == 0
+    assert canary_ticks > 0
+    assert canary_query_durations
+    assert max(canary_query_durations) < CANARY_MAX_STALL_SECONDS
+
+    measured_metrics = [metrics for metrics in wave_metrics if metrics.measured]
+    assert len(measured_metrics) >= measured_wave_target
+    assert all(
+        metrics.fd_count <= measured_metrics[0].fd_count
+        for metrics in measured_metrics[1:]
+    )
+    assert all(
+        metrics.thread_count <= measured_metrics[0].thread_count
+        for metrics in measured_metrics[1:]
+    )
+    rss_allowance = max(
+        RSS_PLATEAU_MIN_ALLOWANCE_BYTES,
+        measured_metrics[0].rss_bytes // 10,
+    )
+    assert (
+        measured_metrics[-1].rss_bytes - measured_metrics[0].rss_bytes <= rss_allowance
+    )
+    assert all(
+        later.canary_ticks > earlier.canary_ticks
+        for earlier, later in zip(
+            measured_metrics,
+            measured_metrics[1:],
+            strict=False,
+        )
+    )
+
+    assert metrics_path.stat().st_size > 0
+
+    captured = capsys.readouterr()
+    worker_output = f"{caplog.text}\n{captured.out}\n{captured.err}"
+    for forbidden in ("TMPRL1101", "Potential deadlock", "didn't yield"):
+        assert forbidden not in worker_output

--- a/tests/unit/test_app_async_runtime.py
+++ b/tests/unit/test_app_async_runtime.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import uvloop
+
+from tracecat.async_runtime import (
+    AppAsyncRuntime,
+    AppAsyncRuntimeState,
+    use_app_async_runtime,
+)
+from tracecat.storage import blob as blob_module
+from tracecat.storage.backends import s3 as s3_module
+from tracecat.storage.backends.s3 import S3ObjectStorage
+from tracecat.storage.blob import get_storage_client
+from tracecat.storage.object import ExternalObject
+
+
+def test_app_async_runtime_collapses_64_callers_onto_one_s3_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All activity threads reuse one loop-owned entered S3 client."""
+    caller_count = 64
+    start_barrier = threading.Barrier(caller_count + 1)
+    observed_loop_ids: set[int] = set()
+    observed_loop_types: set[type[asyncio.AbstractEventLoop]] = set()
+    observed_thread_ids: set[int] = set()
+    observation_lock = threading.Lock()
+    runtime = AppAsyncRuntime(
+        name="test-app-io",
+        loop_factory=uvloop.new_event_loop,
+    )
+
+    blob_module.clear_storage_session_cache()
+    monkeypatch.setattr(
+        blob_module.config,
+        "TRACECAT__BLOB_STORAGE_ENDPOINT",
+        None,
+        raising=False,
+    )
+
+    async def use_client() -> object:
+        with observation_lock:
+            loop = asyncio.get_running_loop()
+            observed_loop_ids.add(id(loop))
+            observed_loop_types.add(type(loop))
+            observed_thread_ids.add(threading.get_ident())
+        async with get_storage_client() as client:
+            await asyncio.sleep(0)
+            return client
+
+    def caller() -> object:
+        start_barrier.wait(timeout=10)
+        return runtime.run_sync(use_client())
+
+    with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+        mock_session = mock_session_cls.return_value
+        mock_client = AsyncMock()
+        mock_session.client.return_value.__aenter__.return_value = mock_client
+
+        runtime.start()
+        try:
+            with ThreadPoolExecutor(max_workers=caller_count) as executor:
+                futures = [executor.submit(caller) for _ in range(caller_count)]
+                start_barrier.wait(timeout=10)
+                clients = [future.result(timeout=10) for future in futures]
+        finally:
+            runtime.close(cleanup=blob_module.close_storage_client_cache)
+
+        assert clients == [mock_client] * caller_count
+        assert len(observed_loop_ids) == 1
+        assert observed_loop_types == {uvloop.Loop}
+        assert len(observed_thread_ids) == 1
+        mock_session_cls.assert_called_once()
+        mock_session.client.return_value.__aenter__.assert_awaited_once()
+        mock_session.client.return_value.__aexit__.assert_awaited_once_with(
+            None, None, None
+        )
+        assert len(blob_module._STORAGE_CLIENTS) == 0
+
+
+def test_sync_storage_keeps_cpu_on_activity_thread_and_io_on_uvloop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only S3 coroutines cross from an activity thread to the app loop."""
+    runtime = AppAsyncRuntime(
+        name="test-app-io",
+        loop_factory=uvloop.new_event_loop,
+    )
+    storage = S3ObjectStorage(bucket="bucket", threshold_bytes=0)
+    cpu_thread_ids: list[int] = []
+    io_thread_ids: list[int] = []
+    io_loop_types: list[type[asyncio.AbstractEventLoop]] = []
+    original_prepare = s3_module._prepare_payload
+    original_verify = s3_module._verify_and_deserialize
+
+    def prepare(data: object) -> s3_module._PreparedPayload:
+        cpu_thread_ids.append(threading.get_ident())
+        return original_prepare(data)
+
+    def verify(content: bytes, *, expected_sha256: str, key: str) -> object:
+        cpu_thread_ids.append(threading.get_ident())
+        return original_verify(content, expected_sha256=expected_sha256, key=key)
+
+    async def record_io(*_args: object, **_kwargs: object) -> None:
+        io_thread_ids.append(threading.get_ident())
+        io_loop_types.append(type(asyncio.get_running_loop()))
+
+    prepared = original_prepare({"payload": "value"})
+
+    async def download(**_kwargs: object) -> bytes:
+        io_thread_ids.append(threading.get_ident())
+        io_loop_types.append(type(asyncio.get_running_loop()))
+        return prepared.content
+
+    monkeypatch.setattr(s3_module, "_prepare_payload", prepare)
+    monkeypatch.setattr(s3_module, "_verify_and_deserialize", verify)
+    monkeypatch.setattr(blob_module, "ensure_bucket_exists", record_io)
+    monkeypatch.setattr(blob_module, "upload_file", record_io)
+    monkeypatch.setattr(s3_module, "cached_blob_download", download)
+
+    def activity_work() -> tuple[int, object]:
+        activity_thread_id = threading.get_ident()
+        stored = storage.store_sync("key", {"payload": "value"})
+        assert isinstance(stored, ExternalObject)
+        return activity_thread_id, storage.retrieve_sync(stored)
+
+    runtime.start()
+    try:
+        with use_app_async_runtime(runtime):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                activity_thread_id, retrieved = executor.submit(activity_work).result(
+                    timeout=10
+                )
+    finally:
+        runtime.close()
+
+    assert retrieved == {"payload": "value"}
+    assert cpu_thread_ids == [activity_thread_id, activity_thread_id]
+    assert io_thread_ids == [runtime.thread_id, runtime.thread_id, runtime.thread_id]
+    assert io_loop_types == [uvloop.Loop, uvloop.Loop, uvloop.Loop]
+
+
+def test_app_async_runtime_preserves_context_and_exceptions() -> None:
+    runtime = AppAsyncRuntime(name="test-app-io")
+    request_id = contextvars.ContextVar("request_id", default="missing")
+
+    async def read_context() -> str:
+        return request_id.get()
+
+    async def raise_error() -> None:
+        raise LookupError("preserved")
+
+    async def raise_timeout_error() -> None:
+        raise TimeoutError("from coroutine")
+
+    runtime.start()
+    try:
+        token = request_id.set("activity-request")
+        try:
+            assert runtime.run_sync(read_context()) == "activity-request"
+        finally:
+            request_id.reset(token)
+
+        with pytest.raises(LookupError, match="preserved"):
+            runtime.run_sync(raise_error())
+        with pytest.raises(TimeoutError, match="from coroutine"):
+            runtime.run_sync(raise_timeout_error())
+    finally:
+        runtime.close()
+
+
+@pytest.mark.anyio
+async def test_app_async_runtime_async_bridge_preserves_context_and_exceptions() -> (
+    None
+):
+    runtime = AppAsyncRuntime(name="test-app-io")
+    request_id = contextvars.ContextVar("request_id", default="missing")
+
+    async def read_context() -> str:
+        return request_id.get()
+
+    async def raise_error() -> None:
+        raise LookupError("preserved")
+
+    runtime.start()
+    try:
+        token = request_id.set("temporal-request")
+        try:
+            assert await runtime.run_async(read_context()) == "temporal-request"
+        finally:
+            request_id.reset(token)
+
+        with pytest.raises(LookupError, match="preserved"):
+            await runtime.run_async(raise_error())
+    finally:
+        await runtime.aclose()
+
+
+@pytest.mark.anyio
+async def test_blob_operations_route_off_the_temporal_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppAsyncRuntime(name="test-app-io")
+    caller_loop = asyncio.get_running_loop()
+    operation_loop_ids: list[int] = []
+    operation_thread_ids: list[int] = []
+
+    blob_module.clear_storage_session_cache()
+    monkeypatch.setattr(
+        blob_module.config,
+        "TRACECAT__BLOB_STORAGE_ENDPOINT",
+        None,
+        raising=False,
+    )
+
+    with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+        mock_session = mock_session_cls.return_value
+        mock_client = AsyncMock()
+
+        async def put_object(**_kwargs: object) -> None:
+            operation_loop_ids.append(id(asyncio.get_running_loop()))
+            operation_thread_ids.append(threading.get_ident())
+
+        mock_client.put_object.side_effect = put_object
+        mock_session.client.return_value.__aenter__.return_value = mock_client
+
+        runtime.start()
+        try:
+            with use_app_async_runtime(runtime):
+                await blob_module.upload_file(b"one", "one", "bucket")
+                await blob_module.upload_file(b"two", "two", "bucket")
+        finally:
+            await runtime.aclose(cleanup=blob_module.close_storage_client_cache)
+
+    assert operation_loop_ids == [operation_loop_ids[0], operation_loop_ids[0]]
+    assert operation_loop_ids[0] != id(caller_loop)
+    assert operation_thread_ids == [runtime.thread_id, runtime.thread_id]
+    mock_session_cls.assert_called_once()
+    mock_session.client.return_value.__aenter__.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_app_async_runtime_async_cancellation_cancels_submitted_task() -> None:
+    runtime = AppAsyncRuntime(name="test-app-io")
+    started = threading.Event()
+    cancelled = threading.Event()
+
+    async def wait_forever() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    runtime.start()
+    try:
+        task = asyncio.create_task(runtime.run_async(wait_forever()))
+        assert await asyncio.to_thread(started.wait, 5)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert await asyncio.to_thread(cancelled.wait, 5)
+    finally:
+        await runtime.aclose()
+
+
+@pytest.mark.anyio
+async def test_app_async_runtime_drains_cancelled_task_before_cleanup() -> None:
+    runtime = AppAsyncRuntime(name="test-app-io")
+    started = threading.Event()
+    finalizing = threading.Event()
+    release_finalizer = threading.Event()
+    cleanup_called = threading.Event()
+
+    async def cancellable_work() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            finalizing.set()
+            await asyncio.to_thread(release_finalizer.wait)
+
+    async def cleanup() -> None:
+        cleanup_called.set()
+
+    runtime.start()
+    caller_task = asyncio.create_task(runtime.run_async(cancellable_work()))
+    assert await asyncio.to_thread(started.wait, 5)
+    caller_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller_task
+    assert await asyncio.to_thread(finalizing.wait, 5)
+
+    close_task = asyncio.create_task(runtime.aclose(cleanup=cleanup))
+    await asyncio.sleep(0.05)
+    assert cleanup_called.is_set() is False
+
+    release_finalizer.set()
+    await close_task
+    assert cleanup_called.is_set() is True
+    assert runtime.health.pending_submissions == 0
+
+
+def test_app_async_runtime_sync_interruption_cancels_submitted_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = AppAsyncRuntime(name="test-app-io")
+    submitted: Future[None] = Future()
+    result_calls = 0
+
+    def interrupt_result(*_args: object, **_kwargs: object) -> None:
+        nonlocal result_calls
+        result_calls += 1
+        if result_calls == 1:
+            raise TimeoutError
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(submitted, "result", interrupt_result)
+    monkeypatch.setattr(runtime, "_submit", lambda _coro: submitted)
+    coroutine = asyncio.sleep(0)
+    with pytest.raises(KeyboardInterrupt):
+        runtime.run_sync(coroutine)
+
+    assert submitted.cancelled()
+    assert result_calls == 2
+    coroutine.close()
+
+
+@pytest.mark.anyio
+async def test_app_async_runtime_rejects_blocking_from_event_loop_threads() -> None:
+    runtime = AppAsyncRuntime(name="test-app-io")
+    runtime.start()
+    try:
+        with pytest.raises(RuntimeError, match="event-loop thread"):
+            runtime.run_sync(asyncio.sleep(0))
+
+        async def block_from_app_loop() -> None:
+            with pytest.raises(RuntimeError, match="event-loop thread"):
+                runtime.run_sync(asyncio.sleep(0))
+
+        await runtime.run_async(block_from_app_loop())
+    finally:
+        await runtime.aclose()
+
+
+def test_app_async_runtime_reports_readiness_and_stops_intake() -> None:
+    runtime = AppAsyncRuntime(name="test-app-io")
+
+    assert runtime.state is AppAsyncRuntimeState.NEW
+    assert runtime.is_healthy is False
+
+    runtime.start()
+    health = runtime.health
+    assert health.state is AppAsyncRuntimeState.RUNNING
+    assert health.ready is True
+    assert health.thread_alive is True
+    assert health.loop_running is True
+    assert runtime.is_healthy is True
+
+    runtime.close()
+    assert runtime.state is AppAsyncRuntimeState.STOPPED
+    assert runtime.is_healthy is False
+
+    coroutine = asyncio.sleep(0)
+    with pytest.raises(RuntimeError, match="not accepting submissions"):
+        runtime.run_sync(coroutine)
+
+
+def test_app_async_runtime_reports_loop_start_failure() -> None:
+    def fail_loop_creation() -> asyncio.AbstractEventLoop:
+        raise LookupError("loop factory failed")
+
+    runtime = AppAsyncRuntime(loop_factory=fail_loop_creation)
+
+    with pytest.raises(RuntimeError, match="failed to start") as exc_info:
+        runtime.start()
+
+    assert isinstance(exc_info.value.__cause__, LookupError)
+    assert runtime.state is AppAsyncRuntimeState.FAILED
+    assert runtime.health.thread_alive is False

--- a/tests/unit/test_app_async_runtime.py
+++ b/tests/unit/test_app_async_runtime.py
@@ -386,3 +386,36 @@ def test_app_async_runtime_reports_loop_start_failure() -> None:
     assert isinstance(exc_info.value.__cause__, LookupError)
     assert runtime.state is AppAsyncRuntimeState.FAILED
     assert runtime.health.thread_alive is False
+
+
+def test_app_async_runtime_failed_close_cancels_stranded_submissions() -> None:
+    """A dead loop must not leave close() waiting forever on orphaned Futures."""
+    runtime = AppAsyncRuntime(name="test-app-io")
+    stranded: Future[None] = Future()
+
+    runtime.start()
+    with runtime._lock:
+        runtime._pending.add(stranded)
+    runtime_loop = runtime._loop
+    runtime_thread = runtime._thread
+    assert runtime_loop is not None
+    assert runtime_thread is not None
+
+    runtime_loop.call_soon_threadsafe(runtime_loop.stop)
+    runtime_thread.join(timeout=5)
+    assert runtime_thread.is_alive() is False
+    assert runtime.state is AppAsyncRuntimeState.FAILED
+
+    # Numeric thread identifiers may be reused after the owner thread exits.
+    # close() must compare Thread objects instead of rejecting this caller.
+    with runtime._lock:
+        runtime._thread_id = threading.get_ident()
+
+    with pytest.raises(RuntimeError, match="failed during shutdown") as exc_info:
+        runtime.close(timeout=1)
+
+    assert stranded.cancelled() is True
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == (
+        "App async runtime loop stopped outside close()"
+    )

--- a/tests/unit/test_app_async_runtime.py
+++ b/tests/unit/test_app_async_runtime.py
@@ -309,6 +309,54 @@ async def test_app_async_runtime_drains_cancelled_task_before_cleanup() -> None:
     assert runtime.health.pending_submissions == 0
 
 
+@pytest.mark.anyio
+async def test_app_async_runtime_close_timeout_bounds_cancelled_finalizer() -> None:
+    """One shutdown deadline bounds draining, cleanup, and thread joining."""
+    runtime = AppAsyncRuntime(name="test-app-io")
+    started = threading.Event()
+    finalizing = threading.Event()
+    release_finalizer = threading.Event()
+    cleanup_called = threading.Event()
+
+    async def cancellable_work() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            finalizing.set()
+            await asyncio.to_thread(release_finalizer.wait)
+
+    async def cleanup() -> None:
+        cleanup_called.set()
+
+    runtime.start()
+    runtime_thread = runtime._thread
+    assert runtime_thread is not None
+    caller_task = asyncio.create_task(runtime.run_async(cancellable_work()))
+    assert await asyncio.to_thread(started.wait, 5)
+    caller_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller_task
+    assert await asyncio.to_thread(finalizing.wait, 5)
+
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="did not stop within 0.05 seconds",
+        ) as exc_info:
+            await asyncio.wait_for(
+                runtime.aclose(cleanup=cleanup, timeout=0.05),
+                timeout=1,
+            )
+        assert isinstance(exc_info.value.__cause__, TimeoutError)
+        assert cleanup_called.is_set() is False
+    finally:
+        release_finalizer.set()
+        await asyncio.to_thread(runtime_thread.join, 5)
+
+    assert runtime_thread.is_alive() is False
+
+
 def test_app_async_runtime_sync_interruption_cancels_submitted_task(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_app_async_runtime.py
+++ b/tests/unit/test_app_async_runtime.py
@@ -332,6 +332,7 @@ async def test_app_async_runtime_close_timeout_bounds_cancelled_finalizer() -> N
     runtime.start()
     runtime_thread = runtime._thread
     assert runtime_thread is not None
+    assert runtime_thread.daemon is True
     caller_task = asyncio.create_task(runtime.run_async(cancellable_work()))
     assert await asyncio.to_thread(started.wait, 5)
     caller_task.cancel()

--- a/tests/unit/test_app_async_runtime.py
+++ b/tests/unit/test_app_async_runtime.py
@@ -436,6 +436,37 @@ def test_app_async_runtime_reports_loop_start_failure() -> None:
     assert runtime.health.thread_alive is False
 
 
+def test_app_async_runtime_start_timeout_stops_late_loop() -> None:
+    release_loop_factory = threading.Event()
+
+    def slow_loop_creation() -> asyncio.AbstractEventLoop:
+        assert release_loop_factory.wait(timeout=5)
+        return asyncio.new_event_loop()
+
+    runtime = AppAsyncRuntime(loop_factory=slow_loop_creation)
+
+    with pytest.raises(RuntimeError, match="failed to start") as exc_info:
+        runtime.start(timeout=0.05)
+
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+    runtime_thread = runtime._thread
+    assert runtime_thread is not None
+    assert runtime_thread.is_alive() is True
+
+    release_loop_factory.set()
+    runtime_thread.join(timeout=5)
+    stopped_without_intervention = not runtime_thread.is_alive()
+    if not stopped_without_intervention:
+        runtime_loop = runtime._loop
+        if runtime_loop is not None:
+            runtime_loop.call_soon_threadsafe(runtime_loop.stop)
+        runtime_thread.join(timeout=5)
+
+    assert stopped_without_intervention is True
+    assert runtime.state is AppAsyncRuntimeState.FAILED
+    assert runtime.health.loop_running is False
+
+
 def test_app_async_runtime_failed_close_cancels_stranded_submissions() -> None:
     """A dead loop must not leave close() waiting forever on orphaned Futures."""
     runtime = AppAsyncRuntime(name="test-app-io")

--- a/tests/unit/test_materialize_context.py
+++ b/tests/unit/test_materialize_context.py
@@ -6,25 +6,18 @@ import pytest
 from botocore.exceptions import HTTPClientError
 from temporalio.exceptions import ApplicationError
 
+from tracecat.async_runtime import AppAsyncRuntime, use_app_async_runtime
 from tracecat.dsl import action
-from tracecat.dsl.action import materialize_context
+from tracecat.dsl.action import materialize_context, materialize_context_sync
 from tracecat.dsl.schemas import ExecutionContext, TaskResult
 from tracecat.storage import blob as blob_module
 from tracecat.storage.blob import get_storage_client
 from tracecat.storage.object import CollectionObject, InlineObject, ObjectRef
 
 
-def _close_run_sync_runner() -> None:
-    runner = getattr(action._thread_local, "runner", None)
-    if runner is not None:
-        runner.close()
-        delattr(action._thread_local, "runner")
-
-
-def test_run_sync_reuses_storage_client_until_runner_closes(
+def test_run_sync_reuses_storage_client_until_app_runtime_closes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _close_run_sync_runner()
     blob_module.clear_storage_session_cache()
     monkeypatch.setattr(
         blob_module.config,
@@ -37,31 +30,31 @@ def test_run_sync_reuses_storage_client_until_runner_closes(
         async with get_storage_client() as client:
             return client
 
-    try:
-        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
-            mock_session = mock_session_cls.return_value
-            mock_client = AsyncMock()
-            mock_session.client.return_value.__aenter__.return_value = mock_client
+    runtime = AppAsyncRuntime(name="test-app-io")
+    with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+        mock_session = mock_session_cls.return_value
+        mock_client = AsyncMock()
+        mock_session.client.return_value.__aenter__.return_value = mock_client
 
-            assert action.run_sync(use_client()) is mock_client
-            assert action.run_sync(use_client()) is mock_client
+        runtime.start()
+        try:
+            with use_app_async_runtime(runtime):
+                assert action.run_sync(use_client()) is mock_client
+                assert action.run_sync(use_client()) is mock_client
 
-            mock_session_cls.assert_called_once()
-            mock_session.client.assert_called_once_with(
-                "s3", config=blob_module._STORAGE_CLIENT_CONFIG
-            )
-            mock_session.client.return_value.__aenter__.assert_awaited_once()
-            mock_session.client.return_value.__aexit__.assert_not_awaited()
+                mock_session_cls.assert_called_once()
+                mock_session.client.assert_called_once_with(
+                    "s3", config=blob_module._STORAGE_CLIENT_CONFIG
+                )
+                mock_session.client.return_value.__aenter__.assert_awaited_once()
+                mock_session.client.return_value.__aexit__.assert_not_awaited()
+        finally:
+            runtime.close(cleanup=blob_module.close_storage_client_cache)
 
-            _close_run_sync_runner()
-
-            mock_session.client.return_value.__aexit__.assert_awaited_once_with(
-                None, None, None
-            )
-            assert len(blob_module._STORAGE_CLIENTS) == 0
-    finally:
-        _close_run_sync_runner()
-        blob_module.clear_storage_session_cache()
+        mock_session.client.return_value.__aexit__.assert_awaited_once_with(
+            None, None, None
+        )
+        assert len(blob_module._STORAGE_CLIENTS) == 0
 
 
 @pytest.mark.anyio
@@ -79,6 +72,26 @@ async def test_materialize_context_marks_storage_transport_errors_retryable(
 
     with pytest.raises(ApplicationError) as exc_info:
         await materialize_context(ctx)
+
+    assert exc_info.value.non_retryable is False
+    assert exc_info.value.type == "StorageMaterializationError"
+
+
+def test_materialize_context_sync_marks_storage_transport_errors_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_transport_error(*_args: object, **_kwargs: object) -> object:
+        raise HTTPClientError(error=RuntimeError("Connection reset"))
+
+    monkeypatch.setattr(
+        action,
+        "retrieve_stored_object_sync",
+        raise_transport_error,
+    )
+    ctx = ExecutionContext(ACTIONS={}, TRIGGER=InlineObject(data={"trigger": 1}))
+
+    with pytest.raises(ApplicationError) as exc_info:
+        materialize_context_sync(ctx)
 
     assert exc_info.value.non_retryable is False
     assert exc_info.value.type == "StorageMaterializationError"

--- a/tests/unit/test_storage_blob.py
+++ b/tests/unit/test_storage_blob.py
@@ -4,11 +4,12 @@ import asyncio
 import hashlib
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Protocol, cast
 from unittest.mock import AsyncMock, patch
 from urllib.parse import urlparse
 
 import pytest
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, HTTPClientError
 
 from tracecat.storage import blob as blob_module
 from tracecat.storage.blob import (
@@ -27,6 +28,10 @@ from tracecat.storage.blob import (
 )
 
 
+class _PoolConfig(Protocol):
+    max_pool_connections: int
+
+
 class TestS3Operations:
     """Test S3/MinIO operations."""
 
@@ -41,6 +46,10 @@ class TestS3Operations:
         """Create a mock S3 client."""
         mock_client = AsyncMock()
         return mock_client
+
+    def test_storage_client_pool_limit_is_explicit(self) -> None:
+        storage_config = cast(_PoolConfig, blob_module._STORAGE_CLIENT_CONFIG)
+        assert storage_config.max_pool_connections == 10
 
     @pytest.mark.anyio
     @patch("tracecat.storage.blob.get_storage_client")
@@ -206,6 +215,206 @@ class TestS3Operations:
             mock_session.client.return_value.__aexit__.assert_awaited_once_with(
                 None, None, None
             )
+
+    @pytest.mark.anyio
+    async def test_invalidate_storage_client_recreates_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            first_client = AsyncMock()
+            second_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.side_effect = [
+                first_client,
+                second_client,
+            ]
+
+            async with get_storage_client() as client:
+                assert client is first_client
+
+            await blob_module.invalidate_storage_client()
+
+            async with get_storage_client() as client:
+                assert client is second_client
+
+            await blob_module.close_storage_client_cache()
+
+            assert mock_session_cls.call_count == 2
+            assert mock_session.client.return_value.__aenter__.await_count == 2
+            assert mock_session.client.return_value.__aexit__.await_count == 2
+
+    @pytest.mark.anyio
+    async def test_invalidate_waits_for_active_storage_client_users(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Invalidation never closes a connector beneath another operation."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            first_client = AsyncMock()
+            second_client = AsyncMock()
+            first_context = mock_session.client.return_value
+            first_context.__aenter__.side_effect = [first_client, second_client]
+
+            release_user = asyncio.Event()
+            user_started = asyncio.Event()
+
+            async def active_user() -> None:
+                async with get_storage_client() as client:
+                    assert client is first_client
+                    user_started.set()
+                    await release_user.wait()
+
+            user_task = asyncio.create_task(active_user())
+            await user_started.wait()
+            invalidation_task = asyncio.create_task(
+                blob_module.invalidate_storage_client()
+            )
+            await asyncio.sleep(0)
+
+            first_context.__aexit__.assert_not_awaited()
+            async with get_storage_client() as client:
+                assert client is second_client
+            health = blob_module.storage_client_cache_health()
+            assert health.loop_count == 1
+            assert health.entered_client_count == 2
+            assert health.active_user_count == 1
+
+            release_user.set()
+            await user_task
+            await invalidation_task
+            await blob_module.close_storage_client_cache()
+
+            assert first_context.__aexit__.await_count == 2
+
+    @pytest.mark.anyio
+    async def test_transport_failure_invalidates_shared_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            first_client = AsyncMock()
+            second_client = AsyncMock()
+            first_client.put_object.side_effect = HTTPClientError(
+                error=RuntimeError("Connection reset")
+            )
+            mock_session.client.return_value.__aenter__.side_effect = [
+                first_client,
+                second_client,
+            ]
+
+            with pytest.raises(HTTPClientError):
+                await upload_file(b"payload", "key", "bucket")
+
+            async with get_storage_client() as client:
+                assert client is second_client
+            await blob_module.close_storage_client_cache()
+
+            assert mock_session_cls.call_count == 2
+            assert mock_session.client.return_value.__aexit__.await_count == 2
+
+    @pytest.mark.anyio
+    async def test_s3_service_error_keeps_shared_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Service responses do not imply a poisoned HTTP transport."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            client = AsyncMock()
+            client.put_object.side_effect = ClientError(
+                error_response={"Error": {"Code": "AccessDenied"}},
+                operation_name="PutObject",
+            )
+            mock_session.client.return_value.__aenter__.return_value = client
+
+            with pytest.raises(ClientError):
+                await upload_file(b"payload", "key", "bucket")
+
+            async with get_storage_client() as reused_client:
+                assert reused_client is client
+            await blob_module.close_storage_client_cache()
+
+            mock_session_cls.assert_called_once()
+            mock_session.client.return_value.__aenter__.assert_awaited_once()
+            mock_session.client.return_value.__aexit__.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_retired_client_failure_does_not_invalidate_replacement(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            first_client = AsyncMock()
+            second_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.side_effect = [
+                first_client,
+                second_client,
+            ]
+            old_user_started = asyncio.Event()
+            release_old_user = asyncio.Event()
+
+            async def fail_using_old_client() -> None:
+                async with get_storage_client() as client:
+                    assert client is first_client
+                    old_user_started.set()
+                    await release_old_user.wait()
+                    raise HTTPClientError(error=RuntimeError("Connection reset"))
+
+            old_user_task = asyncio.create_task(fail_using_old_client())
+            await old_user_started.wait()
+            invalidation_task = asyncio.create_task(
+                blob_module.invalidate_storage_client()
+            )
+            await asyncio.sleep(0)
+
+            async with get_storage_client() as client:
+                assert client is second_client
+
+            release_old_user.set()
+            with pytest.raises(HTTPClientError):
+                await old_user_task
+            await invalidation_task
+
+            async with get_storage_client() as client:
+                assert client is second_client
+            await blob_module.close_storage_client_cache()
+
+            assert mock_session_cls.call_count == 2
+            assert mock_session.client.return_value.__aexit__.await_count == 2
 
     def test_get_storage_client_uses_new_session_for_new_event_loop(self, monkeypatch):
         """get_storage_client does not reuse aioboto3 sessions across event loops."""

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -104,7 +104,6 @@ class TestBlobStorageTransportRetries:
             "tracecat.storage.utils.blob.download_file",
             fake_download_file,
         )
-
         content = await cached_blob_download(
             sha256="retry-http-client-error-sha",
             bucket="bucket",
@@ -215,6 +214,17 @@ class TestSizedMemoryCache:
         assert result == b"hello"
         assert cache.total_bytes == 5
         assert cache.item_count == 1
+
+    @pytest.mark.anyio
+    async def test_clear_releases_all_entries(self) -> None:
+        cache = SizedMemoryCache(max_bytes=1024, ttl=300.0)
+        await cache.set("key1", b"hello")
+        await cache.set("key2", b"world")
+
+        await cache.clear()
+
+        assert cache.total_bytes == 0
+        assert cache.item_count == 0
 
     @pytest.mark.anyio
     async def test_get_missing_key_returns_none(self):

--- a/tests/unit/test_storage_collection.py
+++ b/tests/unit/test_storage_collection.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 from pydantic import TypeAdapter
 from temporalio.exceptions import ApplicationError
 
+from tracecat.async_runtime import AppAsyncRuntime, use_app_async_runtime
 from tracecat.dsl.action import (
     DSLActivities,
     NormalizeTriggerInputsActivityInputs,
@@ -553,21 +554,26 @@ class TestCollectionStorageFunctions:
 
         monkeypatch.setattr(blob, "select_object_content", over_max_record_size)
 
-        # This should succeed after refactor, because indexed lookup should avoid S3 Select.
+        # Sync DSL activities run with the worker-owned app runtime installed.
+        runtime = AppAsyncRuntime(name="test-app-io")
+        runtime.start()
         try:
-            normalized = await asyncio.to_thread(
-                DSLActivities.normalize_trigger_inputs_activity,
-                NormalizeTriggerInputsActivityInputs(
-                    input_schema={},
-                    trigger_inputs=collection.at(0),
-                    key="wf-123/looped-subflow/normalized-trigger-input.json",
-                ),
-            )
+            with use_app_async_runtime(runtime):
+                normalized = await asyncio.to_thread(
+                    DSLActivities.normalize_trigger_inputs_activity,
+                    NormalizeTriggerInputsActivityInputs(
+                        input_schema={},
+                        trigger_inputs=collection.at(0),
+                        key="wf-123/looped-subflow/normalized-trigger-input.json",
+                    ),
+                )
         except ApplicationError:  # pragma: no cover - expected red failure today
             pytest.fail(
                 "Looped subflow indexed trigger input retrieval still depends on "
                 "S3 Select and fails with OverMaxRecordSize"
             )
+        finally:
+            await runtime.aclose()
 
         resolved = await get_object_storage().retrieve(normalized)
         assert resolved == items[0]

--- a/tests/unit/test_worker_activity_registration.py
+++ b/tests/unit/test_worker_activity_registration.py
@@ -143,6 +143,71 @@ async def test_dsl_worker_treats_empty_concurrency_env_vars_as_defaults(
 
 
 @pytest.mark.anyio
+async def test_dsl_worker_shuts_down_when_app_io_runtime_dies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lost app I/O runtime must end the worker instead of failing forever.
+
+    Every storage activity depends on that runtime, so the process should ask
+    for shutdown and let the orchestrator restart it.
+    """
+    from tracecat.dsl import worker
+
+    shutdown_event = asyncio.Event()
+    worker_exited = threading.Event()
+
+    class _FakeWorker:
+        def __init__(self, _client: object, **kwargs: object) -> None:
+            del kwargs
+
+        async def __aenter__(self) -> _FakeWorker:
+            # Simulate the app I/O loop dying underneath a running worker.
+            app_runtime = get_app_async_runtime()
+            assert app_runtime is not None
+            runtime_loop = app_runtime._loop
+            assert runtime_loop is not None
+            runtime_loop.call_soon_threadsafe(runtime_loop.stop)
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: object,
+        ) -> None:
+            del exc_type, exc, tb
+            worker_exited.set()
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    monkeypatch.setattr(worker, "_APP_RUNTIME_WATCHDOG_INTERVAL_SECONDS", 0.05)
+    monkeypatch.setattr(worker, "get_temporal_client", AsyncMock(return_value=object()))
+    monkeypatch.setattr(worker, "get_activities", lambda: [])
+    monkeypatch.setattr(worker, "Worker", _FakeWorker)
+    monkeypatch.setattr(worker, "new_sandbox_runner", lambda: object())
+    close_storage_client_cache = AsyncMock()
+    monkeypatch.setattr(
+        worker,
+        "close_storage_client_cache",
+        close_storage_client_cache,
+    )
+
+    with pytest.raises(RuntimeError, match="failed during shutdown") as exc_info:
+        await asyncio.wait_for(
+            worker.main(shutdown_event=shutdown_event),
+            timeout=10,
+        )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == (
+        "App async runtime loop stopped outside close()"
+    )
+    assert shutdown_event.is_set()
+    assert worker_exited.is_set()
+    close_storage_client_cache.assert_not_awaited()
+    assert get_app_async_runtime() is None
+
+
+@pytest.mark.anyio
 async def test_dsl_worker_closes_app_io_after_activity_pool_drains(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_worker_activity_registration.py
+++ b/tests/unit/test_worker_activity_registration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from collections.abc import Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
@@ -21,6 +22,7 @@ from tracecat.agent.preset.activities import (
     resolve_agent_preset_version_ref_activity,
 )
 from tracecat.agent.worker import get_activities as get_agent_worker_activities
+from tracecat.async_runtime import get_app_async_runtime
 from tracecat.dsl.worker import get_activities as get_dsl_worker_activities
 
 
@@ -122,7 +124,10 @@ async def test_dsl_worker_treats_empty_concurrency_env_vars_as_defaults(
     monkeypatch.setattr(worker, "get_activities", lambda: [])
     monkeypatch.setattr(worker, "Worker", _FakeWorker)
     monkeypatch.setattr(worker, "new_sandbox_runner", lambda: object())
-    monkeypatch.setattr(worker, "close_storage_client_cache", AsyncMock())
+    close_storage_client_cache = AsyncMock()
+    monkeypatch.setattr(
+        worker, "close_storage_client_cache", close_storage_client_cache
+    )
 
     await worker.main(shutdown_event=shutdown_event)
 
@@ -133,6 +138,73 @@ async def test_dsl_worker_treats_empty_concurrency_env_vars_as_defaults(
         "max_concurrent_workflow_tasks": 100,
         "graceful_shutdown_timeout": timedelta(seconds=30),
     }
+    close_storage_client_cache.assert_awaited_once()
+    assert get_app_async_runtime() is None
+
+
+@pytest.mark.anyio
+async def test_dsl_worker_closes_app_io_after_activity_pool_drains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tracecat.dsl import worker
+
+    shutdown_event = asyncio.Event()
+    activity_started = threading.Event()
+    release_activity = threading.Event()
+    lifecycle: list[str] = []
+
+    class _FakeWorker:
+        def __init__(
+            self,
+            _client: object,
+            **kwargs: object,
+        ) -> None:
+            activity_executor = kwargs["activity_executor"]
+            assert isinstance(activity_executor, ThreadPoolExecutor)
+            self.activity_executor = activity_executor
+
+        async def __aenter__(self) -> _FakeWorker:
+            def activity_work() -> None:
+                activity_started.set()
+                assert release_activity.wait(timeout=5)
+                lifecycle.append("activity_pool_drained")
+
+            self.activity_executor.submit(activity_work)
+            assert activity_started.wait(timeout=5)
+            shutdown_event.set()
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: object,
+        ) -> None:
+            del exc_type, exc, tb
+            lifecycle.append("temporal_drained")
+            release_activity.set()
+
+    async def close_storage() -> None:
+        lifecycle.append("storage_client_closed")
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    monkeypatch.setenv("TEMPORAL__THREADPOOL_MAX_WORKERS", "1")
+    monkeypatch.setenv("TEMPORAL__MAX_CONCURRENT_ACTIVITIES", "1")
+    monkeypatch.setenv("TEMPORAL__MAX_CONCURRENT_WORKFLOW_TASKS", "2")
+    monkeypatch.setattr(worker, "get_temporal_client", AsyncMock(return_value=object()))
+    monkeypatch.setattr(worker, "get_activities", lambda: [])
+    monkeypatch.setattr(worker, "Worker", _FakeWorker)
+    monkeypatch.setattr(worker, "new_sandbox_runner", lambda: object())
+    monkeypatch.setattr(worker, "close_storage_client_cache", close_storage)
+
+    await worker.main(shutdown_event=shutdown_event)
+
+    assert lifecycle == [
+        "temporal_drained",
+        "activity_pool_drained",
+        "storage_client_closed",
+    ]
+    assert get_app_async_runtime() is None
 
 
 @pytest.mark.anyio

--- a/tracecat/async_runtime.py
+++ b/tracecat/async_runtime.py
@@ -153,6 +153,14 @@ class AppAsyncRuntime:
                 self._thread_id = threading.get_ident()
             loop.call_soon(self._mark_running)
             loop.run_forever()
+            with self._lock:
+                stopping = self._state is AppAsyncRuntimeState.STOPPING
+            if not stopping:
+                # Only close() stops the loop on purpose. Anything else means
+                # the runtime silently lost its I/O loop and must report it.
+                self._record_failure(
+                    RuntimeError("App async runtime loop stopped outside close()")
+                )
         except BaseException as exc:
             self._record_failure(exc)
             self._ready.set()
@@ -281,6 +289,16 @@ class AppAsyncRuntime:
                     # instead of being mistaken for this bridge's poll tick.
                     if future.done():
                         return future.result()
+                    with self._lock:
+                        state = self._state
+                        failure = self._failure
+                    if state in (
+                        AppAsyncRuntimeState.FAILED,
+                        AppAsyncRuntimeState.STOPPED,
+                    ):
+                        raise RuntimeError(
+                            "App async runtime stopped while a submission was pending"
+                        ) from failure
         except BaseException:
             future.cancel()
             raise
@@ -306,7 +324,9 @@ class AppAsyncRuntime:
         timeout: float = 30.0,
     ) -> None:
         """Stop intake, drain submissions, clean up, and join the loop thread."""
-        if threading.get_ident() == self.thread_id:
+        with self._lock:
+            runtime_thread = self._thread
+        if threading.current_thread() is runtime_thread:
             raise RuntimeError("App async runtime cannot close from its own thread")
 
         with self._close_lock:
@@ -330,21 +350,35 @@ class AppAsyncRuntime:
                 raise RuntimeError("App async runtime cannot close while starting")
             if self._state is AppAsyncRuntimeState.RUNNING:
                 self._state = AppAsyncRuntimeState.STOPPING
+            # A failed runtime has already lost its loop, so draining and
+            # loop-owned cleanup are impossible; only join and report.
+            failed = self._state is AppAsyncRuntimeState.FAILED
             loop = self._loop
             thread = self._thread
             pending = list(self._pending)
 
         cleanup_error: BaseException | None = None
         try:
-            if pending:
+            if failed:
+                # There is no live loop left to finish accepted submissions.
+                # Cancel their thread-safe Futures so blocked callers wake up,
+                # then join the owner thread and report the original failure.
+                for future in pending:
+                    future.cancel()
+            elif pending:
                 wait(pending)
-            if loop is not None and loop.is_running():
+            if not failed and loop is not None and loop.is_running():
                 drain_future = self._submit(
                     self._drain_loop_tasks(),
                     allow_stopping=True,
                 )
                 drain_future.result()
-            if cleanup is not None and loop is not None and loop.is_running():
+            if (
+                not failed
+                and cleanup is not None
+                and loop is not None
+                and loop.is_running()
+            ):
                 cleanup_future = self._submit(cleanup(), allow_stopping=True)
                 cleanup_future.result()
         except BaseException as exc:

--- a/tracecat/async_runtime.py
+++ b/tracecat/async_runtime.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import StrEnum
 from functools import wraps
+from time import monotonic
 from typing import Any
 
 
@@ -340,6 +341,8 @@ class AppAsyncRuntime:
     ) -> None:
         """Serialize close calls while performing ordered loop shutdown."""
 
+        deadline = monotonic() + timeout
+
         with self._lock:
             if self._state is AppAsyncRuntimeState.NEW:
                 self._state = AppAsyncRuntimeState.STOPPED
@@ -357,7 +360,8 @@ class AppAsyncRuntime:
             thread = self._thread
             pending = list(self._pending)
 
-        cleanup_error: BaseException | None = None
+        shutdown_error: BaseException | None = None
+        shutdown_futures: list[Future[Any]] = []
         try:
             if failed:
                 # There is no live loop left to finish accepted submissions.
@@ -366,13 +370,22 @@ class AppAsyncRuntime:
                 for future in pending:
                     future.cancel()
             elif pending:
-                wait(pending)
+                _, incomplete = wait(
+                    pending,
+                    timeout=max(0.0, deadline - monotonic()),
+                )
+                if incomplete:
+                    raise TimeoutError(
+                        "App async runtime timed out while draining "
+                        f"{len(incomplete)} accepted submission(s)"
+                    )
             if not failed and loop is not None and loop.is_running():
                 drain_future = self._submit(
                     self._drain_loop_tasks(),
                     allow_stopping=True,
                 )
-                drain_future.result()
+                shutdown_futures.append(drain_future)
+                drain_future.result(timeout=max(0.0, deadline - monotonic()))
             if (
                 not failed
                 and cleanup is not None
@@ -380,21 +393,30 @@ class AppAsyncRuntime:
                 and loop.is_running()
             ):
                 cleanup_future = self._submit(cleanup(), allow_stopping=True)
-                cleanup_future.result()
+                shutdown_futures.append(cleanup_future)
+                cleanup_future.result(timeout=max(0.0, deadline - monotonic()))
         except BaseException as exc:
-            cleanup_error = exc
+            shutdown_error = exc
         finally:
+            # Cancel every stage that could not finish within the shared
+            # deadline before asking the owning loop to stop.
+            for future in (*pending, *shutdown_futures):
+                if not future.done():
+                    future.cancel()
             if loop is not None and loop.is_running():
                 loop.call_soon_threadsafe(loop.stop)
             if thread is not None:
-                thread.join(timeout=timeout)
+                thread.join(timeout=max(0.0, deadline - monotonic()))
 
         if thread is not None and thread.is_alive():
-            raise RuntimeError(
+            thread_error = RuntimeError(
                 f"App async runtime thread did not stop within {timeout} seconds"
             )
-        if cleanup_error is not None:
-            raise cleanup_error
+            if shutdown_error is not None:
+                raise thread_error from shutdown_error
+            raise thread_error
+        if shutdown_error is not None:
+            raise shutdown_error
         with self._lock:
             failure = self._failure
         if failure is not None:

--- a/tracecat/async_runtime.py
+++ b/tracecat/async_runtime.py
@@ -120,7 +120,10 @@ class AppAsyncRuntime:
             thread = threading.Thread(
                 target=self._run_loop,
                 name=self._name,
-                daemon=False,
+                # close() still performs ordered shutdown and joins this thread.
+                # Daemonize only as a final escape hatch when a coroutine ignores
+                # cancellation beyond the shutdown deadline.
+                daemon=True,
             )
             self._thread = thread
             thread.start()

--- a/tracecat/async_runtime.py
+++ b/tracecat/async_runtime.py
@@ -1,0 +1,442 @@
+"""Process-owned event loop for application async I/O.
+
+Temporal runs synchronous activities in a thread pool. Those threads must not
+create their own long-lived event loops for async application resources such as
+aiobotocore clients. ``AppAsyncRuntime`` owns one loop in one dedicated thread
+and provides cancellation-aware bridges for both sync and async callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable, Coroutine, Iterator
+from concurrent.futures import Future, wait
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import StrEnum
+from functools import wraps
+from typing import Any
+
+
+class AppAsyncRuntimeState(StrEnum):
+    """Lifecycle state for an ``AppAsyncRuntime``."""
+
+    NEW = "new"
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class AppAsyncRuntimeHealth:
+    """Thread-safe runtime health snapshot."""
+
+    state: AppAsyncRuntimeState
+    ready: bool
+    thread_alive: bool
+    loop_running: bool
+    pending_submissions: int
+
+
+type AsyncCleanup = Callable[[], Coroutine[Any, Any, None]]
+_SYNC_RESULT_POLL_SECONDS = 0.1
+
+
+class AppAsyncRuntime:
+    """Own one application event loop in a dedicated thread.
+
+    The runtime is deliberately explicit: callers start it before accepting
+    work, submit application I/O to it, then stop intake and drain all accepted
+    submissions before closing loop-owned resources and joining the thread.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = "tracecat-app-io",
+        loop_factory: Callable[[], asyncio.AbstractEventLoop] = asyncio.new_event_loop,
+    ) -> None:
+        self._name = name
+        self._loop_factory = loop_factory
+        self._state = AppAsyncRuntimeState.NEW
+        self._lock = threading.RLock()
+        self._close_lock = threading.Lock()
+        self._ready = threading.Event()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._thread_id: int | None = None
+        self._failure: BaseException | None = None
+        self._pending: set[Future[Any]] = set()
+
+    @property
+    def state(self) -> AppAsyncRuntimeState:
+        """Return the current lifecycle state."""
+        with self._lock:
+            return self._state
+
+    @property
+    def health(self) -> AppAsyncRuntimeHealth:
+        """Return a non-blocking health snapshot."""
+        with self._lock:
+            thread = self._thread
+            loop = self._loop
+            return AppAsyncRuntimeHealth(
+                state=self._state,
+                ready=self._ready.is_set(),
+                thread_alive=thread is not None and thread.is_alive(),
+                loop_running=loop is not None and loop.is_running(),
+                pending_submissions=len(self._pending),
+            )
+
+    @property
+    def is_healthy(self) -> bool:
+        """Return whether the runtime is ready to accept submissions."""
+        health = self.health
+        return (
+            health.state is AppAsyncRuntimeState.RUNNING
+            and health.ready
+            and health.thread_alive
+            and health.loop_running
+        )
+
+    @property
+    def thread_id(self) -> int | None:
+        """Return the dedicated runtime thread identifier when started."""
+        with self._lock:
+            return self._thread_id
+
+    def start(self, *, timeout: float = 10.0) -> None:
+        """Start the dedicated loop thread and wait until it is running."""
+        with self._lock:
+            if self._state is not AppAsyncRuntimeState.NEW:
+                raise RuntimeError(
+                    f"App async runtime cannot start from state {self._state.value}"
+                )
+            self._state = AppAsyncRuntimeState.STARTING
+            thread = threading.Thread(
+                target=self._run_loop,
+                name=self._name,
+                daemon=False,
+            )
+            self._thread = thread
+            thread.start()
+
+        if not self._ready.wait(timeout=timeout):
+            with self._lock:
+                self._state = AppAsyncRuntimeState.FAILED
+                self._failure = TimeoutError(
+                    f"App async runtime did not become ready within {timeout} seconds"
+                )
+                loop = self._loop
+            if loop is not None:
+                loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=timeout)
+            raise RuntimeError("App async runtime failed to start") from self._failure
+
+        with self._lock:
+            started = self._state is AppAsyncRuntimeState.RUNNING
+            failure = self._failure
+        if not started:
+            thread.join(timeout=timeout)
+            raise RuntimeError("App async runtime failed to start") from failure
+
+    def _run_loop(self) -> None:
+        loop: asyncio.AbstractEventLoop | None = None
+        try:
+            loop = self._loop_factory()
+            asyncio.set_event_loop(loop)
+            with self._lock:
+                self._loop = loop
+                self._thread_id = threading.get_ident()
+            loop.call_soon(self._mark_running)
+            loop.run_forever()
+        except BaseException as exc:
+            self._record_failure(exc)
+            self._ready.set()
+        finally:
+            try:
+                if loop is not None:
+                    self._shutdown_loop(loop)
+            except BaseException as exc:
+                self._record_failure(exc)
+            finally:
+                try:
+                    asyncio.set_event_loop(None)
+                except BaseException as exc:
+                    self._record_failure(exc)
+                with self._lock:
+                    if self._state is not AppAsyncRuntimeState.FAILED:
+                        self._state = AppAsyncRuntimeState.STOPPED
+
+    def _record_failure(self, exc: BaseException) -> None:
+        with self._lock:
+            if self._failure is None:
+                self._failure = exc
+            self._state = AppAsyncRuntimeState.FAILED
+
+    def _mark_running(self) -> None:
+        with self._lock:
+            if self._state is AppAsyncRuntimeState.STARTING:
+                self._state = AppAsyncRuntimeState.RUNNING
+        self._ready.set()
+
+    @staticmethod
+    def _shutdown_loop(loop: asyncio.AbstractEventLoop) -> None:
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.run_until_complete(loop.shutdown_default_executor())
+        loop.close()
+
+    def _discard_submission(self, future: Future[Any]) -> None:
+        with self._lock:
+            self._pending.discard(future)
+
+    @staticmethod
+    async def _drain_loop_tasks() -> None:
+        """Wait for submitted tasks whose thread-safe Future was cancelled."""
+        current = asyncio.current_task()
+        tasks = [task for task in asyncio.all_tasks() if task is not current]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    @staticmethod
+    def _close_rejected_coroutine(coro: Coroutine[Any, Any, object]) -> None:
+        coro.close()
+
+    def _submit[T](
+        self,
+        coro: Coroutine[Any, Any, T],
+        *,
+        allow_stopping: bool = False,
+    ) -> Future[T]:
+        with self._lock:
+            accepted_states = (
+                {AppAsyncRuntimeState.RUNNING, AppAsyncRuntimeState.STOPPING}
+                if allow_stopping
+                else {AppAsyncRuntimeState.RUNNING}
+            )
+            loop = self._loop
+            if self._state not in accepted_states or loop is None:
+                self._close_rejected_coroutine(coro)
+                raise RuntimeError(
+                    "App async runtime is not accepting submissions "
+                    f"(state={self._state.value})"
+                )
+            try:
+                future = asyncio.run_coroutine_threadsafe(coro, loop)
+            except BaseException:
+                self._close_rejected_coroutine(coro)
+                raise
+            self._pending.add(future)
+            future.add_done_callback(self._discard_submission)
+            return future
+
+    def submit[T](self, coro: Coroutine[Any, Any, T]) -> Future[T]:
+        """Submit a coroutine and return a thread-safe future."""
+        return self._submit(coro)
+
+    def _assert_blocking_submission_allowed(self) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        raise RuntimeError(
+            "AppAsyncRuntime.run_sync() cannot block an event-loop thread; "
+            "use await run_async() instead"
+        )
+
+    def run_sync[T](self, coro: Coroutine[Any, Any, T]) -> T:
+        """Submit from synchronous code and block only the caller thread.
+
+        If Temporal injects cancellation into a synchronous activity while it
+        is blocked in ``Future.result()``, the submitted app-loop task is
+        cancelled before the exception is propagated.
+        """
+        try:
+            self._assert_blocking_submission_allowed()
+        except BaseException:
+            self._close_rejected_coroutine(coro)
+            raise
+
+        future = self._submit(coro)
+        try:
+            while True:
+                try:
+                    # Temporal cancels a synchronous threaded activity by
+                    # injecting CancelledError into its Python thread. Polling
+                    # keeps the thread from sleeping indefinitely in the
+                    # condition variable, so the exception is delivered and
+                    # the app-loop Future is cancelled promptly.
+                    return future.result(timeout=_SYNC_RESULT_POLL_SECONDS)
+                except TimeoutError:
+                    # A completed coroutine may itself raise TimeoutError.
+                    # Re-read it without a timeout so that exception propagates
+                    # instead of being mistaken for this bridge's poll tick.
+                    if future.done():
+                        return future.result()
+        except BaseException:
+            future.cancel()
+            raise
+
+    async def run_async[T](self, coro: Coroutine[Any, Any, T]) -> T:
+        """Submit from async code without blocking the caller event loop."""
+        with self._lock:
+            runtime_loop = self._loop
+        if runtime_loop is asyncio.get_running_loop():
+            return await coro
+
+        future = self._submit(coro)
+        try:
+            return await asyncio.wrap_future(future)
+        except BaseException:
+            future.cancel()
+            raise
+
+    def close(
+        self,
+        *,
+        cleanup: AsyncCleanup | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        """Stop intake, drain submissions, clean up, and join the loop thread."""
+        if threading.get_ident() == self.thread_id:
+            raise RuntimeError("App async runtime cannot close from its own thread")
+
+        with self._close_lock:
+            self._close_locked(cleanup=cleanup, timeout=timeout)
+
+    def _close_locked(
+        self,
+        *,
+        cleanup: AsyncCleanup | None,
+        timeout: float,
+    ) -> None:
+        """Serialize close calls while performing ordered loop shutdown."""
+
+        with self._lock:
+            if self._state is AppAsyncRuntimeState.NEW:
+                self._state = AppAsyncRuntimeState.STOPPED
+                return
+            if self._state is AppAsyncRuntimeState.STOPPED:
+                return
+            if self._state is AppAsyncRuntimeState.STARTING:
+                raise RuntimeError("App async runtime cannot close while starting")
+            if self._state is AppAsyncRuntimeState.RUNNING:
+                self._state = AppAsyncRuntimeState.STOPPING
+            loop = self._loop
+            thread = self._thread
+            pending = list(self._pending)
+
+        cleanup_error: BaseException | None = None
+        try:
+            if pending:
+                wait(pending)
+            if loop is not None and loop.is_running():
+                drain_future = self._submit(
+                    self._drain_loop_tasks(),
+                    allow_stopping=True,
+                )
+                drain_future.result()
+            if cleanup is not None and loop is not None and loop.is_running():
+                cleanup_future = self._submit(cleanup(), allow_stopping=True)
+                cleanup_future.result()
+        except BaseException as exc:
+            cleanup_error = exc
+        finally:
+            if loop is not None and loop.is_running():
+                loop.call_soon_threadsafe(loop.stop)
+            if thread is not None:
+                thread.join(timeout=timeout)
+
+        if thread is not None and thread.is_alive():
+            raise RuntimeError(
+                f"App async runtime thread did not stop within {timeout} seconds"
+            )
+        if cleanup_error is not None:
+            raise cleanup_error
+        with self._lock:
+            failure = self._failure
+        if failure is not None:
+            raise RuntimeError("App async runtime failed during shutdown") from failure
+
+    async def aclose(
+        self,
+        *,
+        cleanup: AsyncCleanup | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        """Asynchronously close without blocking the caller event loop."""
+        await asyncio.to_thread(self.close, cleanup=cleanup, timeout=timeout)
+
+
+_APP_ASYNC_RUNTIME: AppAsyncRuntime | None = None
+_APP_ASYNC_RUNTIME_LOCK = threading.RLock()
+
+
+def get_app_async_runtime() -> AppAsyncRuntime | None:
+    """Return the installed process runtime, if any."""
+    with _APP_ASYNC_RUNTIME_LOCK:
+        return _APP_ASYNC_RUNTIME
+
+
+def install_app_async_runtime(runtime: AppAsyncRuntime) -> None:
+    """Install the worker-owned runtime for application I/O routing."""
+    global _APP_ASYNC_RUNTIME
+    with _APP_ASYNC_RUNTIME_LOCK:
+        if _APP_ASYNC_RUNTIME is not None and _APP_ASYNC_RUNTIME is not runtime:
+            raise RuntimeError("A different app async runtime is already installed")
+        _APP_ASYNC_RUNTIME = runtime
+
+
+def uninstall_app_async_runtime(runtime: AppAsyncRuntime) -> None:
+    """Remove the installed runtime if it matches ``runtime``."""
+    global _APP_ASYNC_RUNTIME
+    with _APP_ASYNC_RUNTIME_LOCK:
+        if _APP_ASYNC_RUNTIME is runtime:
+            _APP_ASYNC_RUNTIME = None
+
+
+@contextmanager
+def use_app_async_runtime(runtime: AppAsyncRuntime) -> Iterator[AppAsyncRuntime]:
+    """Install a runtime for the duration of a worker lifecycle."""
+    install_app_async_runtime(runtime)
+    try:
+        yield runtime
+    finally:
+        uninstall_app_async_runtime(runtime)
+
+
+def run_sync[T](coro: Coroutine[Any, Any, T]) -> T:
+    """Run a coroutine on the installed app runtime from synchronous code."""
+    runtime = get_app_async_runtime()
+    if runtime is None:
+        coro.close()
+        raise RuntimeError("No app async runtime is installed")
+    return runtime.run_sync(coro)
+
+
+async def run_async[T](coro: Coroutine[Any, Any, T]) -> T:
+    """Route a coroutine through the app runtime when one is installed."""
+    runtime = get_app_async_runtime()
+    if runtime is None:
+        return await coro
+    return await runtime.run_async(coro)
+
+
+def run_on_app_async_runtime[**P, T](
+    func: Callable[P, Coroutine[Any, Any, T]],
+) -> Callable[P, Coroutine[Any, Any, T]]:
+    """Route an async function through the installed app runtime."""
+
+    @wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        return await run_async(func(*args, **kwargs))
+
+    return wrapper

--- a/tracecat/async_runtime.py
+++ b/tracecat/async_runtime.py
@@ -152,6 +152,8 @@ class AppAsyncRuntime:
             with self._lock:
                 self._loop = loop
                 self._thread_id = threading.get_ident()
+                if self._state is not AppAsyncRuntimeState.STARTING:
+                    return
             loop.call_soon(self._mark_running)
             loop.run_forever()
             with self._lock:

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import threading
-import weakref
-from collections.abc import Callable, Coroutine, Mapping
+from collections.abc import Callable, Mapping
 from typing import Any, cast
 
 import dateparser
@@ -15,6 +13,7 @@ from tracecat_ee.agent.schemas import AgentActionArgs, PresetAgentActionArgs
 from tracecat import config
 from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.preset.service import AgentPresetService
+from tracecat.async_runtime import run_sync as run_sync
 from tracecat.auth.types import Role
 from tracecat.common import is_iterable
 from tracecat.dsl.common import (
@@ -55,7 +54,9 @@ from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.collection import (
     materialize_collection_values,
+    materialize_collection_values_sync,
     store_collection,
+    store_collection_sync,
 )
 from tracecat.storage.object import (
     CollectionObject,
@@ -66,40 +67,11 @@ from tracecat.storage.object import (
     collection_item_key,
     get_object_storage,
     retrieve_stored_object,
+    retrieve_stored_object_sync,
 )
 from tracecat.storage.utils import is_retryable_storage_transport_error
 from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
-
-_thread_local = threading.local()
-
-
-def _close_asyncio_runner(runner: asyncio.Runner) -> None:
-    try:
-        runner.close()
-    except Exception as e:
-        logger.warning(
-            "Failed to close thread-local asyncio runner",
-            error=e,
-        )
-
-
-# ThreadPoolExecutor clears thread locals when worker threads exit; closing the
-# runner there lets storage loop-close hooks drain clients without per-call churn.
-class _ThreadLocalRunner:
-    def __init__(self) -> None:
-        runner = asyncio.Runner()
-        runner.__enter__()  # create & keep loop
-        self._runner = runner
-        self._finalizer = weakref.finalize(self, _close_asyncio_runner, runner)
-        self._finalizer.atexit = False
-
-    def run[T: Any](self, coro: Coroutine[Any, Any, T]) -> T:
-        return self._runner.run(coro)
-
-    def close(self) -> None:
-        if self._finalizer.alive:
-            self._finalizer()
 
 
 async def _resolve_mcp_integrations(
@@ -270,15 +242,6 @@ class PrepareSubflowActivityInput(BaseModel):
     """Use committed WorkflowDefinition alias (True) or draft Workflow alias (False)."""
 
 
-def run_sync[T: Any](coro: Coroutine[Any, Any, T]) -> T:
-    """Run a coroutine in the current thread."""
-    runner = getattr(_thread_local, "runner", None)
-    if runner is None:
-        runner = _ThreadLocalRunner()
-        _thread_local.runner = runner
-    return runner.run(coro)
-
-
 async def _store_collection_as_refs(prefix: str, items: list[Any]) -> CollectionObject:
     """Store collection items as StoredObject handles and persist refs in chunks."""
     storage = get_object_storage()
@@ -287,6 +250,19 @@ async def _store_collection_as_refs(prefix: str, items: list[Any]) -> Collection
         stored = await storage.store(collection_item_key(prefix, i), item)
         refs.append(stored.model_dump())
     return await store_collection(prefix, refs, element_kind="stored_object")
+
+
+def _store_collection_as_refs_sync(
+    prefix: str,
+    items: list[Any],
+) -> CollectionObject:
+    """Store collection items while keeping CPU work on the caller thread."""
+    storage = get_object_storage()
+    refs = [
+        storage.store_sync(collection_item_key(prefix, index), item).model_dump()
+        for index, item in enumerate(items)
+    ]
+    return store_collection_sync(prefix, refs, element_kind="stored_object")
 
 
 async def _materialize_task_result(task_result: TaskResult) -> MaterializedTaskResult:
@@ -320,6 +296,43 @@ async def _materialize_task_result(task_result: TaskResult) -> MaterializedTaskR
                 )
             else:
                 raw_result = await materialize_collection_values(collection)
+        case _:
+            raise TypeError(
+                "Expected TaskResult.result to be a StoredObject, "
+                f"got {type(task_result.result).__name__}"
+            )
+
+    return MaterializedTaskResult(
+        result=raw_result,
+        result_typename=task_result.result_typename,
+        error=task_result.error,
+        error_typename=task_result.error_typename,
+        interaction=task_result.interaction,
+        interaction_id=task_result.interaction_id,
+        interaction_type=task_result.interaction_type,
+    )
+
+
+def _materialize_task_result_sync(
+    task_result: TaskResult,
+) -> MaterializedTaskResult:
+    """Materialize a task result from a synchronous activity thread."""
+    storage = get_object_storage()
+    match task_result.result:
+        case InlineObject(data=data):
+            if task_result.collection_index is not None and isinstance(data, list):
+                raw_result = data[task_result.collection_index]
+            else:
+                raw_result = data
+        case ExternalObject():
+            raw_result = storage.retrieve_sync(task_result.result)
+        case CollectionObject() as collection:
+            if task_result.collection_index is not None:
+                raw_result = storage.retrieve_sync(
+                    collection.at(task_result.collection_index)
+                )
+            else:
+                raw_result = materialize_collection_values_sync(collection)
         case _:
             raise TypeError(
                 "Expected TaskResult.result to be a StoredObject, "
@@ -426,6 +439,53 @@ async def materialize_context(ctx: ExecutionContext) -> MaterializedExecutionCon
     return result
 
 
+def materialize_context_sync(
+    ctx: ExecutionContext,
+) -> MaterializedExecutionContext:
+    """Materialize context while keeping CPU work on the activity thread."""
+    result: MaterializedExecutionContext = {}
+    logger.debug("Materializing context", ctx=ctx, typ=type(ctx))
+
+    try:
+        if actions := ctx.get("ACTIONS"):
+            result["ACTIONS"] = {
+                ref: _materialize_task_result_sync(
+                    TaskResult.model_validate(task_result)
+                )
+                for ref, task_result in actions.items()
+            }
+        if trigger := ctx.get("TRIGGER"):
+            validated = StoredObjectValidator.validate_python(trigger)
+            result["TRIGGER"] = retrieve_stored_object_sync(validated)
+    except Exception as e:
+        retryable = is_retryable_storage_transport_error(e)
+        logger.warning(
+            "Error materializing context",
+            error=e,
+            retryable=retryable,
+        )
+        if retryable:
+            raise ApplicationError(
+                "Failed to materialize context",
+                non_retryable=False,
+                type="StorageMaterializationError",
+            ) from e
+        raise ApplicationError(
+            "Failed to materialize context",
+            non_retryable=True,
+        ) from e
+
+    if env := ctx.get("ENV"):
+        result["ENV"] = env
+    if secrets := ctx.get("SECRETS"):
+        result["SECRETS"] = secrets
+    if vars := ctx.get("VARS"):
+        result["VARS"] = vars
+    if var := ctx.get("var"):
+        result["var"] = var
+    return result
+
+
 class ValidateActionActivityInput(BaseModel):
     role: Role
     task: ActionStatement
@@ -511,7 +571,7 @@ class DSLActivities:
         to the calling workflow.
         """
         # Materialize any StoredObjects in operand
-        materialized = run_sync(materialize_context(operand))
+        materialized = materialize_context_sync(operand)
 
         expr_str = expression.strip()
 
@@ -539,9 +599,9 @@ class DSLActivities:
         that expressions evaluate against raw values even when results are externalized.
         """
         # Materialize any StoredObjects in operand
-        materialized = run_sync(materialize_context(input.operand))
+        materialized = materialize_context_sync(input.operand)
         result = eval_templated_object(input.obj, operand=materialized)
-        stored = run_sync(get_object_storage().store(input.key, result))
+        stored = get_object_storage().store_sync(input.key, result)
         return stored
 
     @staticmethod
@@ -568,7 +628,7 @@ class DSLActivities:
     ) -> int:
         """Evaluate for_each expression to get iteration count for looped subflows."""
         # Materialize any StoredObjects in operand
-        materialized = run_sync(materialize_context(input.operand))
+        materialized = materialize_context_sync(input.operand)
 
         # Get iterables from for_each expression
         iterators = get_iterables_from_expression(
@@ -765,9 +825,9 @@ class DSLActivities:
         that expressions evaluate against raw values even when results are externalized.
         """
         # Materialize any StoredObjects in operand
-        materialized = run_sync(materialize_context(input.operand))
+        materialized = materialize_context_sync(input.operand)
         result = eval_templated_object(input.obj, operand=materialized)
-        stored = run_sync(get_object_storage().store(input.key, result))
+        stored = get_object_storage().store_sync(input.key, result)
         return stored
 
     @staticmethod
@@ -780,9 +840,9 @@ class DSLActivities:
             value = {}
             storage = get_object_storage()
             if inputs.trigger_inputs is not None:
-                value = run_sync(storage.retrieve(inputs.trigger_inputs))
+                value = storage.retrieve_sync(inputs.trigger_inputs)
             normalized = normalize_trigger_inputs(inputs.input_schema, value)
-            stored = run_sync(storage.store(inputs.key, normalized))
+            stored = storage.store_sync(inputs.key, normalized)
             return stored
         except ValidationError as e:
             logger.info("Validation error when normalizing trigger inputs", error=e)
@@ -827,7 +887,7 @@ def _evaluate_scatter_input(input: ScatterActionInput) -> StoredObject:
     Returns CollectionObject if externalized, InlineObject otherwise.
     """
     # Materialize any StoredObjects in operand
-    materialized = run_sync(materialize_context(input.operand))
+    materialized = materialize_context_sync(input.operand)
     result = eval_templated_object(input.collection, operand=materialized)
 
     # Treat None as empty collection (will be handled by empty check below)
@@ -843,7 +903,7 @@ def _evaluate_scatter_input(input: ScatterActionInput) -> StoredObject:
     # Guard CollectionObject: only use chunked storage when externalization
     # is enabled. Fall back to inline list for non-externalized deployments.
     if config.TRACECAT__RESULT_EXTERNALIZATION_ENABLED:
-        return run_sync(_store_collection_as_refs(input.key, items))
+        return _store_collection_as_refs_sync(input.key, items)
     else:
         return InlineObject(data=items, typename="list")
 
@@ -931,7 +991,7 @@ def _resolve_subflow_batch(
         )
 
     # Materialize any StoredObjects in operand
-    materialized = run_sync(materialize_context(input.operand))
+    materialized = materialize_context_sync(input.operand)
 
     # Get iterables from for_each expression
     iterators = get_iterables_from_expression(expr=task.for_each, operand=materialized)
@@ -987,7 +1047,7 @@ def _resolve_subflow_batch(
     trigger_inputs_stored: list[StoredObject] = []
     for i, trigger_input in enumerate(trigger_inputs_list):
         key = collection_item_key(input.key, i)
-        stored = run_sync(storage.store(key, trigger_input))
+        stored = storage.store_sync(key, trigger_input)
         trigger_inputs_stored.append(stored)
 
     return ResolvedSubflowBatch(

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -1,8 +1,9 @@
 import asyncio
 import dataclasses
 import os
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from datetime import timedelta
 
 from temporalio import workflow
@@ -16,6 +17,7 @@ from tracecat import __version__ as APP_VERSION
 
 _MIN_CONCURRENT_ACTIVITIES = 1
 _MIN_CONCURRENT_WORKFLOW_TASKS = 2
+_APP_RUNTIME_WATCHDOG_INTERVAL_SECONDS = 5.0
 
 with workflow.unsafe.imports_passed_through():
     import sentry_sdk
@@ -25,7 +27,11 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_version_ref_activity,
     )
-    from tracecat.async_runtime import AppAsyncRuntime, use_app_async_runtime
+    from tracecat.async_runtime import (
+        AppAsyncRuntime,
+        AppAsyncRuntimeState,
+        use_app_async_runtime,
+    )
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.init_activities import (
@@ -106,6 +112,71 @@ def get_activities() -> list[Callable]:
     return activities
 
 
+async def _watch_app_async_runtime(
+    app_runtime: AppAsyncRuntime,
+    shutdown_event: asyncio.Event,
+    *,
+    interval_seconds: float,
+) -> None:
+    """Shut the worker down if it loses the app I/O runtime.
+
+    Every activity that touches blob storage depends on that runtime, so a dead
+    runtime would otherwise leave this process consuming task slots while
+    failing every storage activity. Request a graceful shutdown instead and let
+    the orchestrator restart the worker.
+    """
+    while not shutdown_event.is_set():
+        state = app_runtime.state
+        # Normal shutdown sets shutdown_event and cancels this task before the
+        # runtime enters STOPPING. Any non-RUNNING state here is unexpected.
+        if state is not AppAsyncRuntimeState.RUNNING:
+            logger.critical(
+                "App async runtime is no longer running; shutting down worker",
+                app_runtime_state=state.value,
+            )
+            shutdown_event.set()
+            return
+        try:
+            async with asyncio.timeout(interval_seconds):
+                await shutdown_event.wait()
+        except TimeoutError:
+            continue
+
+
+@asynccontextmanager
+async def _app_async_runtime_lifespan(
+    shutdown_event: asyncio.Event,
+    *,
+    watchdog_interval_seconds: float,
+) -> AsyncIterator[AppAsyncRuntime]:
+    """Own the worker's application runtime and its watchdog."""
+    app_runtime = AppAsyncRuntime(
+        name="tracecat-worker-app-io",
+        loop_factory=uvloop.new_event_loop,
+    )
+    app_runtime.start()
+    try:
+        with use_app_async_runtime(app_runtime):
+            runtime_watchdog = asyncio.create_task(
+                _watch_app_async_runtime(
+                    app_runtime,
+                    shutdown_event,
+                    interval_seconds=watchdog_interval_seconds,
+                ),
+                name="app-async-runtime-watchdog",
+            )
+            try:
+                yield app_runtime
+            finally:
+                runtime_watchdog.cancel()
+                try:
+                    await runtime_watchdog
+                except asyncio.CancelledError:
+                    pass
+    finally:
+        await app_runtime.aclose(cleanup=close_storage_client_cache)
+
+
 async def main(shutdown_event: asyncio.Event | None = None) -> None:
     if shutdown_event is None:
         shutdown_event = asyncio.Event()
@@ -162,44 +233,39 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
             "TEMPORAL__MAX_CONCURRENT_WORKFLOW_TASKS must be at least 2 when workflow caching is enabled."
         )
 
-    app_runtime = AppAsyncRuntime(
-        name="tracecat-worker-app-io",
-        loop_factory=uvloop.new_event_loop,
-    )
-    app_runtime.start()
-    try:
-        with use_app_async_runtime(app_runtime):
-            with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
-                workflows: list[type] = [DSLWorkflow]
+    async with _app_async_runtime_lifespan(
+        shutdown_event,
+        watchdog_interval_seconds=_APP_RUNTIME_WATCHDOG_INTERVAL_SECONDS,
+    ) as app_runtime:
+        with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
+            workflows: list[type] = [DSLWorkflow]
 
-                async with Worker(
-                    client,
-                    task_queue=os.environ.get(
-                        "TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"
-                    ),
-                    activities=activities,
-                    workflows=workflows,
-                    workflow_runner=new_sandbox_runner(),
-                    interceptors=interceptors,
+            async with Worker(
+                client,
+                task_queue=os.environ.get(
+                    "TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"
+                ),
+                activities=activities,
+                workflows=workflows,
+                workflow_runner=new_sandbox_runner(),
+                interceptors=interceptors,
+                disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
+                activity_executor=executor,
+                max_concurrent_activities=max_concurrent_activities,
+                max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
+                graceful_shutdown_timeout=timedelta(seconds=30),
+            ):
+                logger.info(
+                    "Worker started, ctrl+c to exit",
                     disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
-                    activity_executor=executor,
+                    threadpool_max_workers=threadpool_max_workers,
                     max_concurrent_activities=max_concurrent_activities,
                     max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
-                    graceful_shutdown_timeout=timedelta(seconds=30),
-                ):
-                    logger.info(
-                        "Worker started, ctrl+c to exit",
-                        disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
-                        threadpool_max_workers=threadpool_max_workers,
-                        max_concurrent_activities=max_concurrent_activities,
-                        max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
-                        app_io_thread_id=app_runtime.thread_id,
-                    )
-                    await shutdown_event.wait()
-                    logger.info("Worker shutdown requested")
-                logger.info("Temporal Worker context exited")
-    finally:
-        await app_runtime.aclose(cleanup=close_storage_client_cache)
+                    app_io_thread_id=app_runtime.thread_id,
+                )
+                await shutdown_event.wait()
+                logger.info("Worker shutdown requested")
+            logger.info("Temporal Worker context exited")
 
 
 if __name__ == "__main__":

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -25,6 +25,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_version_ref_activity,
     )
+    from tracecat.async_runtime import AppAsyncRuntime, use_app_async_runtime
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.init_activities import (
@@ -161,37 +162,44 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
             "TEMPORAL__MAX_CONCURRENT_WORKFLOW_TASKS must be at least 2 when workflow caching is enabled."
         )
 
+    app_runtime = AppAsyncRuntime(
+        name="tracecat-worker-app-io",
+        loop_factory=uvloop.new_event_loop,
+    )
+    app_runtime.start()
     try:
-        with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
-            workflows: list[type] = [DSLWorkflow]
+        with use_app_async_runtime(app_runtime):
+            with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
+                workflows: list[type] = [DSLWorkflow]
 
-            async with Worker(
-                client,
-                task_queue=os.environ.get(
-                    "TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"
-                ),
-                activities=activities,
-                workflows=workflows,
-                workflow_runner=new_sandbox_runner(),
-                interceptors=interceptors,
-                disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
-                activity_executor=executor,
-                max_concurrent_activities=max_concurrent_activities,
-                max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
-                graceful_shutdown_timeout=timedelta(seconds=30),
-            ):
-                logger.info(
-                    "Worker started, ctrl+c to exit",
+                async with Worker(
+                    client,
+                    task_queue=os.environ.get(
+                        "TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"
+                    ),
+                    activities=activities,
+                    workflows=workflows,
+                    workflow_runner=new_sandbox_runner(),
+                    interceptors=interceptors,
                     disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
-                    threadpool_max_workers=threadpool_max_workers,
+                    activity_executor=executor,
                     max_concurrent_activities=max_concurrent_activities,
                     max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
-                )
-                await shutdown_event.wait()
-                logger.info("Worker shutdown requested")
-            logger.info("Temporal Worker context exited")
+                    graceful_shutdown_timeout=timedelta(seconds=30),
+                ):
+                    logger.info(
+                        "Worker started, ctrl+c to exit",
+                        disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
+                        threadpool_max_workers=threadpool_max_workers,
+                        max_concurrent_activities=max_concurrent_activities,
+                        max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
+                        app_io_thread_id=app_runtime.thread_id,
+                    )
+                    await shutdown_event.wait()
+                    logger.info("Worker shutdown requested")
+                logger.info("Temporal Worker context exited")
     finally:
-        await close_storage_client_cache()
+        await app_runtime.aclose(cleanup=close_storage_client_cache)
 
 
 if __name__ == "__main__":

--- a/tracecat/storage/backends/inline.py
+++ b/tracecat/storage/backends/inline.py
@@ -27,8 +27,24 @@ class InlineObjectStorage(ObjectStorage):
         del key  # Unused in inline storage
         return InlineObject(data=data)
 
+    def store_sync(self, key: str, data: Any) -> StoredObject:
+        """Store data inline from a synchronous activity thread."""
+        del key
+        return InlineObject(data=data)
+
     async def retrieve(self, stored: StoredObject) -> Any:
         """Return inline data from StoredObject."""
+        match stored:
+            case InlineObject(data=data):
+                return data
+            case _:
+                raise NotImplementedError(
+                    f"InlineObjectStorage does not support {stored.type} references. "
+                    "This ref was created by a different storage backend."
+                )
+
+    def retrieve_sync(self, stored: StoredObject) -> Any:
+        """Return inline data from a synchronous activity thread."""
         match stored:
             case InlineObject(data=data):
                 return data

--- a/tracecat/storage/backends/s3.py
+++ b/tracecat/storage/backends/s3.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+from dataclasses import dataclass
 from typing import Any
 
+from tracecat.async_runtime import run_sync
 from tracecat.logger import logger
 from tracecat.storage import blob
 from tracecat.storage.collection import (
     get_collection_item,
+    get_collection_item_sync,
     materialize_collection_values,
+    materialize_collection_values_sync,
 )
 from tracecat.storage.object import (
     CollectionObject,
@@ -24,6 +29,27 @@ from tracecat.storage.utils import (
     deserialize_object,
     serialize_object,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedPayload:
+    content: bytes
+    sha256: str
+
+
+def _prepare_payload(data: Any) -> _PreparedPayload:
+    content = serialize_object(data)
+    return _PreparedPayload(content=content, sha256=compute_sha256(content))
+
+
+def _verify_and_deserialize(content: bytes, *, expected_sha256: str, key: str) -> Any:
+    actual_sha256 = compute_sha256(content)
+    if actual_sha256 != expected_sha256:
+        raise ValueError(
+            f"Integrity check failed for {key}: "
+            f"expected {expected_sha256}, got {actual_sha256}"
+        )
+    return deserialize_object(content)
 
 
 class S3ObjectStorage(ObjectStorage):
@@ -47,37 +73,31 @@ class S3ObjectStorage(ObjectStorage):
         self.bucket = bucket
         self.threshold_bytes = threshold_bytes
 
-    async def store(
+    def _inline_result(
         self,
+        *,
         key: str,
         data: Any,
-    ) -> StoredObject:
-        """Store data, externalizing if over threshold."""
-        # Serialize to JSON
-        serialized = serialize_object(data)
-        size_bytes = len(serialized)
-
-        # Keep inline if under threshold
-        if size_bytes <= self.threshold_bytes:
-            logger.debug(
-                "Keeping data inline",
-                key=key,
-                size_bytes=size_bytes,
-                threshold_bytes=self.threshold_bytes,
-            )
-            return InlineObject(data=data)
-
-        # Externalize to S3
-        sha256 = compute_sha256(serialized)
-
-        await blob.ensure_bucket_exists(self.bucket)
-        await blob.upload_file(
-            content=serialized,
+        size_bytes: int,
+    ) -> InlineObject | None:
+        if size_bytes > self.threshold_bytes:
+            return None
+        logger.debug(
+            "Keeping data inline",
             key=key,
-            bucket=self.bucket,
-            content_type="application/json",
+            size_bytes=size_bytes,
+            threshold_bytes=self.threshold_bytes,
         )
+        return InlineObject(data=data)
 
+    def _external_result(
+        self,
+        *,
+        key: str,
+        data: Any,
+        prepared: _PreparedPayload,
+    ) -> ExternalObject:
+        size_bytes = len(prepared.content)
         logger.info(
             "Externalized large object to S3",
             key=key,
@@ -85,18 +105,62 @@ class S3ObjectStorage(ObjectStorage):
             size_bytes=size_bytes,
             threshold_bytes=self.threshold_bytes,
         )
-
-        ref = ObjectRef(
-            backend="s3",
-            bucket=self.bucket,
-            key=key,
-            size_bytes=size_bytes,
-            sha256=sha256,
-            content_type="application/json",
-            encoding="json",
+        return ExternalObject(
+            ref=ObjectRef(
+                backend="s3",
+                bucket=self.bucket,
+                key=key,
+                size_bytes=size_bytes,
+                sha256=prepared.sha256,
+                content_type="application/json",
+                encoding="json",
+            ),
+            typename=type(data).__name__,
         )
 
-        return ExternalObject(ref=ref, typename=type(data).__name__)
+    async def store(
+        self,
+        key: str,
+        data: Any,
+    ) -> StoredObject:
+        """Store data, externalizing if over threshold."""
+        # Serialization and hashing can be substantial for multi-megabyte
+        # workflow payloads. Keep that CPU work off both the Temporal loop and
+        # the dedicated app I/O loop.
+        prepared = await asyncio.to_thread(_prepare_payload, data)
+        size_bytes = len(prepared.content)
+
+        if inline := self._inline_result(key=key, data=data, size_bytes=size_bytes):
+            return inline
+
+        # Externalize to S3
+        await blob.ensure_bucket_exists(self.bucket)
+        await blob.upload_file(
+            content=prepared.content,
+            key=key,
+            bucket=self.bucket,
+            content_type="application/json",
+        )
+
+        return self._external_result(key=key, data=data, prepared=prepared)
+
+    def store_sync(self, key: str, data: Any) -> StoredObject:
+        """Store data while keeping CPU work on the activity thread."""
+        prepared = _prepare_payload(data)
+        size_bytes = len(prepared.content)
+        if inline := self._inline_result(key=key, data=data, size_bytes=size_bytes):
+            return inline
+
+        run_sync(blob.ensure_bucket_exists(self.bucket))
+        run_sync(
+            blob.upload_file(
+                content=prepared.content,
+                key=key,
+                bucket=self.bucket,
+                content_type="application/json",
+            )
+        )
+        return self._external_result(key=key, data=data, prepared=prepared)
 
     async def retrieve(self, stored: StoredObject) -> Any:
         """Retrieve data from StoredObject (inline or from S3)."""
@@ -116,15 +180,14 @@ class S3ObjectStorage(ObjectStorage):
                     key=ref.key,
                 )
 
-                # Verify integrity (still needed - cache may return stale data on hash collision)
-                actual_sha256 = compute_sha256(content)
-                if actual_sha256 != ref.sha256:
-                    raise ValueError(
-                        f"Integrity check failed for {ref.key}: "
-                        f"expected {ref.sha256}, got {actual_sha256}"
-                    )
-
-                return deserialize_object(content)
+                # Integrity verification and JSON decoding are CPU work, so do
+                # not serialize concurrent large payloads on either event loop.
+                return await asyncio.to_thread(
+                    _verify_and_deserialize,
+                    content,
+                    expected_sha256=ref.sha256,
+                    key=ref.key,
+                )
             case CollectionObject() as coll:
                 if coll.index is not None:
                     # Retrieve specific item by index
@@ -132,3 +195,30 @@ class S3ObjectStorage(ObjectStorage):
                 else:
                     # Retrieve and materialize entire collection
                     return await materialize_collection_values(coll)
+
+    def retrieve_sync(self, stored: StoredObject) -> Any:
+        """Retrieve data while keeping verification on the activity thread."""
+        match stored:
+            case InlineObject(data=data):
+                return data
+            case ExternalObject(ref=ref):
+                if ref.backend != "s3":
+                    raise ValueError(
+                        f"S3ObjectStorage cannot retrieve from backend: {ref.backend}"
+                    )
+                content = run_sync(
+                    cached_blob_download(
+                        sha256=ref.sha256,
+                        bucket=ref.bucket,
+                        key=ref.key,
+                    )
+                )
+                return _verify_and_deserialize(
+                    content,
+                    expected_sha256=ref.sha256,
+                    key=ref.key,
+                )
+            case CollectionObject() as coll:
+                if coll.index is not None:
+                    return get_collection_item_sync(coll, coll.index)
+                return materialize_collection_values_sync(coll)

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -20,7 +20,9 @@ from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import ClientError
 
 from tracecat import config
+from tracecat.async_runtime import run_on_app_async_runtime
 from tracecat.logger import logger
+from tracecat.storage.transport import is_retryable_storage_transport_error
 
 if TYPE_CHECKING:
     from aiobotocore.response import StreamingBody
@@ -35,11 +37,13 @@ DEFAULT_DOWNLOAD_CHUNK_SIZE_BYTES = 8 * 1024 * 1024  # 8MB
 DEFAULT_UPLOAD_CHUNK_SIZE_BYTES = 8 * 1024 * 1024  # 8MB
 DEFAULT_UPLOAD_MAX_CONCURRENCY = 4
 DEFAULT_UPLOAD_MAX_IO_QUEUE_SIZE = 2
+STORAGE_CLIENT_MAX_POOL_CONNECTIONS = 10
 
 # Shared S3/MinIO client config: explicit standard-mode retries so transient
 # failures (throttling, 5xx, connection resets) are retried with backoff instead
 # of surfacing on the first error.
 _STORAGE_CLIENT_CONFIG = AioConfig(
+    max_pool_connections=STORAGE_CLIENT_MAX_POOL_CONNECTIONS,
     retries={
         # botocore's "max_attempts" means retries-after-initial; use
         # "total_max_attempts" so the knob is the total request count.
@@ -49,13 +53,28 @@ _STORAGE_CLIENT_CONFIG = AioConfig(
 )
 
 
-@dataclass
+@dataclass(eq=False, slots=True, weakref_slot=True)
 class _StorageClientEntry:
     context: AbstractAsyncContextManager[S3Client] | None = field(
         default=None, repr=False
     )
     client: S3Client | None = field(default=None, repr=False)
     lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+    idle: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+    active_users: int = 0
+    closing: bool = False
+
+    def __post_init__(self) -> None:
+        self.idle.set()
+
+
+@dataclass(frozen=True, slots=True)
+class StorageClientCacheHealth:
+    """Thread-safe storage-client ownership snapshot."""
+
+    loop_count: int
+    entered_client_count: int
+    active_user_count: int
 
 
 # aiobotocore clients own the aiohttp ClientSession/TCPConnector that opens file
@@ -65,6 +84,7 @@ class _StorageClientEntry:
 _STORAGE_CLIENTS: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, _StorageClientEntry
 ] = weakref.WeakKeyDictionary()
+_STORAGE_CLIENT_ENTRIES: weakref.WeakSet[_StorageClientEntry] = weakref.WeakSet()
 _STORAGE_CLIENT_CLOSE_HOOK_LOOPS: weakref.WeakSet[asyncio.AbstractEventLoop] = (
     weakref.WeakSet()
 )
@@ -94,28 +114,52 @@ def _create_storage_client_context() -> AbstractAsyncContextManager[S3Client]:
     return session.client("s3", config=_STORAGE_CLIENT_CONFIG)
 
 
-async def _get_storage_client() -> S3Client:
+async def _acquire_storage_client() -> tuple[_StorageClientEntry, S3Client]:
     loop = asyncio.get_running_loop()
-    with _STORAGE_CLIENTS_LOCK:
-        entry = _STORAGE_CLIENTS.get(loop)
-        if entry is None:
-            entry = _StorageClientEntry()
-            _STORAGE_CLIENTS[loop] = entry
-            _ensure_storage_client_loop_close_hook(loop)
+    while True:
+        with _STORAGE_CLIENTS_LOCK:
+            entry = _STORAGE_CLIENTS.get(loop)
+            if entry is None:
+                entry = _StorageClientEntry()
+                _STORAGE_CLIENTS[loop] = entry
+                _STORAGE_CLIENT_ENTRIES.add(entry)
+                _ensure_storage_client_loop_close_hook(loop)
 
-    async with entry.lock:
-        client = entry.client
-        if client is None:
-            context = _create_storage_client_context()
-            try:
-                client = await context.__aenter__()
-            except Exception:
-                entry.context = None
-                entry.client = None
-                raise
-            entry.context = context
-            entry.client = client
-        return client
+        async with entry.lock:
+            # Invalidation removes an entry before waiting for its active users.
+            # A caller that captured that entry just before removal must retry
+            # against the replacement instead of acquiring a closing client.
+            if entry.closing:
+                continue
+            client = entry.client
+            if client is None:
+                context = _create_storage_client_context()
+                try:
+                    client = await context.__aenter__()
+                except Exception:
+                    with _STORAGE_CLIENTS_LOCK:
+                        entry.context = None
+                        entry.client = None
+                    raise
+                with _STORAGE_CLIENTS_LOCK:
+                    entry.context = context
+                    entry.client = client
+            with _STORAGE_CLIENTS_LOCK:
+                entry.active_users += 1
+                entry.idle.clear()
+            return entry, client
+
+
+def _release_storage_client(entry: _StorageClientEntry) -> None:
+    # Every entry is owned by one event loop, so release is deliberately
+    # synchronous. A second cancellation cannot interrupt lease accounting and
+    # leave shutdown waiting forever for an already-exited operation.
+    with _STORAGE_CLIENTS_LOCK:
+        entry.active_users -= 1
+        if entry.active_users < 0:
+            raise RuntimeError("Storage client active-user count became negative")
+        if entry.active_users == 0:
+            entry.idle.set()
 
 
 def clear_storage_session_cache() -> None:
@@ -129,10 +173,29 @@ def clear_storage_session_cache() -> None:
         _STORAGE_CLIENTS.clear()
 
 
+def storage_client_cache_health() -> StorageClientCacheHealth:
+    """Return the number of owning loops and entered storage clients."""
+    with _STORAGE_CLIENTS_LOCK:
+        loop_count = len(_STORAGE_CLIENTS)
+        entries = list(_STORAGE_CLIENT_ENTRIES)
+    return StorageClientCacheHealth(
+        loop_count=loop_count,
+        entered_client_count=sum(entry.client is not None for entry in entries),
+        active_user_count=sum(entry.active_users for entry in entries),
+    )
+
+
 def _pop_storage_client_entries_for_loop_shutdown(
     loop: asyncio.AbstractEventLoop,
+    *,
+    expected_entry: _StorageClientEntry | None = None,
 ) -> list[_StorageClientEntry]:
     with _STORAGE_CLIENTS_LOCK:
+        if (
+            expected_entry is not None
+            and _STORAGE_CLIENTS.get(loop) is not expected_entry
+        ):
+            return []
         entry = _STORAGE_CLIENTS.pop(loop, None)
     return [entry] if entry is not None else []
 
@@ -153,11 +216,16 @@ def _pop_storage_client_entries_for_cache_shutdown(
 
 async def _close_storage_client_entry(entry: _StorageClientEntry) -> None:
     async with entry.lock:
-        context = entry.context
-        entry.context = None
-        entry.client = None
+        entry.closing = True
+    await entry.idle.wait()
+    async with entry.lock:
+        with _STORAGE_CLIENTS_LOCK:
+            context = entry.context
         if context is not None:
             await context.__aexit__(None, None, None)
+        with _STORAGE_CLIENTS_LOCK:
+            entry.context = None
+            entry.client = None
 
 
 async def _close_storage_client_entries(
@@ -204,6 +272,29 @@ async def close_storage_client_cache() -> None:
     await _close_storage_client_entries(entries)
 
 
+async def _invalidate_storage_client_for_current_loop(
+    *,
+    expected_entry: _StorageClientEntry | None = None,
+) -> None:
+    loop = asyncio.get_running_loop()
+    entries = _pop_storage_client_entries_for_loop_shutdown(
+        loop,
+        expected_entry=expected_entry,
+    )
+    await _close_storage_client_entries(entries)
+
+
+@run_on_app_async_runtime
+async def invalidate_storage_client() -> None:
+    """Discard the current loop's client after a transport failure.
+
+    The next storage operation creates and enters a fresh client on the same
+    owning loop. This must execute on the app runtime when one is installed so
+    a caller never tries to close a client owned by another event loop.
+    """
+    await _invalidate_storage_client_for_current_loop()
+
+
 @asynccontextmanager
 async def get_storage_client() -> AsyncIterator[S3Client]:
     """Get a configured S3 client for either AWS S3.
@@ -211,9 +302,28 @@ async def get_storage_client() -> AsyncIterator[S3Client]:
     Yields:
         Configured aioboto3 S3 client
     """
-    yield await _get_storage_client()
+    entry, client = await _acquire_storage_client()
+    transport_failed = False
+    try:
+        yield client
+    except Exception as exc:
+        # Only transport failures retire the connector; S3 service responses
+        # and application errors leave the healthy client reusable.
+        transport_failed = is_retryable_storage_transport_error(exc)
+        raise
+    finally:
+        _release_storage_client(entry)
+        if transport_failed:
+            try:
+                await _invalidate_storage_client_for_current_loop(expected_entry=entry)
+            except Exception as close_error:
+                logger.warning(
+                    "Failed to invalidate storage client after transport error",
+                    error=close_error,
+                )
 
 
+@run_on_app_async_runtime
 async def ensure_bucket_exists(bucket: str) -> None:
     """Ensure the storage bucket exists, creating it if necessary.
 
@@ -248,6 +358,7 @@ async def ensure_bucket_exists(bucket: str) -> None:
                 raise
 
 
+@run_on_app_async_runtime
 async def get_bucket_lifecycle(
     bucket: str,
 ) -> GetBucketLifecycleConfigurationOutputTypeDef | None:
@@ -277,6 +388,7 @@ async def get_bucket_lifecycle(
             raise
 
 
+@run_on_app_async_runtime
 async def configure_bucket_lifecycle(
     bucket: str,
     expiration_days: int,
@@ -346,6 +458,7 @@ async def configure_bucket_lifecycle(
             raise
 
 
+@run_on_app_async_runtime
 async def generate_presigned_download_url(
     key: str,
     bucket: str,
@@ -409,6 +522,7 @@ async def generate_presigned_download_url(
             raise
 
 
+@run_on_app_async_runtime
 async def generate_presigned_upload_url(
     key: str,
     bucket: str,
@@ -460,6 +574,7 @@ async def generate_presigned_upload_url(
             raise
 
 
+@run_on_app_async_runtime
 async def upload_file(
     content: bytes,
     key: str,
@@ -505,6 +620,7 @@ async def upload_file(
         raise
 
 
+@run_on_app_async_runtime
 async def upload_file_from_path(
     path: Path,
     key: str,
@@ -562,6 +678,7 @@ async def upload_file_from_path(
         raise
 
 
+@run_on_app_async_runtime
 async def copy_file(
     *,
     source_key: str,
@@ -600,6 +717,7 @@ async def copy_file(
         raise
 
 
+@run_on_app_async_runtime
 async def download_file(key: str, bucket: str) -> bytes:
     """Download a file from S3.
 
@@ -627,6 +745,7 @@ async def download_file(key: str, bucket: str) -> bytes:
     return content
 
 
+@run_on_app_async_runtime
 async def download_file_range(
     *,
     key: str,
@@ -750,6 +869,7 @@ async def open_download_stream(
         raise
 
 
+@run_on_app_async_runtime
 async def download_file_to_path(
     *,
     key: str,
@@ -839,6 +959,7 @@ async def download_file_to_path(
     return bytes_written
 
 
+@run_on_app_async_runtime
 async def delete_file(key: str, bucket: str) -> None:
     """Delete a file from S3.
 
@@ -868,6 +989,7 @@ async def delete_file(key: str, bucket: str) -> None:
         raise
 
 
+@run_on_app_async_runtime
 async def file_exists(key: str, bucket: str) -> bool:
     """Check if a file exists in S3.
 
@@ -888,6 +1010,7 @@ async def file_exists(key: str, bucket: str) -> bool:
         raise
 
 
+@run_on_app_async_runtime
 async def select_object_content(
     key: str,
     bucket: str,

--- a/tracecat/storage/collection.py
+++ b/tracecat/storage/collection.py
@@ -19,14 +19,17 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import math
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel
 from temporalio import activity
 
 from tracecat import config
+from tracecat.async_runtime import run_sync
 from tracecat.logger import logger
 from tracecat.storage import blob
 from tracecat.storage.object import (
@@ -34,6 +37,7 @@ from tracecat.storage.object import (
     ObjectRef,
     StoredObjectValidator,
     retrieve_stored_object,
+    retrieve_stored_object_sync,
 )
 from tracecat.storage.utils import (
     cached_blob_download,
@@ -93,6 +97,86 @@ class CollectionChunkV1(BaseModel):
     """Items in this chunk. Type depends on manifest's element_kind."""
 
 
+@dataclass(frozen=True, slots=True)
+class _PreparedCollectionBlob:
+    key: str
+    content: bytes
+    ref: ObjectRef
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedCollectionManifest:
+    value: CollectionObject
+    blob: _PreparedCollectionBlob
+
+
+def _prepare_collection_chunk(
+    *,
+    prefix: str,
+    index: int,
+    start: int,
+    items: list[Any],
+    bucket: str,
+) -> _PreparedCollectionBlob:
+    """Serialize and hash one collection chunk without performing I/O."""
+    chunk = CollectionChunkV1(start=start, items=items)
+    key = f"{prefix}/chunks/{index}.json"
+    content = serialize_object(chunk.model_dump())
+    ref = ObjectRef(
+        backend="s3",
+        bucket=bucket,
+        key=key,
+        size_bytes=len(content),
+        sha256=compute_sha256(content),
+        content_type="application/json",
+        encoding="json",
+    )
+    return _PreparedCollectionBlob(key=key, content=content, ref=ref)
+
+
+def _prepare_collection_manifest(
+    *,
+    prefix: str,
+    count: int,
+    chunk_size: int,
+    element_kind: Literal["value", "stored_object"],
+    chunk_refs: list[ObjectRef],
+    bucket: str,
+) -> _PreparedCollectionManifest:
+    """Serialize and hash a collection manifest without performing I/O."""
+    manifest = CollectionManifestV1(
+        count=count,
+        chunk_size=chunk_size,
+        element_kind=element_kind,
+        chunks=chunk_refs,
+    )
+    manifest_key = f"{prefix}/manifest.json"
+    manifest_bytes = serialize_object(manifest.model_dump())
+    manifest_ref = ObjectRef(
+        backend="s3",
+        bucket=bucket,
+        key=manifest_key,
+        size_bytes=len(manifest_bytes),
+        sha256=compute_sha256(manifest_bytes),
+        content_type="application/json",
+        encoding="json",
+    )
+    return _PreparedCollectionManifest(
+        value=CollectionObject(
+            manifest_ref=manifest_ref,
+            count=count,
+            chunk_size=chunk_size,
+            element_kind=element_kind,
+            typename="list",
+        ),
+        blob=_PreparedCollectionBlob(
+            key=manifest_key,
+            content=manifest_bytes,
+            ref=manifest_ref,
+        ),
+    )
+
+
 # === Storage Functions === #
 
 
@@ -119,95 +203,129 @@ async def store_collection(
         CollectionObject handle suitable for workflow history.
     """
 
-    chunk_size = chunk_size or config.TRACECAT__COLLECTION_CHUNK_SIZE
-    bucket = bucket or config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW
-
+    resolved_chunk_size = chunk_size or config.TRACECAT__COLLECTION_CHUNK_SIZE
+    resolved_bucket = bucket or config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW
     count = len(items)
-    num_chunks = math.ceil(count / chunk_size) if count > 0 else 1
+    num_chunks = math.ceil(count / resolved_chunk_size) if count > 0 else 1
 
     logger.debug(
         "Storing collection",
         prefix=prefix,
         count=count,
-        chunk_size=chunk_size,
+        chunk_size=resolved_chunk_size,
         num_chunks=num_chunks,
     )
 
-    await blob.ensure_bucket_exists(bucket)
-
-    # Upload chunks
+    await blob.ensure_bucket_exists(resolved_bucket)
     chunk_refs: list[ObjectRef] = []
-    for i in range(num_chunks):
-        start = i * chunk_size
-        end = min(start + chunk_size, count)
-        chunk_items = items[start:end]
-
-        chunk = CollectionChunkV1(
+    for index in range(num_chunks):
+        start = index * resolved_chunk_size
+        end = min(start + resolved_chunk_size, count)
+        prepared_blob = await asyncio.to_thread(
+            _prepare_collection_chunk,
+            prefix=prefix,
+            index=index,
             start=start,
-            items=chunk_items,
+            items=items[start:end],
+            bucket=resolved_bucket,
         )
-        chunk_key = f"{prefix}/chunks/{i}.json"
-        chunk_bytes = serialize_object(chunk.model_dump())
-
         await blob.upload_file(
-            content=chunk_bytes,
-            key=chunk_key,
-            bucket=bucket,
+            content=prepared_blob.content,
+            key=prepared_blob.key,
+            bucket=resolved_bucket,
             content_type="application/json",
         )
+        chunk_refs.append(prepared_blob.ref)
 
-        chunk_ref = ObjectRef(
-            backend="s3",
-            bucket=bucket,
-            key=chunk_key,
-            size_bytes=len(chunk_bytes),
-            sha256=compute_sha256(chunk_bytes),
-            content_type="application/json",
-            encoding="json",
-        )
-        chunk_refs.append(chunk_ref)
-
-    # Upload manifest
-    manifest = CollectionManifestV1(
+    prepared_manifest = await asyncio.to_thread(
+        _prepare_collection_manifest,
+        prefix=prefix,
         count=count,
-        chunk_size=chunk_size,
+        chunk_size=resolved_chunk_size,
         element_kind=element_kind,
-        chunks=chunk_refs,
+        chunk_refs=chunk_refs,
+        bucket=resolved_bucket,
     )
-    manifest_key = f"{prefix}/manifest.json"
-    manifest_bytes = serialize_object(manifest.model_dump())
-
     await blob.upload_file(
-        content=manifest_bytes,
-        key=manifest_key,
-        bucket=bucket,
+        content=prepared_manifest.blob.content,
+        key=prepared_manifest.blob.key,
+        bucket=resolved_bucket,
         content_type="application/json",
-    )
-
-    manifest_ref = ObjectRef(
-        backend="s3",
-        bucket=bucket,
-        key=manifest_key,
-        size_bytes=len(manifest_bytes),
-        sha256=compute_sha256(manifest_bytes),
-        content_type="application/json",
-        encoding="json",
     )
 
     logger.info(
         "Stored collection manifest",
         prefix=prefix,
         count=count,
-        num_chunks=len(chunk_refs),
+        num_chunks=num_chunks,
     )
+    return prepared_manifest.value
 
-    return CollectionObject(
-        manifest_ref=manifest_ref,
+
+def store_collection_sync(
+    prefix: str,
+    items: list[Any],
+    element_kind: Literal["value", "stored_object"] = "value",
+    chunk_size: int | None = None,
+    bucket: str | None = None,
+) -> CollectionObject:
+    """Store a collection from a synchronous activity thread."""
+    resolved_chunk_size = chunk_size or config.TRACECAT__COLLECTION_CHUNK_SIZE
+    resolved_bucket = bucket or config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW
+    count = len(items)
+    num_chunks = math.ceil(count / resolved_chunk_size) if count > 0 else 1
+    logger.debug(
+        "Storing collection",
+        prefix=prefix,
         count=count,
-        chunk_size=chunk_size,
-        element_kind=element_kind,
-        typename="list",
+        chunk_size=resolved_chunk_size,
+        num_chunks=num_chunks,
     )
+    run_sync(blob.ensure_bucket_exists(resolved_bucket))
+    chunk_refs: list[ObjectRef] = []
+    for index in range(num_chunks):
+        start = index * resolved_chunk_size
+        end = min(start + resolved_chunk_size, count)
+        prepared_blob = _prepare_collection_chunk(
+            prefix=prefix,
+            index=index,
+            start=start,
+            items=items[start:end],
+            bucket=resolved_bucket,
+        )
+        run_sync(
+            blob.upload_file(
+                content=prepared_blob.content,
+                key=prepared_blob.key,
+                bucket=resolved_bucket,
+                content_type="application/json",
+            )
+        )
+        chunk_refs.append(prepared_blob.ref)
+
+    prepared_manifest = _prepare_collection_manifest(
+        prefix=prefix,
+        count=count,
+        chunk_size=resolved_chunk_size,
+        element_kind=element_kind,
+        chunk_refs=chunk_refs,
+        bucket=resolved_bucket,
+    )
+    run_sync(
+        blob.upload_file(
+            content=prepared_manifest.blob.content,
+            key=prepared_manifest.blob.key,
+            bucket=resolved_bucket,
+            content_type="application/json",
+        )
+    )
+    logger.info(
+        "Stored collection manifest",
+        prefix=prefix,
+        count=count,
+        num_chunks=num_chunks,
+    )
+    return prepared_manifest.value
 
 
 async def _fetch_manifest(collection: CollectionObject) -> CollectionManifestV1:
@@ -218,14 +336,34 @@ async def _fetch_manifest(collection: CollectionObject) -> CollectionManifestV1:
         key=collection.manifest_ref.key,
     )
 
-    # Verify integrity
+    return await asyncio.to_thread(
+        _parse_manifest,
+        content,
+        collection.manifest_ref,
+    )
+
+
+def _fetch_manifest_sync(collection: CollectionObject) -> CollectionManifestV1:
+    """Fetch and parse a manifest from a synchronous activity thread."""
+    ref = collection.manifest_ref
+    content = run_sync(
+        cached_blob_download(
+            sha256=ref.sha256,
+            bucket=ref.bucket,
+            key=ref.key,
+        )
+    )
+    return _parse_manifest(content, ref)
+
+
+def _parse_manifest(content: bytes, ref: ObjectRef) -> CollectionManifestV1:
+    """Validate and parse collection-manifest bytes."""
     actual_sha256 = compute_sha256(content)
-    if actual_sha256 != collection.manifest_ref.sha256:
+    if actual_sha256 != ref.sha256:
         raise ValueError(
-            f"Manifest integrity check failed: expected {collection.manifest_ref.sha256}, "
+            f"Manifest integrity check failed: expected {ref.sha256}, "
             f"got {actual_sha256}"
         )
-
     data = deserialize_object(content)
     return CollectionManifestV1.model_validate(data)
 
@@ -238,7 +376,23 @@ async def _fetch_chunk(ref: ObjectRef) -> CollectionChunkV1:
         key=ref.key,
     )
 
-    # Verify integrity
+    return await asyncio.to_thread(_parse_chunk, content, ref)
+
+
+def _fetch_chunk_sync(ref: ObjectRef) -> CollectionChunkV1:
+    """Fetch and parse a chunk from a synchronous activity thread."""
+    content = run_sync(
+        cached_blob_download(
+            sha256=ref.sha256,
+            bucket=ref.bucket,
+            key=ref.key,
+        )
+    )
+    return _parse_chunk(content, ref)
+
+
+def _parse_chunk(content: bytes, ref: ObjectRef) -> CollectionChunkV1:
+    """Validate and parse collection-chunk bytes."""
     actual_sha256 = compute_sha256(content)
     if actual_sha256 != ref.sha256:
         raise ValueError(
@@ -260,6 +414,16 @@ async def _fetch_chunk_item(ref: ObjectRef, local_index: int) -> Any:
         The item at the given index.
     """
     chunk = await _fetch_chunk(ref)
+    if local_index < 0 or local_index >= len(chunk.items):
+        raise IndexError(
+            f"Chunk index {local_index} out of range for chunk with {len(chunk.items)} items"
+        )
+    return chunk.items[local_index]
+
+
+def _fetch_chunk_item_sync(ref: ObjectRef, local_index: int) -> Any:
+    """Fetch one chunk item from a synchronous activity thread."""
+    chunk = _fetch_chunk_sync(ref)
     if local_index < 0 or local_index >= len(chunk.items):
         raise IndexError(
             f"Chunk index {local_index} out of range for chunk with {len(chunk.items)} items"
@@ -314,6 +478,33 @@ async def get_collection_page(
     return items
 
 
+def get_collection_page_sync(
+    collection: CollectionObject,
+    offset: int = 0,
+    limit: int | None = None,
+) -> list[Any]:
+    """Get a collection page from a synchronous activity thread."""
+    if offset < 0:
+        raise ValueError(f"offset must be >= 0, got {offset}")
+    if offset >= collection.count or limit == 0:
+        return []
+
+    resolved_limit = collection.count - offset if limit is None else limit
+    end = min(offset + resolved_limit, collection.count)
+    manifest = _fetch_manifest_sync(collection)
+    start_chunk = offset // collection.chunk_size
+    end_chunk = (end - 1) // collection.chunk_size
+
+    items: list[Any] = []
+    for chunk_idx in range(start_chunk, end_chunk + 1):
+        chunk = _fetch_chunk_sync(manifest.chunks[chunk_idx])
+        chunk_start = chunk_idx * collection.chunk_size
+        local_start = max(0, offset - chunk_start)
+        local_end = min(len(chunk.items), end - chunk_start)
+        items.extend(chunk.items[local_start:local_end])
+    return items
+
+
 async def get_collection_item(collection: CollectionObject, index: int) -> Any:
     """Get a single item from a collection by index.
 
@@ -349,6 +540,26 @@ async def get_collection_item(collection: CollectionObject, index: int) -> Any:
     return await retrieve_stored_object(stored)
 
 
+def get_collection_item_sync(collection: CollectionObject, index: int) -> Any:
+    """Get one collection item from a synchronous activity thread."""
+    if index < 0:
+        index = collection.count + index
+    if index < 0 or index >= collection.count:
+        raise IndexError(
+            f"Collection index {index} out of range [0, {collection.count})"
+        )
+
+    manifest = _fetch_manifest_sync(collection)
+    chunk_idx = index // collection.chunk_size
+    local_idx = index % collection.chunk_size
+    item = _fetch_chunk_item_sync(manifest.chunks[chunk_idx], local_idx)
+    if collection.element_kind == "value":
+        return item
+
+    stored = StoredObjectValidator.validate_python(item)
+    return retrieve_stored_object_sync(stored)
+
+
 async def materialize_collection_values(
     collection: CollectionObject,
     offset: int = 0,
@@ -381,6 +592,23 @@ async def materialize_collection_values(
         value = await retrieve_stored_object(stored)
         values.append(value)
 
+    return values
+
+
+def materialize_collection_values_sync(
+    collection: CollectionObject,
+    offset: int = 0,
+    limit: int | None = None,
+) -> list[Any]:
+    """Materialize collection values from a synchronous activity thread."""
+    items = get_collection_page_sync(collection, offset, limit)
+    if collection.element_kind == "value":
+        return items
+
+    values: list[Any] = []
+    for item in items:
+        stored = StoredObjectValidator.validate_python(item)
+        values.append(retrieve_stored_object_sync(stored))
     return values
 
 

--- a/tracecat/storage/object.py
+++ b/tracecat/storage/object.py
@@ -39,6 +39,7 @@ from pydantic import (
 )
 
 from tracecat import config
+from tracecat.async_runtime import run_sync
 from tracecat.logger import logger
 
 # === Types === #
@@ -276,6 +277,19 @@ class ObjectStorage(ABC):
         """
         raise NotImplementedError
 
+    def store_sync(
+        self,
+        key: str,
+        data: Any,
+    ) -> StoredObject:
+        """Store data from a synchronous activity thread.
+
+        Built-in backends override this to keep CPU work on the caller thread.
+        The fallback preserves compatibility for custom async-only backends by
+        bridging their coroutine onto the application runtime.
+        """
+        return run_sync(self.store(key, data))
+
     @abstractmethod
     async def retrieve(self, stored: StoredObject) -> Any:
         """Retrieve data from a StoredObject.
@@ -291,6 +305,13 @@ class ObjectStorage(ABC):
             FileNotFoundError: If the object doesn't exist (for externalized data)
         """
         raise NotImplementedError
+
+    def retrieve_sync(self, stored: StoredObject) -> Any:
+        """Retrieve data from a synchronous activity thread.
+
+        Built-in backends override this to keep CPU work on the caller thread.
+        """
+        return run_sync(self.retrieve(stored))
 
 
 def get_object_storage_for(stored: StoredObject) -> ObjectStorage:
@@ -321,6 +342,18 @@ async def retrieve_stored_object(stored: StoredObject) -> Any:
         case ExternalObject() | CollectionObject():
             storage = get_object_storage_for(stored)
             return await storage.retrieve(stored)
+        case _:
+            raise TypeError(f"Expected StoredObject, got {type(stored).__name__}")
+
+
+def retrieve_stored_object_sync(stored: StoredObject) -> Any:
+    """Retrieve a StoredObject from a synchronous activity thread."""
+    match stored:
+        case InlineObject(data=data):
+            return data
+        case ExternalObject() | CollectionObject():
+            storage = get_object_storage_for(stored)
+            return storage.retrieve_sync(stored)
         case _:
             raise TypeError(f"Expected StoredObject, got {type(stored).__name__}")
 

--- a/tracecat/storage/transport.py
+++ b/tracecat/storage/transport.py
@@ -1,0 +1,31 @@
+"""Transport-error classification shared by blob storage layers."""
+
+from __future__ import annotations
+
+from botocore.exceptions import HTTPClientError
+
+
+def is_retryable_storage_transport_error(exc: BaseException) -> bool:
+    """Return true for transient blob-storage transport failures.
+
+    This deliberately excludes S3 service responses, missing objects,
+    integrity failures, validation failures, and user/data errors. Exception
+    chains are traversed so callers can preserve domain-specific wrappers.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException | None] = [exc]
+    while stack:
+        current = stack.pop()
+        if current is None:
+            continue
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+        if isinstance(current, HTTPClientError):
+            return True
+        if isinstance(current, BaseExceptionGroup):
+            stack.extend(current.exceptions)
+        stack.append(current.__cause__)
+        stack.append(current.__context__)
+    return False

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -8,14 +8,15 @@ import math
 import threading
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import orjson
-from botocore.exceptions import HTTPClientError
 from cachetools import TTLCache
 
 from tracecat.logger import logger
 from tracecat.storage import blob
+from tracecat.storage.transport import is_retryable_storage_transport_error
 
 if TYPE_CHECKING:
     from tracecat.storage.object import InlineObject, StoredObject
@@ -26,33 +27,6 @@ BLOB_CACHE_MAX_BYTES = 500 * 1024 * 1024  # 500 MB total pool
 BLOB_CACHE_TTL = 300.0  # 5 minutes
 STORAGE_TRANSPORT_RETRY_ATTEMPTS = 3
 STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS = 0.25
-
-
-def is_retryable_storage_transport_error(exc: BaseException) -> bool:
-    """Return true for transient blob-storage transport failures.
-
-    Keep this deliberately narrow: retry aiobotocore/botocore HTTP client
-    transport failures, but do not retry S3 service errors, missing objects,
-    integrity failures, validation errors, or user/data errors. Walk the
-    exception chain so a wrapped transport error is still detected.
-    """
-    seen: set[int] = set()
-    stack: list[BaseException | None] = [exc]
-    while stack:
-        current = stack.pop()
-        if current is None:
-            continue
-        current_id = id(current)
-        if current_id in seen:
-            continue
-        seen.add(current_id)
-        if isinstance(current, HTTPClientError):
-            return True
-        if isinstance(current, BaseExceptionGroup):
-            stack.extend(current.exceptions)
-        stack.append(current.__cause__)
-        stack.append(current.__context__)
-    return False
 
 
 async def retry_storage_transport_error[T](
@@ -126,6 +100,15 @@ class SizedMemoryCache:
                     max_bytes=self._max_bytes,
                 )
 
+    async def clear(self) -> None:
+        """Clear all entries while preserving the cache allocation."""
+        await asyncio.to_thread(self.clear_sync)
+
+    def clear_sync(self) -> None:
+        """Clear all entries from a synchronous caller."""
+        with self._lock:
+            self._cache.clear()
+
     @property
     def total_bytes(self) -> int:
         with self._lock:
@@ -139,6 +122,11 @@ class SizedMemoryCache:
 
 # Module-level cache for blob downloads and S3 Select results
 _blob_cache = SizedMemoryCache(max_bytes=BLOB_CACHE_MAX_BYTES, ttl=BLOB_CACHE_TTL)
+
+
+async def clear_blob_cache() -> None:
+    """Clear process-local materialized blob bytes."""
+    await _blob_cache.clear()
 
 
 def serialize_object(data: Any) -> bytes:
@@ -175,6 +163,18 @@ def compute_sha256(content: bytes) -> str:
         Hex-encoded SHA-256 hash
     """
     return hashlib.sha256(content).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedSelectValue:
+    value: Any
+    content: bytes
+
+
+def _prepare_select_value(result_bytes: bytes) -> _PreparedSelectValue:
+    data = deserialize_object(result_bytes)
+    value = data.get("_1")
+    return _PreparedSelectValue(value=value, content=serialize_object(value))
 
 
 async def cached_blob_download(sha256: str, bucket: str, key: str) -> bytes:
@@ -243,7 +243,7 @@ async def cached_select_item(
     cached = await _blob_cache.get(cache_key)
     if cached is not None:
         logger.debug("Select cache hit", sha256=sha256[:16], index=local_index)
-        return deserialize_object(cached)
+        return await asyncio.to_thread(deserialize_object, cached)
 
     expression = f"SELECT s.items[{local_index}] FROM s3object s"
     result_bytes = await retry_storage_transport_error(
@@ -257,24 +257,21 @@ async def cached_select_item(
         bucket=bucket,
     )
 
-    # S3 Select returns {"_1": <item>} for indexed array access
-    data = deserialize_object(result_bytes)
-    item = data.get("_1")
-
-    # Serialize item for byte-aware cache
-    item_bytes = serialize_object(item)
-    if len(item_bytes) <= MAX_CACHEABLE_BLOB_SIZE:
-        await _blob_cache.set(cache_key, item_bytes)
+    # S3 Select returns {"_1": <item>} for indexed array access. Keep JSON
+    # parsing/serialization off both application event loops.
+    prepared = await asyncio.to_thread(_prepare_select_value, result_bytes)
+    if len(prepared.content) <= MAX_CACHEABLE_BLOB_SIZE:
+        await _blob_cache.set(cache_key, prepared.content)
         logger.debug("Cached select item", sha256=sha256[:16], index=local_index)
     else:
         logger.debug(
             "Select item too large to cache",
             sha256=sha256[:16],
             index=local_index,
-            size_bytes=len(item_bytes),
+            size_bytes=len(prepared.content),
             max_size=MAX_CACHEABLE_BLOB_SIZE,
         )
-    return item
+    return prepared.value
 
 
 async def resolve_to_inline(stored: StoredObject) -> InlineObject:


### PR DESCRIPTION
## Summary

- Route worker blob-storage I/O through one process-owned `AppAsyncRuntime` running uvloop.
- Reuse one loop-affine aiobotocore client and connector pool while keeping serialization, hashing, parsing, and expression work on Temporal activity threads.
- Preserve cancellation and context propagation across sync and async bridges, drain accepted submissions before S3 cleanup, and shut the worker down if the application loop dies.
- Add focused lifecycle, concurrency, storage-cache, and Linux Temporal/MinIO load coverage.

## Root cause

Synchronous Temporal activities previously created persistent thread-local asyncio runners. Each runner owned a separate event loop and therefore a separate loop-bound S3 client and connector pool. At worker concurrency, this multiplied threads, file descriptors, and retained resources, while recycled threads could leave clients bound to closed loops.

The new worker-owned application runtime gives loop-affine I/O resources one explicit home without moving CPU-heavy payload work onto the Temporal event loop.

## Impact

Workers now share one S3 I/O loop and bounded connector pool across activity threads. Normal shutdown drains Temporal work and the activity executor before closing loop-owned storage resources. If the application loop stops unexpectedly, the watchdog requests graceful worker shutdown so the process can be restarted instead of consuming task slots while storage activities fail indefinitely.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check` on changed runtime and test files
- `uv run basedpyright --warnings` on changed runtime and test files: 0 errors, 0 warnings
- Focused storage/runtime unit suite: 140 passed
- Runtime-death race tests repeated 20 times each: 40 passed
- Pre-commit hooks passed
- Linux-only Temporal/MinIO load test added; skipped locally on macOS

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 1,375 | 225 |
| Tests | 1,652 | 48 |

## Related

Resolves [ENG-1606](https://linear.app/tracecat/issue/ENG-1606/fixworker-collapse-s3-access-onto-one-app-event-loop).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse all worker blob-storage I/O onto one process-owned async runtime using `uvloop`, reusing a single loop-bound `aiobotocore` S3 client and a bounded connector pool. Improves performance, reduces FD/thread churn, and hardens startup, shutdown, and cancellation behavior. Resolves ENG-1606.

- **Refactors**
  - Added `AppAsyncRuntime`: one dedicated event loop/thread with cancellation-aware bridges for sync and async callers.
  - Reuse a single loop-affine `aiobotocore` S3 client and connector pool (`max_pool_connections=10`).
  - Added sync paths in storage and DSL (`store_sync`/`retrieve_sync`/`materialize_*_sync`) to keep CPU work on activity threads and avoid loop hops.
  - Centralized transport error classification; only retry transient HTTP client failures.

- **Bug Fixes**
  - Removed per-thread asyncio runners that leaked clients and FDs under concurrency.
  - Preserved cancellation and context across sync/async boundaries; drain accepted submissions before S3 cleanup.
  - Added a watchdog that shuts the worker down if the app runtime stops; bound startup and shutdown to deadlines (stop loop on startup timeout; allow worker exit if shutdown exceeds its deadline).

<sup>Written for commit d3c7f7feeb1f5cade7f39cc160a667dbd2bdac0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

