### PR TITLE
feat(mcp): add revision guards to skill update and publish tools

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -437,6 +437,12 @@
   Use this before updating, publishing, or attaching skills to agent presets.
 </ResponseField>
 
+<ResponseField name="get_skill" type="tool">
+  Return a workspace skill summary, including its current draft revision.
+
+  Use the returned `draft_revision` as `base_revision` for `update_skill` and as `expected_draft_revision` for `publish_skill`.
+</ResponseField>
+
 <ResponseField name="upload_skill" type="tool">
   Upload a local skill directory into Tracecat as a workspace skill.
 
@@ -448,11 +454,15 @@
 <ResponseField name="update_skill" type="tool">
   Replace an existing skill draft with a local skill directory.
 
+  `base_revision` must equal the skill's current `draft_revision` (fetch it with `get_skill`); on a `draft_revision_conflict` error, re-read the skill and reconcile before retrying so concurrent edits are never overwritten.
+
   This does not publish the draft. Call `publish_skill` after the update if the skill should be attachable to agent presets.
 </ResponseField>
 
 <ResponseField name="publish_skill" type="tool">
   Publish a skill draft into an immutable skill version.
+
+  `expected_draft_revision` must equal the skill's current `draft_revision` (returned by `get_skill` and `update_skill`); on a `draft_revision_conflict` error, re-read the skill and confirm the draft contents before retrying so an unreviewed concurrent edit is never published.
 
   Only published skill versions can be attached to agent presets.
 </ResponseField>

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -10061,9 +10061,12 @@ async def test_update_skill_replaces_existing_draft(
         return workspace_id, role
 
     class _SkillService:
-        async def replace_skill_draft(self, *, skill_id: uuid.UUID, params):
+        async def replace_skill_draft(
+            self, *, skill_id: uuid.UUID, params, base_revision=None
+        ):
             captured["skill_id"] = skill_id
             captured["params"] = params
+            captured["base_revision"] = base_revision
             now = datetime.now(UTC)
             return SkillRead(
                 id=skill_id,
@@ -10093,6 +10096,7 @@ async def test_update_skill_replaces_existing_draft(
         workspace_id=str(workspace_id),
         skill_id=skill_id,
         name="botsv3-ir",
+        base_revision=1,
         description="Updated description",
         files=[
             SkillUploadFile(
@@ -10109,6 +10113,7 @@ async def test_update_skill_replaces_existing_draft(
     params = captured["params"]
     uploaded_content = base64.b64decode(params.files[0].content_base64).decode("utf-8")
     assert captured["skill_id"] == skill_id
+    assert captured["base_revision"] == 1
     assert params.name == "botsv3-ir"
     assert "name: botsv3-ir" in uploaded_content
     assert "description: Updated description" in uploaded_content
@@ -10130,8 +10135,11 @@ async def test_publish_skill_uses_workspace_skill_service(
         return workspace_id, role
 
     class _SkillService:
-        async def publish_skill(self, requested_skill_id: uuid.UUID):
+        async def publish_skill(
+            self, requested_skill_id: uuid.UUID, *, expected_draft_revision=None
+        ):
             captured["skill_id"] = requested_skill_id
+            captured["expected_draft_revision"] = expected_draft_revision
             now = datetime.now(UTC)
             return SkillVersionRead(
                 id=version_id,
@@ -10158,13 +10166,186 @@ async def test_publish_skill_uses_workspace_skill_service(
     result = await _tool(mcp_server.publish_skill)(
         workspace_id=str(workspace_id),
         skill_id=skill_id,
+        expected_draft_revision=3,
     )
 
     payload = _payload(result)
     assert captured["skill_id"] == skill_id
+    assert captured["expected_draft_revision"] == 3
     assert payload["id"] == str(version_id)
     assert payload["skill_id"] == str(skill_id)
     assert payload["version"] == 1
+
+
+@pytest.mark.anyio
+async def test_get_skill_returns_draft_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    skill_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _SkillService:
+        async def get_skill_read(self, requested_skill_id: uuid.UUID):
+            now = datetime.now(UTC)
+            return SkillRead(
+                id=requested_skill_id,
+                workspace_id=workspace_id,
+                name="botsv3-ir",
+                slug="botsv3-ir",
+                description="BOTSv3 IR skill",
+                current_version_id=None,
+                draft_revision=7,
+                created_at=now,
+                updated_at=now,
+                deleted_at=None,
+                current_version=None,
+                is_draft_publishable=True,
+                draft_validation_errors=[],
+                draft_file_count=1,
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.SkillService,
+        "with_session",
+        lambda role: _AsyncContext(_SkillService()),
+    )
+
+    result = await _tool(mcp_server.get_skill)(
+        workspace_id=str(workspace_id),
+        skill_id=skill_id,
+    )
+
+    payload = _payload(result)
+    assert payload["id"] == str(skill_id)
+    assert payload["draft_revision"] == 7
+
+
+@pytest.mark.anyio
+async def test_get_skill_missing_raises_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    skill_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _SkillService:
+        async def get_skill_read(self, requested_skill_id: uuid.UUID):
+            return None
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.SkillService,
+        "with_session",
+        lambda role: _AsyncContext(_SkillService()),
+    )
+
+    with pytest.raises(ToolError, match="not found"):
+        await _tool(mcp_server.get_skill)(
+            workspace_id=str(workspace_id),
+            skill_id=skill_id,
+        )
+
+
+@pytest.mark.anyio
+async def test_update_skill_surfaces_draft_revision_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    skill_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _SkillService:
+        async def replace_skill_draft(
+            self, *, skill_id: uuid.UUID, params, base_revision=None
+        ):
+            raise TracecatValidationError(
+                "Draft revision conflict",
+                detail={
+                    "code": "draft_revision_conflict",
+                    "current_revision": 5,
+                },
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.SkillService,
+        "with_session",
+        lambda role: _AsyncContext(_SkillService()),
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await _tool(mcp_server.update_skill)(
+            workspace_id=str(workspace_id),
+            skill_id=skill_id,
+            name="botsv3-ir",
+            base_revision=4,
+            files=[
+                SkillUploadFile(
+                    path="SKILL.md",
+                    content_base64=base64.b64encode(
+                        b"---\nname: botsv3-ir\n---\n\n# Triage\n"
+                    ).decode("ascii"),
+                    content_type="text/markdown; charset=utf-8",
+                )
+            ],
+        )
+
+    message = str(exc_info.value)
+    assert "draft_revision_conflict" in message
+    assert "'current_revision': 5" in message
+
+
+@pytest.mark.anyio
+async def test_publish_skill_surfaces_draft_revision_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    skill_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _SkillService:
+        async def publish_skill(
+            self, requested_skill_id: uuid.UUID, *, expected_draft_revision=None
+        ):
+            raise TracecatValidationError(
+                "Draft revision conflict",
+                detail={
+                    "code": "draft_revision_conflict",
+                    "current_revision": 9,
+                },
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.SkillService,
+        "with_session",
+        lambda role: _AsyncContext(_SkillService()),
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await _tool(mcp_server.publish_skill)(
+            workspace_id=str(workspace_id),
+            skill_id=skill_id,
+            expected_draft_revision=8,
+        )
+
+    message = str(exc_info.value)
+    assert "draft_revision_conflict" in message
+    assert "'current_revision': 9" in message
 
 
 def _prompt_source_text() -> str:

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -610,6 +610,63 @@ class TestSkillService:
         assert {file.path for file in draft.files} == {"SKILL.md", "payload.bin"}
         assert old_file is None
 
+    async def test_replace_skill_draft_enforces_base_revision(
+        self,
+        skill_service: SkillService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stale base revision conflicts; the matching revision applies."""
+
+        async def _has_entitlement(_entitlement):
+            return True
+
+        monkeypatch.setattr(skill_service, "has_entitlement", _has_entitlement)
+
+        created = await skill_service.upload_skill(
+            SkillUpload(
+                name="revision-guard-skill",
+                files=[
+                    SkillUploadFile(
+                        path="SKILL.md",
+                        content_base64=base64.b64encode(
+                            b"---\nname: revision-guard-skill\n---\n\n# Original\n"
+                        ).decode(),
+                        content_type="text/markdown; charset=utf-8",
+                    ),
+                ],
+            )
+        )
+        params = SkillUpload(
+            name="revision-guard-skill",
+            files=[
+                SkillUploadFile(
+                    path="SKILL.md",
+                    content_base64=base64.b64encode(
+                        b"---\nname: revision-guard-skill\n---\n\n# Updated\n"
+                    ).decode(),
+                    content_type="text/markdown; charset=utf-8",
+                ),
+            ],
+        )
+
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await skill_service.replace_skill_draft(
+                skill_id=created.id,
+                params=params,
+                base_revision=created.draft_revision + 1,
+            )
+        assert exc_info.value.detail == {
+            "code": "draft_revision_conflict",
+            "current_revision": created.draft_revision,
+        }
+
+        updated = await skill_service.replace_skill_draft(
+            skill_id=created.id,
+            params=params,
+            base_revision=created.draft_revision,
+        )
+        assert updated.draft_revision == created.draft_revision + 1
+
     async def test_replace_skill_draft_rejects_invalid_manifest_before_blob_upload(
         self,
         skill_service: SkillService,
@@ -1712,6 +1769,35 @@ class TestSkillService:
 
         with pytest.raises(TracecatValidationError, match="failed validation"):
             await skill_service.publish_skill(created.id)
+
+    async def test_publish_skill_enforces_expected_draft_revision(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """A stale expected revision conflicts; the matching revision publishes."""
+
+        created = await skill_service.create_skill(
+            SkillCreate(name="publish-revision-skill")
+        )
+        draft = await skill_service.get_draft(created.id)
+        assert draft is not None
+
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await skill_service.publish_skill(
+                created.id,
+                expected_draft_revision=draft.draft_revision + 1,
+            )
+        assert exc_info.value.detail == {
+            "code": "draft_revision_conflict",
+            "current_revision": draft.draft_revision,
+        }
+
+        published = await skill_service.publish_skill(
+            created.id,
+            expected_draft_revision=draft.draft_revision,
+        )
+        assert published.skill_id == created.id
+        assert published.version == 1
 
     async def test_publish_rejects_file_directory_path_collisions(
         self,

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -1567,13 +1567,23 @@ class SkillService(BaseWorkspaceService):
     @require_scope("agent:update")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def replace_skill_draft(
-        self, *, skill_id: uuid.UUID, params: SkillUpload
+        self,
+        *,
+        skill_id: uuid.UUID,
+        params: SkillUpload,
+        base_revision: int | None = None,
     ) -> SkillRead:
-        """Replace an existing skill's mutable draft with a full file tree."""
+        """Replace an existing skill's mutable draft with a full file tree.
+
+        When ``base_revision`` is provided, the replacement only applies if the
+        draft is still at that revision; otherwise a structured
+        ``draft_revision_conflict`` validation error is raised.
+        """
 
         skill = await self._get_skill_for_update(skill_id)
         if skill is None:
             raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
+        self._check_draft_revision(skill, base_revision)
 
         prepared_draft = await self._prepare_validated_upload_draft(params)
         await self._replace_draft_with_blob_map(
@@ -1902,6 +1912,21 @@ class SkillService(BaseWorkspaceService):
                     )
         return prepared_operations
 
+    @staticmethod
+    def _check_draft_revision(skill: Skill, expected_revision: int | None) -> None:
+        """Enforce optimistic concurrency on the skill draft when requested."""
+
+        if expected_revision is None:
+            return
+        if skill.draft_revision != expected_revision:
+            raise TracecatValidationError(
+                "Draft revision conflict",
+                detail={
+                    "code": "draft_revision_conflict",
+                    "current_revision": skill.draft_revision,
+                },
+            )
+
     @require_scope("agent:update")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def patch_draft(
@@ -1912,14 +1937,7 @@ class SkillService(BaseWorkspaceService):
         skill = await self._get_skill_for_update(skill_id)
         if skill is None:
             raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
-        if skill.draft_revision != params.base_revision:
-            raise TracecatValidationError(
-                "Draft revision conflict",
-                detail={
-                    "code": "draft_revision_conflict",
-                    "current_revision": skill.draft_revision,
-                },
-            )
+        self._check_draft_revision(skill, params.base_revision)
 
         prepared_operations = await self._prepare_draft_patch_operations(
             skill=skill,
@@ -2072,12 +2090,23 @@ class SkillService(BaseWorkspaceService):
 
     @require_scope("agent:update")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
-    async def publish_skill(self, skill_id: uuid.UUID) -> SkillVersionRead:
-        """Publish the current draft into a new immutable skill version."""
+    async def publish_skill(
+        self,
+        skill_id: uuid.UUID,
+        *,
+        expected_draft_revision: int | None = None,
+    ) -> SkillVersionRead:
+        """Publish the current draft into a new immutable skill version.
+
+        When ``expected_draft_revision`` is provided, publishing only applies
+        if the draft is still at that revision; otherwise a structured
+        ``draft_revision_conflict`` validation error is raised.
+        """
 
         skill = await self._get_skill_for_update(skill_id)
         if skill is None:
             raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
+        self._check_draft_revision(skill, expected_draft_revision)
         rows = await self._list_draft_rows(skill.id)
         validation = await self._validate_manifest_rows(
             [(draft_file.path, blob_row) for draft_file, blob_row in rows]

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -8244,6 +8244,37 @@ async def list_skills(
 
 
 @mcp.tool()
+async def get_skill(
+    workspace_id: uuid.UUID,
+    skill_id: uuid.UUID,
+) -> SkillRead:
+    """Return a workspace skill summary, including its current draft revision.
+
+    Use the returned `draft_revision` as `base_revision` for `update_skill`
+    and as `expected_draft_revision` for `publish_skill`.
+    """
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with SkillService.with_session(role=role) as svc:
+            skill = await svc.get_skill_read(skill_id)
+        if skill is None:
+            raise ToolError(f"Skill '{skill_id}' not found")
+        return skill
+    except ToolError:
+        raise
+    except ValidationError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to get skill", error=str(e), skill_id=str(skill_id))
+        raise ToolError(f"Failed to get skill: {e}") from None
+
+
+@mcp.tool()
 async def upload_skill(
     workspace_id: uuid.UUID,
     name: str,
@@ -8289,15 +8320,32 @@ async def upload_skill(
         raise ToolError(f"Failed to upload skill: {e}") from None
 
 
+def _skill_validation_tool_error(e: TracecatValidationError) -> ToolError:
+    """Render a skill validation error with its structured detail attached.
+
+    Revision conflicts carry ``current_revision`` in the detail; agents need it
+    to recover without another read.
+    """
+
+    if e.detail is not None:
+        return ToolError(f"{e}: {e.detail}")
+    return ToolError(str(e))
+
+
 @mcp.tool()
 async def update_skill(
     workspace_id: uuid.UUID,
     skill_id: uuid.UUID,
     name: str,
+    base_revision: int,
     files: list[SkillUploadFile],
     description: str | None = None,
 ) -> SkillRead:
     """Replace an existing skill draft with a local skill directory.
+
+    `base_revision` must equal the skill's current `draft_revision` (fetch it
+    with `get_skill`); on a `draft_revision_conflict` error, re-read the skill
+    and reconcile before retrying so concurrent edits are never overwritten.
 
     This does not publish the draft. Call `publish_skill` after the update if
     the skill should be attachable to agent presets.
@@ -8319,14 +8367,18 @@ async def update_skill(
             }
         )
         async with SkillService.with_session(role=role) as svc:
-            updated = await svc.replace_skill_draft(skill_id=skill_id, params=params)
+            updated = await svc.replace_skill_draft(
+                skill_id=skill_id,
+                params=params,
+                base_revision=base_revision,
+            )
         return SkillRead.model_validate(updated)
     except ToolError:
         raise
     except ValidationError as e:
         raise ToolError(str(e)) from e
     except TracecatValidationError as e:
-        raise ToolError(str(e)) from e
+        raise _skill_validation_tool_error(e) from e
     except TracecatNotFoundError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -8338,8 +8390,15 @@ async def update_skill(
 async def publish_skill(
     workspace_id: uuid.UUID,
     skill_id: uuid.UUID,
+    expected_draft_revision: int,
 ) -> SkillVersionRead:
     """Publish a skill draft into an immutable skill version.
+
+    `expected_draft_revision` must equal the skill's current `draft_revision`
+    (returned by `get_skill` and `update_skill`); on a
+    `draft_revision_conflict` error, re-read the skill and confirm the draft
+    contents before retrying so an unreviewed concurrent edit is never
+    published.
 
     Only published skill versions can be attached to agent presets.
     """
@@ -8347,13 +8406,16 @@ async def publish_skill(
     try:
         _, role = await _resolve_workspace_role(workspace_id)
         async with SkillService.with_session(role=role) as svc:
-            return await svc.publish_skill(skill_id)
+            return await svc.publish_skill(
+                skill_id,
+                expected_draft_revision=expected_draft_revision,
+            )
     except ToolError:
         raise
     except ValidationError as e:
         raise ToolError(str(e)) from e
     except TracecatValidationError as e:
-        raise ToolError(str(e)) from e
+        raise _skill_validation_tool_error(e) from e
     except TracecatNotFoundError as e:
         raise ToolError(str(e)) from e
     except Exception as e:


### PR DESCRIPTION
## What

Adds optimistic-concurrency revision guards to the MCP skill editing surface so local coding agents can no longer silently overwrite concurrent UI edits or publish an unreviewed draft:

- `update_skill` now requires `base_revision`, forwarded to `SkillService.replace_skill_draft`. A stale revision raises a structured `draft_revision_conflict` error instead of clobbering the draft.
- `publish_skill` now requires `expected_draft_revision`, forwarded to `SkillService.publish_skill`. Publishing a draft that moved since the agent last read it fails the same way.
- New `get_skill` MCP tool (wraps existing `SkillService.get_skill_read`) so agents can fetch the current `draft_revision`; previously `list_skills` returned `SkillReadMinimal`, which does not expose it.
- Revision-conflict tool errors include the structured detail (`current_revision`) so agents can recover without another read.

## Why

`update_skill` was a full draft replacement with no concurrency token, racing against UI draft edits (which use `patch_draft`'s `base_revision` check). `publish_skill` had the same race: an agent could push revision N, the UI could create revision N+1, and the agent would accidentally publish N+1. Both now share the same conflict semantics as `patch_draft` via a common `_check_draft_revision` helper.

Service-layer params are optional (`None` = no check) so the REST router and existing callers are unchanged; the MCP layer makes them required.

## Testing

- `tests/unit/test_skill_service.py`: stale-revision conflict + matching-revision success for both `replace_skill_draft` and `publish_skill` (62 passed).
- `tests/unit/test_mcp_server.py`: pass-through of the new params, conflict surfacing with `current_revision` in the tool error, `get_skill` happy path and not-found (16 skill tests passed).
- `tests/unit/test_agent_preset_service.py` (existing `publish_skill` callers): 90 passed.
- `ruff`, `ruff format`, `basedpyright --warnings` clean on changed files.
- Live-tested against a local `just cluster` stack (see PR comments for transcript).

## LOC breakdown

| Category | + | - |
| --- | --- | --- |
| Logic | 107 | 16 |
| Tests | 269 | 2 |
| Generated (MCP docs snippet) | 10 | 0 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optimistic concurrency to MCP skill updates and publishes to prevent overwriting concurrent UI edits or publishing a stale draft. Introduces `get_skill` so agents can read `draft_revision` and recover from conflicts without extra roundtrips.

- **New Features**
  - `update_skill` now requires `base_revision`; conflicts raise `draft_revision_conflict` with `current_revision`.
  - `publish_skill` now requires `expected_draft_revision`; same conflict behavior.
  - New `get_skill` tool returns `draft_revision` (and other summary fields).
  - Service layer accepts optional params for backwards compatibility; MCP tools make them required.

- **Migration**
  - Agents must call `get_skill` to read `draft_revision`, then pass it as `base_revision` to `update_skill` and as `expected_draft_revision` to `publish_skill`.
  - On `draft_revision_conflict`, use the provided `current_revision` to re-read and retry. REST callers are unchanged.

<sup>Written for commit 21c804a634e3677416df4370a4bca42d7c8eba37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

