### PR TITLE
fix(sandbox): raise NSTUN UDP capacity to 2048

### DIFF
--- a/docker/nsjail/nstun-bounded-memory.patch
+++ b/docker/nsjail/nstun-bounded-memory.patch
@@ -1,5 +1,17 @@
+diff --git a/monitor.cc b/monitor.cc
+--- a/monitor.cc
++++ b/monitor.cc
+@@ -83,7 +83,7 @@ struct fdHandler_t {
+ /* --- per-thread context -------------------------------- */
+ 
+ constexpr size_t MAX_EVENTS = 16;
+-constexpr size_t MAX_HANDLERS = 2048;
++constexpr size_t MAX_HANDLERS = 4096;
+ constexpr size_t MAX_PERIODICS = 16;
+ constexpr int kSetupTimeoutSec = 10;
+ constexpr int kShutdownEscalationSec = 2;
 diff --git a/nstun/core.h b/nstun/core.h
-index 0e033ff..3be3bdf 100644
+index 0e033ff..4999e14 100644
 --- a/nstun/core.h
 +++ b/nstun/core.h
 @@ -11,6 +11,7 @@
@@ -10,7 +22,15 @@ index 0e033ff..3be3bdf 100644
  
  #include "net_defs.h"
  #include "nstun.h"
-@@ -25,11 +26,24 @@ constexpr size_t UDP_QUEUE_PACKET_MAX = 1500;
+@@ -19,17 +20,31 @@
+ namespace nstun {
+ 
+ constexpr size_t NSTUN_MAX_FLOWS = 1024;
+-constexpr size_t NSTUN_MAX_FDS = 2048;
++constexpr size_t NSTUN_MAX_UDP_FLOWS = 2048;
++constexpr size_t NSTUN_MAX_FDS = 4096;
+ constexpr size_t NSTUN_MAX_RULES = 128;
+ constexpr size_t UDP_QUEUE_PACKET_MAX = 1500;
  constexpr size_t UDP_QUEUE_MAX_PACKETS = 50;
  constexpr int VLEN = 64;
  
@@ -33,12 +53,12 @@ index 0e033ff..3be3bdf 100644
 +/* UDP and ICMP sockets are owned by the parent NSTUN process and are not
 + * constrained by the jailed child's RLIMIT_NOFILE. Bound their aggregate
 + * kernel socket memory separately while leaving headroom for DNS bursts. */
-+constexpr size_t UDP_ICMP_SOCKET_BUDGET = 1024;
++constexpr size_t UDP_ICMP_SOCKET_BUDGET = 2048;
 +static_assert(UDP_ICMP_SOCKET_BUDGET < NSTUN_MAX_FDS);
  
  
  /* Removed MemcmpLess in favor of C++20 operator<=> */
-@@ -62,6 +75,22 @@ struct __attribute__((packed)) IcmpFlowKey6 {
+@@ -62,6 +77,22 @@ struct __attribute__((packed)) IcmpFlowKey6 {
  
  struct Context;
  
@@ -61,7 +81,7 @@ index 0e033ff..3be3bdf 100644
  enum class FlowType { TCP, UDP, ICMP };
  enum class ProxyMode : uint8_t { NONE, SOCKS5, HTTP_CONNECT };
  
-@@ -118,11 +147,16 @@ struct UdpFlow {
+@@ -118,11 +149,16 @@ struct UdpFlow {
  	uint32_t bnd_ip;
  	uint16_t bnd_port;
  	bool host_fd_is_listener;
@@ -80,7 +100,7 @@ index 0e033ff..3be3bdf 100644
  	size_t c_tx_queue_head;
  	size_t c_tx_queue_tail;
  	size_t c_tx_queue_count;
-@@ -149,7 +183,7 @@ struct TcpFlow {
+@@ -149,7 +185,7 @@ struct TcpFlow {
  	size_t tx_acked_offset;
  	size_t rx_sent_offset;
  
@@ -89,7 +109,7 @@ index 0e033ff..3be3bdf 100644
  	std::unique_ptr<uint8_t[]> c_tcp_tx_buf;
  	size_t c_tcp_tx_len;
  	std::unique_ptr<uint8_t[]> c_proxy_rx_buf;
-@@ -164,6 +198,7 @@ struct TcpFlow {
+@@ -164,6 +200,7 @@ struct TcpFlow {
  
  struct IcmpFlow {
  	struct FlowHeader header;
@@ -97,15 +117,20 @@ index 0e033ff..3be3bdf 100644
  };
  
  
-@@ -185,6 +220,7 @@ struct Context {
+@@ -185,9 +222,10 @@ struct Context {
  
  	TcpFlow c_ipv4_tcp_flows[NSTUN_MAX_FLOWS];
  	size_t num_c_ipv4_tcp_flows;
+-	UdpFlow c_ipv4_udp_flows[NSTUN_MAX_FLOWS];
 +	size_t udp_icmp_socket_count;
- 	UdpFlow c_ipv4_udp_flows[NSTUN_MAX_FLOWS];
++	UdpFlow c_ipv4_udp_flows[NSTUN_MAX_UDP_FLOWS];
  	size_t num_c_ipv4_udp_flows;
- 	UdpFlow c_ipv6_udp_flows[NSTUN_MAX_FLOWS];
-@@ -222,6 +258,44 @@ struct Context {
+-	UdpFlow c_ipv6_udp_flows[NSTUN_MAX_FLOWS];
++	UdpFlow c_ipv6_udp_flows[NSTUN_MAX_UDP_FLOWS];
+ 	size_t num_c_ipv6_udp_flows;
+ 	TcpFlow c_ipv6_tcp_flows[NSTUN_MAX_FLOWS];
+ 	size_t num_c_ipv6_tcp_flows;
+@@ -222,6 +260,44 @@ struct Context {
  
  };
  
@@ -364,7 +389,7 @@ index 643d037..d1edeb8 100644
  		return nullptr;
  	}
 diff --git a/nstun/udp.cc b/nstun/udp.cc
-index 6f7804b..bb37b9a 100644
+index 6f7804b..69bf0ce 100644
 --- a/nstun/udp.cc
 +++ b/nstun/udp.cc
 @@ -5,6 +5,7 @@
@@ -391,6 +416,38 @@ index 6f7804b..bb37b9a 100644
  static const char* udp_state_to_str(UdpSocks5State state) {
  	struct {
  		const uint64_t state;
+@@ -47,7 +57,7 @@ static constexpr time_t UDP_TIMEOUT_ESTABLISHED = 60;
+ static constexpr time_t UDP_TIMEOUT_CONNECTING = 5; /* SOCKS5 TCP setup */
+ static UdpFlow* find_ipv4_udp_flow(Context* ctx, const FlowKey4& key4) {
+ 	size_t active_seen = 0;
+-	for (size_t i = 0; i < NSTUN_MAX_FLOWS; ++i) {
++	for (size_t i = 0; i < NSTUN_MAX_UDP_FLOWS; ++i) {
+ 		UdpFlow& flow = ctx->c_ipv4_udp_flows[i];
+ 		if (flow.header.active) {
+ 			if (!flow.header.is_ipv6 &&
+@@ -66,7 +76,7 @@ static UdpFlow* find_ipv4_udp_flow(Context* ctx, const FlowKey4& key4) {
+ 
+ static UdpFlow* find_ipv6_udp_flow(Context* ctx, const FlowKey6& key6) {
+ 	size_t active_seen = 0;
+-	for (size_t i = 0; i < NSTUN_MAX_FLOWS; ++i) {
++	for (size_t i = 0; i < NSTUN_MAX_UDP_FLOWS; ++i) {
+ 		UdpFlow& flow = ctx->c_ipv6_udp_flows[i];
+ 		if (flow.header.active) {
+ 			if (memcmp(&flow.header.key6, &key6, sizeof(key6)) == 0) {
+@@ -102,11 +112,11 @@ static UdpFlow* alloc_udp_flow(UdpFlow* flows, size_t max_flows) {
+ }
+ 
+ static UdpFlow* alloc_ipv4_udp_flow(Context* ctx) {
+-	return alloc_udp_flow(ctx->c_ipv4_udp_flows, NSTUN_MAX_FLOWS);
++	return alloc_udp_flow(ctx->c_ipv4_udp_flows, NSTUN_MAX_UDP_FLOWS);
+ }
+ 
+ static UdpFlow* alloc_ipv6_udp_flow(Context* ctx) {
+-	return alloc_udp_flow(ctx->c_ipv6_udp_flows, NSTUN_MAX_FLOWS);
++	return alloc_udp_flow(ctx->c_ipv6_udp_flows, NSTUN_MAX_UDP_FLOWS);
+ }
+ 
+ static void prepare_recvmmsg(Context* ctx) {
 @@ -133,6 +143,7 @@ void udp_destroy_flow(Context* ctx, UdpFlow* flow) {
  			LOG_W("Failed to remove host_fd from monitor");
  		}
@@ -565,6 +622,42 @@ index 6f7804b..bb37b9a 100644
  	size_t idx = flow->c_tx_queue_tail;
  	memcpy(flow->c_tx_queue[idx].data, data, data_len);
  	flow->c_tx_queue[idx].len = data_len;
+@@ -759,7 +802,7 @@ void handle_udp4_impl(
+ 			break;
+ 		}
+ 
+-		if (ctx->num_c_ipv4_udp_flows >= NSTUN_MAX_FLOWS) {
++		if (ctx->num_c_ipv4_udp_flows >= NSTUN_MAX_UDP_FLOWS) {
+ 			LOG_W("Maximum number of UDP flows reached, dropping");
+ 			send_icmp4_error(
+ 			    ctx, ip, ntohs(ip->tot_len), ICMP_DEST_UNREACH, ICMP_PORT_UNREACH);
+@@ -778,7 +821,7 @@ void handle_udp4_impl(
+ 
+ 	if (flow->use_socks5 && flow->state != UDP_S5_ESTABLISHED) {
+ 		/* Cap queued packet size to prevent memory exhaustion:
+-		 * NSTUN_MAX_FLOWS * 50 packets * UDP_QUEUE_PACKET_MAX = ~75MB worst case */
++		 * NSTUN_MAX_UDP_FLOWS * 50 packets * UDP_QUEUE_PACKET_MAX = ~150MB worst case */
+ 		if (!udp_enqueue_packet(flow, data, data_len, "UDP")) {
+ 			return;
+ 		}
+@@ -934,7 +977,7 @@ static void handle_host_udp_accept_pkt6(Context* ctx, int listen_fd, const nstun
+ 
+ 	UdpFlow* flow = find_ipv6_udp_flow(ctx, key6);
+ 	if (!flow) {
+-		if (ctx->num_c_ipv6_udp_flows >= NSTUN_MAX_FLOWS) {
++		if (ctx->num_c_ipv6_udp_flows >= NSTUN_MAX_UDP_FLOWS) {
+ 			LOG_W("Maximum number of IPv6 UDP flows reached, dropping");
+ 			return;
+ 		}
+@@ -983,7 +1026,7 @@ static void handle_host_udp_accept_pkt4(Context* ctx, int listen_fd, const nstun
+ 
+ 	UdpFlow* flow = find_ipv4_udp_flow(ctx, key4);
+ 	if (!flow) {
+-		if (ctx->num_c_ipv4_udp_flows >= NSTUN_MAX_FLOWS) {
++		if (ctx->num_c_ipv4_udp_flows >= NSTUN_MAX_UDP_FLOWS) {
+ 			LOG_W("Maximum number of UDP flows reached, dropping");
+ 			return;
+ 		}
 @@ -1152,22 +1195,28 @@ static UdpFlow* udp_create_flow6(Context* ctx, const FlowKey6& key6, const RuleR
  		    flow->use_socks5 ? 1 : 0, guest_port, tcp_fd,
  		    flow->header.is_redirected ? " [redirected]" : "");
@@ -611,3 +704,12 @@ index 6f7804b..bb37b9a 100644
  		flow->state = UDP_S5_ESTABLISHED;
  		LOG_D("Flow %d: initialized to UDP_S5_ESTABLISHED (IPv6)", fd);
  		set_udp_flow_by_fd(ctx, fd, flow);
+@@ -1249,7 +1298,7 @@ void handle_udp6_impl(
+ 			break;
+ 		}
+ 
+-		if (ctx->num_c_ipv6_udp_flows >= NSTUN_MAX_FLOWS) {
++		if (ctx->num_c_ipv6_udp_flows >= NSTUN_MAX_UDP_FLOWS) {
+ 			LOG_W("Maximum number of IPv6 UDP flows reached, dropping");
+ 			send_icmp6_error(ctx, ip, sizeof(ip6_hdr) + payload_size, ICMP6_DST_UNREACH,
+ 			    ICMP6_DST_UNREACH_NOPORT);

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -94,7 +94,11 @@ def clean_redis_db() -> Iterator[None]:
 
 
 class _LiteLLMRequestPayload(TypedDict, total=False):
+    messages: list[object]
     model: str
+    path: str
+    stream: bool
+    tools: list[str]
 
 
 class _SkillVisibilityMessage(TypedDict):
@@ -112,7 +116,13 @@ _STDIO_MCP_BURST_FLOWS_PER_SERVER = 128
 _STDIO_MCP_BURST_FLOW_COUNT = (
     _STDIO_MCP_BURST_SERVER_COUNT * _STDIO_MCP_BURST_FLOWS_PER_SERVER
 )
+_STDIO_MCP_BASH_FLOW_COUNT = 256
+_STDIO_MCP_COMBINED_FLOW_COUNT = (
+    _STDIO_MCP_BURST_FLOW_COUNT + _STDIO_MCP_BASH_FLOW_COUNT
+)
 _STDIO_MCP_BURST_PARENT_NOFILE_LIMIT = 4096
+_STDIO_MCP_BASH_TOOL_USE_ID = "toolu_tracecat_bash_network_probe"
+_STDIO_MCP_BASH_RESULT_MARKER = "TRACE_CAT_BASH_NETWORK_PROBE_OK"
 _RFC1918_NETWORKS = (
     IPv4Network("10.0.0.0/8"),
     IPv4Network("172.16.0.0/12"),
@@ -183,6 +193,31 @@ def main():
             sockets[0].sendto(f"initialized:{server_id}".encode(), (host, ports[0]))
         elif request_id is not None:
             respond(request_id, {})
+
+
+if __name__ == "__main__":
+    main()
+"""
+_STDIO_MCP_BASH_PROBE_SOURCE = f"""\
+import socket
+import sys
+
+
+def main():
+    host, raw_ports = sys.argv[1:]
+    ports = [int(port) for port in raw_ports.split(",")]
+    sockets = []
+    for port in ports:
+        udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_socket.sendto(b"x", (host, port))
+        sockets.append(udp_socket)
+
+    for udp_socket in sockets:
+        udp_socket.settimeout(8)
+        if udp_socket.recv(3) != b"ack":
+            raise RuntimeError("Bash UDP probe was not acknowledged")
+
+    print("{_STDIO_MCP_BASH_RESULT_MARKER}", len(sockets), flush=True)
 
 
 if __name__ == "__main__":
@@ -378,6 +413,12 @@ def _build_stdio_mcp_burst_servers(
     return servers
 
 
+def _write_bash_network_probe(job_dir: Path) -> Path:
+    probe_path = job_dir / "bash_network_probe.py"
+    probe_path.write_text(_STDIO_MCP_BASH_PROBE_SOURCE)
+    return session_paths_module.JAILED_AGENT_JOB_DIR / probe_path.name
+
+
 def _make_fake_claude_options() -> _FakeClaudeOptions:
     return _FakeClaudeOptions(env={"ANTHROPIC_AUTH_TOKEN": "fake-llm-token"})
 
@@ -392,10 +433,27 @@ def _decode_litellm_request_payload(body_bytes: bytes) -> _LiteLLMRequestPayload
     if not isinstance(decoded, dict):
         return {}
 
+    payload: _LiteLLMRequestPayload = {}
     model = decoded.get("model")
     if isinstance(model, str):
-        return {"model": model}
-    return {}
+        payload["model"] = model
+
+    stream = decoded.get("stream")
+    if isinstance(stream, bool):
+        payload["stream"] = stream
+
+    messages = decoded.get("messages")
+    if isinstance(messages, list):
+        payload["messages"] = messages
+
+    tools = decoded.get("tools")
+    if isinstance(tools, list):
+        tool_names: list[str] = []
+        for tool in tools:
+            if isinstance(tool, dict) and isinstance(name := tool.get("name"), str):
+                tool_names.append(name)
+        payload["tools"] = tool_names
+    return payload
 
 
 def _parse_skill_visibility_message(message: object) -> _SkillVisibilityMessage:
@@ -541,6 +599,7 @@ class _FakeProxy:
 
 class _FakeLLMSocketProxy:
     instances: list[_FakeLLMSocketProxy] = []
+    scripted_bash_command: str | None = None
 
     def __init__(
         self,
@@ -556,6 +615,7 @@ class _FakeLLMSocketProxy:
         self.started = False
         self.stopped = False
         self.request_count = 0
+        self.message_request_count = 0
         self.requests: list[_LiteLLMRequestPayload] = []
         self._server: asyncio.Server | None = None
         type(self).instances.append(self)
@@ -605,7 +665,40 @@ class _FakeLLMSocketProxy:
         self.request_count += 1
 
         request_body = _decode_litellm_request_payload(body_bytes)
+        request_line = headers.partition(b"\r\n")[0].decode("latin1")
+        request_line_parts = request_line.split()
+        if len(request_line_parts) >= 2:
+            request_body["path"] = request_line_parts[1]
         self.requests.append(request_body)
+
+        request_path = request_body.get("path", "")
+        is_messages_request = request_path.partition("?")[0] == "/v1/messages"
+        is_nonstream_messages_request = (
+            is_messages_request and request_body.get("stream") is not True
+        )
+        if is_nonstream_messages_request:
+            self.message_request_count += 1
+
+        if (
+            self.scripted_bash_command is not None
+            and self.message_request_count == 1
+            and is_nonstream_messages_request
+        ):
+            content = [
+                {
+                    "type": "tool_use",
+                    "id": _STDIO_MCP_BASH_TOOL_USE_ID,
+                    "name": "Bash",
+                    "input": {
+                        "command": self.scripted_bash_command,
+                        "description": "Exercise sandbox networking after MCP startup",
+                    },
+                }
+            ]
+            stop_reason = "tool_use"
+        else:
+            content = [{"type": "text", "text": "fake claude response"}]
+            stop_reason = "end_turn"
 
         body = json.dumps(
             {
@@ -613,8 +706,8 @@ class _FakeLLMSocketProxy:
                 "type": "message",
                 "role": "assistant",
                 "model": request_body.get("model") or "customer-alias",
-                "content": [{"type": "text", "text": "fake claude response"}],
-                "stop_reason": "end_turn",
+                "content": content,
+                "stop_reason": stop_reason,
                 "stop_sequence": None,
                 "usage": {
                     "input_tokens": 1,
@@ -970,6 +1063,7 @@ async def _run_full_claude_harness_runtime_case(
     enable_internet_access: bool = False,
     executor_input: AgentExecutorInput | None = None,
     job_dir: Path | None = None,
+    scripted_bash_command: str | None = None,
 ) -> None:
     _patch_agent_management_credentials(monkeypatch)
     _FakeLLMSocketProxy.instances.clear()
@@ -1003,6 +1097,11 @@ async def _run_full_claude_harness_runtime_case(
         del self
         persisted_session_lines.append((sdk_session_id, session_line, internal))
 
+    monkeypatch.setattr(
+        _FakeLLMSocketProxy,
+        "scripted_bash_command",
+        scripted_bash_command,
+    )
     monkeypatch.setattr(executor_activity, "LLMSocketProxy", _FakeLLMSocketProxy)
     monkeypatch.setattr(
         nsjail_module,
@@ -1055,7 +1154,7 @@ async def _run_full_claude_harness_runtime_case(
     assert result.success is True
     assert result.error is None
     assert result.output == "fake claude response"
-    assert result.result_num_turns == 1
+    assert result.result_num_turns == (2 if scripted_bash_command else 1)
     assert result.messages is None
 
     assert len(_FakeLLMSocketProxy.instances) == 1
@@ -1075,20 +1174,31 @@ async def _run_stdio_mcp_startup_burst_case(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Initialize one real agent across a cold, multi-uvx MCP startup burst."""
-    if not 1024 < _STDIO_MCP_BURST_FLOW_COUNT < 2048:
-        raise AssertionError("startup burst must distinguish the old and new budgets")
+    """Initialize many MCPs, then make the agent use Bash under retained load."""
+    if not 1024 < _STDIO_MCP_BURST_FLOW_COUNT < _STDIO_MCP_COMBINED_FLOW_COUNT:
+        raise AssertionError("MCP startup must exceed the old 1024-flow budget")
+    if _STDIO_MCP_COMBINED_FLOW_COUNT >= 2048:
+        raise AssertionError("combined MCP and Bash burst must fit the new budget")
 
     udp_sinks, parent_address = _open_private_parent_udp_sinks(
-        _STDIO_MCP_BURST_FLOW_COUNT
+        _STDIO_MCP_COMBINED_FLOW_COUNT
     )
-    destination_ports = [sink.getsockname()[1] for sink in udp_sinks]
+    mcp_destination_ports = [
+        sink.getsockname()[1] for sink in udp_sinks[:_STDIO_MCP_BURST_FLOW_COUNT]
+    ]
+    bash_destination_ports = [
+        sink.getsockname()[1] for sink in udp_sinks[_STDIO_MCP_BURST_FLOW_COUNT:]
+    ]
     job_dir = tmp_path / "stdio-mcp-startup-burst"
     job_dir.mkdir(parents=True)
     mcp_servers = _build_stdio_mcp_burst_servers(
         job_dir=job_dir,
         parent_address=parent_address,
-        destination_ports=destination_ports,
+        destination_ports=mcp_destination_ports,
+    )
+    bash_probe_path = _write_bash_network_probe(job_dir)
+    bash_command = f"python3 {bash_probe_path} {parent_address} " + ",".join(
+        str(port) for port in bash_destination_ports
     )
     base_input = _make_passthrough_executor_input(enable_internet_access=False)
     executor_input = base_input.model_copy(
@@ -1160,6 +1270,7 @@ async def _run_stdio_mcp_startup_burst_case(
             tmp_path=tmp_path,
             executor_input=executor_input,
             job_dir=job_dir,
+            scripted_bash_command=bash_command,
         )
         await asyncio.sleep(0.1)
     finally:
@@ -1167,11 +1278,29 @@ async def _run_stdio_mcp_startup_burst_case(
             loop.remove_reader(sink.fileno())
             sink.close()
 
-    assert received_packets == _STDIO_MCP_BURST_FLOW_COUNT, received_packets
+    assert received_packets == _STDIO_MCP_COMBINED_FLOW_COUNT, received_packets
     expected_initialized_servers = {
         str(server_index) for server_index in range(_STDIO_MCP_BURST_SERVER_COUNT)
     }
     assert initialized_servers == expected_initialized_servers, initialized_servers
+
+    [proxy] = _FakeLLMSocketProxy.instances
+    message_requests = [
+        request
+        for request in proxy.requests
+        if request.get("path", "").partition("?")[0] == "/v1/messages"
+        and request.get("stream") is not True
+    ]
+    assert len(message_requests) == 2, message_requests
+    assert "Bash" in message_requests[0].get("tools", [])
+    # Web tools execute provider-side, so assert that the agent can select them
+    # without miscounting them as jailed NSTUN flows.
+    advertised_tools = json.dumps(message_requests[0].get("messages", []))
+    assert "WebFetch" in advertised_tools
+    assert "WebSearch" in advertised_tools
+    bash_result = json.dumps(message_requests[1].get("messages", []))
+    assert _STDIO_MCP_BASH_TOOL_USE_ID in bash_result
+    assert _STDIO_MCP_BASH_RESULT_MARKER in bash_result
 
 
 async def _run_mcp_compression_initialize_case(
@@ -2543,7 +2672,7 @@ async def test_run_agent_activity_spawns_full_claude_harness_runtime_with_nstun_
 
 
 @pytest.mark.anyio
-async def test_agent_nsjail_initializes_many_uvx_stdio_mcp_servers_during_udp_burst(
+async def test_agent_nsjail_handles_stdio_mcp_startup_and_bash_network_burst(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -6,12 +6,15 @@ import json
 import os
 import platform
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
 import uuid
+import zipfile
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from dataclasses import dataclass, replace
+from ipaddress import IPv4Address, IPv4Network, ip_address, ip_network
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, TypedDict, cast
@@ -27,6 +30,7 @@ import tracecat.agent.runtime.session_paths as session_paths_module
 import tracecat.agent.sandbox.llm_proxy as llm_proxy_module
 import tracecat.agent.sandbox.nsjail as nsjail_module
 import tracecat.agent.sandbox.shim_entrypoint as shim_entrypoint
+import tracecat.sandbox.networking as sandbox_networking
 from tracecat import config as app_config
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import (
@@ -35,6 +39,8 @@ from tracecat.agent.common.stream_types import (
     UnifiedStreamEvent,
 )
 from tracecat.agent.common.types import (
+    MCPServerConfig,
+    MCPStdioServerConfig,
     MCPToolDefinition,
     SandboxAgentConfig,
     SandboxSubagentConfig,
@@ -64,6 +70,12 @@ from tracecat.agent.skill.service import SkillService
 from tracecat.agent.skill.types import ResolvedSkillRef
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
+from tracecat.sandbox.types import (
+    SandboxEgressRule,
+    SandboxNetworkPolicy,
+    SandboxNetworkProtocol,
+    SandboxNetworkPurpose,
+)
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -93,6 +105,89 @@ class _SkillVisibilityMessage(TypedDict):
 class _DuckDBSmokeMessage(TypedDict):
     duckdb_extension_count: int
     duckdb_path: str
+
+
+_STDIO_MCP_BURST_SERVER_COUNT = 12
+_STDIO_MCP_BURST_FLOWS_PER_SERVER = 128
+_STDIO_MCP_BURST_FLOW_COUNT = (
+    _STDIO_MCP_BURST_SERVER_COUNT * _STDIO_MCP_BURST_FLOWS_PER_SERVER
+)
+_STDIO_MCP_BURST_PARENT_NOFILE_LIMIT = 4096
+_RFC1918_NETWORKS = (
+    IPv4Network("10.0.0.0/8"),
+    IPv4Network("172.16.0.0/12"),
+    IPv4Network("192.168.0.0/16"),
+)
+_STDIO_MCP_BURST_SERVER_SOURCE = """\
+import json
+import socket
+import sys
+import time
+
+
+def respond(request_id, result):
+    payload = {"jsonrpc": "2.0", "id": request_id, "result": result}
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+def main():
+    server_id, host, raw_ports = sys.argv[1:]
+    ports = [int(port) for port in raw_ports.split(",")]
+    sockets = []
+    for port in ports:
+        udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_socket.sendto(b"x", (host, port))
+        sockets.append(udp_socket)
+        time.sleep(0.02)
+
+    for udp_socket in sockets:
+        udp_socket.settimeout(8)
+        if udp_socket.recv(3) != b"ack":
+            raise RuntimeError("startup UDP probe was not acknowledged")
+
+    for raw_line in sys.stdin:
+        message = json.loads(raw_line)
+        request_id = message.get("id")
+        method = message.get("method")
+        if method == "initialize":
+            params = message.get("params")
+            protocol_version = (
+                params.get("protocolVersion", "2025-06-18")
+                if isinstance(params, dict)
+                else "2025-06-18"
+            )
+            respond(
+                request_id,
+                {
+                    "protocolVersion": protocol_version,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {
+                        "name": f"tracecat-burst-{server_id}",
+                        "version": "1.0.0",
+                    },
+                },
+            )
+        elif method == "tools/list":
+            respond(
+                request_id,
+                {
+                    "tools": [
+                        {
+                            "name": "ping",
+                            "description": "Return a deterministic test response.",
+                            "inputSchema": {"type": "object", "properties": {}},
+                        }
+                    ]
+                },
+            )
+            sockets[0].sendto(f"initialized:{server_id}".encode(), (host, ports[0]))
+        elif request_id is not None:
+            respond(request_id, {})
+
+
+if __name__ == "__main__":
+    main()
+"""
 
 
 @dataclass(slots=True)
@@ -171,6 +266,116 @@ def _docker_nsjail_fallback_enabled() -> bool:
         os.environ.get("TRACECAT__AGENT_NSJAIL_DOCKER_FALLBACK_CHILD") != "1"
         and shutil.which("docker") is not None
     )
+
+
+def _private_parent_ipv4_address() -> IPv4Address:
+    parent_address = ip_address(socket.gethostbyname(socket.gethostname()))
+    if not isinstance(parent_address, IPv4Address) or not any(
+        parent_address in network for network in _RFC1918_NETWORKS
+    ):
+        pytest.skip(
+            f"agent executor address {parent_address} is not a private IPv4 address"
+        )
+    return parent_address
+
+
+def _open_private_parent_udp_sinks(
+    count: int,
+) -> tuple[tuple[socket.socket, ...], IPv4Address]:
+    """Keep one deterministic parent destination open for every startup flow."""
+    parent_address = _private_parent_ipv4_address()
+    sinks: list[socket.socket] = []
+    try:
+        for _ in range(count):
+            sink = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sinks.append(sink)
+            sink.bind((str(parent_address), 0))
+    except OSError as exc:
+        for sink in sinks:
+            sink.close()
+        pytest.skip(f"could not open {count} parent UDP sinks: {exc}")
+    return tuple(sinks), parent_address
+
+
+def _write_stdio_mcp_burst_wheel(
+    job_dir: Path,
+    server_index: int,
+) -> tuple[Path, str]:
+    """Build a dependency-free local wheel for one cold uvx MCP process."""
+    module_name = f"tracecat_mcp_burst_{server_index}"
+    package_name = f"tracecat-mcp-burst-{server_index}"
+    command_name = package_name
+    dist_info = f"{module_name}-1.0.0.dist-info"
+    wheel_path = job_dir / f"{module_name}-1.0.0-py3-none-any.whl"
+    files = {
+        f"{module_name}.py": _STDIO_MCP_BURST_SERVER_SOURCE,
+        f"{dist_info}/METADATA": (
+            f"Metadata-Version: 2.1\nName: {package_name}\nVersion: 1.0.0\n"
+        ),
+        f"{dist_info}/WHEEL": (
+            "Wheel-Version: 1.0\n"
+            "Generator: tracecat-test\n"
+            "Root-Is-Purelib: true\n"
+            "Tag: py3-none-any\n"
+        ),
+        f"{dist_info}/entry_points.txt": (
+            f"[console_scripts]\n{command_name} = {module_name}:main\n"
+        ),
+    }
+    record_path = f"{dist_info}/RECORD"
+    files[record_path] = "".join(f"{path},,\n" for path in (*files, record_path))
+    with zipfile.ZipFile(wheel_path, "w", compression=zipfile.ZIP_DEFLATED) as wheel:
+        for path, contents in files.items():
+            wheel.writestr(path, contents)
+    return wheel_path, command_name
+
+
+def _build_stdio_mcp_burst_servers(
+    *,
+    job_dir: Path,
+    parent_address: IPv4Address,
+    destination_ports: list[int],
+) -> list[MCPServerConfig]:
+    if len(destination_ports) != _STDIO_MCP_BURST_FLOW_COUNT:
+        raise ValueError(
+            f"expected {_STDIO_MCP_BURST_FLOW_COUNT} destination ports, "
+            f"got {len(destination_ports)}"
+        )
+
+    servers: list[MCPServerConfig] = []
+    for server_index in range(_STDIO_MCP_BURST_SERVER_COUNT):
+        start = server_index * _STDIO_MCP_BURST_FLOWS_PER_SERVER
+        server_ports = destination_ports[
+            start : start + _STDIO_MCP_BURST_FLOWS_PER_SERVER
+        ]
+        wheel_path, command_name = _write_stdio_mcp_burst_wheel(
+            job_dir,
+            server_index,
+        )
+        jailed_wheel_path = session_paths_module.JAILED_AGENT_JOB_DIR / wheel_path.name
+        server: MCPStdioServerConfig = {
+            "type": "stdio",
+            "name": f"startup-burst-{server_index}",
+            "command": "uvx",
+            "args": [
+                "--offline",
+                "--from",
+                str(jailed_wheel_path),
+                command_name,
+                str(server_index),
+                str(parent_address),
+                ",".join(str(port) for port in server_ports),
+            ],
+            "timeout": 15,
+            "id": str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"https://tracecat.invalid/mcp-startup-burst/{server_index}",
+                )
+            ),
+        }
+        servers.append(server)
+    return servers
 
 
 def _make_fake_claude_options() -> _FakeClaudeOptions:
@@ -763,6 +968,8 @@ async def _run_full_claude_harness_runtime_case(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     enable_internet_access: bool = False,
+    executor_input: AgentExecutorInput | None = None,
+    job_dir: Path | None = None,
 ) -> None:
     _patch_agent_management_credentials(monkeypatch)
     _FakeLLMSocketProxy.instances.clear()
@@ -770,7 +977,10 @@ async def _run_full_claude_harness_runtime_case(
     await broker.start()
     stream_sink = _InMemoryStreamSink()
     persisted_session_lines: list[tuple[str, str, bool]] = []
-    job_dir = Path(tempfile.mkdtemp(prefix="tcaj-", dir="/tmp"))
+    if job_dir is None:
+        job_dir = Path(tempfile.mkdtemp(prefix="tcaj-", dir="/tmp"))
+    else:
+        job_dir.mkdir(parents=True, exist_ok=True)
 
     async def fake_create_job_directory(self: SandboxedAgentExecutor) -> Path:
         del self
@@ -833,9 +1043,10 @@ async def _run_full_claude_harness_runtime_case(
 
     try:
         result = await run_agent_activity(
-            _make_passthrough_executor_input(
+            executor_input
+            or _make_passthrough_executor_input(
                 enable_internet_access=enable_internet_access
-            ),
+            )
         )
     finally:
         await broker.stop()
@@ -857,6 +1068,110 @@ async def _run_full_claude_harness_runtime_case(
     assert stream_sink.errors == []
     # Terminal END is emitted by the workflow, not the executor loopback.
     assert stream_sink.done_count == 0
+
+
+async def _run_stdio_mcp_startup_burst_case(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Initialize one real agent across a cold, multi-uvx MCP startup burst."""
+    if not 1024 < _STDIO_MCP_BURST_FLOW_COUNT < 2048:
+        raise AssertionError("startup burst must distinguish the old and new budgets")
+
+    udp_sinks, parent_address = _open_private_parent_udp_sinks(
+        _STDIO_MCP_BURST_FLOW_COUNT
+    )
+    destination_ports = [sink.getsockname()[1] for sink in udp_sinks]
+    job_dir = tmp_path / "stdio-mcp-startup-burst"
+    job_dir.mkdir(parents=True)
+    mcp_servers = _build_stdio_mcp_burst_servers(
+        job_dir=job_dir,
+        parent_address=parent_address,
+        destination_ports=destination_ports,
+    )
+    base_input = _make_passthrough_executor_input(enable_internet_access=False)
+    executor_input = base_input.model_copy(
+        update={
+            "config": replace(base_input.config, mcp_servers=mcp_servers),
+        }
+    )
+
+    original_network_policy = sandbox_networking.configured_sandbox_network_policy
+
+    def network_policy_with_udp_fixture(
+        purpose: SandboxNetworkPurpose,
+    ) -> SandboxNetworkPolicy:
+        policy = original_network_policy(purpose)
+        return replace(
+            policy,
+            allowed_rules=(
+                SandboxEgressRule(
+                    destination=ip_network(f"{parent_address}/32"),
+                    protocol=SandboxNetworkProtocol.UDP,
+                ),
+                *policy.allowed_rules,
+            ),
+        )
+
+    async def passthrough_stdio_env(
+        servers: list[MCPServerConfig] | None,
+        *,
+        role: Role,
+    ) -> list[MCPServerConfig] | None:
+        del role
+        return servers
+
+    monkeypatch.setattr(
+        sandbox_networking,
+        "configured_sandbox_network_policy",
+        network_policy_with_udp_fixture,
+    )
+    monkeypatch.setattr(
+        executor_activity,
+        "_hydrate_stdio_env",
+        passthrough_stdio_env,
+    )
+
+    received_packets = 0
+    initialized_servers: set[str] = set()
+    loop = asyncio.get_running_loop()
+
+    def echo_startup_packet(sink: socket.socket) -> None:
+        nonlocal received_packets
+        try:
+            data, source = sink.recvfrom(128)
+        except BlockingIOError:
+            return
+        if data == b"x":
+            received_packets += 1
+        elif data.startswith(b"initialized:"):
+            initialized_servers.add(data.decode().partition(":")[2])
+        sink.sendto(b"ack", source)
+
+    for sink in udp_sinks:
+        sink.setblocking(False)
+        loop.add_reader(sink.fileno(), echo_startup_packet, sink)
+
+    try:
+        await _run_full_claude_harness_runtime_case(
+            disable_nsjail_mode=False,
+            monkeypatch=monkeypatch,
+            tmp_path=tmp_path,
+            executor_input=executor_input,
+            job_dir=job_dir,
+        )
+        await asyncio.sleep(0.1)
+    finally:
+        for sink in udp_sinks:
+            loop.remove_reader(sink.fileno())
+            sink.close()
+
+    assert received_packets == _STDIO_MCP_BURST_FLOW_COUNT, received_packets
+    expected_initialized_servers = {
+        str(server_index) for server_index in range(_STDIO_MCP_BURST_SERVER_COUNT)
+    }
+    assert initialized_servers == expected_initialized_servers, initialized_servers
 
 
 async def _run_mcp_compression_initialize_case(
@@ -1126,6 +1441,7 @@ def _run_nsjail_harness_in_docker_or_skip(
     cli_flag: str = "--run-nsjail-harness-smoke",
     failure_label: str = "Dockerized nsjail harness fallback failed.",
     requires_tun: bool = False,
+    parent_nofile_limit: int | None = None,
 ) -> None:
     if os.environ.get("TRACECAT__AGENT_NSJAIL_DOCKER_FALLBACK_CHILD") == "1":
         pytest.skip("nsjail unavailable inside Docker fallback child")
@@ -1141,8 +1457,6 @@ def _run_nsjail_harness_in_docker_or_skip(
     )
     if docker_info.returncode != 0:
         pytest.skip("Docker daemon unavailable for nsjail fallback")
-    if requires_tun and not Path("/dev/net/tun").exists():
-        pytest.skip("Dockerized nsjail NSTUN smoke requires host /dev/net/tun")
 
     repo_root = Path(__file__).resolve().parents[2]
     compose_env = os.environ.copy()
@@ -1165,6 +1479,17 @@ def _run_nsjail_harness_in_docker_or_skip(
         if requires_tun
         else []
     )
+    privileged_lines = ["    privileged: true"] if requires_tun else []
+    ulimit_lines = (
+        [
+            "    ulimits:",
+            "      nofile:",
+            f"        soft: {parent_nofile_limit}",
+            f"        hard: {parent_nofile_limit}",
+        ]
+        if parent_nofile_limit is not None
+        else []
+    )
     override_path = Path(
         tempfile.mkstemp(prefix="tracecat-agent-nsjail-test-", suffix=".yml")[1]
     )
@@ -1175,11 +1500,13 @@ def _run_nsjail_harness_in_docker_or_skip(
                 "  api:",
                 "    build:",
                 "      target: test",
+                *privileged_lines,
                 "    cap_add:",
                 "      - SYS_ADMIN",
                 "    security_opt:",
                 "      - seccomp:unconfined",
                 "      - systempaths=unconfined",
+                *ulimit_lines,
                 *device_lines,
                 "    volumes:",
                 f"      - {json.dumps(tests_mount)}",
@@ -1258,6 +1585,23 @@ def _run_nsjail_nstun_smoke_from_cli() -> None:
                 monkeypatch=monkeypatch,
                 tmp_path=tmp_path,
                 enable_internet_access=True,
+            )
+        finally:
+            monkeypatch.undo()
+            shutil.rmtree(tmp_path, ignore_errors=True)
+
+    asyncio.run(run())
+
+
+def _run_nsjail_stdio_mcp_burst_smoke_from_cli() -> None:
+    async def run() -> None:
+        monkeypatch = pytest.MonkeyPatch()
+        tmp_path = Path(tempfile.mkdtemp(prefix="tracecat-agent-stdio-mcp-burst-"))
+        try:
+            _set_disable_nsjail_mode(monkeypatch, False)
+            await _run_stdio_mcp_startup_burst_case(
+                monkeypatch=monkeypatch,
+                tmp_path=tmp_path,
             )
         finally:
             monkeypatch.undo()
@@ -2199,6 +2543,29 @@ async def test_run_agent_activity_spawns_full_claude_harness_runtime_with_nstun_
 
 
 @pytest.mark.anyio
+async def test_agent_nsjail_initializes_many_uvx_stdio_mcp_servers_during_udp_burst(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    if not _agent_nsjail_available():
+        _run_nsjail_harness_in_docker_or_skip(
+            cli_flag="--run-nsjail-stdio-mcp-burst-smoke",
+            failure_label="Dockerized stdio MCP startup burst smoke failed.",
+            requires_tun=True,
+            parent_nofile_limit=_STDIO_MCP_BURST_PARENT_NOFILE_LIMIT,
+        )
+        return
+    if not Path("/dev/net/tun").exists():
+        pytest.skip("agent stdio MCP startup burst smoke requires /dev/net/tun")
+
+    _set_disable_nsjail_mode(monkeypatch, False)
+    await _run_stdio_mcp_startup_burst_case(
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+
+
+@pytest.mark.anyio
 async def test_run_agent_activity_reproduces_mcp_compression_initialize_timeout_in_each_sandbox_mode(
     full_harness_disable_nsjail_mode: bool,
     tmp_path: Path,
@@ -2560,6 +2927,8 @@ if __name__ == "__main__":
         _run_nsjail_harness_smoke_from_cli()
     elif sys.argv[1:] == ["--run-nsjail-nstun-smoke"]:
         _run_nsjail_nstun_smoke_from_cli()
+    elif sys.argv[1:] == ["--run-nsjail-stdio-mcp-burst-smoke"]:
+        _run_nsjail_stdio_mcp_burst_smoke_from_cli()
     elif sys.argv[1:] == ["--run-nsjail-skills-smoke"]:
         _run_nsjail_skills_smoke_from_cli()
     elif sys.argv[1:] == ["--run-nsjail-mcp-compression-smoke"]:
@@ -2570,6 +2939,7 @@ if __name__ == "__main__":
         raise SystemExit(
             "Usage: python -m tests.unit.test_agent_sandbox_litellm "
             "[--run-nsjail-harness-smoke|--run-nsjail-nstun-smoke|"
+            "--run-nsjail-stdio-mcp-burst-smoke|"
             "--run-nsjail-skills-smoke|--run-nsjail-mcp-compression-smoke|"
             "--run-nsjail-duckdb-smoke]"
         )

--- a/tests/unit/test_executor_sandbox_nsjail.py
+++ b/tests/unit/test_executor_sandbox_nsjail.py
@@ -64,6 +64,9 @@ from tracecat.sandbox.types import (
 _DOCKER_CHILD_ENV = "TRACECAT__EXECUTOR_ACTION_SMOKE_DOCKER_CHILD"
 _SKIP_SENTINEL = "TRACE_CAT_EXECUTOR_ACTION_SMOKE_SKIP:"
 _SMOKE_URI = "s3://tracecat-test-registry/smoke/site-packages.tar.gz"
+_NSTUN_UDP_SOCKET_BUDGET = 2048
+_NSTUN_UDP_SOCKET_PROBE_OVERFLOW = 16
+_NSTUN_PARENT_NOFILE_LIMIT = 4096
 _RFC1918_NETWORKS = (
     IPv4Network("10.0.0.0/8"),
     IPv4Network("172.16.0.0/12"),
@@ -197,6 +200,16 @@ def _run_executor_action_smoke_in_docker_or_skip(smoke_case: SmokeCase) -> None:
         if Path("/dev/net/tun").exists()
         else []
     )
+    ulimit_lines = (
+        [
+            "    ulimits:",
+            "      nofile:",
+            f"        soft: {_NSTUN_PARENT_NOFILE_LIMIT}",
+            f"        hard: {_NSTUN_PARENT_NOFILE_LIMIT}",
+        ]
+        if smoke_case is SmokeCase.NSJAIL_SOCKET_BUDGET
+        else []
+    )
     override_path = Path(
         tempfile.mkstemp(prefix="tracecat-executor-action-smoke-", suffix=".yml")[1]
     )
@@ -211,6 +224,7 @@ def _run_executor_action_smoke_in_docker_or_skip(smoke_case: SmokeCase) -> None:
                 "    security_opt:",
                 "      - seccomp:unconfined",
                 "      - systempaths=unconfined",
+                *ulimit_lines,
                 *device_lines,
                 "    volumes:",
                 f"      - {json.dumps(tests_mount)}",
@@ -910,7 +924,9 @@ async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
     if reason := _missing_prerequisite(smoke_case):
         _skip_smoke(reason)
 
-    udp_sinks, parent_address = _open_private_parent_udp_sinks(1040)
+    udp_sinks, parent_address = _open_private_parent_udp_sinks(
+        _NSTUN_UDP_SOCKET_BUDGET + _NSTUN_UDP_SOCKET_PROBE_OVERFLOW
+    )
     destination_ports = [sink.getsockname()[1] for sink in udp_sinks]
     script_name = "udp_socket_budget.py"
     (tmp_path / script_name).write_text(
@@ -950,7 +966,7 @@ async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
                     cpu_seconds=10,
                     max_open_files=16,
                     max_processes=16,
-                    timeout_seconds=10,
+                    timeout_seconds=20,
                 ),
             ),
             script_name=script_name,
@@ -969,7 +985,11 @@ async def _run_nstun_socket_budget_smoke_case(tmp_path: Path) -> None:
             sink.close()
 
     assert result.success, result.error
-    assert received_packets == 1024, (received_packets, result.stderr)
+    assert received_packets == _NSTUN_UDP_SOCKET_BUDGET, (
+        received_packets,
+        result.stderr,
+    )
+    assert "Too many FD handlers in monitor" not in result.stderr, result.stderr
     assert "Maximum number of UDP flows reached" in result.stderr, result.stderr
     assert "UDP/ICMP parent socket budget exhausted" not in result.stderr
     assert "UDP/ICMP parent socket accounting underflow" not in result.stderr


### PR DESCRIPTION
## What changed

- Raise the shared parent UDP/ICMP socket budget from 1,024 to 2,048 per NSTUN sandbox.
- Give UDP its own 2,048-flow capacity while keeping TCP and ICMP flow tables at 1,024.
- Raise the FD lookup and monitor-handler ceilings to 4,096 so they do not reject flows before the socket budget does.
- Extend the exact-limit Docker regression to open 2,064 UDP destinations and verify exactly 2,048 are accepted.
- Add a production-path agent regression that starts 12 separate cold `uvx` stdio MCP servers, drives 128 acknowledged startup mappings per server (1,536 total), and requires every server to complete MCP tool discovery.
- After MCP initialization, make Claude invoke its real Bash tool inside the same jail. Bash opens and acknowledges another 256 UDP mappings, and the test requires its tool result to reach the second model turn (1,792 combined flows).
- Verify Bash is exposed locally and WebFetch/WebSearch are available as deferred provider-side tools without counting them as jailed NSTUN traffic.
- Let the agent Docker fallback create its Linux TUN device in a privileged test container instead of skipping when the macOS host has no `/dev/net/tun`.

## Why

MCP startup can create a short, repeatable burst of DNS/UDP flows. NSTUN retains those parent mappings long enough for the burst to fill the current reservation budget, causing subsequent resolver attempts and MCP connections to fail.

Raising only the reservation counter is insufficient: the UDP flow arrays, numeric FD lookup, and monitor handler table are independent ceilings. This changes them together while preserving hard overflow behavior at 2,048 parent UDP/ICMP sockets per active sandbox.

The synthetic limit test proves the hard boundary. The agent scenario covers the missing production chain: agent executor, broker shim, Claude CLI, concurrent cold `uvx` processes, MCP initialize/tool discovery, a real Bash tool round trip under retained MCP load, and the shared NSTUN parent.

WebFetch and WebSearch execute through the model provider rather than inside NsJail, so they do not consume this sandbox's NSTUN reservations. The regression verifies that they remain selectable but does not manufacture fake NSTUN flows for them.

## Capacity and risk

- Each active sandbox may now consume up to 2,048 host-side UDP/ICMP sockets; host exposure still scales with concurrent sandboxes.
- The combined agent scenario reaches 1,792 mappings and leaves 256 mappings of headroom below the new hard cap.
- TCP and ICMP fixed flow-table counts remain unchanged.
- The bounded-memory patch still enforces the 8 MiB NSTUN context assertion.
- Attempts beyond the UDP flow cap are still dropped rather than growing without bound.

## Validation

- `uv run pytest --confcutdir=tests/unit tests/unit/test_executor_sandbox_nsjail.py::test_nstun_bounds_parent_udp_sockets -x -vv`
- `uv run pytest --confcutdir=tests/unit tests/unit/test_agent_sandbox_litellm.py::test_agent_nsjail_handles_stdio_mcp_startup_and_bash_network_burst -x -vv`
- `uv run pytest --confcutdir=tests/unit tests/unit/test_agent_sandbox_litellm.py::test_run_agent_activity_spawns_full_claude_harness_runtime_in_each_sandbox_mode -k direct -x -vv`
- Red/green control: the 1,536-flow MCP phase failed against `origin/main` at the old 1,024 UDP-flow ceiling. This branch passes all 12 MCP initializations plus the 256-flow Bash call (1,792 total).
- `uv run ruff check tests/unit/test_agent_sandbox_litellm.py tests/unit/test_executor_sandbox_nsjail.py`
- `uv run ruff format --check tests/unit/test_agent_sandbox_litellm.py tests/unit/test_executor_sandbox_nsjail.py`
- `uv run basedpyright tests/unit/test_agent_sandbox_litellm.py tests/unit/test_executor_sandbox_nsjail.py`
- Applied the patch to the pinned NsJail source and built the Docker image successfully.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Infra/config | 114 | 12 |
| Tests | 532 | 13 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises NSTUN UDP capacity to 2048 to prevent DNS/UDP bursts during MCP startup from exhausting the parent socket budget and causing resolver/MCP failures. Old: UDP/ICMP parents capped at 1024 with lower FD/handler ceilings; New: UDP has its own 2048-flow cap with `NSTUN_MAX_FDS` and monitor handler ceilings at 4096; overflow still hard-drops.

- Introduces `NSTUN_MAX_UDP_FLOWS=2048`; TCP/ICMP tables remain 1024; `UDP_ICMP_SOCKET_BUDGET=2048`.
- Raises `MAX_HANDLERS` and `NSTUN_MAX_FDS` to 4096 so the socket budget governs rejection.
- Extends Docker NSTUN limit test to open 2,064 UDP destinations, assert exactly 2,048 accepted, and set container `ulimits.nofile` to 4096; also asserts no monitor handler overflow.
- Adds a production-path agent test: starts 12 cold `uvx` stdio MCP servers (1,536 UDP startup probes), then executes a Bash probe for 256 more flows (total 1,792 < 2,048); verifies all servers initialize and Bash completes; confirms web tools are listed without inflating jailed flow counts. New CLI: `--run-nsjail-stdio-mcp-burst-smoke`.
- Docker fallback now runs privileged to create `/dev/net/tun` and can set `nofile=4096`; tests allow UDP egress to the parent via a targeted network policy override.
- Memory bounds unchanged; excess flows beyond the UDP cap still drop without unbounded growth.

**Review/rollout**
- Confirm limits align in `monitor.cc`, `nstun/core.h`, and `nstun/udp.cc`: `MAX_HANDLERS=4096`, `NSTUN_MAX_FDS=4096`, `NSTUN_MAX_UDP_FLOWS=2048`, `UDP_ICMP_SOCKET_BUDGET=2048`.
- Ensure environments running NSTUN or Docker fallbacks allow privileged containers, have `/dev/net/tun`, and set `nofile` ≥ 4096.

<sup>Written for commit 4c4193483bd2fe1ce8641d08fdeec16811a3090b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
