### PR TITLE
fix(release): limit update-version to git-tracked files

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -201,11 +201,24 @@ append_matching_files() {
 # also descends into untracked paths under the repo root - nested clones of other
 # repositories and extra git worktrees - and rewrites version strings that do not
 # belong to this checkout.
+#
+# Only regular files (mode 100644/100755) qualify. Tracked symlinks such as
+# docs/CLAUDE.md would otherwise match through their target, and sed -i then
+# replaces the link itself with a regular file.
 tracked_candidate_files() {
-    git ls-files -z -- \
+    local entry mode path
+
+    git ls-files -s -z -- \
         ':(glob)**/docker-compose*.yml' \
         'docs' \
-        'deployments'
+        'deployments' |
+        while IFS= read -r -d '' entry; do
+            mode="${entry%% *}"
+            path="${entry#*$'\t'}"
+            case "$mode" in
+            100644 | 100755) printf '%s\0' "$path" ;;
+            esac
+        done
 }
 
 # Capture Tracecat-specific version contexts, including files that only carry the

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -52,6 +52,13 @@ escape_sed_replacement() {
     printf '%s\n' "$1" | sed 's/[&/]/\\&/g'
 }
 
+# Version discovery is scoped to this checkout's tracked files, so a git work
+# tree is required.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: $0 must be run inside the tracecat git checkout"
+    exit 1
+fi
+
 # Extract current version from __init__.py
 INIT_FILE="tracecat/__init__.py"
 REGISTRY_INIT_FILE="packages/tracecat-registry/tracecat_registry/__init__.py"
@@ -190,24 +197,27 @@ append_matching_files() {
     done
 }
 
