### PR TITLE
feat(logging): test audit webhooks

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5529,6 +5529,42 @@ export const $AuditSettingsUpdate = {
   description: "Settings for audit logging.",
 } as const
 
+export const $AuditWebhookTestResult = {
+  properties: {
+    ok: {
+      type: "boolean",
+      title: "Ok",
+    },
+    receiver_status_code: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Receiver Status Code",
+    },
+    error_category: {
+      anyOf: [
+        {
+          type: "string",
+          enum: ["receiver_error", "timeout", "request_error"],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Error Category",
+    },
+  },
+  type: "object",
+  required: ["ok"],
+  title: "AuditWebhookTestResult",
+  description: "Result of a synchronous audit webhook test-fire request.",
+} as const
+
 export const $AuthDiscoverRequest = {
   properties: {
     email: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -88,6 +88,7 @@ import type {
   AdminRevokeOrganizationInvitationResponse,
   AdminSyncOrgRepositoryData,
   AdminSyncOrgRepositoryResponse,
+  AdminTestAuditWebhookResponse,
   AdminUpdateAuditSettingsData,
   AdminUpdateAuditSettingsResponse,
   AdminUpdateOrganizationData,
@@ -693,6 +694,7 @@ import type {
   SettingsGetAuditSettingsResponse,
   SettingsGetGitSettingsResponse,
   SettingsGetSamlSettingsResponse,
+  SettingsTestAuditWebhookResponse,
   SettingsUpdateAgentSettingsData,
   SettingsUpdateAgentSettingsResponse,
   SettingsUpdateAppSettingsData,
@@ -7599,6 +7601,20 @@ export const adminUpdateAuditSettings = (
 }
 
 /**
+ * Test Audit Webhook
+ * Send a test event to the platform audit webhook.
+ * @returns AuditWebhookTestResult Successful Response
+ * @throws ApiError
+ */
+export const adminTestAuditWebhook =
+  (): CancelablePromise<AdminTestAuditWebhookResponse> => {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/admin/settings/audit/test",
+    })
+  }
+
+/**
  * Get Registry Settings
  * Get platform registry settings.
  * @returns PlatformRegistrySettingsRead Successful Response
@@ -8874,6 +8890,19 @@ export const settingsUpdateAuditSettings = (
     },
   })
 }
+
+/**
+ * Test Audit Webhook
+ * @returns AuditWebhookTestResult Successful Response
+ * @throws ApiError
+ */
+export const settingsTestAuditWebhook =
+  (): CancelablePromise<SettingsTestAuditWebhookResponse> => {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/settings/audit/test",
+    })
+  }
 
 /**
  * Get Agent Settings

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -88,6 +88,7 @@ import type {
   AdminRevokeOrganizationInvitationResponse,
   AdminSyncOrgRepositoryData,
   AdminSyncOrgRepositoryResponse,
+  AdminTestAuditWebhookData,
   AdminTestAuditWebhookResponse,
   AdminUpdateAuditSettingsData,
   AdminUpdateAuditSettingsResponse,
@@ -694,6 +695,7 @@ import type {
   SettingsGetAuditSettingsResponse,
   SettingsGetGitSettingsResponse,
   SettingsGetSamlSettingsResponse,
+  SettingsTestAuditWebhookData,
   SettingsTestAuditWebhookResponse,
   SettingsUpdateAgentSettingsData,
   SettingsUpdateAgentSettingsResponse,
@@ -7602,17 +7604,25 @@ export const adminUpdateAuditSettings = (
 
 /**
  * Test Audit Webhook
- * Send a test event to the platform audit webhook.
+ * Probe the submitted platform audit webhook configuration.
+ * @param data The data for the request.
+ * @param data.requestBody
  * @returns AuditWebhookTestResult Successful Response
  * @throws ApiError
  */
-export const adminTestAuditWebhook =
-  (): CancelablePromise<AdminTestAuditWebhookResponse> => {
-    return __request(OpenAPI, {
-      method: "POST",
-      url: "/admin/settings/audit/test",
-    })
-  }
+export const adminTestAuditWebhook = (
+  data: AdminTestAuditWebhookData
+): CancelablePromise<AdminTestAuditWebhookResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/admin/settings/audit/test",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
 
 /**
  * Get Registry Settings
@@ -8893,16 +8903,25 @@ export const settingsUpdateAuditSettings = (
 
 /**
  * Test Audit Webhook
+ * Probe the submitted audit webhook configuration with a marked test event.
+ * @param data The data for the request.
+ * @param data.requestBody
  * @returns AuditWebhookTestResult Successful Response
  * @throws ApiError
  */
-export const settingsTestAuditWebhook =
-  (): CancelablePromise<SettingsTestAuditWebhookResponse> => {
-    return __request(OpenAPI, {
-      method: "POST",
-      url: "/settings/audit/test",
-    })
-  }
+export const settingsTestAuditWebhook = (
+  data: SettingsTestAuditWebhookData
+): CancelablePromise<SettingsTestAuditWebhookResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/settings/audit/test",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
 
 /**
  * Get Agent Settings

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1400,6 +1400,15 @@ export type AuditSettingsUpdate = {
 }
 
 /**
+ * Result of a synchronous audit webhook test-fire request.
+ */
+export type AuditWebhookTestResult = {
+  ok: boolean
+  receiver_status_code?: number | null
+  error_category?: "receiver_error" | "timeout" | "request_error" | null
+}
+
+/**
  * Request payload for pre-auth discovery.
  */
 export type AuthDiscoverRequest = {
@@ -12093,6 +12102,8 @@ export type AdminUpdateAuditSettingsData = {
 
 export type AdminUpdateAuditSettingsResponse = PlatformAuditSettingsRead
 
+export type AdminTestAuditWebhookResponse = AuditWebhookTestResult
+
 export type AdminGetRegistrySettingsResponse = PlatformRegistrySettingsRead
 
 export type AdminUpdateRegistrySettingsData = {
@@ -12462,6 +12473,8 @@ export type SettingsUpdateAuditSettingsData = {
 }
 
 export type SettingsUpdateAuditSettingsResponse = void
+
+export type SettingsTestAuditWebhookResponse = AuditWebhookTestResult
 
 export type SettingsGetAgentSettingsResponse = AgentSettingsRead
 
@@ -17515,6 +17528,16 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/admin/settings/audit/test": {
+    post: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AuditWebhookTestResult
+      }
+    }
+  }
   "/admin/settings/registry": {
     get: {
       res: {
@@ -18257,6 +18280,16 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError
+      }
+    }
+  }
+  "/settings/audit/test": {
+    post: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AuditWebhookTestResult
       }
     }
   }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -12102,6 +12102,10 @@ export type AdminUpdateAuditSettingsData = {
 
 export type AdminUpdateAuditSettingsResponse = PlatformAuditSettingsRead
 
+export type AdminTestAuditWebhookData = {
+  requestBody: PlatformAuditSettingsUpdate
+}
+
 export type AdminTestAuditWebhookResponse = AuditWebhookTestResult
 
 export type AdminGetRegistrySettingsResponse = PlatformRegistrySettingsRead
@@ -12473,6 +12477,10 @@ export type SettingsUpdateAuditSettingsData = {
 }
 
 export type SettingsUpdateAuditSettingsResponse = void
+
+export type SettingsTestAuditWebhookData = {
+  requestBody: AuditSettingsUpdate
+}
 
 export type SettingsTestAuditWebhookResponse = AuditWebhookTestResult
 
@@ -17530,11 +17538,16 @@ export type $OpenApiTs = {
   }
   "/admin/settings/audit/test": {
     post: {
+      req: AdminTestAuditWebhookData
       res: {
         /**
          * Successful Response
          */
         200: AuditWebhookTestResult
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
       }
     }
   }
@@ -18285,11 +18298,16 @@ export type $OpenApiTs = {
   }
   "/settings/audit/test": {
     post: {
+      req: SettingsTestAuditWebhookData
       res: {
         /**
          * Successful Response
          */
         200: AuditWebhookTestResult
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
       }
     }
   }

--- a/frontend/src/components/admin/platform-audit-settings.tsx
+++ b/frontend/src/components/admin/platform-audit-settings.tsx
@@ -10,6 +10,8 @@ export function PlatformAuditSettings() {
     auditSettingsError,
     updateAuditSettings,
     updateAuditSettingsIsPending,
+    testAuditWebhook,
+    testAuditWebhookIsPending,
   } = useAdminAuditSettings()
 
   return (
@@ -19,6 +21,8 @@ export function PlatformAuditSettings() {
       auditSettingsError={auditSettingsError}
       updateAuditSettings={updateAuditSettings}
       updateAuditSettingsIsPending={updateAuditSettingsIsPending}
+      testAuditWebhook={testAuditWebhook}
+      testAuditWebhookIsPending={testAuditWebhookIsPending}
       decryptFailureTitle="Unable to decrypt platform settings"
     />
   )

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2Icon,
   LogsIcon,
   PlusIcon,
+  SendIcon,
   Trash2Icon,
   UnlinkIcon,
 } from "lucide-react"
@@ -150,6 +151,8 @@ interface AuditSettingsFormProps {
     requestBody: AuditSettingsUpdateBody
   }) => Promise<unknown>
   updateAuditSettingsIsPending: boolean
+  testAuditWebhook: () => void
+  testAuditWebhookIsPending: boolean
   decryptFailureTitle?: string
 }
 
