### PR TITLE
fix(cases): raise linked-row cap to 5,000 and batch

### DIFF
--- a/tests/unit/api/test_api_case_rows.py
+++ b/tests/unit/api/test_api_case_rows.py
@@ -13,6 +13,7 @@ from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.rows import internal_router as internal_case_rows_router
 from tracecat.cases.rows import router as case_rows_router
 from tracecat.cases.rows.schemas import CaseTableRowLinkCreate
+from tracecat.cases.rows.service import MAX_LINKED_ROWS_PER_CASE
 from tracecat.cases.schemas import CaseReadMinimal
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.pagination import CursorPaginatedResponse
@@ -90,12 +91,11 @@ async def test_link_case_row_returns_400_for_value_error(
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()
     row_id = uuid.uuid4()
+    expected_error = f"A case can have at most {MAX_LINKED_ROWS_PER_CASE} linked rows"
     with patch.object(case_rows_router, "CaseTableRowsService") as mock_service_cls:
         mock_service = AsyncMock()
         mock_service.get_case_or_raise.return_value = MagicMock()
-        mock_service.link_row.side_effect = ValueError(
-            "A case can have at most 200 linked rows"
-        )
+        mock_service.link_row.side_effect = ValueError(expected_error)
         mock_service_cls.return_value = mock_service
 
         with pytest.raises(HTTPException) as exc_info:
@@ -107,7 +107,7 @@ async def test_link_case_row_returns_400_for_value_error(
             )
 
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert exc_info.value.detail == "A case can have at most 200 linked rows"
+    assert exc_info.value.detail == expected_error
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_case_table_rows_service.py
+++ b/tests/unit/test_case_table_rows_service.py
@@ -7,9 +7,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.rows import service as case_rows_service_module
 from tracecat.cases.rows.schemas import CaseTableRowLinkCreate
 from tracecat.cases.rows.service import (
-    MAX_LINKED_ROWS_PER_CASE,
     MAX_TABLES_PER_CASE,
     CaseTableRowsService,
 )
@@ -167,6 +167,11 @@ async def test_link_row_returns_existing_link_when_limit_reached_after_initial_m
     case_rows_service: CaseTableRowsService,
     tables_service: TablesService,
 ) -> None:
+    test_link_limit = 2
+    monkeypatch.setattr(
+        case_rows_service_module, "MAX_LINKED_ROWS_PER_CASE", test_link_limit
+    )
+
     case = await _create_case(cases_service)
     table_id, row_id = await _create_table_with_row(
         tables_service,
@@ -187,7 +192,7 @@ async def test_link_row_returns_existing_link_when_limit_reached_after_initial_m
             table_id=table_id,
             row_id=uuid.uuid4(),
         )
-        for _ in range(MAX_LINKED_ROWS_PER_CASE - 1)
+        for _ in range(test_link_limit - 1)
     ]
     session.add_all([existing_link, *filler_links])
     await session.commit()

--- a/tests/unit/test_case_table_rows_service.py
+++ b/tests/unit/test_case_table_rows_service.py
@@ -1,5 +1,7 @@
 import uuid
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from sqlalchemy import func, select
@@ -15,7 +17,7 @@ from tracecat.cases.rows.service import (
 )
 from tracecat.cases.schemas import CaseCreate
 from tracecat.cases.service import CasesService
-from tracecat.db.models import CaseTableRow
+from tracecat.db.models import CaseTableRow, Table
 from tracecat.pagination import BaseCursorPaginator
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import TableColumnCreate, TableCreate, TableRowInsert
@@ -223,6 +225,77 @@ async def test_link_row_returns_existing_link_when_limit_reached_after_initial_m
 
     assert link.id == existing_link.id
     assert calls == 2
