### PR TITLE
fix(agent): disable tool search for Bedrock models

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -1298,15 +1298,29 @@ class TestClaudeAgentRuntimeRun:
         assert captured_options
         assert captured_options[0].env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "128000"
 
-    def test_enables_tool_search(
+    @pytest.mark.parametrize(
+        ("provider", "expected"),
+        [
+            ("anthropic", "true"),
+            ("bedrock", "false"),
+        ],
+    )
+    def test_configures_tool_search_by_root_provider(
         self,
         sample_init_payload: RuntimeInitPayload,
+        provider: str,
+        expected: str,
     ) -> None:
-        # Always on: the CLI would otherwise disable deferred tool loading
-        # because the socket bridge is not a first-party Anthropic host.
-        env = ClaudeAgentRuntime._sdk_env(sample_init_payload)
+        payload = replace(
+            sample_init_payload,
+            config=sample_init_payload.config.model_copy(
+                update={"model_provider": provider}
+            ),
+        )
 
-        assert env["ENABLE_TOOL_SEARCH"] == "true"
+        env = ClaudeAgentRuntime._sdk_env(payload)
+
+        assert env["ENABLE_TOOL_SEARCH"] == expected
 
     @pytest.mark.anyio
     async def test_agents_toggle_adds_agent_tool_without_custom_subagents(
@@ -1478,6 +1492,36 @@ class TestClaudeAgentRuntimeRun:
             "EnterWorktree",
             "ExitWorktree",
         }
+        assert "ToolSearch" not in (agent_def.disallowedTools or [])
+
+    def test_bedrock_subagent_disallows_tool_search(
+        self,
+        mock_socket_writer: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+    ) -> None:
+        child = SandboxSubagentConfig(
+            alias="analyst",
+            description="Use for Bedrock analysis.",
+            prompt="Analyze the request.",
+            config=sample_init_payload.config.model_copy(
+                update={
+                    "model_name": "bedrock-profile",
+                    "model_provider": "bedrock",
+                }
+            ),
+            mcp_auth_token="child-mcp-token",
+        )
+        payload = replace(sample_init_payload, subagents=[child])
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+        )
+
+        definitions = runtime._build_agent_definitions(payload=payload)
+
+        assert definitions is not None
+        assert "ToolSearch" in (definitions["analyst"].disallowedTools or [])
+        assert runtime._sdk_env(payload)["ENABLE_TOOL_SEARCH"] == "true"
 
     def test_explicit_subagent_without_scoped_tools_stays_toolless(
         self,

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -220,6 +220,8 @@ CHILD_AGENT_DISALLOWED_TOOLS = [
     *CLAUDE_CODE_STATEFUL_TOOLS,
 ]
 
+TOOL_SEARCH_TOOL_NAME = "ToolSearch"
+
 # Tools that require internet access (these bypass sandbox network isolation
 # because they're executed server-side by Anthropic, not in the sandbox)
 INTERNET_TOOLS = [
@@ -1345,6 +1347,8 @@ class ClaudeAgentRuntime:
             )
 
             disallowed_tools = list(CHILD_AGENT_DISALLOWED_TOOLS)
+            if subagent.config.model_provider == "bedrock":
+                disallowed_tools.append(TOOL_SEARCH_TOOL_NAME)
             if not self._runtime_internet_access_enabled:
                 disallowed_tools.extend(INTERNET_TOOLS)
 
@@ -1493,12 +1497,13 @@ class ClaudeAgentRuntime:
             env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = (
                 CUSTOM_MODEL_PROVIDER_AUTO_COMPACT_WINDOW
             )
-        # The CLI disables tool search (deferred tool loading) for
-        # non-first-party base URLs — ours is always the socket bridge — unless
-        # explicitly enabled. Every leg terminates at the managed LiteLLM or an
-        # Anthropic-compatible passthrough gateway; both tolerate its wire
-        # artifacts (defer_loading, tool_reference; verified on LiteLLM 1.89).
-        env["ENABLE_TOOL_SEARCH"] = "true"
+        # Bedrock does not consistently support tool search across APIs, models,
+        # and opaque inference profiles. Explicitly disable it for Bedrock roots
+        # so the CLI sends full tool definitions without tool_reference blocks.
+        # Bedrock subagents are handled through their per-agent disallowed tools.
+        env["ENABLE_TOOL_SEARCH"] = (
+            "false" if payload.config.model_provider == "bedrock" else "true"
+        )
         return env
 
     def _build_options(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable tool search for Bedrock models to avoid inconsistent support for deferred tool loading. Previously tool search was always on; now Bedrock roots disable it via `ENABLE_TOOL_SEARCH="false"`, and Bedrock subagents explicitly disallow the `ToolSearch` tool.

- Bedrock root agents: `_sdk_env` sets `ENABLE_TOOL_SEARCH` to "false" so the CLI sends full tool definitions without `tool_reference`.
- Bedrock subagents: `_build_agent_definitions` adds `ToolSearch` to `disallowedTools`, even when the root provider is non-Bedrock.
- Non-Bedrock (e.g., Anthropic) agents retain `ENABLE_TOOL_SEARCH="true"`.

<sup>Written for commit 481428f3de03507f1dc84a518997db9f9f5b9ea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

