### PR TITLE
fix: refresh workflows after case-trigger imports

### DIFF
--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy import select
 
 from tracecat.auth.types import Role
+from tracecat.cases.enums import CaseEventType
 from tracecat.db.models import CaseTag, CaseTrigger, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
 from tracecat.identifiers.workflow import WorkflowUUID
@@ -125,6 +126,41 @@ async def test_workflow_import_case_trigger_creates_tags(test_role: Role):
         )
         tag_result = await service.session.execute(tag_stmt)
         assert tag_result.scalar_one().ref == "phishing"
+
+
+@pytest.mark.anyio
+async def test_workflow_import_online_case_trigger_returns_loaded_updated_at(
+    test_role: Role,
+) -> None:
+    external = ExternalWorkflowDefinition(
+        definition=DSLInput(
+            **{
+                "title": "online_case_trigger_import",
+                "description": "Workflow import with an online case trigger",
+                "entrypoint": {"expects": {}, "ref": None},
+                "actions": [
+                    {
+                        "ref": "entrypoint_1",
+                        "action": "core.transform.reshape",
+                        "args": {"value": "ENTRYPOINT_1"},
+                    }
+                ],
+                "returns": "${{ ACTIONS.entrypoint_1.result }}",
+            }
+        ),
+        case_trigger=CaseTriggerConfig(
+            status="online",
+            event_types=[CaseEventType.CASE_CREATED],
+        ),
+    )
+
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await service.create_workflow_from_external_definition(
+            external.model_dump(mode="json")
+        )
+
+        assert workflow.version == 1
+        assert workflow.updated_at is not None
 
 
 def test_external_workflow_definition_omits_empty_case_trigger():

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -337,7 +337,12 @@ async def test_external_import_publishes_before_online_case_trigger(
         alias="imported-case-trigger",
         registry_lock=registry_lock,
     )
-    session = SimpleNamespace(add=MagicMock(), flush=AsyncMock(), commit=AsyncMock())
+    session = SimpleNamespace(
+        add=MagicMock(),
+        flush=AsyncMock(),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+    )
     service = WorkflowsManagementService(cast(Any, session), role=role)
     dsl = DSLInput(
         **{
@@ -445,6 +450,7 @@ async def test_external_import_publishes_before_online_case_trigger(
     session.add.assert_called_once_with(workflow)
     session.flush.assert_awaited_once()
     session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(workflow)
     assert len(case_trigger_calls) == 1
     assert case_trigger_calls[0]["workflow_id"] == workflow.id
     assert case_trigger_calls[0]["params"].status == "online"

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1487,6 +1487,8 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 commit=False,
             )
             await self.session.commit()
+            # Keep server-generated fields loaded for response serialization.
+            await self.session.refresh(workflow)
         return workflow
 
     @require_scope("workflow:create")


### PR DESCRIPTION
## Summary

- refresh imported workflows after committing case-trigger setup
- add a real async-session regression test for online case-trigger imports
- require the existing orchestration test to verify the refresh

## Root cause

An online case-trigger import creates an initial workflow definition and updates `Workflow.version`. SQLAlchemy then expires the server-generated `updated_at` field during the update. The service committed and returned the ORM object without refreshing it, so API response serialization attempted implicit asynchronous database I/O and raised `MissingGreenlet` after the import had already committed.

## Impact

This prevents `POST /api/workflows` imports from returning a false HTTP 500 after successfully writing the workflow, reducing the risk that a retry creates a duplicate workflow.

## Validation

- reproduced the production `MissingGreenlet` with the new real-session regression test before applying the fix
- `uv run pytest tests/unit/test_export.py tests/unit/test_workflow_management.py -x` (41 passed)
- `uv run ruff check tracecat/workflow/management/management.py tests/unit/test_export.py tests/unit/test_workflow_management.py`
- `uv run ruff format --check tracecat/workflow/management/management.py tests/unit/test_export.py tests/unit/test_workflow_management.py`
- `uv run basedpyright tracecat/workflow/management/management.py tests/unit/test_export.py tests/unit/test_workflow_management.py`
- pre-commit hooks passed

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 2 | 0 |
| Tests | 43 | 1 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes workflows after committing online case-trigger imports to keep server-generated fields loaded and prevent MissingGreenlet during response serialization. Previously the API returned an expired workflow with an unloaded updated_at and sent a 500 for POST /api/workflows; now it refreshes the workflow before returning, so the response succeeds and includes updated_at, reducing duplicate-creation risk from client retries.

**Review notes**
- Refresh the workflow after commit in create_workflow_from_external_definition to keep updated_at loaded.
- Add a real-session regression test that imports an online case trigger and asserts updated_at is present.
- Update the orchestration test to require session.refresh(workflow).
- No API changes and no migrations required.

<sup>Written for commit 15ab14748f89c21483c2ed9c11b54f65dda65039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

