### PR TITLE
fix(sandbox): raise NSTUN socket budget to 1024

### DIFF
--- a/docker/nsjail/nstun-bounded-memory.patch
+++ b/docker/nsjail/nstun-bounded-memory.patch
@@ -33,7 +33,7 @@ index 0e033ff..3be3bdf 100644
 +/* UDP and ICMP sockets are owned by the parent NSTUN process and are not
 + * constrained by the jailed child's RLIMIT_NOFILE. Bound their aggregate
 + * kernel socket memory separately while leaving headroom for DNS bursts. */
-+constexpr size_t UDP_ICMP_SOCKET_BUDGET = 256;
++constexpr size_t UDP_ICMP_SOCKET_BUDGET = 1024;
 +static_assert(UDP_ICMP_SOCKET_BUDGET < NSTUN_MAX_FDS);
  
  

--- a/tests/unit/test_executor_sandbox_nsjail.py
+++ b/tests/unit/test_executor_sandbox_nsjail.py
@@ -910,7 +910,7 @@ async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
     if reason := _missing_prerequisite(smoke_case):
         _skip_smoke(reason)
 
-    udp_sinks, parent_address = _open_private_parent_udp_sinks(272)
+    udp_sinks, parent_address = _open_private_parent_udp_sinks(1040)
     destination_ports = [sink.getsockname()[1] for sink in udp_sinks]
     script_name = "udp_socket_budget.py"
     (tmp_path / script_name).write_text(
@@ -969,9 +969,9 @@ async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
             sink.close()
 
     assert result.success, result.error
-    assert received_packets == 256, (received_packets, result.stderr)
-    assert "Maximum number of UDP flows reached" not in result.stderr
-    assert "UDP/ICMP parent socket budget exhausted" in result.stderr, result.stderr
+    assert received_packets == 1024, (received_packets, result.stderr)
+    assert "Maximum number of UDP flows reached" in result.stderr, result.stderr
+    assert "UDP/ICMP parent socket budget exhausted" not in result.stderr
     assert "UDP/ICMP parent socket accounting underflow" not in result.stderr
 
 


### PR DESCRIPTION
## Summary

- Raise the independent NSTUN UDP/ICMP parent-socket budget from 256 to 1,024.
- Keep the NSTUN descriptor-table ceiling unchanged at 2,048, preserving the compile-time `UDP_ICMP_SOCKET_BUDGET < NSTUN_MAX_FDS` guard.
- Update the Docker runtime smoke to drive 1,040 destinations, verify all 1,024 IPv4 UDP flow slots are admitted, and confirm the flow-table boundary—not the parent budget—rejects the remainder.

## Why

The existing 256-socket parent cap is below the desired allowance for larger DNS and UDP/ICMP bursts. This follow-up tuning sets the budget to 1,024 while retaining a hard per-sandbox bound at half of the 2,048-entry NSTUN FD table.

## Safety boundary

- Parent UDP/ICMP sockets remain independently bounded at 1,024 per sandbox.
- The existing 1,024-flow IPv4 UDP table and 2,048-entry FD table are unchanged.
- Move-only reservation accounting, cleanup paths, TCP buffer limits, and the jailed child's resource limits are unchanged.
- No egress policy, CIDR, DNS routing, Helm, or Kubernetes behavior changes.

## Validation

- `uv run pytest --confcutdir=tests/unit tests/unit/test_executor_sandbox_nsjail.py::test_nstun_bounds_parent_udp_sockets -vv` — passed against a rebuilt patched NsJail image
- `uv run ruff check tests/unit/test_executor_sandbox_nsjail.py`
- `uv run ruff format --check tests/unit/test_executor_sandbox_nsjail.py`
- `uv run basedpyright tests/unit/test_executor_sandbox_nsjail.py`
- Pre-commit hooks, hardcoded-secret scan, and signed-commit verification passed

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 1 | 1 |
| Tests | 4 | 4 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the NSTUN parent UDP/ICMP socket budget from 256 to 1,024 to handle larger DNS and UDP/ICMP bursts. Old behavior rejected flows past 256 with “UDP/ICMP parent socket budget exhausted”; new behavior admits up to 1,024 and then hits the IPv4 UDP flow-table limit with “Maximum number of UDP flows reached”.

- Bumps `UDP_ICMP_SOCKET_BUDGET` to 1,024 while keeping the 2,048 FD table and the `UDP_ICMP_SOCKET_BUDGET < NSTUN_MAX_FDS` guard unchanged.
- Updates the Docker runtime smoke test to drive 1,040 destinations, expect 1,024 packets received, and assert the flow-table boundary message.
- No changes to egress policy, TCP buffers, jailed `RLIMIT_NOFILE`, or descriptor-table ceilings; no migration required.

<sup>Written for commit 1093f27c7a9079d629e81f5770d2787d14520771. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

