### PR TITLE
fix(agents): disable Claude Code attribution header for non-Anthropic providers

### DIFF
--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -1488,6 +1488,14 @@ class ClaudeAgentRuntime:
             env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = (
                 CUSTOM_MODEL_PROVIDER_AUTO_COMPACT_WINDOW
             )
+        # Claude Code prepends an attribution header, which LiteLLM calls "billing
+        # metadata", to the start of the first message. Since it includes a content
+        # hash, doing this invalidates the KV Cache, making inference 90% slower
+        # with anything that isn't Anthropic and isn't already stripping it. By
+        # setting this in the environment, Claude Code will skip adding it to the
+        # message altogether.
+        if payload.config.model_provider != "anthropic":
+            env["CLAUDE_CODE_ATTRIBUTION_HEADER"] = "0"
         # The CLI disables tool search (deferred tool loading) for
         # non-first-party base URLs — ours is always the socket bridge — unless
         # explicitly enabled. Every leg terminates at the managed LiteLLM or an


### PR DESCRIPTION
## Summary

Claude Code prepends an attribution header (what LiteLLM calls "billing
metadata") to the start of the first message in every conversation. That
header includes a content hash, so it invalidates the KV cache on every
request — inference against anything that isn't Anthropic (and isn't already
stripping the header) becomes up to 90% slower.

This sets `CLAUDE_CODE_ATTRIBUTION_HEADER=0` in the Claude SDK child-process
environment whenever the configured model provider isn't `anthropic`, which
tells Claude Code to skip adding the header to the message entirely.

## Reference

- https://unsloth.ai/docs/basics/claude-code#fixing-90-slower-inference-in-claude-code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Claude Code’s attribution header for non-Anthropic providers to prevent KV cache invalidation that made inference up to 90% slower. Set `CLAUDE_CODE_ATTRIBUTION_HEADER=0` in the SDK child process when the model provider isn’t `anthropic`, so messages skip the header and caching works as expected.

<sup>Written for commit 09aa7c290c4e873dc23abe9195428cd3b80f4e1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

