### PR TITLE
fix(expressions): cache jsonpath parser to fix import-lock deadlock

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py
+++ b/packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py
@@ -4,14 +4,34 @@ This module provides a lightweight JSONPath evaluation function that avoids
 importing heavy tracecat modules during SDK-style invocation.
 """
 
+import threading
+from functools import lru_cache
 from typing import Any
 
-import jsonpath_ng.ext
 import jsonpath_ng.jsonpath as jsonpath_nodes
 from jsonpath_ng.exceptions import JsonPathParserError
+from jsonpath_ng.ext.parser import ExtentedJsonPathParser
 
 from tracecat_registry._internal.exceptions import TracecatExpressionError
 from tracecat_registry._internal.logger import logger
+
+# jsonpath_ng builds a new PLY parser per parse() call, and without a shipped
+# parsetab module every call re-imports the missing table module and regenerates
+# the LALR table. That import-lock traffic can deadlock the process if a Temporal
+# activity thread is cancelled while holding the import lock. Build one parser at
+# import time (before any worker threads exist) and serialize access: PLY's
+# LRParser mutates shared state during parse and is not thread-safe. Parsed
+# expression trees are immutable, so caching and sharing them across threads is
+# safe.
+_JSONPATH_PARSER = ExtentedJsonPathParser()
+_JSONPATH_PARSER_LOCK = threading.Lock()
+
+
+@lru_cache(maxsize=4096)
+def _parse_jsonpath(expr: str) -> jsonpath_nodes.JSONPath:
+    """Parse a jsonpath expression using the shared process-wide parser."""
+    with _JSONPATH_PARSER_LOCK:
+        return _JSONPATH_PARSER.parse(expr)
 
 
 def eval_jsonpath(
@@ -29,7 +49,7 @@ def eval_jsonpath(
         )
     try:
         # Try to evaluate the expression
-        jsonpath_expr = jsonpath_ng.ext.parse(expr)
+        jsonpath_expr = _parse_jsonpath(expr)
     except JsonPathParserError as e:
         logger.error(f"Invalid jsonpath expression: {expr!r}")
         raise TracecatExpressionError(f"Invalid jsonpath {expr!r}") from e

--- a/packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py
+++ b/packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py
@@ -5,7 +5,7 @@ importing heavy tracecat modules during SDK-style invocation.
 """
 
 import threading
-from functools import lru_cache
+from collections import OrderedDict
 from typing import Any
 
 import jsonpath_ng.jsonpath as jsonpath_nodes
@@ -20,18 +20,46 @@ from tracecat_registry._internal.logger import logger
 # the LALR table. That import-lock traffic can deadlock the process if a Temporal
 # activity thread is cancelled while holding the import lock. Build one parser at
 # import time (before any worker threads exist) and serialize access: PLY's
-# LRParser mutates shared state during parse and is not thread-safe. Parsed
-# expression trees are immutable, so caching and sharing them across threads is
-# safe.
+# LRParser mutates shared state during parse and is not thread-safe. Callers treat
+# parsed expression trees as read-only, so sharing them across threads is safe.
 _JSONPATH_PARSER = ExtentedJsonPathParser()
 _JSONPATH_PARSER_LOCK = threading.Lock()
+_JSONPATH_CACHE_MAXSIZE = 1024
+_JSONPATH_CACHE_MAX_EXPR_LENGTH = 256
+_JSONPATH_CACHE: OrderedDict[str, jsonpath_nodes.JSONPath] = OrderedDict()
+_JSONPATH_CACHE_LOCK = threading.Lock()
 
 
-@lru_cache(maxsize=4096)
+def _get_cached_jsonpath(expr: str) -> jsonpath_nodes.JSONPath | None:
+    with _JSONPATH_CACHE_LOCK:
+        parsed = _JSONPATH_CACHE.get(expr)
+        if parsed is not None:
+            _JSONPATH_CACHE.move_to_end(expr)
+        return parsed
+
+
+def _cache_jsonpath(expr: str, parsed: jsonpath_nodes.JSONPath) -> None:
+    with _JSONPATH_CACHE_LOCK:
+        _JSONPATH_CACHE[expr] = parsed
+        if len(_JSONPATH_CACHE) > _JSONPATH_CACHE_MAXSIZE:
+            _JSONPATH_CACHE.popitem(last=False)
+
+
 def _parse_jsonpath(expr: str) -> jsonpath_nodes.JSONPath:
