### PR TITLE
feat(cases): expose custom field display names

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -276,7 +276,7 @@
 <ResponseField name="list_case_fields" type="tool">
   List case field definitions in a workspace.
 
-  Returns a JSON array of field objects with `id`, `type`, `description`, `nullable`, `default`, `reserved`, `options`, and optional `kind`.
+  Returns a JSON array of field objects with `id`, `display_name`, `type`, `description`, `nullable`, `default`, `reserved`, `options`, and optional `kind`.
 </ResponseField>
 
 <ResponseField name="create_case_field" type="tool">

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8234,6 +8234,10 @@ export const $CaseFieldRead = {
       type: "string",
       title: "Id",
     },
+    display_name: {
+      type: "string",
+      title: "Display Name",
+    },
     type: {
       $ref: "#/components/schemas/CaseFieldReadType",
     },
@@ -8296,6 +8300,7 @@ export const $CaseFieldRead = {
   type: "object",
   required: [
     "id",
+    "display_name",
     "type",
     "description",
     "nullable",
@@ -8312,6 +8317,10 @@ export const $CaseFieldReadMinimal = {
     id: {
       type: "string",
       title: "Id",
+    },
+    display_name: {
+      type: "string",
+      title: "Display Name",
     },
     type: {
       $ref: "#/components/schemas/CaseFieldReadType",
@@ -8370,7 +8379,15 @@ export const $CaseFieldReadMinimal = {
     },
   },
   type: "object",
-  required: ["id", "type", "description", "nullable", "default", "reserved"],
+  required: [
+    "id",
+    "display_name",
+    "type",
+    "description",
+    "nullable",
+    "default",
+    "reserved",
+  ],
   title: "CaseFieldReadMinimal",
   description: "Minimal read model for a case field.",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2215,6 +2215,7 @@ export type CaseFieldKind = "LONG_TEXT" | "URL"
  */
 export type CaseFieldRead = {
   id: string
+  display_name: string
   type: CaseFieldReadType
   description: string
   nullable: boolean
@@ -2231,6 +2232,7 @@ export type CaseFieldRead = {
  */
 export type CaseFieldReadMinimal = {
   id: string
+  display_name: string
   type: CaseFieldReadType
   description: string
   nullable: boolean

--- a/tests/unit/test_case_fields_service.py
+++ b/tests/unit/test_case_fields_service.py
@@ -168,6 +168,47 @@ class TestCaseFieldsService:
         assert field.type is CaseFieldReadType.SELECT
         assert field.options == ["low", "high"]
 
+    async def test_case_field_read_display_name(self) -> None:
+        """Read display names from metadata and fall back to the field ID."""
+        cases = [
+            (
+                "analyst_verdict",
+                sa.types.Text(),
+                {
+                    "analyst_verdict": {
+                        "type": "TEXT",
+                        "display_name": "Analyst Verdict",
+                    }
+                },
+                "Analyst Verdict",
+            ),
+            (
+                "analyst_verdict",
+                sa.types.Text(),
+                {"analyst_verdict": {"type": "TEXT"}},
+                "analyst_verdict",
+            ),
+            ("analyst_verdict", sa.types.Text(), None, "analyst_verdict"),
+            ("case_id", sa.types.UUID(), None, "case_id"),
+        ]
+
+        for field_id, field_type, field_schema, expected_display_name in cases:
+            column = ReflectedColumn(
+                name=field_id,
+                type=field_type,
+                nullable=True,
+                default=None,
+                comment=None,
+            )
+
+            field = CaseFieldReadMinimal.from_sa(
+                column,
+                field_schema=field_schema,
+            )
+
+            assert field.id == field_id
+            assert field.display_name == expected_display_name
+
     async def test_create_field(self, case_fields_service: CaseFieldsService) -> None:
         """Test creating a case field."""
         # Create field parameters

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -185,6 +185,7 @@ class CaseFieldReadMinimal(Schema):
     """Minimal read model for a case field."""
 
     id: str
+    display_name: str
     type: CaseFieldReadType
     description: str
     nullable: bool
@@ -213,8 +214,10 @@ class CaseFieldReadMinimal(Schema):
         kind: CaseFieldKind | None = None
         required_on_closure = False
         options: list[str] | None = None
+        display_name = column["name"]
         if field_schema and (meta := field_schema.get(column["name"])):
             read_type = CaseFieldReadType(meta["type"])
+            display_name = meta.get("display_name") or column["name"]
             options = meta.get("options")
             if kind_str := meta.get("kind"):
                 kind = CaseFieldKind(kind_str)
@@ -225,6 +228,7 @@ class CaseFieldReadMinimal(Schema):
         return cls.model_validate(
             {
                 "id": column["name"],
+                "display_name": display_name,
                 "type": read_type,
                 "description": column.get("comment") or "",
                 "nullable": column["nullable"],

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -6326,8 +6326,9 @@ async def list_case_fields(
 ) -> MCPPaginatedResponse[CaseFieldReadMinimal]:
     """List case field definitions in a workspace.
 
-    Returns a JSON array of field objects with `id`, `type`, `description`,
-    `nullable`, `default`, `reserved`, `options`, and optional `kind`.
+    Returns a JSON array of field objects with `id`, `display_name`, `type`,
+    `description`, `nullable`, `default`, `reserved`, `options`, and optional
+    `kind`.
     """
 
     try:


### PR DESCRIPTION


## Description

Adds `display_name` to case custom-field read metadata. The API reads the value from the stored field metadata and falls back to the field ID for existing fields that do not have a display name yet.

This keeps the response non-null and backward-compatible while allowing a later save flow to backfill the display name. The generated frontend client and MCP tool documentation are updated to match the API contract.

### LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 7 | 2 |
| Tests | 41 | 0 |
| Docs | 1 | 1 |
| Generated | 20 | 1 |

## Related Issues

- [ENG-1643](https://linear.app/tracecat/issue/ENG-1643/add-ability-to-read-display-name-into-the-custom-fields-metadata)

## Screenshots / Recordings

Not applicable; this PR only changes API metadata.

## Steps to QA

1. Run `uv run pytest tests/unit/test_case_fields_service.py`.
2. Run `uv run pytest tests/unit/api/test_api_cases.py -k "case_field or get_case"`.
3. Confirm a field with metadata returns its stored `display_name`.
4. Confirm a field without that metadata returns its field ID as `display_name`.

