### PR TITLE
feat(agent): add configurable timeout columns

### DIFF
--- a/alembic/versions/4e4a211c481e_add_agent_timeout_seconds.py
+++ b/alembic/versions/4e4a211c481e_add_agent_timeout_seconds.py
@@ -1,0 +1,57 @@
+"""Add configurable agent timeouts.
+
+Revision ID: 4e4a211c481e
+Revises: 2792569cf359
+Create Date: 2026-08-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4e4a211c481e"
+down_revision: str | None = "2792569cf359"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Existing rows retain null as an explicit "inherit the deployment timeout"
+    # sentinel. New presets receive the product default at the API boundary.
+    op.add_column(
+        "agent_preset",
+        sa.Column("timeout_seconds", sa.Integer(), nullable=True),
+    )
+    op.create_check_constraint(
+        op.f("ck_agent_preset_timeout_seconds_range"),
+        "agent_preset",
+        "timeout_seconds >= 5 AND timeout_seconds <= 3600",
+    )
+    op.add_column(
+        "agent_preset_version",
+        sa.Column("timeout_seconds", sa.Integer(), nullable=True),
+    )
+    op.create_check_constraint(
+        op.f("ck_agent_preset_version_timeout_seconds_range"),
+        "agent_preset_version",
+        "timeout_seconds >= 5 AND timeout_seconds <= 3600",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("ck_agent_preset_version_timeout_seconds_range"),
+        "agent_preset_version",
+        type_="check",
+    )
+    op.drop_column("agent_preset_version", "timeout_seconds")
+    op.drop_constraint(
+        op.f("ck_agent_preset_timeout_seconds_range"),
+        "agent_preset",
+        type_="check",
+    )
+    op.drop_column("agent_preset", "timeout_seconds")

--- a/alembic/versions/4e4a211c481e_add_agent_timeout_seconds.py
+++ b/alembic/versions/4e4a211c481e_add_agent_timeout_seconds.py
@@ -1,7 +1,7 @@
 """Add configurable agent timeouts.
 
 Revision ID: 4e4a211c481e
-Revises: 2792569cf359
+Revises: c20c04c7d2a9
 Create Date: 2026-08-10
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "4e4a211c481e"
-down_revision: str | None = "2792569cf359"
+down_revision: str | None = "c20c04c7d2a9"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3560,6 +3560,10 @@ class AgentPreset(SoftDeleteMixin, WorkspaceModel):
 
     __tablename__ = "agent_preset"
     __table_args__ = (
+        CheckConstraint(
+            "timeout_seconds >= 5 AND timeout_seconds <= 3600",
+            name="timeout_seconds_range",
+        ),
         Index(
             "uq_agent_preset_workspace_slug_active",
             "workspace_id",
@@ -3656,6 +3660,11 @@ class AgentPreset(SoftDeleteMixin, WorkspaceModel):
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"
     )
+    timeout_seconds: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        doc="Maximum active runtime for each agent turn, or null to inherit",
+    )
     enable_thinking: Mapped[bool] = mapped_column(
         Boolean,
         default=True,
@@ -3711,7 +3720,13 @@ class AgentPresetVersion(WorkspaceModel):
     """Immutable version snapshot for an agent preset."""
 
     __tablename__ = "agent_preset_version"
-    __table_args__ = (UniqueConstraint("workspace_id", "preset_id", "version"),)
+    __table_args__ = (
+        CheckConstraint(
+            "timeout_seconds >= 5 AND timeout_seconds <= 3600",
+            name="timeout_seconds_range",
+        ),
+        UniqueConstraint("workspace_id", "preset_id", "version"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID,
@@ -3790,6 +3805,11 @@ class AgentPresetVersion(WorkspaceModel):
     )
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"
+    )
+    timeout_seconds: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        doc="Maximum active runtime for each agent turn, or null to inherit",
     )
     enable_thinking: Mapped[bool] = mapped_column(
         Boolean,


### PR DESCRIPTION
## Stack

1. **This PR:** standalone nullable timeout columns and database constraints
2. #3050: application, runtime, API, UI, generated client, and tests

Merge this PR first. The follow-up PR targets this branch.

## Verification

- `uv run alembic heads`
- `uv run alembic upgrade 2792569cf359:4e4a211c481e --sql`
- Migration pre-commit hooks

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Infra/config | 57 | 0 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nullable `timeout_seconds` to `agent_preset` and `agent_preset_version`, with DB check constraints and ORM validation enforcing 5–3600s. Null inherits the deployment timeout; API sets the product default for new presets.

<sup>Written for commit 016ed777d4d1d14d828fea453e473033e5ab589f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

