### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/docs/agents/custom-llm-providers.mdx
+++ b/docs/agents/custom-llm-providers.mdx
@@ -7,6 +7,17 @@ Use a custom LLM provider when an agent should call your own OpenAI-compatible g
 
 Custom providers are managed as custom sources in organization agent settings.
 
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is available as a built-in named provider. It is an OpenAI-compatible gateway that also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+To use it:
+
+1. In organization or workspace agent settings, add an `ORCAROUTER_API_KEY` credential (optionally `ORCAROUTER_BASE_URL` to override `https://api.orcarouter.ai/v1`).
+2. Select any `orcarouter/*` model from the agent model catalog, such as `orcarouter/auto`.
+
+Requests for `orcarouter/*` models route through the managed LiteLLM gateway directly to OrcaRouter.
+
 ## Routing model
 
 Each agent uses its own model configuration to decide where its LLM requests go.

--- a/frontend/src/components/ai-elements/model-selector.tsx
+++ b/frontend/src/components/ai-elements/model-selector.tsx
@@ -148,6 +148,7 @@ export type ModelSelectorLogoProps = Omit<
     | "zhipuai-coding-plan"
     | "perplexity"
     | "openrouter"
+    | "orcarouter"
     | "zenmux"
     | "v0"
     | "iflowcn"

--- a/frontend/src/components/settings/workspace-model-settings.tsx
+++ b/frontend/src/components/settings/workspace-model-settings.tsx
@@ -97,6 +97,8 @@ function getProviderDisplayLabel(provider: string): string {
       return "Mistral AI"
     case "openai":
       return "OpenAI"
+    case "orcarouter":
+      return "OrcaRouter"
     case "vertex_ai":
       return "Google Vertex AI"
     case "custom-model-provider":

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -86,6 +86,48 @@ def test_openai_injects_optional_base_url() -> None:
     assert data["api_base"] == "https://api.openai.example/v1"
 
 
+def test_orcarouter_injects_api_key_and_defaults_base_url() -> None:
+    data = {"model": "orcarouter/auto"}
+    creds = {"ORCAROUTER_API_KEY": "test-orcarouter-key"}
+
+    _inject_provider_credentials(data, "orcarouter", creds)
+
+    assert data["api_key"] == "test-orcarouter-key"
+    assert data["model"] == "openai/orcarouter/auto"
+    assert data["api_base"] == "https://api.orcarouter.ai/v1"
+
+
+def test_orcarouter_preserves_openai_prefixed_model() -> None:
+    data = {"model": "openai/gpt-5"}
+    creds = {"ORCAROUTER_API_KEY": "test-orcarouter-key"}
+
+    _inject_provider_credentials(data, "orcarouter", creds)
+
+    assert data["api_key"] == "test-orcarouter-key"
+    assert data["model"] == "openai/gpt-5"
+    assert data["api_base"] == "https://api.orcarouter.ai/v1"
+
+
+def test_orcarouter_injects_optional_base_url() -> None:
+    data = {"model": "orcarouter/fusion"}
+    creds = {
+        "ORCAROUTER_API_KEY": "test-orcarouter-key",
+        "ORCAROUTER_BASE_URL": "https://orcarouter.example/v1",
+    }
+
+    _inject_provider_credentials(data, "orcarouter", creds)
+
+    assert data["api_key"] == "test-orcarouter-key"
+    assert data["api_base"] == "https://orcarouter.example/v1"
+
+
+def test_orcarouter_missing_api_key_raises() -> None:
+    data = {"model": "orcarouter/auto"}
+
+    with pytest.raises(ProxyException, match="Provider credentials incomplete"):
+        _inject_provider_credentials(data, "orcarouter", {})
+
+
 def test_azure_ai_does_not_require_api_version() -> None:
     data = {"model": "azure_ai"}
     creds = {

--- a/tracecat/agent/config.py
+++ b/tracecat/agent/config.py
@@ -143,7 +143,19 @@ MODEL_CONFIGS = {
             "required": ["custom-model-provider"],
         },
     ),
+    "orcarouter/auto": ModelConfig(
+        name="orcarouter/auto",
+        provider="orcarouter",
+        org_secret_name="agent-orcarouter-credentials",
+        secrets={
+            "required": ["orcarouter"],
+        },
+    ),
 }