+# Candidate files come from the git index rather than a filesystem walk. A walk
+# also descends into untracked paths under the repo root - nested clones of other
+# repositories and extra git worktrees - and rewrites version strings that do not
+# belong to this checkout.
+tracked_candidate_files() {
+    git ls-files -z -- \
+        ':(glob)**/docker-compose*.yml' \
+        'docs' \
+        'deployments'
+}
+
 # Capture Tracecat-specific version contexts, including files that only carry the
 # current version string rather than an image tag or raw GitHub URL.
 append_matching_files < <(
-    rg -l \
-        -g 'docker-compose*.yml' \
-        -g 'docs/**/*' \
-        -g 'deployments/**/*' \
-        "\\$\\{TRACECAT__IMAGE_TAG:-${VERSION_SEARCH_PATTERN}\\}|variable \"tracecat_image_tag\"|raw\\.githubusercontent\\.com/TracecatHQ/tracecat/${VERSION_SEARCH_PATTERN}/|TF_VAR_tracecat_image_tag=${VERSION_SEARCH_PATTERN}" \
-        .
+    tracked_candidate_files | xargs -0 rg -l \
+        "\\$\\{TRACECAT__IMAGE_TAG:-${VERSION_SEARCH_PATTERN}\\}|variable \"tracecat_image_tag\"|raw\\.githubusercontent\\.com/TracecatHQ/tracecat/${VERSION_SEARCH_PATTERN}/|TF_VAR_tracecat_image_tag=${VERSION_SEARCH_PATTERN}"
 )
 
 append_matching_files < <(
-    rg -l --fixed-strings \
-        -g 'docker-compose*.yml' \
-        -g 'docs/**/*' \
-        -g 'deployments/**/*' \
-        "$CURRENT_VERSION" \
-        .
+    tracked_candidate_files | xargs -0 rg -l --fixed-strings \
+        "$CURRENT_VERSION"
 )
 
 run_sed_in_place() {


### PR DESCRIPTION
## Problem

`just update-version <tag>` discovered files to rewrite with a filesystem walk
(`rg -l -g 'docker-compose*.yml' -g 'docs/**/*' -g 'deployments/**/*' .`). That walk
is not bounded by the repository's own tracked content, so anything sitting under
the repo root that happens to match the globs gets rewritten — including untracked
directories that belong to *other* repositories.

Two real cases hit during a recent release run:

- A separate Kubernetes infrastructure repository cloned into `deployments/k8s/`
  (untracked here). The bump rewrote its Terraform `variables.tf` files, even though
  the Kubernetes deployment target is maintained in its own repository.
- Extra git worktrees of other branches kept under an untracked `trees/` directory.
  The bump rewrote their `docker-compose*.yml` files, dirtying unrelated branches.

Both had to be reverted by hand. This has bitten multiple release runs.

## Fix

Derive candidate files from the git index instead of walking the filesystem:

- Added a `tracked_candidate_files` helper that runs
  `git ls-files -z -- ':(glob)**/docker-compose*.yml' 'docs' 'deployments'`,
  translating the previous ripgrep globs into equivalent git pathspecs.
- Both discovery passes now pipe that NUL-delimited list into `rg -l` via `xargs -0`
  rather than pointing ripgrep at `.`.
- Added an early guard so the script fails loudly if it is not run inside a git work
  tree, instead of silently discovering nothing.

This solves the general problem: any path not tracked by the current checkout is
untouched. No path is hardcoded as an exclusion, so future nested clones, scratch
directories, and worktrees are all covered automatically.

Everything else is unchanged — the static file list, the confirmation prompt, the
substitution rules, and the output format all behave exactly as before for tracked
files.

## Verification

Set up the failure case locally: an untracked `untracked-test/` directory holding
copies of `docker-compose.yml`, plus an untracked `deployments/k8s-test/` directory
holding copies of the Fargate `variables.tf` files.

1. Confirmed the old discovery command matches the untracked copies — the pre-fix
   `rg` walk listed both `deployments/k8s-test/variables.tf` and
   `deployments/k8s-test/ecs-variables.tf`, and both `untracked-test` compose files.
2. Ran `yes | just update-version 1.0.0-beta.99-rc.1` with the fix applied. The
   proposed-file list and the resulting `git status` contained exactly the same
   tracked files as before (compose files, `deployments/fargate/**`,
   `docs/self-hosting/**`, `docs/overview/getting-started.mdx`, the two `__init__.py`
   files, and the issue template). No untracked path appeared.
3. Confirmed all untracked copies still carry the previous version string after the
   run.
4. Confirmed `tracecat/__init__.py` and the registry `__init__.py` both received
   `__version__ = "1.0.0-beta.99-rc.1"` and `__pep440_version__ = "1.0.0b99+rc.1"`,
   matching the existing PEP 440 conversion behaviour for a two-segment prerelease
   tag.
5. Spot-checked the rewritten diffs (`docker-compose.yml` image tags,
   `deployments/fargate/variables.tf` `tracecat_image_tag` default) for correctness,
   then reset the working tree and removed the test directories before committing.

Also checked one edge of the pathspec translation: the git pathspecs additionally
surface `.github/docker-compose.integration.yml` and the `docs/CLAUDE.md` symlink,
which ripgrep skipped as hidden/symlinked. Neither contains a matching version
string, so the effective file set is identical.

## LOC breakdown

| Category | + | - |
| --- | --- | --- |
| Infra/config | 22 | 12 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits the release `update-version` script to git-tracked regular files and requires a git work tree. Previously it walked the filesystem and could rewrite untracked paths, nested repos, or replace tracked symlinks; now it derives candidates from the index and skips symlinks, avoiding those edits while keeping behavior identical for tracked files.

- Discover candidates via `git ls-files -s -z -- ':(glob)**/docker-compose*.yml' 'docs' 'deployments'`, filtering to modes 100644/100755 (skip symlinks).
- Pipe NUL-delimited paths to `rg -l` with `xargs -0` instead of scanning `.`.
- Fail fast when not inside a git work tree.

<sup>Written for commit 84376a0f888df8b077087a42554cbbd80532cef1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

