### PR TITLE
fix(ui): correct MCP and Skills navigation UI

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/skills/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/skills/layout.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: "Skills",
 }
 
+/** Applies shared metadata and renders the nested Skills route content. */
 export default function SkillsLayout({
   children,
 }: {

--- a/frontend/src/app/workspaces/[workspaceId]/skills/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/skills/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Skills",
+}
+
+export default function SkillsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -441,7 +441,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   title: "MCP access",
                   href: `${basePath}/mcp`,
                   icon: TerminalIcon,
-                  isActive: pathname?.startsWith(`${basePath}/mcp`),
+                  isActive:
+                    pathname === `${basePath}/mcp` ||
+                    pathname?.startsWith(`${basePath}/mcp/`),
                 }
               : null,
           ].filter((item) => item !== null)}

--- a/frontend/tests/app-sidebar.test.tsx
+++ b/frontend/tests/app-sidebar.test.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from "react"
 import { AppSidebar } from "@/components/sidebar/app-sidebar"
 
 const mockUseScopeCheck = jest.fn<boolean | undefined, [string]>()
+let mockPathname = "/workspaces/workspace-1/workflows"
 let mockScopes: Record<string, boolean | undefined> = {}
 let mockEntitlements: Record<string, boolean> = {}
 let mockEntitlementsIsLoading = false
@@ -14,7 +15,7 @@ let mockHasEntitlementData = true
 
 jest.mock("next/navigation", () => ({
   useParams: () => ({}),
-  usePathname: () => "/workspaces/workspace-1/workflows",
+  usePathname: () => mockPathname,
 }))
 
 jest.mock("@/components/auth/scope-guard", () => ({
@@ -31,7 +32,27 @@ jest.mock("@/components/sidebar/app-menu", () => ({
 }))
 
 jest.mock("@/components/sidebar/sidebar-user-nav", () => ({
-  SidebarUserNav: () => <div>User nav</div>,
+  SidebarUserNav: ({
+    manageItems,
+  }: {
+    manageItems: {
+      title: string
+      href: string
+      isActive?: boolean
+    }[]
+  }) => (
+    <nav>
+      {manageItems.map((item) => (
+        <a
+          href={item.href}
+          data-active={item.isActive ? "true" : "false"}
+          key={item.href}
+        >
+          {item.title}
+        </a>
+      ))}
+    </nav>
+  ),
 }))
 
 jest.mock("@/components/ui/collapsible", () => ({
@@ -72,15 +93,17 @@ jest.mock("@/components/ui/sidebar", () => ({
     asChild,
     children,
     disabled,
+    isActive,
     type,
   }: {
     asChild?: boolean
     children: ReactNode
     disabled?: boolean
+    isActive?: boolean
     type?: "button" | "submit" | "reset"
   }) =>
     asChild ? (
-      <>{children}</>
+      <div data-active={isActive ? "true" : "false"}>{children}</div>
     ) : (
       <button type={type ?? "button"} disabled={disabled}>
         {children}
@@ -122,6 +145,7 @@ jest.mock("@/providers/workspace-id", () => ({
 describe("AppSidebar", () => {
   beforeEach(() => {
     mockUseScopeCheck.mockReset()
+    mockPathname = "/workspaces/workspace-1/workflows"
     mockScopes = {}
     mockEntitlements = {
       agent_addons: true,
@@ -189,5 +213,23 @@ describe("AppSidebar", () => {
 
     expect(screen.getByText("Chat")).toBeInTheDocument()
     expect(screen.getAllByText("Locked")).toHaveLength(1)
+  })
+
+  it("only highlights MCP servers on the MCP servers page", () => {
+    mockPathname = "/workspaces/workspace-1/mcp-servers"
+    mockScopes = {
+      "integration:read": true,
+      "workspace:read": true,
+    }
+
+    render(<AppSidebar />)
+
+    expect(
+      screen.getByRole("link", { name: "MCP servers" }).closest("[data-active]")
+    ).toHaveAttribute("data-active", "true")
+    expect(screen.getByRole("link", { name: "MCP access" })).toHaveAttribute(
+      "data-active",
+      "false"
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Match the MCP access sidebar item only on the `/mcp` route or its child routes.
- Add a regression test covering the MCP servers page's active sidebar state.
- Set the Skills route metadata so both the list and detail pages use `Skills` as the browser title.

## Root cause

The MCP access item used a broad `startsWith("/mcp")` check. That prefix also matched the separate `/mcp-servers` route, causing both sidebar entries to appear selected.

The Skills route had no metadata boundary, so both `/skills` and `/skills/{skillId}` inherited the app-wide `Tracecat` title.

## User impact

- Selecting MCP servers now highlights only MCP servers.
- Skills list and detail pages now display `Skills` in the browser tab.

## Validation

- `pnpm -C frontend exec biome check --write src/components/sidebar/app-sidebar.tsx tests/app-sidebar.test.tsx`
- `pnpm -C frontend test -- --runInBand tests/app-sidebar.test.tsx`
- `pnpm -C frontend exec biome check --write 'src/app/workspaces/[workspaceId]/skills/layout.tsx'`
- `pnpm -C frontend run typecheck`
- Pre-commit hooks

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 17 | 1 |
| Tests | 45 | 3 |