### PR TITLE
fix(ui): keep remaining command item values selector-safe

### DIFF
--- a/frontend/src/components/cases/case-column-picker.tsx
+++ b/frontend/src/components/cases/case-column-picker.tsx
@@ -74,7 +74,8 @@ function ColumnOption({
   return (
     <CommandItem
       key={columnId}
-      value={searchValue}
+      value={columnId}
+      keywords={[searchValue]}
       onSelect={() => !isDisabled && onToggle(columnId)}
       disabled={isDisabled}
       className="text-xs"

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -644,10 +644,11 @@ export function CustomFieldInner({
                           No option found
                         </CommandEmpty>
                         <CommandGroup>
-                          {options.map((option) => (
+                          {options.map((option, index) => (
                             <CommandItem
                               key={option}
-                              value={option}
+                              value={`${index}`}
+                              keywords={[option]}
                               className="text-sm"
                               onSelect={() => {
                                 field.onChange(option)
@@ -771,10 +772,11 @@ export function CustomFieldInner({
                           No option found
                         </CommandEmpty>
                         <CommandGroup>
-                          {options.map((option) => (
+                          {options.map((option, index) => (
                             <CommandItem
                               key={option}
-                              value={option}
+                              value={`${index}`}
+                              keywords={[option]}
                               className="text-sm"
                               onSelect={() => toggleOption(option)}
                             >

--- a/frontend/src/components/cases/case-workflow-trigger.tsx
+++ b/frontend/src/components/cases/case-workflow-trigger.tsx
@@ -86,7 +86,10 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
               {availableWorkflows.map((workflow) => (
                 <CommandItem
                   key={workflow.id}
-                  value={`${workflow.title} ${workflow.alias ?? ""}`.trim()}
+                  value={workflow.id}
+                  keywords={[
+                    `${workflow.title} ${workflow.alias ?? ""}`.trim(),
+                  ]}
                   onSelect={() => {
                     setSelectedWorkflowId(workflow.id)
                     setSelectedWorkflowTitle(workflow.title)

--- a/frontend/src/components/cases/multiselect-case-filters.tsx
+++ b/frontend/src/components/cases/multiselect-case-filters.tsx
@@ -92,13 +92,14 @@ export function CaseFilterMultiSelect<T extends string>({
           <CommandList>
             <CommandEmpty>{emptyMessage}</CommandEmpty>
             <CommandGroup>
-              {options.map((option) => {
+              {options.map((option, index) => {
                 const isSelected = valueSet.has(option.value)
                 const Icon = option.icon
                 return (
                   <CommandItem
                     key={option.value}
-                    value={`${option.label} ${option.value}`}
+                    value={`${index}`}
+                    keywords={[`${option.label} ${option.value}`]}
                     className="flex items-center gap-2 text-xs"
                     onSelect={() => {
                       const nextValue = isSelected

--- a/frontend/src/components/dashboard/file-tree-command.tsx
+++ b/frontend/src/components/dashboard/file-tree-command.tsx
@@ -49,7 +49,7 @@ export function FileTreeCommand({ items, onSelect }: FileTreeCommandProps) {
       return (
         <React.Fragment key={item.path}>
           <CommandItem
-            value={item.path}
+            value={encodeURIComponent(item.path)}
             onSelect={() => {
               setSelectedItem(item.path)
               if (onSelect) {

--- a/frontend/src/components/dashboard/workflows-header.tsx
+++ b/frontend/src/components/dashboard/workflows-header.tsx
@@ -272,7 +272,8 @@ function TagFilterSelect({
                 return (
                   <CommandItem
                     key={tag.id}
-                    value={`${tag.name} ${tag.ref}`}
+                    value={tag.id}
+                    keywords={[`${tag.name} ${tag.ref}`]}
                     onSelect={() => {
                       const nextValue = isSelected
                         ? value.filter((item) => item !== tag.ref)

--- a/frontend/src/components/filters/filter-multi-select.tsx
+++ b/frontend/src/components/filters/filter-multi-select.tsx
@@ -209,12 +209,13 @@ export function FilterMultiSelect<T extends string>({
           <CommandList>
             <CommandEmpty>{emptyMessage}</CommandEmpty>
             <CommandGroup>
-              {options.map((option) => {
+              {options.map((option, index) => {
                 const isSelected = valueSet.has(option.value)
                 return (
                   <CommandItem
                     key={option.value}
-                    value={`${option.label} ${option.value}`}
+                    value={`${index}`}
+                    keywords={[`${option.label} ${option.value}`]}
                     onSelect={() => {
                       const nextValue = isSelected
                         ? value.filter((item) => item !== option.value)

--- a/frontend/src/components/tables/cell-editors.tsx
+++ b/frontend/src/components/tables/cell-editors.tsx
@@ -381,12 +381,13 @@ function MultiSelectCellEditor({
           <CommandList>
             <CommandEmpty>No options found.</CommandEmpty>
             <CommandGroup>
-              {options.map((option) => {
+              {options.map((option, index) => {
                 const isSelected = valueSet.has(option)
                 return (
                   <CommandItem
                     key={option}
-                    value={option}
+                    value={`${index}`}
+                    keywords={[option]}
                     className="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-xs outline-none [&_svg]:size-3.5"
                     onSelect={() => {
                       const nextValue = isSelected


### PR DESCRIPTION
## Summary

Follow-up to #2910. A production error page showed cmdk crashing with:

```
Failed to execute 'querySelector' on 'Element': '[cmdk-item=""][data-value=""hello""]' is not a valid selector.
```

cmdk interpolates each `CommandItem`'s `value` into a CSS attribute selector, so any user-controlled string containing `"` or `\` (e.g. a select option literally stored as `"hello"`) throws and takes down the page via the global error boundary. #2910 fixed the chat action picker, chat history, and tags input, but several command menus still passed raw user-controlled strings as `value`.

This PR fixes the remaining call sites by keeping `value` selector-safe (list index or a backend-validated ID) and moving the user-visible text into cmdk's `keywords` prop so text search keeps working:

- `tables/cell-editors.tsx` — table multi-select cell editor (`value={option}`)
- `cases/case-panel-custom-fields.tsx` — case custom-field single- and multi-select (`value={option}`)
- `cases/case-workflow-trigger.tsx` — workflow picker (`value` was `title + alias`; now `workflow.id` with title/alias as keywords)
- `dashboard/workflows-header.tsx` — tag filter (`value` included `tag.name`; now `tag.id`)
- `cases/multiselect-case-filters.tsx`, `filters/filter-multi-select.tsx` — generic filter menus (`value` included `option.label`)
- `cases/case-column-picker.tsx` — column picker (`value` included user-defined dropdown/field names; now the `columnId`, which is built from backend-validated identifiers)
- `dashboard/file-tree-command.tsx` — folder tree (folder names are unconstrained strings; `value` is now `encodeURIComponent(path)`; this menu has no search input, so no keywords needed)

Selection handlers all use closures over the real option objects, so behavior is unchanged; only cmdk's internal value/filter strings change.

Left as-is (values are not user-controlled): `table-link-rows-to-case-command.tsx` (case short IDs), `agent-presets-builder.tsx` (model/provider keys), static filter option labels.

## Validation

- Ad-hoc jsdom test (not committed): rendered `FilterMultiSelect` with an option literally equal to `"hello"` — items now render with `data-value="0"`, typing in the search input no longer throws, text search matches via `keywords`, and selecting returns the original value.
- `pnpm -C frontend run typecheck`, Biome on changed files, and the full frontend jest suite (98 suites / 553 tests) pass.

## LOC breakdown

| Category | + | - |
|---|---|---|
| Logic | 24 | 14 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `cmdk` crashes caused by invalid CSS selectors when user strings were used as `CommandItem.value`. Use selector-safe values (IDs, indices, or encoded paths) and move display text into `keywords` so search still works.

- **Bug Fixes**
  - Updated remaining command menus to use safe values: case custom fields, table multi-select editor, workflow picker, tag filter, generic filter menus, column picker, and file tree.
  - Values now use backend-validated IDs, list indices, or `encodeURIComponent(path)` (file tree).
  - Search uses `keywords`; selection behavior is unchanged.
  - Left as-is where values are already safe: case short IDs, model/provider keys, and static labels.

<sup>Written for commit d3ffea5aa418f2dff94bdb6541dc76c4996cb09f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

