### PR TITLE
docs: add voice conventions and CLAUDE.md symlink

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,6 +47,9 @@ When renaming or moving a page, add a redirect in `docs/docs.json` `redirects` a
 ## Tone and style
 
 - Always use active voice.
+- Name the actor. `A Tracecat-side codec encrypts payloads` beats `Payloads are encrypted`, which hides who does the work and reads as weaker in security pages.
+- State facts positively. Avoid double negatives such as `no path can resume the tool without a recorded decision`; write `every path that resumes the tool requires a recorded decision`. Keep a single negative when it carries the meaning, such as `Tracecat never persists a credential value in workflow state`.
+- Do not lead with what the product lacks when a positive statement covers the same fact. `API tokens are hashed one-way` beats `API tokens are not encrypted, because Tracecat never needs to read one back`.
 - Always address the reader directly.
 - If a user explicitly asks for a different voice, follow that request instead of the default.
 - Clarity over cleverness and verbosity: always keep sentences concise, do not add unnecessary words.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -84,3 +84,5 @@ When renaming or moving a page, add a redirect in `docs/docs.json` `redirects` a
 4. **Use absolute link paths** without file extensions (e.g., `/automations/overview`).
 5. **Check for existing snippets** in `snippets/` before duplicating content.
 6. **Start body content at `##`.** The frontmatter `title` renders as H1; do not add another H1 in the body.
+7. **Show the shape of any value the reader must supply.** Naming an environment variable is not documentation. If a page tells the reader to provision a value, show its format and how to generate it.
+8. **Update every copy of a repeated claim.** The same limitation is often stated on both a `security/` page and a `self-hosting/` page. Changing one and leaving the other produces contradictory pages, which is worse than one stale page. Search for the claim before editing it.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Records the docs conventions that came out of the security docs pass in #3224, so
the next agent working in `docs/` follows them without being told.

### Tone and style

Three bullets added next to the existing `Always use active voice` rule:

- **Name the actor.** `A Tracecat-side codec encrypts payloads` beats
  `Payloads are encrypted`, which hides who does the work.
- **State facts positively.** Avoid double negatives, with an explicit carve-out
  for single negatives that carry the meaning — otherwise the rule would wrongly
  ban lines like `Tracecat never persists a credential value in workflow state`.
- **Do not lead with what the product lacks** when a positive statement covers
  the same fact.

Active voice, conciseness, and the bold rule were already covered, so they are
left untouched.

### Key rules

Two entries added, both from concrete gaps found during that pass:

- **Show the shape of any value the reader must supply.** The docs named
  `TEMPORAL__PAYLOAD_ENCRYPTION_KEYRING` but never showed its JSON format, so
  payload encryption could not be enabled from the docs alone.
- **Update every copy of a repeated claim.** The `TRACECAT__DB_ENCRYPTION_KEY`
  rotation warning existed on both a `security/` page and a `self-hosting/` page.
  Editing one and leaving the other would have left the docs contradicting
  themselves.

### `docs/CLAUDE.md` symlink

Adds `docs/CLAUDE.md` as a symlink to `AGENTS.md`, matching the existing pattern
at the repository root and in `frontend/`. Recorded as git mode `120000`.

Note that `tracecat/AGENTS.md` still has no `CLAUDE.md` symlink, if you want that
made consistent in a follow-up.

## Lines of code

| Category | + | - |
| --- | --- | --- |
| Docs | 6 | 0 |

## Test plan

Agent instructions and a symlink, no product code or published docs pages
touched.
