### PR TITLE
fix(sandbox): raise bounded NSTUN socket budget

### DIFF
--- a/docker/nsjail/nstun-bounded-memory.patch
+++ b/docker/nsjail/nstun-bounded-memory.patch
@@ -31,9 +31,9 @@ index 0e033ff..3be3bdf 100644
 +constexpr size_t TCP_FLOW_BUDGET = TCP_BUFFER_BUDGET / TCP_FLOW_BUFFER_BYTES;
 +static_assert(TCP_FLOW_BUDGET > 0);
 +/* UDP and ICMP sockets are owned by the parent NSTUN process and are not
-+ * constrained by the jailed child's RLIMIT_NOFILE. Keep their aggregate bound
-+ * in the same range as the roughly 120 TCP flows admitted by the buffer budget. */
-+constexpr size_t UDP_ICMP_SOCKET_BUDGET = 128;
++ * constrained by the jailed child's RLIMIT_NOFILE. Use NSTUN's intrinsic
++ * descriptor-table ceiling instead of a lower workload-specific heuristic. */
++constexpr size_t UDP_ICMP_SOCKET_BUDGET = NSTUN_MAX_FDS;
  
  
  /* Removed MemcmpLess in favor of C++20 operator<=> */

--- a/docker/nsjail/nstun-bounded-memory.patch
+++ b/docker/nsjail/nstun-bounded-memory.patch
@@ -10,7 +10,7 @@ index 0e033ff..3be3bdf 100644
  
  #include "net_defs.h"
  #include "nstun.h"
-@@ -25,11 +26,23 @@ constexpr size_t UDP_QUEUE_PACKET_MAX = 1500;
+@@ -25,11 +26,24 @@ constexpr size_t UDP_QUEUE_PACKET_MAX = 1500;
  constexpr size_t UDP_QUEUE_MAX_PACKETS = 50;
  constexpr int VLEN = 64;
  
@@ -31,9 +31,10 @@ index 0e033ff..3be3bdf 100644
 +constexpr size_t TCP_FLOW_BUDGET = TCP_BUFFER_BUDGET / TCP_FLOW_BUFFER_BYTES;
 +static_assert(TCP_FLOW_BUDGET > 0);
 +/* UDP and ICMP sockets are owned by the parent NSTUN process and are not
-+ * constrained by the jailed child's RLIMIT_NOFILE. Use NSTUN's intrinsic
-+ * descriptor-table ceiling instead of a lower workload-specific heuristic. */
-+constexpr size_t UDP_ICMP_SOCKET_BUDGET = NSTUN_MAX_FDS;
++ * constrained by the jailed child's RLIMIT_NOFILE. Bound their aggregate
++ * kernel socket memory separately while leaving headroom for DNS bursts. */
++constexpr size_t UDP_ICMP_SOCKET_BUDGET = 256;
++static_assert(UDP_ICMP_SOCKET_BUDGET < NSTUN_MAX_FDS);
  
  
  /* Removed MemcmpLess in favor of C++20 operator<=> */

