### PR TITLE
refactor(authz): centralize grant scope validation

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -10,9 +10,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from tracecat.audit.logger import audit_log
-from tracecat.authz.controls import require_scope, validate_scope_string
+from tracecat.authz.controls import (
+    ensure_can_grant_scopes,
+    require_scope,
+    validate_scope_string,
+)
 from tracecat.authz.enums import ScopeSource
 from tracecat.authz.scopes import PRESET_ROLE_SCOPES
+from tracecat.authz.service import resolve_grantable_role, resolve_granter_scopes
 from tracecat.db.models import (
     Group,
     GroupMember,
@@ -286,27 +291,25 @@ class RBACService(BaseOrgService):
 
     async def _set_role_scopes(self, role_id: UUID, scope_ids: list[UUID]) -> None:
         """Set the scopes for a role (replaces existing)."""
+        stmt = select(Scope).where(
+            Scope.id.in_(scope_ids),
+            (Scope.organization_id == self.organization_id)
+            | (Scope.organization_id.is_(None)),
+        )
+        scopes = (await self.session.execute(stmt)).scalars().all()
+        if len(scopes) != len(set(scope_ids)):
+            raise TracecatNotFoundError("Scope not found")
+        await self._ensure_can_grant_scopes(scopes)
+
         # Delete existing role-scope associations
         await self.session.execute(
             delete(RoleScope).where(RoleScope.role_id == role_id)
         )
 
         # Add new associations
-        for scope_id in scope_ids:
-            await self._assert_scope_exists(scope_id)
-            role_scope = RoleScope(role_id=role_id, scope_id=scope_id)
+        for scope in scopes:
+            role_scope = RoleScope(role_id=role_id, scope_id=scope.id)
             self.session.add(role_scope)
-
-    async def _assert_scope_exists(self, scope_id: UUID) -> None:
-        """Assert a scope exists and is accessible to the organization."""
-        stmt = select(Scope.id).where(
-            Scope.id == scope_id,
-            (Scope.organization_id == self.organization_id)
-            | (Scope.organization_id.is_(None)),
-        )
-        result = await self.session.execute(stmt)
-        if result.scalar_one_or_none() is None:
-            raise TracecatNotFoundError("Scope not found")
 
     async def _assert_group_exists(self, group_id: UUID) -> None:
         """Assert a group exists and belongs to the organization."""
@@ -318,15 +321,32 @@ class RBACService(BaseOrgService):
         if result.scalar_one_or_none() is None:
             raise TracecatNotFoundError("Group not found")
 
-    async def _assert_role_exists(self, role_id: UUID) -> None:
-        """Assert a role exists and belongs to the organization."""
-        stmt = select(DBRole.id).where(
-            DBRole.id == role_id,
-            DBRole.organization_id == self.organization_id,
+    async def _ensure_can_grant_scopes(self, scopes: Sequence[Scope]) -> None:
+        """Reject grants containing scopes the caller does not hold."""
+        if self.role.is_platform_superuser:
+            return
+        granter_scopes = await resolve_granter_scopes(self.session, self.role)
+        ensure_can_grant_scopes(granter_scopes, [scope.name for scope in scopes])
+
+    async def _ensure_role_assignable(self, role_id: UUID) -> None:
+        """Reject role grants containing scopes the caller does not hold."""
+        await resolve_grantable_role(
+            self.session, self.role, self.organization_id, role_id
+        )
+
+    async def _ensure_group_membership_assignable(self, group_id: UUID) -> None:
+        """Reject membership grants containing scopes the caller does not hold."""
+        stmt = (
+            select(Scope)
+            .join(RoleScope, RoleScope.scope_id == Scope.id)
+            .join(GroupRoleAssignment, GroupRoleAssignment.role_id == RoleScope.role_id)
+            .where(
+                GroupRoleAssignment.group_id == group_id,
+                GroupRoleAssignment.organization_id == self.organization_id,
+            )
         )
         result = await self.session.execute(stmt)
-        if result.scalar_one_or_none() is None:
-            raise TracecatNotFoundError("Role not found")
+        await self._ensure_can_grant_scopes(result.scalars().all())
 
     # =========================================================================
     # Group Management
@@ -416,6 +436,7 @@ class RBACService(BaseOrgService):
         """Add a user to a group."""
         # Verify group exists
         await self._assert_group_exists(group_id)
+        await self._ensure_group_membership_assignable(group_id)
 
         # Verify user belongs to this organization
         stmt = select(OrganizationMembership).where(
@@ -551,7 +572,7 @@ class RBACService(BaseOrgService):
         """
         # Verify role and group exist
         await self._assert_group_exists(group_id)
-        await self._assert_role_exists(role_id)
+        await self._ensure_role_assignable(role_id)
 
         # Verify workspace exists if provided
         if workspace_id is not None:
@@ -591,7 +612,7 @@ class RBACService(BaseOrgService):
         assignment = await self.get_group_role_assignment(assignment_id)
 
         # Verify new role exists
-        await self._assert_role_exists(role_id)
+        await self._ensure_role_assignable(role_id)
 
         assignment.role_id = role_id
         await self.session.commit()
@@ -688,7 +709,7 @@ class RBACService(BaseOrgService):
             raise TracecatNotFoundError("User not found in organization")
 
         # Verify role exists
-        await self._assert_role_exists(role_id)
+        await self._ensure_role_assignable(role_id)
 
         # Verify workspace exists if provided
         if workspace_id is not None:
@@ -734,7 +755,7 @@ class RBACService(BaseOrgService):
         assignment = await self.get_user_assignment(assignment_id)
 
         # Verify new role exists
-        await self._assert_role_exists(role_id)
+        await self._ensure_role_assignable(role_id)
 
         assignment.role_id = role_id
         await self.session.commit()

--- a/tests/unit/test_api_exception_handlers.py
+++ b/tests/unit/test_api_exception_handlers.py
@@ -1,0 +1,126 @@
+"""Tests for API exception handler status code and payload mapping."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tracecat.api.app import (
+    authorization_exception_handler,
+    scope_denied_exception_handler,
+)
+from tracecat.api.common import tracecat_exception_handler
+from tracecat.exceptions import (
+    ScopeDeniedError,
+    TracecatAuthorizationError,
+    TracecatException,
+    TracecatRLSViolationError,
+    TracecatValidationError,
+)
+
+
+def _build_app(exc: Exception) -> FastAPI:
+    """Build an app registering the same handlers as the real API.
+
+    Mirrors create_app() so subtype dispatch is exercised as in production:
+    Starlette resolves handlers along the exception MRO, so a subtype with its
+    own handler must win over the generic authorization handler.
+    """
+    app = FastAPI()
+    app.add_exception_handler(TracecatException, tracecat_exception_handler)
+    app.add_exception_handler(
+        TracecatAuthorizationError, authorization_exception_handler
+    )
+    app.add_exception_handler(ScopeDeniedError, scope_denied_exception_handler)
+
+    async def boom() -> None:
+        raise exc
+
+    app.add_api_route("/boom", boom, methods=["GET"])
+    return app
+
+
+def _get(exc: Exception):
+    with TestClient(_build_app(exc), raise_server_exceptions=False) as client:
+        return client.get("/boom")
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_status"),
+    [
+        pytest.param(
+            TracecatAuthorizationError("denied"), 403, id="authorization-error-403"
+        ),
+        pytest.param(
+            ScopeDeniedError(
+                required_scopes=["org:rbac:update"], missing_scopes=["org:rbac:update"]
+            ),
+            403,
+            id="scope-denied-subclass-403",
+        ),
+        pytest.param(
+            TracecatRLSViolationError(
+                "RLS blocked", table="secret", operation="SELECT"
+            ),
+            403,
+            id="rls-subclass-403",
+        ),
+        pytest.param(
+            TracecatValidationError("bad"), 500, id="other-tracecat-error-500"
+        ),
+    ],
+)
+def test_exception_handler_status_codes(exc: Exception, expected_status: int) -> None:
+    """Authorization denials return 403, not the generic 500."""
+    assert _get(exc).status_code == expected_status
+
+
+def test_authorization_response_is_fixed_and_opaque() -> None:
+    """The generic 403 body must not echo the exception message."""
+    response = _get(
+        TracecatAuthorizationError(
+            "Cannot grant scopes not held by the caller: org:owner:assign"
+        )
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Forbidden"}
+
+
+def test_rls_violation_does_not_leak_internal_state() -> None:
+    """RLS denials must not expose table, operation, or tenant identifiers.
+
+    TracecatRLSViolationError puts these on ``detail``; serializing that on a
+    403 would hand an unauthorized caller schema and tenant information.
+    """
+    response = _get(
+        TracecatRLSViolationError(
+            "RLS blocked access",
+            table="secret",
+            operation="SELECT",
+            org_id="org-abc-123",
+            workspace_id="ws-xyz-789",
+        )
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Forbidden"}
+
+    body = response.text
+    for leaked in ("secret", "SELECT", "org-abc-123", "ws-xyz-789", "RLS"):
+        assert leaked not in body
+
+
+def test_scope_denied_keeps_its_structured_body() -> None:
+    """The allowlisted subtype handler still returns machine-readable detail."""
+    response = _get(
+        ScopeDeniedError(
+            required_scopes=["org:rbac:update"], missing_scopes=["org:rbac:update"]
+        )
+    )
+
+    assert response.status_code == 403
+    error = response.json()["error"]
+    assert error["code"] == "insufficient_scope"
+    assert error["missing_scopes"] == ["org:rbac:update"]

--- a/tests/unit/test_authz_grant_resolver.py
+++ b/tests/unit/test_authz_grant_resolver.py
@@ -1,0 +1,363 @@
+"""Tests for the canonical grant resolver.
+
+These pin the defining invariant: the scope ceiling is decided from live
+database state, never from the cached ``Role.scopes`` snapshot. Each test
+deliberately puts cached and database state in conflict, so replacing the
+live query with ``Role.scopes`` flips the outcome and fails the test.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.authz.seeding import seed_system_scopes
+from tracecat.authz.service import resolve_grantable_role
+from tracecat.db.models import (
+    Group,
+    GroupMember,
+    GroupRoleAssignment,
+    Organization,
+    OrganizationMembership,
+    RoleScope,
+    Scope,
+    User,
+    UserRoleAssignment,
+    Workspace,
+)
+from tracecat.db.models import Role as DBRole
+from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
+
+pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("db")]
+
+OWNER_SCOPE = "org:owner:assign"
+ADMIN_SCOPE = "org:member:read"
+
+
+@pytest.fixture
+async def org(session: AsyncSession) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Test Org",
+        slug=f"test-org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(org)
+    await session.commit()
+    return org
+
+
+@pytest.fixture
+async def granter_user(session: AsyncSession, org: Organization) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"granter-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="test",
+    )
+    session.add(user)
+    await session.flush()
+    session.add(OrganizationMembership(user_id=user.id, organization_id=org.id))
+    await session.commit()
+    return user
+
+
+@pytest.fixture
+async def seeded(session: AsyncSession) -> None:
+    await seed_system_scopes(session)
+
+
+@pytest.fixture
+async def workspace(session: AsyncSession, org: Organization) -> Workspace:
+    ws = Workspace(
+        id=uuid.uuid4(),
+        name=f"ws-{uuid.uuid4().hex[:8]}",
+        organization_id=org.id,
+    )
+    session.add(ws)
+    await session.commit()
+    return ws
+
+
+async def _scope(session: AsyncSession, name: str) -> Scope:
+    result = await session.execute(select(Scope).where(Scope.name == name))
+    return result.scalars().one()
+
+
+async def _make_role(
+    session: AsyncSession, org: Organization, name: str, scope_names: list[str]
+) -> DBRole:
+    role = DBRole(id=uuid.uuid4(), name=name, slug=None, organization_id=org.id)
+    session.add(role)
+    await session.flush()
+    for scope_name in scope_names:
+        scope = await _scope(session, scope_name)
+        session.add(RoleScope(role_id=role.id, scope_id=scope.id))
+    await session.commit()
+    return role
+
+
+async def _assign(
+    session: AsyncSession,
+    org: Organization,
+    user: User,
+    role: DBRole,
+    workspace_id: uuid.UUID | None = None,
+) -> None:
+    session.add(
+        UserRoleAssignment(
+            organization_id=org.id,
+            user_id=user.id,
+            workspace_id=workspace_id,
+            role_id=role.id,
+        )
+    )
+    await session.commit()
+
+
+async def _assign_via_group(
+    session: AsyncSession,
+    org: Organization,
+    user: User,
+    role: DBRole,
+    workspace_id: uuid.UUID | None = None,
+) -> None:
+    group = Group(
+        id=uuid.uuid4(),
+        name=f"group-{uuid.uuid4().hex[:8]}",
+        organization_id=org.id,
+    )
+    session.add(group)
+    await session.flush()
+    session.add(GroupMember(group_id=group.id, user_id=user.id))
+    session.add(
+        GroupRoleAssignment(
+            organization_id=org.id,
+            group_id=group.id,
+            role_id=role.id,
+            workspace_id=workspace_id,
+        )
+    )
+    await session.commit()
+
+
+def _role_claiming(user: User, org: Organization, scopes: set[str]) -> Role:
+    """Build a request role whose cached scopes may disagree with the database."""
+    return Role(
+        type="user",
+        user_id=user.id,
+        organization_id=org.id,
+        service_id="tracecat-api",
+        scopes=frozenset(scopes),
+    )
+
+
+async def test_denies_when_cached_scopes_exceed_database(
+    session: AsyncSession,
+    org: Organization,
+    granter_user: User,
+    seeded: None,
+) -> None:
+    """A stale cache claiming owner scope must not authorize an owner grant.
+
+    Models a just-demoted owner: the request snapshot still carries the owner
+    scope, but the database says they only hold the admin scope.
+    """
+    admin_role = await _make_role(session, org, "Admin", [ADMIN_SCOPE])
+    await _assign(session, org, granter_user, admin_role)
+    target = await _make_role(session, org, "Owner Target", [OWNER_SCOPE])
+
+    # Cached snapshot claims MORE than the database grants.
+    granter = _role_claiming(granter_user, org, {OWNER_SCOPE, ADMIN_SCOPE})
+
+    with pytest.raises(
+        TracecatAuthorizationError,
+        match="Cannot grant scopes not held by the caller",
+    ):
+        await resolve_grantable_role(session, granter, org.id, target.id)
+
+
+async def test_allows_when_database_exceeds_cached_scopes(
+    session: AsyncSession,
+    org: Organization,
+    granter_user: User,
+    seeded: None,
+) -> None:
+    """A stale cache missing owner scope must not block an owner grant.
+
+    Models a just-promoted owner: the database already grants the owner scope
+    while the request snapshot predates the promotion.
+    """
+    owner_role = await _make_role(session, org, "Owner", [OWNER_SCOPE, ADMIN_SCOPE])
+    await _assign(session, org, granter_user, owner_role)
+    target = await _make_role(session, org, "Owner Target", [OWNER_SCOPE])
+
+    # Cached snapshot claims LESS than the database grants.
+    granter = _role_claiming(granter_user, org, {ADMIN_SCOPE})
+
+    resolved = await resolve_grantable_role(session, granter, org.id, target.id)
+    assert resolved.id == target.id
+
+
+async def test_group_membership_counts_toward_ceiling(
+    session: AsyncSession,
+    org: Organization,
+    granter_user: User,
+    seeded: None,
+) -> None:
+    """Privileges held solely via group membership authorize a grant.
+
+    The cached snapshot claims nothing, so this also pins that the live
+    query unions the group path, not just direct assignments.
+    """
+    owner_role = await _make_role(session, org, "Owner", [OWNER_SCOPE])
+    await _assign_via_group(session, org, granter_user, owner_role)
+    target = await _make_role(session, org, "Owner Target", [OWNER_SCOPE])
+
+    granter = _role_claiming(granter_user, org, set())
+
+    resolved = await resolve_grantable_role(session, granter, org.id, target.id)
+    assert resolved.id == target.id
+
+
+async def test_workspace_scoped_assignment_counts_in_workspace_context(
+    session: AsyncSession,
+    org: Organization,
+    granter_user: User,
+    workspace: Workspace,
+    seeded: None,
+) -> None:
+    """A workspace-scoped direct assignment applies when granting in that workspace."""
+    owner_role = await _make_role(session, org, "Owner", [OWNER_SCOPE])
+    await _assign(session, org, granter_user, owner_role, workspace_id=workspace.id)
+    target = await _make_role(session, org, "Owner Target", [OWNER_SCOPE])
+
+    granter = Role(
+        type="user",
+        user_id=granter_user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+        service_id="tracecat-api",
+        scopes=frozenset(),
+    )
+
+    resolved = await resolve_grantable_role(session, granter, org.id, target.id)
+    assert resolved.id == target.id
+
+
+async def test_workspace_scoped_assignment_ignored_in_org_context(
+    session: AsyncSession,
+    org: Organization,
+    granter_user: User,
+    workspace: Workspace,
+    seeded: None,
+) -> None:
+    """A workspace-scoped group grant does not raise the org-context ceiling.
+
+    The cached snapshot claims the owner scope, so passing requires the live
+    query to correctly exclude workspace-scoped assignments when the granter
+    is operating without a workspace context.
+    """
+    owner_role = await _make_role(session, org, "Owner", [OWNER_SCOPE])
+    await _assign_via_group(
+        session, org, granter_user, owner_role, workspace_id=workspace.id
+    )
+    target = await _make_role(session, org, "Owner Target", [OWNER_SCOPE])
+
+    granter = _role_claiming(granter_user, org, {OWNER_SCOPE})
+
+    with pytest.raises(
+        TracecatAuthorizationError,
+        match="Cannot grant scopes not held by the caller",
+    ):
+        await resolve_grantable_role(session, granter, org.id, target.id)
+
+
+async def test_service_role_falls_back_to_cached_scopes(
+    session: AsyncSession,
+    org: Organization,
+    seeded: None,
+) -> None:
+    """Service principals have no user row; the ceiling uses cached scopes."""
+    target = await _make_role(session, org, "Owner Target", [OWNER_SCOPE])
+
+    granter = Role(
+        type="service",
+        user_id=None,
+        organization_id=org.id,
+        service_id="tracecat-api",
+        scopes=frozenset({OWNER_SCOPE}),
+    )
+
+    resolved = await resolve_grantable_role(session, granter, org.id, target.id)
+    assert resolved.id == target.id
+
+
+async def test_service_role_denied_beyond_cached_scopes(
+    session: AsyncSession,
+    org: Organization,
+    seeded: None,
+) -> None:
+    """The cached-scope fallback still enforces the ceiling for service roles."""
+    target = await _make_role(session, org, "Owner Target", [OWNER_SCOPE])
+
+    granter = Role(
+        type="service",
+        user_id=None,
+        organization_id=org.id,
+        service_id="tracecat-api",
+        scopes=frozenset({ADMIN_SCOPE}),
+    )
+
+    with pytest.raises(
+        TracecatAuthorizationError,
+        match="Cannot grant scopes not held by the caller",
+    ):
+        await resolve_grantable_role(session, granter, org.id, target.id)
+
+
+async def test_rejects_role_from_another_organization(
+    session: AsyncSession,
+    org: Organization,
+    granter_user: User,
+    seeded: None,
+) -> None:
+    """Ownership is validated: a role in another org is not resolvable."""
+    other_org = Organization(
+        id=uuid.uuid4(),
+        name="Other Org",
+        slug=f"other-org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(other_org)
+    await session.commit()
+    foreign_role = await _make_role(session, other_org, "Foreign", [ADMIN_SCOPE])
+
+    granter = _role_claiming(granter_user, org, {OWNER_SCOPE, ADMIN_SCOPE})
+
+    with pytest.raises(TracecatNotFoundError):
+        await resolve_grantable_role(session, granter, org.id, foreign_role.id)
+
+
+async def test_superuser_bypasses_ceiling(
+    session: AsyncSession,
+    org: Organization,
+    granter_user: User,
+    seeded: None,
+) -> None:
+    """Platform superusers are not bound by the ceiling."""
+    target = await _make_role(session, org, "Owner Target", [OWNER_SCOPE])
+    granter = Role(
+        type="user",
+        user_id=granter_user.id,
+        organization_id=org.id,
+        service_id="tracecat-api",
+        is_platform_superuser=True,
+        scopes=frozenset(),
+    )
+
+    resolved = await resolve_grantable_role(session, granter, org.id, target.id)
+    assert resolved.id == target.id

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -9,16 +9,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
-from tracecat.authz.scopes import ADMIN_SCOPES
+from tracecat.authz.scopes import ADMIN_SCOPES, EDITOR_SCOPES
+from tracecat.authz.seeding import seed_system_scopes
 from tracecat.authz.service import MembershipService
 from tracecat.db.models import (
     Membership,
     Organization,
+    RoleScope,
+    Scope,
     User,
     UserRoleAssignment,
     Workspace,
 )
 from tracecat.db.models import Role as DBRole
+from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.workspaces.schemas import WorkspaceMembershipCreate
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("db")]
@@ -284,3 +288,136 @@ async def test_create_membership_duplicate_raises_integrity_error(
             workspace_id=workspace.id,
             params=WorkspaceMembershipCreate(user_id=member_user.id),
         )
+
+
+@pytest.fixture
+async def scoped_workspace_editor_role(
+    session: AsyncSession,
+    organization: Organization,
+    workspace_editor_role: DBRole,
+) -> DBRole:
+    """Attach real editor scopes to the default role.
+
+    Without backing RoleScope rows the grant ceiling is vacuous, so escalation
+    through membership creation would go unnoticed.
+    """
+    await seed_system_scopes(session)
+    result = await session.execute(
+        select(Scope).where(Scope.name.in_(sorted(EDITOR_SCOPES)))
+    )
+    for scope in result.scalars().all():
+        session.add(RoleScope(role_id=workspace_editor_role.id, scope_id=scope.id))
+    await session.commit()
+    return workspace_editor_role
+
+
+async def test_create_membership_rejects_inviter_without_editor_scopes(
+    session: AsyncSession,
+    organization: Organization,
+    workspace: Workspace,
+    actor_user: User,
+    member_user: User,
+    scoped_workspace_editor_role: DBRole,
+) -> None:
+    """A caller holding only the invite scope cannot grant the editor role.
+
+    Membership creation assigns workspace-editor, so an unbounded write would
+    let a single scope escalate into the full editor scope set.
+    """
+    inviter_role = DBRole(
+        id=uuid.uuid4(),
+        name="Inviter Only",
+        slug=None,
+        organization_id=organization.id,
+    )
+    session.add(inviter_role)
+    await session.flush()
+    invite_scope = (
+        (
+            await session.execute(
+                select(Scope).where(Scope.name == "workspace:member:invite")
+            )
+        )
+        .scalars()
+        .one()
+    )
+    session.add(RoleScope(role_id=inviter_role.id, scope_id=invite_scope.id))
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=actor_user.id,
+            workspace_id=workspace.id,
+            role_id=inviter_role.id,
+        )
+    )
+    await session.commit()
+
+    service = MembershipService(
+        session=session,
+        role=Role(
+            type="user",
+            user_id=actor_user.id,
+            organization_id=organization.id,
+            workspace_id=workspace.id,
+            service_id="tracecat-api",
+            scopes=frozenset({"workspace:member:invite"}),
+        ),
+    )
+
+    with pytest.raises(
+        TracecatAuthorizationError,
+        match="Cannot grant scopes not held by the caller",
+    ):
+        await service.create_membership(
+            workspace_id=workspace.id,
+            params=WorkspaceMembershipCreate(user_id=member_user.id),
+        )
+
+
+async def test_create_membership_allows_admin_inviter(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    workspace: Workspace,
+    member_user: User,
+    scoped_workspace_editor_role: DBRole,
+    organization: Organization,
+    actor_user: User,
+) -> None:
+    """An admin inviter still grants membership once the ceiling applies."""
+    admin_role = DBRole(
+        id=uuid.uuid4(),
+        name="Workspace Admin",
+        slug=None,
+        organization_id=organization.id,
+    )
+    session.add(admin_role)
+    await session.flush()
+    result = await session.execute(
+        select(Scope).where(Scope.name.in_(sorted(ADMIN_SCOPES)))
+    )
+    for scope in result.scalars().all():
+        session.add(RoleScope(role_id=admin_role.id, scope_id=scope.id))
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=actor_user.id,
+            workspace_id=workspace.id,
+            role_id=admin_role.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.create_membership(
+        workspace_id=workspace.id,
+        params=WorkspaceMembershipCreate(user_id=member_user.id),
+    )
+
+    membership = (
+        await session.execute(
+            select(Membership).where(
+                Membership.user_id == member_user.id,
+                Membership.workspace_id == workspace.id,
+            )
+        )
+    ).scalar_one_or_none()
+    assert membership is not None

--- a/tests/unit/test_organization_service.py
+++ b/tests/unit/test_organization_service.py
@@ -16,6 +16,7 @@ from tracecat.auth.api_keys import ORG_API_KEY_PREFIX, generate_managed_api_key
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import ORG_ADMIN_SCOPES, ORG_MEMBER_SCOPES, ORG_OWNER_SCOPES
+from tracecat.authz.seeding import seed_system_scopes
 from tracecat.db.models import (
     AccessToken,
     Group,
@@ -25,6 +26,8 @@ from tracecat.db.models import (
     Organization,
     OrganizationInvitation,
     OrganizationMembership,
+    RoleScope,
+    Scope,
     ServiceAccount,
     ServiceAccountApiKey,
     User,
@@ -100,7 +103,12 @@ async def user_in_org1(session: AsyncSession, org1: Organization) -> User:
 
 @pytest.fixture
 async def admin_in_org1(session: AsyncSession, org1: Organization) -> User:
-    """Create an admin user that belongs to org1."""
+    """Create an admin user that belongs to org1.
+
+    Backed by a real org-wide admin assignment so grant ceilings, which read
+    the caller's scopes from the database, see a genuine admin rather than an
+    empty scope set.
+    """
     user = User(
         id=uuid.uuid4(),
         email=f"admin-org1-{uuid.uuid4().hex[:8]}@example.com",
@@ -118,6 +126,29 @@ async def admin_in_org1(session: AsyncSession, org1: Organization) -> User:
         organization_id=org1.id,
     )
     session.add(membership)
+
+    await seed_system_scopes(session)
+    admin_db_role = DBRole(
+        id=uuid.uuid4(),
+        name="Org Admin",
+        slug=None,
+        organization_id=org1.id,
+    )
+    session.add(admin_db_role)
+    await session.flush()
+    scope_result = await session.execute(
+        select(Scope).where(Scope.name.in_(sorted(ORG_ADMIN_SCOPES)))
+    )
+    for scope in scope_result.scalars().all():
+        session.add(RoleScope(role_id=admin_db_role.id, scope_id=scope.id))
+    session.add(
+        UserRoleAssignment(
+            organization_id=org1.id,
+            user_id=user.id,
+            workspace_id=None,
+            role_id=admin_db_role.id,
+        )
+    )
     await session.commit()
     return user
 
@@ -202,7 +233,12 @@ async def org1_admin_role(session: AsyncSession, org1: Organization) -> DBRole:
 
 @pytest.fixture
 async def org1_owner_role(session: AsyncSession, org1: Organization) -> DBRole:
-    """Create an RBAC 'organization-owner' role for org1."""
+    """Create an RBAC 'organization-owner' role for org1.
+
+    Carries the real owner scope set: the grant ceiling is enforced from
+    scopes, so an unscoped role would be vacuously grantable.
+    """
+    await seed_system_scopes(session)
     role = DBRole(
         id=uuid.uuid4(),
         name="Organization Owner",
@@ -211,6 +247,36 @@ async def org1_owner_role(session: AsyncSession, org1: Organization) -> DBRole:
         organization_id=org1.id,
     )
     session.add(role)
+    await session.flush()
+    scope_result = await session.execute(
+        select(Scope).where(Scope.name.in_(sorted(ORG_OWNER_SCOPES)))
+    )
+    for scope in scope_result.scalars().all():
+        session.add(RoleScope(role_id=role.id, scope_id=scope.id))
+    await session.commit()
+    return role
+
+
+@pytest.fixture
+async def org1_privileged_custom_role(
+    session: AsyncSession, org1: Organization
+) -> DBRole:
+    """Create a slug-less custom role carrying an owner-only scope."""
+    await seed_system_scopes(session)
+    scope_result = await session.execute(
+        select(Scope).where(Scope.name == "org:owner:assign")
+    )
+    scope = scope_result.scalars().one()
+    role = DBRole(
+        id=uuid.uuid4(),
+        name="Privileged Custom Role",
+        slug=None,
+        description="Custom role with an owner-only scope",
+        organization_id=org1.id,
+    )
+    session.add(role)
+    await session.flush()
+    session.add(RoleScope(role_id=role.id, scope_id=scope.id))
     await session.commit()
     return role
 
@@ -1130,19 +1196,67 @@ class TestOrganizationServiceInvitations:
         admin_in_org1: User,
         org1_owner_role: DBRole,
     ):
-        """Test that org admins cannot create OWNER invitations."""
+        """Test that org admins cannot create OWNER invitations.
+
+        Enforced by the scope ceiling rather than a slug check: the owner role
+        carries org:owner:assign, which an admin does not hold.
+        """
         # Org admin (not superuser) should not be able to create OWNER invitations
         role = create_admin_role(org1.id, admin_in_org1.id)
         service = OrgService(session, role=role)
 
         with pytest.raises(
             TracecatAuthorizationError,
-            match="Only organization owners can create owner invitations",
+            match="Cannot grant scopes not held by the caller",
         ):
             await service.create_invitation(
                 email="newowner@example.com",
                 role_id=org1_owner_role.id,
             )
+
+    @pytest.mark.anyio
+    async def test_create_invitation_rejects_unheld_scopes_via_custom_role(
+        self,
+        session: AsyncSession,
+        org1: Organization,
+        admin_in_org1: User,
+        org1_privileged_custom_role: DBRole,
+    ):
+        """Test the owner-slug check cannot be bypassed with a custom role.
+
+        A custom role has slug=None, so the slug check alone lets an admin
+        invite an alternate account holding org:owner:assign.
+        """
+        role = create_admin_role(org1.id, admin_in_org1.id)
+        service = OrgService(session, role=role)
+
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
+            await service.create_invitation(
+                email="escalated@example.com",
+                role_id=org1_privileged_custom_role.id,
+            )
+
+    @pytest.mark.anyio
+    async def test_superuser_can_create_invitation_with_privileged_custom_role(
+        self,
+        session: AsyncSession,
+        org1: Organization,
+        admin_in_org1: User,
+        org1_privileged_custom_role: DBRole,
+    ):
+        """Test the scope ceiling does not block platform superusers."""
+        role = create_superuser_role(org1.id, admin_in_org1.id)
+        service = OrgService(session, role=role)
+
+        invitation = await service.create_invitation(
+            email="newowner@example.com",
+            role_id=org1_privileged_custom_role.id,
+        )
+
+        assert invitation.role_id == org1_privileged_custom_role.id
 
     @pytest.mark.anyio
     async def test_superuser_can_create_owner_invitation(

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -6,6 +6,7 @@ import pytest
 
 from tracecat.auth.types import Role
 from tracecat.authz.controls import (
+    ensure_can_grant_scopes,
     get_missing_scopes,
     has_all_scopes,
     has_any_scope,
@@ -27,7 +28,7 @@ from tracecat.authz.scopes import (
     WORKSPACE_OPERATIONAL_SCOPES,
 )
 from tracecat.contexts import ctx_role
-from tracecat.exceptions import ScopeDeniedError
+from tracecat.exceptions import ScopeDeniedError, TracecatAuthorizationError
 
 
 @pytest.fixture(autouse=True)
@@ -242,6 +243,34 @@ class TestGetMissingScopes:
         scopes = frozenset({"workflow:*"})
         missing = get_missing_scopes(scopes, {"workflow:read", "workflow:execute"})
         assert missing == set()
+
+
+class TestEnsureCanGrantScopes:
+    """Tests for the scope-ceiling check, including wildcard semantics.
+
+    Wildcard matching is inherited from ``has_scope``; these pin the ceiling
+    behavior on both sides of the wildcard so a change to ``has_scope``
+    semantics cannot silently open an escalation path.
+    """
+
+    def test_exact_match_allowed(self):
+        ensure_can_grant_scopes(frozenset({"org:member:read"}), ["org:member:read"])
+
+    def test_wildcard_granter_covers_concrete_scope(self):
+        ensure_can_grant_scopes(frozenset({"org:*"}), ["org:owner:assign"])
+
+    def test_concrete_granter_cannot_grant_wildcard_scope(self):
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match=r"Cannot grant scopes not held by the caller: org:\*",
+        ):
+            ensure_can_grant_scopes(
+                frozenset({"org:read", "org:owner:assign"}), ["org:*"]
+            )
+
+    def test_empty_granter_denied(self):
+        with pytest.raises(TracecatAuthorizationError):
+            ensure_can_grant_scopes(frozenset(), ["org:member:read"])
 
 
 class TestSystemRoleScopes:

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -16,13 +16,16 @@ from tracecat.authz.seeding import seed_system_scopes
 from tracecat.db.models import (
     Group,
     GroupMember,
+    GroupRoleAssignment,
     Organization,
     OrganizationMembership,
+    RoleScope,
     Scope,
     User,
     UserRoleAssignment,
     Workspace,
 )
+from tracecat.db.models import Role as DBRole
 from tracecat.exceptions import (
     TracecatAuthorizationError,
     TracecatNotFoundError,
@@ -88,11 +91,84 @@ async def seeded_scopes(session: AsyncSession) -> list[Scope]:
 
 
 @pytest.fixture
-def role(org: Organization, user: User) -> Role:
-    """Create a test role for the service."""
+def admin_assignable_scopes(seeded_scopes: list[Scope]) -> list[Scope]:
+    """Return seeded scopes held by the organization-admin test role."""
+    return [scope for scope in seeded_scopes if scope.name in ORG_ADMIN_SCOPES]
+
+
+@pytest.fixture
+async def privileged_role(
+    session: AsyncSession,
+    org: Organization,
+    user: User,
+    seeded_scopes: list[Scope],
+) -> DBRole:
+    """Create a pre-existing role with an owner-only scope."""
+    owner_scope = next(
+        scope for scope in seeded_scopes if scope.name == "org:owner:assign"
+    )
+    privileged_role = DBRole(
+        name="Privileged Test Role",
+        slug=None,
+        description=None,
+        organization_id=org.id,
+        created_by=user.id,
+    )
+    session.add(privileged_role)
+    await session.flush()
+    session.add(RoleScope(role_id=privileged_role.id, scope_id=owner_scope.id))
+    await session.commit()
+    await session.refresh(privileged_role, ["scopes"])
+    return privileged_role
+
+
+@pytest.fixture
+async def role(
+    session: AsyncSession,
+    org: Organization,
+    seeded_scopes: list[Scope],
+) -> Role:
+    """Create a test role for the service.
+
+    The caller is a separate admin user backed by a real org-wide assignment:
+    grant ceilings read the caller's scopes from the database, so an
+    in-memory-only role would be denied. Keeping the caller distinct from the
+    ``user`` fixture leaves that user's assignment slots free for tests.
+    """
+    admin_user = User(
+        id=uuid.uuid4(),
+        email="admin@example.com",
+        hashed_password="test",
+    )
+    session.add(admin_user)
+    await session.flush()
+    session.add(OrganizationMembership(user_id=admin_user.id, organization_id=org.id))
+
+    admin_role = DBRole(
+        name="Test Org Admin",
+        slug=None,
+        description=None,
+        organization_id=org.id,
+        created_by=admin_user.id,
+    )
+    session.add(admin_role)
+    await session.flush()
+    for scope in seeded_scopes:
+        if scope.name in ORG_ADMIN_SCOPES:
+            session.add(RoleScope(role_id=admin_role.id, scope_id=scope.id))
+    session.add(
+        UserRoleAssignment(
+            organization_id=org.id,
+            user_id=admin_user.id,
+            workspace_id=None,
+            role_id=admin_role.id,
+        )
+    )
+    await session.commit()
+
     return Role(
         type="user",
-        user_id=user.id,
+        user_id=admin_user.id,
         organization_id=org.id,
         service_id="tracecat-api",
         scopes=ORG_ADMIN_SCOPES,
@@ -210,17 +286,54 @@ class TestRBACServiceRoles:
         self,
         session: AsyncSession,
         role: Role,
-        seeded_scopes: list[Scope],
+        admin_assignable_scopes: list[Scope],
     ):
         """Create a role with scopes assigned."""
         service = RBACService(session, role=role)
-        scope_ids = [s.id for s in seeded_scopes[:3]]
+        scope_ids = [scope.id for scope in admin_assignable_scopes[:3]]
 
         custom_role = await service.create_role(
             name="Custom Role With Scopes",
             scope_ids=scope_ids,
         )
         assert len(custom_role.scopes) == 3
+
+    async def test_create_role_rejects_unheld_scopes(
+        self,
+        session: AsyncSession,
+        role: Role,
+        privileged_role: DBRole,
+    ):
+        """Creating a role cannot grant scopes outside the caller's ceiling."""
+        service = RBACService(session, role=role)
+
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
+            await service.create_role(
+                name="Escalated Role",
+                scope_ids=[privileged_role.scopes[0].id],
+            )
+
+    async def test_update_role_rejects_unheld_scopes(
+        self,
+        session: AsyncSession,
+        role: Role,
+        privileged_role: DBRole,
+    ):
+        """Updating a role cannot grant scopes outside the caller's ceiling."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(name="Assignable Role")
+
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
+            await service.update_role(
+                custom_role.id,
+                scope_ids=[privileged_role.scopes[0].id],
+            )
 
     async def test_update_role(
         self,
@@ -345,6 +458,34 @@ class TestRBACServiceGroups:
         await service.add_group_member(group.id, user.id)
 
         with pytest.raises(TracecatValidationError):
+            await service.add_group_member(group.id, user.id)
+
+    async def test_add_member_rejects_unheld_group_role(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        user: User,
+        privileged_role: DBRole,
+    ):
+        """Adding a member cannot grant scopes outside the caller's ceiling."""
+        service = RBACService(session, role=role)
+        group = await service.create_group(name="Privileged Group")
+        session.add(
+            GroupRoleAssignment(
+                organization_id=org.id,
+                group_id=group.id,
+                role_id=privileged_role.id,
+                workspace_id=None,
+                assigned_by=user.id,
+            )
+        )
+        await session.commit()
+
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
             await service.add_group_member(group.id, user.id)
 
     async def test_remove_member_from_group(
@@ -520,6 +661,49 @@ class TestRBACServiceAssignments:
 
         assert updated.role_id == role2.id
 
+    async def test_create_assignment_rejects_unheld_role(
+        self,
+        session: AsyncSession,
+        role: Role,
+        privileged_role: DBRole,
+    ):
+        """Group assignment creation enforces the caller's scope ceiling."""
+        service = RBACService(session, role=role)
+        group = await service.create_group(name="Target Group")
+
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
+            await service.create_group_role_assignment(
+                group_id=group.id,
+                role_id=privileged_role.id,
+            )
+
+    async def test_update_assignment_rejects_unheld_role(
+        self,
+        session: AsyncSession,
+        role: Role,
+        privileged_role: DBRole,
+    ):
+        """Group assignment updates enforce the caller's scope ceiling."""
+        service = RBACService(session, role=role)
+        assignable_role = await service.create_role(name="Assignable Role")
+        group = await service.create_group(name="Target Group")
+        assignment = await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=assignable_role.id,
+        )
+
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
+            await service.update_group_role_assignment(
+                assignment.id,
+                role_id=privileged_role.id,
+            )
+
 
 @pytest.mark.anyio
 class TestRBACServiceUserAssignments:
@@ -645,6 +829,49 @@ class TestRBACServiceUserAssignments:
                 role_id=custom_role.id,
             )
 
+    async def test_create_user_assignment_rejects_unheld_role(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        privileged_role: DBRole,
+    ):
+        """User assignment creation enforces the caller's scope ceiling."""
+        service = RBACService(session, role=role)
+
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
+            await service.create_user_assignment(
+                user_id=user.id,
+                role_id=privileged_role.id,
+            )
+
+    async def test_update_user_assignment_rejects_unheld_role(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        privileged_role: DBRole,
+    ):
+        """User assignment updates enforce the caller's scope ceiling."""
+        service = RBACService(session, role=role)
+        assignable_role = await service.create_role(name="Assignable Role")
+        assignment = await service.create_user_assignment(
+            user_id=user.id,
+            role_id=assignable_role.id,
+        )
+
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
+            await service.update_user_assignment(
+                assignment.id,
+                role_id=privileged_role.id,
+            )
+
 
 @pytest.mark.anyio
 class TestRBACServiceScopeComputation:
@@ -666,13 +893,13 @@ class TestRBACServiceScopeComputation:
         session: AsyncSession,
         role: Role,
         user: User,
-        seeded_scopes: list[Scope],
+        admin_assignable_scopes: list[Scope],
     ):
         """User gets scopes from group membership."""
         service = RBACService(session, role=role)
 
         # Create role with scopes
-        scope_ids = [s.id for s in seeded_scopes[:2]]
+        scope_ids = [scope.id for scope in admin_assignable_scopes[:2]]
         custom_role = await service.create_role(
             name="Test Role",
             scope_ids=scope_ids,
@@ -690,7 +917,10 @@ class TestRBACServiceScopeComputation:
 
         # Get scopes
         scopes = await service.get_group_scopes(user.id)
-        expected_names = {seeded_scopes[0].name, seeded_scopes[1].name}
+        expected_names = {
+            admin_assignable_scopes[0].name,
+            admin_assignable_scopes[1].name,
+        }
         assert scopes == expected_names
 
     async def test_get_group_scopes_workspace_specific(
@@ -699,7 +929,7 @@ class TestRBACServiceScopeComputation:
         role: Role,
         user: User,
         workspace: Workspace,
-        seeded_scopes: list[Scope],
+        admin_assignable_scopes: list[Scope],
     ):
         """Workspace-specific assignments only apply when workspace matches."""
         service = RBACService(session, role=role)
@@ -707,7 +937,7 @@ class TestRBACServiceScopeComputation:
         # Create role with scopes
         custom_role = await service.create_role(
             name="Workspace Role",
-            scope_ids=[seeded_scopes[0].id],
+            scope_ids=[admin_assignable_scopes[0].id],
         )
 
         # Create group, add user, and assign to specific workspace
@@ -727,7 +957,7 @@ class TestRBACServiceScopeComputation:
         scopes_with_ws = await service.get_group_scopes(
             user.id, workspace_id=workspace.id
         )
-        assert seeded_scopes[0].name in scopes_with_ws
+        assert admin_assignable_scopes[0].name in scopes_with_ws
 
     async def test_get_group_scopes_org_wide_applies_to_workspace(
         self,
@@ -735,7 +965,7 @@ class TestRBACServiceScopeComputation:
         role: Role,
         user: User,
         workspace: Workspace,
-        seeded_scopes: list[Scope],
+        admin_assignable_scopes: list[Scope],
     ):
         """Org-wide assignments apply even when workspace is specified."""
         service = RBACService(session, role=role)
@@ -743,7 +973,7 @@ class TestRBACServiceScopeComputation:
         # Create role with scopes
         custom_role = await service.create_role(
             name="Org Role",
-            scope_ids=[seeded_scopes[0].id],
+            scope_ids=[admin_assignable_scopes[0].id],
         )
 
         # Create group, add user, and assign org-wide
@@ -757,4 +987,4 @@ class TestRBACServiceScopeComputation:
 
         # With workspace context, org-wide scopes still apply
         scopes = await service.get_group_scopes(user.id, workspace_id=workspace.id)
-        assert seeded_scopes[0].name in scopes
+        assert admin_assignable_scopes[0].name in scopes

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -11,10 +11,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import ADMIN_SCOPES
+from tracecat.authz.seeding import seed_system_scopes
 from tracecat.db.models import (
     Membership,
     Organization,
     OrganizationMembership,
+    RoleScope,
+    Scope,
     User,
     Workspace,
 )
@@ -700,6 +703,44 @@ class TestCreateInvitation:
         assert len(invitation.token) == 64
         assert invitation.expires_at > datetime.now(UTC)
         assert invitation.accepted_at is None
+
+    async def test_create_invitation_rejects_unheld_scopes(
+        self,
+        session: AsyncSession,
+        inv_org: Organization,
+        inv_workspace: Workspace,
+        admin_user: User,
+    ):
+        """Test a workspace invitation cannot grant scopes the inviter lacks."""
+        await seed_system_scopes(session)
+        scope_result = await session.execute(
+            select(Scope).where(Scope.name == "org:owner:assign")
+        )
+        scope = scope_result.scalars().one()
+        privileged_role = DBRole(
+            id=uuid.uuid4(),
+            name="Privileged Role",
+            slug=None,
+            description="Custom role with an owner-only scope",
+            organization_id=inv_org.id,
+        )
+        session.add(privileged_role)
+        await session.flush()
+        session.add(RoleScope(role_id=privileged_role.id, scope_id=scope.id))
+        await session.commit()
+
+        role = create_workspace_admin_role(inv_org.id, inv_workspace.id, admin_user.id)
+        service = WorkspaceService(session, role=role)
+
+        params = WorkspaceInvitationCreate(
+            email="escalated@example.com",
+            role_id=str(privileged_role.id),
+        )
+        with pytest.raises(
+            TracecatAuthorizationError,
+            match="Cannot grant scopes not held by the caller",
+        ):
+            await service.create_invitation(inv_workspace.id, params)
 
     async def test_create_invitation_duplicate_pending_fails(
         self,

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -100,7 +100,12 @@ from tracecat.db.exceptions import AuthPoolExhaustedError
 from tracecat.db.rls import set_rls_context_from_role
 from tracecat.db.soft_delete import assert_soft_delete_listener_registered
 from tracecat.editor.router import router as editor_router
-from tracecat.exceptions import EntitlementRequired, ScopeDeniedError, TracecatException
+from tracecat.exceptions import (
+    EntitlementRequired,
+    ScopeDeniedError,
+    TracecatAuthorizationError,
+    TracecatException,
+)
 from tracecat.feature_flags import FeatureFlag, FlagLike, is_feature_enabled
 from tracecat.feature_flags.router import router as feature_flags_router
 from tracecat.inbox.router import router as inbox_router
@@ -402,6 +407,32 @@ def entitlement_exception_handler(request: Request, exc: Exception) -> Response:
     )
 
 
+def authorization_exception_handler(request: Request, exc: Exception) -> Response:
+    """Handle TracecatAuthorizationError exceptions with a 403 Forbidden response.
+
+    Without this, authorization denials fall through to the generic
+    TracecatException handler, which returns 500.
+
+    The body is deliberately fixed. Subtypes such as TracecatRLSViolationError
+    carry internal state (table, operation, org/workspace IDs) on ``detail``,
+    and denial messages may embed identifiers, so nothing derived from the
+    exception is serialized here. Subtypes that need a structured body must
+    register their own handler with an explicitly chosen payload, as
+    ScopeDeniedError does.
+    """
+    logger.warning(
+        "Authorization denied",
+        path=request.url.path,
+        role=ctx_role.get(),
+        exception_type=type(exc).__name__,
+        detail=exc.detail if isinstance(exc, TracecatException) else None,
+    )
+    return ORJSONResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
+        content={"detail": "Forbidden"},
+    )
+
+
 def scope_denied_exception_handler(request: Request, exc: Exception) -> Response:
     """Handle ScopeDeniedError exceptions with a 403 Forbidden response.
 
@@ -656,6 +687,11 @@ def create_app(**kwargs) -> FastAPI:
         fastapi_users_auth_exception_handler,
     )
     app.add_exception_handler(EntitlementRequired, entitlement_exception_handler)
+    # Registered before ScopeDeniedError for readability only; Starlette dispatches
+    # on the exception MRO, so the subclass handler still wins.
+    app.add_exception_handler(
+        TracecatAuthorizationError, authorization_exception_handler
+    )
     app.add_exception_handler(ScopeDeniedError, scope_denied_exception_handler)
     app.add_exception_handler(HTTPException, http_exception_handler)
 

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -25,7 +25,7 @@ from fastapi.security import (
     HTTPBearer,
     OAuth2PasswordBearer,
 )
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -50,20 +50,12 @@ from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.engine import AuthSession, get_async_session_auth_context_manager
 from tracecat.db.models import (
-    GroupMember,
-    GroupRoleAssignment,
     Organization,
     OrganizationMembership,
-    RoleScope,
-    Scope,
     ServiceAccount,
     ServiceAccountApiKey,
     User,
-    UserRoleAssignment,
     Workspace,
-)
-from tracecat.db.models import (
-    Role as DBRole,
 )
 from tracecat.db.rls import set_rls_context, set_rls_context_from_role
 from tracecat.identifiers import InternalServiceID
@@ -223,55 +215,12 @@ async def _compute_effective_scopes_cached(
     organization_id: uuid.UUID,
     workspace_id: uuid.UUID | None,
 ) -> frozenset[str]:
+    from tracecat.authz.service import query_effective_scopes
+
     async with get_async_session_auth_context_manager() as session:
-        user_workspace_condition = (
-            or_(
-                UserRoleAssignment.workspace_id.is_(None),
-                UserRoleAssignment.workspace_id == workspace_id,
-            )
-            if workspace_id is not None
-            else UserRoleAssignment.workspace_id.is_(None)
+        return await query_effective_scopes(
+            session, user_id, organization_id, workspace_id
         )
-
-        group_workspace_condition = (
-            or_(
-                GroupRoleAssignment.workspace_id.is_(None),
-                GroupRoleAssignment.workspace_id == workspace_id,
-            )
-            if workspace_id is not None
-            else GroupRoleAssignment.workspace_id.is_(None)
-        )
-        # Direct user role assignments → Role → RoleScope → Scope
-        user_scopes = (
-            select(Scope.name)
-            .join(RoleScope, RoleScope.scope_id == Scope.id)
-            .join(DBRole, DBRole.id == RoleScope.role_id)
-            .join(UserRoleAssignment, UserRoleAssignment.role_id == DBRole.id)
-            .where(
-                UserRoleAssignment.user_id == user_id,
-                UserRoleAssignment.organization_id == organization_id,
-                user_workspace_condition,
-            )
-        )
-
-        # Group role assignments → GroupMember → GroupRoleAssignment → Role → RoleScope → Scope
-        group_scopes = (
-            select(Scope.name)
-            .join(RoleScope, RoleScope.scope_id == Scope.id)
-            .join(DBRole, DBRole.id == RoleScope.role_id)
-            .join(GroupRoleAssignment, GroupRoleAssignment.role_id == DBRole.id)
-            .join(GroupMember, GroupMember.group_id == GroupRoleAssignment.group_id)
-            .where(
-                GroupMember.user_id == user_id,
-                GroupRoleAssignment.organization_id == organization_id,
-                group_workspace_condition,
-            )
-        )
-
-        # Single atomic query: union both assignment paths
-        combined = user_scopes.union(group_scopes)
-        result = await session.execute(combined)
-        return frozenset(result.scalars().all())
 
 
 def get_role_from_user(

--- a/tracecat/authz/controls.py
+++ b/tracecat/authz/controls.py
@@ -2,13 +2,13 @@ import asyncio
 import functools
 import inspect
 import re
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterable
 from fnmatch import fnmatch
 from typing import Any, Protocol, TypeVar, cast, runtime_checkable
 
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
-from tracecat.exceptions import ScopeDeniedError
+from tracecat.exceptions import ScopeDeniedError, TracecatAuthorizationError
 from tracecat.logger import logger
 
 T = TypeVar("T", bound=Callable[..., Coroutine[Any, Any, Any] | Any])
@@ -144,6 +144,29 @@ def has_any_scope(user_scopes: frozenset[str], required_scopes: set[str]) -> boo
         True if at least one required scope is satisfied
     """
     return any(has_scope(user_scopes, scope) for scope in required_scopes)
+
+
+def ensure_can_grant_scopes(
+    caller_scopes: frozenset[str], scope_names: Iterable[str]
+) -> None:
+    """Reject grants containing scopes the caller does not hold.
+
+    Canonical scope-ceiling policy. Every role-grant producer must call this,
+    including invitations, so a grant can never exceed the granter's own scopes.
+
+    Takes resolved scopes rather than a Role so callers must decide explicitly
+    whether to pass live or cached state; grant decisions must pass live state.
+
+    Raises:
+        TracecatAuthorizationError: If any scope is outside the caller's ceiling.
+    """
+    denied = sorted(
+        {name for name in scope_names if not has_scope(caller_scopes, name)}
+    )
+    if denied:
+        raise TracecatAuthorizationError(
+            "Cannot grant scopes not held by the caller: " + ", ".join(denied)
+        )
 
 
 def get_missing_scopes(

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -2,22 +2,176 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from uuid import UUID
 
-from sqlalchemy import and_, delete, func, literal, select
+from sqlalchemy import and_, delete, func, literal, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlalchemy.sql.elements import ColumnElement
 
 from tracecat.auth.types import Role
-from tracecat.authz.controls import require_scope
+from tracecat.authz.controls import ensure_can_grant_scopes, require_scope
 from tracecat.contexts import ctx_role
-from tracecat.db.models import Membership, User, UserRoleAssignment, Workspace
+from tracecat.db.engine import SupportsExecute
+from tracecat.db.models import (
+    GroupMember,
+    GroupRoleAssignment,
+    Membership,
+    RoleScope,
+    Scope,
+    User,
+    UserRoleAssignment,
+    Workspace,
+)
 from tracecat.db.models import Role as DBRole
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.identifiers import OrganizationID, UserID, WorkspaceID
 from tracecat.service import BaseService
 from tracecat.workspaces.schemas import (
     WorkspaceMember,
     WorkspaceMembershipCreate,
 )
+
+
+async def query_effective_scopes(
+    session: SupportsExecute,
+    user_id: UserID,
+    organization_id: OrganizationID,
+    workspace_id: WorkspaceID | None,
+) -> frozenset[str]:
+    """Read a user's effective scopes from live database state.
+
+    Uncached. Use for authorization decisions that must not act on a stale
+    snapshot, such as scope-ceiling checks on role grants.
+    """
+    user_workspace_condition = (
+        or_(
+            UserRoleAssignment.workspace_id.is_(None),
+            UserRoleAssignment.workspace_id == workspace_id,
+        )
+        if workspace_id is not None
+        else UserRoleAssignment.workspace_id.is_(None)
+    )
+
+    group_workspace_condition = (
+        or_(
+            GroupRoleAssignment.workspace_id.is_(None),
+            GroupRoleAssignment.workspace_id == workspace_id,
+        )
+        if workspace_id is not None
+        else GroupRoleAssignment.workspace_id.is_(None)
+    )
+    # Direct user role assignments → Role → RoleScope → Scope
+    user_scopes = (
+        select(Scope.name)
+        .join(RoleScope, RoleScope.scope_id == Scope.id)
+        .join(DBRole, DBRole.id == RoleScope.role_id)
+        .join(UserRoleAssignment, UserRoleAssignment.role_id == DBRole.id)
+        .where(
+            UserRoleAssignment.user_id == user_id,
+            UserRoleAssignment.organization_id == organization_id,
+            user_workspace_condition,
+        )
+    )
+
+    # Group role assignments → GroupMember → GroupRoleAssignment → Role → RoleScope → Scope
+    group_scopes = (
+        select(Scope.name)
+        .join(RoleScope, RoleScope.scope_id == Scope.id)
+        .join(DBRole, DBRole.id == RoleScope.role_id)
+        .join(GroupRoleAssignment, GroupRoleAssignment.role_id == DBRole.id)
+        .join(GroupMember, GroupMember.group_id == GroupRoleAssignment.group_id)
+        .where(
+            GroupMember.user_id == user_id,
+            GroupRoleAssignment.organization_id == organization_id,
+            group_workspace_condition,
+        )
+    )
+
+    # Single atomic query: union both assignment paths
+    combined = user_scopes.union(group_scopes)
+    result = await session.execute(combined)
+    return frozenset(result.scalars().all())
+
+
+async def resolve_granter_scopes(
+    session: AsyncSession, granter: Role
+) -> frozenset[str]:
+    """Read the granter's scopes from live state for a grant decision.
+
+    ``Role.scopes`` is a per-request snapshot backed by a TTL cache, so a
+    just-demoted user can still carry privileged scopes there. Grant ceilings
+    must not be decided from that snapshot.
+    """
+    if granter.user_id is None or granter.organization_id is None:
+        return granter.scopes or frozenset()
+    return await query_effective_scopes(
+        session, granter.user_id, granter.organization_id, granter.workspace_id
+    )
+
+
+async def resolve_grantable_role(
+    session: AsyncSession,
+    granter: Role,
+    organization_id: OrganizationID,
+    role_id: UUID,
+) -> DBRole:
+    """Resolve a role for a durable grant, enforcing the scope ceiling.
+
+    The single entry point for role grants. Validates existence and
+    organization ownership, loads the role's scopes, and rejects grants
+    exceeding the granter's own scopes.
+
+    Raises:
+        TracecatNotFoundError: If the role is missing or owned by another org.
+        TracecatAuthorizationError: If the role carries scopes the granter lacks.
+    """
+    return await _resolve_grantable(
+        session, granter, organization_id, DBRole.id == role_id, "Role not found"
+    )
+
+
+async def resolve_grantable_role_by_slug(
+    session: AsyncSession,
+    granter: Role,
+    organization_id: OrganizationID,
+    slug: str,
+) -> DBRole:
+    """Resolve a preset role by slug for a durable grant, enforcing the ceiling."""
+    return await _resolve_grantable(
+        session,
+        granter,
+        organization_id,
+        DBRole.slug == slug,
+        f"Role not found: {slug}",
+    )
+
+
+async def _resolve_grantable(
+    session: AsyncSession,
+    granter: Role,
+    organization_id: OrganizationID,
+    selector: ColumnElement[bool],
+    not_found_message: str,
+) -> DBRole:
+    """Load a role with its scopes in one query, then apply the ceiling."""
+    stmt = (
+        select(DBRole)
+        .where(DBRole.organization_id == organization_id, selector)
+        .options(selectinload(DBRole.scopes))
+    )
+    role = (await session.execute(stmt)).scalar_one_or_none()
+    if role is None:
+        raise TracecatNotFoundError(not_found_message)
+
+    if not granter.is_platform_superuser:
+        granter_scopes = await resolve_granter_scopes(session, granter)
+        ensure_can_grant_scopes(granter_scopes, [scope.name for scope in role.scopes])
+    return role
 
 
 @dataclass
@@ -139,22 +293,24 @@ class MembershipService(BaseService):
         Note: The authorization cache is request-scoped, so changes will be
         reflected in subsequent requests automatically.
         """
-        # Resolve workspace org + default role in one DB read.
-        org_role_stmt = (
-            select(Workspace.organization_id, DBRole.id)
-            .join(
-                DBRole,
-                and_(
-                    DBRole.organization_id == Workspace.organization_id,
-                    DBRole.slug == "workspace-editor",
-                ),
-            )
-            .where(Workspace.id == workspace_id)
-        )
-        org_role_row = (await self.session.execute(org_role_stmt)).first()
-        if org_role_row is None:
+        org_stmt = select(Workspace.organization_id).where(Workspace.id == workspace_id)
+        organization_id = (await self.session.execute(org_stmt)).scalar_one_or_none()
+        if organization_id is None:
             raise TracecatValidationError("Workspace or default role not found")
-        organization_id, role_id = org_role_row
+
+        # Membership grants the editor role, so it is a role grant: apply the
+        # same scope ceiling as invitations rather than assigning unconditionally.
+        if self.role is None:
+            raise TracecatAuthorizationError(
+                "Operator context is required to grant workspace membership"
+            )
+        try:
+            granted_role = await resolve_grantable_role_by_slug(
+                self.session, self.role, organization_id, "workspace-editor"
+            )
+        except TracecatNotFoundError as e:
+            raise TracecatValidationError("Workspace or default role not found") from e
+        role_id = granted_role.id
 
         # Heal stale direct assignments left behind by prior failed remove flows.
         await self.session.execute(

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -24,7 +24,8 @@ from tracecat.auth.users import (
     get_user_db_context,
     get_user_manager_context,
 )
-from tracecat.authz.controls import has_scope, require_scope
+from tracecat.authz.controls import require_scope
+from tracecat.authz.service import resolve_grantable_role
 from tracecat.db.models import (
     AccessToken,
     Group,
@@ -39,7 +40,6 @@ from tracecat.db.models import (
     UserRoleAssignment,
     Workspace,
 )
-from tracecat.db.models import Role as DBRole
 from tracecat.exceptions import (
     TracecatAuthorizationError,
     TracecatNotFoundError,
@@ -524,26 +524,14 @@ class OrgService(BaseOrgService):
                 "User must be authenticated to create invitation"
             )
 
-        # Validate role_id exists and belongs to this organization
-        role_result = await self.session.execute(
-            select(DBRole).where(
-                DBRole.id == role_id,
-                DBRole.organization_id == self.organization_id,
+        try:
+            await resolve_grantable_role(
+                self.session, self.role, self.organization_id, role_id
             )
-        )
-        role_obj = role_result.scalar_one_or_none()
-        if role_obj is None:
-            raise TracecatValidationError("Invalid role ID for this organization")
-
-        # Prevent privilege escalation: only owners (via scope) or superusers
-        # can assign the organization-owner role
-        if role_obj.slug == "organization-owner":
-            if not self.role.is_superuser and not has_scope(
-                self.role.scopes or frozenset(), "org:owner:assign"
-            ):
-                raise TracecatAuthorizationError(
-                    "Only organization owners can create owner invitations"
-                )
+        except TracecatNotFoundError as e:
+            raise TracecatValidationError(
+                "Invalid role ID for this organization"
+            ) from e
 
         # Check if user with this email is already a member (case-insensitive)
         existing_member_stmt = (

--- a/tracecat/workspaces/router.py
+++ b/tracecat/workspaces/router.py
@@ -256,12 +256,9 @@ async def create_workspace_membership(
     )
     service = MembershipService(session, role=role)
     try:
+        # TracecatAuthorizationError intentionally propagates: the API-wide
+        # handler maps it to 403, which is correct for a scope-ceiling denial.
         await service.create_membership(workspace_id, params=params)
-    except TracecatAuthorizationError as e:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User does not have the required scope",
-        ) from e
     except IntegrityError as e:
         logger.error("INTEGRITY ERROR", error=str(e))
         raise HTTPException(

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -16,6 +16,7 @@ from tracecat.auth.types import Role
 from tracecat.authz.controls import has_scope, require_scope
 from tracecat.authz.enums import OwnerType
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.authz.service import resolve_grantable_role
 from tracecat.cases.service import CaseFieldsService
 from tracecat.db.models import (
     Invitation,
@@ -323,16 +324,14 @@ class WorkspaceService(BaseOrgService):
         except ValueError as e:
             raise TracecatValidationError("Invalid role ID format") from e
 
-        # Validate role_id exists and belongs to this organization
-        role_result = await self.session.execute(
-            select(DBRole).where(
-                DBRole.id == role_id,
-                DBRole.organization_id == self.organization_id,
+        try:
+            await resolve_grantable_role(
+                self.session, self.role, self.organization_id, role_id
             )
-        )
-        role_obj = role_result.scalar_one_or_none()
-        if role_obj is None:
-            raise TracecatValidationError("Invalid role ID for this organization")
+        except TracecatNotFoundError as e:
+            raise TracecatValidationError(
+                "Invalid role ID for this organization"
+            ) from e
 
         # Check for existing pending invitation that hasn't expired
         now = datetime.now(UTC)


### PR DESCRIPTION
Centralizes scope validation for role grants so the same ceiling applies across user assignments, group assignments, workspace membership, and service-account grants.

## LOC breakdown

| Category | + | - |
|---|---|---|
| Logic | 308 | 113 |
| Tests | 1060 | 46 |

## Test plan

- `uv run pytest tests/unit -k "authz or rbac or membership or organization or workspace"`