+
+# Default API base for the OrcaRouter provider. Workspaces can override this
+# with an ORCAROUTER_BASE_URL credential field.
+ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
 
 PROVIDER_CREDENTIAL_CONFIGS = {
     "openai": ProviderCredentialConfig(
@@ -422,6 +434,28 @@ PROVIDER_CREDENTIAL_CONFIGS = {
                 label="API Version",
                 type="text",
                 description="Optional Azure AI API version appended as the api-version query parameter.",
+                required=False,
+            ),
+        ],
+    ),
+    "orcarouter": ProviderCredentialConfig(
+        provider="orcarouter",
+        label="OrcaRouter",
+        fields=[
+            ProviderCredentialField(
+                key="ORCAROUTER_API_KEY",
+                label="API Key",
+                type="password",
+                description="Your OrcaRouter API key from the OrcaRouter dashboard.",
+            ),
+            ProviderCredentialField(
+                key="ORCAROUTER_BASE_URL",
+                label="Base URL",
+                type="text",
+                description=(
+                    "Optional custom base URL for the OrcaRouter API. "
+                    "Defaults to https://api.orcarouter.ai/v1."
+                ),
                 required=False,
             ),
         ],

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -17,6 +17,7 @@ from litellm.proxy._types import LitellmUserRoles, ProxyException, UserAPIKeyAut
 from litellm.types.utils import CallTypesLiteral
 
 from tracecat import config as app_config
+from tracecat.agent.config import ORCAROUTER_DEFAULT_BASE_URL
 from tracecat.agent.litellm_compat import apply_patch
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.tokens import verify_llm_token
@@ -429,6 +430,7 @@ class TracecatCallbackHandler(CustomLogger):
             "openai",
             "anthropic",
             "custom-model-provider",
+            "orcarouter",
         }:
             data["api_base"] = base_url
 
@@ -558,6 +560,24 @@ def _inject_provider_credentials(
                 data["model"] = f"openai/{data['model']}"
             if base_url := creds.get("OPENAI_BASE_URL"):
                 data["api_base"] = base_url
+
+        case "orcarouter":
+            api_key = creds.get("ORCAROUTER_API_KEY")
+            if not api_key:
+                raise ProxyException(
+                    message="Provider credentials incomplete",
+                    type="auth_error",
+                    param=None,
+                    code=401,
+                )
+            data["api_key"] = api_key
+            if not data.get("model", "").startswith("openai/"):
+                data["model"] = f"openai/{data['model']}"
+            # OrcaRouter is an OpenAI-compatible gateway, so route it through
+            # the LiteLLM `openai/*` route with OrcaRouter's API base.
+            data["api_base"] = creds.get("ORCAROUTER_BASE_URL") or (
+                ORCAROUTER_DEFAULT_BASE_URL
+            )
 
         case "anthropic":
             api_key = creds.get("ANTHROPIC_API_KEY")

--- a/tracecat/agent/platform_catalog.json
+++ b/tracecat/agent/platform_catalog.json
@@ -3371,6 +3371,83 @@
         "supports_minimal_reasoning_effort": false,
         "provider": "openai"
       }