-    """Parse a jsonpath expression using the shared process-wide parser."""
+    """Parse a JSONPath, caching expressions with bounded source lengths."""
+    cacheable = len(expr) <= _JSONPATH_CACHE_MAX_EXPR_LENGTH
+    if cacheable and (parsed := _get_cached_jsonpath(expr)) is not None:
+        return parsed
+
     with _JSONPATH_PARSER_LOCK:
-        return _JSONPATH_PARSER.parse(expr)
+        # Another thread may have populated the cache while this thread waited.
+        if cacheable and (parsed := _get_cached_jsonpath(expr)) is not None:
+            return parsed
+
+        parsed = _JSONPATH_PARSER.parse(expr)
+        if cacheable:
+            _cache_jsonpath(expr, parsed)
+        return parsed
 
 
 def eval_jsonpath(

--- a/packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py
+++ b/packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py
@@ -19,11 +19,16 @@ from tracecat_registry._internal.logger import logger
 # parsetab module every call re-imports the missing table module and regenerates
 # the LALR table. That import-lock traffic can deadlock the process if a Temporal
 # activity thread is cancelled while holding the import lock. Build one parser at
-# import time (before any worker threads exist) and serialize access: PLY's
-# LRParser mutates shared state during parse and is not thread-safe. Callers treat
-# parsed expression trees as read-only, so sharing them across threads is safe.
+# module import time and serialize access: PLY's LRParser mutates shared state
+# during parse and is not thread-safe. Callers treat parsed expression trees as
+# read-only, so sharing them across threads is safe.
 _JSONPATH_PARSER = ExtentedJsonPathParser()
 _JSONPATH_PARSER_LOCK = threading.Lock()
+
+# functools.lru_cache may execute the wrapped function multiple times for
+# concurrent misses. Separate cache and parser locks keep hits from waiting on
+# parsing, while the second cache lookup coalesces cacheable misses. These limits
+# affect retention only; longer JSONPaths remain valid and parse without caching.
 _JSONPATH_CACHE_MAXSIZE = 1024
 _JSONPATH_CACHE_MAX_EXPR_LENGTH = 256
 _JSONPATH_CACHE: OrderedDict[str, jsonpath_nodes.JSONPath] = OrderedDict()
@@ -31,6 +36,7 @@ _JSONPATH_CACHE_LOCK = threading.Lock()
 
 
 def _get_cached_jsonpath(expr: str) -> jsonpath_nodes.JSONPath | None:
+    """Return a cached JSONPath and update its LRU position."""
     with _JSONPATH_CACHE_LOCK:
         parsed = _JSONPATH_CACHE.get(expr)
         if parsed is not None:
@@ -39,6 +45,7 @@ def _get_cached_jsonpath(expr: str) -> jsonpath_nodes.JSONPath | None:
 
 
 def _cache_jsonpath(expr: str, parsed: jsonpath_nodes.JSONPath) -> None:
+    """Cache a JSONPath, evicting the least recently used entry if full."""
     with _JSONPATH_CACHE_LOCK:
         _JSONPATH_CACHE[expr] = parsed
         if len(_JSONPATH_CACHE) > _JSONPATH_CACHE_MAXSIZE:
@@ -46,7 +53,11 @@ def _cache_jsonpath(expr: str, parsed: jsonpath_nodes.JSONPath) -> None:
 
 
 def _parse_jsonpath(expr: str) -> jsonpath_nodes.JSONPath:
-    """Parse a JSONPath, caching expressions with bounded source lengths."""
+    """Parse a JSONPath using the shared process-wide parser.
+
+    Expressions exceeding the cache admission limit remain valid and are parsed
+    without being retained.
+    """
     cacheable = len(expr) <= _JSONPATH_CACHE_MAX_EXPR_LENGTH
     if cacheable and (parsed := _get_cached_jsonpath(expr)) is not None:
         return parsed

--- a/tests/unit/test_jsonpath_cache.py
+++ b/tests/unit/test_jsonpath_cache.py
@@ -1,0 +1,189 @@
+import threading
+from _thread import LockType
+from collections import OrderedDict
+from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from types import ModuleType
+
+import jsonpath_ng.jsonpath as jsonpath_nodes
+import pytest
+from tracecat_registry._internal import jsonpath as registry_jsonpath
+
+from tracecat.expressions import common as core_jsonpath
+
+
+@dataclass(frozen=True, slots=True)
+class _JsonPathCacheHarness:
+    name: str
+    module: ModuleType
+    parse: Callable[[str], jsonpath_nodes.JSONPath]
+    cache: OrderedDict[str, jsonpath_nodes.JSONPath]
+    cache_lock: LockType
+    parser_lock: LockType
+    get_cached: Callable[[str], jsonpath_nodes.JSONPath | None]
+    max_entries: int
+    max_expr_length: int
+
+
+_HARNESSES = (
+    _JsonPathCacheHarness(
+        name="core",
+        module=core_jsonpath,
+        parse=core_jsonpath.parse_jsonpath,
+        cache=core_jsonpath._JSONPATH_CACHE,
+        cache_lock=core_jsonpath._JSONPATH_CACHE_LOCK,
+        parser_lock=core_jsonpath._JSONPATH_PARSER_LOCK,
+        get_cached=core_jsonpath._get_cached_jsonpath,
+        max_entries=core_jsonpath._JSONPATH_CACHE_MAXSIZE,
+        max_expr_length=core_jsonpath._JSONPATH_CACHE_MAX_EXPR_LENGTH,
+    ),
+    _JsonPathCacheHarness(
+        name="registry",
+        module=registry_jsonpath,
+        parse=registry_jsonpath._parse_jsonpath,
+        cache=registry_jsonpath._JSONPATH_CACHE,
+        cache_lock=registry_jsonpath._JSONPATH_CACHE_LOCK,
+        parser_lock=registry_jsonpath._JSONPATH_PARSER_LOCK,
+        get_cached=registry_jsonpath._get_cached_jsonpath,
+        max_entries=registry_jsonpath._JSONPATH_CACHE_MAXSIZE,
+        max_expr_length=registry_jsonpath._JSONPATH_CACHE_MAX_EXPR_LENGTH,
+    ),
+)
+
+
+class _CountingParser:
+    def __init__(self) -> None:
+        self.calls = 0
+        self._lock = threading.Lock()
+
+    def parse(self, expr: str) -> jsonpath_nodes.JSONPath:
+        with self._lock:
+            self.calls += 1
+        return jsonpath_nodes.Root()
+
+
+@pytest.fixture(params=_HARNESSES, ids=[harness.name for harness in _HARNESSES])
+def jsonpath_cache(
+    request: pytest.FixtureRequest,
+) -> Iterator[_JsonPathCacheHarness]:
+    harness: _JsonPathCacheHarness = request.param
+    with harness.cache_lock:
+        harness.cache.clear()
+    yield harness
+    with harness.cache_lock:
+        harness.cache.clear()
+
+
+def test_cache_admission_uses_expression_length(
+    jsonpath_cache: _JsonPathCacheHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = _CountingParser()
+    monkeypatch.setattr(jsonpath_cache.module, "_JSONPATH_PARSER", parser)
+    cached_expr = "$." + "a" * (jsonpath_cache.max_expr_length - 2)
+    uncached_expr = cached_expr + "a"
+
+    cached_first = jsonpath_cache.parse(cached_expr)
+    cached_second = jsonpath_cache.parse(cached_expr)
+    uncached_first = jsonpath_cache.parse(uncached_expr)
+    uncached_second = jsonpath_cache.parse(uncached_expr)
+
+    assert cached_first is cached_second
+    assert uncached_first is not uncached_second
+    assert parser.calls == 3
+    assert list(jsonpath_cache.cache) == [cached_expr]
+
+
+def test_cache_evicts_the_least_recently_used_expression(
+    jsonpath_cache: _JsonPathCacheHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = _CountingParser()
+    monkeypatch.setattr(jsonpath_cache.module, "_JSONPATH_PARSER", parser)
+    expressions = [f"$.field_{index}" for index in range(jsonpath_cache.max_entries)]
+
+    for expr in expressions:
+        jsonpath_cache.parse(expr)
+    jsonpath_cache.parse(expressions[0])
+    jsonpath_cache.parse("$.overflow")
+
+    assert len(jsonpath_cache.cache) == jsonpath_cache.max_entries
+    assert expressions[0] in jsonpath_cache.cache
+    assert expressions[1] not in jsonpath_cache.cache
+    assert "$.overflow" in jsonpath_cache.cache
+    assert parser.calls == jsonpath_cache.max_entries + 1
+
+
+def test_concurrent_cacheable_misses_parse_once(
+    jsonpath_cache: _JsonPathCacheHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = _CountingParser()
+    monkeypatch.setattr(jsonpath_cache.module, "_JSONPATH_PARSER", parser)
+    worker_count = 8
+    initial_lookups = 0
+    initial_lookups_lock = threading.Lock()
+    all_initial_lookups_complete = threading.Event()
+
+    def counted_get_cached(expr: str) -> jsonpath_nodes.JSONPath | None:
+        nonlocal initial_lookups
+        parsed = jsonpath_cache.get_cached(expr)
+        with initial_lookups_lock:
+            initial_lookups += 1
+            if initial_lookups == worker_count:
+                all_initial_lookups_complete.set()
+        return parsed
+
+    monkeypatch.setattr(
+        jsonpath_cache.module, "_get_cached_jsonpath", counted_get_cached
+    )
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        jsonpath_cache.parser_lock.acquire()
+        try:
+            futures = [
+                executor.submit(jsonpath_cache.parse, "$.shared")
+                for _ in range(worker_count)
+            ]
+            all_workers_reached_parser_lock = all_initial_lookups_complete.wait(5)
+        finally:
+            jsonpath_cache.parser_lock.release()
+
+        results = [future.result() for future in futures]
+
+    assert all_workers_reached_parser_lock
+    assert parser.calls == 1
+    assert all(parsed is results[0] for parsed in results)
+
+
+def test_cache_hit_does_not_wait_for_parser_lock(
+    jsonpath_cache: _JsonPathCacheHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = _CountingParser()
+    monkeypatch.setattr(jsonpath_cache.module, "_JSONPATH_PARSER", parser)
+    cached = jsonpath_cache.parse("$.cached")
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        jsonpath_cache.parser_lock.acquire()
+        try:
+            future = executor.submit(jsonpath_cache.parse, "$.cached")
+            parsed = future.result(timeout=1)
+        finally:
+            jsonpath_cache.parser_lock.release()
+
+    assert parsed is cached
+    assert parser.calls == 1
+
+
+def test_oversized_valid_expression_still_parses(
+    jsonpath_cache: _JsonPathCacheHarness,
+) -> None:
+    field = "a" * jsonpath_cache.max_expr_length
+    expr = f"$.{field}"
+
+    parsed = jsonpath_cache.parse(expr)
+
+    assert [match.value for match in parsed.find({field: 42})] == [42]
+    assert expr not in jsonpath_cache.cache

--- a/tracecat/expressions/common.py
+++ b/tracecat/expressions/common.py
@@ -1,8 +1,8 @@
 import threading
+from collections import OrderedDict
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from enum import StrEnum, auto
-from functools import lru_cache
 from typing import Any, TypeVar
 
 import jsonpath_ng.jsonpath as jsonpath_nodes
@@ -17,18 +17,46 @@ from tracecat.logger import logger
 # the LALR table. That import-lock traffic can deadlock the process if a Temporal
 # activity thread is cancelled while holding the import lock. Build one parser at
 # import time (before any worker threads exist) and serialize access: PLY's
-# LRParser mutates shared state during parse and is not thread-safe. Parsed
-# expression trees are immutable, so caching and sharing them across threads is
-# safe.
+# LRParser mutates shared state during parse and is not thread-safe. Callers treat
+# parsed expression trees as read-only, so sharing them across threads is safe.
 _JSONPATH_PARSER = ExtentedJsonPathParser()
 _JSONPATH_PARSER_LOCK = threading.Lock()
+_JSONPATH_CACHE_MAXSIZE = 1024
+_JSONPATH_CACHE_MAX_EXPR_LENGTH = 256
+_JSONPATH_CACHE: OrderedDict[str, jsonpath_nodes.JSONPath] = OrderedDict()
+_JSONPATH_CACHE_LOCK = threading.Lock()
 
 
-@lru_cache(maxsize=4096)
+def _get_cached_jsonpath(expr: str) -> jsonpath_nodes.JSONPath | None:
+    with _JSONPATH_CACHE_LOCK:
+        parsed = _JSONPATH_CACHE.get(expr)
+        if parsed is not None:
+            _JSONPATH_CACHE.move_to_end(expr)
+        return parsed
+
+
+def _cache_jsonpath(expr: str, parsed: jsonpath_nodes.JSONPath) -> None:
+    with _JSONPATH_CACHE_LOCK:
+        _JSONPATH_CACHE[expr] = parsed
+        if len(_JSONPATH_CACHE) > _JSONPATH_CACHE_MAXSIZE:
+            _JSONPATH_CACHE.popitem(last=False)
+
+
 def parse_jsonpath(expr: str) -> jsonpath_nodes.JSONPath:
-    """Parse a jsonpath expression using the shared process-wide parser."""
+    """Parse a JSONPath, caching expressions with bounded source lengths."""
+    cacheable = len(expr) <= _JSONPATH_CACHE_MAX_EXPR_LENGTH
+    if cacheable and (parsed := _get_cached_jsonpath(expr)) is not None:
+        return parsed
+
     with _JSONPATH_PARSER_LOCK:
-        return _JSONPATH_PARSER.parse(expr)
+        # Another thread may have populated the cache while this thread waited.
+        if cacheable and (parsed := _get_cached_jsonpath(expr)) is not None:
+            return parsed
+
+        parsed = _JSONPATH_PARSER.parse(expr)
+        if cacheable:
+            _cache_jsonpath(expr, parsed)
+        return parsed
 
 
 # Maximum number of key segments allowed after the variable name in VARS expressions.

--- a/tracecat/expressions/common.py
+++ b/tracecat/expressions/common.py
@@ -1,14 +1,35 @@
+import threading
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from enum import StrEnum, auto
+from functools import lru_cache
 from typing import Any, TypeVar
 
-import jsonpath_ng.ext
 import jsonpath_ng.jsonpath as jsonpath_nodes
 from jsonpath_ng.exceptions import JsonPathParserError
+from jsonpath_ng.ext.parser import ExtentedJsonPathParser
 
 from tracecat.exceptions import TracecatExpressionError
 from tracecat.logger import logger
+
+# jsonpath_ng builds a new PLY parser per parse() call, and without a shipped
+# parsetab module every call re-imports the missing table module and regenerates
+# the LALR table. That import-lock traffic can deadlock the process if a Temporal
+# activity thread is cancelled while holding the import lock. Build one parser at
+# import time (before any worker threads exist) and serialize access: PLY's
+# LRParser mutates shared state during parse and is not thread-safe. Parsed
+# expression trees are immutable, so caching and sharing them across threads is
+# safe.
+_JSONPATH_PARSER = ExtentedJsonPathParser()
+_JSONPATH_PARSER_LOCK = threading.Lock()
+
+
+@lru_cache(maxsize=4096)
+def parse_jsonpath(expr: str) -> jsonpath_nodes.JSONPath:
+    """Parse a jsonpath expression using the shared process-wide parser."""
+    with _JSONPATH_PARSER_LOCK:
+        return _JSONPATH_PARSER.parse(expr)
+
 
 # Maximum number of key segments allowed after the variable name in VARS expressions.
 # This is currently limited to support `VARS.<name>.<key>` paths, and can be increased
@@ -124,7 +145,7 @@ def eval_jsonpath(
         )
     try:
         # Try to evaluate the expression
-        jsonpath_expr = jsonpath_ng.ext.parse(expr)
+        jsonpath_expr = parse_jsonpath(expr)
     except JsonPathParserError as e:
         logger.error(
             "Invalid jsonpath expression", expr=repr(expr), context_type=context_type

--- a/tracecat/expressions/common.py
+++ b/tracecat/expressions/common.py
@@ -16,11 +16,16 @@ from tracecat.logger import logger
 # parsetab module every call re-imports the missing table module and regenerates
 # the LALR table. That import-lock traffic can deadlock the process if a Temporal
 # activity thread is cancelled while holding the import lock. Build one parser at
-# import time (before any worker threads exist) and serialize access: PLY's
-# LRParser mutates shared state during parse and is not thread-safe. Callers treat
-# parsed expression trees as read-only, so sharing them across threads is safe.
+# module import time and serialize access: PLY's LRParser mutates shared state
+# during parse and is not thread-safe. Callers treat parsed expression trees as
+# read-only, so sharing them across threads is safe.
 _JSONPATH_PARSER = ExtentedJsonPathParser()
 _JSONPATH_PARSER_LOCK = threading.Lock()
+
+# functools.lru_cache may execute the wrapped function multiple times for
+# concurrent misses. Separate cache and parser locks keep hits from waiting on
+# parsing, while the second cache lookup coalesces cacheable misses. These limits
+# affect retention only; longer JSONPaths remain valid and parse without caching.
 _JSONPATH_CACHE_MAXSIZE = 1024
 _JSONPATH_CACHE_MAX_EXPR_LENGTH = 256
 _JSONPATH_CACHE: OrderedDict[str, jsonpath_nodes.JSONPath] = OrderedDict()
@@ -28,6 +33,7 @@ _JSONPATH_CACHE_LOCK = threading.Lock()
 
 
 def _get_cached_jsonpath(expr: str) -> jsonpath_nodes.JSONPath | None:
+    """Return a cached JSONPath and update its LRU position."""
     with _JSONPATH_CACHE_LOCK:
         parsed = _JSONPATH_CACHE.get(expr)
         if parsed is not None:
@@ -36,6 +42,7 @@ def _get_cached_jsonpath(expr: str) -> jsonpath_nodes.JSONPath | None:
 
 
 def _cache_jsonpath(expr: str, parsed: jsonpath_nodes.JSONPath) -> None:
+    """Cache a JSONPath, evicting the least recently used entry if full."""
     with _JSONPATH_CACHE_LOCK:
         _JSONPATH_CACHE[expr] = parsed
         if len(_JSONPATH_CACHE) > _JSONPATH_CACHE_MAXSIZE:
@@ -43,7 +50,11 @@ def _cache_jsonpath(expr: str, parsed: jsonpath_nodes.JSONPath) -> None:
 
 
 def parse_jsonpath(expr: str) -> jsonpath_nodes.JSONPath:
-    """Parse a JSONPath, caching expressions with bounded source lengths."""
+    """Parse a JSONPath using the shared process-wide parser.
+
+    Expressions exceeding the cache admission limit remain valid and are parsed
+    without being retained.
+    """
     cacheable = len(expr) <= _JSONPATH_CACHE_MAX_EXPR_LENGTH
     if cacheable and (parsed := _get_cached_jsonpath(expr)) is not None:
         return parsed

--- a/tracecat/expressions/validator/base.py
+++ b/tracecat/expressions/validator/base.py
@@ -5,12 +5,16 @@ from collections.abc import Awaitable, Callable, Iterable, Sequence
 from typing import Any, Literal, override
 
 import jsonpath_ng.exceptions
-import jsonpath_ng.ext
 from lark import Token, Tree, Visitor, v_args
 from lark.exceptions import VisitError
 
 from tracecat.expressions import functions
-from tracecat.expressions.common import VISITOR_NODE_TO_EXPR_TYPE, ExprContext, ExprType
+from tracecat.expressions.common import (
+    VISITOR_NODE_TO_EXPR_TYPE,
+    ExprContext,
+    ExprType,
+    parse_jsonpath,
+)
 from tracecat.logger import logger
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.validation.schemas import ValidationDetail
@@ -354,7 +358,7 @@ class BaseExprValidator[ResultT](Visitor[Token]):
             )
             return
         try:
-            jsonpath_ng.ext.parse("$" + combined_segments)
+            parse_jsonpath("$" + combined_segments)
         except jsonpath_ng.exceptions.JSONPathError as e:
             self.logger.error("Invalid jsonpath body", error=str(e))
             self.add(


### PR DESCRIPTION
## Tracking

- [ENG-1608: Prevent JSONPath parser races under multithreaded evaluation](https://linear.app/tracecat/issue/ENG-1608/prevent-jsonpath-parser-races-under-multithreaded-evaluation)

## Problem

`jsonpath_ng.ext.parse(expr)` constructs a brand-new PLY parser on **every call**. jsonpath_ng ships no pre-generated parsetab module and passes `write_tables=0`, so each call:

1. attempts `import parser_jsonpath_parsetab`, which always fails and therefore goes through `importlib._find_and_load` — taking Python's per-module import lock — on every single expression evaluation, and
2. falls back to regenerating the full LALR parse table (~7 ms of pure-Python CPU per call).

Since `eval_jsonpath` sits on the expression-evaluation hot path, every workflow expression pays this tax. Worse, under many concurrent Temporal sync-activity threads the import-lock traffic is a deadlock hazard: threads queued on the import lock cannot heartbeat, activities hit their heartbeat timeout, and the SDK cancels them by injecting exceptions into the threads. If an injection lands while a thread is inside the import critical section, the import lock leaks permanently — threads blocked in C-level `lock.acquire()` can never receive injected exceptions — and the worker wedges irrecoverably.

This is not theoretical: the temporal CI job for #3215 deadlocked exactly this way (61 of 64 activity threads parked on the leaked import lock in the faulthandler dump; the job hung until its 60-minute timeout).

## Fix

Build one `ExtentedJsonPathParser` per parser module at module import time, removing parser construction and parse-table generation from the expression hot path. Serialize cache misses with a parser lock because PLY's `LRParser` mutates instance state during parsing and is not thread-safe. Current callers treat cached expression trees as read-only, so they can safely share parsed results.

The process-local cache deliberately uses a small manual LRU rather than `functools.lru_cache`:

- Cache hits take only the cache lock, so they do not wait behind an unrelated slow parse.
- A miss acquires the parser lock and rechecks the cache, coalescing concurrent cacheable misses for the same expression into one parse.
- Each module retains at most 1024 expressions, and only expressions up to 256 characters are admitted.
- Longer expressions remain valid and parse normally without being retained; the limit does not change JSONPath validation semantics.

Applied in three places:

- `tracecat/expressions/common.py` — shared `parse_jsonpath()`, used by `eval_jsonpath`
- `tracecat/expressions/validator/base.py` — validator reuses `parse_jsonpath()`
- `packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py` — standalone copy of the same parser and cache behavior because the registry package cannot import `tracecat.*`

## Verification

- Parser-cache regression suite covering both implementations: 10 passed
- Focused core expression and parsing tests: 18 passed
- Focused registry JSONPath tests: 27 passed
- Focused validator JSONPath test: 1 passed
- Concurrent cold-miss coverage verifies one parse across eight simultaneous callers
- Oversized-expression coverage verifies valid paths still parse without entering the cache
- `uv run ruff check`, `uv run ruff format --check`, and targeted `uv run basedpyright`: clean
- Signed commit hooks: passed

## LOC breakdown

| Category | + | - |
|---|---:|---:|
| Logic | 130 | 7 |
| Tests | 189 | 0 |