--- a/tests/unit/test_executor_sandbox_nsjail.py
+++ b/tests/unit/test_executor_sandbox_nsjail.py
@@ -878,12 +878,12 @@ async def _run_current_builtin_smoke_case(
 
 
 async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
-    """A low-FD guest reaches NSTUN's intrinsic UDP flow-table limit."""
+    """A low-FD guest cannot amplify one socket beyond the parent budget."""
     smoke_case = SmokeCase.NSJAIL_SOCKET_BUDGET
     if reason := _missing_prerequisite(smoke_case):
         _skip_smoke(reason)
 
-    udp_sinks, parent_address = _open_private_parent_udp_sinks(1_040)
+    udp_sinks, parent_address = _open_private_parent_udp_sinks(272)
     destination_ports = [sink.getsockname()[1] for sink in udp_sinks]
     script_name = "udp_socket_budget.py"
     (tmp_path / script_name).write_text(
@@ -942,9 +942,9 @@ async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
             sink.close()
 
     assert result.success, result.error
-    assert received_packets == 1_024, (received_packets, result.stderr)
-    assert "Maximum number of UDP flows reached" in result.stderr, result.stderr
-    assert "UDP/ICMP parent socket budget exhausted" not in result.stderr
+    assert received_packets == 256, (received_packets, result.stderr)
+    assert "Maximum number of UDP flows reached" not in result.stderr
+    assert "UDP/ICMP parent socket budget exhausted" in result.stderr, result.stderr
     assert "UDP/ICMP parent socket accounting underflow" not in result.stderr
 
 

--- a/tests/unit/test_executor_sandbox_nsjail.py
+++ b/tests/unit/test_executor_sandbox_nsjail.py
@@ -53,6 +53,9 @@ from tracecat.sandbox.networking import NSTUN_GATEWAY_IP4, write_sandbox_network
 from tracecat.sandbox.types import (
     ResourceLimits,
     SandboxConfig,
+    SandboxEgressRule,
+    SandboxNetworkPolicy,
+    SandboxNetworkProtocol,
     SandboxNetworkPurpose,
     SandboxNetworkRequest,
 )
@@ -479,18 +482,41 @@ def _write_network_policy_artifact_source(source_dir: Path) -> None:
     )
 
 
-def _open_private_parent_listener() -> tuple[socket.socket, IPv4Address, int]:
-    """Open a listener on the executor container's RFC 1918 address."""
+def _private_parent_ipv4_address() -> IPv4Address:
     parent_address = ip_address(socket.gethostbyname(socket.gethostname()))
     if not isinstance(parent_address, IPv4Address) or not any(
         parent_address in network for network in _RFC1918_NETWORKS
     ):
         _skip_smoke(f"executor address {parent_address} is not a private IPv4 address")
+    return parent_address
+
+
+def _open_private_parent_listener() -> tuple[socket.socket, IPv4Address, int]:
+    """Open a listener on the executor container's RFC 1918 address."""
+    parent_address = _private_parent_ipv4_address()
 
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.bind((str(parent_address), 0))
     listener.listen(4)
     return listener, parent_address, listener.getsockname()[1]
+
+
+def _open_private_parent_udp_sinks(
+    count: int,
+) -> tuple[tuple[socket.socket, ...], IPv4Address]:
+    """Keep deterministic UDP destinations open in the executor namespace."""
+    parent_address = _private_parent_ipv4_address()
+    sinks: list[socket.socket] = []
+    try:
+        for _ in range(count):
+            sink = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sinks.append(sink)
+            sink.bind((str(parent_address), 0))
+    except OSError as exc:
+        for sink in sinks:
+            sink.close()
+        _skip_smoke(f"could not open {count} parent UDP sinks: {exc}")
+    return tuple(sinks), parent_address
 
 
 def _open_parent_loopback_dns_listener() -> socket.socket:
@@ -852,11 +878,13 @@ async def _run_current_builtin_smoke_case(
 
 
 async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
-    """A low-FD guest cannot amplify one UDP socket into unbounded parent FDs."""
+    """A low-FD guest reaches NSTUN's intrinsic UDP flow-table limit."""
     smoke_case = SmokeCase.NSJAIL_SOCKET_BUDGET
     if reason := _missing_prerequisite(smoke_case):
         _skip_smoke(reason)
 
+    udp_sinks, parent_address = _open_private_parent_udp_sinks(1_040)
+    destination_ports = [sink.getsockname()[1] for sink in udp_sinks]
     script_name = "udp_socket_budget.py"
     (tmp_path / script_name).write_text(
         "\n".join(
@@ -864,32 +892,59 @@ async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
                 "import socket",
                 "import time",
                 "",
+                f"destination_ports = {destination_ports!r}",
                 "udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)",
-                "for port in range(10_000, 10_256):",
-                '    udp_socket.sendto(b"x", ("1.1.1.1", port))',
+                "for port in destination_ports:",
+                f'    udp_socket.sendto(b"x", ("{parent_address}", port))',
+                "    time.sleep(0.002)",
                 "time.sleep(2)",
                 "",
             ]
         )
     )
 
-    result = await NsjailExecutor().execute(
-        tmp_path,
-        SandboxConfig(
-            network=SandboxNetworkRequest(SandboxNetworkPurpose.SCRIPT),
-            resources=ResourceLimits(
-                memory_mb=128,
-                cpu_seconds=10,
-                max_open_files=16,
-                max_processes=16,
-                timeout_seconds=10,
+    try:
+        result = await NsjailExecutor().execute(
+            tmp_path,
+            SandboxConfig(
+                network=SandboxNetworkRequest(
+                    SandboxNetworkPurpose.SCRIPT,
+                    policy=SandboxNetworkPolicy(
+                        allowed_rules=(
+                            SandboxEgressRule(
+                                destination=ip_network(f"{parent_address}/32"),
+                                protocol=SandboxNetworkProtocol.UDP,
+                            ),
+                        ),
+                    ),
+                ),
+                resources=ResourceLimits(
+                    memory_mb=128,
+                    cpu_seconds=10,
+                    max_open_files=16,
+                    max_processes=16,
+                    timeout_seconds=10,
+                ),
             ),
-        ),
-        script_name=script_name,
-    )
+            script_name=script_name,
+        )
+        received_packets = 0
+        for sink in udp_sinks:
+            sink.setblocking(False)
+            try:
+                data, _ = sink.recvfrom(1)
+            except BlockingIOError:
+                continue
+            if data == b"x":
+                received_packets += 1
+    finally:
+        for sink in udp_sinks:
+            sink.close()
 
     assert result.success, result.error
-    assert "UDP/ICMP parent socket budget exhausted" in result.stderr
+    assert received_packets == 1_024, (received_packets, result.stderr)
+    assert "Maximum number of UDP flows reached" in result.stderr, result.stderr
+    assert "UDP/ICMP parent socket budget exhausted" not in result.stderr
     assert "UDP/ICMP parent socket accounting underflow" not in result.stderr
 
 


### PR DESCRIPTION
## Summary

- Raise the independent NSTUN UDP/ICMP parent-socket budget from 128 to 256, while keeping it eight times below the `NSTUN_MAX_FDS` descriptor-table ceiling.
- Preserve the existing parent-socket accounting, upstream flow-table limits, and separate TCP memory budget.
- Make the Docker runtime smoke deterministic by sending one low-FD guest socket to 272 parent-side UDP sinks and verifying exactly 256 flows are admitted before the parent budget rejects the remainder.

## Why

EU QA found that a cold `uvx` stdio MCP startup can exceed the original 128-socket budget while resolving and installing its runtime. NSTUN retains established UDP flows for 60 seconds, so later DNS queries could be rejected with `UDP/ICMP parent socket budget exhausted` and surface as `EAI_AGAIN`.

The initial version of this PR tied the budget to `NSTUN_MAX_FDS` (2,048). Review correctly identified that the FD-table size is not a parent-memory budget. The final 256 limit retains an independent resource boundary while giving the installer burst twice the deployed allowance. Three fresh local cold-start measurements peaked at 70 parent socket FDs.

## Safety boundary

- UDP/ICMP parent sockets remain capped at 256 per sandbox, independently of the 2,048-entry FD table.
- NSTUN's 1,024-flow IPv4/IPv6 UDP tables and descriptor-index checks remain unchanged.
- The existing move-only reservation continues to cover UDP, SOCKS5 control/data, and ICMP socket creation and cleanup.
- NsJail still runs one sandbox workload per process with existing wall-clock, CPU, memory, process, and guest-FD limits.
- No Helm, Kubernetes, CIDR, DNS parser, or public/private egress behavior changes.

## Validation

- `git apply --check` against pinned NsJail commit `388b9655a696e88df3185d09e36c0378a8532904`
- `docker build --target nsjail-builder --progress=plain .`
- `uv run pytest --confcutdir=tests/unit tests/unit/test_executor_sandbox_nsjail.py::test_nstun_bounds_parent_udp_sockets -vv`
- `uv run pytest --confcutdir=tests/unit 'tests/unit/test_executor_sandbox_nsjail.py::test_action_runner_executes_registry_action_smoke[asyncio-nsjail-network-policy]' -vv`
- `uv run ruff check tests/unit/test_executor_sandbox_nsjail.py`
- `uv run ruff format --check tests/unit/test_executor_sandbox_nsjail.py`
- `uv run basedpyright tests/unit/test_executor_sandbox_nsjail.py`
- Three fresh measurements of the cold `uvx` recipe peaked at 70 parent socket FDs.
- Three fresh runs with the final 256 cap all connected and returned `get_current_time` and `convert_time`.
- Commit hooks, hardcoded-secret scanning, and signed-commit verification passed.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 5 | 4 |
| Tests | 74 | 19 |

## Linear

[ENG-1647: Fix stdio MCP DNS failures caused by NSTUN socket budget](https://linear.app/tracecat/issue/ENG-1647/fix-stdio-mcp-dns-failures-caused-by-nstun-socket-budget)
