### PR TITLE
feat(cases): persist custom field display names

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8196,6 +8196,19 @@ export const $CaseFieldCreate = {
       ],
       title: "Options",
     },
+    display_name: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 255,
+          minLength: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Display Name",
+    },
     kind: {
       anyOf: [
         {
@@ -8487,6 +8500,19 @@ export const $CaseFieldUpdate = {
         },
       ],
       title: "Options",
+    },
+    display_name: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 255,
+          minLength: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Display Name",
     },
     required_on_closure: {
       anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2198,6 +2198,7 @@ export type CaseFieldCreate = {
   nullable?: boolean
   default?: unknown | null
   options?: Array<string> | null
+  display_name?: string | null
   kind?: CaseFieldKind | null
   required_on_closure?: boolean
 }
@@ -2283,6 +2284,7 @@ export type CaseFieldUpdate = {
    */
   is_index?: boolean | null
   options?: Array<string> | null
+  display_name?: string | null
   required_on_closure?: boolean | null
 }
 

--- a/tests/unit/test_case_fields_service.py
+++ b/tests/unit/test_case_fields_service.py
@@ -227,6 +227,56 @@ class TestCaseFieldsService:
             # Verify the method was called with the right parameters
             mock_create_column.assert_called_once_with(field_params)
 
+    async def test_write_field_display_name_metadata(
+        self,
+        case_fields_service: CaseFieldsService,
+    ) -> None:
+        """Write, preserve, and backfill field display-name metadata."""
+        with (
+            patch.object(case_fields_service.editor, "create_column"),
+            patch.object(case_fields_service.editor, "update_column"),
+        ):
+            await case_fields_service.create_field(
+                CaseFieldCreate(
+                    name="analyst_verdict",
+                    display_name="Analyst Verdict",
+                    type=SqlType.TEXT,
+                )
+            )
+            schema = await case_fields_service.get_field_schema()
+            assert schema["analyst_verdict"]["display_name"] == "Analyst Verdict"
+
+            await case_fields_service.create_field(
+                CaseFieldCreate(name="legacy_field", type=SqlType.TEXT)
+            )
+            schema = await case_fields_service.get_field_schema()
+            assert schema["legacy_field"]["display_name"] == "legacy_field"
+
+            await case_fields_service.update_field(
+                "analyst_verdict",
+                CaseFieldUpdate(display_name="Analyst decision"),
+            )
+            schema = await case_fields_service.get_field_schema()
+            assert schema["analyst_verdict"]["display_name"] == "Analyst decision"
+
+            await case_fields_service.update_field(
+                "analyst_verdict",
+                CaseFieldUpdate(nullable=True),
+            )
+            schema = await case_fields_service.get_field_schema()
+            assert schema["analyst_verdict"]["display_name"] == "Analyst decision"
+
+            await case_fields_service._update_field_schema(
+                "legacy_field",
+                {"type": "TEXT"},
+            )
+            await case_fields_service.update_field(
+                "legacy_field",
+                CaseFieldUpdate(nullable=True),
+            )
+            schema = await case_fields_service.get_field_schema()
+            assert schema["legacy_field"]["display_name"] == "legacy_field"
+
     async def test_create_field_rejects_internal_name(
         self, case_fields_service: CaseFieldsService
     ) -> None:
@@ -362,7 +412,11 @@ class TestCaseFieldsService:
 
             mock_update_schema.assert_called_once_with(
                 "my_field",
-                {"type": "TEXT", "required_on_closure": True},
+                {
+                    "type": "TEXT",
+                    "display_name": "my_field",
+                    "required_on_closure": True,
+                },
             )
 
     async def test_update_field_rejects_internal_name(

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -6387,6 +6387,7 @@ async def test_case_field_sync_preserves_select_options(
                 "type": "case_field",
                 "id": "severity_band",
                 "name": "severity_band",
+                "display_name": "Severity Band",
                 "field_type": "select",
                 "options": ["low", "medium", "high"],
                 "required_on_closure": True,
@@ -6405,6 +6406,7 @@ async def test_case_field_sync_preserves_select_options(
         select(CaseFields).where(CaseFields.workspace_id == svc_role.workspace_id)
     )
     assert definition is not None
+    assert definition.schema["severity_band"]["display_name"] == "Severity Band"
     assert definition.schema["severity_band"]["options"] == ["low", "medium", "high"]
     assert definition.schema["severity_band"]["required_on_closure"] is True
 
@@ -6412,6 +6414,7 @@ async def test_case_field_sync_preserves_select_options(
     field_spec = yaml.safe_load(
         projection.files[f"{CASE_FIELD_ROOT}/severity_band.yml"]
     )
+    assert field_spec["display_name"] == "Severity Band"
     assert field_spec["options"] == ["low", "medium", "high"]
     assert field_spec["required_on_closure"] is True
 

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -244,6 +244,7 @@ class CaseFieldReadMinimal(Schema):
 class CaseFieldCreate(CustomFieldCreate):
     """Create a new case field."""
 
+    display_name: str | None = Field(default=None, min_length=1, max_length=255)
     kind: CaseFieldKind | None = Field(default=None)
     required_on_closure: bool = Field(default=False)
 
@@ -263,6 +264,7 @@ class CaseFieldCreate(CustomFieldCreate):
 class CaseFieldUpdate(CustomFieldUpdate):
     """Update a case field."""
 
+    display_name: str | None = Field(default=None, min_length=1, max_length=255)
     required_on_closure: bool | None = Field(default=None)
 
     @model_validator(mode="before")

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1543,7 +1543,10 @@ class CaseFieldsService(CustomFieldsService):
         params.nullable = True
         await self.editor.create_column(params)
 
-        field_def: dict[str, Any] = {"type": params.type.value}
+        field_def: dict[str, Any] = {
+            "type": params.type.value,
+            "display_name": params.display_name or params.name,
+        }
 
         if params.type in (SqlType.SELECT, SqlType.MULTI_SELECT) and params.options:
             field_def["options"] = normalize_column_options(params.options)
@@ -1739,6 +1742,13 @@ class CaseFieldsService(CustomFieldsService):
 
         if field_type:
             new_field_def: dict[str, Any] = {"type": field_type}
+
+            if isinstance(params, CaseFieldUpdate) and params.display_name is not None:
+                new_field_def["display_name"] = params.display_name
+            else:
+                new_field_def["display_name"] = (
+                    current_field_def.get("display_name") or field_id
+                )
 
             # Update options if provided (even empty list clears options)
             if params.options is not None:

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -3076,6 +3076,7 @@ def _build_tag_update_params(
 def _build_case_field_update_params(
     *,
     name: str | None = None,
+    display_name: str | None = None,
     type: SqlType | None = None,
     options: list[str] | None = None,
     options_provided: bool = False,
@@ -3084,6 +3085,8 @@ def _build_case_field_update_params(
     update_kwargs: dict[str, Any] = {}
     if name is not None:
         update_kwargs["name"] = name
+    if display_name is not None:
+        update_kwargs["display_name"] = display_name
     if type is not None:
         update_kwargs["type"] = type
     if options_provided:
@@ -6362,6 +6365,7 @@ async def create_case_field(
     workspace_id: uuid.UUID,
     name: str,
     type: str,
+    display_name: str | None = None,
     kind: str | None = None,
     options: list[str] | None = None,
 ) -> MCPMessageResponse:
@@ -6374,6 +6378,7 @@ async def create_case_field(
         workspace_id: The workspace ID.
         name: Field name / column id. Schema: string matching
             `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+        display_name: Optional human-readable field name. Defaults to `name`.
         type: Uppercase SqlType value: TEXT, INTEGER, NUMERIC, DATE, BOOLEAN,
             TIMESTAMPTZ, JSONB, SELECT, or MULTI_SELECT.
         kind: Optional semantic kind. Valid values: LONG_TEXT and URL.
@@ -6392,6 +6397,7 @@ async def create_case_field(
             await svc.create_field(
                 CaseFieldCreate(
                     name=name,
+                    display_name=display_name,
                     type=parsed_type,
                     kind=parsed_kind,
                     options=options,
@@ -6412,6 +6418,7 @@ async def update_case_field(
     workspace_id: uuid.UUID,
     field_id: str,
     name: str | None = None,
+    display_name: str | None = None,
     type: str | None = None,
     options: list[str] | None = None,
 ) -> MCPMessageResponse:
@@ -6422,6 +6429,7 @@ async def update_case_field(
         field_id: Existing field id from `list_case_fields` (field name, not UUID).
         name: Optional new field name. Schema: string matching
             `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+        display_name: Optional new human-readable field name.
         type: Optional uppercase SqlType value.
         options: Optional list of strings. Use `[]` to clear select options.
 
@@ -6437,6 +6445,7 @@ async def update_case_field(
                 field_id,
                 _build_case_field_update_params(
                     name=name,
+                    display_name=display_name,
                     type=parsed_type,
                     options=options,
                     options_provided=options_provided,

--- a/tracecat/workspace_sync/adapters/case_field.py
+++ b/tracecat/workspace_sync/adapters/case_field.py
@@ -75,6 +75,7 @@ class CaseFieldAdapter(FlatManifestAdapter):
             specs[source_id] = CaseFieldResourceSpec(
                 id=source_id,
                 name=str(field_def.get("name") or ref),
+                display_name=str(field_def.get("display_name") or ref),
                 field_type=field_def.get("type"),
                 kind=field_def.get("kind"),
                 options=field_def.get("options"),
@@ -124,6 +125,7 @@ class CaseFieldAdapter(FlatManifestAdapter):
             if field_id not in current_schema:
                 field_params = CaseFieldCreate(
                     name=spec.name,
+                    display_name=spec.display_name,
                     type=field_type,
                     kind=_case_field_kind(field_kind),
                     options=field_options,
@@ -134,7 +136,10 @@ class CaseFieldAdapter(FlatManifestAdapter):
                 await field_service.editor.create_column(field_params)
                 # Mirror the new column into the schema map, copying only the
                 # parts that are present so the entry stays minimal.
-                field_def: dict[str, Any] = {"type": field_params.type.value}
+                field_def: dict[str, Any] = {
+                    "type": field_params.type.value,
+                    "display_name": field_params.display_name or field_params.name,
+                }
                 if field_params.options:
                     field_def["options"] = field_params.options
                 if field_params.kind is not None:
@@ -149,6 +154,7 @@ class CaseFieldAdapter(FlatManifestAdapter):
                     field_id,
                     CaseFieldUpdate(
                         name=spec.name if spec.name != field_id else None,
+                        display_name=spec.display_name,
                         type=field_type,
                         options=field_options,
                         required_on_closure=spec.required_on_closure,

--- a/tracecat/workspace_sync/schemas.py
+++ b/tracecat/workspace_sync/schemas.py
@@ -636,6 +636,12 @@ class CaseFieldResourceSpec(BaseModel):
         description="Stable source id; the field's single-segment file path key.",
     )
     name: str = Field(min_length=1, description="Case field name.")
+    display_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description="Optional human-readable case field name.",
+    )
     field_type: str | None = Field(
         default=None, description="Underlying field data type, if specified."
     )


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Adds optional `display_name` fields to the case-field create and update models and persists them in the field metadata JSONB.

- Create uses the supplied display name or defaults to the field ID.
- Update replaces an explicit display name, preserves an existing one, or backfills a missing value from the field ID.
- Workspace sync carries display names through projection and import.
- MCP create/update tools and generated frontend API types expose the new input.

### ENG-1641 chain

1. **[#3241 / ENG-1643](https://github.com/TracecatHQ/tracecat/pull/3241)** — read `display_name` from metadata and fall back to the field ID.
2. **This PR / ENG-1644** — write, preserve, and backfill `display_name` metadata.
3. **ENG-1646 remains** — update the frontend to display and edit the human-readable name while keeping the field ID as the stable reference.

After this PR, the backend contract is complete. ENG-1646 is the remaining user-facing step for ENG-1641.

### LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 35 | 2 |
| Tests | 58 | 1 |
| Generated | 28 | 0 |

## Related Issues

- [ENG-1644](https://linear.app/tracecat/issue/ENG-1644/add-writes-to-display-name-into-the-custom-fields-metadata)
- Parent: [ENG-1641](https://linear.app/tracecat/issue/ENG-1641/migrate-custom-fields-from-id-only-to-name-reference)

## Screenshots / Recordings

Not applicable; frontend behavior is covered by ENG-1646.

## Steps to QA

1. Run `uv run pytest tests/unit/test_case_fields_service.py`.
2. Run `uv run pytest tests/unit/test_mcp_server.py -k "case_field"`.
3. Run `uv run pytest tests/unit/api/test_api_cases.py -k "case_field"`.
4. Run `uv run pytest tests/unit/test_workspace_sync_acceptance_contract.py -k "case_field"`.
