### PR TITLE
fix(agent): force-remove sandbox-owned job trees

### DIFF
--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -28,6 +28,7 @@ from tracecat_ee.agent.activities import (
     EmitSessionErrorInputs,
 )
 
+from tracecat.agent.common.config import build_agent_runtime_uv_env
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.common.types import MCPToolDefinition
@@ -40,6 +41,7 @@ from tracecat.agent.executor.activity import (
     run_agent_activity,
 )
 from tracecat.agent.executor.loopback import LoopbackResult
+from tracecat.agent.runtime.session_paths import job_uv_state_dir
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.session.activities import (
     CreateSessionInput,
@@ -97,6 +99,28 @@ def mock_agent_config() -> AgentConfig:
             model_provider="anthropic",
         ),
     )
+
+
+def _seed_realistic_agent_job_tree(job_dir: Path) -> list[Path]:
+    """Seed the job-scoped paths that the executor removes after each run."""
+    seeded_paths: list[Path] = []
+    uv_state_dir = job_uv_state_dir(job_dir)
+    for env_var, configured_path in build_agent_runtime_uv_env(uv_state_dir).items():
+        if env_var == "UV_LINK_MODE":
+            continue
+        nested_file = Path(configured_path) / "nested" / f"{env_var.lower()}.state"
+        nested_file.parent.mkdir(parents=True, exist_ok=True)
+        nested_file.write_text("job-scoped uv state")
+        seeded_paths.extend((nested_file.parent, nested_file))
+
+    socket_path = job_dir / "sockets" / "control.sock"
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    socket_path.write_text("socket placeholder")
+    skill_path = job_dir / "home" / ".claude" / "skills" / "example" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_text("# Example")
+    seeded_paths.extend((uv_state_dir, socket_path, skill_path))
+    return seeded_paths
 
 
 class TestSessionActivities:
@@ -2556,3 +2580,202 @@ class TestSandboxedAgentExecutorSkillCaching:
         assert args == (job_dir, True)
         assert kwargs == {}
         assert not job_dir.exists()