+
+
+@pytest.mark.anyio
+async def test_list_rows_batches_hydration_by_table(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+    cases_service: CasesService,
+    case_rows_service: CaseTableRowsService,
+    tables_service: TablesService,
+) -> None:
+    case = await _create_case(cases_service)
+    table_id, first_row_id = await _create_table_with_row(
+        tables_service,
+        name=f"case_rows_batch_hydration_{uuid.uuid4().hex[:8]}",
+        value="first",
+    )
+    table = await tables_service.get_table(table_id)
+    second_row = await tables_service.insert_row(
+        table,
+        TableRowInsert(data={"value": "second"}),
+    )
+    second_row_id = second_row.get("id")
+    assert isinstance(second_row_id, uuid.UUID)
+
+    for row_id in (first_row_id, second_row_id):
+        await case_rows_service.link_row(
+            case=case,
+            params=CaseTableRowLinkCreate(table_id=table_id, row_id=row_id),
+        )
+
+    missing_row_id = uuid.uuid4()
+    session.add(
+        CaseTableRow(
+            workspace_id=case_rows_service.workspace_id,
+            case_id=case.id,
+            table_id=table_id,
+            row_id=missing_row_id,
+        )
+    )
+    await session.commit()
+
+    original_get_rows = case_rows_service.tables.get_rows
+    get_rows_calls: list[tuple[uuid.UUID, set[uuid.UUID]]] = []
+
+    async def tracked_get_rows(
+        table: Table, row_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, dict[str, Any]]:
+        get_rows_calls.append((table.id, set(row_ids)))
+        return await original_get_rows(table, row_ids)
+
+    monkeypatch.setattr(case_rows_service.tables, "get_rows", tracked_get_rows)
+
+    page = await case_rows_service.list_rows(
+        case_id=case.id,
+        limit=10,
+        include_row_data=True,
+    )
+
+    assert get_rows_calls == [(table_id, {first_row_id, second_row_id, missing_row_id})]
+    rows_by_id = {row.row_id: row for row in page.items}
+    first_row = rows_by_id[first_row_id]
+    assert first_row.row_data is not None
+    assert first_row.row_data["value"] == "first"
+    assert first_row.is_row_available is True
+    second_row = rows_by_id[second_row_id]
+    assert second_row.row_data is not None
+    assert second_row.row_data["value"] == "second"
+    assert second_row.is_row_available is True
+    missing_row = rows_by_id[missing_row_id]
+    assert missing_row.row_data is None
+    assert missing_row.is_row_available is False
 
 
 @pytest.mark.anyio

--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -333,6 +333,22 @@ class CaseTableRowsService(BaseWorkspaceService):
         include_row_data: bool,
     ) -> list[CaseTableRowRead]:
         tables_by_id = await self._get_tables_by_id([link.table_id for link in links])
+        rows_by_table_id: dict[uuid.UUID, dict[uuid.UUID, dict[str, Any]]] = {}
+        if include_row_data:
+            row_ids_by_table_id: dict[uuid.UUID, set[uuid.UUID]] = defaultdict(set)
+            for link in links:
+                if link.table_id in tables_by_id:
+                    row_ids_by_table_id[link.table_id].add(link.row_id)
+
+            for table_id, row_ids in row_ids_by_table_id.items():
+                try:
+                    rows_by_table_id[table_id] = await self.tables.get_rows(
+                        tables_by_id[table_id], list(row_ids)
+                    )
+                except sa_exc.DBAPIError as exc:
+                    if not isinstance(exc.orig, UndefinedTableError):
+                        raise
+
         hydrated: list[CaseTableRowRead] = []
 
         for link in links:
@@ -340,15 +356,8 @@ class CaseTableRowsService(BaseWorkspaceService):
             row_data: dict[str, Any] | None = None
             is_available = False
             if include_row_data and table is not None:
-                try:
-                    row_data = await self.tables.get_row(table, link.row_id)
-                    is_available = True
-                except TracecatNotFoundError:
-                    is_available = False
-                except sa_exc.DBAPIError as exc:
-                    if not isinstance(exc.orig, UndefinedTableError):
-                        raise
-                    is_available = False
+                row_data = rows_by_table_id.get(link.table_id, {}).get(link.row_id)
+                is_available = row_data is not None
             elif not include_row_data:
                 is_available = True
 