@@ -245,6 +248,8 @@ export function AuditSettingsForm({
   auditSettingsError,
   updateAuditSettings,
   updateAuditSettingsIsPending,
+  testAuditWebhook,
+  testAuditWebhookIsPending,
   decryptFailureTitle = "Unable to decrypt organization settings",
 }: AuditSettingsFormProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -408,8 +413,8 @@ export function AuditSettingsForm({
         </Alert>
       )}
 
-      <div className="flex items-center justify-between rounded-lg border p-4">
-        <div className="flex items-center gap-3">
+      <div className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
           {isConnected ? (
             <CheckCircle2Icon className="size-5 text-green-500" />
           ) : (
@@ -423,7 +428,20 @@ export function AuditSettingsForm({
           </div>
         </div>
         {isConnected ? (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => testAuditWebhook()}
+              disabled={
+                testAuditWebhookIsPending || updateAuditSettingsIsPending
+              }
+              className="gap-2"
+            >
+              <SendIcon className="size-3.5" />
+              {testAuditWebhookIsPending ? "Testing..." : "Test"}
+            </Button>
             <Button size="sm" onClick={() => handleDialogOpenChange(true)}>
               Update
             </Button>
@@ -638,6 +656,8 @@ export function OrgSettingsAuditForm() {
     auditSettingsError,
     updateAuditSettings,
     updateAuditSettingsIsPending,
+    testAuditWebhook,
+    testAuditWebhookIsPending,
   } = useOrgAuditSettings()
 
   return (
@@ -647,6 +667,8 @@ export function OrgSettingsAuditForm() {
       auditSettingsError={auditSettingsError}
       updateAuditSettings={updateAuditSettings}
       updateAuditSettingsIsPending={updateAuditSettingsIsPending}
+      testAuditWebhook={testAuditWebhook}
+      testAuditWebhookIsPending={testAuditWebhookIsPending}
     />
   )
 }

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -35,7 +35,6 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { Switch } from "@/components/ui/switch"
 import { useOrgAuditSettings } from "@/lib/hooks"
 
@@ -151,7 +150,7 @@ interface AuditSettingsFormProps {
     requestBody: AuditSettingsUpdateBody
   }) => Promise<unknown>
   updateAuditSettingsIsPending: boolean
-  testAuditWebhook: () => void
+  testAuditWebhook: (params: { requestBody: AuditSettingsUpdateBody }) => void
   testAuditWebhookIsPending: boolean
   decryptFailureTitle?: string
 }
@@ -272,9 +271,23 @@ export function AuditSettingsForm({
     control: form.control,
     name: "headers",
   })
+  const formUrlIsEmpty = form.watch("audit_webhook_url").trim() === ""
 
-  const onSubmit = async (data: AuditDialogFormValues) => {
+  const buildUpdateBody = (
+    data: AuditDialogFormValues
+  ): AuditSettingsUpdateBody | null => {
     const nextUrl = data.audit_webhook_url.trim()
+    if (nextUrl === "") {
+      // Saving without a URL disconnects: clear the whole configuration so no
+      // stale headers, payload, wrapper, or TLS override outlives the URL.
+      return {
+        audit_webhook_url: null,
+        audit_webhook_custom_headers: null,
+        audit_webhook_payload_attribute: null,
+        audit_webhook_custom_payload: null,
+        audit_webhook_verify_ssl: true,
+      }
+    }
     const nextHeaders = data.headers.reduce<Record<string, string>>(
       (headers, header) => {
         const headerKey = header.key.trim()
@@ -294,27 +307,41 @@ export function AuditSettingsForm({
         message:
           'Custom payload must be a JSON object, e.g. { "event": "audit" }',
       })
-      return
+      return null
     }
 
+    return {
+      audit_webhook_url: nextUrl,
+      audit_webhook_custom_headers:
+        Object.keys(nextHeaders).length > 0 ? nextHeaders : null,
+      audit_webhook_payload_attribute:
+        data.audit_webhook_payload_attribute.trim() === ""
+          ? null
+          : data.audit_webhook_payload_attribute.trim(),
+      audit_webhook_custom_payload: customPayload,
+      audit_webhook_verify_ssl: data.audit_webhook_verify_ssl,
+    }
+  }
+
+  const onSubmit = async (data: AuditDialogFormValues) => {
+    const requestBody = buildUpdateBody(data)
+    if (!requestBody) {
+      return
+    }
     try {
-      await updateAuditSettings({
-        requestBody: {
-          audit_webhook_url: nextUrl === "" ? null : nextUrl,
-          audit_webhook_custom_headers:
-            Object.keys(nextHeaders).length > 0 ? nextHeaders : null,
-          audit_webhook_payload_attribute:
-            data.audit_webhook_payload_attribute.trim() === ""
-              ? null
-              : data.audit_webhook_payload_attribute.trim(),
-          audit_webhook_custom_payload: customPayload,
-          audit_webhook_verify_ssl: data.audit_webhook_verify_ssl,
-        },
-      })
+      await updateAuditSettings({ requestBody })
       setDialogOpen(false)
     } catch {
       console.error("Failed to update audit settings")
     }
+  }
+
+  const onTestForm = (data: AuditDialogFormValues) => {
+    const requestBody = buildUpdateBody(data)
+    if (!requestBody?.audit_webhook_url) {
+      return
+    }
+    testAuditWebhook({ requestBody })
   }
 
   const handleDisconnect = async () => {
@@ -429,19 +456,6 @@ export function AuditSettingsForm({
         </div>
         {isConnected ? (
           <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => testAuditWebhook()}
-              disabled={
-                testAuditWebhookIsPending || updateAuditSettingsIsPending
-              }
-              className="gap-2"
-            >
-              <SendIcon className="size-3.5" />
-              {testAuditWebhookIsPending ? "Testing..." : "Test"}
-            </Button>
             <Button size="sm" onClick={() => handleDialogOpenChange(true)}>
               Update
             </Button>
@@ -464,7 +478,7 @@ export function AuditSettingsForm({
       </div>
 
       <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-        <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-xl">
+        <DialogContent className="flex max-h-[85vh] flex-col overflow-hidden sm:max-w-xl">
           <DialogHeader>
             <DialogTitle>
               {isConnected ? "Update audit webhook" : "Connect audit webhook"}
@@ -474,7 +488,7 @@ export function AuditSettingsForm({
               request options.
             </DialogDescription>
           </DialogHeader>
-          <ScrollArea className="flex-1 pr-1">
+          <div className="no-scrollbar min-h-0 flex-1 overflow-y-auto">
             <Form {...form}>
               <form
                 onSubmit={form.handleSubmit(onSubmit)}
@@ -637,12 +651,35 @@ export function AuditSettingsForm({
                   )}
                 />
 
-                <Button type="submit" disabled={updateAuditSettingsIsPending}>
-                  {updateAuditSettingsIsPending ? "Saving..." : "Save changes"}
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={form.handleSubmit(onTestForm)}
+                    disabled={
+                      testAuditWebhookIsPending ||
+                      updateAuditSettingsIsPending ||
+                      formUrlIsEmpty
+                    }
+                    className="gap-2"
+                  >
+                    <SendIcon className="size-3.5" />
+                    {testAuditWebhookIsPending ? "Testing..." : "Test"}
+                  </Button>
+                  <Button
+                    type="submit"
+                    disabled={
+                      updateAuditSettingsIsPending || testAuditWebhookIsPending
+                    }
+                  >
+                    {updateAuditSettingsIsPending
+                      ? "Saving..."
+                      : "Save changes"}
+                  </Button>
+                </div>
               </form>
             </Form>
-          </ScrollArea>
+          </div>
         </DialogContent>
       </Dialog>
     </>

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -20,6 +20,7 @@ import {
   type AdminUserRead,
   type AgentCatalogListResponse,
   type AgentCatalogRead,
+  type AuditWebhookTestResult,
   adminCreateOrganization,
   adminCreateOrganizationDomain,
   adminCreateOrganizationInvitation,
@@ -55,6 +56,7 @@ import {
   adminRegistrySyncRepository,
   adminRevokeOrganizationInvitation,
   adminSyncOrgRepository,
+  adminTestAuditWebhook,
   adminUpdateAuditSettings,
   adminUpdateOrganization,
   adminUpdateOrganizationDomain,
@@ -80,7 +82,16 @@ import {
   type TierUpdate,
 } from "@/client"
 import { request as apiRequest } from "@/client/core/request"
-import { retryHandler, type TracecatApiError } from "@/lib/errors"
+import { toast } from "@/components/ui/use-toast"
+import {
+  getAuditWebhookTestDescription,
+  getAuditWebhookTestTitle,
+} from "@/lib/audit-webhook-test"
+import {
+  getApiErrorDetail,
+  retryHandler,
+  type TracecatApiError,
+} from "@/lib/errors"
 
 export interface AdminPlatformCatalogEntry {
   id: string
@@ -888,6 +899,25 @@ export function useAdminAuditSettings() {
     },
   })
 
+  const { mutate: testAuditWebhook, isPending: testAuditWebhookIsPending } =
+    useMutation<AuditWebhookTestResult, TracecatApiError>({
+      mutationFn: adminTestAuditWebhook,
+      onSuccess: (result) => {
+        toast({
+          title: getAuditWebhookTestTitle(result),
+          description: getAuditWebhookTestDescription(result),
+          variant: result.ok ? "default" : "destructive",
+        })
+      },
+      onError: (error) => {
+        console.error("Failed to test platform audit webhook", error)
+        toast({
+          title: "Failed to test audit webhook",
+          description: getApiErrorDetail(error) ?? "Unknown error",
+        })
+      },
+    })
+
   return {
     auditSettings,
     auditSettingsIsLoading,
@@ -895,6 +925,8 @@ export function useAdminAuditSettings() {
     updateAuditSettings,
     updateAuditSettingsIsPending,
     updateAuditSettingsError,
+    testAuditWebhook,
+    testAuditWebhookIsPending,
   }
 }
 

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -16,6 +16,7 @@ import {
   type AdminOrgInvitationCreate,
   type AdminRegistryGetRegistryStatusResponse,
   type AdminRegistryListRegistryVersionsResponse,
+  type AdminTestAuditWebhookData,
   type AdminUserCreate,
   type AdminUserRead,
   type AgentCatalogListResponse,
@@ -900,7 +901,11 @@ export function useAdminAuditSettings() {
   })
 
   const { mutate: testAuditWebhook, isPending: testAuditWebhookIsPending } =
-    useMutation<AuditWebhookTestResult, TracecatApiError>({
+    useMutation<
+      AuditWebhookTestResult,
+      TracecatApiError,
+      AdminTestAuditWebhookData
+    >({
       mutationFn: adminTestAuditWebhook,
       onSuccess: (result) => {
         toast({

--- a/frontend/src/lib/audit-webhook-test.ts
+++ b/frontend/src/lib/audit-webhook-test.ts
@@ -1,0 +1,31 @@
+import type { AuditWebhookTestResult } from "@/client"
+
+function formatErrorCategory(category: string | null | undefined): string {
+  switch (category) {
+    case "receiver_error":
+      return "receiver error"
+    case "timeout":
+      return "timeout"
+    case "request_error":
+      return "request error"
+    default:
+      return "request failed"
+  }
+}
+
+export function getAuditWebhookTestTitle(
+  result: AuditWebhookTestResult
+): string {
+  return result.ok
+    ? "Audit webhook test succeeded"
+    : "Audit webhook test failed"
+}
+
+export function getAuditWebhookTestDescription(
+  result: AuditWebhookTestResult
+): string {
+  if (result.receiver_status_code != null) {
+    return `Receiver returned ${result.receiver_status_code}.`
+  }
+  return `Tracecat could not reach the receiver: ${formatErrorCategory(result.error_category)}.`
+}

--- a/frontend/src/lib/audit-webhook-test.ts
+++ b/frontend/src/lib/audit-webhook-test.ts
@@ -13,6 +13,7 @@ function formatErrorCategory(category: string | null | undefined): string {
   }
 }
 
+/** Return the toast title for an audit webhook test result. */
 export function getAuditWebhookTestTitle(
   result: AuditWebhookTestResult
 ): string {
@@ -21,6 +22,7 @@ export function getAuditWebhookTestTitle(
     : "Audit webhook test failed"
 }
 
+/** Return the receiver status or categorized failure description. */
 export function getAuditWebhookTestDescription(
   result: AuditWebhookTestResult
 ): string {

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -238,6 +238,7 @@ import {
   type SecretReadMinimal,
   type SecretUpdate,
   type SessionRead,
+  type SettingsTestAuditWebhookData,
   type SettingsUpdateAgentSettingsData,
   type SettingsUpdateAppSettingsData,
   type SettingsUpdateAuditSettingsData,
@@ -3125,7 +3126,11 @@ export function useOrgAuditSettings() {
   })
 
   const { mutate: testAuditWebhook, isPending: testAuditWebhookIsPending } =
-    useMutation<AuditWebhookTestResult, TracecatApiError>({
+    useMutation<
+      AuditWebhookTestResult,
+      TracecatApiError,
+      SettingsTestAuditWebhookData
+    >({
       mutationFn: settingsTestAuditWebhook,
       onSuccess: (result) => {
         toast({

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -24,6 +24,7 @@ import {
   ApiError,
   type AppSettingsRead,
   type AuditSettingsRead,
+  type AuditWebhookTestResult,
   type AwsAssumeRoleAccessRead,
   actionsDeleteAction,
   actionsGetAction,
@@ -257,6 +258,7 @@ import {
   settingsGetAuditSettings,
   settingsGetGitSettings,
   settingsGetSamlSettings,
+  settingsTestAuditWebhook,
   settingsUpdateAgentSettings,
   settingsUpdateAppSettings,
   settingsUpdateAuditSettings,
@@ -384,6 +386,10 @@ import {
 } from "@/hooks/use-stdio-mcp-verification-status"
 import { type AgentSessionWithStatus, enrichAgentSession } from "@/lib/agents"
 import { client as apiClient, getBaseUrl } from "@/lib/api"
+import {
+  getAuditWebhookTestDescription,
+  getAuditWebhookTestTitle,
+} from "@/lib/audit-webhook-test"
 import {
   listCaseDurationDefinitions,
   listCaseDurations,
@@ -3118,6 +3124,34 @@ export function useOrgAuditSettings() {
     },
   })
 
+  const { mutate: testAuditWebhook, isPending: testAuditWebhookIsPending } =
+    useMutation<AuditWebhookTestResult, TracecatApiError>({
+      mutationFn: settingsTestAuditWebhook,
+      onSuccess: (result) => {
+        toast({
+          title: getAuditWebhookTestTitle(result),
+          description: getAuditWebhookTestDescription(result),
+          variant: result.ok ? "default" : "destructive",
+        })
+      },
+      onError: (error: TracecatApiError) => {
+        switch (error.status) {
+          case 403:
+            toast({
+              title: "Forbidden",
+              description: "You cannot perform this action",
+            })
+            break
+          default:
+            console.error("Failed to test audit webhook", error)
+            toast({
+              title: "Failed to test audit webhook",
+              description: getApiErrorDetail(error) ?? "Unknown error",
+            })
+        }
+      },
+    })
+
   return {
     // Get
     auditSettings,
@@ -3127,6 +3161,9 @@ export function useOrgAuditSettings() {
     updateAuditSettings,
     updateAuditSettingsIsPending,
     updateAuditSettingsError,
+    // Test
+    testAuditWebhook,
+    testAuditWebhookIsPending,
   }
 }
 

--- a/packages/tracecat-ee/tracecat_ee/admin/settings/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/settings/router.py
@@ -7,10 +7,11 @@ from fastapi import APIRouter, HTTPException, status
 from tracecat.audit.service import (
     AuditService,
     AuditWebhookNotConfiguredError,
-    AuditWebhookTestResult,
+    AuditWebhookUrlNotAllowedError,
 )
 from tracecat.auth.credentials import SuperuserRole
 from tracecat.db.dependencies import AsyncDBSessionBypass
+from tracecat.settings.schemas import AuditWebhookTestResult
 from tracecat_ee.admin.settings.schemas import (
     PlatformAuditSettingsRead,
     PlatformAuditSettingsUpdate,
@@ -46,18 +47,25 @@ async def update_audit_settings(
 @router.post("/audit/test", response_model=AuditWebhookTestResult)
 async def test_audit_webhook(
     role: SuperuserRole,
+    params: PlatformAuditSettingsUpdate,
 ) -> AuditWebhookTestResult:
-    """Send a test event to the platform audit webhook."""
+    """Probe the submitted platform audit webhook configuration."""
     try:
         return await AuditService.probe_webhook(
             sink="platform",
             organization_id=None,
             role=role,
+            settings=params,
         )
     except AuditWebhookNotConfiguredError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Audit webhook is not configured",
+        ) from exc
+    except AuditWebhookUrlNotAllowedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Audit webhook URL is not allowed",
         ) from exc
 
 

--- a/packages/tracecat-ee/tracecat_ee/admin/settings/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/settings/router.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 
+from tracecat.audit.service import (
+    AuditService,
+    AuditWebhookNotConfiguredError,
+    AuditWebhookTestResult,
+)
 from tracecat.auth.credentials import SuperuserRole
 from tracecat.db.dependencies import AsyncDBSessionBypass
 from tracecat_ee.admin.settings.schemas import (
@@ -36,6 +41,24 @@ async def update_audit_settings(
     """Update platform audit settings."""
     service = AdminSettingsService(session, role)
     return await service.update_audit_settings(params)
+
+
+@router.post("/audit/test", response_model=AuditWebhookTestResult)
+async def test_audit_webhook(
+    role: SuperuserRole,
+) -> AuditWebhookTestResult:
+    """Send a test event to the platform audit webhook."""
+    try:
+        return await AuditService.probe_webhook(
+            sink="platform",
+            organization_id=None,
+            role=role,
+        )
+    except AuditWebhookNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Audit webhook is not configured",
+        ) from exc
 
 
 @router.get("/registry", response_model=PlatformRegistrySettingsRead)

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -525,6 +525,7 @@ def test_non_git_org_settings_routes_remain_user_only() -> None:
         settings_router.update_app_settings,
         settings_router.get_audit_settings,
         settings_router.update_audit_settings,
+        settings_router.test_audit_webhook,
         settings_router.get_agent_settings,
         settings_router.update_agent_settings,
     ]

--- a/tests/unit/api/test_api_audit_webhook_test.py
+++ b/tests/unit/api/test_api_audit_webhook_test.py
@@ -354,6 +354,9 @@ async def test_probe_url_guard_uses_real_resolver_for_loopback() -> None:
     [
         "https://example.com:99999/hook",
         "https://[::1/hook",
+        # An over-long DNS label makes getaddrinfo raise UnicodeError, not
+        # gaierror; the guard must still map it to a client error.
+        f"https://{'a' * 64}.example.test/hook",
     ],
 )
 async def test_org_audit_webhook_test_returns_400_for_malformed_url(

--- a/tests/unit/api/test_api_audit_webhook_test.py
+++ b/tests/unit/api/test_api_audit_webhook_test.py
@@ -106,7 +106,7 @@ def allow_probe_url(monkeypatch: pytest.MonkeyPatch) -> None:
     delivery-path tests must not depend on real DNS for their example hosts.
     """
 
-    async def _noop(url: str, *, default_port: int) -> None:
+    async def _noop(url: str) -> None:
         return None
 
     monkeypatch.setattr(
@@ -233,7 +233,7 @@ async def test_org_audit_webhook_test_timeout_includes_dns_resolution(
     test_admin_role: Role,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _hang(url: str, *, default_port: int) -> None:
+    async def _hang(url: str) -> None:
         await asyncio.Event().wait()
 
     monkeypatch.setattr(
@@ -322,7 +322,7 @@ async def test_probe_rejects_private_address_without_connecting(
 ) -> None:
     """A URL resolving to a private address is a 400 and never connects."""
 
-    async def _reject(url: str, *, default_port: int) -> None:
+    async def _reject(url: str) -> None:
         raise audit_service_module.DisallowedUrlError("Host is not allowed")
 
     monkeypatch.setattr(
@@ -343,9 +343,7 @@ async def test_probe_rejects_private_address_without_connecting(
 async def test_probe_url_guard_uses_real_resolver_for_loopback() -> None:
     """The shared guard rejects a loopback URL end to end."""
     with pytest.raises(network.DisallowedUrlError):
-        await network.validate_url_resolves_public_async(
-            "http://127.0.0.1:9000/ingest", default_port=443
-        )
+        await network.validate_url_resolves_public_async("http://127.0.0.1:9000/ingest")
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_audit_webhook_test.py
+++ b/tests/unit/api/test_api_audit_webhook_test.py
@@ -12,6 +12,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from tracecat_ee.admin.settings import router as admin_settings_router
 
+from tracecat import network
 from tracecat.audit import service as audit_service_module
 from tracecat.auth.types import Role
 from tracecat.settings import router as settings_router
@@ -227,6 +228,36 @@ async def test_org_audit_webhook_test_enforces_wall_clock_timeout(
 
 
 @pytest.mark.anyio
+async def test_org_audit_webhook_test_timeout_includes_dns_resolution(
+    client: TestClient,
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _hang(url: str, *, default_port: int) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        "tracecat.audit.service._AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        audit_service_module, "validate_url_resolves_public_async", _hang
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test", json=_TEST_BODY)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "ok": False,
+        "receiver_status_code": None,
+        "error_category": "timeout",
+    }
+    assert FakeAuditWebhookClient.calls == []
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "body",
     [
@@ -311,12 +342,42 @@ async def test_probe_rejects_private_address_without_connecting(
 @pytest.mark.anyio
 async def test_probe_url_guard_uses_real_resolver_for_loopback() -> None:
     """The shared guard rejects a loopback URL end to end."""
-    from tracecat import network
-
     with pytest.raises(network.DisallowedUrlError):
         await network.validate_url_resolves_public_async(
             "http://127.0.0.1:9000/ingest", default_port=443
         )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com:99999/hook",
+        "https://[::1/hook",
+    ],
+)
+async def test_org_audit_webhook_test_returns_400_for_malformed_url(
+    client: TestClient,
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+    url: str,
+) -> None:
+    monkeypatch.setattr(
+        audit_service_module,
+        "validate_url_resolves_public_async",
+        network.validate_url_resolves_public_async,
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post(
+        "/settings/audit/test", json={**_TEST_BODY, "audit_webhook_url": url}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Audit webhook URL is not allowed"}
+    assert FakeAuditWebhookClient.calls == []
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_audit_webhook_test.py
+++ b/tests/unit/api/test_api_audit_webhook_test.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from inspect import signature
 from typing import Any
 
@@ -14,8 +15,9 @@ from tracecat_ee.admin.settings import router as admin_settings_router
 from tracecat.audit import service as audit_service_module
 from tracecat.auth.types import Role
 from tracecat.settings import router as settings_router
+from tracecat.settings.schemas import AuditSettingsUpdate
 
-_SINK_SETTINGS: dict[str, Any] = {
+_TEST_BODY: dict[str, Any] = {
     "audit_webhook_url": "https://audit.example.test/ingest",
     "audit_webhook_custom_headers": {
         "X-Custom-Audit": "secret-value",
@@ -30,8 +32,6 @@ _SINK_SETTINGS: dict[str, Any] = {
 class FakeAuditWebhookClient:
     status_code = status.HTTP_200_OK
     calls: list[dict[str, Any]] = []
-    settings_reads = 0
-    settings_reads_active = 0
 
     def __init__(self, *, timeout: float, verify: bool) -> None:
         self.timeout = timeout
@@ -43,16 +43,18 @@ class FakeAuditWebhookClient:
     async def __aexit__(self, *args: object) -> None:
         return None
 
-    async def post(
+    @asynccontextmanager
+    async def stream(
         self,
+        method: str,
         url: str,
         *,
         json: dict[str, Any],
         headers: dict[str, str],
-    ) -> httpx.Response:
-        assert self.settings_reads_active == 0
+    ) -> AsyncIterator[httpx.Response]:
         self.calls.append(
             {
+                "method": method,
                 "url": url,
                 "json": json,
                 "headers": headers,
@@ -60,20 +62,22 @@ class FakeAuditWebhookClient:
                 "verify": self.verify,
             }
         )
-        return httpx.Response(self.status_code)
+        yield httpx.Response(self.status_code)
 
 
 class HangingAuditWebhookClient(FakeAuditWebhookClient):
-    async def post(
+    @asynccontextmanager
+    async def stream(
         self,
+        method: str,
         url: str,
         *,
         json: dict[str, Any],
         headers: dict[str, str],
-    ) -> httpx.Response:
-        assert self.settings_reads_active == 0
+    ) -> AsyncIterator[httpx.Response]:
         self.calls.append(
             {
+                "method": method,
                 "url": url,
                 "json": json,
                 "headers": headers,
@@ -83,52 +87,30 @@ class HangingAuditWebhookClient(FakeAuditWebhookClient):
         )
         await asyncio.Event().wait()
         raise AssertionError("wall-clock timeout should cancel the request")
+        yield httpx.Response(self.status_code)
 
 
 @pytest.fixture(autouse=True)
 def reset_fake_client() -> None:
     FakeAuditWebhookClient.status_code = status.HTTP_200_OK
     FakeAuditWebhookClient.calls = []
-    FakeAuditWebhookClient.settings_reads = 0
-    FakeAuditWebhookClient.settings_reads_active = 0
     HangingAuditWebhookClient.calls = []
 
 
 @pytest.fixture(autouse=True)
-def clear_audit_setting_cache() -> Iterator[None]:
-    audit_service_module._get_audit_setting_cached.cache_clear()
-    yield
-    audit_service_module._get_audit_setting_cached.cache_clear()
+def allow_probe_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve every probe URL to a public address unless a test overrides it.
 
+    The probe rejects URLs that do not resolve to public addresses, so the
+    delivery-path tests must not depend on real DNS for their example hosts.
+    """
 
-@pytest.fixture
-def sink_settings(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
-    """Back self-managed cache misses without touching PostgreSQL."""
-    settings = dict(_SINK_SETTINGS)
-
-    async def read_setting(key: str, *, default: Any = None) -> Any | None:
-        FakeAuditWebhookClient.settings_reads += 1
-        FakeAuditWebhookClient.settings_reads_active += 1
-        try:
-            value = settings.get(key)
-            return default if value is None and default is not None else value
-        finally:
-            FakeAuditWebhookClient.settings_reads_active -= 1
-
-    async def fetch_platform_setting(key: str) -> Any | None:
-        return await read_setting(key)
-
-    async def get_setting(
-        key: str, *, role: Any = None, session: Any = None, default: Any = None
-    ) -> Any | None:
-        assert session is None
-        return await read_setting(key, default=default)
+    async def _noop(url: str, *, default_port: int) -> None:
+        return None
 
     monkeypatch.setattr(
-        audit_service_module, "_fetch_platform_setting", fetch_platform_setting
+        audit_service_module, "validate_url_resolves_public_async", _noop
     )
-    monkeypatch.setattr("tracecat.settings.service.get_setting", get_setting)
-    return settings
 
 
 def test_audit_webhook_test_routes_do_not_hold_request_sessions() -> None:
@@ -139,17 +121,16 @@ def test_audit_webhook_test_routes_do_not_hold_request_sessions() -> None:
 
 
 @pytest.mark.anyio
-async def test_org_audit_webhook_test_posts_marked_event(
+async def test_org_audit_webhook_test_posts_marked_event_from_submitted_config(
     client: TestClient,
     test_admin_role: Role,
-    sink_settings: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
     )
 
-    response = client.post("/settings/audit/test")
+    response = client.post("/settings/audit/test", json=_TEST_BODY)
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
@@ -176,20 +157,22 @@ async def test_org_audit_webhook_test_posts_marked_event(
 
 
 @pytest.mark.anyio
-async def test_org_audit_webhook_test_reads_fresh_settings(
+async def test_org_audit_webhook_test_probes_submitted_not_saved_url(
     client: TestClient,
     test_admin_role: Role,
-    sink_settings: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A test fired right after a save must not post to the stale URL."""
+    """The probe must target exactly the submitted configuration."""
     monkeypatch.setattr(
         "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
     )
 
-    client.post("/settings/audit/test")
-    sink_settings["audit_webhook_url"] = "https://audit.example.test/updated"
-    client.post("/settings/audit/test")
+    client.post("/settings/audit/test", json=_TEST_BODY)
+    updated_body = {
+        **_TEST_BODY,
+        "audit_webhook_url": "https://audit.example.test/updated",
+    }
+    client.post("/settings/audit/test", json=updated_body)
 
     assert len(FakeAuditWebhookClient.calls) == 2
     assert (
@@ -201,7 +184,6 @@ async def test_org_audit_webhook_test_reads_fresh_settings(
 async def test_org_audit_webhook_test_surfaces_receiver_error(
     client: TestClient,
     test_admin_role: Role,
-    sink_settings: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     FakeAuditWebhookClient.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -209,7 +191,7 @@ async def test_org_audit_webhook_test_surfaces_receiver_error(
         "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
     )
 
-    response = client.post("/settings/audit/test")
+    response = client.post("/settings/audit/test", json=_TEST_BODY)
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
@@ -223,7 +205,6 @@ async def test_org_audit_webhook_test_surfaces_receiver_error(
 async def test_org_audit_webhook_test_enforces_wall_clock_timeout(
     client: TestClient,
     test_admin_role: Role,
-    sink_settings: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -233,7 +214,7 @@ async def test_org_audit_webhook_test_enforces_wall_clock_timeout(
         "tracecat.audit.service.httpx.AsyncClient", HangingAuditWebhookClient
     )
 
-    response = client.post("/settings/audit/test")
+    response = client.post("/settings/audit/test", json=_TEST_BODY)
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
@@ -246,18 +227,25 @@ async def test_org_audit_webhook_test_enforces_wall_clock_timeout(
 
 
 @pytest.mark.anyio
-async def test_org_audit_webhook_test_returns_400_when_unconfigured(
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},
+        {"audit_webhook_url": None},
+        {"audit_webhook_url": "   "},
+    ],
+)
+async def test_org_audit_webhook_test_returns_400_without_url(
     client: TestClient,
     test_admin_role: Role,
-    sink_settings: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
+    body: dict[str, Any],
 ) -> None:
-    sink_settings["audit_webhook_url"] = None
     monkeypatch.setattr(
         "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
     )
 
-    response = client.post("/settings/audit/test")
+    response = client.post("/settings/audit/test", json=body)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json() == {"detail": "Audit webhook is not configured"}
@@ -265,17 +253,83 @@ async def test_org_audit_webhook_test_returns_400_when_unconfigured(
 
 
 @pytest.mark.anyio
+async def test_probe_times_out_when_socket_budget_exhausted(
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe shares the delivery socket cap and honors the wall clock."""
+    monkeypatch.setattr(
+        "tracecat.audit.service._AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS", 0.05
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+    loop = asyncio.get_running_loop()
+    audit_service_module._post_semaphores[loop] = asyncio.Semaphore(0)
+    try:
+        result = await audit_service_module.AuditService.probe_webhook(
+            sink="organization",
+            organization_id=test_admin_role.organization_id,
+            role=test_admin_role,
+            settings=AuditSettingsUpdate(
+                audit_webhook_url="https://audit.example.test/ingest"
+            ),
+        )
+    finally:
+        audit_service_module._post_semaphores.pop(loop, None)
+
+    assert result.ok is False
+    assert result.error_category == "timeout"
+    assert FakeAuditWebhookClient.calls == []
+
+
+@pytest.mark.anyio
+async def test_probe_rejects_private_address_without_connecting(
+    client: TestClient,
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A URL resolving to a private address is a 400 and never connects."""
+
+    async def _reject(url: str, *, default_port: int) -> None:
+        raise audit_service_module.DisallowedUrlError("Host is not allowed")
+
+    monkeypatch.setattr(
+        audit_service_module, "validate_url_resolves_public_async", _reject
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test", json=_TEST_BODY)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Audit webhook URL is not allowed"}
+    assert FakeAuditWebhookClient.calls == []
+
+
+@pytest.mark.anyio
+async def test_probe_url_guard_uses_real_resolver_for_loopback() -> None:
+    """The shared guard rejects a loopback URL end to end."""
+    from tracecat import network
+
+    with pytest.raises(network.DisallowedUrlError):
+        await network.validate_url_resolves_public_async(
+            "http://127.0.0.1:9000/ingest", default_port=443
+        )
+
+
+@pytest.mark.anyio
 async def test_platform_audit_webhook_test_posts_platform_event(
     client: TestClient,
     test_admin_role: Role,
-    sink_settings: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
     )
 
-    response = client.post("/admin/settings/audit/test")
+    response = client.post("/admin/settings/audit/test", json=_TEST_BODY)
 
     assert response.status_code == status.HTTP_200_OK
     assert len(FakeAuditWebhookClient.calls) == 1

--- a/tests/unit/api/test_api_audit_webhook_test.py
+++ b/tests/unit/api/test_api_audit_webhook_test.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from inspect import signature
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from tracecat_ee.admin.settings import router as admin_settings_router
+
+from tracecat.audit import service as audit_service_module
+from tracecat.auth.types import Role
+from tracecat.settings import router as settings_router
+
+_SINK_SETTINGS: dict[str, Any] = {
+    "audit_webhook_url": "https://audit.example.test/ingest",
+    "audit_webhook_custom_headers": {
+        "X-Custom-Audit": "secret-value",
+        "x-tracecat-test": "false",
+    },
+    "audit_webhook_custom_payload": {"customer_field": "customer-value"},
+    "audit_webhook_verify_ssl": False,
+    "audit_webhook_payload_attribute": "event",
+}
+
+
+class FakeAuditWebhookClient:
+    status_code = status.HTTP_200_OK
+    calls: list[dict[str, Any]] = []
+    settings_reads = 0
+    settings_reads_active = 0
+
+    def __init__(self, *, timeout: float, verify: bool) -> None:
+        self.timeout = timeout
+        self.verify = verify
+
+    async def __aenter__(self) -> FakeAuditWebhookClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str],
+    ) -> httpx.Response:
+        assert self.settings_reads_active == 0
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": self.timeout,
+                "verify": self.verify,
+            }
+        )
+        return httpx.Response(self.status_code)
+
+
+class HangingAuditWebhookClient(FakeAuditWebhookClient):
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str],
+    ) -> httpx.Response:
+        assert self.settings_reads_active == 0
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": self.timeout,
+                "verify": self.verify,
+            }
+        )
+        await asyncio.Event().wait()
+        raise AssertionError("wall-clock timeout should cancel the request")
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_client() -> None:
+    FakeAuditWebhookClient.status_code = status.HTTP_200_OK
+    FakeAuditWebhookClient.calls = []
+    FakeAuditWebhookClient.settings_reads = 0
+    FakeAuditWebhookClient.settings_reads_active = 0
+    HangingAuditWebhookClient.calls = []
+
+
+@pytest.fixture(autouse=True)
+def clear_audit_setting_cache() -> Iterator[None]:
+    audit_service_module._get_audit_setting_cached.cache_clear()
+    yield
+    audit_service_module._get_audit_setting_cached.cache_clear()
+
+
+@pytest.fixture
+def sink_settings(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Back self-managed cache misses without touching PostgreSQL."""
+    settings = dict(_SINK_SETTINGS)
+
+    async def read_setting(key: str, *, default: Any = None) -> Any | None:
+        FakeAuditWebhookClient.settings_reads += 1
+        FakeAuditWebhookClient.settings_reads_active += 1
+        try:
+            value = settings.get(key)
+            return default if value is None and default is not None else value
+        finally:
+            FakeAuditWebhookClient.settings_reads_active -= 1
+
+    async def fetch_platform_setting(key: str) -> Any | None:
+        return await read_setting(key)
+
+    async def get_setting(
+        key: str, *, role: Any = None, session: Any = None, default: Any = None
+    ) -> Any | None:
+        assert session is None
+        return await read_setting(key, default=default)
+
+    monkeypatch.setattr(
+        audit_service_module, "_fetch_platform_setting", fetch_platform_setting
+    )
+    monkeypatch.setattr("tracecat.settings.service.get_setting", get_setting)
+    return settings
+
+
+def test_audit_webhook_test_routes_do_not_hold_request_sessions() -> None:
+    assert "session" not in signature(settings_router.test_audit_webhook).parameters
+    assert (
+        "session" not in signature(admin_settings_router.test_audit_webhook).parameters
+    )
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_posts_marked_event(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_settings: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "ok": True,
+        "receiver_status_code": status.HTTP_200_OK,
+        "error_category": None,
+    }
+    assert len(FakeAuditWebhookClient.calls) == 1
+    call = FakeAuditWebhookClient.calls[0]
+    assert call["url"] == "https://audit.example.test/ingest"
+    assert call["verify"] is False
+    assert call["timeout"] == 5.0
+    assert call["headers"]["X-Custom-Audit"] == "secret-value"
+    assert "x-tracecat-test" not in call["headers"]
+    assert call["headers"]["X-Tracecat-Test"] == "true"
+    event = call["json"]["event"]
+    assert event["organization_id"] == str(test_admin_role.organization_id)
+    assert event["actor_id"] == str(test_admin_role.user_id)
+    assert event["resource_type"] == "organization_setting"
+    assert event["resource_id"] is None
+    assert event["action"] == "connect"
+    assert event["data"] == {"test": True}
+    assert event["customer_field"] == "customer-value"
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_reads_fresh_settings(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_settings: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A test fired right after a save must not post to the stale URL."""
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    client.post("/settings/audit/test")
+    sink_settings["audit_webhook_url"] = "https://audit.example.test/updated"
+    client.post("/settings/audit/test")
+
+    assert len(FakeAuditWebhookClient.calls) == 2
+    assert (
+        FakeAuditWebhookClient.calls[1]["url"] == "https://audit.example.test/updated"
+    )
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_surfaces_receiver_error(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_settings: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeAuditWebhookClient.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "ok": False,
+        "receiver_status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "error_category": "receiver_error",
+    }
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_enforces_wall_clock_timeout(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_settings: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.audit.service._AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", HangingAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "ok": False,
+        "receiver_status_code": None,
+        "error_category": "timeout",
+    }
+    assert len(HangingAuditWebhookClient.calls) == 1
+    assert HangingAuditWebhookClient.calls[0]["headers"]["X-Tracecat-Test"] == "true"
+
+
+@pytest.mark.anyio
+async def test_org_audit_webhook_test_returns_400_when_unconfigured(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_settings: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink_settings["audit_webhook_url"] = None
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/settings/audit/test")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Audit webhook is not configured"}
+    assert FakeAuditWebhookClient.calls == []
+
+
+@pytest.mark.anyio
+async def test_platform_audit_webhook_test_posts_platform_event(
+    client: TestClient,
+    test_admin_role: Role,
+    sink_settings: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.audit.service.httpx.AsyncClient", FakeAuditWebhookClient
+    )
+
+    response = client.post("/admin/settings/audit/test")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(FakeAuditWebhookClient.calls) == 1
+    event = FakeAuditWebhookClient.calls[0]["json"]["event"]
+    assert event["organization_id"] is None
+    assert event["actor_id"] == str(test_admin_role.user_id)
+    assert event["resource_type"] == "platform_setting"
+    assert event["resource_id"] is None
+    assert event["data"] == {"test": True}

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -888,68 +888,6 @@ async def test_audit_setting_cache_clear_restores_fresh_reads(
 
 
 @pytest.mark.anyio
-async def test_test_delivery_reads_fresh_without_evicting_cache(
-    monkeypatch: pytest.MonkeyPatch,
-    role: Role,
-) -> None:
-    """A test reads fresh settings without touching any tenant's cache."""
-    organization_a = role.organization_id
-    organization_b = uuid.uuid4()
-    assert organization_a is not None
-    urls = {
-        organization_a: "https://a.example.com/old",
-        organization_b: "https://b.example.com/old",
-    }
-    reads: list[uuid.UUID] = []
-
-    async def get_setting(
-        key: str,
-        *,
-        role: Role | None = None,
-        session: Any = None,
-        default: Any = None,
-    ) -> Any:
-        assert role is not None and role.organization_id is not None
-        assert session is None
-        reads.append(role.organization_id)
-        if key == "audit_webhook_url":
-            return urls[role.organization_id]
-        return default
-
-    monkeypatch.setattr("tracecat.settings.service.get_setting", get_setting)
-    service_a = AuditService(AsyncMock(), role=role)
-    role_b = role.model_copy(update={"organization_id": organization_b})
-    service_b = AuditService(AsyncMock(), role=role_b)
-
-    assert await service_a._get_webhook_url() == "https://a.example.com/old"
-    assert await service_b._get_webhook_url() == "https://b.example.com/old"
-    urls[organization_a] = "https://a.example.com/new"
-    urls[organization_b] = "https://b.example.com/new"
-    event = AuditEvent(
-        organization_id=organization_a,
-        workspace_id=None,
-        actor_type=AuditEventActor.USER,
-        actor_id=uuid.uuid4(),
-        actor_label=None,
-        resource_type="organization_setting",
-        resource_id=None,
-        action="connect",
-        status=AuditEventStatus.SUCCESS,
-    )
-
-    delivery = await AuditService._resolve_test_delivery(
-        sink="organization",
-        organization_id=organization_a,
-        payload=event,
-    )
-
-    assert delivery is not None
-    assert delivery.webhook_url == "https://a.example.com/new"
-    assert await service_b._get_webhook_url() == "https://b.example.com/old"
-    assert reads.count(organization_b) == 1
-
-
-@pytest.mark.anyio
 async def test_post_event_uses_custom_payload_headers_and_verify_ssl(
     monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
 ) -> None:

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -888,6 +888,68 @@ async def test_audit_setting_cache_clear_restores_fresh_reads(
 
 
 @pytest.mark.anyio
+async def test_test_delivery_reads_fresh_without_evicting_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    role: Role,
+) -> None:
+    """A test reads fresh settings without touching any tenant's cache."""
+    organization_a = role.organization_id
+    organization_b = uuid.uuid4()
+    assert organization_a is not None
+    urls = {
+        organization_a: "https://a.example.com/old",
+        organization_b: "https://b.example.com/old",
+    }
+    reads: list[uuid.UUID] = []
+
+    async def get_setting(
+        key: str,
+        *,
+        role: Role | None = None,
+        session: Any = None,
+        default: Any = None,
+    ) -> Any:
+        assert role is not None and role.organization_id is not None
+        assert session is None
+        reads.append(role.organization_id)
+        if key == "audit_webhook_url":
+            return urls[role.organization_id]
+        return default
+
+    monkeypatch.setattr("tracecat.settings.service.get_setting", get_setting)
+    service_a = AuditService(AsyncMock(), role=role)
+    role_b = role.model_copy(update={"organization_id": organization_b})
+    service_b = AuditService(AsyncMock(), role=role_b)
+
+    assert await service_a._get_webhook_url() == "https://a.example.com/old"
+    assert await service_b._get_webhook_url() == "https://b.example.com/old"
+    urls[organization_a] = "https://a.example.com/new"
+    urls[organization_b] = "https://b.example.com/new"
+    event = AuditEvent(
+        organization_id=organization_a,
+        workspace_id=None,
+        actor_type=AuditEventActor.USER,
+        actor_id=uuid.uuid4(),
+        actor_label=None,
+        resource_type="organization_setting",
+        resource_id=None,
+        action="connect",
+        status=AuditEventStatus.SUCCESS,
+    )
+
+    delivery = await AuditService._resolve_test_delivery(
+        sink="organization",
+        organization_id=organization_a,
+        payload=event,
+    )
+
+    assert delivery is not None
+    assert delivery.webhook_url == "https://a.example.com/new"
+    assert await service_b._get_webhook_url() == "https://b.example.com/old"
+    assert reads.count(organization_b) == 1
+
+
+@pytest.mark.anyio
 async def test_post_event_uses_custom_payload_headers_and_verify_ssl(
     monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
 ) -> None:
@@ -1129,7 +1191,13 @@ async def test_create_event_settings_failure_does_not_raise(
     assert "secret-host" not in str(logger_mock.warning.call_args_list)
 
 
-def _delivery(tag: str, url: str = "https://example.com/audit") -> _AuditDelivery:
+def _delivery(
+    tag: str,
+    url: str = "https://example.com/audit",
+    *,
+    organization_id: uuid.UUID | None = None,
+    workspace_id: uuid.UUID | None = None,
+) -> _AuditDelivery:
     """Build a minimal delivery whose resource_id doubles as an identifying tag."""
     return _AuditDelivery(
         webhook_url=url,
@@ -1138,6 +1206,8 @@ def _delivery(tag: str, url: str = "https://example.com/audit") -> _AuditDeliver
         verify_ssl=True,
         resource_type=cast(Any, "workflow"),
         action=cast(Any, "update"),
+        organization_id=organization_id,
+        workspace_id=workspace_id,
     )
 
 
@@ -1243,6 +1313,8 @@ async def test_deliver_http_status_failures_log_status_without_secrets(
         verify_ssl=True,
         resource_type=cast(Any, "workflow"),
         action=cast(Any, "update"),
+        organization_id=None,
+        workspace_id=None,
     )
 
     with patch("tracecat.audit.service.logger.warning", side_effect=capture_warning):
@@ -1261,6 +1333,109 @@ async def test_deliver_http_status_failures_log_status_without_secrets(
     assert webhook_url not in all_logs
     assert payload_marker not in all_logs
     assert str(status_code) in all_logs  # status is present, only as the field
+
+
+@respx.mock
+@pytest.mark.anyio
+async def test_deliver_success_logs_outcome_without_secrets(
+    fresh_delivery_tasks: None,
+) -> None:
+    """A successful delivery logs its outcome and discriminators, never secrets.
+
+    The spawn-time debug line only proves a task started, so this info line is
+    the sole confirmation that the sink actually accepted the event.
+    """
+    webhook_url = "https://secret-host.example.com/audit-hook"
+    payload_marker = "payload-secret-marker"
+    organization_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    respx.post(webhook_url).mock(return_value=httpx.Response(200))
+
+    infos: list[tuple[str, dict[str, object]]] = []
+
+    def capture_info(msg: str, **kwargs: object) -> None:
+        infos.append((msg, kwargs))
+
+    with patch("tracecat.audit.service.logger.info", side_effect=capture_info):
+        _spawn_delivery(
+            _delivery(
+                payload_marker,
+                url=webhook_url,
+                organization_id=organization_id,
+                workspace_id=workspace_id,
+            )
+        )
+        await flush_audit_deliveries()
+
+    delivered = [kwargs for m, kwargs in infos if m == "Delivered audit webhook"]
+    assert len(delivered) == 1
+    kwargs = delivered[0]
+    assert kwargs["status_code"] == 200
+    assert kwargs["attempts"] == 1
+    assert kwargs["retried"] is False
+    assert kwargs["resource_type"] == "workflow"
+    assert kwargs["action"] == "update"
+    assert kwargs["organization_id"] == organization_id
+    assert kwargs["workspace_id"] == workspace_id
+    assert isinstance(kwargs["duration_ms"], int)
+    # Same containment guarantee as the failure path.
+    all_logs = repr(infos)
+    assert webhook_url not in all_logs
+    assert "secret-host" not in all_logs
+    assert payload_marker not in all_logs
+
+
+@respx.mock
+@pytest.mark.anyio
+async def test_deliver_success_after_retry_is_flagged(
+    fresh_delivery_tasks: None,
+) -> None:
+    """A delivery that recovers from a transient failure logs retried=True.
+
+    Without this, a flaky sink is indistinguishable from a healthy one because
+    the eventual success is the only line emitted.
+    """
+    webhook_url = "https://example.com/audit"
+    respx.post(webhook_url).mock(side_effect=[httpx.Response(503), httpx.Response(200)])
+
+    infos: list[tuple[str, dict[str, object]]] = []
+
+    def capture_info(msg: str, **kwargs: object) -> None:
+        infos.append((msg, kwargs))
+
+    with patch("tracecat.audit.service.logger.info", side_effect=capture_info):
+        _spawn_delivery(_delivery("retried"))
+        await flush_audit_deliveries()
+
+    delivered = [kwargs for m, kwargs in infos if m == "Delivered audit webhook"]
+    assert len(delivered) == 1
+    assert delivered[0]["status_code"] == 200
+    assert delivered[0]["attempts"] == 2
+    assert delivered[0]["retried"] is True
+
+
+@respx.mock
+@pytest.mark.anyio
+async def test_deliver_exhausted_retries_logs_no_success(
+    fresh_delivery_tasks: None,
+) -> None:
+    """An exhausted delivery must not emit the success line."""
+    webhook_url = "https://example.com/audit"
+    respx.post(webhook_url).mock(return_value=httpx.Response(500))
+
+    infos: list[tuple[str, dict[str, object]]] = []
+
+    def capture_info(msg: str, **kwargs: object) -> None:
+        infos.append((msg, kwargs))
+
+    with (
+        patch("tracecat.audit.service.logger.info", side_effect=capture_info),
+        patch("tracecat.audit.service.logger.warning"),
+    ):
+        _spawn_delivery(_delivery("exhausted"))
+        await flush_audit_deliveries()
+
+    assert [kwargs for m, kwargs in infos if m == "Delivered audit webhook"] == []
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -31,7 +31,7 @@ from tracecat.audit.service import (
     _AuditDelivery,
     _spawn_delivery,
 )
-from tracecat.audit.types import AuditEvent, AuditMetadata
+from tracecat.audit.types import AuditEvent, AuditMetadata, AuditWebhookConfig
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.auth.users import UserManager
 from tracecat.authz.scopes import ADMIN_SCOPES
@@ -307,14 +307,9 @@ async def test_create_event_streams_exact_payload_contract(
         audit_service, "_get_webhook_url", AsyncMock(return_value=webhook_url)
     )
     monkeypatch.setattr(
-        audit_service, "_get_custom_headers", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(
-        audit_service, "_get_custom_payload", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(audit_service, "_get_verify_ssl", AsyncMock(return_value=True))
-    monkeypatch.setattr(
-        audit_service, "_get_payload_attribute", AsyncMock(return_value=None)
+        audit_service,
+        "_resolve_config",
+        AsyncMock(return_value=AuditWebhookConfig(webhook_url=webhook_url)),
     )
     mock_user = MagicMock()
     mock_user.email = "actor@example.test"
@@ -894,30 +889,20 @@ async def test_post_event_uses_custom_payload_headers_and_verify_ssl(
     webhook_url = "https://example.com/audit"
     monkeypatch.setattr(
         audit_service,
-        "_get_custom_headers",
-        AsyncMock(return_value={"X-Custom-Header": "custom-value"}),
-    )
-    monkeypatch.setattr(
-        audit_service,
-        "_get_custom_payload",
+        "_resolve_config",
         AsyncMock(
-            return_value={
-                "resource_type": "organization",
-                "resource_id": "not-a-uuid",
-                "status": "INVALID_STATUS",
-                "custom": "yes",
-            }
+            return_value=AuditWebhookConfig(
+                webhook_url=webhook_url,
+                custom_headers={"X-Custom-Header": "custom-value"},
+                custom_payload={
+                    "resource_type": "organization",
+                    "resource_id": "not-a-uuid",
+                    "status": "INVALID_STATUS",
+                    "custom": "yes",
+                },
+                verify_ssl=False,
+            )
         ),
-    )
-    monkeypatch.setattr(
-        audit_service,
-        "_get_verify_ssl",
-        AsyncMock(return_value=False),
-    )
-    monkeypatch.setattr(
-        audit_service,
-        "_get_payload_attribute",
-        AsyncMock(return_value=None),
     )
 
     response_mock = MagicMock()
@@ -967,23 +952,15 @@ async def test_post_event_wraps_payload_when_attribute_configured(
     webhook_url = "https://example.com/audit"
     monkeypatch.setattr(
         audit_service,
-        "_get_custom_headers",
-        AsyncMock(return_value={"X-Custom-Header": "custom-value"}),
-    )
-    monkeypatch.setattr(
-        audit_service,
-        "_get_custom_payload",
-        AsyncMock(return_value={"custom": "yes"}),
-    )
-    monkeypatch.setattr(
-        audit_service,
-        "_get_verify_ssl",
-        AsyncMock(return_value=True),
-    )
-    monkeypatch.setattr(
-        audit_service,
-        "_get_payload_attribute",
-        AsyncMock(return_value="event"),
+        "_resolve_config",
+        AsyncMock(
+            return_value=AuditWebhookConfig(
+                webhook_url=webhook_url,
+                custom_headers={"X-Custom-Header": "custom-value"},
+                custom_payload={"custom": "yes"},
+                payload_attribute="event",
+            )
+        ),
     )
 
     response_mock = MagicMock()
@@ -1027,14 +1004,9 @@ async def test_post_event_failure_does_not_log_webhook_url(
 ) -> None:
     webhook_url = "https://secret-host.example.com/audit-hook"
     monkeypatch.setattr(
-        audit_service, "_get_custom_headers", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(
-        audit_service, "_get_custom_payload", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(audit_service, "_get_verify_ssl", AsyncMock(return_value=True))
-    monkeypatch.setattr(
-        audit_service, "_get_payload_attribute", AsyncMock(return_value=None)
+        audit_service,
+        "_resolve_config",
+        AsyncMock(return_value=AuditWebhookConfig(webhook_url=webhook_url)),
     )
 
     client_mock = AsyncMock()
@@ -1107,7 +1079,7 @@ async def test_create_event_settings_failure_does_not_raise(
     )
     monkeypatch.setattr(
         audit_service,
-        "_get_custom_headers",
+        "_resolve_config",
         AsyncMock(side_effect=SQLAlchemyError("settings lookup failed")),
     )
     monkeypatch.setattr(audit_service, "_get_actor_label", AsyncMock(return_value=None))
@@ -1432,14 +1404,9 @@ async def test_decorator_delivers_attempt_and_terminal(
     monkeypatch.setattr(AuditService, "_get_webhook_url", get_webhook_url)
     monkeypatch.setattr(AuditService, "_get_actor_label", get_actor_label)
     monkeypatch.setattr(
-        AuditService, "_get_custom_headers", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(
-        AuditService, "_get_custom_payload", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(AuditService, "_get_verify_ssl", AsyncMock(return_value=True))
-    monkeypatch.setattr(
-        AuditService, "_get_payload_attribute", AsyncMock(return_value=None)
+        AuditService,
+        "_resolve_config",
+        AsyncMock(return_value=AuditWebhookConfig(webhook_url=webhook_url)),
     )
 
     service = _AuditedService(AsyncMock(), role)
@@ -1470,7 +1437,9 @@ async def test_settings_resolution_failure_is_non_fatal_and_leaks_no_url(
     async def get_actor_label(_self: AuditService) -> str | None:
         return None
 
-    async def broken_verify_ssl(_self: AuditService) -> bool:
+    async def broken_resolve_config(
+        _self: AuditService, *, webhook_url: str
+    ) -> AuditWebhookConfig:
         raise RuntimeError("settings backend down")
 
     async def deliver(delivery: _AuditDelivery) -> None:
@@ -1478,16 +1447,7 @@ async def test_settings_resolution_failure_is_non_fatal_and_leaks_no_url(
 
     monkeypatch.setattr(AuditService, "_get_webhook_url", get_webhook_url)
     monkeypatch.setattr(AuditService, "_get_actor_label", get_actor_label)
-    monkeypatch.setattr(
-        AuditService, "_get_custom_headers", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(
-        AuditService, "_get_custom_payload", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(AuditService, "_get_verify_ssl", broken_verify_ssl)
-    monkeypatch.setattr(
-        AuditService, "_get_payload_attribute", AsyncMock(return_value=None)
-    )
+    monkeypatch.setattr(AuditService, "_resolve_config", broken_resolve_config)
 
     warnings: list[tuple[str, dict[str, object]]] = []
 

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -538,43 +538,46 @@ class AuditService(BaseService):
         if not webhook_url:
             raise AuditWebhookNotConfiguredError
 
-        # A probe is a caller-controlled request that echoes the receiver's
-        # status, so an unresolved-to-public URL would be an internal-network
-        # oracle. Reject before any connection; the error carries no address.
-        try:
-            await validate_url_resolves_public_async(
-                webhook_url, default_port=_AUDIT_WEBHOOK_TEST_DEFAULT_PORT
-            )
-        except DisallowedUrlError as exc:
-            raise AuditWebhookUrlNotAllowedError from exc
-
-        event = cls._build_test_event(
-            sink=sink, organization_id=organization_id, role=role
-        )
-        delivery = cls._assemble_delivery(
-            webhook_url=webhook_url,
-            payload=event,
-            custom_headers=cls._normalize_custom_headers(
-                settings.audit_webhook_custom_headers
-            ),
-            custom_payload=cls._normalize_custom_payload(
-                settings.audit_webhook_custom_payload
-            ),
-            verify_ssl=cls._normalize_verify_ssl(settings.audit_webhook_verify_ssl),
-            payload_attribute=cls._normalize_payload_attribute(
-                settings.audit_webhook_payload_attribute
-            ),
-        )
-
-        headers = {
-            key: value
-            for key, value in (delivery.headers or {}).items()
-            if key.lower() != _TEST_HEADER.lower()
-        }
-        headers[_TEST_HEADER] = "true"
-
         try:
             async with asyncio.timeout(_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS):
+                # A probe is a caller-controlled request that echoes the
+                # receiver's status, so an unresolved-to-public URL would be an
+                # internal-network oracle. Reject before any connection; the
+                # error carries no address.
+                try:
+                    await validate_url_resolves_public_async(
+                        webhook_url, default_port=_AUDIT_WEBHOOK_TEST_DEFAULT_PORT
+                    )
+                except DisallowedUrlError as exc:
+                    raise AuditWebhookUrlNotAllowedError from exc
+
+                event = cls._build_test_event(
+                    sink=sink, organization_id=organization_id, role=role
+                )
+                delivery = cls._assemble_delivery(
+                    webhook_url=webhook_url,
+                    payload=event,
+                    custom_headers=cls._normalize_custom_headers(
+                        settings.audit_webhook_custom_headers
+                    ),
+                    custom_payload=cls._normalize_custom_payload(
+                        settings.audit_webhook_custom_payload
+                    ),
+                    verify_ssl=cls._normalize_verify_ssl(
+                        settings.audit_webhook_verify_ssl
+                    ),
+                    payload_attribute=cls._normalize_payload_attribute(
+                        settings.audit_webhook_payload_attribute
+                    ),
+                )
+
+                headers = {
+                    key: value
+                    for key, value in (delivery.headers or {}).items()
+                    if key.lower() != _TEST_HEADER.lower()
+                }
+                headers[_TEST_HEADER] = "true"
+
                 # Probes share the process-wide socket budget with live
                 # delivery; one that cannot get a slot within the wall clock
                 # times out instead of queueing without bound.

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -15,13 +15,12 @@ import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Literal, Self
+from typing import Any, Self
 
 import httpx
 import orjson
 from async_lru import alru_cache
 from cryptography.fernet import InvalidToken
-from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from tenacity import (
@@ -51,9 +50,14 @@ from tracecat.db.engine import (
 from tracecat.db.models import PlatformSetting, ServiceAccount, User
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
+from tracecat.network import (
+    DisallowedUrlError,
+    validate_url_resolves_public_async,
+)
 from tracecat.sanitization import redact_sensitive_text
 from tracecat.secrets.encryption import decrypt_value
 from tracecat.service import BaseService
+from tracecat.settings.schemas import AuditSettingsUpdate, AuditWebhookTestResult
 
 # Union type for roles that can be used for audit logging
 AuditableRole = Role | PlatformRole
@@ -223,18 +227,21 @@ async def _fetch_platform_setting(key: str) -> Any | None:
     return orjson.loads(value)
 
 
-async def _read_audit_setting(
+@alru_cache(ttl=30)
+async def _get_audit_setting_cached(
     sink: AuditSink,
     organization_id: OrganizationID | None,
     key: str,
     default: Any = None,
 ) -> Any | None:
-    """Uncached audit-setting read on its own short-lived session.
+    """Cached audit-setting read keyed by (sink, org, key, default).
 
-    ``organization_id`` is ``None`` for the platform sink or org-sink calls
-    with no org identity. Decrypted values live in process memory only and are
-    never logged.
+    Runs on its own session so no request session is captured or hashed; bounded
+    30s staleness. ``organization_id`` is ``None`` for the platform sink or
+    org-sink calls with no org identity. Decrypted values live in process memory
+    only and are never logged.
     """
+    logger.debug("Audit setting cache miss", sink=sink, key=key)
     if sink == "platform":
         value = await _fetch_platform_setting(key)
         return default if value is None and default is not None else value
@@ -253,22 +260,6 @@ async def _read_audit_setting(
     return await get_setting(key, role=role, session=None, default=default)
 
 
-@alru_cache(ttl=30)
-async def _get_audit_setting_cached(
-    sink: AuditSink,
-    organization_id: OrganizationID | None,
-    key: str,
-    default: Any = None,
-) -> Any | None:
-    """Cached audit-setting read keyed by (sink, org, key, default).
-
-    Runs on its own session so no request session is captured or hashed;
-    bounded 30s staleness.
-    """
-    logger.debug("Audit setting cache miss", sink=sink, key=key)
-    return await _read_audit_setting(sink, organization_id, key, default)
-
-
 def clear_audit_setting_cache() -> None:
     """Make committed audit setting changes visible to the next event."""
     _get_audit_setting_cached.cache_clear()
@@ -278,23 +269,17 @@ _AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS = 5.0
 
 _TEST_HEADER = "X-Tracecat-Test"
 
-AuditWebhookTestErrorCategory = Literal[
-    "receiver_error",
-    "timeout",
-    "request_error",
-]
-
 
 class AuditWebhookNotConfiguredError(Exception):
     """Raised when an audit webhook test is requested without a sink."""
 
 
-class AuditWebhookTestResult(BaseModel):
-    """Result of a synchronous audit webhook test-fire request."""
+class AuditWebhookUrlNotAllowedError(Exception):
+    """Raised when a probe URL resolves to a non-public address."""
 
-    ok: bool
-    receiver_status_code: int | None = None
-    error_category: AuditWebhookTestErrorCategory | None = None
+
+# Probe posts happen over unpadded default HTTP/HTTPS ports when none is given.
+_AUDIT_WEBHOOK_TEST_DEFAULT_PORT = 443
 
 
 class AuditService(BaseService):
@@ -539,22 +524,47 @@ class AuditService(BaseService):
         sink: AuditSink,
         organization_id: OrganizationID | None,
         role: AuditableRole,
+        settings: AuditSettingsUpdate,
     ) -> AuditWebhookTestResult:
-        """Post one marked test event and report the receiver's response.
+        """Post one marked test event to the submitted webhook configuration.
 
-        Reuses the real payload assembly and delivery headers so a passing
-        probe exercises the same request shape as live delivery.
+        Probes the caller-provided settings rather than persisted state, so a
+        connection can be tested while it is being configured and a save can be
+        verified with exactly the values that were just written. Reuses the
+        real payload assembly and delivery headers so a passing probe exercises
+        the same request shape as live delivery. Never touches the database.
         """
+        webhook_url = cls._normalize_webhook_url(settings.audit_webhook_url)
+        if not webhook_url:
+            raise AuditWebhookNotConfiguredError
+
+        # A probe is a caller-controlled request that echoes the receiver's
+        # status, so an unresolved-to-public URL would be an internal-network
+        # oracle. Reject before any connection; the error carries no address.
+        try:
+            await validate_url_resolves_public_async(
+                webhook_url, default_port=_AUDIT_WEBHOOK_TEST_DEFAULT_PORT
+            )
+        except DisallowedUrlError as exc:
+            raise AuditWebhookUrlNotAllowedError from exc
+
         event = cls._build_test_event(
             sink=sink, organization_id=organization_id, role=role
         )
-        delivery = await cls._resolve_test_delivery(
-            sink=sink,
-            organization_id=organization_id,
+        delivery = cls._assemble_delivery(
+            webhook_url=webhook_url,
             payload=event,
+            custom_headers=cls._normalize_custom_headers(
+                settings.audit_webhook_custom_headers
+            ),
+            custom_payload=cls._normalize_custom_payload(
+                settings.audit_webhook_custom_payload
+            ),
+            verify_ssl=cls._normalize_verify_ssl(settings.audit_webhook_verify_ssl),
+            payload_attribute=cls._normalize_payload_attribute(
+                settings.audit_webhook_payload_attribute
+            ),
         )
-        if delivery is None:
-            raise AuditWebhookNotConfiguredError
 
         headers = {
             key: value
@@ -565,15 +575,24 @@ class AuditService(BaseService):
 
         try:
             async with asyncio.timeout(_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS):
-                async with httpx.AsyncClient(
-                    timeout=_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS,
-                    verify=delivery.verify_ssl,
-                ) as client:
-                    response = await client.post(
-                        delivery.webhook_url,
-                        json=delivery.request_payload,
-                        headers=headers,
-                    )
+                # Probes share the process-wide socket budget with live
+                # delivery; one that cannot get a slot within the wall clock
+                # times out instead of queueing without bound.
+                async with _get_post_semaphore():
+                    async with httpx.AsyncClient(
+                        timeout=_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS,
+                        verify=delivery.verify_ssl,
+                    ) as client:
+                        # Stream so the receiver's body is never buffered; the
+                        # probe only ever reads the status line.
+                        async with client.stream(
+                            "POST",
+                            delivery.webhook_url,
+                            json=delivery.request_payload,
+                            headers=headers,
+                        ) as response:
+                            ok = response.is_success
+                            receiver_status_code = response.status_code
         except (TimeoutError, httpx.TimeoutException) as exc:
             logger.warning(
                 "Audit webhook test timed out",
@@ -589,10 +608,9 @@ class AuditService(BaseService):
             )
             return AuditWebhookTestResult(ok=False, error_category="request_error")
 
-        ok = response.is_success
         return AuditWebhookTestResult(
             ok=ok,
-            receiver_status_code=response.status_code,
+            receiver_status_code=receiver_status_code,
             error_category=None if ok else "receiver_error",
         )
 
@@ -624,58 +642,6 @@ class AuditService(BaseService):
             action="connect",
             status=AuditEventStatus.SUCCESS,
             data={"test": True},
-        )
-
-    @classmethod
-    async def _resolve_test_delivery(
-        cls,
-        *,
-        sink: AuditSink,
-        organization_id: OrganizationID | None,
-        payload: AuditEvent,
-    ) -> _AuditDelivery | None:
-        """Resolve a test delivery from uncached settings reads.
-
-        Each sequential read opens and closes its own short-lived session, so a
-        probe fired right after a save tests the saved settings on any replica,
-        and the returned delivery posts without holding a database connection.
-        """
-        if sink == "organization" and organization_id is None:
-            raise ValueError("Organization audit settings require an organization ID")
-
-        webhook_url = cls._normalize_webhook_url(
-            await _read_audit_setting(sink, organization_id, "audit_webhook_url")
-        )
-        if not webhook_url:
-            return None
-
-        custom_headers = cls._normalize_custom_headers(
-            await _read_audit_setting(
-                sink, organization_id, "audit_webhook_custom_headers"
-            )
-        )
-        custom_payload = cls._normalize_custom_payload(
-            await _read_audit_setting(
-                sink, organization_id, "audit_webhook_custom_payload"
-            )
-        )
-        verify_ssl = cls._normalize_verify_ssl(
-            await _read_audit_setting(
-                sink, organization_id, "audit_webhook_verify_ssl", True
-            )
-        )
-        payload_attribute = cls._normalize_payload_attribute(
-            await _read_audit_setting(
-                sink, organization_id, "audit_webhook_payload_attribute"
-            )
-        )
-        return cls._assemble_delivery(
-            webhook_url=webhook_url,
-            payload=payload,
-            custom_headers=custom_headers,
-            custom_payload=custom_payload,
-            verify_ssl=verify_ssl,
-            payload_attribute=payload_attribute,
         )
 
     async def _post_event(self, *, webhook_url: str, payload: AuditEvent) -> None:

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -10,16 +10,18 @@ ENG-1514 spool.
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 import httpx
 import orjson
 from async_lru import alru_cache
 from cryptography.fernet import InvalidToken
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from tenacity import (
@@ -69,9 +71,12 @@ class _AuditDelivery:
     request_payload: dict[str, Any]
     headers: dict[str, str] | None
     verify_ssl: bool
-    # Non-sensitive discriminators for failure logging; never the payload contents.
+    # Non-sensitive discriminators for delivery logging; never the payload
+    # contents and never the sink URL, whose path may carry a credential.
     resource_type: AuditResourceType
     action: AuditAction
+    organization_id: uuid.UUID | None
+    workspace_id: uuid.UUID | None
 
 
 # Strong refs to in-flight delivery tasks; done callbacks release them.
@@ -143,6 +148,7 @@ async def _deliver(delivery: _AuditDelivery) -> None:
     """
     response: httpx.Response | None = None
     attempts = 0
+    started = time.perf_counter()
     try:
         # One slot spans all attempts; the socket itself is only open per post.
         async with _get_post_semaphore():
@@ -173,8 +179,27 @@ async def _deliver(delivery: _AuditDelivery) -> None:
             status_code=response.status_code if response is not None else None,
             resource_type=delivery.resource_type,
             action=delivery.action,
+            organization_id=delivery.organization_id,
+            workspace_id=delivery.workspace_id,
             attempts=attempts,
+            duration_ms=round((time.perf_counter() - started) * 1000),
         )
+        return
+    # Confirms the sink actually accepted the event, which the spawn-time
+    # "Streamed audit event" line cannot. `retried` flags a delivery that
+    # recovered from a transient failure. Same discriminators as the failure
+    # path: no payload contents, no sink URL.
+    logger.info(
+        "Delivered audit webhook",
+        status_code=response.status_code if response is not None else None,
+        resource_type=delivery.resource_type,
+        action=delivery.action,
+        organization_id=delivery.organization_id,
+        workspace_id=delivery.workspace_id,
+        attempts=attempts,
+        retried=attempts > 1,
+        duration_ms=round((time.perf_counter() - started) * 1000),
+    )
 
 
 async def _fetch_platform_setting(key: str) -> Any | None:
@@ -198,21 +223,18 @@ async def _fetch_platform_setting(key: str) -> Any | None:
     return orjson.loads(value)
 
 
-@alru_cache(ttl=30)
-async def _get_audit_setting_cached(
+async def _read_audit_setting(
     sink: AuditSink,
     organization_id: OrganizationID | None,
     key: str,
     default: Any = None,
 ) -> Any | None:
-    """Cached audit-setting read keyed by (sink, org, key, default).
+    """Uncached audit-setting read on its own short-lived session.
 
-    Runs on its own session so no request session is captured or hashed; bounded
-    30s staleness. ``organization_id`` is ``None`` for the platform sink or
-    org-sink calls with no org identity. Decrypted values live in process memory
-    only and are never logged.
+    ``organization_id`` is ``None`` for the platform sink or org-sink calls
+    with no org identity. Decrypted values live in process memory only and are
+    never logged.
     """
-    logger.debug("Audit setting cache miss", sink=sink, key=key)
     if sink == "platform":
         value = await _fetch_platform_setting(key)
         return default if value is None and default is not None else value
@@ -231,9 +253,48 @@ async def _get_audit_setting_cached(
     return await get_setting(key, role=role, session=None, default=default)
 
 
+@alru_cache(ttl=30)
+async def _get_audit_setting_cached(
+    sink: AuditSink,
+    organization_id: OrganizationID | None,
+    key: str,
+    default: Any = None,
+) -> Any | None:
+    """Cached audit-setting read keyed by (sink, org, key, default).
+
+    Runs on its own session so no request session is captured or hashed;
+    bounded 30s staleness.
+    """
+    logger.debug("Audit setting cache miss", sink=sink, key=key)
+    return await _read_audit_setting(sink, organization_id, key, default)
+
+
 def clear_audit_setting_cache() -> None:
     """Make committed audit setting changes visible to the next event."""
     _get_audit_setting_cached.cache_clear()
+
+
+_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS = 5.0
+
+_TEST_HEADER = "X-Tracecat-Test"
+
+AuditWebhookTestErrorCategory = Literal[
+    "receiver_error",
+    "timeout",
+    "request_error",
+]
+
+
+class AuditWebhookNotConfiguredError(Exception):
+    """Raised when an audit webhook test is requested without a sink."""
+
+
+class AuditWebhookTestResult(BaseModel):
+    """Result of a synchronous audit webhook test-fire request."""
+
+    ok: bool
+    receiver_status_code: int | None = None
+    error_category: AuditWebhookTestErrorCategory | None = None
 
 
 class AuditService(BaseService):
@@ -318,11 +379,17 @@ class AuditService(BaseService):
         2. Organization setting `audit_webhook_url`
         """
 
-        value = await self._get_audit_setting("audit_webhook_url")
+        return self._normalize_webhook_url(
+            await self._get_audit_setting("audit_webhook_url")
+        )
+
+    @staticmethod
+    def _normalize_webhook_url(value: Any) -> str | None:
+        """Validate and normalize a stored audit webhook URL."""
         if value is None:
             return None
         if not isinstance(value, str):
-            self.logger.warning(
+            logger.warning(
                 "audit_webhook_url must be a string",
                 value_type=type(value),
             )
@@ -337,11 +404,17 @@ class AuditService(BaseService):
         Note: reads are cached with a 30s TTL, so setting changes take effect
         within that bounded window rather than immediately.
         """
-        value = await self._get_audit_setting("audit_webhook_custom_headers")
+        return self._normalize_custom_headers(
+            await self._get_audit_setting("audit_webhook_custom_headers")
+        )
+
+    @staticmethod
+    def _normalize_custom_headers(value: Any) -> dict[str, str] | None:
+        """Validate stored custom audit webhook headers."""
         if value is None:
             return None
         if not isinstance(value, dict):
-            self.logger.warning(
+            logger.warning(
                 "audit_webhook_custom_headers must be a dict",
                 value_type=type(value),
             )
@@ -351,11 +424,17 @@ class AuditService(BaseService):
 
     async def _get_custom_payload(self) -> dict[str, Any] | None:
         """Fetch the configured custom payload for the audit webhook."""
-        value = await self._get_audit_setting("audit_webhook_custom_payload")
+        return self._normalize_custom_payload(
+            await self._get_audit_setting("audit_webhook_custom_payload")
+        )
+
+    @staticmethod
+    def _normalize_custom_payload(value: Any) -> dict[str, Any] | None:
+        """Validate a stored custom audit webhook payload."""
         if value is None:
             return None
         if not isinstance(value, dict):
-            self.logger.warning(
+            logger.warning(
                 "audit_webhook_custom_payload must be a dict",
                 value_type=type(value),
             )
@@ -364,9 +443,15 @@ class AuditService(BaseService):
 
     async def _get_verify_ssl(self) -> bool:
         """Fetch SSL verification setting for audit webhook requests."""
-        value = await self._get_audit_setting("audit_webhook_verify_ssl", default=True)
+        return self._normalize_verify_ssl(
+            await self._get_audit_setting("audit_webhook_verify_ssl", default=True)
+        )
+
+    @staticmethod
+    def _normalize_verify_ssl(value: Any) -> bool:
+        """Validate the stored audit webhook TLS verification setting."""
         if not isinstance(value, bool):
-            self.logger.warning(
+            logger.warning(
                 "audit_webhook_verify_ssl must be a bool",
                 value_type=type(value),
             )
@@ -375,11 +460,17 @@ class AuditService(BaseService):
 
     async def _get_payload_attribute(self) -> str | None:
         """Fetch optional wrapper attribute for webhook payloads."""
-        value = await self._get_audit_setting("audit_webhook_payload_attribute")
+        return self._normalize_payload_attribute(
+            await self._get_audit_setting("audit_webhook_payload_attribute")
+        )
+
+    @staticmethod
+    def _normalize_payload_attribute(value: Any) -> str | None:
+        """Validate and normalize the stored payload wrapper attribute."""
         if value is None:
             return None
         if not isinstance(value, str):
-            self.logger.warning(
+            logger.warning(
                 "audit_webhook_payload_attribute must be a string",
                 value_type=type(value),
             )
@@ -400,6 +491,26 @@ class AuditService(BaseService):
         custom_payload = await self._get_custom_payload()
         verify_ssl = await self._get_verify_ssl()
         payload_attribute = await self._get_payload_attribute()
+        return self._assemble_delivery(
+            webhook_url=webhook_url,
+            payload=payload,
+            custom_headers=custom_headers,
+            custom_payload=custom_payload,
+            verify_ssl=verify_ssl,
+            payload_attribute=payload_attribute,
+        )
+
+    @staticmethod
+    def _assemble_delivery(
+        *,
+        webhook_url: str,
+        payload: AuditEvent,
+        custom_headers: dict[str, str] | None,
+        custom_payload: dict[str, Any] | None,
+        verify_ssl: bool,
+        payload_attribute: str | None,
+    ) -> _AuditDelivery:
+        """Assemble a detached delivery from already-resolved settings."""
         event_payload = payload.model_dump(mode="json")
         if custom_payload:
             # Custom fields may enrich an event but cannot replace the canonical
@@ -417,6 +528,154 @@ class AuditService(BaseService):
             verify_ssl=verify_ssl,
             resource_type=payload.resource_type,
             action=payload.action,
+            organization_id=payload.organization_id,
+            workspace_id=payload.workspace_id,
+        )
+
+    @classmethod
+    async def probe_webhook(
+        cls,
+        *,
+        sink: AuditSink,
+        organization_id: OrganizationID | None,
+        role: AuditableRole,
+    ) -> AuditWebhookTestResult:
+        """Post one marked test event and report the receiver's response.
+
+        Reuses the real payload assembly and delivery headers so a passing
+        probe exercises the same request shape as live delivery.
+        """
+        event = cls._build_test_event(
+            sink=sink, organization_id=organization_id, role=role
+        )
+        delivery = await cls._resolve_test_delivery(
+            sink=sink,
+            organization_id=organization_id,
+            payload=event,
+        )
+        if delivery is None:
+            raise AuditWebhookNotConfiguredError
+
+        headers = {
+            key: value
+            for key, value in (delivery.headers or {}).items()
+            if key.lower() != _TEST_HEADER.lower()
+        }
+        headers[_TEST_HEADER] = "true"
+
+        try:
+            async with asyncio.timeout(_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS):
+                async with httpx.AsyncClient(
+                    timeout=_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS,
+                    verify=delivery.verify_ssl,
+                ) as client:
+                    response = await client.post(
+                        delivery.webhook_url,
+                        json=delivery.request_payload,
+                        headers=headers,
+                    )
+        except (TimeoutError, httpx.TimeoutException) as exc:
+            logger.warning(
+                "Audit webhook test timed out",
+                sink=sink,
+                error_type=type(exc).__name__,
+            )
+            return AuditWebhookTestResult(ok=False, error_category="timeout")
+        except httpx.RequestError as exc:
+            logger.warning(
+                "Audit webhook test request failed",
+                sink=sink,
+                error_type=type(exc).__name__,
+            )
+            return AuditWebhookTestResult(ok=False, error_category="request_error")
+
+        ok = response.is_success
+        return AuditWebhookTestResult(
+            ok=ok,
+            receiver_status_code=response.status_code,
+            error_category=None if ok else "receiver_error",
+        )
+
+    @staticmethod
+    def _build_test_event(
+        *,
+        sink: AuditSink,
+        organization_id: OrganizationID | None,
+        role: AuditableRole,
+    ) -> AuditEvent:
+        """Build the clearly-marked synthetic event a probe delivers."""
+        actor_id = role.actor_id
+        if actor_id is None:
+            raise ValueError("Audit webhook test requires an auditable actor")
+        resource_type = (
+            "platform_setting" if sink == "platform" else "organization_setting"
+        )
+        request_audit = ctx_request_audit.get()
+        return AuditEvent(
+            organization_id=organization_id,
+            workspace_id=role.workspace_id if isinstance(role, Role) else None,
+            actor_type=AuditEventActor.USER,
+            actor_id=actor_id,
+            actor_label=None,
+            ip_address=request_audit.client_ip if request_audit is not None else None,
+            user_agent=request_audit.user_agent if request_audit is not None else None,
+            resource_type=resource_type,
+            resource_id=None,
+            action="connect",
+            status=AuditEventStatus.SUCCESS,
+            data={"test": True},
+        )
+
+    @classmethod
+    async def _resolve_test_delivery(
+        cls,
+        *,
+        sink: AuditSink,
+        organization_id: OrganizationID | None,
+        payload: AuditEvent,
+    ) -> _AuditDelivery | None:
+        """Resolve a test delivery from uncached settings reads.
+
+        Each sequential read opens and closes its own short-lived session, so a
+        probe fired right after a save tests the saved settings on any replica,
+        and the returned delivery posts without holding a database connection.
+        """
+        if sink == "organization" and organization_id is None:
+            raise ValueError("Organization audit settings require an organization ID")
+
+        webhook_url = cls._normalize_webhook_url(
+            await _read_audit_setting(sink, organization_id, "audit_webhook_url")
+        )
+        if not webhook_url:
+            return None
+
+        custom_headers = cls._normalize_custom_headers(
+            await _read_audit_setting(
+                sink, organization_id, "audit_webhook_custom_headers"
+            )
+        )
+        custom_payload = cls._normalize_custom_payload(
+            await _read_audit_setting(
+                sink, organization_id, "audit_webhook_custom_payload"
+            )
+        )
+        verify_ssl = cls._normalize_verify_ssl(
+            await _read_audit_setting(
+                sink, organization_id, "audit_webhook_verify_ssl", True
+            )
+        )
+        payload_attribute = cls._normalize_payload_attribute(
+            await _read_audit_setting(
+                sink, organization_id, "audit_webhook_payload_attribute"
+            )
+        )
+        return cls._assemble_delivery(
+            webhook_url=webhook_url,
+            payload=payload,
+            custom_headers=custom_headers,
+            custom_payload=custom_payload,
+            verify_ssl=verify_ssl,
+            payload_attribute=payload_attribute,
         )
 
     async def _post_event(self, *, webhook_url: str, payload: AuditEvent) -> None:

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -39,6 +39,7 @@ from tracecat.audit.types import (
     AuditMetadataValue,
     AuditResourceType,
     AuditSink,
+    AuditWebhookConfig,
 )
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import PlatformRole, Role
@@ -278,10 +279,6 @@ class AuditWebhookUrlNotAllowedError(Exception):
     """Raised when a probe URL resolves to a non-public address."""
 
 
-# Probe posts happen over unpadded default HTTP/HTTPS ports when none is given.
-_AUDIT_WEBHOOK_TEST_DEFAULT_PORT = 443
-
-
 class AuditService(BaseService):
     """Stream user-driven events to an audit webhook if configured.
 
@@ -364,17 +361,11 @@ class AuditService(BaseService):
         2. Organization setting `audit_webhook_url`
         """
 
-        return self._normalize_webhook_url(
-            await self._get_audit_setting("audit_webhook_url")
-        )
-
-    @staticmethod
-    def _normalize_webhook_url(value: Any) -> str | None:
-        """Validate and normalize a stored audit webhook URL."""
+        value = await self._get_audit_setting("audit_webhook_url")
         if value is None:
             return None
         if not isinstance(value, str):
-            logger.warning(
+            self.logger.warning(
                 "audit_webhook_url must be a string",
                 value_type=type(value),
             )
@@ -383,86 +374,53 @@ class AuditService(BaseService):
         cleaned = value.strip()
         return cleaned or None
 
-    async def _get_custom_headers(self) -> dict[str, str] | None:
-        """Fetch the configured custom headers for the audit webhook.
-
-        Note: reads are cached with a 30s TTL, so setting changes take effect
-        within that bounded window rather than immediately.
-        """
-        return self._normalize_custom_headers(
-            await self._get_audit_setting("audit_webhook_custom_headers")
-        )
-
-    @staticmethod
-    def _normalize_custom_headers(value: Any) -> dict[str, str] | None:
-        """Validate stored custom audit webhook headers."""
-        if value is None:
-            return None
-        if not isinstance(value, dict):
-            logger.warning(
+    async def _resolve_config(self, *, webhook_url: str) -> AuditWebhookConfig:
+        """Resolve loosely typed stored settings into one delivery config."""
+        custom_headers = await self._get_audit_setting("audit_webhook_custom_headers")
+        if custom_headers is not None and not isinstance(custom_headers, dict):
+            self.logger.warning(
                 "audit_webhook_custom_headers must be a dict",
-                value_type=type(value),
+                value_type=type(custom_headers),
             )
-            return None
+            custom_headers = None
 
-        return value
-
-    async def _get_custom_payload(self) -> dict[str, Any] | None:
-        """Fetch the configured custom payload for the audit webhook."""
-        return self._normalize_custom_payload(
-            await self._get_audit_setting("audit_webhook_custom_payload")
-        )
-
-    @staticmethod
-    def _normalize_custom_payload(value: Any) -> dict[str, Any] | None:
-        """Validate a stored custom audit webhook payload."""
-        if value is None:
-            return None
-        if not isinstance(value, dict):
-            logger.warning(
+        custom_payload = await self._get_audit_setting("audit_webhook_custom_payload")
+        if custom_payload is not None and not isinstance(custom_payload, dict):
+            self.logger.warning(
                 "audit_webhook_custom_payload must be a dict",
-                value_type=type(value),
+                value_type=type(custom_payload),
             )
-            return None
-        return value
+            custom_payload = None
 
-    async def _get_verify_ssl(self) -> bool:
-        """Fetch SSL verification setting for audit webhook requests."""
-        return self._normalize_verify_ssl(
-            await self._get_audit_setting("audit_webhook_verify_ssl", default=True)
+        verify_ssl = await self._get_audit_setting(
+            "audit_webhook_verify_ssl", default=True
         )
-
-    @staticmethod
-    def _normalize_verify_ssl(value: Any) -> bool:
-        """Validate the stored audit webhook TLS verification setting."""
-        if not isinstance(value, bool):
-            logger.warning(
+        if not isinstance(verify_ssl, bool):
+            self.logger.warning(
                 "audit_webhook_verify_ssl must be a bool",
-                value_type=type(value),
+                value_type=type(verify_ssl),
             )
-            return True
-        return value
+            verify_ssl = True
 
-    async def _get_payload_attribute(self) -> str | None:
-        """Fetch optional wrapper attribute for webhook payloads."""
-        return self._normalize_payload_attribute(
-            await self._get_audit_setting("audit_webhook_payload_attribute")
+        payload_attribute = await self._get_audit_setting(
+            "audit_webhook_payload_attribute"
         )
-
-    @staticmethod
-    def _normalize_payload_attribute(value: Any) -> str | None:
-        """Validate and normalize the stored payload wrapper attribute."""
-        if value is None:
-            return None
-        if not isinstance(value, str):
-            logger.warning(
+        if payload_attribute is not None and not isinstance(payload_attribute, str):
+            self.logger.warning(
                 "audit_webhook_payload_attribute must be a string",
-                value_type=type(value),
+                value_type=type(payload_attribute),
             )
-            return None
+            payload_attribute = None
+        elif payload_attribute is not None:
+            payload_attribute = payload_attribute.strip() or None
 
-        cleaned = value.strip()
-        return cleaned or None
+        return AuditWebhookConfig(
+            webhook_url=webhook_url,
+            custom_headers=custom_headers,
+            custom_payload=custom_payload,
+            verify_ssl=verify_ssl,
+            payload_attribute=payload_attribute,
+        )
 
     async def _build_delivery(
         self, *, webhook_url: str, payload: AuditEvent
@@ -472,45 +430,31 @@ class AuditService(BaseService):
         Runs while the request session is live; the returned delivery needs no
         session and is safe to post from a detached background task.
         """
-        custom_headers = await self._get_custom_headers()
-        custom_payload = await self._get_custom_payload()
-        verify_ssl = await self._get_verify_ssl()
-        payload_attribute = await self._get_payload_attribute()
-        return self._assemble_delivery(
-            webhook_url=webhook_url,
-            payload=payload,
-            custom_headers=custom_headers,
-            custom_payload=custom_payload,
-            verify_ssl=verify_ssl,
-            payload_attribute=payload_attribute,
-        )
+        config = await self._resolve_config(webhook_url=webhook_url)
+        return self._assemble_delivery(config=config, payload=payload)
 
     @staticmethod
     def _assemble_delivery(
         *,
-        webhook_url: str,
+        config: AuditWebhookConfig,
         payload: AuditEvent,
-        custom_headers: dict[str, str] | None,
-        custom_payload: dict[str, Any] | None,
-        verify_ssl: bool,
-        payload_attribute: str | None,
     ) -> _AuditDelivery:
         """Assemble a detached delivery from already-resolved settings."""
         event_payload = payload.model_dump(mode="json")
-        if custom_payload:
+        if config.custom_payload:
             # Custom fields may enrich an event but cannot replace the canonical
             # audit contract with invalid or misleading values.
-            event_payload = {**custom_payload, **event_payload}
+            event_payload = {**config.custom_payload, **event_payload}
         request_payload: dict[str, Any]
-        if payload_attribute:
-            request_payload = {payload_attribute: event_payload}
+        if config.payload_attribute:
+            request_payload = {config.payload_attribute: event_payload}
         else:
             request_payload = event_payload
         return _AuditDelivery(
-            webhook_url=webhook_url,
+            webhook_url=config.webhook_url,
             request_payload=request_payload,
-            headers=custom_headers,
-            verify_ssl=verify_ssl,
+            headers=config.custom_headers,
+            verify_ssl=config.verify_ssl,
             resource_type=payload.resource_type,
             action=payload.action,
             organization_id=payload.organization_id,
@@ -534,9 +478,21 @@ class AuditService(BaseService):
         real payload assembly and delivery headers so a passing probe exercises
         the same request shape as live delivery. Never touches the database.
         """
-        webhook_url = cls._normalize_webhook_url(settings.audit_webhook_url)
+        webhook_url = (settings.audit_webhook_url or "").strip()
         if not webhook_url:
             raise AuditWebhookNotConfiguredError
+        payload_attribute = settings.audit_webhook_payload_attribute
+        config = AuditWebhookConfig(
+            webhook_url=webhook_url,
+            custom_headers=settings.audit_webhook_custom_headers,
+            custom_payload=settings.audit_webhook_custom_payload,
+            verify_ssl=settings.audit_webhook_verify_ssl,
+            payload_attribute=(
+                payload_attribute.strip() or None
+                if payload_attribute is not None
+                else None
+            ),
+        )
 
         try:
             async with asyncio.timeout(_AUDIT_WEBHOOK_TEST_TIMEOUT_SECONDS):
@@ -545,31 +501,14 @@ class AuditService(BaseService):
                 # internal-network oracle. Reject before any connection; the
                 # error carries no address.
                 try:
-                    await validate_url_resolves_public_async(
-                        webhook_url, default_port=_AUDIT_WEBHOOK_TEST_DEFAULT_PORT
-                    )
+                    await validate_url_resolves_public_async(webhook_url)
                 except DisallowedUrlError as exc:
                     raise AuditWebhookUrlNotAllowedError from exc
 
                 event = cls._build_test_event(
                     sink=sink, organization_id=organization_id, role=role
                 )
-                delivery = cls._assemble_delivery(
-                    webhook_url=webhook_url,
-                    payload=event,
-                    custom_headers=cls._normalize_custom_headers(
-                        settings.audit_webhook_custom_headers
-                    ),
-                    custom_payload=cls._normalize_custom_payload(
-                        settings.audit_webhook_custom_payload
-                    ),
-                    verify_ssl=cls._normalize_verify_ssl(
-                        settings.audit_webhook_verify_ssl
-                    ),
-                    payload_attribute=cls._normalize_payload_attribute(
-                        settings.audit_webhook_payload_attribute
-                    ),
-                )
+                delivery = cls._assemble_delivery(config=config, payload=event)
 
                 headers = {
                     key: value

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -25,6 +25,7 @@ AuditAction = Literal[
     "accept",
     "revoke",
     "sign_in",
+    "connect",
     "sync",
     "promote",
     "demote",

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -12,6 +13,19 @@ from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 AuditSink = Literal["organization", "platform"]
 type AuditMetadataValue = str | bool | int | None | list[str]
 type AuditMetadata = Mapping[str, AuditMetadataValue]
+
+
+@dataclass(frozen=True, slots=True)
+class AuditWebhookConfig:
+    """Validated settings used to assemble an audit webhook delivery."""
+
+    webhook_url: str
+    custom_headers: dict[str, str] | None = None
+    custom_payload: dict[str, Any] | None = None
+    verify_ssl: bool = True
+    payload_attribute: str | None = None
+
+
 AuditAction = Literal[
     "create",
     "update",

--- a/tracecat/integrations/providers/base.py
+++ b/tracecat/integrations/providers/base.py
@@ -31,12 +31,11 @@ from tracecat.integrations.types import (
 from tracecat.logger import logger
 from tracecat.network import (
     DisallowedUrlError,
+    SocketInfo,
     is_disallowed_address,
     validate_resolved_addresses,
 )
 
-SocketAddress = tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes]
-SocketInfo = tuple[socket.AddressFamily, socket.SocketKind, int, str, SocketAddress]
 _OAUTH_AUTHORIZATION_SERVER_WELL_KNOWN = "/.well-known/oauth-authorization-server"
 
 
@@ -218,12 +217,15 @@ def validate_oauth_endpoint_resolves_public(
         raise ValueError(f"OAuth endpoint must include a hostname: {url}")
     port = parsed.port or 443
     try:
-        infos = socket.getaddrinfo(
-            hostname,
-            port,
-            type=socket.SOCK_STREAM,
-            proto=socket.IPPROTO_TCP,
-        )
+        infos = [
+            SocketInfo(*info)
+            for info in socket.getaddrinfo(
+                hostname,
+                port,
+                type=socket.SOCK_STREAM,
+                proto=socket.IPPROTO_TCP,
+            )
+        ]
     except socket.gaierror as exc:
         raise ValueError("OAuth endpoint host could not be resolved") from exc
     _validate_oauth_resolved_addresses(infos)
@@ -241,13 +243,16 @@ async def validate_oauth_endpoint_resolves_public_async(
         raise ValueError(f"OAuth endpoint must include a hostname: {url}")
     port = parsed.port or 443
     try:
-        infos = await asyncio.to_thread(
-            socket.getaddrinfo,
-            hostname,
-            port,
-            type=socket.SOCK_STREAM,
-            proto=socket.IPPROTO_TCP,
-        )
+        infos = [
+            SocketInfo(*info)
+            for info in await asyncio.to_thread(
+                socket.getaddrinfo,
+                hostname,
+                port,
+                type=socket.SOCK_STREAM,
+                proto=socket.IPPROTO_TCP,
+            )
+        ]
     except socket.gaierror as exc:
         raise ValueError("OAuth endpoint host could not be resolved") from exc
     _validate_oauth_resolved_addresses(infos)

--- a/tracecat/integrations/providers/base.py
+++ b/tracecat/integrations/providers/base.py
@@ -29,6 +29,11 @@ from tracecat.integrations.types import (
     TokenResponse,
 )
 from tracecat.logger import logger
+from tracecat.network import (
+    DisallowedUrlError,
+    is_disallowed_address,
+    validate_resolved_addresses,
+)
 
 SocketAddress = tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes]
 SocketInfo = tuple[socket.AddressFamily, socket.SocketKind, int, str, SocketAddress]
@@ -103,7 +108,7 @@ def validate_oauth_endpoint(url: str, base_domain: str | None = None) -> None:
         address = ipaddress.ip_address(normalized_hostname)
     except ValueError:
         address = None
-    if address and _is_disallowed_oauth_address(address):
+    if address and is_disallowed_address(address):
         raise ValueError("OAuth endpoint host is not allowed")
 
     # Validate against base domain if provided
@@ -194,34 +199,11 @@ def mcp_requested_scopes(
     return requested
 
 
-def _is_disallowed_oauth_address(
-    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
-) -> bool:
-    # ``is_global`` is the authoritative "publicly routable" check and rejects
-    # ranges the explicit flags miss (e.g. CGNAT 100.64.0.0/10, TEST-NET, and
-    # other non-global assignments). Keep the explicit flags for clarity and to
-    # guard against any address class not yet covered by ``is_global``.
-    return (
-        not address.is_global
-        or address.is_private
-        or address.is_loopback
-        or address.is_link_local
-        or address.is_reserved
-        or address.is_multicast
-        or address.is_unspecified
-    )
-
-
 def _validate_oauth_resolved_addresses(infos: Sequence[SocketInfo]) -> None:
-    if not infos:
-        raise ValueError("OAuth endpoint host could not be resolved")
-    for *_, sockaddr in infos:
-        try:
-            address = ipaddress.ip_address(sockaddr[0])
-        except (IndexError, ValueError) as exc:
-            raise ValueError("OAuth endpoint host is not allowed") from exc
-        if _is_disallowed_oauth_address(address):
-            raise ValueError("OAuth endpoint host is not allowed")
+    try:
+        validate_resolved_addresses(infos)
+    except DisallowedUrlError as exc:
+        raise ValueError("OAuth endpoint host is not allowed") from exc
 
 
 def validate_oauth_endpoint_resolves_public(

--- a/tracecat/network.py
+++ b/tracecat/network.py
@@ -59,11 +59,15 @@ async def validate_url_resolves_public_async(url: str, *, default_port: int) -> 
     Raises :class:`DisallowedUrlError` on a missing host, resolution failure, or
     any non-public address, without echoing the resolved address.
     """
-    parsed = urlparse(url)
-    hostname = parsed.hostname
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise DisallowedUrlError("URL is invalid") from exc
     if not hostname:
         raise DisallowedUrlError("URL must include a hostname")
-    port = parsed.port or default_port
+    port = port or default_port
     try:
         # getaddrinfo is blocking C I/O (hosts file, resolv.conf, network
         # resolver); keep it off the event loop so a slow DNS server for one

--- a/tracecat/network.py
+++ b/tracecat/network.py
@@ -1,0 +1,80 @@
+"""Shared SSRF guards for outbound URLs to caller-influenced destinations.
+
+Resolves a hostname and rejects any address that is not publicly routable, so
+a request cannot be steered at loopback, private, link-local, or cloud-metadata
+targets. Callers that also require a specific scheme enforce that separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from collections.abc import Sequence
+from typing import Any
+from urllib.parse import urlparse
+
+_SocketInfo = tuple[socket.AddressFamily, socket.SocketKind, int, str, tuple[Any, ...]]
+
+
+class DisallowedUrlError(ValueError):
+    """Raised when a URL resolves to a non-public or unroutable address."""
+
+
+def is_disallowed_address(
+    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    # ``is_global`` is the authoritative "publicly routable" check and rejects
+    # ranges the explicit flags miss (e.g. CGNAT 100.64.0.0/10, TEST-NET, and
+    # other non-global assignments). Keep the explicit flags for clarity and to
+    # guard against any address class not yet covered by ``is_global``.
+    return (
+        not address.is_global
+        or address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+def validate_resolved_addresses(infos: Sequence[_SocketInfo]) -> None:
+    """Reject any resolved address that is not publicly routable."""
+    if not infos:
+        raise DisallowedUrlError("Host could not be resolved")
+    for *_, sockaddr in infos:
+        try:
+            address = ipaddress.ip_address(sockaddr[0])
+        except (IndexError, ValueError) as exc:
+            raise DisallowedUrlError("Host is not allowed") from exc
+        if is_disallowed_address(address):
+            raise DisallowedUrlError("Host is not allowed")
+
+
+async def validate_url_resolves_public_async(url: str, *, default_port: int) -> None:
+    """Resolve the URL host off-thread and require public addresses.
+
+    ``default_port`` is used only for resolution when the URL omits a port.
+    Raises :class:`DisallowedUrlError` on a missing host, resolution failure, or
+    any non-public address, without echoing the resolved address.
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        raise DisallowedUrlError("URL must include a hostname")
+    port = parsed.port or default_port
+    try:
+        # getaddrinfo is blocking C I/O (hosts file, resolv.conf, network
+        # resolver); keep it off the event loop so a slow DNS server for one
+        # URL cannot stall every other coroutine on the loop.
+        infos = await asyncio.to_thread(
+            socket.getaddrinfo,
+            hostname,
+            port,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        raise DisallowedUrlError("Host could not be resolved") from exc
+    validate_resolved_addresses(infos)

--- a/tracecat/network.py
+++ b/tracecat/network.py
@@ -11,11 +11,15 @@ import asyncio
 import ipaddress
 import socket
 from collections.abc import Sequence
-from typing import Any, NamedTuple
+from dataclasses import dataclass
+from typing import Any
 from urllib.parse import urlparse
 
 
-class SocketInfo(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class SocketInfo:
+    """Named representation of one ``socket.getaddrinfo`` result."""
+
     address_family: socket.AddressFamily
     socket_kind: socket.SocketKind
     protocol: int
@@ -76,12 +80,21 @@ async def validate_url_resolves_public_async(url: str) -> None:
     # derive it from the scheme so http and https URLs both resolve correctly.
     port = port or (443 if parsed.scheme == "https" else 80)
     try:
-        # getaddrinfo is blocking C I/O (hosts file, resolv.conf, network
-        # resolver); keep it off the event loop so a slow DNS server for one
-        # URL cannot stall every other coroutine on the loop.
         infos = [
-            SocketInfo(*info)
-            for info in await asyncio.to_thread(
+            SocketInfo(
+                address_family=address_family,
+                socket_kind=socket_kind,
+                protocol=protocol,
+                canonical_name=canonical_name,
+                socket_address=socket_address,
+            )
+            for (
+                address_family,
+                socket_kind,
+                protocol,
+                canonical_name,
+                socket_address,
+            ) in await asyncio.to_thread(
                 socket.getaddrinfo,
                 hostname,
                 port,

--- a/tracecat/network.py
+++ b/tracecat/network.py
@@ -11,10 +11,16 @@ import asyncio
 import ipaddress
 import socket
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, NamedTuple
 from urllib.parse import urlparse
 
-_SocketInfo = tuple[socket.AddressFamily, socket.SocketKind, int, str, tuple[Any, ...]]
+
+class SocketInfo(NamedTuple):
+    address_family: socket.AddressFamily
+    socket_kind: socket.SocketKind
+    protocol: int
+    canonical_name: str
+    socket_address: tuple[Any, ...]
 
 
 class DisallowedUrlError(ValueError):
@@ -39,23 +45,22 @@ def is_disallowed_address(
     )
 
 
-def validate_resolved_addresses(infos: Sequence[_SocketInfo]) -> None:
+def validate_resolved_addresses(infos: Sequence[SocketInfo]) -> None:
     """Reject any resolved address that is not publicly routable."""
     if not infos:
         raise DisallowedUrlError("Host could not be resolved")
-    for *_, sockaddr in infos:
+    for info in infos:
         try:
-            address = ipaddress.ip_address(sockaddr[0])
+            address = ipaddress.ip_address(info.socket_address[0])
         except (IndexError, ValueError) as exc:
             raise DisallowedUrlError("Host is not allowed") from exc
         if is_disallowed_address(address):
             raise DisallowedUrlError("Host is not allowed")
 
 
-async def validate_url_resolves_public_async(url: str, *, default_port: int) -> None:
+async def validate_url_resolves_public_async(url: str) -> None:
     """Resolve the URL host off-thread and require public addresses.
 
-    ``default_port`` is used only for resolution when the URL omits a port.
     Raises :class:`DisallowedUrlError` on a missing host, resolution failure, or
     any non-public address, without echoing the resolved address.
     """
@@ -67,18 +72,23 @@ async def validate_url_resolves_public_async(url: str, *, default_port: int) -> 
         raise DisallowedUrlError("URL is invalid") from exc
     if not hostname:
         raise DisallowedUrlError("URL must include a hostname")
-    port = port or default_port
+    # The port barely affects host resolution, but getaddrinfo requires one;
+    # derive it from the scheme so http and https URLs both resolve correctly.
+    port = port or (443 if parsed.scheme == "https" else 80)
     try:
         # getaddrinfo is blocking C I/O (hosts file, resolv.conf, network
         # resolver); keep it off the event loop so a slow DNS server for one
         # URL cannot stall every other coroutine on the loop.
-        infos = await asyncio.to_thread(
-            socket.getaddrinfo,
-            hostname,
-            port,
-            type=socket.SOCK_STREAM,
-            proto=socket.IPPROTO_TCP,
-        )
+        infos = [
+            SocketInfo(*info)
+            for info in await asyncio.to_thread(
+                socket.getaddrinfo,
+                hostname,
+                port,
+                type=socket.SOCK_STREAM,
+                proto=socket.IPPROTO_TCP,
+            )
+        ]
     except (socket.gaierror, UnicodeError) as exc:
         # UnicodeError covers malformed DNS labels (e.g. a label over 63 chars),
         # which getaddrinfo raises instead of gaierror.

--- a/tracecat/network.py
+++ b/tracecat/network.py
@@ -79,6 +79,8 @@ async def validate_url_resolves_public_async(url: str, *, default_port: int) -> 
             type=socket.SOCK_STREAM,
             proto=socket.IPPROTO_TCP,
         )
-    except socket.gaierror as exc:
+    except (socket.gaierror, UnicodeError) as exc:
+        # UnicodeError covers malformed DNS labels (e.g. a label over 63 chars),
+        # which getaddrinfo raises instead of gaierror.
         raise DisallowedUrlError("Host could not be resolved") from exc
     validate_resolved_addresses(infos)

--- a/tracecat/settings/router.py
+++ b/tracecat/settings/router.py
@@ -6,7 +6,7 @@ from tracecat import config
 from tracecat.audit.service import (
     AuditService,
     AuditWebhookNotConfiguredError,
-    AuditWebhookTestResult,
+    AuditWebhookUrlNotAllowedError,
 )
 from tracecat.auth.dependencies import OrgActorRole, OrgUserRole
 from tracecat.auth.enums import AuthType
@@ -22,6 +22,7 @@ from tracecat.settings.schemas import (
     AppSettingsUpdate,
     AuditSettingsRead,
     AuditSettingsUpdate,
+    AuditWebhookTestResult,
     GitSettingsRead,
     GitSettingsUpdate,
     SAMLSettingsRead,
@@ -238,17 +239,25 @@ async def update_audit_settings(
 async def test_audit_webhook(
     *,
     role: OrgUserRole,
+    params: AuditSettingsUpdate,
 ) -> AuditWebhookTestResult:
+    """Probe the submitted audit webhook configuration with a marked test event."""
     try:
         return await AuditService.probe_webhook(
             sink="organization",
             organization_id=role.organization_id,
             role=role,
+            settings=params,
         )
     except AuditWebhookNotConfiguredError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Audit webhook is not configured",
+        ) from exc
+    except AuditWebhookUrlNotAllowedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Audit webhook URL is not allowed",
         ) from exc
 
 

--- a/tracecat/settings/router.py
+++ b/tracecat/settings/router.py
@@ -3,6 +3,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
+from tracecat.audit.service import (
+    AuditService,
+    AuditWebhookNotConfiguredError,
+    AuditWebhookTestResult,
+)
 from tracecat.auth.dependencies import OrgActorRole, OrgUserRole
 from tracecat.auth.enums import AuthType
 from tracecat.authz.controls import require_scope
@@ -226,6 +231,25 @@ async def update_audit_settings(
 ) -> None:
     service = SettingsService(session, role)
     await service.update_audit_settings(params)
+
+
+@router.post("/audit/test", response_model=AuditWebhookTestResult)
+@require_scope("org:settings:update")
+async def test_audit_webhook(
+    *,
+    role: OrgUserRole,
+) -> AuditWebhookTestResult:
+    try:
+        return await AuditService.probe_webhook(
+            sink="organization",
+            organization_id=role.organization_id,
+            role=role,
+        )
+    except AuditWebhookNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Audit webhook is not configured",
+        ) from exc
 
 
 @router.get("/agent", response_model=AgentSettingsRead)

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
@@ -185,6 +185,21 @@ class AuditSettingsUpdate(BaseSettingsGroup):
             "Disable only for trusted on-prem/self-signed endpoints."
         ),
     )
+
+
+AuditWebhookTestErrorCategory = Literal[
+    "receiver_error",
+    "timeout",
+    "request_error",
+]
+
+
+class AuditWebhookTestResult(BaseModel):
+    """Result of a synchronous audit webhook test-fire request."""
+
+    ok: bool
+    receiver_status_code: int | None = None
+    error_category: AuditWebhookTestErrorCategory | None = None
 
 
 class AgentSettingsRead(BaseSettingsGroup):


### PR DESCRIPTION
## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 656 | 124 |
| Tests | 554 | 77 |
| Generated | 135 | 0 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Test Audit Webhook” to probe org and platform audit webhook connectivity using the submitted config, with SSRF protections and a strict 5s wall‑clock timeout. Also centralizes webhook config resolution and adds safe delivery outcome logs.

- **New Features**
  - POST `/settings/audit/test` and `/admin/settings/audit/test` return `AuditWebhookTestResult` with `ok`, `receiver_status_code`, and `error_category` (`receiver_error` | `timeout` | `request_error`); 400 on missing, malformed, or disallowed URL.
  - Probe uses a 5s wall‑clock timeout (includes DNS), shares the delivery socket budget, streams the request and reads status only, and forces `X-Tracecat-Test: true` (drops any user `x-tracecat-test`).
  - Frontend Test button and toasts in org and platform audit settings; Test uses current form values without saving and disables Save while testing; saving with an empty URL fully disconnects and clears headers/payload/TLS overrides.

- **Refactors**
  - Introduced `AuditWebhookConfig` (dataclass) and centralized settings resolution via `_resolve_config`; delivery assembly via `_assemble_delivery`.
  - Added shared SSRF guard in `tracecat/network.py`; reused in `tracecat/integrations/providers/base.py`; maps malformed DNS labels to a client error.
  - Added delivery success logs with status, attempts, retried flag, duration, and resource/org/workspace identifiers; no secrets or URLs; added `connect` audit action and expanded tests for probe endpoints, URL guard (loopback/malformed), timeout/DNS/socket budget behavior, and delivery logging.

<sup>Written for commit f8e8f4a274be49be03eea1faff6364d5f895ae78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<img width="804" height="902" alt="image" src="https://github.com/user-attachments/assets/6877626f-0085-4748-854f-da389fca7421" />

QAed locally and in RunReveal
<img width="1127" height="346" alt="image" src="https://github.com/user-attachments/assets/78b1d087-9180-4869-a53d-5df678ff66b6" />