+
+
+class TestSandboxedAgentExecutorJobCleanup:
+    """Tests for activity-owned per-job directory cleanup."""
+
+    @pytest.fixture
+    def executor(
+        self,
+        mock_role: Role,
+        mock_session_id: uuid.UUID,
+        mock_agent_config: AgentConfig,
+    ) -> SandboxedAgentExecutor:
+        return SandboxedAgentExecutor(
+            input=AgentExecutorInput(
+                session_id=mock_session_id,
+                workspace_id=mock_role.workspace_id or uuid.uuid4(),
+                user_prompt="Test prompt",
+                config=mock_agent_config,
+                role=mock_role,
+                mcp_auth_token="mock-jwt-token",
+                llm_gateway_auth_token="mock-llm-token",
+            )
+        )
+
+    @pytest.mark.anyio
+    async def test_cleanup_removes_realistic_uv_state_tree(
+        self,
+        executor: SandboxedAgentExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Activity cleanup removes every job path, including nested UV state."""
+        job_dir = tmp_path / "job"
+        seeded_paths = _seed_realistic_agent_job_tree(job_dir)
+        executor._job_dir = job_dir
+
+        assert all(path.exists() for path in seeded_paths)
+
+        await executor._cleanup()
+
+        assert not job_dir.exists()
+        assert all(not path.exists() for path in seeded_paths)
+        assert not job_uv_state_dir(job_dir).exists()
+
+    @pytest.mark.anyio
+    async def test_run_cancellation_removes_job_scoped_uv_state(
+        self,
+        executor: SandboxedAgentExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A propagated mid-run cancellation still removes job-scoped UV state."""
+        job_dir = tmp_path / "job"
+        uv_state_dir = job_uv_state_dir(job_dir)
+        proxy = AsyncMock()
+
+        async def fake_create_job_directory() -> Path:
+            _seed_realistic_agent_job_tree(job_dir)
+            return job_dir
+
+        async def fail_run_with_broker(
+            *_args: object,
+            **_kwargs: object,
+        ) -> None:
+            raise asyncio.CancelledError("runtime cancelled mid-flight")
+
+        monkeypatch.setattr(
+            executor, "_create_job_directory", fake_create_job_directory
+        )
+        monkeypatch.setattr(
+            executor,
+            "_create_llm_socket_proxy",
+            AsyncMock(return_value=proxy),
+        )
+        monkeypatch.setattr(
+            executor,
+            "_load_artifact_working_set",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(executor, "_run_with_broker", fail_run_with_broker)
+
+        with pytest.raises(
+            asyncio.CancelledError, match="runtime cancelled mid-flight"
+        ):
+            await executor.run()
+
+        assert not job_dir.exists()
+        assert not uv_state_dir.exists()
+        proxy.stop.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_run_success_removes_job_scoped_uv_state(
+        self,
+        executor: SandboxedAgentExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A normally completed run removes its job directory and UV state."""
+        job_dir = tmp_path / "job"
+        uv_state_dir = job_uv_state_dir(job_dir)
+        proxy = AsyncMock()
+
+        async def fake_create_job_directory() -> Path:
+            _seed_realistic_agent_job_tree(job_dir)
+            return job_dir
+
+        async def fake_run_with_broker(
+            *_args: object,
+            **kwargs: object,
+        ) -> None:
+            result = cast(AgentExecutorResult, kwargs["result"])
+            result.success = True
+
+        monkeypatch.setattr(
+            executor, "_create_job_directory", fake_create_job_directory
+        )
+        monkeypatch.setattr(
+            executor,
+            "_create_llm_socket_proxy",
+            AsyncMock(return_value=proxy),
+        )
+        monkeypatch.setattr(
+            executor,
+            "_load_artifact_working_set",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(executor, "_run_with_broker", fake_run_with_broker)
+
+        result = await executor.run()
+
+        assert result.success is True
+        assert not job_dir.exists()
+        assert not uv_state_dir.exists()
+        proxy.stop.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_cleanup_swallows_rmtree_error_and_warns(
+        self,
+        executor: SandboxedAgentExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Activity cleanup logs and swallows an explicit rmtree failure."""
+        job_dir = tmp_path / "job"
+        _seed_realistic_agent_job_tree(job_dir)
+        executor._job_dir = job_dir
+        real_rmtree = shutil.rmtree
+        warning = MagicMock()
+
+        def fail_rmtree(_path: Path) -> None:
+            raise OSError("simulated cleanup failure")
+
+        monkeypatch.setattr(
+            "tracecat.agent.executor.activity.shutil.rmtree", fail_rmtree
+        )
+        monkeypatch.setattr("tracecat.agent.executor.activity.logger.warning", warning)
+
+        try:
+            await executor._cleanup()
+
+            assert job_dir.exists()
+            warning.assert_called_once_with(
+                "Failed to clean up job directory",
+                job_dir=str(job_dir),
+                error="simulated cleanup failure",
+            )
+        finally:
+            real_rmtree(job_dir, ignore_errors=True)
+
+    @pytest.mark.anyio
+    async def test_cleanup_read_only_uv_subtree_survives_and_warns(
+        self,
+        executor: SandboxedAgentExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A 0555 UV cache directory survives activity cleanup and emits a warning."""
+        job_dir = tmp_path / "job"
+        _seed_realistic_agent_job_tree(job_dir)
+        read_only_dir = job_uv_state_dir(job_dir) / "cache" / "read-only"
+        nested_file = read_only_dir / "archive" / "artifact"
+        nested_file.parent.mkdir(parents=True)
+        nested_file.write_text("cached artifact")
+        read_only_dir.chmod(0o555)
+        executor._job_dir = job_dir
+        warning = MagicMock()
+        monkeypatch.setattr("tracecat.agent.executor.activity.logger.warning", warning)
+
+        try:
+            await executor._cleanup()
+
+            assert job_dir.exists()
+            assert read_only_dir.exists()
+            warning.assert_called_once()
+            assert warning.call_args.args == ("Failed to clean up job directory",)
+            assert warning.call_args.kwargs["job_dir"] == str(job_dir)
+        finally:
+            if read_only_dir.exists():
+                read_only_dir.chmod(0o700)
+            shutil.rmtree(job_dir, ignore_errors=True)

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -2582,6 +2582,79 @@ class TestSandboxedAgentExecutorSkillCaching:
         assert kwargs == {}
         assert not job_dir.exists()
 
+    @pytest.mark.parametrize(
+        "setup_error",
+        [
+            pytest.param(RuntimeError("staging failed"), id="ordinary-error"),
+            pytest.param(
+                asyncio.CancelledError("staging cancelled"),
+                id="cancellation",
+            ),
+        ],
+    )
+    @pytest.mark.anyio
+    async def test_create_job_directory_preserves_setup_failure_when_cleanup_fails(
+        self,
+        mock_role: Role,
+        mock_session_id: uuid.UUID,
+        mock_agent_config: AgentConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        setup_error: BaseException,
+    ) -> None:
+        """Cleanup errors do not replace the setup failure being handled."""
+        mock_executor_input = AgentExecutorInput(
+            session_id=mock_session_id,
+            workspace_id=mock_role.workspace_id or uuid.uuid4(),
+            user_prompt="Test prompt",
+            config=mock_agent_config,
+            role=mock_role,
+            mcp_auth_token="mock-jwt-token",
+            llm_gateway_auth_token="mock-llm-token",
+        )
+        mock_executor = SandboxedAgentExecutor(input=mock_executor_input)
+        job_dir = tmp_path / "agent-job-test"
+        warning = MagicMock()
+
+        async def fail_stage_resolved_skills(_skills_dir: Path) -> None:
+            raise setup_error
+
+        async def fail_cleanup_in_thread(
+            func: object, /, *args: object, **kwargs: object
+        ) -> None:
+            assert func is force_rmtree
+            assert args == (job_dir,)
+            assert kwargs == {}
+            raise OSError("cleanup failed")
+
+        def fake_mkdtemp(*, prefix: str, dir: Path) -> str:
+            del prefix, dir
+            job_dir.mkdir()
+            return str(job_dir)
+
+        monkeypatch.setattr(
+            mock_executor, "_stage_resolved_skills", fail_stage_resolved_skills
+        )
+        monkeypatch.setattr(
+            "tracecat.agent.executor.activity.asyncio.to_thread",
+            fail_cleanup_in_thread,
+        )
+        monkeypatch.setattr(
+            "tracecat.agent.executor.activity.tempfile.mkdtemp", fake_mkdtemp
+        )
+        monkeypatch.setattr("tracecat.agent.executor.activity.logger.warning", warning)
+
+        with pytest.raises(type(setup_error)) as exc_info:
+            await mock_executor._create_job_directory()
+
+        assert exc_info.value is setup_error
+        assert job_dir.exists()
+        warning.assert_called_once_with(
+            "Failed to clean up job directory after setup failure",
+            job_dir=str(job_dir),
+            error="cleanup failed",
+        )
+
 
 class TestSandboxedAgentExecutorJobCleanup:
     """Tests for activity-owned per-job directory cleanup."""

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -29,6 +29,7 @@ from tracecat_ee.agent.activities import (
 )
 
 from tracecat.agent.common.config import build_agent_runtime_uv_env
+from tracecat.agent.common.fs import force_rmtree
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.common.types import MCPToolDefinition
@@ -2520,7 +2521,7 @@ class TestSandboxedAgentExecutorSkillCaching:
 
         assert len(to_thread_calls) == 1
         func, args, kwargs = to_thread_calls[0]
-        assert func is shutil.rmtree
+        assert func is force_rmtree
         assert args == (job_dir,)
         assert kwargs == {}
         assert not job_dir.exists()
@@ -2576,8 +2577,8 @@ class TestSandboxedAgentExecutorSkillCaching:
 
         assert len(to_thread_calls) == 1
         func, args, kwargs = to_thread_calls[0]
-        assert func is shutil.rmtree
-        assert args == (job_dir, True)
+        assert func is force_rmtree
+        assert args == (job_dir,)
         assert kwargs == {}
         assert not job_dir.exists()
 
@@ -2728,12 +2729,11 @@ class TestSandboxedAgentExecutorJobCleanup:
         real_rmtree = shutil.rmtree
         warning = MagicMock()
 
-        def fail_rmtree(_path: Path) -> None:
+        def fail_rmtree(path: Path) -> None:
+            assert path == job_dir
             raise OSError("simulated cleanup failure")
 
-        monkeypatch.setattr(
-            "tracecat.agent.executor.activity.shutil.rmtree", fail_rmtree
-        )
+        monkeypatch.setattr("tracecat.agent.common.fs.shutil.rmtree", fail_rmtree)
         monkeypatch.setattr("tracecat.agent.executor.activity.logger.warning", warning)
 
         try:
@@ -2749,13 +2749,13 @@ class TestSandboxedAgentExecutorJobCleanup:
             real_rmtree(job_dir, ignore_errors=True)
 
     @pytest.mark.anyio
-    async def test_cleanup_read_only_uv_subtree_survives_and_warns(
+    async def test_cleanup_removes_read_only_uv_subtree(
         self,
         executor: SandboxedAgentExecutor,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """A 0555 UV cache directory survives activity cleanup and emits a warning."""
+        """Activity cleanup removes a sandbox-owned 0555 UV cache subtree."""
         job_dir = tmp_path / "job"
         _seed_realistic_agent_job_tree(job_dir)
         read_only_dir = job_uv_state_dir(job_dir) / "cache" / "read-only"
@@ -2770,11 +2770,9 @@ class TestSandboxedAgentExecutorJobCleanup:
         try:
             await executor._cleanup()
 
-            assert job_dir.exists()
-            assert read_only_dir.exists()
-            warning.assert_called_once()
-            assert warning.call_args.args == ("Failed to clean up job directory",)
-            assert warning.call_args.kwargs["job_dir"] == str(job_dir)
+            assert not job_dir.exists()
+            assert not read_only_dir.exists()
+            warning.assert_not_called()
         finally:
             if read_only_dir.exists():
                 read_only_dir.chmod(0o700)

--- a/tests/unit/test_agent_common_fs.py
+++ b/tests/unit/test_agent_common_fs.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import shutil
+import stat
+from pathlib import Path
+
+from tracecat.agent.common.fs import force_rmtree
+
+
+def test_force_rmtree_does_not_follow_symlinks(tmp_path: Path) -> None:
+    """Cleanup never changes or removes file and directory targets outside its root."""
+    outside_file = tmp_path / "outside-file"
+    outside_file.write_text("sentinel")
+    outside_file.chmod(0o640)
+    outside_file_mode = stat.S_IMODE(outside_file.stat().st_mode)
+
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    outside_content = outside_dir / "sentinel"
+    outside_content.write_text("untouched")
+    outside_dir.chmod(0o750)
+    outside_dir_mode = stat.S_IMODE(outside_dir.stat().st_mode)
+
+    root = tmp_path / "job"
+    containing_dir = root / "uv-state" / "cache"
+    containing_dir.mkdir(parents=True)
+    (containing_dir / "file-link").symlink_to(outside_file)
+    (containing_dir / "dir-link").symlink_to(
+        outside_dir,
+        target_is_directory=True,
+    )
+    containing_dir.chmod(0o555)
+
+    try:
+        force_rmtree(root)
+
+        assert not root.exists()
+        assert outside_file.read_text() == "sentinel"
+        assert stat.S_IMODE(outside_file.stat().st_mode) == outside_file_mode
+        assert outside_content.read_text() == "untouched"
+        assert stat.S_IMODE(outside_dir.stat().st_mode) == outside_dir_mode
+    finally:
+        if containing_dir.exists():
+            containing_dir.chmod(0o700)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_force_rmtree_removes_mode_zero_directory(tmp_path: Path) -> None:
+    """Cleanup opens a mode-000 directory before descending into nested content."""
+    root = tmp_path / "job"
+    blocked_dir = root / "uv-state" / "blocked"
+    nested_dir = blocked_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "artifact").write_text("cached")
+    blocked_dir.chmod(0o000)
+
+    try:
+        force_rmtree(root)
+
+        assert not root.exists()
+    finally:
+        if blocked_dir.exists():
+            blocked_dir.chmod(0o700)
+        if nested_dir.exists():
+            nested_dir.chmod(0o700)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_force_rmtree_removes_read_only_root(tmp_path: Path) -> None:
+    """Cleanup restores owner access when the tree root itself is mode 0555."""
+    root = tmp_path / "uv-state"
+    root.mkdir()
+    (root / "artifact").write_text("cached")
+    root.chmod(0o555)
+
+    try:
+        force_rmtree(root)
+
+        assert not root.exists()
+    finally:
+        if root.exists():
+            root.chmod(0o700)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_force_rmtree_missing_root_is_noop(tmp_path: Path) -> None:
+    """Cleanup is idempotent when the requested root is already absent."""
+    root = tmp_path / "missing"
+
+    force_rmtree(root)
+
+    assert not root.exists()
+
+
+def test_force_rmtree_removes_deep_read_only_directories(tmp_path: Path) -> None:
+    """Cleanup normalizes read-only directories at every level of a deep tree."""
+    root = tmp_path / "job"
+    first_level = root / "uv-state" / "first"
+    second_level = first_level / "second"
+    third_level = second_level / "third"
+    third_level.mkdir(parents=True)
+    (third_level / "artifact").write_text("cached")
+    second_level.chmod(0o555)
+    first_level.chmod(0o555)
+
+    try:
+        force_rmtree(root)
+
+        assert not root.exists()
+    finally:
+        if first_level.exists():
+            first_level.chmod(0o700)
+        if second_level.exists():
+            second_level.chmod(0o700)
+        if third_level.exists():
+            third_level.chmod(0o700)
+        shutil.rmtree(root, ignore_errors=True)

--- a/tests/unit/test_agent_nsjail.py
+++ b/tests/unit/test_agent_nsjail.py
@@ -17,6 +17,7 @@ async def test_spawned_claude_shim_uses_explicit_stdio_limit(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """The stdio-limit test uses a fixture-owned job directory and leaks no temp state."""
     monkeypatch.setattr(nsjail_module, "TRACECAT__DISABLE_NSJAIL", True)
     captured: dict[str, Any] = {}
 
@@ -39,6 +40,7 @@ async def test_spawned_claude_shim_uses_explicit_stdio_limit(
         socket_dir=socket_dir,
         init_payload_path=tmp_path / "init.json",
         pipe_stdin=True,
+        job_dir=tmp_path / "job",
     )
 
     assert captured["kwargs"]["limit"] == nsjail_module.CLAUDE_SHIM_STDIO_LIMIT_BYTES

--- a/tests/unit/test_agent_runtime_broker.py
+++ b/tests/unit/test_agent_runtime_broker.py
@@ -536,3 +536,46 @@ async def test_transport_connect_applies_selected_direct_port_to_sdk_options(
     agent_entry = cast(dict[str, Any], agent.mcpServers[0])
     child_server = cast(dict[str, Any], agent_entry["tracecat-registry-analyst"])
     assert child_server["url"] == f"http://127.0.0.1:{selected_port}/mcp"
+
+
+@pytest.mark.anyio
+async def test_transport_close_removes_runtime_owned_job_directory(
+    tmp_path: Path,
+) -> None:
+    """Transport close removes a job directory owned by the spawned runtime."""
+    job_dir = tmp_path / "runtime-owned-job"
+    uv_file = job_dir / "uv-state" / "cache" / "archive" / "artifact"
+    uv_file.parent.mkdir(parents=True)
+    uv_file.write_text("cached artifact")
+    transport = _make_transport(job_dir, use_jailed_paths=False)
+    transport._spawned_runtime = transport_module.SpawnedRuntime(
+        process=cast(Any, _FakeSandboxProcess()),
+        job_dir=job_dir,
+    )
+
+    await transport.close()
+
+    assert not job_dir.exists()
+    assert transport._spawned_runtime is None
+
+
+@pytest.mark.anyio
+async def test_transport_close_preserves_caller_owned_job_directory(
+    tmp_path: Path,
+) -> None:
+    """Transport close leaves activity-owned state when the spawn owns no job dir."""
+    job_dir = tmp_path / "caller-owned-job"
+    uv_file = job_dir / "uv-state" / "cache" / "archive" / "artifact"
+    uv_file.parent.mkdir(parents=True)
+    uv_file.write_text("cached artifact")
+    transport = _make_transport(job_dir, use_jailed_paths=False)
+    transport._spawned_runtime = transport_module.SpawnedRuntime(
+        process=cast(Any, _FakeSandboxProcess()),
+        job_dir=None,
+    )
+
+    await transport.close()
+
+    assert job_dir.is_dir()
+    assert uv_file.is_file()
+    assert transport._spawned_runtime is None

--- a/tests/unit/test_agent_sandbox_config.py
+++ b/tests/unit/test_agent_sandbox_config.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
-from tracecat.agent.common.config import AGENT_RUNTIME_PROTECTED_ENV_VARS
+from tracecat.agent.common.config import (
+    AGENT_RUNTIME_PROTECTED_ENV_VARS,
+    build_agent_runtime_uv_env,
+)
 from tracecat.agent.common.exceptions import AgentSandboxValidationError
 from tracecat.agent.sandbox.config import (
     AgentSandboxConfig,
@@ -156,3 +163,71 @@ def test_build_agent_nsjail_config_mounts_fresh_procfs() -> None:
 
     assert 'src: "/proc"' not in config_text
     assert 'mount { dst: "/proc" fstype: "proc" rw: false }' in config_text
+
+
+@pytest.mark.slow
+def test_real_uv_resolves_managed_directories_inside_job_state(
+    tmp_path: Path,
+) -> None:
+    """Real UV path commands resolve only inside the configured per-job state."""
+    uv_binary = shutil.which("uv")
+    if uv_binary is None:
+        prefix_uv = Path(sys.prefix) / "bin" / "uv"
+        if prefix_uv.is_file():
+            uv_binary = str(prefix_uv)
+        else:
+            pytest.skip("uv executable is not available")
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    uv_state_dir = tmp_path / "uv-state"
+    uv_env = build_agent_runtime_uv_env(uv_state_dir)
+    path_env_values = [value for key, value in uv_env.items() if key != "UV_LINK_MODE"]
+    assert len(path_env_values) == 7
+    env = {
+        "HOME": str(home_dir),
+        "PATH": os.environ.get("PATH", os.defpath),
+        **uv_env,
+    }
+    command_candidates: tuple[tuple[tuple[str, ...], str | None], ...] = (
+        (("cache", "dir"), None),
+        (("auth", "dir"), None),
+        (("tool", "dir"), None),
+        (("tool", "dir"), "--bin"),
+        (("python", "dir"), None),
+        (("python", "dir"), "--bin"),
+    )
+    supported_commands: list[tuple[str, ...]] = []
+    for command, required_flag in command_candidates:
+        help_result = subprocess.run(
+            [uv_binary, *command, "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        help_text = help_result.stdout + help_result.stderr
+        if help_result.returncode != 0:
+            continue
+        if required_flag is not None and required_flag not in help_text:
+            continue
+        if required_flag is None:
+            supported_commands.append(command)
+        else:
+            supported_commands.append((*command, required_flag))
+
+    assert supported_commands
+    for command in supported_commands:
+        result = subprocess.run(
+            [uv_binary, *command, "--offline", "--no-config"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        reported_dir = Path(result.stdout.strip()).resolve()
+        # Assert against uv_state_dir, not tmp_path: HOME also lives under tmp_path,
+        # so a variable uv ignored would fall back to HOME and still pass.
+        assert reported_dir.is_relative_to(uv_state_dir.resolve()), (
+            f"uv {' '.join(command)} escaped per-job state: {reported_dir}"
+        )

--- a/tests/unit/test_agent_sandbox_nsjail.py
+++ b/tests/unit/test_agent_sandbox_nsjail.py
@@ -1,15 +1,23 @@
 from __future__ import annotations
 
+import shutil
+import stat
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from tracecat.agent.common.config import build_agent_runtime_uv_env
+from tracecat.agent.runtime.session_paths import (
+    JAILED_AGENT_UV_STATE_DIR,
+    job_uv_state_dir,
+)
+from tracecat.agent.sandbox import nsjail as nsjail_module
 from tracecat.agent.sandbox.config import AgentSandboxConfig
 from tracecat.agent.sandbox.nsjail import (
     SESSION_HOME_ENV_VAR,
     SESSION_WORK_DIR_ENV_VAR,
+    SpawnedRuntime,
     cleanup_spawned_runtime,
     spawn_jailed_runtime,
 )
@@ -215,3 +223,234 @@ async def test_spawn_nsjail_runtime_mounts_job_scoped_uv_state(
     assert (
         f'src: "{uv_state_dir}" dst: "/run/tracecat/uv-state" is_bind: true rw: true'
     ) in (job_dir / "nsjail.cfg").read_text()
+
+
+@pytest.mark.anyio
+async def test_direct_runtime_isolates_uv_state_across_two_jobs(
+    tmp_path: Path,
+) -> None:
+    """Direct runtimes point all seven UV paths at distinct per-job state trees."""
+    socket_dir = tmp_path / "sockets"
+    socket_dir.mkdir()
+    job_dirs = (tmp_path / "job-a", tmp_path / "job-b")
+    mock_process = MagicMock()
+
+    with (
+        patch("tracecat.agent.sandbox.nsjail.TRACECAT__DISABLE_NSJAIL", True),
+        patch(
+            "tracecat.agent.sandbox.nsjail.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=mock_process),
+        ) as create_subprocess_exec,
+    ):
+        for job_dir in job_dirs:
+            await spawn_jailed_runtime(
+                socket_dir=socket_dir,
+                init_payload_path=tmp_path / "init.json",
+                control_socket_required=False,
+                pipe_stdin=True,
+                job_dir=job_dir,
+            )
+
+    assert len(create_subprocess_exec.await_args_list) == 2
+    for job_dir, call in zip(
+        job_dirs, create_subprocess_exec.await_args_list, strict=True
+    ):
+        uv_state_dir = job_uv_state_dir(job_dir)
+        env = call.kwargs["env"]
+        expected_uv_env = build_agent_runtime_uv_env(uv_state_dir)
+        assert {key: env[key] for key in expected_uv_env} == expected_uv_env
+        uv_path_values = [
+            Path(value)
+            for key, value in expected_uv_env.items()
+            if key != "UV_LINK_MODE"
+        ]
+        assert len(uv_path_values) == 7
+        assert all(path.is_relative_to(uv_state_dir) for path in uv_path_values)
+
+    job_a_marker = job_uv_state_dir(job_dirs[0]) / "cache" / "job-a.marker"
+    job_a_marker.parent.mkdir(parents=True, exist_ok=True)
+    job_a_marker.write_text("job a")
+    job_b_marker = job_uv_state_dir(job_dirs[1]) / "cache" / job_a_marker.name
+
+    assert job_uv_state_dir(job_dirs[0]) != job_uv_state_dir(job_dirs[1])
+    assert job_a_marker.is_file()
+    assert not job_b_marker.exists()
+
+
+@pytest.mark.anyio
+async def test_nsjail_runtime_isolates_two_jobs_by_uv_mount_source(
+    tmp_path: Path,
+) -> None:
+    """NSJail jobs share the jailed UV path but bind distinct host sources."""
+    rootfs = tmp_path / "rootfs"
+    rootfs.mkdir()
+    nsjail_path = tmp_path / "nsjail"
+    nsjail_path.touch()
+    socket_dir = tmp_path / "sockets"
+    socket_dir.mkdir()
+    llm_socket_path = socket_dir / "llm.sock"
+    llm_socket_path.touch()
+    mcp_socket_path = socket_dir / "mcp.sock"
+    mcp_socket_path.touch()
+    init_payload_path = tmp_path / "init.json"
+    init_payload_path.write_text("{}")
+    job_dirs = (tmp_path / "job-a", tmp_path / "job-b")
+    mock_process = MagicMock()
+
+    with (
+        patch("tracecat.agent.sandbox.nsjail.TRACECAT__DISABLE_NSJAIL", False),
+        patch(
+            "tracecat.agent.sandbox.nsjail.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=mock_process),
+        ) as create_subprocess_exec,
+    ):
+        for job_dir in job_dirs:
+            await spawn_jailed_runtime(
+                socket_dir=socket_dir,
+                llm_socket_path=llm_socket_path,
+                mcp_socket_path=mcp_socket_path,
+                init_payload_path=init_payload_path,
+                config=AgentSandboxConfig(),
+                nsjail_path=str(nsjail_path),
+                rootfs_path=str(rootfs),
+                control_socket_required=False,
+                pipe_stdin=False,
+                job_dir=job_dir,
+            )
+
+    expected_jailed_env = build_agent_runtime_uv_env(JAILED_AGENT_UV_STATE_DIR)
+    assert len(create_subprocess_exec.await_args_list) == 2
+    for call in create_subprocess_exec.await_args_list:
+        env = call.kwargs["env"]
+        assert {key: env[key] for key in expected_jailed_env} == expected_jailed_env
+
+    mount_lines: list[str] = []
+    for job_dir in job_dirs:
+        config_lines = (job_dir / "nsjail.cfg").read_text().splitlines()
+        matching_lines = [
+            line.strip()
+            for line in config_lines
+            if f'dst: "{JAILED_AGENT_UV_STATE_DIR}"' in line
+        ]
+        assert len(matching_lines) == 1
+        mount_line = matching_lines[0]
+        assert f'src: "{job_uv_state_dir(job_dir)}"' in mount_line
+        mount_lines.append(mount_line)
+
+    assert mount_lines[0] != mount_lines[1]
+
+
+@pytest.mark.anyio
+async def test_spawn_creates_uv_state_with_owner_only_permissions(
+    tmp_path: Path,
+) -> None:
+    """A newly created per-job UV state directory has mode 0700."""
+    socket_dir = tmp_path / "sockets"
+    socket_dir.mkdir()
+    job_dir = tmp_path / "job"
+
+    with (
+        patch("tracecat.agent.sandbox.nsjail.TRACECAT__DISABLE_NSJAIL", True),
+        patch(
+            "tracecat.agent.sandbox.nsjail.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=MagicMock()),
+        ),
+    ):
+        await spawn_jailed_runtime(
+            socket_dir=socket_dir,
+            init_payload_path=tmp_path / "init.json",
+            control_socket_required=False,
+            pipe_stdin=True,
+            job_dir=job_dir,
+        )
+
+    assert stat.S_IMODE(job_uv_state_dir(job_dir).stat().st_mode) == 0o700
+
+
+@pytest.mark.anyio
+async def test_spawn_preserves_preexisting_uv_state_permissions(
+    tmp_path: Path,
+) -> None:
+    """Exist-ok creation leaves a pre-existing mode-0777 UV state directory loose."""
+    socket_dir = tmp_path / "sockets"
+    socket_dir.mkdir()
+    job_dir = tmp_path / "job"
+    uv_state_dir = job_uv_state_dir(job_dir)
+    uv_state_dir.mkdir(parents=True)
+    uv_state_dir.chmod(0o777)
+
+    with (
+        patch("tracecat.agent.sandbox.nsjail.TRACECAT__DISABLE_NSJAIL", True),
+        patch(
+            "tracecat.agent.sandbox.nsjail.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=MagicMock()),
+        ),
+    ):
+        await spawn_jailed_runtime(
+            socket_dir=socket_dir,
+            init_payload_path=tmp_path / "init.json",
+            control_socket_required=False,
+            pipe_stdin=True,
+            job_dir=job_dir,
+        )
+
+    assert stat.S_IMODE(uv_state_dir.stat().st_mode) == 0o777
+
+
+def test_cleanup_spawned_runtime_swallows_rmtree_error_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Runtime-owned cleanup logs and swallows a raising rmtree call."""
+    job_dir = tmp_path / "job"
+    job_uv_state_dir(job_dir).mkdir(parents=True)
+    result = SpawnedRuntime(process=MagicMock(), job_dir=job_dir)
+    real_rmtree = shutil.rmtree
+    warning = MagicMock()
+
+    def fail_rmtree(path: Path, *, ignore_errors: bool) -> None:
+        assert path == job_dir
+        assert ignore_errors is True
+        raise OSError("simulated cleanup failure")
+
+    monkeypatch.setattr(nsjail_module.shutil, "rmtree", fail_rmtree)
+    monkeypatch.setattr(nsjail_module.logger, "warning", warning)
+
+    try:
+        cleanup_spawned_runtime(result)
+
+        assert job_dir.exists()
+        warning.assert_called_once_with(
+            "Failed to clean up job dir",
+            job_dir=str(job_dir),
+            error="simulated cleanup failure",
+        )
+    finally:
+        real_rmtree(job_dir, ignore_errors=True)
+
+
+def test_cleanup_spawned_runtime_silently_leaves_read_only_uv_subtree(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Ignore-errors cleanup silently leaves a runtime-owned 0555 UV subtree."""
+    job_dir = tmp_path / "job"
+    read_only_dir = job_uv_state_dir(job_dir) / "cache" / "read-only"
+    nested_file = read_only_dir / "archive" / "artifact"
+    nested_file.parent.mkdir(parents=True)
+    nested_file.write_text("cached artifact")
+    read_only_dir.chmod(0o555)
+    result = SpawnedRuntime(process=MagicMock(), job_dir=job_dir)
+    warning = MagicMock()
+    monkeypatch.setattr(nsjail_module.logger, "warning", warning)
+
+    try:
+        cleanup_spawned_runtime(result)
+
+        assert job_dir.exists()
+        assert read_only_dir.exists()
+        warning.assert_not_called()
+    finally:
+        if read_only_dir.exists():
+            read_only_dir.chmod(0o700)
+        shutil.rmtree(job_dir, ignore_errors=True)

--- a/tests/unit/test_agent_sandbox_nsjail.py
+++ b/tests/unit/test_agent_sandbox_nsjail.py
@@ -368,10 +368,10 @@ async def test_spawn_creates_uv_state_with_owner_only_permissions(
 
 
 @pytest.mark.anyio
-async def test_spawn_preserves_preexisting_uv_state_permissions(
+async def test_spawn_normalizes_preexisting_uv_state_permissions(
     tmp_path: Path,
 ) -> None:
-    """Exist-ok creation leaves a pre-existing mode-0777 UV state directory loose."""
+    """Spawn normalizes a pre-existing UV state directory to owner-only mode."""
     socket_dir = tmp_path / "sockets"
     socket_dir.mkdir()
     job_dir = tmp_path / "job"
@@ -394,7 +394,7 @@ async def test_spawn_preserves_preexisting_uv_state_permissions(
             job_dir=job_dir,
         )
 
-    assert stat.S_IMODE(uv_state_dir.stat().st_mode) == 0o777
+    assert stat.S_IMODE(uv_state_dir.stat().st_mode) == 0o700
 
 
 def test_cleanup_spawned_runtime_swallows_rmtree_error_and_warns(
@@ -408,12 +408,11 @@ def test_cleanup_spawned_runtime_swallows_rmtree_error_and_warns(
     real_rmtree = shutil.rmtree
     warning = MagicMock()
 
-    def fail_rmtree(path: Path, *, ignore_errors: bool) -> None:
+    def fail_rmtree(path: Path) -> None:
         assert path == job_dir
-        assert ignore_errors is True
         raise OSError("simulated cleanup failure")
 
-    monkeypatch.setattr(nsjail_module.shutil, "rmtree", fail_rmtree)
+    monkeypatch.setattr("tracecat.agent.common.fs.shutil.rmtree", fail_rmtree)
     monkeypatch.setattr(nsjail_module.logger, "warning", warning)
 
     try:
@@ -429,11 +428,11 @@ def test_cleanup_spawned_runtime_swallows_rmtree_error_and_warns(
         real_rmtree(job_dir, ignore_errors=True)
 
 
-def test_cleanup_spawned_runtime_silently_leaves_read_only_uv_subtree(
+def test_cleanup_spawned_runtime_removes_read_only_uv_subtree(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Ignore-errors cleanup silently leaves a runtime-owned 0555 UV subtree."""
+    """Runtime cleanup removes a sandbox-owned 0555 UV cache subtree."""
     job_dir = tmp_path / "job"
     read_only_dir = job_uv_state_dir(job_dir) / "cache" / "read-only"
     nested_file = read_only_dir / "archive" / "artifact"
@@ -447,8 +446,8 @@ def test_cleanup_spawned_runtime_silently_leaves_read_only_uv_subtree(
     try:
         cleanup_spawned_runtime(result)
 
-        assert job_dir.exists()
-        assert read_only_dir.exists()
+        assert not job_dir.exists()
+        assert not read_only_dir.exists()
         warning.assert_not_called()
     finally:
         if read_only_dir.exists():

--- a/tracecat/agent/common/fs.py
+++ b/tracecat/agent/common/fs.py
@@ -1,0 +1,19 @@
+"""Filesystem helpers for agent runtime cleanup."""
+
+import os
+import shutil
+from pathlib import Path
+
+
+def force_rmtree(root: Path) -> None:
+    """Delete a tree that sandboxed code may have made unreadable."""
+    try:
+        os.chmod(root, 0o700)
+    except FileNotFoundError:
+        return
+    for dirpath, dirnames, _ in os.walk(root, followlinks=False):
+        for name in dirnames:
+            path = os.path.join(dirpath, name)
+            if not os.path.islink(path):
+                os.chmod(path, 0o700)
+    shutil.rmtree(root)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -831,7 +831,14 @@ class SandboxedAgentExecutor:
             )
             return job_dir
         except BaseException:
-            await asyncio.to_thread(force_rmtree, job_dir)
+            try:
+                await asyncio.to_thread(force_rmtree, job_dir)
+            except Exception as cleanup_error:
+                logger.warning(
+                    "Failed to clean up job directory after setup failure",
+                    job_dir=str(job_dir),
+                    error=str(cleanup_error),
+                )
             raise
 
     async def _load_artifact_working_set(self) -> ArtifactWorkingSetInput | None:

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -32,6 +32,7 @@ from tracecat.agent.common.config import (
     TRACECAT__DISABLE_NSJAIL,
 )
 from tracecat.agent.common.exceptions import AgentSandboxExecutionError
+from tracecat.agent.common.fs import force_rmtree
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import ToolCallContent
 from tracecat.agent.common.types import (
@@ -494,7 +495,15 @@ class SandboxedAgentExecutor:
                 error=str(e),
             )
             self._agent_fs_hydration_failed = True
-            shutil.rmtree(work_dir, ignore_errors=True)
+            # Best effort: a work dir we cannot reset must not fail the turn.
+            try:
+                force_rmtree(work_dir)
+            except Exception as cleanup_error:
+                logger.warning(
+                    "Failed to reset agent work dir after hydration failure",
+                    work_dir=str(work_dir),
+                    error=str(cleanup_error),
+                )
             work_dir.mkdir(parents=True, exist_ok=True)
         self._log_benchmark_phase("agent_fs_hydrate_complete")
 
@@ -822,7 +831,7 @@ class SandboxedAgentExecutor:
             )
             return job_dir
         except BaseException:
-            await asyncio.to_thread(shutil.rmtree, job_dir, True)
+            await asyncio.to_thread(force_rmtree, job_dir)
             raise
 
     async def _load_artifact_working_set(self) -> ArtifactWorkingSetInput | None:
@@ -1012,7 +1021,7 @@ class SandboxedAgentExecutor:
         # Clean up job directory
         if self._job_dir and self._job_dir.exists():
             try:
-                await asyncio.to_thread(shutil.rmtree, self._job_dir)
+                await asyncio.to_thread(force_rmtree, self._job_dir)
                 logger.debug("Cleaned up job directory", job_dir=str(self._job_dir))
             except Exception as e:
                 logger.warning(

--- a/tracecat/agent/sandbox/nsjail.py
+++ b/tracecat/agent/sandbox/nsjail.py
@@ -42,6 +42,7 @@ from tracecat.agent.common.exceptions import (
     AgentSandboxExecutionError,
     AgentSandboxTimeoutError,
 )
+from tracecat.agent.common.fs import force_rmtree
 from tracecat.agent.runtime.session_paths import (
     JAILED_AGENT_HOME_DIR,
     JAILED_AGENT_JOB_DIR,
@@ -211,7 +212,13 @@ async def spawn_jailed_runtime(
 
     try:
         job_dir.mkdir(parents=True, exist_ok=True)
-        job_uv_state_dir(job_dir).mkdir(mode=0o700, exist_ok=True)
+        uv_state_dir = job_uv_state_dir(job_dir)
+        uv_state_dir.mkdir(mode=0o700, exist_ok=True)
+        if uv_state_dir.is_symlink() or not uv_state_dir.is_dir():
+            raise AgentSandboxExecutionError(
+                f"UV state path must be a real directory: {uv_state_dir}"
+            )
+        uv_state_dir.chmod(0o700)
 
         # Direct subprocess mode for testing (no nsjail)
         if TRACECAT__DISABLE_NSJAIL:
@@ -547,6 +554,6 @@ async def wait_for_process(
 def _cleanup_job_dir(job_dir: Path) -> None:
     """Clean up a job directory (best effort)."""
     try:
-        shutil.rmtree(job_dir, ignore_errors=True)
+        force_rmtree(job_dir)
     except Exception as e:
         logger.warning("Failed to clean up job dir", job_dir=str(job_dir), error=str(e))


### PR DESCRIPTION
Follow-up to #3210, which scoped uv's mutable state to a per-job `uv-state` tree. This adds the teardown coverage that work was missing, and fixes a leak that coverage exposed.

## The problem

`uv-state` and the session work dir are bind-mounted **read-write** into the sandbox, and nsjail maps the in-jail uid to the executor's host uid (`tracecat/agent/sandbox/config.py`). Sandboxed job code can therefore `chmod 0555` (or `0000`) a directory it created. `shutil.rmtree` then fails, because unlinking a directory's children requires write and execute permission on that directory.

End-of-job teardown is the only bound on per-job disk use, so a job could permanently leak its own tree — repeatedly — until the executor's disk filled and every agent job on that node failed. On the runtime-owned path `ignore_errors=True` also meant this happened with nothing logged at all.

## The fix

`force_rmtree` in a new `tracecat/agent/common/fs.py`: normalize directory modes, then delete. No error classification, no `onexc` handler, no retry loop — because the uid mapping means the executor owns everything the job wrote, and an owner can always chmod its own files back regardless of the current mode.

Three properties are load-bearing:

- `chmod(root)` before the walk, and top-down walk order — a `0o000` directory cannot be listed at all, so each directory must be opened up before `os.walk` descends into it.
- `followlinks=False`, so the walk never descends out of the tree.
- the `os.path.islink` skip — `os.chmod` follows symlinks and Linux cannot chmod a symlink itself, so without it a symlink planted inside `uv-state` would redirect the chmod at a target outside the job directory.

Wired into all four job-tree deletion sites: the production teardown in `_cleanup`, the session work dir, the job-dir setup-failure path, and `_cleanup_job_dir`. Every surrounding `try`/`except` and log line is unchanged, except that the work-dir reset now catches explicitly to preserve its best-effort contract (a work dir we cannot reset must not fail the turn).

Also drops `ignore_errors=True` from `_cleanup_job_dir` so its `except` block stops being dead code, and re-applies `0o700` after the `exist_ok=True` mkdir, since `Path.mkdir(mode=...)` does not re-apply the mode to an existing directory.

## Tests

Teardown coverage that did not exist before:

- The production `_cleanup` path removes a realistic `uv-state` tree (seeded from `build_agent_runtime_uv_env`, so a new `UV_*` variable is covered automatically).
- `run()`'s `finally: await self._cleanup()` exercised for real on both the success and the mid-run failure path — previously every `run()` test stubbed `_cleanup` out.
- Per-job isolation across two jobs: distinct state roots in direct mode, distinct bind-mount sources under nsjail.
- `transport.close()` for both ownership cases, pinning that a caller-owned job dir is deliberately left for the activity to remove.
- Real `uv` resolves every queryable managed directory inside the per-job tree, network-free, asserted against `uv_state_dir` rather than the temp root so a variable uv ignored cannot pass by falling back to `$HOME`.
- Recovery from `0o555`, `0o000`, a read-only root, and read-only directories nested more than one level deep.
- **A symlink-escape sentinel**: a link planted inside a read-only `uv-state` pointing at a file and a directory outside the job root; both targets must survive with their modes unchanged.
- Idempotent cleanup of an already-missing path.

Also fixes an existing test that leaked a real `/tmp/agent-runtime-*` tree on every run by spawning without a `job_dir`.

## Out of scope

Two known gaps are deliberately not addressed here:

- **Crash-path leaks.** No `finally` runs after SIGKILL, OOM, or node loss, and nothing reaps orphaned job dirs. `/tmp` only clears on container restart. This wants a reaper (or a lifetime-bound filesystem) and its own design discussion.
- **Observability.** A cleanup failure is still only a warning line. A counter for cleanup failures and orphan bytes would make the remaining failure modes visible instead of silent.

The session root `/tmp/tracecat-agent-{session_id}` and the agent skill cache are likewise never removed by any code path, unchanged by this PR.

## LOC breakdown

| Category | + | - |
|---|---|---|
| Logic | 40 | 5 |
| Tests | 700 | 4 |
| **Total** | **740** | **9** |

## Review guide

- `tracecat/agent/common/fs.py` is the whole fix — 19 lines. The three properties above are the ones to scrutinize; the `islink` skip is what separates this from a helper that can chmod arbitrary paths.
- `tests/unit/test_agent_common_fs.py::test_force_rmtree_does_not_follow_symlinks` is the hard safety gate.
- In `tracecat/agent/executor/activity.py`, note that the work-dir reset intentionally swallows and logs rather than propagating, unlike the other three call sites.
- Three tests in the first commit assert the leaky behavior and are inverted by the second commit. That split is intentional: the first commit documents the defect, the second fixes it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes job directory cleanup leaks by force-deleting sandbox-owned trees, preventing disk fill from read-only `uv-state` directories. Applies safe top-down chmod and symlink-avoidance, wires cleanup into all teardown paths, and preserves original setup errors when cleanup fails.

- **Bug Fixes**
  - Added `force_rmtree` to normalize directory modes, skip symlinks, and delete the tree without following links.
  - Replaced `shutil.rmtree` with `force_rmtree` in executor `_cleanup`, work-dir reset after hydration failure, job-dir setup failure, and nsjail `_cleanup_job_dir`.
  - Preserved setup errors: cleanup failures are logged and never overwrite the original job-dir setup or hydration errors.
  - Ensured `uv-state` is a real directory with `0o700`, and re-applied mode when it already exists; removed `ignore_errors=True` where it hid failures.
  - Strengthened tests for teardown: read-only and `000` directories, symlink-escape safety, idempotent missing paths, per-job `uv` state isolation in direct and `nsjail` modes, correct cleanup for runtime-owned vs caller-owned job dirs, and end-to-end cleanup on success and cancellation.

<sup>Written for commit 5f67946ffe168c23a78de91b8a650ace59517481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