--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -28,7 +28,7 @@ from tracecat.pagination import BaseCursorPaginator, CursorPaginatedResponse
 from tracecat.service import BaseWorkspaceService
 from tracecat.tables.service import TablesService
 
-MAX_LINKED_ROWS_PER_CASE = 200
+MAX_LINKED_ROWS_PER_CASE = 5_000
 MAX_TABLES_PER_CASE = 10
 
 

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -75,6 +75,7 @@ _RETRYABLE_DB_EXCEPTIONS = (
     InvalidCachedStatementError,
     InFailedSQLTransactionError,
 )
+_TABLE_ROW_READ_BATCH_SIZE = 5_000
 _TABLE_SYSTEM_COLUMNS = frozenset({"id", "created_at", "updated_at"})
 
 DYNAMIC_WORKSPACE_TENANT_COLUMN = "__tc_workspace_id"
@@ -865,6 +866,37 @@ class BaseTablesService(BaseWorkspaceService):
         if row is None:
             raise TracecatNotFoundError(f"Row {row_id} not found in table {table.name}")
         return dict(row)
+
+    async def get_rows(
+        self, table: Table, row_ids: Sequence[UUID]
+    ) -> dict[UUID, dict[str, Any]]:
+        """Get rows by ID, keyed by row ID."""
+        if not row_ids:
+            return {}
+
+        schema_name = self._get_schema_name()
+        sanitized_table_name = self._sanitize_identifier(table.name)
+        table_clause = sa.table(sanitized_table_name, schema=schema_name)
+        conn = await self.session.connection()
+        rows_by_id: dict[UUID, dict[str, Any]] = {}
+        unique_row_ids = list(dict.fromkeys(row_ids))
+
+        for start in range(0, len(unique_row_ids), _TABLE_ROW_READ_BATCH_SIZE):
+            batch = unique_row_ids[start : start + _TABLE_ROW_READ_BATCH_SIZE]
+            stmt = (
+                sa.select(*self._visible_columns(table))
+                .select_from(table_clause)
+                .where(sa.column("id").in_(batch))
+            )
+            result = await conn.execute(stmt)
+            for row in result.mappings():
+                row_data: dict[str, Any] = dict(row)
+                row_id = row_data.get("id")
+                if not isinstance(row_id, UUID):
+                    raise TypeError("Table row ID must be a UUID")
+                rows_by_id[row_id] = row_data
+
+        return rows_by_id
 
     async def insert_row(
         self,


### PR DESCRIPTION
## Summary

- Raise the maximum linked table rows per Case from 200 to 5,000.
- Keep the cap-boundary service test fast by using a small test-local limit.
- Derive the API error assertion from the production limit instead of a stale literal.

## Why

High-cardinality Case relationships can legitimately exceed 200 linked rows. The fixed guard rejects those links even though the link metadata is indexed and the API supports cursor pagination.

## Impact

Cases can now link up to 5,000 table rows. This does not change the linked-row API page size or require a database migration.

## Validation

- `PG_PORT=7732 MINIO_PORT=11300 REDIS_PORT=8679 uv run pytest tests/unit/test_case_table_rows_service.py tests/unit/api/test_api_case_rows.py -q` — 10 passed
- `uv run ruff check tracecat/cases/rows/service.py tests/unit/test_case_table_rows_service.py tests/unit/api/test_api_case_rows.py`
- `uv run ruff format --check tracecat/cases/rows/service.py tests/unit/test_case_table_rows_service.py tests/unit/api/test_api_case_rows.py`
- `uv run basedpyright tracecat/cases/rows/service.py tests/unit/test_case_table_rows_service.py tests/unit/api/test_api_case_rows.py`
- Repository pre-commit hooks

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 1 | 1 |
| Tests | 11 | 6 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the maximum linked rows per Case from 200 to 5,000 and batch row hydration by table to reduce DB calls and correctly mark missing rows. No pagination changes or migrations; tests use a small local limit via monkeypatch, assert the `MAX_LINKED_ROWS_PER_CASE` error, and verify batched hydration.

<sup>Written for commit 15fa91cda99b3d5f8edccc241e506d6a4f0acc16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

