### PR TITLE
feat(cases): show agent activity in comment threads

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6464,6 +6464,63 @@ export const $CaseBatchUpdate = {
   description: "Request body for updating multiple cases.",
 } as const
 
+export const $CaseCommentAgentInvocationRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    preset_name: {
+      type: "string",
+      title: "Preset Name",
+    },
+    preset_slug: {
+      type: "string",
+      title: "Preset Slug",
+    },
+    status: {
+      $ref: "#/components/schemas/CaseCommentAgentInvocationStatus",
+    },
+    session_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Session Id",
+    },
+    error: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Error",
+    },
+  },
+  type: "object",
+  required: ["id", "preset_name", "preset_slug", "status"],
+  title: "CaseCommentAgentInvocationRead",
+  description:
+    "Read model for an agent invocation triggered by a comment mention.",
+} as const
+
+export const $CaseCommentAgentInvocationStatus = {
+  type: "string",
+  enum: ["pending", "running", "succeeded", "failed"],
+  title: "CaseCommentAgentInvocationStatus",
+  description:
+    "Lifecycle state for an agent invoked from a case-comment mention.",
+} as const
+
 export const $CaseCommentCreate = {
   properties: {
     content: {
@@ -6534,6 +6591,16 @@ export const $CaseCommentMentionRead = {
       type: "string",
       format: "date-time",
       title: "Created At",
+    },
+    invocation: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseCommentAgentInvocationRead",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
   },
   type: "object",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6464,6 +6464,40 @@ export const $CaseBatchUpdate = {
   description: "Request body for updating multiple cases.",
 } as const
 
+export const $CaseCommentAgentAttributionRead = {
+  properties: {
+    invocation_id: {
+      type: "string",
+      format: "uuid",
+      title: "Invocation Id",
+    },
+    preset_name: {
+      type: "string",
+      title: "Preset Name",
+    },
+    preset_slug: {
+      type: "string",
+      title: "Preset Slug",
+    },
+    session_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Session Id",
+    },
+  },
+  type: "object",
+  required: ["invocation_id", "preset_name", "preset_slug"],
+  title: "CaseCommentAgentAttributionRead",
+  description: "Read model for agent attribution on a generated comment reply.",
+} as const
+
 export const $CaseCommentAgentInvocationRead = {
   properties: {
     id: {
@@ -6645,6 +6679,16 @@ export const $CaseCommentRead = {
       anyOf: [
         {
           $ref: "#/components/schemas/CaseCommentWorkflowRead",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    agent: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseCommentAgentAttributionRead",
         },
         {
           type: "null",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6498,6 +6498,28 @@ export const $CaseCommentAgentAttributionRead = {
   description: "Read model for agent attribution on a generated comment reply.",
 } as const
 
+export const $CaseCommentAgentInvocationError = {
+  properties: {
+    kind: {
+      $ref: "#/components/schemas/CaseCommentAgentInvocationErrorKind",
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+  },
+  type: "object",
+  required: ["kind", "message"],
+  title: "CaseCommentAgentInvocationError",
+  description:
+    "Structured terminal failure persisted for a comment agent invocation.",
+} as const
+
+export const $CaseCommentAgentInvocationErrorKind = {
+  type: "string",
+  enum: ["startup", "preparation", "agent_turn", "completion", "cancelled"],
+} as const
+
 export const $CaseCommentAgentInvocationRead = {
   properties: {
     id: {
@@ -6531,13 +6553,12 @@ export const $CaseCommentAgentInvocationRead = {
     error: {
       anyOf: [
         {
-          type: "string",
+          $ref: "#/components/schemas/CaseCommentAgentInvocationError",
         },
         {
           type: "null",
         },
       ],
-      title: "Error",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1688,6 +1688,27 @@ export type CaseBatchUpdate = {
   update: CaseUpdate
 }
 
+/**
+ * Read model for an agent invocation triggered by a comment mention.
+ */
+export type CaseCommentAgentInvocationRead = {
+  id: string
+  preset_name: string
+  preset_slug: string
+  status: CaseCommentAgentInvocationStatus
+  session_id?: string | null
+  error?: string | null
+}
+
+/**
+ * Lifecycle state for an agent invoked from a case-comment mention.
+ */
+export type CaseCommentAgentInvocationStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+
 export type CaseCommentCreate = {
   content: string
   parent_id?: string | null
@@ -1702,6 +1723,7 @@ export type CaseCommentMentionRead = {
   target_id: string
   label: string
   created_at: string
+  invocation?: CaseCommentAgentInvocationRead | null
 }
 
 export type CaseCommentRead = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1689,6 +1689,16 @@ export type CaseBatchUpdate = {
 }
 
 /**
+ * Read model for agent attribution on a generated comment reply.
+ */
+export type CaseCommentAgentAttributionRead = {
+  invocation_id: string
+  preset_name: string
+  preset_slug: string
+  session_id?: string | null
+}
+
+/**
  * Read model for an agent invocation triggered by a comment mention.
  */
 export type CaseCommentAgentInvocationRead = {
@@ -1733,6 +1743,7 @@ export type CaseCommentRead = {
   content: string
   parent_id?: string | null
   workflow?: CaseCommentWorkflowRead | null
+  agent?: CaseCommentAgentAttributionRead | null
   user?: UserRead | null
   last_edited_at?: string | null
   deleted_at?: string | null

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1699,6 +1699,21 @@ export type CaseCommentAgentAttributionRead = {
 }
 
 /**
+ * Structured terminal failure persisted for a comment agent invocation.
+ */
+export type CaseCommentAgentInvocationError = {
+  kind: CaseCommentAgentInvocationErrorKind
+  message: string
+}
+
+export type CaseCommentAgentInvocationErrorKind =
+  | "startup"
+  | "preparation"
+  | "agent_turn"
+  | "completion"
+  | "cancelled"
+
+/**
  * Read model for an agent invocation triggered by a comment mention.
  */
 export type CaseCommentAgentInvocationRead = {
@@ -1707,7 +1722,7 @@ export type CaseCommentAgentInvocationRead = {
   preset_slug: string
   status: CaseCommentAgentInvocationStatus
   session_id?: string | null
-  error?: string | null
+  error?: CaseCommentAgentInvocationError | null
 }
 
 /**

--- a/frontend/src/components/cases/case-chat.tsx
+++ b/frontend/src/components/cases/case-chat.tsx
@@ -1,15 +1,20 @@
 "use client"
 
-import { useSearchParams } from "next/navigation"
 import { ChatInterface } from "@/components/chat/chat-interface"
+import { useCaseChatSession } from "@/hooks/use-case-chat-session"
 
+/** Render a case-scoped chat synchronized with the selected URL session. */
 export function CaseChat({ caseId }: { caseId: string }) {
-  const searchParams = useSearchParams()
-  const chatId = searchParams?.get("chatId") ?? undefined
+  const { chatId, openChatSession } = useCaseChatSession()
 
   return (
     <div className="flex h-full flex-col">
-      <ChatInterface chatId={chatId} entityType="case" entityId={caseId} />
+      <ChatInterface
+        chatId={chatId}
+        entityType="case"
+        entityId={caseId}
+        onChatSelect={openChatSession}
+      />
     </div>
   )
 }

--- a/frontend/src/components/cases/case-comment-agent.tsx
+++ b/frontend/src/components/cases/case-comment-agent.tsx
@@ -138,7 +138,8 @@ function FailedInvocationStatus({
           {invocation.preset_name} could not finish.
         </p>
         <p className="whitespace-pre-wrap break-words text-muted-foreground">
-          {invocation.error ?? "The agent could not complete the request."}
+          {invocation.error?.message ??
+            "The agent could not complete the request."}
         </p>
         <p className="text-xs text-muted-foreground">
           Mention {invocation.preset_name} again to retry.

--- a/frontend/src/components/cases/case-comment-agent.tsx
+++ b/frontend/src/components/cases/case-comment-agent.tsx
@@ -1,0 +1,197 @@
+"use client"
+
+import {
+  AlertCircleIcon,
+  BotIcon,
+  ClockIcon,
+  LoaderCircleIcon,
+} from "lucide-react"
+
+import type {
+  CaseCommentAgentAttributionRead,
+  CaseCommentAgentInvocationRead,
+  CaseCommentMentionRead,
+} from "@/client"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { useCaseChatSession } from "@/hooks/use-case-chat-session"
+
+function CaseCommentAgentAvatar({ presetName }: { presetName: string }) {
+  return (
+    <Avatar
+      role="img"
+      aria-label={`Agent avatar for ${presetName}`}
+      className="size-5"
+    >
+      <AvatarFallback className="text-muted-foreground">
+        <BotIcon aria-hidden="true" className="size-3" />
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
+function ViewAgentSession({
+  presetName,
+  sessionId,
+}: {
+  presetName: string
+  sessionId: string
+}) {
+  const { openChatSession } = useCaseChatSession()
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-6 shrink-0 px-1.5 text-xs text-muted-foreground"
+      aria-label={`View ${presetName} session`}
+      onClick={() => openChatSession(sessionId)}
+    >
+      View session
+    </Button>
+  )
+}
+
+/** Render the snapshotted agent identity for a generated comment reply. */
+export function CaseCommentAgentAttribution({
+  attribution,
+}: {
+  attribution: CaseCommentAgentAttributionRead
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <CaseCommentAgentAvatar presetName={attribution.preset_name} />
+      <span className="truncate text-sm font-medium text-foreground">
+        {attribution.preset_name}
+      </span>
+      <Badge
+        variant="secondary"
+        className="h-5 shrink-0 rounded-full px-1.5 text-[10px] leading-none"
+      >
+        Agent
+      </Badge>
+      {attribution.session_id ? (
+        <ViewAgentSession
+          presetName={attribution.preset_name}
+          sessionId={attribution.session_id}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function ActiveInvocationStatus({
+  invocation,
+}: {
+  invocation: CaseCommentAgentInvocationRead
+}) {
+  const running = invocation.status === "running"
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground"
+    >
+      <CaseCommentAgentAvatar presetName={invocation.preset_name} />
+      {running ? (
+        <LoaderCircleIcon
+          aria-hidden="true"
+          className="size-3.5 animate-spin"
+        />
+      ) : (
+        <ClockIcon aria-hidden="true" className="size-3.5 animate-pulse" />
+      )}
+      <span className="min-w-0 flex-1 truncate">
+        <span className="font-medium text-foreground">
+          {invocation.preset_name}
+        </span>{" "}
+        {running ? "is thinking..." : "is preparing..."}
+      </span>
+      {running && invocation.session_id ? (
+        <ViewAgentSession
+          presetName={invocation.preset_name}
+          sessionId={invocation.session_id}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function FailedInvocationStatus({
+  invocation,
+}: {
+  invocation: CaseCommentAgentInvocationRead
+}) {
+  return (
+    <div role="alert" className="flex min-w-0 items-start gap-2 text-sm">
+      <CaseCommentAgentAvatar presetName={invocation.preset_name} />
+      <AlertCircleIcon
+        aria-hidden="true"
+        className="mt-0.5 size-3.5 shrink-0 text-destructive"
+      />
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <p className="font-medium text-destructive">
+          {invocation.preset_name} could not finish.
+        </p>
+        <p className="whitespace-pre-wrap break-words text-muted-foreground">
+          {invocation.error ?? "The agent could not complete the request."}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Mention {invocation.preset_name} again to retry.
+        </p>
+      </div>
+      {invocation.session_id ? (
+        <ViewAgentSession
+          presetName={invocation.preset_name}
+          sessionId={invocation.session_id}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function InvocationStatus({
+  invocation,
+}: {
+  invocation: CaseCommentAgentInvocationRead
+}) {
+  switch (invocation.status) {
+    case "pending":
+    case "running":
+      return <ActiveInvocationStatus invocation={invocation} />
+    case "failed":
+      return <FailedInvocationStatus invocation={invocation} />
+    case "succeeded":
+      return null
+  }
+}
+
+/** Render non-successful agent invocations in persisted mention order. */
+export function CaseCommentAgentInvocationList({
+  mentions,
+}: {
+  mentions: CaseCommentMentionRead[] | undefined
+}) {
+  const invocations =
+    mentions?.flatMap(({ invocation }) => (invocation ? [invocation] : [])) ??
+    []
+  const visibleInvocations = invocations.filter(
+    ({ status }) => status !== "succeeded"
+  )
+
+  if (visibleInvocations.length === 0) {
+    return null
+  }
+
+  return (
+    <div aria-label="Agent activity" className="space-y-2 pt-1">
+      {visibleInvocations.map((invocation) => (
+        <InvocationStatus key={invocation.id} invocation={invocation} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/cases/case-comments-section.tsx
+++ b/frontend/src/components/cases/case-comments-section.tsx
@@ -40,6 +40,10 @@ import {
   ModelSelectorList,
   ModelSelectorTrigger,
 } from "@/components/ai-elements/model-selector"
+import {
+  CaseCommentAgentAttribution,
+  CaseCommentAgentInvocationList,
+} from "@/components/cases/case-comment-agent"
 import { CaseCommentViewer } from "@/components/cases/case-description-editor"
 import {
   CaseEventTimestamp,
@@ -540,7 +544,9 @@ function CommentRow({
     <div className="group space-y-3">
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
-          {comment.is_deleted ? null : isWorkflowComment && comment.workflow ? (
+          {comment.is_deleted ? null : comment.agent ? (
+            <CaseCommentAgentAttribution attribution={comment.agent} />
+          ) : isWorkflowComment && comment.workflow ? (
             <div className="flex min-w-0 items-center gap-2">
               {getWorkflowStatusBadge(workflowStatus)}
               <span className="truncate text-sm font-medium text-foreground">
@@ -620,6 +626,9 @@ function CommentRow({
           </div>
         </ScrollArea>
       )}
+      {!comment.is_deleted ? (
+        <CaseCommentAgentInvocationList mentions={comment.mentions} />
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/components/chat/messages.tsx
+++ b/frontend/src/components/chat/messages.tsx
@@ -9,6 +9,7 @@ import { type ComponentProps, useEffect, useRef } from "react"
 import type { Streamdown } from "streamdown"
 import { MarkdownWithFrontmatter } from "@/components/ai-elements/markdown-with-frontmatter"
 import { Dots } from "@/components/loading/dots"
+import { invalidateCaseCommentQueries } from "@/lib/cases/comment-queries"
 import { invalidateCaseActivityQueries } from "@/lib/cases/invalidation"
 import {
   ALLOWED_MARKDOWN_IMAGE_PREFIXES,
@@ -186,9 +187,7 @@ export function Messages({
       // Force-refetch the case & related queries so the UI updates instantly
       queryClient.invalidateQueries({ queryKey: ["cases", workspaceId] })
       invalidateCaseActivityQueries(queryClient, entityId, workspaceId)
-      queryClient.invalidateQueries({
-        queryKey: ["case-comments", entityId, workspaceId],
-      })
+      invalidateCaseCommentQueries(queryClient, entityId, workspaceId)
     }
   }, [messages, entityType, entityId, workspaceId, queryClient])
 

--- a/frontend/src/hooks/use-case-chat-session.ts
+++ b/frontend/src/hooks/use-case-chat-session.ts
@@ -1,0 +1,27 @@
+"use client"
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useCallback } from "react"
+
+import { useWorkspaceChatOpen } from "@/hooks/use-workspace-chat-open"
+
+/** Read and select the case-chat session represented by the current URL. */
+export function useCaseChatSession() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [, setChatOpen] = useWorkspaceChatOpen()
+  const chatId = searchParams?.get("chatId") ?? undefined
+
+  const openChatSession = useCallback(
+    (sessionId: string) => {
+      const nextParams = new URLSearchParams(searchParams?.toString() ?? "")
+      nextParams.set("chatId", sessionId)
+      router.replace(`${pathname}?${nextParams.toString()}`, { scroll: false })
+      setChatOpen(true)
+    },
+    [pathname, router, searchParams, setChatOpen]
+  )
+
+  return { chatId, openChatSession }
+}

--- a/frontend/src/lib/cases/comment-queries.test.tsx
+++ b/frontend/src/lib/cases/comment-queries.test.tsx
@@ -1,0 +1,246 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+
+import {
+  type CaseCommentAgentInvocationStatus,
+  type CaseCommentRead,
+  type CaseCommentThreadRead,
+  casesCreateComment,
+  casesListComments,
+  casesListCommentThreads,
+} from "@/client"
+import {
+  CASE_COMMENT_ACTIVE_POLL_INTERVAL_MS,
+  caseCommentQueryKeys,
+  invalidateCaseCommentQueries,
+} from "@/lib/cases/comment-queries"
+import { ENTITY_TO_INVALIDATION } from "@/lib/chat"
+import {
+  useCaseComments,
+  useCaseCommentThreads,
+  useCreateCaseComment,
+} from "@/lib/hooks"
+
+jest.mock("@/client", () => ({
+  casesCreateComment: jest.fn(),
+  casesListComments: jest.fn(),
+  casesListCommentThreads: jest.fn(),
+}))
+
+jest.mock("@/components/ui/use-toast", () => ({
+  toast: jest.fn(),
+}))
+
+jest.mock("@/lib/api", () => ({
+  client: {},
+  getBaseUrl: jest.fn(() => "http://localhost"),
+}))
+
+const caseId = "case-test"
+const workspaceId = "workspace-test"
+const timestamp = "2026-08-11T12:00:00Z"
+
+function makeComment(
+  id: string,
+  status?: CaseCommentAgentInvocationStatus
+): CaseCommentRead {
+  return {
+    id,
+    created_at: timestamp,
+    updated_at: timestamp,
+    content: `${id} content`,
+    mentions: status
+      ? [
+          {
+            id: `${id}-mention`,
+            target_type: "agent",
+            target_id: `${id}-preset`,
+            label: `${id} agent`,
+            created_at: timestamp,
+            invocation: {
+              id: `${id}-invocation`,
+              preset_name: `${id} agent`,
+              preset_slug: `${id}-agent`,
+              status,
+            },
+          },
+        ]
+      : [],
+  }
+}
+
+function makeThread(
+  root: CaseCommentRead,
+  replies: CaseCommentRead[] = []
+): CaseCommentThreadRead {
+  return {
+    comment: root,
+    replies,
+    reply_count: replies.length,
+    last_activity_at: timestamp,
+  }
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: Number.POSITIVE_INFINITY,
+        retry: false,
+      },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+async function flushImmediateTimers(): Promise<void> {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(0)
+  })
+}
+
+describe("case comment query behavior", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("polls both public comment views only while an invocation is active", async () => {
+    const pendingSource = makeComment("source", "pending")
+    const runningReply = makeComment("running-reply", "running")
+    const succeededSource = makeComment("source", "succeeded")
+    const failedComment = makeComment("failed-source", "failed")
+    const attributedReply: CaseCommentRead = {
+      ...makeComment("agent-reply"),
+      agent: {
+        invocation_id: "source-invocation",
+        preset_name: "source agent",
+        preset_slug: "source-agent",
+      },
+    }
+
+    jest
+      .mocked(casesListComments)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([pendingSource])
+      .mockResolvedValueOnce([succeededSource, failedComment, attributedReply])
+    jest
+      .mocked(casesListCommentThreads)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        makeThread(makeComment("thread-root"), [runningReply]),
+      ])
+      .mockResolvedValueOnce([makeThread(succeededSource, [attributedReply])])
+
+    const queryClient = createQueryClient()
+    const { result, unmount } = renderHook(
+      () => ({
+        flat: useCaseComments({ caseId, workspaceId }),
+        threaded: useCaseCommentThreads({ caseId, workspaceId }),
+      }),
+      { wrapper: createWrapper(queryClient) }
+    )
+    await flushImmediateTimers()
+
+    expect(result.current.flat.caseComments).toEqual([])
+    expect(result.current.threaded.caseCommentThreads).toEqual([])
+    expect(casesListComments).toHaveBeenCalledTimes(1)
+    expect(casesListCommentThreads).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(
+        CASE_COMMENT_ACTIVE_POLL_INTERVAL_MS * 2
+      )
+    })
+    expect(casesListComments).toHaveBeenCalledTimes(1)
+    expect(casesListCommentThreads).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      invalidateCaseCommentQueries(queryClient, caseId, workspaceId)
+    })
+    await flushImmediateTimers()
+    expect(result.current.flat.caseComments).toEqual([pendingSource])
+    expect(result.current.threaded.caseCommentThreads).toEqual([
+      makeThread(makeComment("thread-root"), [runningReply]),
+    ])
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(CASE_COMMENT_ACTIVE_POLL_INTERVAL_MS)
+    })
+    await flushImmediateTimers()
+    expect(casesListComments).toHaveBeenCalledTimes(3)
+    expect(casesListCommentThreads).toHaveBeenCalledTimes(3)
+    await waitFor(() =>
+      expect(result.current.flat.caseComments).toEqual([
+        succeededSource,
+        failedComment,
+        attributedReply,
+      ])
+    )
+    await waitFor(() =>
+      expect(result.current.threaded.caseCommentThreads).toEqual([
+        makeThread(succeededSource, [attributedReply]),
+      ])
+    )
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(
+        CASE_COMMENT_ACTIVE_POLL_INTERVAL_MS * 3
+      )
+    })
+    expect(casesListComments).toHaveBeenCalledTimes(3)
+    expect(casesListCommentThreads).toHaveBeenCalledTimes(3)
+
+    unmount()
+  })
+
+  it("invalidates flat and threaded caches from comment and agent-tool entry points", async () => {
+    const queryClient = createQueryClient()
+    const commentsKey = caseCommentQueryKeys.comments(caseId, workspaceId)
+    const threadsKey = caseCommentQueryKeys.threads(caseId, workspaceId)
+    const createdComment = makeComment("created")
+    jest.mocked(casesCreateComment).mockResolvedValue(createdComment)
+
+    queryClient.setQueryData(commentsKey, [makeComment("existing")])
+    queryClient.setQueryData(threadsKey, [
+      makeThread(makeComment("existing-thread")),
+    ])
+
+    const { result } = renderHook(
+      () => useCreateCaseComment({ caseId, workspaceId }),
+      { wrapper: createWrapper(queryClient) }
+    )
+    await act(async () => {
+      await result.current.createComment({ content: "New comment" })
+    })
+
+    expect(queryClient.getQueryState(commentsKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(threadsKey)?.isInvalidated).toBe(true)
+
+    queryClient.setQueryData(commentsKey, [createdComment])
+    queryClient.setQueryData(threadsKey, [makeThread(createdComment)])
+    expect(queryClient.getQueryState(commentsKey)?.isInvalidated).toBe(false)
+    expect(queryClient.getQueryState(threadsKey)?.isInvalidated).toBe(false)
+
+    const caseInvalidation = ENTITY_TO_INVALIDATION.case
+    expect(caseInvalidation.predicate("core.cases.create_comment")).toBe(true)
+    act(() => {
+      caseInvalidation.handler(queryClient, workspaceId, caseId)
+    })
+
+    expect(queryClient.getQueryState(commentsKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(threadsKey)?.isInvalidated).toBe(true)
+  })
+})

--- a/frontend/src/lib/cases/comment-queries.ts
+++ b/frontend/src/lib/cases/comment-queries.ts
@@ -1,0 +1,58 @@
+import type { QueryClient } from "@tanstack/react-query"
+
+import type { CaseCommentRead, CaseCommentThreadRead } from "@/client"
+
+/** Poll interval used while a case-comment agent invocation is active. */
+export const CASE_COMMENT_ACTIVE_POLL_INTERVAL_MS = 1_000
+
+/** Stable query keys for flat and threaded case-comment responses. */
+export const caseCommentQueryKeys = {
+  comments: (caseId: string, workspaceId: string) =>
+    ["case-comments", caseId, workspaceId] as const,
+  threads: (caseId: string, workspaceId: string) =>
+    ["case-comment-threads", caseId, workspaceId] as const,
+}
+
+function commentHasActiveInvocation(comment: CaseCommentRead): boolean {
+  return Boolean(
+    comment.mentions?.some(({ invocation }) =>
+      invocation
+        ? invocation.status === "pending" || invocation.status === "running"
+        : false
+    )
+  )
+}
+
+/** Return whether flat comment data contains a pending or running invocation. */
+export function hasActiveCaseCommentInvocations(
+  comments: CaseCommentRead[] | undefined
+): boolean {
+  return Boolean(comments?.some(commentHasActiveInvocation))
+}
+
+/** Return whether threaded comment data contains a pending or running invocation. */
+export function hasActiveCaseCommentThreadInvocations(
+  threads: CaseCommentThreadRead[] | undefined
+): boolean {
+  return Boolean(
+    threads?.some(
+      ({ comment, replies }) =>
+        commentHasActiveInvocation(comment) ||
+        Boolean(replies?.some(commentHasActiveInvocation))
+    )
+  )
+}
+
+/** Invalidate both flat and threaded case-comment query families. */
+export function invalidateCaseCommentQueries(
+  queryClient: QueryClient,
+  caseId: string,
+  workspaceId: string
+): void {
+  queryClient.invalidateQueries({
+    queryKey: caseCommentQueryKeys.comments(caseId, workspaceId),
+  })
+  queryClient.invalidateQueries({
+    queryKey: caseCommentQueryKeys.threads(caseId, workspaceId),
+  })
+}

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -10,6 +10,7 @@ import type {
   ChatReadVercel,
   UIMessage,
 } from "@/client"
+import { invalidateCaseCommentQueries } from "@/lib/cases/comment-queries"
 import { invalidateCaseActivityQueries } from "@/lib/cases/invalidation"
 
 export type ApprovalCard = {
@@ -305,10 +306,7 @@ export const ENTITY_TO_INVALIDATION: Record<
       // Invalidate cases list for workspace
       queryClient.invalidateQueries({ queryKey: ["cases", workspaceId] })
       invalidateCaseActivityQueries(queryClient, entityId, workspaceId)
-      // Invalidate case comments
-      queryClient.invalidateQueries({
-        queryKey: ["case-comments", entityId, workspaceId],
-      })
+      invalidateCaseCommentQueries(queryClient, entityId, workspaceId)
     },
   },
   agent_preset: {

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -395,6 +395,13 @@ import {
   listCaseDurationDefinitions,
   listCaseDurations,
 } from "@/lib/case-durations"
+import {
+  CASE_COMMENT_ACTIVE_POLL_INTERVAL_MS,
+  caseCommentQueryKeys,
+  hasActiveCaseCommentInvocations,
+  hasActiveCaseCommentThreadInvocations,
+  invalidateCaseCommentQueries,
+} from "@/lib/cases/comment-queries"
 import { invalidateCaseActivityQueries } from "@/lib/cases/invalidation"
 import type { ModelInfo } from "@/lib/chat"
 import {
@@ -4138,9 +4145,13 @@ export function useCaseComments({
     isLoading: caseCommentsIsLoading,
     error: caseCommentsError,
   } = useQuery<CaseCommentRead[], TracecatApiError>({
-    queryKey: ["case-comments", caseId, workspaceId],
+    queryKey: caseCommentQueryKeys.comments(caseId, workspaceId),
     queryFn: async () => await casesListComments({ caseId, workspaceId }),
     enabled,
+    refetchInterval: (query) =>
+      hasActiveCaseCommentInvocations(query.state.data)
+        ? CASE_COMMENT_ACTIVE_POLL_INTERVAL_MS
+        : false,
   })
 
   return {
@@ -4160,9 +4171,13 @@ export function useCaseCommentThreads({
     isLoading: caseCommentThreadsIsLoading,
     error: caseCommentThreadsError,
   } = useQuery<CaseCommentThreadRead[], TracecatApiError>({
-    queryKey: ["case-comment-threads", caseId, workspaceId],
+    queryKey: caseCommentQueryKeys.threads(caseId, workspaceId),
     queryFn: async () => await casesListCommentThreads({ caseId, workspaceId }),
     enabled,
+    refetchInterval: (query) =>
+      hasActiveCaseCommentThreadInvocations(query.state.data)
+        ? CASE_COMMENT_ACTIVE_POLL_INTERVAL_MS
+        : false,
   })
 
   return {
@@ -4170,19 +4185,6 @@ export function useCaseCommentThreads({
     caseCommentThreadsIsLoading,
     caseCommentThreadsError,
   }
-}
-
-function invalidateCaseCommentQueries(
-  queryClient: ReturnType<typeof useQueryClient>,
-  caseId: string,
-  workspaceId: string
-) {
-  queryClient.invalidateQueries({
-    queryKey: ["case-comments", caseId, workspaceId],
-  })
-  queryClient.invalidateQueries({
-    queryKey: ["case-comment-threads", caseId, workspaceId],
-  })
 }
 
 export function useCreateCaseComment({

--- a/frontend/tests/case-chat.test.tsx
+++ b/frontend/tests/case-chat.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { CaseChat } from "@/components/cases/case-chat"
+import { useCaseChatSession } from "@/hooks/use-case-chat-session"
+
+const caseId = "case-test"
+const pathname = `/workspaces/workspace-test/cases/${caseId}`
+const mockReplace = jest.fn()
+let currentSearchParams = new URLSearchParams()
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => currentSearchParams,
+}))
+
+jest.mock("@/components/chat/chat-interface", () => ({
+  ChatInterface: ({
+    chatId,
+    onChatSelect,
+  }: {
+    chatId?: string
+    onChatSelect?: (chatId: string) => void
+  }) => (
+    <div>
+      <div>Selected session: {chatId ?? "none"}</div>
+      <button type="button" onClick={() => onChatSelect?.("next-session")}>
+        Select another session
+      </button>
+    </div>
+  ),
+}))
+
+function TestCaseChat() {
+  const { openChatSession } = useCaseChatSession()
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => openChatSession("invocation-session")}
+      >
+        View invocation session
+      </button>
+      <CaseChat caseId={caseId} />
+    </>
+  )
+}
+
+describe("case chat session navigation", () => {
+  beforeEach(() => {
+    currentSearchParams = new URLSearchParams("tab=comments&view=expanded")
+    localStorage.clear()
+    mockReplace.mockReset()
+    mockReplace.mockImplementation((href: string) => {
+      const url = new URL(href, "http://localhost")
+      currentSearchParams = new URLSearchParams(url.search)
+    })
+  })
+
+  it("opens a requested session and keeps later CaseChat selections in sync", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<TestCaseChat />)
+
+    expect(screen.getByText("Selected session: none")).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", { name: "View invocation session" })
+    )
+
+    expect(mockReplace).toHaveBeenLastCalledWith(
+      `${pathname}?tab=comments&view=expanded&chatId=invocation-session`,
+      { scroll: false }
+    )
+    expect(localStorage.getItem("workspace_chat_open")).toBe("true")
+
+    rerender(<TestCaseChat />)
+    expect(
+      screen.getByText("Selected session: invocation-session")
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", { name: "Select another session" })
+    )
+
+    expect(mockReplace).toHaveBeenLastCalledWith(
+      `${pathname}?tab=comments&view=expanded&chatId=next-session`,
+      { scroll: false }
+    )
+
+    rerender(<TestCaseChat />)
+    expect(
+      screen.getByText("Selected session: next-session")
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/tests/case-comments-section.test.tsx
+++ b/frontend/tests/case-comments-section.test.tsx
@@ -12,6 +12,9 @@ import {
 } from "@testing-library/react"
 import {
   type AgentPresetReadMinimal,
+  type CaseCommentAgentInvocationStatus,
+  type CaseCommentMentionRead,
+  type CaseCommentRead,
   type CaseCommentThreadRead,
   foldersListFolders,
   workflowsListWorkflows,
@@ -30,6 +33,8 @@ import {
   useUpdateCaseComment,
 } from "@/lib/hooks"
 import { getTextareaCaretCoordinates } from "@/lib/textarea-caret"
+
+const mockOpenChatSession = jest.fn()
 
 jest.mock("@/client", () => {
   const actual = jest.requireActual("@/client")
@@ -50,6 +55,13 @@ jest.mock("@/hooks/use-entitlements", () => ({
 
 jest.mock("@/hooks/use-agent-presets", () => ({
   useAgentPresets: jest.fn(),
+}))
+
+jest.mock("@/hooks/use-case-chat-session", () => ({
+  useCaseChatSession: () => ({
+    chatId: undefined,
+    openChatSession: mockOpenChatSession,
+  }),
 }))
 
 jest.mock("@/components/auth/scope-guard", () => ({
@@ -251,6 +263,36 @@ function createAgentPresetFixtures(): AgentPresetReadMinimal[] {
       updated_at: "2024-01-01T00:00:00Z",
     },
   ]
+}
+
+function createAgentMention({
+  id,
+  presetName,
+  status,
+  sessionId,
+  error,
+}: {
+  id: string
+  presetName: string
+  status: CaseCommentAgentInvocationStatus
+  sessionId?: string | null
+  error?: string | null
+}): CaseCommentMentionRead {
+  return {
+    id: `${id}-mention`,
+    target_type: "agent",
+    target_id: `${id}-preset`,
+    label: `Outdated ${presetName}`,
+    created_at: "2024-01-01T00:00:00Z",
+    invocation: {
+      id: `${id}-invocation`,
+      preset_name: presetName,
+      preset_slug: id,
+      status,
+      session_id: sessionId,
+      error,
+    },
+  }
 }
 
 function mockAgentPresets(presets: AgentPresetReadMinimal[]) {
@@ -762,6 +804,200 @@ describe("CommentSection", () => {
       "href",
       "/workspaces/workspace-1/workflows/wf_789/executions/exec_999"
     )
+  })
+
+  it("renders the complete agent lifecycle and reply attribution contract", () => {
+    const timestamp = "2024-01-03T00:00:00Z"
+    const sourceComment: CaseCommentRead = {
+      id: "agent-source",
+      created_at: timestamp,
+      updated_at: timestamp,
+      content: "Please investigate this case",
+      parent_id: null,
+      workflow: null,
+      user: {
+        id: "user-1",
+        email: "owner@example.com",
+        role: "admin",
+        first_name: "Owner",
+        last_name: "One",
+        settings: {},
+      },
+      is_deleted: false,
+      mentions: [
+        createAgentMention({
+          id: "preparing",
+          presetName: "Preparing agent",
+          status: "pending",
+        }),
+        createAgentMention({
+          id: "thinking",
+          presetName: "Thinking agent",
+          status: "running",
+          sessionId: "thinking-session",
+        }),
+        createAgentMention({
+          id: "succeeded",
+          presetName: "Succeeded agent",
+          status: "succeeded",
+          sessionId: "succeeded-session",
+        }),
+        createAgentMention({
+          id: "failed",
+          presetName: "Failed agent",
+          status: "failed",
+          sessionId: "failed-session",
+          error: "Timed out while investigating the case.",
+        }),
+      ],
+    }
+    const attributedReply: CaseCommentRead = {
+      id: "agent-reply",
+      created_at: timestamp,
+      updated_at: timestamp,
+      content: "Here is what I found",
+      parent_id: sourceComment.id,
+      user: null,
+      workflow: null,
+      agent: {
+        invocation_id: "succeeded-invocation",
+        preset_name: "Snapshot reply agent",
+        preset_slug: "snapshot-reply-agent",
+        session_id: "reply-session",
+      },
+      is_deleted: false,
+    }
+    const attributedReplyWithoutSession: CaseCommentRead = {
+      ...attributedReply,
+      id: "agent-reply-without-session",
+      content: "A historical agent reply",
+      agent: {
+        invocation_id: "historical-invocation",
+        preset_name: "Historical reply agent",
+        preset_slug: "historical-reply-agent",
+        session_id: null,
+      },
+    }
+    const systemReply: CaseCommentRead = {
+      id: "system-reply",
+      created_at: timestamp,
+      updated_at: timestamp,
+      content: "A system-authored comment",
+      parent_id: sourceComment.id,
+      user: null,
+      workflow: null,
+      agent: null,
+      is_deleted: false,
+    }
+    const workflowComment: CaseCommentRead = {
+      id: "workflow-fallback",
+      created_at: timestamp,
+      updated_at: timestamp,
+      content: "A workflow-authored comment",
+      parent_id: null,
+      user: null,
+      workflow: {
+        workflow_id: "workflow-1",
+        title: "Automated workflow",
+        alias: null,
+        wf_exec_id: null,
+        status: "succeeded",
+      },
+      agent: null,
+      is_deleted: false,
+    }
+
+    mockUseCaseCommentThreads.mockReturnValue({
+      caseCommentThreads: [
+        {
+          comment: sourceComment,
+          replies: [
+            attributedReply,
+            attributedReplyWithoutSession,
+            systemReply,
+          ],
+          reply_count: 3,
+          last_activity_at: timestamp,
+        },
+        {
+          comment: workflowComment,
+          replies: [],
+          reply_count: 0,
+          last_activity_at: timestamp,
+        },
+      ],
+      caseCommentThreadsIsLoading: false,
+      caseCommentThreadsError: null,
+    })
+    mockUseCaseComments.mockReturnValue({
+      caseComments: [],
+      caseCommentsIsLoading: false,
+      caseCommentsError: null,
+    })
+
+    renderCommentSection()
+
+    const activity = screen.getByLabelText("Agent activity")
+    expect(activity.children).toHaveLength(3)
+    expect(activity.children[0]).toHaveTextContent(
+      "Preparing agent is preparing..."
+    )
+    expect(activity.children[1]).toHaveTextContent(
+      "Thinking agent is thinking..."
+    )
+    expect(activity.children[2]).toHaveTextContent(
+      "Failed agent could not finish."
+    )
+    expect(within(activity).getAllByRole("status")).toHaveLength(2)
+    expect(within(activity).getByRole("alert")).toHaveTextContent(
+      "Mention Failed agent again to retry."
+    )
+    expect(
+      screen.getByText("Timed out while investigating the case.")
+    ).toHaveClass("whitespace-pre-wrap", "break-words")
+    expect(screen.queryByText("Succeeded agent")).not.toBeInTheDocument()
+    expect(screen.queryByText(/Outdated .* agent/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /retry/i })
+    ).not.toBeInTheDocument()
+
+    expect(screen.getByText("Snapshot reply agent")).toBeInTheDocument()
+    expect(screen.getByText("Historical reply agent")).toBeInTheDocument()
+    expect(screen.getAllByText("Agent")).toHaveLength(2)
+    expect(
+      screen.getByRole("img", {
+        name: "Agent avatar for Snapshot reply agent",
+      })
+    ).toBeInTheDocument()
+    expect(screen.getByText("Tracecat")).toBeInTheDocument()
+    expect(screen.getByText("Automated workflow")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "View Historical reply agent session",
+      })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "View Preparing agent session" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "View Succeeded agent session" })
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Thinking agent session" })
+    )
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Failed agent session" })
+    )
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Snapshot reply agent session" })
+    )
+    expect(mockOpenChatSession).toHaveBeenNthCalledWith(1, "thinking-session")
+    expect(mockOpenChatSession).toHaveBeenNthCalledWith(2, "failed-session")
+    expect(mockOpenChatSession).toHaveBeenNthCalledWith(3, "reply-session")
+    expect(
+      screen.getAllByRole("button", { name: "More options" })
+    ).toHaveLength(1)
   })
 
   describe("agent mention autocomplete", () => {

--- a/frontend/tests/case-comments-section.test.tsx
+++ b/frontend/tests/case-comments-section.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "@testing-library/react"
 import {
   type AgentPresetReadMinimal,
+  type CaseCommentAgentInvocationRead,
   type CaseCommentAgentInvocationStatus,
   type CaseCommentMentionRead,
   type CaseCommentRead,
@@ -276,7 +277,7 @@ function createAgentMention({
   presetName: string
   status: CaseCommentAgentInvocationStatus
   sessionId?: string | null
-  error?: string | null
+  error?: CaseCommentAgentInvocationRead["error"]
 }): CaseCommentMentionRead {
   return {
     id: `${id}-mention`,
@@ -847,7 +848,10 @@ describe("CommentSection", () => {
           presetName: "Failed agent",
           status: "failed",
           sessionId: "failed-session",
-          error: "Timed out while investigating the case.",
+          error: {
+            kind: "agent_turn",
+            message: "Timed out while investigating the case.",
+          },
         }),
       ],
     }

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -675,6 +675,127 @@ class TestCaseCommentsService:
         assert failed_data.status == CaseCommentAgentInvocationStatus.FAILED
         assert failed_data.error == "agent_turn: model unavailable"
 
+    async def test_comment_reads_project_agent_attribution_across_surfaces(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+        workflow: Workflow,
+    ) -> None:
+        preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Attribution agent",
+        )
+        preset_name = preset.name
+        preset_slug = preset.slug
+        source = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(content=_mention_token(preset_name, preset.id)),
+        )
+        [invocation] = await _load_comment_invocations(session, source.id)
+        agent_session = AgentSession(
+            workspace_id=case_comments_service.workspace_id,
+            entity_type="case",
+            entity_id=test_case.id,
+            agent_preset_id=preset.id,
+        )
+        session.add(agent_session)
+        await session.flush()
+        invocation.session_id = agent_session.id
+        invocation.status = CaseCommentAgentInvocationStatus.RUNNING.value
+        await session.commit()
+
+        completion = CaseCommentAgentInvocationCompletionService(
+            session,
+            case_comments_service.role,
+        )
+        reply = await completion.create_reply_and_mark_succeeded(
+            agent_session.id,
+            "Investigated the case",
+        )
+        assert reply is not None
+
+        system_comment = CaseComment(
+            workspace_id=case_comments_service.workspace_id,
+            case_id=test_case.id,
+            content="Automated case update",
+            user_id=None,
+        )
+        workflow_comment = CaseComment(
+            workspace_id=case_comments_service.workspace_id,
+            case_id=test_case.id,
+            content="Workflow case update",
+            user_id=None,
+            workflow_id=workflow.id,
+            workflow_title=workflow.title,
+            workflow_alias=workflow.alias,
+            workflow_wf_exec_id="wf_test/exec_test",
+            workflow_status=CaseCommentWorkflowStatus.RUNNING.value,
+        )
+        session.add_all([system_comment, workflow_comment])
+        preset.name = "Renamed attribution agent"
+        preset.slug = "renamed-attribution-agent"
+        preset.deleted_at = datetime.now(UTC)
+        await session.commit()
+
+        flat_by_id = {
+            comment.id: comment
+            for comment in await case_comments_service.list_comments(test_case)
+        }
+        threads_by_id = {
+            thread.comment.id: thread
+            for thread in await case_comments_service.list_comment_threads(test_case)
+        }
+        source_thread = threads_by_id[source.id]
+        single_thread = await case_comments_service.get_comment_thread(reply.id)
+        assert single_thread == source_thread
+        assert flat_by_id[source.id] == source_thread.comment
+        assert flat_by_id[reply.id] == source_thread.replies[0]
+
+        source_read = source_thread.comment
+        assert source_read.agent is None
+        assert len(source_read.mentions) == 1
+        invocation_read = source_read.mentions[0].invocation
+        assert invocation_read is not None
+        assert invocation_read.id == invocation.id
+        assert invocation_read.status == CaseCommentAgentInvocationStatus.SUCCEEDED
+        assert invocation_read.session_id == agent_session.id
+        assert invocation_read.preset_name == preset_name
+        assert invocation_read.preset_slug == preset_slug
+
+        reply_read = source_thread.replies[0]
+        assert reply_read.id == reply.id
+        assert reply_read.user is None
+        assert reply_read.workflow is None
+        assert reply_read.agent is not None
+        assert reply_read.agent.invocation_id == invocation.id
+        assert reply_read.agent.session_id == agent_session.id
+        assert reply_read.agent.preset_name == preset_name
+        assert reply_read.agent.preset_slug == preset_slug
+
+        system_read = flat_by_id[system_comment.id]
+        assert system_read.user is None
+        assert system_read.workflow is None
+        assert system_read.agent is None
+        workflow_read = flat_by_id[workflow_comment.id]
+        assert workflow_read.user is None
+        assert workflow_read.workflow is not None
+        assert workflow_read.agent is None
+
+        await case_comments_service.delete_comment(source)
+        tombstoned = await case_comments_service.get_comment_thread(source.id)
+        assert tombstoned is not None
+        assert tombstoned.comment.is_deleted is True
+        assert tombstoned.comment.content == "Comment deleted"
+        assert tombstoned.comment.mentions[0].invocation == invocation_read
+        assert tombstoned.replies[0].agent == reply_read.agent
+
+        await session.delete(reply)
+        await session.flush()
+        await session.delete(source)
+        await session.commit()
+
     async def test_dispatch_and_prepare_pinned_isolated_session(
         self,
         case_comments_service: CaseCommentsService,

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -355,16 +355,72 @@ class TestCaseCommentsService:
             if item.id == comment.id
         )
         assert len(serialized_comment.mentions) == 1
-        assert serialized_comment.mentions[0].target_id == preset.id
-        assert serialized_comment.mentions[0].label == "Response agent"
+        serialized_mention = serialized_comment.mentions[0]
+        assert serialized_mention.target_id == preset.id
+        assert serialized_mention.label == "Response agent"
+        assert serialized_mention.invocation is not None
+        assert serialized_mention.invocation.id == invocation.id
+        assert serialized_mention.invocation.preset_name == "Response agent"
+        assert (
+            serialized_mention.invocation.preset_slug
+            == "case-comment-mention-response-agent"
+        )
+        assert (
+            serialized_mention.invocation.status
+            == CaseCommentAgentInvocationStatus.PENDING
+        )
+        assert serialized_mention.invocation.session_id is None
+        assert serialized_mention.invocation.error is None
 
         threads = await case_comments_service.list_comment_threads(test_case)
         assert len(threads) == 1
         assert threads[0].comment.mentions[0].target_id == preset.id
+        assert threads[0].comment.mentions[0].invocation is not None
 
         thread = await case_comments_service.get_comment_thread(comment.id)
         assert thread is not None
         assert thread.comment.mentions[0].target_id == preset.id
+        assert thread.comment.mentions[0].invocation is not None
+
+    async def test_comment_reads_embed_running_agent_invocation(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Running agent",
+        )
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(content=_mention_token("Running agent", preset.id)),
+        )
+        [invocation] = await _load_comment_invocations(session, comment.id)
+        agent_session = AgentSession(
+            workspace_id=case_comments_service.workspace_id,
+            entity_type="case",
+            entity_id=test_case.id,
+            agent_preset_id=preset.id,
+        )
+        session.add(agent_session)
+        await session.flush()
+        invocation.session_id = agent_session.id
+        invocation.status = CaseCommentAgentInvocationStatus.RUNNING.value
+        await session.commit()
+
+        serialized = await case_comments_service.serialize_comment_with_mentions(
+            comment
+        )
+
+        assert len(serialized.mentions) == 1
+        invocation_data = serialized.mentions[0].invocation
+        assert invocation_data is not None
+        assert invocation_data.id == invocation.id
+        assert invocation_data.status == CaseCommentAgentInvocationStatus.RUNNING
+        assert invocation_data.session_id == agent_session.id
+        assert invocation_data.error is None
 
     async def test_invocation_failure_is_structured(
         self,
@@ -528,6 +584,96 @@ class TestCaseCommentsService:
             (first_preset.name, first_preset.slug),
             (second_preset.name, second_preset.slug),
         }
+
+        serialized = await case_comments_service.serialize_comment_with_mentions(
+            comment
+        )
+        invocation_names = [
+            mention.invocation.preset_name
+            for mention in serialized.mentions
+            if mention.invocation is not None
+        ]
+        assert invocation_names == [first_preset.name, second_preset.name]
+
+    async def test_comment_reads_embed_terminal_agent_invocations(
+        self,
+        case_comments_service: CaseCommentsService,
+        session: AsyncSession,
+        test_case: Case,
+    ) -> None:
+        succeeded_preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Succeeded agent",
+        )
+        failed_preset = await _create_agent_preset(
+            session,
+            case_comments_service.workspace_id,
+            name="Failed agent",
+        )
+        comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(
+                content=" ".join(
+                    [
+                        _mention_token("Succeeded agent", succeeded_preset.id),
+                        _mention_token("Failed agent", failed_preset.id),
+                    ]
+                )
+            ),
+        )
+        invocations = await _load_comment_invocations(session, comment.id)
+        invocations_by_name = {
+            invocation.preset_name: invocation for invocation in invocations
+        }
+        succeeded = invocations_by_name["Succeeded agent"]
+        failed = invocations_by_name["Failed agent"]
+        succeeded_id = succeeded.id
+        failed_id = failed.id
+        invocation_service = CaseCommentAgentInvocationService(
+            session,
+            case_comments_service.role,
+        )
+        assert await invocation_service.claim_pending(succeeded_id) is not None
+        assert await invocation_service.claim_pending(failed_id) is not None
+        await session.commit()
+
+        reply = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(content="Agent response", parent_id=comment.id),
+        )
+        assert (
+            await invocation_service.mark_succeeded(succeeded_id, reply.id) is not None
+        )
+        assert (
+            await invocation_service.mark_failed(
+                failed_id,
+                "agent_turn: model unavailable",
+            )
+            is not None
+        )
+        await session.commit()
+
+        serialized = next(
+            item
+            for item in await case_comments_service.list_comments(test_case)
+            if item.id == comment.id
+        )
+        invocation_data_by_name = {
+            invocation_data.preset_name: invocation_data
+            for mention in serialized.mentions
+            if (invocation_data := mention.invocation) is not None
+        }
+
+        succeeded_data = invocation_data_by_name["Succeeded agent"]
+        assert succeeded_data.id == succeeded_id
+        assert succeeded_data.status == CaseCommentAgentInvocationStatus.SUCCEEDED
+        assert succeeded_data.error is None
+
+        failed_data = invocation_data_by_name["Failed agent"]
+        assert failed_data.id == failed_id
+        assert failed_data.status == CaseCommentAgentInvocationStatus.FAILED
+        assert failed_data.error == "agent_turn: model unavailable"
 
     async def test_dispatch_and_prepare_pinned_isolated_session(
         self,

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -648,7 +648,7 @@ class TestCaseCommentsService:
         assert (
             await invocation_service.mark_failed(
                 failed_id,
-                "agent_turn: model unavailable",
+                {"kind": "agent_turn", "message": "model unavailable"},
             )
             is not None
         )
@@ -673,7 +673,10 @@ class TestCaseCommentsService:
         failed_data = invocation_data_by_name["Failed agent"]
         assert failed_data.id == failed_id
         assert failed_data.status == CaseCommentAgentInvocationStatus.FAILED
-        assert failed_data.error == "agent_turn: model unavailable"
+        assert failed_data.error == {
+            "kind": "agent_turn",
+            "message": "model unavailable",
+        }
 
     async def test_comment_reads_project_agent_attribution_across_surfaces(
         self,

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -16,6 +16,7 @@ from tracecat.cases.dropdowns.schemas import (
 )
 from tracecat.cases.durations.schemas import CaseDurationRead
 from tracecat.cases.enums import (
+    CaseCommentAgentInvocationStatus,
     CaseEventType,
     CaseFieldKind,
     CaseFieldReadType,
@@ -291,12 +292,24 @@ class CaseCommentWorkflowRead(Schema):
     status: CaseCommentWorkflowStatus
 
 
+class CaseCommentAgentInvocationRead(Schema):
+    """Read model for an agent invocation triggered by a comment mention."""
+
+    id: uuid.UUID
+    preset_name: str
+    preset_slug: str
+    status: CaseCommentAgentInvocationStatus
+    session_id: uuid.UUID | None = None
+    error: str | None = None
+
+
 class CaseCommentMentionRead(Schema):
     id: uuid.UUID
     target_type: MentionTargetType
     target_id: uuid.UUID
     label: str
     created_at: datetime
+    invocation: CaseCommentAgentInvocationRead | None = None
 
 
 class CaseCommentRead(Schema):

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -303,6 +303,15 @@ class CaseCommentAgentInvocationRead(Schema):
     error: str | None = None
 
 
+class CaseCommentAgentAttributionRead(Schema):
+    """Read model for agent attribution on a generated comment reply."""
+
+    invocation_id: uuid.UUID
+    preset_name: str
+    preset_slug: str
+    session_id: uuid.UUID | None = None
+
+
 class CaseCommentMentionRead(Schema):
     id: uuid.UUID
     target_type: MentionTargetType
@@ -319,6 +328,7 @@ class CaseCommentRead(Schema):
     content: str
     parent_id: uuid.UUID | None = None
     workflow: CaseCommentWorkflowRead | None = None
+    agent: CaseCommentAgentAttributionRead | None = None
     user: UserRead | None = None
     last_edited_at: datetime | None = None
     deleted_at: datetime | None = None

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from pydantic import ConfigDict, Field, RootModel, field_validator, model_validator
 
 from tracecat.auth.schemas import UserRead
+from tracecat.cases.agent_invocations.types import CaseCommentAgentInvocationError
 from tracecat.cases.constants import RESERVED_CASE_FIELDS
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownValueInput,
@@ -300,7 +301,7 @@ class CaseCommentAgentInvocationRead(Schema):
     preset_slug: str
     status: CaseCommentAgentInvocationStatus
     session_id: uuid.UUID | None = None
-    error: str | None = None
+    error: CaseCommentAgentInvocationError | None = None
 
 
 class CaseCommentAgentAttributionRead(Schema):

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -50,6 +50,7 @@ from tracecat.cases.schemas import (
     AssigneeChangedEvent,
     CaseBatchItemResult,
     CaseBatchResponse,
+    CaseCommentAgentAttributionRead,
     CaseCommentAgentInvocationRead,
     CaseCommentCreate,
     CaseCommentMentionRead,
@@ -2256,10 +2257,12 @@ class CaseCommentsService(BaseWorkspaceService):
         *,
         user: User | None = None,
         mentions: Sequence[CaseCommentMentionRead] | None = None,
+        agent: CaseCommentAgentAttributionRead | None = None,
     ) -> CaseCommentRead:
         """Serialize a comment for API responses with tombstone semantics."""
         comment_data = CaseCommentRead.model_validate(comment, from_attributes=True)
         comment_data.workflow = self._comment_workflow_data(comment)
+        comment_data.agent = agent
         comment_data.user = (
             UserRead.model_validate(user, from_attributes=True) if user else None
         )
@@ -2316,19 +2319,76 @@ class CaseCommentsService(BaseWorkspaceService):
             )
         return mentions_by_comment_id
 
+    async def _list_reply_attributions_for_comments(
+        self,
+        comment_ids: Sequence[uuid.UUID],
+    ) -> dict[uuid.UUID, CaseCommentAgentAttributionRead]:
+        """Batch-load agent attribution by generated reply comment ID."""
+        if not comment_ids:
+            return {}
+
+        statement = select(
+            CaseCommentAgentInvocation.reply_comment_id,
+            CaseCommentAgentInvocation.id,
+            CaseCommentAgentInvocation.preset_name,
+            CaseCommentAgentInvocation.preset_slug,
+            CaseCommentAgentInvocation.session_id,
+        ).where(
+            CaseCommentAgentInvocation.workspace_id == self.workspace_id,
+            CaseCommentAgentInvocation.reply_comment_id.in_(comment_ids),
+        )
+        result = await self.session.execute(statement)
+        attributions_by_comment_id: dict[
+            uuid.UUID, CaseCommentAgentAttributionRead
+        ] = {}
+        for (
+            reply_comment_id,
+            invocation_id,
+            preset_name,
+            preset_slug,
+            session_id,
+        ) in result.tuples().all():
+            if reply_comment_id is None:
+                continue
+            attributions_by_comment_id[reply_comment_id] = (
+                CaseCommentAgentAttributionRead(
+                    invocation_id=invocation_id,
+                    preset_name=preset_name,
+                    preset_slug=preset_slug,
+                    session_id=session_id,
+                )
+            )
+        return attributions_by_comment_id
+
+    async def _serialize_comment_rows(
+        self,
+        rows: Sequence[tuple[CaseComment, User | None]],
+    ) -> list[CaseCommentRead]:
+        """Serialize comment rows with batch-loaded response metadata."""
+        comment_ids = [comment.id for comment, _ in rows]
+        mentions_by_comment_id = await self._list_mentions_for_comments(comment_ids)
+        attributions_by_comment_id = await self._list_reply_attributions_for_comments(
+            comment_ids
+        )
+        return [
+            self.serialize_comment(
+                comment,
+                user=user,
+                mentions=mentions_by_comment_id.get(comment.id),
+                agent=attributions_by_comment_id.get(comment.id),
+            )
+            for comment, user in rows
+        ]
+
     async def serialize_comment_with_mentions(
         self,
         comment: CaseComment,
         *,
         user: User | None = None,
     ) -> CaseCommentRead:
-        """Serialize one comment after loading its persisted mentions."""
-        mentions_by_comment_id = await self._list_mentions_for_comments([comment.id])
-        return self.serialize_comment(
-            comment,
-            user=user,
-            mentions=mentions_by_comment_id.get(comment.id),
-        )
+        """Serialize one comment with persisted mentions and agent attribution."""
+        serialized = await self._serialize_comment_rows([(comment, user)])
+        return serialized[0]
 
     async def _list_comment_rows(
         self,
@@ -2359,34 +2419,17 @@ class CaseCommentsService(BaseWorkspaceService):
     async def list_comments(self, case: Case) -> list[CaseCommentRead]:
         """List all comments for a case as a flat compatibility view."""
         rows = await self._list_comment_rows(case_id=case.id)
-        mentions_by_comment_id = await self._list_mentions_for_comments(
-            [comment.id for comment, _ in rows]
-        )
-        return [
-            self.serialize_comment(
-                comment,
-                user=user,
-                mentions=mentions_by_comment_id.get(comment.id),
-            )
-            for comment, user in rows
-        ]
+        return await self._serialize_comment_rows(rows)
 
     async def list_comment_threads(self, case: Case) -> list[CaseCommentThreadRead]:
         """List comments grouped by top-level thread."""
         await self._require_replies_entitlement()
         rows = await self._list_comment_rows(case_id=case.id)
-        mentions_by_comment_id = await self._list_mentions_for_comments(
-            [comment.id for comment, _ in rows]
-        )
+        serialized_comments = await self._serialize_comment_rows(rows)
         threads_by_id: dict[uuid.UUID, CaseCommentThreadRead] = {}
         ordered_threads: list[CaseCommentThreadRead] = []
 
-        for comment, user in rows:
-            serialized = self.serialize_comment(
-                comment,
-                user=user,
-                mentions=mentions_by_comment_id.get(comment.id),
-            )
+        for (comment, _), serialized in zip(rows, serialized_comments, strict=True):
             if comment.parent_id is None:
                 if (thread := threads_by_id.get(comment.id)) is not None:
                     if thread.comment.parent_id is not None:
@@ -2441,20 +2484,13 @@ class CaseCommentsService(BaseWorkspaceService):
         if not rows:
             return None
 
-        mentions_by_comment_id = await self._list_mentions_for_comments(
-            [row_comment.id for row_comment, _ in rows]
-        )
+        serialized_comments = await self._serialize_comment_rows(rows)
 
         thread_comment: CaseCommentRead | None = None
         replies: list[CaseCommentRead] = []
         last_activity_at: datetime | None = None
 
-        for row_comment, user in rows:
-            serialized = self.serialize_comment(
-                row_comment,
-                user=user,
-                mentions=mentions_by_comment_id.get(row_comment.id),
-            )
+        for (row_comment, _), serialized in zip(rows, serialized_comments, strict=True):
             if row_comment.id == thread_root_id:
                 thread_comment = serialized
             else:

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -50,6 +50,7 @@ from tracecat.cases.schemas import (
     AssigneeChangedEvent,
     CaseBatchItemResult,
     CaseBatchResponse,
+    CaseCommentAgentInvocationRead,
     CaseCommentCreate,
     CaseCommentMentionRead,
     CaseCommentRead,
@@ -101,6 +102,7 @@ from tracecat.db.models import (
     AgentPreset,
     Case,
     CaseComment,
+    CaseCommentAgentInvocation,
     CaseCommentMention,
     CaseDropdownDefinition,
     CaseDropdownOption,
@@ -2253,7 +2255,7 @@ class CaseCommentsService(BaseWorkspaceService):
         comment: CaseComment,
         *,
         user: User | None = None,
-        mentions: list[CaseCommentMention] | None = None,
+        mentions: Sequence[CaseCommentMentionRead] | None = None,
     ) -> CaseCommentRead:
         """Serialize a comment for API responses with tombstone semantics."""
         comment_data = CaseCommentRead.model_validate(comment, from_attributes=True)
@@ -2261,10 +2263,7 @@ class CaseCommentsService(BaseWorkspaceService):
         comment_data.user = (
             UserRead.model_validate(user, from_attributes=True) if user else None
         )
-        comment_data.mentions = [
-            CaseCommentMentionRead.model_validate(mention, from_attributes=True)
-            for mention in mentions or []
-        ]
+        comment_data.mentions = list(mentions or ())
         if comment.deleted_at is not None:
             comment_data.content = _COMMENT_TOMBSTONE_CONTENT
             comment_data.is_deleted = True
@@ -2273,13 +2272,20 @@ class CaseCommentsService(BaseWorkspaceService):
     async def _list_mentions_for_comments(
         self,
         comment_ids: Sequence[uuid.UUID],
-    ) -> dict[uuid.UUID, list[CaseCommentMention]]:
-        """Batch-load mention records grouped by comment ID."""
+    ) -> dict[uuid.UUID, list[CaseCommentMentionRead]]:
+        """Batch-load mentions and their agent invocations by comment ID."""
         if not comment_ids:
             return {}
 
         statement = (
-            select(CaseCommentMention)
+            select(CaseCommentMention, CaseCommentAgentInvocation)
+            .outerjoin(
+                CaseCommentAgentInvocation,
+                sa.and_(
+                    CaseCommentAgentInvocation.mention_id == CaseCommentMention.id,
+                    CaseCommentAgentInvocation.workspace_id == self.workspace_id,
+                ),
+            )
             .where(
                 CaseCommentMention.workspace_id == self.workspace_id,
                 CaseCommentMention.comment_id.in_(comment_ids),
@@ -2290,9 +2296,24 @@ class CaseCommentsService(BaseWorkspaceService):
             )
         )
         result = await self.session.execute(statement)
-        mentions_by_comment_id: dict[uuid.UUID, list[CaseCommentMention]] = {}
-        for mention in result.scalars().all():
-            mentions_by_comment_id.setdefault(mention.comment_id, []).append(mention)
+        mentions_by_comment_id: dict[uuid.UUID, list[CaseCommentMentionRead]] = {}
+        for mention, invocation in result.tuples().all():
+            invocation_data = (
+                CaseCommentAgentInvocationRead.model_validate(
+                    invocation,
+                    from_attributes=True,
+                )
+                if invocation is not None
+                else None
+            )
+            mention_data = CaseCommentMentionRead.model_validate(
+                mention,
+                from_attributes=True,
+            )
+            mention_data.invocation = invocation_data
+            mentions_by_comment_id.setdefault(mention.comment_id, []).append(
+                mention_data
+            )
         return mentions_by_comment_id
 
     async def serialize_comment_with_mentions(


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/51f66390-0b1c-4f67-a7d8-f047c4a9fc24


- Show a separate pending, running, or failed state for every agent mentioned in a case comment.
- Poll comments only while an invocation is active, then show the finished reply with the saved agent name and avatar.
- Let users open the invocation's existing agent session from the comment thread through the case chat sidebar.
- Keep attribution stable even if the live agent preset is later renamed or deleted.

## Why

Mentioning an agent previously gave very little feedback. Users could not easily tell whether the agent was starting, thinking, finished, or failed, and completed replies looked like generic system comments.

This makes the entire lifecycle visible without adding a second transcript UI.

## Design

1. Comment reads include each mention's invocation state and completed replies include snapshotted agent attribution.
2. The frontend polls once per second only while at least one invocation is pending or running.
3. Pending, running, and failed invocations render directly below the source comment; succeeded status rows disappear when the attributed reply arrives.
4. “View session” selects the existing agent session with `chatId=<session_id>` and opens the case chat sidebar.
5. Shared query keys keep flat comments and threaded comments synchronized.

## Steps to QA

1. Mention one or more agents in a case comment.
2. Confirm each invocation independently shows preparing and thinking states.
3. Open “View session” and confirm the matching case chat session opens.
4. Confirm success removes the temporary state and shows an agent-attributed reply.
5. Confirm failure stays visible with the server error and retry guidance.

## Validation

- Focused backend service coverage for invocation state and attribution across comment read surfaces.
- Frontend coverage for lifecycle rendering, conditional polling, query invalidation, attribution, and session navigation.
- Commit hooks, including Ruff, Python type checking, generated-client verification, Biome, and frontend type checking.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 451 | 74 |
| Tests | 855 | 2 |
| Generated | 180 | 0 |
## Stack

- Base: #3227
- This PR: #3231
- Follow-up: #3232

Linear: [ENG-1604](https://linear.app/tracecat/issue/ENG-1604/featui-agent-invocation-status-and-attribution-in-comment-threads)

