### PR TITLE
feat(api): add universal cursor pagination

### DIFF
--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -464,6 +464,53 @@ class TestPaginate:
         assert seen == expected
 
     @pytest.mark.anyio
+    async def test_database_equal_numeric_values_require_unique_tie_breaker(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        metadata = sa.MetaData()
+        items = sa.Table(
+            "test_numeric_page_items",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("amount", sa.Numeric, nullable=False),
+            prefixes=["TEMPORARY"],
+        )
+        connection = await session.connection()
+        await connection.run_sync(metadata.create_all)
+        await session.execute(items.insert().values(id=1, amount=Decimal("1.0")))
+        await session.execute(items.insert().values(id=2, amount=Decimal("1.00")))
+        statement = sa.select(items.c.id)
+
+        with pytest.raises(
+            PaginationConfigurationError,
+            match="unique tie-breaker",
+        ):
+            await paginate(
+                session,
+                statement,
+                page=PageParams(limit=1),
+                order_by=(items.c.amount.asc(),),
+            )
+
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=1),
+            order_by=(items.c.amount.asc(), items.c.id.asc()),
+        )
+        assert first.items == [1]
+        assert first.next_cursor is not None
+        second = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=1, cursor=first.next_cursor),
+            order_by=(items.c.amount.asc(), items.c.id.asc()),
+        )
+        assert second.items == [2]
+
+    @pytest.mark.anyio
     async def test_non_finite_float_cursor_values_round_trip(
         self,
         session: AsyncSession,
@@ -690,6 +737,96 @@ class TestPaginate:
         )
 
         assert second.items == [3, 4]