+    },
+    {
+      "model_provider": "orcarouter",
+      "model_name": "orcarouter/auto",
+      "metadata": {
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "provider": "orcarouter",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "orcarouter",
+      "model_name": "orcarouter/fusion",
+      "metadata": {
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "provider": "orcarouter",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "orcarouter",
+      "model_name": "orcarouter/free",
+      "metadata": {
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "provider": "orcarouter",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "orcarouter",
+      "model_name": "orcarouter/open-code",
+      "metadata": {
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "provider": "orcarouter",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "orcarouter",
+      "model_name": "orcarouter/code-review",
+      "metadata": {
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "provider": "orcarouter",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
     }
   ]
 }

--- a/tracecat/agent/providers.py
+++ b/tracecat/agent/providers.py
@@ -14,6 +14,7 @@ from pydantic_ai.providers.google import GoogleProvider
 from pydantic_ai.providers.mistral import MistralProvider
 from pydantic_ai.providers.ollama import OllamaProvider
 from pydantic_ai.providers.openai import OpenAIProvider
+from tracecat.agent.config import ORCAROUTER_DEFAULT_BASE_URL
 from tracecat_registry import secrets
 from tracecat_registry.integrations.aws_boto3 import get_sync_session
 
@@ -56,6 +57,16 @@ def get_model(
                 model_name=model_name,
                 provider=OpenAIProvider(
                     base_url=base_url, api_key=secrets.get("OPENAI_API_KEY")
+                ),
+            )
+        case "orcarouter":
+            # OrcaRouter is an OpenAI-compatible gateway; route through the
+            # OpenAI chat schema with OrcaRouter's API base and key.
+            model = OpenAIChatModel(
+                model_name=model_name,
+                provider=OpenAIProvider(
+                    base_url=base_url or ORCAROUTER_DEFAULT_BASE_URL,
+                    api_key=secrets.get("ORCAROUTER_API_KEY"),
                 ),
             )
         case "ollama":

--- a/tracecat/agent/providers.py
+++ b/tracecat/agent/providers.py
@@ -14,9 +14,10 @@ from pydantic_ai.providers.google import GoogleProvider
 from pydantic_ai.providers.mistral import MistralProvider
 from pydantic_ai.providers.ollama import OllamaProvider
 from pydantic_ai.providers.openai import OpenAIProvider
-from tracecat.agent.config import ORCAROUTER_DEFAULT_BASE_URL
 from tracecat_registry import secrets
 from tracecat_registry.integrations.aws_boto3 import get_sync_session
+
+from tracecat.agent.config import ORCAROUTER_DEFAULT_BASE_URL
 
 
 def get_model(


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider rather than relying on the generic OpenAI-compatible endpoint, mirroring how this repo already treats its named gateway providers. Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models behind one API key, and it also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

What this changes:

- `tracecat/agent/config.py`: registers the provider in `PROVIDER_CREDENTIAL_CONFIGS` (label "OrcaRouter", `ORCAROUTER_API_KEY` secret, optional `ORCAROUTER_BASE_URL`) and adds `orcarouter/auto` to `MODEL_CONFIGS`.
- `tracecat/agent/gateway.py`: routes `orcarouter/*` models through the managed LiteLLM gateway by injecting the provider API key and base URL (`https://api.orcarouter.ai/v1` by default).
- `tracecat/agent/providers.py`: resolves `orcarouter` models to an `OpenAIChatModel` pointed at OrcaRouter for direct agent usage.
- `tracecat/agent/platform_catalog.json`: adds five curated `orcarouter/*` catalog entries (`auto`, `fusion`, `free`, `open-code`, `code-review`).
- `frontend/src/components/settings/workspace-model-settings.tsx`: shows the "OrcaRouter" display label.
- `frontend/src/components/ai-elements/model-selector.tsx`: accepts `orcarouter` as a provider for the model logo.
- `tests/unit/test_agent_gateway.py`: covers default/override base URL injection, `openai/` prefix preservation, and missing-key failure.
- `docs/agents/custom-llm-providers.mdx`: documents the provider and its setup.

## Related Issues

None.

## Screenshots / Recordings

None. No visual layout changes; the frontend changes only add a provider label and a union member.

## Steps to QA

1. Unit tests: `pytest tests/unit/test_agent_gateway.py --confcutdir=tests/unit` - 33 passed, 1 warning.
2. Lint: `ruff check tracecat/agent/config.py tracecat/agent/gateway.py tracecat/agent/providers.py tests/unit/test_agent_gateway.py` - clean.
3. Live API: with a real `ORCAROUTER_API_KEY`, `litellm.completion(model="openai/orcarouter/auto", api_base="https://api.orcarouter.ai/v1", ...)` returns 200; `pydantic_ai.Agent(get_model("orcarouter/auto", "orcarouter", None))` completes through OrcaRouter.
4. Runtime path: set an `ORCAROUTER_API_KEY` credential, then pick any `orcarouter/*` model in the agent model catalog; requests route through the managed gateway directly to OrcaRouter.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OrcaRouter as a named LLM provider. Previously, users configured a generic OpenAI-compatible endpoint; now `orcarouter/*` models route via `litellm`’s `openai/*` path with API key and base URL injection, defaulting to `https://api.orcarouter.ai/v1`.

- Builds the `orcarouter` provider in backend: credential config (`ORCAROUTER_API_KEY`, optional `ORCAROUTER_BASE_URL`), gateway injection with conditional `openai/` prefix, and `pydantic-ai` provider construction.
- Adds five curated `orcarouter/*` models to the platform catalog and shows the "OrcaRouter" label/logo in the model selector.
- Unit tests cover base URL defaults/overrides, `openai/` prefix preservation, and missing-key errors.
- Docs explain setup for the new provider.

**Rollout**
- Required: add an `ORCAROUTER_API_KEY` credential (optionally `ORCAROUTER_BASE_URL` to override the default).
- Select any `orcarouter/*` model in agent settings; requests will route through `openai/*` to OrcaRouter.

<sup>Written for commit 6f70901f9dd602367768029ebc88f3181c6dc1da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