+
+    @pytest.mark.anyio
+    async def test_empty_forward_page_can_recover_the_adjacent_surviving_page(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (items.c.id.asc(),)
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2),
+            order_by=order_by,
+        )
+        assert first.items == [1, 2]
+        assert first.next_cursor is not None
+        await session.execute(sa.delete(items).where(items.c.id > 2))
+
+        empty = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=first.next_cursor),
+            order_by=order_by,
+        )
+        assert empty.items == []
+        assert empty.next_cursor is None
+        assert empty.prev_cursor is not None
+
+        recovered = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=empty.prev_cursor),
+            order_by=order_by,
+        )
+        assert recovered.items == [1, 2]
+        assert recovered.next_cursor is None
+        assert recovered.prev_cursor is None
+
+    @pytest.mark.anyio
+    async def test_empty_backward_page_can_recover_the_adjacent_surviving_page(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (items.c.id.asc(),)
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2),
+            order_by=order_by,
+        )
+        second = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=first.next_cursor),
+            order_by=order_by,
+        )
+        third = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=second.next_cursor),
+            order_by=order_by,
+        )
+        assert third.items == [5, 6]
+        assert third.prev_cursor is not None
+        await session.execute(sa.delete(items).where(items.c.id < 5))
+
+        empty = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=third.prev_cursor),
+            order_by=order_by,
+        )
+        assert empty.items == []
+        assert empty.next_cursor is not None
+        assert empty.prev_cursor is None
+
+        recovered = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=empty.next_cursor),
+            order_by=order_by,
+        )
+        assert recovered.items == [5, 6]
+        assert recovered.next_cursor is None
+        assert recovered.prev_cursor is None
 
     @pytest.mark.anyio
     async def test_tampered_cursor_is_rejected(

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -516,6 +517,52 @@ class TestPaginate:
         assert back_to_first.items == first.items
 
     @pytest.mark.anyio
+    async def test_json_cursor_values_accept_every_json_shape(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        metadata = sa.MetaData()
+        items = sa.Table(
+            "test_json_page_items",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("value", JSONB, nullable=False),
+            prefixes=["TEMPORARY"],
+        )
+        connection = await session.connection()
+        await connection.run_sync(metadata.create_all)
+        await session.execute(
+            items.insert(),
+            [
+                {"id": 1, "value": ["alpha"]},
+                {"id": 2, "value": "bravo"},
+                {"id": 3, "value": 42},
+            ],
+        )
+        statement = sa.select(items.c.id)
+        order_by = (items.c.value.asc(), items.c.id.asc())
+        expected = list(
+            (await session.execute(statement.order_by(*order_by))).scalars().all()
+        )
+
+        seen: list[int] = []
+        cursor: str | None = None
+        while True:
+            page = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=1, cursor=cursor),
+                order_by=order_by,
+            )
+            seen.extend(page.items)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+        assert seen == expected
+
+    @pytest.mark.anyio
     async def test_database_equal_numeric_values_require_unique_tie_breaker(
         self,
         session: AsyncSession,
@@ -678,6 +725,33 @@ class TestPaginate:
             cursor = page.next_cursor
 
         assert seen == [4, 3, 2, 1, 6, 5]
+
+    @pytest.mark.anyio
+    async def test_grouped_aggregate_ordering_round_trips(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        item_count = sa.func.count(items.c.id)
+        statement = sa.select(items.c.score).group_by(items.c.score)
+        order_by = (item_count.desc(), items.c.score.asc().nulls_last())
+
+        seen: list[int | None] = []
+        cursor: str | None = None
+        while True:
+            page = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=1, cursor=cursor),
+                order_by=order_by,
+            )
+            seen.extend(page.items)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+        assert seen == [10, 20, None]
 
     @pytest.mark.anyio
     async def test_cursor_is_bound_to_query_filters(

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -464,6 +464,58 @@ class TestPaginate:
         assert seen == expected
 
     @pytest.mark.anyio
+    async def test_binary_cursor_values_round_trip(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        metadata = sa.MetaData()
+        items = sa.Table(
+            "test_binary_page_items",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("value", sa.LargeBinary, nullable=False),
+            prefixes=["TEMPORARY"],
+        )
+        connection = await session.connection()
+        await connection.run_sync(metadata.create_all)
+        await session.execute(
+            items.insert(),
+            [
+                {"id": 1, "value": b"\xff\x00"},
+                {"id": 2, "value": b"\x00"},
+            ],
+        )
+        statement = sa.select(items.c.id)
+        order_by = (items.c.value.desc(), items.c.id.asc())
+
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=1),
+            order_by=order_by,
+        )
+        assert first.items == [1]
+        assert first.next_cursor is not None
+
+        second = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=1, cursor=first.next_cursor),
+            order_by=order_by,
+        )
+        assert second.items == [2]
+        assert second.prev_cursor is not None
+
+        back_to_first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=1, cursor=second.prev_cursor),
+            order_by=order_by,
+        )
+        assert back_to_first.items == first.items
+
+    @pytest.mark.anyio
     async def test_database_equal_numeric_values_require_unique_tie_breaker(
         self,
         session: AsyncSession,

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -1,17 +1,130 @@
 import base64
 import json
 from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any, TypedDict, cast
+from uuid import UUID
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
+from tracecat import config
 from tracecat.pagination import (
     BaseCursorPaginator,
     CursorData,
     CursorPaginationParams,
+    PageParams,
+    PaginationConfigurationError,
+    PaginationError,
+    PaginationErrorCode,
+    paginate,
 )
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+class _PageItemValues(TypedDict):
+    id: int
+    score: int | None
+    label: str
+
+
+class _Priority(StrEnum):
+    LOW = "low"
+    HIGH = "high"
+
+
+class _TypedPageItemValues(TypedDict):
+    id: UUID
+    priority: _Priority
+    amount: Decimal
+    created_at: datetime
+
+
+class _FloatPageItemValues(TypedDict):
+    id: int
+    value: float
+
+
+class _PageItemBase(DeclarativeBase):
+    pass
+
+
+class _MappedPageItem(_PageItemBase):
+    __tablename__ = "test_mapped_page_items"
+    __table_args__ = {"prefixes": ["TEMPORARY"]}
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    label: Mapped[str]
+
+
+async def _create_page_items(session: AsyncSession) -> sa.Table:
+    metadata = sa.MetaData()
+    items = sa.Table(
+        "test_page_items",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("score", sa.Integer, nullable=True),
+        sa.Column("label", sa.String, nullable=False),
+        prefixes=["TEMPORARY"],
+    )
+    connection = await session.connection()
+    await connection.run_sync(metadata.create_all)
+    values: list[_PageItemValues] = [
+        {"id": 1, "score": 10, "label": "2024-01-01"},
+        {"id": 2, "score": 10, "label": "2024-01-02"},
+        {"id": 3, "score": 20, "label": "bravo"},
+        {"id": 4, "score": 20, "label": "charlie"},
+        {"id": 5, "score": None, "label": "delta"},
+        {"id": 6, "score": None, "label": "echo"},
+    ]
+    await session.execute(items.insert(), values)
+    return items
+
+
+async def _create_typed_page_items(session: AsyncSession) -> sa.Table:
+    metadata = sa.MetaData()
+    items = sa.Table(
+        "test_typed_page_items",
+        metadata,
+        sa.Column("id", sa.Uuid, primary_key=True),
+        sa.Column("priority", sa.Enum(_Priority, native_enum=False), nullable=False),
+        sa.Column("amount", sa.Numeric, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        prefixes=["TEMPORARY"],
+    )
+    connection = await session.connection()
+    await connection.run_sync(metadata.create_all)
+    values: list[_TypedPageItemValues] = [
+        {
+            "id": UUID("00000000-0000-4000-8000-000000000001"),
+            "priority": _Priority.LOW,
+            "amount": Decimal("10.25"),
+            "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+        },
+        {
+            "id": UUID("00000000-0000-4000-8000-000000000002"),
+            "priority": _Priority.HIGH,
+            "amount": Decimal("20.50"),
+            "created_at": datetime(2026, 1, 2, tzinfo=UTC),
+        },
+        {
+            "id": UUID("00000000-0000-4000-8000-000000000003"),
+            "priority": _Priority.HIGH,
+            "amount": Decimal("20.50"),
+            "created_at": datetime(2026, 1, 3, tzinfo=UTC),
+        },
+    ]
+    await session.execute(items.insert(), values)
+    return items
+
+
+@pytest.fixture
+def pagination_signing_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "TRACECAT__SIGNING_SECRET", "pagination-test-secret")
 
 
 class TestCursorPaginator:
@@ -116,3 +229,584 @@ class TestCursorPaginator:
         assert recreated.sort_column == "created_at"
         assert recreated.sort_value == timestamp
         assert recreated.id == entity_id
+
+
+class TestPaginate:
+    """Tests for the deep keyset pagination API."""
+
+    @pytest.mark.anyio
+    async def test_single_orm_entity_is_the_default_item(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        connection = await session.connection()
+        await connection.run_sync(_PageItemBase.metadata.create_all)
+        item = _MappedPageItem(id=1, label="first")
+        session.add(item)
+        await session.flush()
+
+        page = await paginate(
+            session,
+            sa.select(_MappedPageItem),
+            page=PageParams(),
+            order_by=(_MappedPageItem.id.asc(),),
+        )
+
+        assert [result.id for result in page.items] == [item.id]
+
+    @pytest.mark.anyio
+    async def test_forward_and_backward_composite_pagination(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (
+            items.c.score.desc().nulls_last(),
+            items.c.id.desc(),
+        )
+
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2),
+            order_by=order_by,
+        )
+        assert first.items == [4, 3]
+        assert first.next_cursor is not None
+        assert first.prev_cursor is None
+        assert first.has_more is True
+        assert first.has_previous is False
+
+        second = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=first.next_cursor),
+            order_by=order_by,
+        )
+        assert second.items == [2, 1]
+        assert second.next_cursor is not None
+        assert second.prev_cursor is not None
+
+        third = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=second.next_cursor),
+            order_by=order_by,
+        )
+        assert third.items == [6, 5]
+        assert third.next_cursor is None
+        assert third.prev_cursor is not None
+
+        back_to_second = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=third.prev_cursor),
+            order_by=order_by,
+        )
+        assert back_to_second.items == second.items
+        assert back_to_second.next_cursor is not None
+        assert back_to_second.prev_cursor is not None
+
+        back_to_first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=back_to_second.prev_cursor),
+            order_by=order_by,
+        )
+        assert back_to_first.items == first.items
+        assert back_to_first.next_cursor is not None
+        assert back_to_first.prev_cursor is None
+
+    @pytest.mark.anyio
+    async def test_mixed_directions_and_default_nulls_last(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (items.c.score.asc(), items.c.id.desc())
+
+        seen: list[int] = []
+        cursor: str | None = None
+        while True:
+            page = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=2, cursor=cursor),
+                order_by=order_by,
+            )
+            seen.extend(page.items)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+        assert seen == [2, 1, 4, 3, 6, 5]
+
+    @pytest.mark.parametrize("score_direction", ["asc", "desc"])
+    @pytest.mark.parametrize("null_placement", ["first", "last"])
+    @pytest.mark.parametrize("id_direction", ["asc", "desc"])
+    @pytest.mark.parametrize("limit", [1, 2, 4])
+    @pytest.mark.anyio
+    async def test_all_ordering_combinations_round_trip(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+        score_direction: str,
+        null_placement: str,
+        id_direction: str,
+        limit: int,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        score_order = (
+            items.c.score.asc() if score_direction == "asc" else items.c.score.desc()
+        )
+        score_order = (
+            score_order.nulls_first()
+            if null_placement == "first"
+            else score_order.nulls_last()
+        )
+        id_order = items.c.id.asc() if id_direction == "asc" else items.c.id.desc()
+        order_by = (score_order, id_order)
+        expected = list(
+            (await session.execute(statement.order_by(*order_by))).scalars().all()
+        )
+
+        pages = []
+        cursor: str | None = None
+        while True:
+            page = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=limit, cursor=cursor),
+                order_by=order_by,
+            )
+            pages.append(page)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+        assert [item for page in pages for item in page.items] == expected
+        current = pages[-1]
+        for expected_page in reversed(pages[:-1]):
+            assert current.prev_cursor is not None
+            current = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=limit, cursor=current.prev_cursor),
+                order_by=order_by,
+            )
+            assert current.items == expected_page.items
+        assert current.prev_cursor is None
+
+    @pytest.mark.anyio
+    async def test_string_cursor_values_are_decoded_by_column_type(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.label)
+        order_by = (items.c.label.asc(), items.c.id.asc())
+
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=1),
+            order_by=order_by,
+        )
+        second = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=1, cursor=first.next_cursor),
+            order_by=order_by,
+        )
+
+        assert first.items == ["2024-01-01"]
+        assert second.items == ["2024-01-02"]
+
+    @pytest.mark.anyio
+    async def test_common_scalar_cursor_types_round_trip(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_typed_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (
+            items.c.priority.asc(),
+            items.c.amount.desc(),
+            items.c.created_at.desc(),
+            items.c.id.asc(),
+        )
+        expected = list(
+            (await session.execute(statement.order_by(*order_by))).scalars().all()
+        )
+
+        seen: list[UUID] = []
+        cursor: str | None = None
+        while True:
+            page = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=1, cursor=cursor),
+                order_by=order_by,
+            )
+            seen.extend(page.items)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+        assert seen == expected
+
+    @pytest.mark.anyio
+    async def test_non_finite_float_cursor_values_round_trip(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        metadata = sa.MetaData()
+        items = sa.Table(
+            "test_float_page_items",
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("value", sa.Float, nullable=False),
+            prefixes=["TEMPORARY"],
+        )
+        connection = await session.connection()
+        await connection.run_sync(metadata.create_all)
+        values: list[_FloatPageItemValues] = [
+            {"id": 1, "value": float("-inf")},
+            {"id": 2, "value": 0.0},
+            {"id": 3, "value": float("inf")},
+            {"id": 4, "value": float("nan")},
+        ]
+        await session.execute(items.insert(), values)
+        statement = sa.select(items.c.id)
+        order_by = (items.c.value.asc(), items.c.id.asc())
+
+        pages = []
+        cursor: str | None = None
+        while True:
+            page = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=1, cursor=cursor),
+                order_by=order_by,
+            )
+            pages.append(page)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+        assert [item for page in pages for item in page.items] == [1, 2, 3, 4]
+        current = pages[-1]
+        for expected_page in reversed(pages[:-1]):
+            assert current.prev_cursor is not None
+            current = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=1, cursor=current.prev_cursor),
+                order_by=order_by,
+            )
+            assert current.items == expected_page.items
+
+        await session.execute(items.insert().values(id=5, value=float("nan")))
+        with pytest.raises(
+            PaginationConfigurationError,
+            match="unique tie-breaker",
+        ):
+            await paginate(
+                session,
+                statement,
+                page=PageParams(limit=4),
+                order_by=(items.c.value.asc(),),
+            )
+
+    @pytest.mark.anyio
+    async def test_row_factory_hides_private_cursor_columns(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id, items.c.label)
+
+        def build_item(row: tuple[object, ...]) -> tuple[int, str]:
+            assert len(row) == 2
+            return cast(int, row[0]), cast(str, row[1])
+
+        page = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2),
+            order_by=(items.c.id.asc(),),
+            row_factory=build_item,
+        )
+
+        assert page.items == [(1, "2024-01-01"), (2, "2024-01-02")]
+
+    @pytest.mark.anyio
+    async def test_computed_ordering_with_distinct_projection(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id, items.c.label).distinct()
+        computed_score = sa.func.coalesce(items.c.score, -1)
+
+        def get_id(row: tuple[object, ...]) -> int:
+            return cast(int, row[0])
+
+        seen: list[int] = []
+        cursor: str | None = None
+        while True:
+            page = await paginate(
+                session,
+                statement,
+                page=PageParams(limit=2, cursor=cursor),
+                order_by=(computed_score.desc(), items.c.id.desc()),
+                row_factory=get_id,
+            )
+            seen.extend(page.items)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+        assert seen == [4, 3, 2, 1, 6, 5]
+
+    @pytest.mark.anyio
+    async def test_cursor_is_bound_to_query_filters(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (items.c.id.asc(),)
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2),
+            order_by=order_by,
+        )
+        assert first.next_cursor is not None
+
+        changed_statement = statement.where(items.c.score == 20)
+        with pytest.raises(PaginationError) as exc_info:
+            await paginate(
+                session,
+                changed_statement,
+                page=PageParams(limit=2, cursor=first.next_cursor),
+                order_by=order_by,
+            )
+
+        assert exc_info.value.code is PaginationErrorCode.CURSOR_MISMATCH
+
+    @pytest.mark.anyio
+    async def test_cursor_accepts_semantically_equivalent_in_filter_order(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        first_statement = sa.select(items.c.id).where(items.c.id.in_([4, 3, 2, 1]))
+        order_by = (items.c.id.asc(),)
+        first = await paginate(
+            session,
+            first_statement,
+            page=PageParams(limit=2),
+            order_by=order_by,
+        )
+        assert first.next_cursor is not None
+
+        equivalent_statement = sa.select(items.c.id).where(items.c.id.in_([1, 2, 3, 4]))
+        second = await paginate(
+            session,
+            equivalent_statement,
+            page=PageParams(limit=2, cursor=first.next_cursor),
+            order_by=order_by,
+        )
+
+        assert second.items == [3, 4]
+
+    @pytest.mark.anyio
+    async def test_cursor_is_bound_to_execution_options(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (items.c.id.asc(),)
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2),
+            order_by=order_by,
+        )
+        assert first.next_cursor is not None
+
+        changed_statement = statement.execution_options(include_deleted=True)
+        with pytest.raises(PaginationError) as exc_info:
+            await paginate(
+                session,
+                changed_statement,
+                page=PageParams(limit=2, cursor=first.next_cursor),
+                order_by=order_by,
+            )
+
+        assert exc_info.value.code is PaginationErrorCode.CURSOR_MISMATCH
+
+    @pytest.mark.anyio
+    async def test_cursor_does_not_depend_on_anchor_row_existing(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (items.c.id.asc(),)
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2),
+            order_by=order_by,
+        )
+        assert first.items == [1, 2]
+        assert first.next_cursor is not None
+        await session.execute(sa.delete(items).where(items.c.id == 2))
+
+        second = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2, cursor=first.next_cursor),
+            order_by=order_by,
+        )
+
+        assert second.items == [3, 4]
+
+    @pytest.mark.anyio
+    async def test_tampered_cursor_is_rejected(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        statement = sa.select(items.c.id)
+        order_by = (items.c.id.asc(),)
+        first = await paginate(
+            session,
+            statement,
+            page=PageParams(limit=2),
+            order_by=order_by,
+        )
+        assert first.next_cursor is not None
+        replacement = "A" if first.next_cursor[0] != "A" else "B"
+        tampered = replacement + first.next_cursor[1:]
+
+        with pytest.raises(PaginationError) as exc_info:
+            await paginate(
+                session,
+                statement,
+                page=PageParams(limit=2, cursor=tampered),
+                order_by=order_by,
+            )
+
+        assert exc_info.value.code is PaginationErrorCode.INVALID_CURSOR
+
+    @pytest.mark.anyio
+    async def test_oversized_cursor_fails_at_its_source(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+        await session.execute(items.insert().values(id=7, score=30, label="a" * 9000))
+        await session.execute(items.insert().values(id=8, score=30, label="b" * 9000))
+
+        with pytest.raises(
+            PaginationConfigurationError,
+            match="compact ordering keys",
+        ):
+            await paginate(
+                session,
+                sa.select(items.c.id).where(items.c.id.in_([7, 8])),
+                page=PageParams(limit=1),
+                order_by=(items.c.label.asc(), items.c.id.asc()),
+            )
+
+    @pytest.mark.anyio
+    async def test_query_configuration_is_explicit(
+        self,
+        session: AsyncSession,
+        pagination_signing_secret: None,
+    ) -> None:
+        items = await _create_page_items(session)
+
+        with pytest.raises(PaginationConfigurationError, match=r"\.asc\(\)"):
+            await paginate(
+                session,
+                sa.select(items.c.id),
+                page=PageParams(),
+                order_by=(items.c.id,),
+            )
+
+        with pytest.raises(PaginationConfigurationError, match="order_by"):
+            await paginate(
+                session,
+                sa.select(items.c.id).order_by(items.c.id),
+                page=PageParams(),
+                order_by=(items.c.id.asc(),),
+            )
+
+        with pytest.raises(PaginationConfigurationError, match="bounds"):
+            await paginate(
+                session,
+                sa.select(items.c.id),
+                page=PageParams.model_construct(limit=0),
+                order_by=(items.c.id.asc(),),
+            )
+
+        with pytest.raises(PaginationConfigurationError, match="FETCH"):
+            await paginate(
+                session,
+                sa.select(items.c.id).fetch(1),
+                page=PageParams(),
+                order_by=(items.c.id.asc(),),
+            )
+
+        with pytest.raises(PaginationConfigurationError, match="row_factory"):
+            await paginate(
+                session,
+                cast(Any, sa.select(items.c.id, items.c.label)),
+                page=PageParams(),
+                order_by=(items.c.id.asc(),),
+            )
+
+        with pytest.raises(
+            PaginationConfigurationError,
+            match="no Python value type",
+        ):
+            await paginate(
+                session,
+                sa.select(items.c.id),
+                page=PageParams(),
+                order_by=(sa.column("id").asc(),),
+            )
+
+        with pytest.raises(
+            PaginationConfigurationError,
+            match="unique tie-breaker",
+        ):
+            await paginate(
+                session,
+                sa.select(items.c.id),
+                page=PageParams(limit=1),
+                order_by=(items.c.score.asc(),),
+            )

--- a/tracecat/pagination.py
+++ b/tracecat/pagination.py
@@ -1,18 +1,700 @@
-"""Cursor-based pagination utilities for Tracecat."""
+"""Cursor-based pagination utilities for Tracecat.
+
+The primary API is :func:`paginate`. Callers provide a scoped SQLAlchemy
+``Select``, an explicit total ordering, and :class:`PageParams`; the module owns
+cursor encoding, seek predicates, navigation direction, and page construction.
+
+The older ``Cursor*`` types remain temporarily for existing callers. New code
+should use ``PageParams``, ``Page``, and ``paginate``.
+"""
 
 import base64
+import hashlib
+import hmac
 import json
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
-from typing import TypeVar
+from enum import Enum, StrEnum
+from itertools import pairwise
+from typing import Any, Self, TypeVar, cast, overload
 from uuid import UUID
 
+import orjson
 import sqlalchemy as sa
-from pydantic import BaseModel, Field, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    PydanticUserError,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+)
+from pydantic_core import PydanticSerializationError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import operators
+from sqlalchemy.sql.elements import ColumnElement, UnaryExpression
+from sqlalchemy.sql.selectable import Select
 
 from tracecat import config
+from tracecat.auth.secrets import get_signing_secret
+from tracecat.exceptions import TracecatValidationError
 
 T = TypeVar("T")
+
+_CURSOR_VERSION = 1
+_CURSOR_SIGNATURE_CONTEXT = b"tracecat.pagination.cursor.v1\0"
+_MAX_CURSOR_LENGTH = 8192
+_JSON_VALUE_ADAPTER = TypeAdapter(JsonValue)
+_FINGERPRINT_JSON_OPTIONS = (
+    orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS | orjson.OPT_UTC_Z
+)
+
+
+class PageParams(BaseModel):
+    """Parameters for retrieving one page.
+
+    A cursor returned in either direction is a complete continuation token;
+    callers do not need to provide a separate direction flag.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    limit: int = Field(
+        default=config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+        description="Maximum items per page",
+    )
+    cursor: str | None = Field(
+        default=None,
+        max_length=_MAX_CURSOR_LENGTH,
+        description="Opaque continuation token",
+    )
+
+
+class Page[T](BaseModel):
+    """A page of canonically ordered items."""
+
+    model_config = ConfigDict(frozen=True)
+
+    items: list[T]
+    next_cursor: str | None = Field(default=None, description="Next-page cursor")
+    prev_cursor: str | None = Field(default=None, description="Previous-page cursor")
+
+    @property
+    def has_more(self) -> bool:
+        """Return whether another page exists in the forward direction."""
+        return self.next_cursor is not None
+
+    @property
+    def has_previous(self) -> bool:
+        """Return whether another page exists in the backward direction."""
+        return self.prev_cursor is not None
+
+
+class PaginationErrorCode(StrEnum):
+    """Machine-readable pagination failures caused by request cursors."""
+
+    INVALID_CURSOR = "invalid_cursor"
+    CURSOR_MISMATCH = "cursor_mismatch"
+    UNSUPPORTED_CURSOR_VERSION = "unsupported_cursor_version"
+
+
+class PaginationError(TracecatValidationError):
+    """A user-facing pagination cursor error."""
+
+    def __init__(self, message: str, *, code: PaginationErrorCode) -> None:
+        super().__init__(message, detail={"code": code.value})
+        self.code = code
+
+
+class PaginationConfigurationError(ValueError):
+    """A developer error in a paginated query definition."""
+
+
+class _Direction(StrEnum):
+    FORWARD = "forward"
+    BACKWARD = "backward"
+
+
+class _SortDirection(StrEnum):
+    ASC = "asc"
+    DESC = "desc"
+
+
+class _NullPlacement(StrEnum):
+    FIRST = "first"
+    LAST = "last"
+
+
+class _CursorPayload(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    version: int
+    direction: _Direction
+    query_fingerprint: str
+    values: list[JsonValue]
+
+
+@dataclass(frozen=True, slots=True)
+class _OrderKey:
+    expression: ColumnElement[Any]
+    direction: _SortDirection
+    nulls: _NullPlacement
+    adapter: TypeAdapter[Any]
+
+    def clause(self) -> ColumnElement[Any]:
+        """Build an explicit SQL ordering clause."""
+        if self.direction is _SortDirection.ASC:
+            clause = self.expression.asc()
+        else:
+            clause = self.expression.desc()
+        if self.nulls is _NullPlacement.FIRST:
+            return clause.nulls_first()
+        return clause.nulls_last()
+
+    def reversed(self) -> Self:
+        """Return the exact inverse ordering for backward retrieval."""
+        direction = (
+            _SortDirection.DESC
+            if self.direction is _SortDirection.ASC
+            else _SortDirection.ASC
+        )
+        nulls = (
+            _NullPlacement.LAST
+            if self.nulls is _NullPlacement.FIRST
+            else _NullPlacement.FIRST
+        )
+        return type(self)(
+            expression=self.expression,
+            direction=direction,
+            nulls=nulls,
+            adapter=self.adapter,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _PageRow[T]:
+    item: T
+    cursor_values: tuple[object, ...]
+
+
+def _normalize_order(expression: ColumnElement[Any]) -> _OrderKey:
+    """Extract direction and null placement from an SQLAlchemy order clause."""
+    current = expression
+    direction: _SortDirection | None = None
+    nulls: _NullPlacement | None = None
+
+    while isinstance(current, UnaryExpression):
+        if current.modifier is operators.asc_op:
+            if direction is not None:
+                raise PaginationConfigurationError(
+                    "Pagination ordering contains more than one direction modifier"
+                )
+            direction = _SortDirection.ASC
+            current = current.element
+            continue
+        if current.modifier is operators.desc_op:
+            if direction is not None:
+                raise PaginationConfigurationError(
+                    "Pagination ordering contains more than one direction modifier"
+                )
+            direction = _SortDirection.DESC
+            current = current.element
+            continue
+        if current.modifier is operators.nulls_first_op:
+            if nulls is not None:
+                raise PaginationConfigurationError(
+                    "Pagination ordering contains more than one NULLS modifier"
+                )
+            nulls = _NullPlacement.FIRST
+            current = current.element
+            continue
+        if current.modifier is operators.nulls_last_op:
+            if nulls is not None:
+                raise PaginationConfigurationError(
+                    "Pagination ordering contains more than one NULLS modifier"
+                )
+            nulls = _NullPlacement.LAST
+            current = current.element
+            continue
+        break
+
+    if direction is None:
+        raise PaginationConfigurationError(
+            "Every pagination ordering expression must specify .asc() or .desc()"
+        )
+
+    try:
+        value_type = current.type.python_type
+    except (AttributeError, NotImplementedError) as exc:
+        raise PaginationConfigurationError(
+            f"Pagination ordering expression {current!s} has no Python value type"
+        ) from exc
+    try:
+        adapter = TypeAdapter(value_type)
+    except (PydanticUserError, TypeError) as exc:
+        raise PaginationConfigurationError(
+            f"Pagination ordering expression {current!s} has an unsupported value type"
+        ) from exc
+
+    return _OrderKey(
+        expression=current,
+        direction=direction,
+        nulls=nulls or _NullPlacement.LAST,
+        adapter=adapter,
+    )
+
+
+def _normalize_ordering(
+    order_by: tuple[ColumnElement[Any], ...],
+) -> tuple[_OrderKey, ...]:
+    if not order_by:
+        raise PaginationConfigurationError(
+            "Pagination requires a deterministic total ordering"
+        )
+    return tuple(_normalize_order(expression) for expression in order_by)
+
+
+def _validate_statement(statement: Select[Any]) -> None:
+    """Reject query state that would compete with paginator-owned clauses."""
+    if statement._order_by_clauses:
+        raise PaginationConfigurationError(
+            "Pass ordering through paginate(order_by=...), not Select.order_by()"
+        )
+    if (
+        statement._limit_clause is not None
+        or statement._offset_clause is not None
+        or statement._fetch_clause is not None
+    ):
+        raise PaginationConfigurationError(
+            "A paginated Select cannot already contain LIMIT, OFFSET, or FETCH"
+        )
+
+
+def _validate_page(page: PageParams) -> None:
+    """Defend pagination limits even if Pydantic validation was bypassed."""
+    if (
+        not config.TRACECAT__LIMIT_MIN
+        <= page.limit
+        <= config.TRACECAT__LIMIT_CURSOR_MAX
+    ):
+        raise PaginationConfigurationError(
+            "Page limit is outside the configured cursor-pagination bounds"
+        )
+
+
+def _fingerprint_json_default(value: object) -> object:
+    """Return a stable JSON representation for uncommon SQL bind values."""
+    if isinstance(value, (set, frozenset)):
+        return sorted(value, key=repr)
+    if isinstance(value, Enum):
+        return (type(value).__module__, type(value).__qualname__, value.value)
+    return (type(value).__module__, type(value).__qualname__, str(value))
+
+
+def _fingerprint_value_sort_key(value: object) -> bytes:
+    """Return a deterministic ordering key for an expanding bind value."""
+    return orjson.dumps(
+        value,
+        default=_fingerprint_json_default,
+        option=_FINGERPRINT_JSON_OPTIONS,
+    )
+
+
+def _normalize_expanding_bind(value: object) -> object:
+    """Canonicalize the order-insensitive values of an SQL ``IN`` clause."""
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return sorted(value, key=_fingerprint_value_sort_key)
+    return value
+
+
+def _query_fingerprint(
+    session: AsyncSession,
+    statement: Select[Any],
+    ordering: tuple[_OrderKey, ...],
+) -> str:
+    """Fingerprint the query, bind values, and canonical ordering."""
+    ordered_statement = statement.order_by(*(key.clause() for key in ordering))
+    compiled = ordered_statement.compile(dialect=session.get_bind().dialect)
+    expanding_parameter_names = {
+        compiled.bind_names[parameter] for parameter in compiled.post_compile_params
+    }
+    fingerprint_parameters: list[tuple[str, object]] = []
+    for name, value in sorted(compiled.params.items()):
+        if name in expanding_parameter_names:
+            value = _normalize_expanding_bind(value)
+        fingerprint_parameters.append((name, value))
+
+    parameters_json = orjson.dumps(
+        fingerprint_parameters,
+        default=_fingerprint_json_default,
+        option=_FINGERPRINT_JSON_OPTIONS,
+    )
+    execution_options_json = orjson.dumps(
+        sorted(statement.get_execution_options().items()),
+        default=_fingerprint_json_default,
+        option=_FINGERPRINT_JSON_OPTIONS,
+    )
+    digest = hashlib.sha256()
+    digest.update(str(compiled).encode())
+    digest.update(b"\0")
+    digest.update(parameters_json)
+    digest.update(b"\0")
+    digest.update(execution_options_json)
+    return digest.hexdigest()
+
+
+def _urlsafe_b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _urlsafe_b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.b64decode(
+        (value + padding).encode("ascii"), altchars=b"-_", validate=True
+    )
+
+
+def _cursor_signature(payload: bytes, *, secret: bytes) -> bytes:
+    return hmac.new(
+        secret,
+        _CURSOR_SIGNATURE_CONTEXT + payload,
+        digestmod=hashlib.sha256,
+    ).digest()
+
+
+def _serialize_cursor_values(
+    values: tuple[object, ...],
+    ordering: tuple[_OrderKey, ...],
+) -> list[JsonValue]:
+    serialized: list[JsonValue] = []
+    try:
+        for value, key in zip(values, ordering, strict=True):
+            if value is None:
+                serialized.append(None)
+                continue
+            if isinstance(value, float) and not math.isfinite(value):
+                if math.isnan(value):
+                    json_value = "NaN"
+                elif value > 0:
+                    json_value = "Infinity"
+                else:
+                    json_value = "-Infinity"
+            else:
+                json_value = key.adapter.dump_python(value, mode="json")
+            serialized.append(_JSON_VALUE_ADAPTER.validate_python(json_value))
+    except (PydanticSerializationError, TypeError, ValueError, ValidationError) as exc:
+        raise PaginationConfigurationError(
+            "Pagination ordering produced a cursor value that cannot be serialized"
+        ) from exc
+    return serialized
+
+
+def _deserialize_cursor_values(
+    values: list[JsonValue],
+    ordering: tuple[_OrderKey, ...],
+) -> tuple[object, ...]:
+    if len(values) != len(ordering):
+        raise PaginationError(
+            "Invalid pagination cursor",
+            code=PaginationErrorCode.INVALID_CURSOR,
+        )
+
+    deserialized: list[object] = []
+    try:
+        for value, key in zip(values, ordering, strict=True):
+            if value is None:
+                deserialized.append(None)
+                continue
+            deserialized.append(key.adapter.validate_python(value))
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise PaginationError(
+            "Invalid pagination cursor",
+            code=PaginationErrorCode.INVALID_CURSOR,
+        ) from exc
+    return tuple(deserialized)
+
+
+def _encode_page_cursor(
+    *,
+    direction: _Direction,
+    query_fingerprint: str,
+    values: tuple[object, ...],
+    ordering: tuple[_OrderKey, ...],
+    secret: bytes,
+) -> str:
+    payload = (
+        _CursorPayload(
+            version=_CURSOR_VERSION,
+            direction=direction,
+            query_fingerprint=query_fingerprint,
+            values=_serialize_cursor_values(values, ordering),
+        )
+        .model_dump_json()
+        .encode()
+    )
+    signature = _cursor_signature(payload, secret=secret)
+    cursor = f"{_urlsafe_b64encode(payload)}.{_urlsafe_b64encode(signature)}"
+    if len(cursor) > _MAX_CURSOR_LENGTH:
+        raise PaginationConfigurationError(
+            "Encoded pagination cursor exceeds the maximum length; "
+            "use compact ordering keys"
+        )
+    return cursor
+
+
+def _decode_page_cursor(
+    cursor: str,
+    *,
+    query_fingerprint: str,
+    ordering: tuple[_OrderKey, ...],
+    secret: bytes,
+) -> tuple[_Direction, tuple[object, ...]]:
+    try:
+        if len(cursor) > _MAX_CURSOR_LENGTH:
+            raise ValueError("Cursor is too long")
+        payload_part, signature_part = cursor.split(".", maxsplit=1)
+        payload = _urlsafe_b64decode(payload_part)
+        signature = _urlsafe_b64decode(signature_part)
+        expected_signature = _cursor_signature(payload, secret=secret)
+        if not hmac.compare_digest(signature, expected_signature):
+            raise ValueError("Cursor signature does not match")
+        decoded = _CursorPayload.model_validate_json(payload)
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise PaginationError(
+            "Invalid pagination cursor",
+            code=PaginationErrorCode.INVALID_CURSOR,
+        ) from exc
+
+    if decoded.version != _CURSOR_VERSION:
+        raise PaginationError(
+            "Unsupported pagination cursor version",
+            code=PaginationErrorCode.UNSUPPORTED_CURSOR_VERSION,
+        )
+    if decoded.query_fingerprint != query_fingerprint:
+        raise PaginationError(
+            "Pagination cursor does not match the current query",
+            code=PaginationErrorCode.CURSOR_MISMATCH,
+        )
+    return decoded.direction, _deserialize_cursor_values(decoded.values, ordering)
+
+
+def _strictly_after(key: _OrderKey, value: object) -> ColumnElement[bool]:
+    """Build the strict comparison after one value in the given ordering."""
+    expression = key.expression
+    if value is None:
+        if key.nulls is _NullPlacement.FIRST:
+            return expression.is_not(None)
+        return sa.false()
+
+    comparison = (
+        expression > value
+        if key.direction is _SortDirection.ASC
+        else expression < value
+    )
+    if key.nulls is _NullPlacement.LAST:
+        return sa.or_(comparison, expression.is_(None))
+    return comparison
+
+
+def _seek_predicate(
+    ordering: tuple[_OrderKey, ...],
+    values: tuple[object, ...],
+) -> ColumnElement[bool]:
+    """Build a lexicographic predicate strictly after the cursor values."""
+    if len(ordering) != len(values):
+        raise PaginationConfigurationError(
+            "Cursor values do not match pagination ordering"
+        )
+
+    branches: list[ColumnElement[bool]] = []
+    equal_prefix: list[ColumnElement[bool]] = []
+    for key, value in zip(ordering, values, strict=True):
+        branches.append(sa.and_(*equal_prefix, _strictly_after(key, value)))
+        equal_prefix.append(key.expression.is_not_distinct_from(value))
+    return sa.or_(*branches)
+
+
+@overload
+async def paginate[T](
+    session: AsyncSession,
+    statement: Select[tuple[T]],
+    *,
+    page: PageParams,
+    order_by: tuple[ColumnElement[Any], ...],
+    row_factory: None = None,
+) -> Page[T]: ...
+
+
+@overload
+async def paginate[T](
+    session: AsyncSession,
+    statement: Select[Any],
+    *,
+    page: PageParams,
+    order_by: tuple[ColumnElement[Any], ...],
+    row_factory: Callable[[tuple[object, ...]], T],
+) -> Page[T]: ...
+
+
+async def paginate[T](
+    session: AsyncSession,
+    statement: Select[Any],
+    *,
+    page: PageParams,
+    order_by: tuple[ColumnElement[Any], ...],
+    row_factory: Callable[[tuple[object, ...]], T] | None = None,
+) -> Page[T]:
+    """Execute a stable keyset-paginated SQLAlchemy query.
+
+    The statement must not already contain ``ORDER BY``, ``LIMIT``, ``OFFSET``,
+    or ``FETCH``. The supplied ordering must end in a key (or key combination)
+    that uniquely identifies each logical result row. All ordering expressions
+    must use explicit ``.asc()`` or ``.desc()`` modifiers.
+
+    Pagination is stateless rather than snapshot-based. Inserts and deletes do
+    not cause offset drift, and a deleted anchor row remains usable, but a row
+    whose ordering values change between requests can move across a cursor.
+    Prefer immutable ordering keys when traversal consistency is important.
+
+    Args:
+        session: Database session used to execute the query.
+        statement: Scoped query selecting one logical item per row.
+        page: Requested page size and optional continuation token.
+        order_by: Complete, deterministic ordering for the result set. Dynamic
+            ``sa.column()`` expressions must include their SQLAlchemy type so
+            cursor values can be decoded without guessing.
+        row_factory: Optional conversion for a multi-column selection. It
+            receives only the statement's original selected values; private
+            cursor columns are hidden.
+
+    Returns:
+        Items in canonical order with opaque next and previous cursors.
+
+    Raises:
+        PaginationConfigurationError: The query does not satisfy pagination
+            invariants.
+        PaginationError: The supplied cursor is invalid or belongs to another
+            query.
+    """
+    _validate_page(page)
+    _validate_statement(statement)
+    ordering = _normalize_ordering(order_by)
+    selected_width = len(statement.column_descriptions)
+    if selected_width == 0:
+        raise PaginationConfigurationError(
+            "A paginated Select must return at least one value"
+        )
+    if selected_width != 1 and row_factory is None:
+        raise PaginationConfigurationError(
+            "Multi-column pagination requires a row_factory"
+        )
+
+    query_fingerprint = _query_fingerprint(session, statement, ordering)
+    secret = get_signing_secret().encode()
+    direction = _Direction.FORWARD
+    cursor_values: tuple[object, ...] | None = None
+    if page.cursor is not None:
+        direction, cursor_values = _decode_page_cursor(
+            page.cursor,
+            query_fingerprint=query_fingerprint,
+            ordering=ordering,
+            secret=secret,
+        )
+
+    query_ordering = (
+        ordering
+        if direction is _Direction.FORWARD
+        else tuple(key.reversed() for key in ordering)
+    )
+    cursor_columns = tuple(
+        key.expression.label(f"_tracecat_page_key_{index}")
+        for index, key in enumerate(ordering)
+    )
+    query = statement.add_columns(*cursor_columns)
+    if cursor_values is not None:
+        query = query.where(_seek_predicate(query_ordering, cursor_values))
+    query = query.order_by(*(key.clause() for key in query_ordering)).limit(
+        page.limit + 1
+    )
+
+    result = await session.execute(query)
+    raw_rows = list(result.all())
+    raw_cursor_values = [tuple(row)[-len(ordering) :] for row in raw_rows]
+    serialized_cursor_values = [
+        _serialize_cursor_values(values, ordering) for values in raw_cursor_values
+    ]
+    if any(
+        previous == current for previous, current in pairwise(serialized_cursor_values)
+    ):
+        raise PaginationConfigurationError(
+            "Pagination ordering is not unique; add a unique tie-breaker"
+        )
+    has_more_in_direction = len(raw_rows) > page.limit
+    raw_rows = raw_rows[: page.limit]
+
+    page_rows: list[_PageRow[T]] = []
+    for row in raw_rows:
+        values = tuple(row)
+        selected_values = values[:selected_width]
+        item = (
+            row_factory(selected_values)
+            if row_factory is not None
+            else cast(T, selected_values[0])
+        )
+        page_rows.append(_PageRow(item=item, cursor_values=values[-len(ordering) :]))
+
+    if direction is _Direction.BACKWARD:
+        page_rows.reverse()
+
+    next_cursor: str | None = None
+    prev_cursor: str | None = None
+    if page_rows:
+        if direction is _Direction.FORWARD:
+            if has_more_in_direction:
+                next_cursor = _encode_page_cursor(
+                    direction=_Direction.FORWARD,
+                    query_fingerprint=query_fingerprint,
+                    values=page_rows[-1].cursor_values,
+                    ordering=ordering,
+                    secret=secret,
+                )
+            if page.cursor is not None:
+                prev_cursor = _encode_page_cursor(
+                    direction=_Direction.BACKWARD,
+                    query_fingerprint=query_fingerprint,
+                    values=page_rows[0].cursor_values,
+                    ordering=ordering,
+                    secret=secret,
+                )
+        else:
+            if page.cursor is not None:
+                next_cursor = _encode_page_cursor(
+                    direction=_Direction.FORWARD,
+                    query_fingerprint=query_fingerprint,
+                    values=page_rows[-1].cursor_values,
+                    ordering=ordering,
+                    secret=secret,
+                )
+            if has_more_in_direction:
+                prev_cursor = _encode_page_cursor(
+                    direction=_Direction.BACKWARD,
+                    query_fingerprint=query_fingerprint,
+                    values=page_rows[0].cursor_values,
+                    ordering=ordering,
+                    secret=secret,
+                )
+
+    return Page(
+        items=[row.item for row in page_rows],
+        next_cursor=next_cursor,
+        prev_cursor=prev_cursor,
+    )
 
 
 class CursorPaginationParams(BaseModel):

--- a/tracecat/pagination.py
+++ b/tracecat/pagination.py
@@ -246,9 +246,12 @@ def _normalize_order(expression: ColumnElement[Any]) -> _OrderKey:
             f"Pagination ordering expression {current!s} has no Python value type"
         ) from exc
     try:
-        adapter = (
-            _BINARY_CURSOR_ADAPTER if value_type is bytes else TypeAdapter(value_type)
-        )
+        if isinstance(current.type, sa.JSON):
+            adapter = _JSON_VALUE_ADAPTER
+        elif value_type is bytes:
+            adapter = _BINARY_CURSOR_ADAPTER
+        else:
+            adapter = TypeAdapter(value_type)
     except (PydanticUserError, TypeError) as exc:
         raise PaginationConfigurationError(
             f"Pagination ordering expression {current!s} has an unsupported value type"
@@ -502,6 +505,16 @@ def _decode_page_cursor(
     )
 
 
+def _bind_cursor_value(key: _OrderKey, value: object) -> ColumnElement[Any]:
+    """Bind a decoded cursor value using its ordering expression's SQL type."""
+    return sa.bindparam(
+        None,
+        value,
+        type_=key.expression.type,
+        unique=True,
+    )
+
+
 def _strictly_after(key: _OrderKey, value: object) -> ColumnElement[bool]:
     """Build the strict comparison after one value in the given ordering."""
     expression = key.expression
@@ -510,10 +523,11 @@ def _strictly_after(key: _OrderKey, value: object) -> ColumnElement[bool]:
             return expression.is_not(None)
         return sa.false()
 
+    bound_value = _bind_cursor_value(key, value)
     comparison = (
-        expression > value
+        expression > bound_value
         if key.direction is _SortDirection.ASC
-        else expression < value
+        else expression < bound_value
     )
     if key.nulls is _NullPlacement.LAST:
         return sa.or_(comparison, expression.is_(None))
@@ -536,10 +550,21 @@ def _seek_predicate(
     equal_prefix: list[ColumnElement[bool]] = []
     for key, value in zip(ordering, values, strict=True):
         branches.append(sa.and_(*equal_prefix, _strictly_after(key, value)))
-        equal_prefix.append(key.expression.is_not_distinct_from(value))
+        equality_value = None if value is None else _bind_cursor_value(key, value)
+        equal_prefix.append(key.expression.is_not_distinct_from(equality_value))
     if boundary is _Boundary.INCLUSIVE:
         branches.append(sa.and_(*equal_prefix))
     return sa.or_(*branches)
+
+
+def _apply_seek_predicate(
+    statement: Select[Any],
+    predicate: ColumnElement[bool],
+) -> Select[Any]:
+    """Apply a cursor predicate at the statement's logical row boundary."""
+    if statement._group_by_clauses:
+        return statement.having(predicate)
+    return statement.where(predicate)
 
 
 @overload
@@ -641,12 +666,13 @@ async def paginate[T](
     )
     query = statement.add_columns(*cursor_columns)
     if cursor_values is not None:
-        query = query.where(
+        query = _apply_seek_predicate(
+            query,
             _seek_predicate(
                 query_ordering,
                 cursor_values,
                 boundary=boundary,
-            )
+            ),
         )
     query = query.order_by(*(key.clause() for key in query_ordering)).limit(
         page.limit + 1

--- a/tracecat/pagination.py
+++ b/tracecat/pagination.py
@@ -121,6 +121,11 @@ class _Direction(StrEnum):
     BACKWARD = "backward"
 
 
+class _Boundary(StrEnum):
+    EXCLUSIVE = "exclusive"
+    INCLUSIVE = "inclusive"
+
+
 class _SortDirection(StrEnum):
     ASC = "asc"
     DESC = "desc"
@@ -136,6 +141,7 @@ class _CursorPayload(BaseModel):
 
     version: int
     direction: _Direction
+    boundary: _Boundary = _Boundary.EXCLUSIVE
     query_fingerprint: str
     values: list[JsonValue]
 
@@ -423,6 +429,7 @@ def _deserialize_cursor_values(
 def _encode_page_cursor(
     *,
     direction: _Direction,
+    boundary: _Boundary = _Boundary.EXCLUSIVE,
     query_fingerprint: str,
     values: tuple[object, ...],
     ordering: tuple[_OrderKey, ...],
@@ -432,6 +439,7 @@ def _encode_page_cursor(
         _CursorPayload(
             version=_CURSOR_VERSION,
             direction=direction,
+            boundary=boundary,
             query_fingerprint=query_fingerprint,
             values=_serialize_cursor_values(values, ordering),
         )
@@ -454,7 +462,7 @@ def _decode_page_cursor(
     query_fingerprint: str,
     ordering: tuple[_OrderKey, ...],
     secret: bytes,
-) -> tuple[_Direction, tuple[object, ...]]:
+) -> tuple[_Direction, _Boundary, tuple[object, ...]]:
     try:
         if len(cursor) > _MAX_CURSOR_LENGTH:
             raise ValueError("Cursor is too long")
@@ -481,7 +489,11 @@ def _decode_page_cursor(
             "Pagination cursor does not match the current query",
             code=PaginationErrorCode.CURSOR_MISMATCH,
         )
-    return decoded.direction, _deserialize_cursor_values(decoded.values, ordering)
+    return (
+        decoded.direction,
+        decoded.boundary,
+        _deserialize_cursor_values(decoded.values, ordering),
+    )
 
 
 def _strictly_after(key: _OrderKey, value: object) -> ColumnElement[bool]:
@@ -505,8 +517,10 @@ def _strictly_after(key: _OrderKey, value: object) -> ColumnElement[bool]:
 def _seek_predicate(
     ordering: tuple[_OrderKey, ...],
     values: tuple[object, ...],
+    *,
+    boundary: _Boundary,
 ) -> ColumnElement[bool]:
-    """Build a lexicographic predicate strictly after the cursor values."""
+    """Build a lexicographic predicate after the cursor values."""
     if len(ordering) != len(values):
         raise PaginationConfigurationError(
             "Cursor values do not match pagination ordering"
@@ -517,6 +531,8 @@ def _seek_predicate(
     for key, value in zip(ordering, values, strict=True):
         branches.append(sa.and_(*equal_prefix, _strictly_after(key, value)))
         equal_prefix.append(key.expression.is_not_distinct_from(value))
+    if boundary is _Boundary.INCLUSIVE:
+        branches.append(sa.and_(*equal_prefix))
     return sa.or_(*branches)
 
 
@@ -598,9 +614,10 @@ async def paginate[T](
     query_fingerprint = _query_fingerprint(session, statement, ordering)
     secret = get_signing_secret().encode()
     direction = _Direction.FORWARD
+    boundary = _Boundary.EXCLUSIVE
     cursor_values: tuple[object, ...] | None = None
     if page.cursor is not None:
-        direction, cursor_values = _decode_page_cursor(
+        direction, boundary, cursor_values = _decode_page_cursor(
             page.cursor,
             query_fingerprint=query_fingerprint,
             ordering=ordering,
@@ -618,7 +635,13 @@ async def paginate[T](
     )
     query = statement.add_columns(*cursor_columns)
     if cursor_values is not None:
-        query = query.where(_seek_predicate(query_ordering, cursor_values))
+        query = query.where(
+            _seek_predicate(
+                query_ordering,
+                cursor_values,
+                boundary=boundary,
+            )
+        )
     query = query.order_by(*(key.clause() for key in query_ordering)).limit(
         page.limit + 1
     )
@@ -629,9 +652,18 @@ async def paginate[T](
     serialized_cursor_values = [
         _serialize_cursor_values(values, ordering) for values in raw_cursor_values
     ]
-    if any(
-        previous == current for previous, current in pairwise(serialized_cursor_values)
-    ):
+    duplicate_ordering = any(
+        previous_values == current_values or previous_serialized == current_serialized
+        for (previous_values, current_values), (
+            previous_serialized,
+            current_serialized,
+        ) in zip(
+            pairwise(raw_cursor_values),
+            pairwise(serialized_cursor_values),
+            strict=True,
+        )
+    )
+    if duplicate_ordering:
         raise PaginationConfigurationError(
             "Pagination ordering is not unique; add a unique tie-breaker"
         )
@@ -664,7 +696,7 @@ async def paginate[T](
                     ordering=ordering,
                     secret=secret,
                 )
-            if page.cursor is not None:
+            if page.cursor is not None and boundary is _Boundary.EXCLUSIVE:
                 prev_cursor = _encode_page_cursor(
                     direction=_Direction.BACKWARD,
                     query_fingerprint=query_fingerprint,
@@ -673,7 +705,7 @@ async def paginate[T](
                     secret=secret,
                 )
         else:
-            if page.cursor is not None:
+            if page.cursor is not None and boundary is _Boundary.EXCLUSIVE:
                 next_cursor = _encode_page_cursor(
                     direction=_Direction.FORWARD,
                     query_fingerprint=query_fingerprint,
@@ -689,6 +721,28 @@ async def paginate[T](
                     ordering=ordering,
                     secret=secret,
                 )
+    elif cursor_values is not None and boundary is _Boundary.EXCLUSIVE:
+        # Concurrent deletes can empty a page after its cursor was issued. A
+        # one-use inclusive cursor restores the adjacent surviving page without
+        # pointing back toward the page now known to be empty.
+        if direction is _Direction.FORWARD:
+            prev_cursor = _encode_page_cursor(
+                direction=_Direction.BACKWARD,
+                boundary=_Boundary.INCLUSIVE,
+                query_fingerprint=query_fingerprint,
+                values=cursor_values,
+                ordering=ordering,
+                secret=secret,
+            )
+        else:
+            next_cursor = _encode_page_cursor(
+                direction=_Direction.FORWARD,
+                boundary=_Boundary.INCLUSIVE,
+                query_fingerprint=query_fingerprint,
+                values=cursor_values,
+                ordering=ordering,
+                secret=secret,
+            )
 
     return Page(
         items=[row.item for row in page_rows],

--- a/tracecat/pagination.py
+++ b/tracecat/pagination.py
@@ -49,6 +49,10 @@ _CURSOR_VERSION = 1
 _CURSOR_SIGNATURE_CONTEXT = b"tracecat.pagination.cursor.v1\0"
 _MAX_CURSOR_LENGTH = 8192
 _JSON_VALUE_ADAPTER = TypeAdapter(JsonValue)
+_BINARY_CURSOR_ADAPTER = TypeAdapter(
+    bytes,
+    config=ConfigDict(ser_json_bytes="base64", val_json_bytes="base64"),
+)
 _FINGERPRINT_JSON_OPTIONS = (
     orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS | orjson.OPT_UTC_Z
 )
@@ -242,7 +246,9 @@ def _normalize_order(expression: ColumnElement[Any]) -> _OrderKey:
             f"Pagination ordering expression {current!s} has no Python value type"
         ) from exc
     try:
-        adapter = TypeAdapter(value_type)
+        adapter = (
+            _BINARY_CURSOR_ADAPTER if value_type is bytes else TypeAdapter(value_type)
+        )
     except (PydanticUserError, TypeError) as exc:
         raise PaginationConfigurationError(
             f"Pagination ordering expression {current!s} has an unsupported value type"


### PR DESCRIPTION
## Summary

- Add a universal keyset-pagination API built around `PageParams`, `Page[T]`, and `paginate`.
- Hide cursor direction, encoding, signing, query binding, seek predicates, backward-page reconstruction, and empty-page recovery inside the pagination module.
- Support SQLAlchemy ORM entities and arbitrary projections, composite mixed-direction ordering, grouped aggregate queries, explicit NULL placement, typed cursor values, lossless binary ordering keys, and arbitrary JSON/JSONB value shapes.
- Harden ordering validation for typed-equivalent values such as PostgreSQL `NUMERIC` values with different scales.
- Preserve the legacy pagination classes so existing services remain unchanged.

## Why

Pagination behavior is currently implemented independently across services, which spreads cursor mechanics and ordering edge cases throughout the codebase. This PR establishes the reusable foundation for a PR stack; follow-up PRs will migrate individual services without coupling those migrations to the abstraction itself.

The API uses stateless keyset pagination. Callers provide a scoped query and a deterministic total ordering ending in a unique tie-breaker. Direct numbered-page jumps and total counts are intentionally outside this module.

If concurrent deletion leaves a cursor-based request empty, the page now exposes a one-use inclusive recovery cursor back toward the adjacent surviving page. This preserves navigation without introducing server-side pagination state or cursor bounce loops.

## Validation

- `uv run pytest tests/unit/test_pagination.py -q` — 50 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- Required pre-commit hooks

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | +771 | -3 |
| Tests | +957 | -0 |
