### PR TITLE
fix(pagination): return adjacent reverse pages

### DIFF
--- a/tests/unit/test_case_table_rows_service.py
+++ b/tests/unit/test_case_table_rows_service.py
@@ -18,7 +18,6 @@ from tracecat.cases.rows.service import (
 from tracecat.cases.schemas import CaseCreate
 from tracecat.cases.service import CasesService
 from tracecat.db.models import CaseTableRow, Table
-from tracecat.pagination import BaseCursorPaginator
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import TableColumnCreate, TableCreate, TableRowInsert
 from tracecat.tables.service import TablesService
@@ -382,11 +381,64 @@ async def test_list_rows_cursor_uses_created_at_and_id_order(
         oldest_small_id,
     ]
 
-    legacy_cursor = BaseCursorPaginator.encode_cursor(middle_large_id)
-    legacy_page = await case_rows_service.list_rows(
-        case_id=case.id,
-        limit=2,
-        cursor=legacy_cursor,
-        include_row_data=False,
+
+@pytest.mark.anyio
+async def test_list_rows_reverse_pagination_cursors_round_trip(
+    session: AsyncSession,
+    cases_service: CasesService,
+    case_rows_service: CaseTableRowsService,
+    tables_service: TablesService,
+) -> None:
+    """Backward cursors return the adjacent page and keep both directions valid."""
+    case = await _create_case(cases_service)
+    table_id, _ = await _create_table_with_row(
+        tables_service,
+        name=f"case_rows_reverse_{uuid.uuid4().hex[:8]}",
+        value="seed",
     )
-    assert [item.id for item in legacy_page.items] == [older_small_id, oldest_small_id]
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    links = [
+        CaseTableRow(
+            workspace_id=case_rows_service.workspace_id,
+            case_id=case.id,
+            table_id=table_id,
+            row_id=uuid.uuid4(),
+            created_at=base_time + timedelta(minutes=i),
+            updated_at=base_time + timedelta(minutes=i),
+        )
+        for i in range(6)
+    ]
+    session.add_all(links)
+    await session.commit()
+    expected_ids = [
+        link.id
+        for link in sorted(links, key=lambda link: link.created_at, reverse=True)
+    ]
+
+    async def get_page(cursor: str | None = None, *, reverse: bool = False):
+        return await case_rows_service.list_rows(
+            case_id=case.id,
+            limit=2,
+            cursor=cursor,
+            reverse=reverse,
+            include_row_data=False,
+        )
+
+    page1 = await get_page()
+    page2 = await get_page(page1.next_cursor)
+    page3 = await get_page(page2.next_cursor)
+    assert [item.id for item in page3.items] == expected_ids[4:6]
+    assert page3.prev_cursor is not None
+
+    back = await get_page(page3.prev_cursor, reverse=True)
+    assert [item.id for item in back.items] == expected_ids[2:4]
+    assert back.next_cursor is not None
+    assert back.prev_cursor is not None
+
+    forward_again = await get_page(back.next_cursor)
+    assert [item.id for item in forward_again.items] == expected_ids[4:6]
+
+    back_to_first = await get_page(back.prev_cursor, reverse=True)
+    assert [item.id for item in back_to_first.items] == expected_ids[:2]
+    assert back_to_first.next_cursor is not None
+    assert back_to_first.prev_cursor is None

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1938,6 +1938,54 @@ class TestCasesService:
 
         assert search_response.model_dump() == list_response.model_dump()
 
+    async def test_search_cases_reverse_pagination_returns_adjacent_page(
+        self, cases_service: CasesService
+    ) -> None:
+        """A previous cursor returns the adjacent page, not the first page."""
+        for i in range(9):
+            await cases_service.create_case(
+                CaseCreate(
+                    summary=f"Reverse pagination case {i}",
+                    description="Case for reverse pagination test",
+                    status=CaseStatus.NEW,
+                    priority=CasePriority.MEDIUM,
+                    severity=CaseSeverity.LOW,
+                )
+            )
+
+        async def get_page(cursor: str | None = None, *, reverse: bool = False):
+            return await cases_service.search_cases(
+                params=CursorPaginationParams(
+                    limit=3,
+                    cursor=cursor,
+                    reverse=reverse,
+                )
+            )
+
+        all_cases = await cases_service.search_cases(
+            params=CursorPaginationParams(limit=20)
+        )
+        expected_ids = [case.id for case in all_cases.items]
+
+        page1 = await get_page()
+        page2 = await get_page(page1.next_cursor)
+        page3 = await get_page(page2.next_cursor)
+        assert [case.id for case in page3.items] == expected_ids[6:9]
+        assert page3.prev_cursor is not None
+
+        back = await get_page(page3.prev_cursor, reverse=True)
+        assert [case.id for case in back.items] == expected_ids[3:6]
+        assert back.next_cursor is not None
+        assert back.prev_cursor is not None
+
+        forward_again = await get_page(back.next_cursor)
+        assert [case.id for case in forward_again.items] == expected_ids[6:9]
+
+        back_to_first = await get_page(back.prev_cursor, reverse=True)
+        assert [case.id for case in back_to_first.items] == expected_ids[:3]
+        assert back_to_first.next_cursor is not None
+        assert back_to_first.prev_cursor is None
+
     async def test_search_cases_gates_duration_selectinload(
         self, cases_service: CasesService
     ) -> None:

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -982,6 +982,7 @@ class TestPaginate:
             )
 
         assert exc_info.value.code is PaginationErrorCode.INVALID_CURSOR
+        assert isinstance(exc_info.value, ValueError)
 
     @pytest.mark.anyio
     async def test_oversized_cursor_fails_at_its_source(

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -1406,6 +1406,53 @@ class TestTableRows:
         assert final_page.has_more is False
         assert final_page.next_cursor is None
 
+    async def test_search_rows_multi_select_cursor_round_trip(
+        self,
+        tables_service: TablesService,
+    ) -> None:
+        table = await tables_service.create_table(
+            TableCreate(
+                name="multi_select_cursor_table",
+                columns=[
+                    TableColumnCreate(
+                        name="tags",
+                        type=SqlType.MULTI_SELECT,
+                        options=["alpha", "beta", "gamma"],
+                    )
+                ],
+            )
+        )
+        for tags in (["gamma"], ["alpha"], ["beta"]):
+            await tables_service.insert_row(
+                table,
+                TableRowInsert(data={"tags": tags}),
+            )
+
+        all_rows = await tables_service.search_rows(
+            table,
+            limit=3,
+            order_by="tags",
+            sort="asc",
+        )
+        first = await tables_service.search_rows(
+            table,
+            limit=1,
+            order_by="tags",
+            sort="asc",
+        )
+        assert first.next_cursor is not None
+        second = await tables_service.search_rows(
+            table,
+            limit=1,
+            cursor=first.next_cursor,
+            order_by="tags",
+            sort="asc",
+        )
+
+        assert [row["id"] for row in first.items + second.items] == [
+            row["id"] for row in all_rows.items[:2]
+        ]
+
     async def test_list_rows_reverse_pagination_flags(
         self, tables_service: TablesService, table: Table
     ) -> None:

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -1418,24 +1418,92 @@ class TestTableRows:
 
         all_rows = await _list_rows(tables_service, table)
         first_page = await _list_rows_page(tables_service, table, limit=2)
-
-        # Navigate backward from the first forward page cursor.
-        reverse_page = await _list_rows_page(
+        second_page = await _list_rows_page(
             tables_service,
             table,
             limit=2,
             cursor=first_page.next_cursor,
+        )
+        assert second_page.prev_cursor is not None
+
+        # Direction is encoded in the previous-page cursor. ``reverse`` remains
+        # accepted by the service for API compatibility.
+        reverse_page = await _list_rows_page(
+            tables_service,
+            table,
+            limit=2,
+            cursor=second_page.prev_cursor,
             reverse=True,
         )
 
-        # The reverse page should contain only rows before the cursor.
-        assert [row["id"] for row in reverse_page.items] == [all_rows[0]["id"]]
+        assert [row["id"] for row in reverse_page.items] == [
+            row["id"] for row in all_rows[:2]
+        ]
 
         # In response direction:
         # - has_more: there is a forward page available (cursor origin and newer items)
         # - has_previous: there are no older rows before this reverse page
         assert reverse_page.has_more is True
         assert reverse_page.has_previous is False
+
+    async def test_list_rows_reverse_pagination_returns_adjacent_page(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """A previous cursor returns the adjacent page, not the first page."""
+        for i in range(7):
+            await tables_service.insert_row(
+                table,
+                TableRowInsert(data={"name": f"User{i}", "age": i}),
+            )
+
+        all_rows = await _list_rows(tables_service, table)
+        expected_ids = [row["id"] for row in all_rows]
+
+        page1 = await _list_rows_page(tables_service, table, limit=2)
+        page2 = await _list_rows_page(
+            tables_service,
+            table,
+            limit=2,
+            cursor=page1.next_cursor,
+        )
+        page3 = await _list_rows_page(
+            tables_service,
+            table,
+            limit=2,
+            cursor=page2.next_cursor,
+        )
+        assert [row["id"] for row in page3.items] == expected_ids[4:6]
+        assert page3.prev_cursor is not None
+
+        back = await _list_rows_page(
+            tables_service,
+            table,
+            limit=2,
+            cursor=page3.prev_cursor,
+            reverse=True,
+        )
+        assert [row["id"] for row in back.items] == expected_ids[2:4]
+        assert back.next_cursor is not None
+        assert back.prev_cursor is not None
+
+        forward_again = await _list_rows_page(
+            tables_service,
+            table,
+            limit=2,
+            cursor=back.next_cursor,
+        )
+        assert [row["id"] for row in forward_again.items] == expected_ids[4:6]
+
+        back_to_first = await _list_rows_page(
+            tables_service,
+            table,
+            limit=2,
+            cursor=back.prev_cursor,
+            reverse=True,
+        )
+        assert [row["id"] for row in back_to_first.items] == expected_ids[:2]
+        assert back_to_first.next_cursor is not None
+        assert back_to_first.prev_cursor is None
 
     async def test_table_editor_list_rows_reverse_pagination_flags(
         self, tables_service: TablesService, table: Table

--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
-from datetime import datetime
 from typing import Any
 
 import sqlalchemy as sa
 from asyncpg.exceptions import UndefinedTableError
-from sqlalchemy import and_, func, or_, select
 from sqlalchemy import exc as sa_exc
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -24,7 +23,11 @@ from tracecat.cases.schemas import TableRowLinkedEvent, TableRowUnlinkedEvent
 from tracecat.cases.service import CaseEventsService
 from tracecat.db.models import Case, CaseTableRow, Table
 from tracecat.exceptions import TracecatNotFoundError
-from tracecat.pagination import BaseCursorPaginator, CursorPaginatedResponse
+from tracecat.pagination import (
+    CursorPaginatedResponse,
+    PageParams,
+    paginate,
+)
 from tracecat.service import BaseWorkspaceService
 from tracecat.tables.service import TablesService
 
@@ -59,7 +62,6 @@ class CaseTableRowsService(BaseWorkspaceService):
         reverse: bool = False,
         include_row_data: bool = True,
     ) -> CursorPaginatedResponse[CaseTableRowRead]:
-        paginator = BaseCursorPaginator(self.session)
         stmt = (
             select(CaseTableRow)
             .where(
@@ -67,89 +69,30 @@ class CaseTableRowsService(BaseWorkspaceService):
                 CaseTableRow.case_id == case_id,
             )
             .options(selectinload(CaseTableRow.case))
-            .order_by(CaseTableRow.created_at.desc(), CaseTableRow.id.desc())
         )
 
-        if cursor:
-            cursor_data = paginator.decode_cursor(cursor)
-            cursor_id = uuid.UUID(cursor_data.id)
-            cursor_created_at: datetime | None = None
-            if cursor_data.sort_column == "created_at" and isinstance(
-                cursor_data.sort_value, datetime
-            ):
-                cursor_created_at = cursor_data.sort_value
-            if cursor_created_at is None:
-                cursor_created_at = await self.session.scalar(
-                    select(CaseTableRow.created_at).where(
-                        CaseTableRow.workspace_id == self.workspace_id,
-                        CaseTableRow.case_id == case_id,
-                        CaseTableRow.id == cursor_id,
-                    )
-                )
-            if cursor_created_at is None:
-                raise ValueError("Invalid cursor for case rows")
-            if reverse:
-                stmt = stmt.where(
-                    or_(
-                        CaseTableRow.created_at > cursor_created_at,
-                        and_(
-                            CaseTableRow.created_at == cursor_created_at,
-                            CaseTableRow.id > cursor_id,
-                        ),
-                    )
-                )
-                stmt = stmt.order_by(
-                    CaseTableRow.created_at.asc(), CaseTableRow.id.asc()
-                )
-            else:
-                stmt = stmt.where(
-                    or_(
-                        CaseTableRow.created_at < cursor_created_at,
-                        and_(
-                            CaseTableRow.created_at == cursor_created_at,
-                            CaseTableRow.id < cursor_id,
-                        ),
-                    )
-                )
-
-        stmt = stmt.limit(limit + 1)
-        result = await self.session.execute(stmt)
-        links = result.scalars().all()
-
-        has_more = len(links) > limit
-        items = links[:limit] if has_more else links
-        has_previous = cursor is not None
-
-        if reverse:
-            items = list(reversed(items))
-
-        hydrated = await self._hydrate_links(items, include_row_data=include_row_data)
-
-        next_cursor = None
-        prev_cursor = None
-        if items and has_more:
-            next_cursor = paginator.encode_cursor(
-                items[-1].id,
-                sort_column="created_at",
-                sort_value=items[-1].created_at,
-            )
-        if items and cursor:
-            prev_cursor = paginator.encode_cursor(
-                items[0].id,
-                sort_column="created_at",
-                sort_value=items[0].created_at,
-            )
-
-        if reverse:
-            next_cursor, prev_cursor = prev_cursor, next_cursor
-            has_more, has_previous = has_previous, has_more
+        # ``reverse`` remains accepted at the service boundary for compatibility;
+        # the opaque cursor now owns scan direction.
+        page = await paginate(
+            self.session,
+            stmt,
+            page=PageParams(limit=limit, cursor=cursor),
+            order_by=(
+                CaseTableRow.created_at.desc(),
+                CaseTableRow.id.desc(),
+            ),
+        )
+        hydrated = await self._hydrate_links(
+            page.items,
+            include_row_data=include_row_data,
+        )
 
         return CursorPaginatedResponse(
             items=hydrated,
-            next_cursor=next_cursor,
-            prev_cursor=prev_cursor,
-            has_more=has_more,
-            has_previous=has_previous,
+            next_cursor=page.next_cursor,
+            prev_cursor=page.prev_cursor,
+            has_more=page.has_more,
+            has_previous=page.has_previous,
         )
 
     async def link_row(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -8,7 +8,7 @@ from typing import cast as typing_cast
 import sqlalchemy as sa
 from asyncpg import UndefinedColumnError
 from pydantic import ValidationError
-from sqlalchemy import and_, cast, func, or_, select
+from sqlalchemy import cast, func, or_, select
 from sqlalchemy.dialects.postgresql import UUID, insert
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -132,9 +132,10 @@ from tracecat.expressions.expectations import (
 )
 from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowUUID, generate_exec_id
 from tracecat.pagination import (
-    BaseCursorPaginator,
     CursorPaginatedResponse,
     CursorPaginationParams,
+    PageParams,
+    paginate,
 )
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tables.common import (
@@ -203,17 +204,6 @@ def _enum_sort_expr(column: Any, ordered_values: Sequence[str]) -> ColumnElement
         ],
         else_=len(ordered_values),
     )
-
-
-def _enum_sort_rank(value: Any, ordered_values: Sequence[str]) -> int:
-    """Map enum/text values to their semantic sort rank."""
-    normalized_value = getattr(value, "value", value)
-    if not isinstance(normalized_value, str):
-        return len(ordered_values)
-    try:
-        return ordered_values.index(normalized_value)
-    except ValueError:
-        return len(ordered_values)
 
 
 CASE_BATCH_LOCK_TIMEOUT = "5s"
@@ -411,7 +401,6 @@ class CasesService(BaseWorkspaceService):
         include_payload: bool = False,
     ) -> CursorPaginatedResponse[CaseReadMinimal]:
         """Search cases with cursor-based pagination and filtering."""
-        paginator = BaseCursorPaginator(self.session)
         include_case_addons = await self.has_entitlement(Entitlement.CASE_ADDONS)
         filters = self._build_search_filters(
             search_term=search_term,
@@ -434,6 +423,7 @@ class CasesService(BaseWorkspaceService):
         # Base query - eagerly load tags, assignee, and dropdown values.
         stmt = (
             select(Case)
+            .where(Case.workspace_id == self.workspace_id)
             .options(selectinload(Case.tags))
             .options(selectinload(Case.assignee))
             .options(
@@ -454,7 +444,11 @@ class CasesService(BaseWorkspaceService):
             stmt = stmt.where(clause)
 
         # Compute total count with applied filters (workspace scoped)
-        count_stmt = select(func.count()).select_from(Case)
+        count_stmt = (
+            select(func.count())
+            .select_from(Case)
+            .where(Case.workspace_id == self.workspace_id)
+        )
         for clause in filters:
             count_stmt = count_stmt.where(clause)
 
@@ -494,143 +488,31 @@ class CasesService(BaseWorkspaceService):
         else:
             sort_attr = getattr(Case, sort_column)
 
-        # Apply cursor-based pagination with sort-column-aware filtering
-        # The cursor stores (sort_column, sort_value, created_at, id) for proper pagination
-        if params.cursor:
-            cursor_data = paginator.decode_cursor(params.cursor)
-            cursor_id = uuid.UUID(cursor_data.id)
-
-            # Check if cursor was created with the same sort column (for proper pagination)
-            cursor_sort_value = cursor_data.sort_value
-            cursor_has_sort_value = (
-                cursor_data.sort_column == sort_column and cursor_sort_value is not None
-            )
-            if cursor_has_sort_value and sort_column == "tasks":
-                cursor_has_sort_value = isinstance(cursor_sort_value, int)
-            elif cursor_has_sort_value and enum_sort_values is not None:
-                cursor_has_sort_value = isinstance(cursor_sort_value, int)
-
-            if cursor_has_sort_value:
-                sort_filter_col = sort_attr
-                sort_cursor_value = cursor_sort_value
-
-                # Composite filtering: (sort_col, id) matches ORDER BY
-                # Use id as tie-breaker since it's always unique
-                if sort_direction == "asc":
-                    if params.reverse:
-                        # Going backward: get records before cursor in sort order
-                        stmt = stmt.where(
-                            or_(
-                                sort_filter_col < sort_cursor_value,
-                                and_(
-                                    sort_filter_col == sort_cursor_value,
-                                    Case.id < cursor_id,
-                                ),
-                            )
-                        )
-                    else:
-                        # Going forward: get records after cursor in sort order
-                        stmt = stmt.where(
-                            or_(
-                                sort_filter_col > sort_cursor_value,
-                                and_(
-                                    sort_filter_col == sort_cursor_value,
-                                    Case.id > cursor_id,
-                                ),
-                            )
-                        )
-                else:
-                    # Descending order
-                    if params.reverse:
-                        # Going backward: get records after cursor in sort order
-                        stmt = stmt.where(
-                            or_(
-                                sort_filter_col > sort_cursor_value,
-                                and_(
-                                    sort_filter_col == sort_cursor_value,
-                                    Case.id > cursor_id,
-                                ),
-                            )
-                        )
-                    else:
-                        # Going forward: get records before cursor in sort order
-                        stmt = stmt.where(
-                            or_(
-                                sort_filter_col < sort_cursor_value,
-                                and_(
-                                    sort_filter_col == sort_cursor_value,
-                                    Case.id < cursor_id,
-                                ),
-                            )
-                        )
-
-        # Apply sorting: (sort_col, id) for stable pagination
-        # Use id as tie-breaker unless we're already sorting by id
+        # The paginator owns cursor validation, seek predicates, scan direction,
+        # and reconstruction of backward pages. ``reverse`` remains accepted at
+        # the service boundary for compatibility; cursor direction is encoded in
+        # the opaque continuation token.
         if sort_column == "id":
-            # No tie-breaker needed when sorting by id (already unique)
             if sort_direction == "asc":
-                stmt = stmt.order_by(sort_attr.asc())
+                ordering = (sort_attr.asc(),)
             else:
-                stmt = stmt.order_by(sort_attr.desc())
+                ordering = (sort_attr.desc(),)
         else:
-            # Add id as tie-breaker for non-unique columns
             if sort_direction == "asc":
-                stmt = stmt.order_by(sort_attr.asc(), Case.id.asc())
+                ordering = (sort_attr.asc(), Case.id.asc())
             else:
-                stmt = stmt.order_by(sort_attr.desc(), Case.id.desc())
+                ordering = (sort_attr.desc(), Case.id.desc())
 
-        # Fetch limit + 1 to determine if there are more items
-        stmt = stmt.limit(params.limit + 1)
-        result = await self.session.execute(stmt)
-        all_cases = result.scalars().all()
+        case_page = await paginate(
+            self.session,
+            stmt,
+            page=PageParams(limit=params.limit, cursor=params.cursor),
+            order_by=ordering,
+        )
+        cases = case_page.items
 
-        # Check if there are more items
-        has_more = len(all_cases) > params.limit
-        cases = all_cases[: params.limit] if has_more else all_cases
-
-        # Fetch task counts for all cases in one query (needed for cursor generation if sorting by tasks)
+        # Fetch task counts for response hydration.
         task_counts = await self.get_task_counts([case.id for case in cases])
-
-        # Generate cursors with sort column info for proper pagination
-        next_cursor = None
-        prev_cursor = None
-        has_previous = params.cursor is not None
-
-        def get_cursor_sort_value(case: Case) -> datetime | str | int | float | None:
-            """Encode cursor sort values using the same semantics as ORDER BY."""
-            if sort_column == "tasks":
-                return task_counts.get(case.id, {}).get("total", 0)
-            if enum_sort_values is not None:
-                return _enum_sort_rank(
-                    getattr(case, sort_column, None), enum_sort_values
-                )
-            return getattr(case, sort_column, None)
-
-        if has_more and cases:
-            last_case = cases[-1]
-            sort_value = get_cursor_sort_value(last_case)
-            next_cursor = paginator.encode_cursor(
-                last_case.id,
-                sort_column=sort_column,
-                sort_value=sort_value,
-            )
-
-        if params.cursor and cases:
-            first_case = cases[0]
-            sort_value = get_cursor_sort_value(first_case)
-            # For reverse pagination, swap the cursor meaning
-            if params.reverse:
-                next_cursor = paginator.encode_cursor(
-                    first_case.id,
-                    sort_column=sort_column,
-                    sort_value=sort_value,
-                )
-            else:
-                prev_cursor = paginator.encode_cursor(
-                    first_case.id,
-                    sort_column=sort_column,
-                    sort_value=sort_value,
-                )
 
         # Convert to CaseReadMinimal objects with tags and dropdown values
         case_items = []
@@ -692,10 +574,10 @@ class CasesService(BaseWorkspaceService):
 
         return CursorPaginatedResponse(
             items=case_items,
-            next_cursor=next_cursor,
-            prev_cursor=prev_cursor,
-            has_more=has_more,
-            has_previous=has_previous,
+            next_cursor=case_page.next_cursor,
+            prev_cursor=case_page.prev_cursor,
+            has_more=case_page.has_more,
+            has_previous=case_page.has_previous,
             total_estimate=total_estimate,
         )
 

--- a/tracecat/pagination.py
+++ b/tracecat/pagination.py
@@ -108,7 +108,7 @@ class PaginationErrorCode(StrEnum):
     UNSUPPORTED_CURSOR_VERSION = "unsupported_cursor_version"
 
 
-class PaginationError(TracecatValidationError):
+class PaginationError(TracecatValidationError, ValueError):
     """A user-facing pagination cursor error."""
 
     def __init__(self, message: str, *, code: PaginationErrorCode) -> None:

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -41,6 +41,9 @@ from tracecat.pagination import (
     BaseCursorPaginator,
     CursorPaginatedResponse,
     CursorPaginationParams,
+    PageParams,
+    PaginationError,
+    paginate,
 )
 from tracecat.service import BaseWorkspaceService
 from tracecat.tables.common import (
@@ -1385,10 +1388,10 @@ class BaseTablesService(BaseWorkspaceService):
         """
         schema_name = self._get_schema_name()
         sanitized_table_name = self._sanitize_identifier(table.name)
-        conn = await self.session.connection()
 
         # Build the base query
-        stmt = sa.select(*self._visible_columns(table)).select_from(
+        visible_columns = self._visible_columns(table)
+        stmt = sa.select(*visible_columns).select_from(
             sa.table(sanitized_table_name, schema=schema_name)
         )
 
@@ -1474,97 +1477,47 @@ class BaseTablesService(BaseWorkspaceService):
         if sort_column not in valid_columns:
             raise ValueError(f"Invalid order_by column: {sort_column}")
 
-        sort_col = sa.column(self._sanitize_identifier(sort_column))
-
-        # Apply cursor-based pagination with sort-column-aware filtering
-        if params.cursor:
-            try:
-                cursor_data = BaseCursorPaginator.decode_cursor(params.cursor)
-            except Exception as e:
-                raise ValueError(f"Invalid cursor: {e}") from e
-
-            cursor_id = UUID(cursor_data.id)
-
-            # Check if cursor was created with the same sort column
-            cursor_sort_value = cursor_data.sort_value
-            cursor_has_sort_value = (
-                cursor_data.sort_column == sort_column and cursor_sort_value is not None
-            )
-
-            if cursor_has_sort_value:
-                # Use sort column value for cursor filtering
-                sort_cursor_value = cursor_sort_value
-
-                # Composite filtering: (sort_col, id) matches ORDER BY
-                if sort_direction == "asc":
-                    if params.reverse:
-                        # Going backward: get records before cursor in sort order
-                        stmt = stmt.where(
-                            sa.or_(
-                                sort_col < sort_cursor_value,
-                                sa.and_(
-                                    sort_col == sort_cursor_value,
-                                    sa.column("id") < cursor_id,
-                                ),
-                            )
-                        )
-                    else:
-                        # Going forward: get records after cursor in sort order
-                        stmt = stmt.where(
-                            sa.or_(
-                                sort_col > sort_cursor_value,
-                                sa.and_(
-                                    sort_col == sort_cursor_value,
-                                    sa.column("id") > cursor_id,
-                                ),
-                            )
-                        )
-                else:
-                    # Descending order
-                    if params.reverse:
-                        # Going backward: get records after cursor in sort order
-                        stmt = stmt.where(
-                            sa.or_(
-                                sort_col > sort_cursor_value,
-                                sa.and_(
-                                    sort_col == sort_cursor_value,
-                                    sa.column("id") > cursor_id,
-                                ),
-                            )
-                        )
-                    else:
-                        # Going forward: get records before cursor in sort order
-                        stmt = stmt.where(
-                            sa.or_(
-                                sort_col < sort_cursor_value,
-                                sa.and_(
-                                    sort_col == sort_cursor_value,
-                                    sa.column("id") < cursor_id,
-                                ),
-                            )
-                        )
-
-        # Apply sorting: (sort_col, id) for stable pagination
-        # Use id as tie-breaker unless we're already sorting by id
         if sort_column == "id":
-            # No tie-breaker needed when sorting by id (already unique)
-            if sort_direction == "asc":
-                stmt = stmt.order_by(sort_col.asc())
-            else:
-                stmt = stmt.order_by(sort_col.desc())
+            sort_type: sa.types.TypeEngine = sa.Uuid()
+        elif sort_column in {"created_at", "updated_at"}:
+            sort_type = sa.TIMESTAMP(timezone=True)
         else:
-            # Add id as tie-breaker for non-unique columns
-            if sort_direction == "asc":
-                stmt = stmt.order_by(sort_col.asc(), sa.column("id").asc())
-            else:
-                stmt = stmt.order_by(sort_col.desc(), sa.column("id").desc())
+            table_column = next(
+                column for column in table.columns if column.name == sort_column
+            )
+            sort_type = self._sa_type_for_column(SqlType(table_column.type))
 
-        # Fetch limit + 1 to determine if there are more items
-        stmt = stmt.limit(params.limit + 1)
+        sort_col = sa.column(self._sanitize_identifier(sort_column), sort_type)
+        id_col = sa.column("id", sa.Uuid())
+
+        # ``reverse`` remains accepted at the service boundary for compatibility;
+        # the opaque cursor now owns scan direction.
+        if sort_column == "id":
+            if sort_direction == "asc":
+                ordering = (sort_col.asc(),)
+            else:
+                ordering = (sort_col.desc(),)
+        else:
+            if sort_direction == "asc":
+                ordering = (sort_col.asc(), id_col.asc())
+            else:
+                ordering = (sort_col.desc(), id_col.desc())
+
+        visible_names = tuple(column.name for column in visible_columns)
+
+        def build_row(values: tuple[object, ...]) -> dict[str, Any]:
+            return dict(zip(visible_names, values, strict=True))
 
         try:
-            result = await conn.execute(stmt)
-            rows = [dict(row) for row in result.mappings().all()]
+            page = await paginate(
+                self.session,
+                stmt,
+                page=PageParams(limit=params.limit, cursor=params.cursor),
+                order_by=ordering,
+                row_factory=build_row,
+            )
+        except PaginationError:
+            raise
         except ProgrammingError as e:
             while (cause := e.__cause__) is not None:
                 e = cause
@@ -1583,47 +1536,12 @@ class BaseTablesService(BaseWorkspaceService):
             )
             raise
 
-        # Check if there are more items
-        has_more = len(rows) > params.limit
-        if has_more:
-            rows = rows[: params.limit]
-        has_previous = params.cursor is not None
-
-        # Generate cursors with sort column info for proper pagination
-        next_cursor = None
-        prev_cursor = None
-
-        if rows:
-            if has_more:
-                # Generate next cursor from the last item
-                last_item = rows[-1]
-                next_cursor = BaseCursorPaginator.encode_cursor(
-                    last_item["id"],
-                    sort_column=sort_column,
-                    sort_value=last_item.get(sort_column),
-                )
-
-            if params.cursor:
-                # If we used a cursor to get here, we can go back
-                first_item = rows[0]
-                prev_cursor = BaseCursorPaginator.encode_cursor(
-                    first_item["id"],
-                    sort_column=sort_column,
-                    sort_value=first_item.get(sort_column),
-                )
-
-        # If we were doing reverse pagination, swap the cursors and reverse items
-        if params.reverse:
-            rows = list(reversed(rows))
-            next_cursor, prev_cursor = prev_cursor, next_cursor
-            has_more, has_previous = has_previous, has_more
-
         return CursorPaginatedResponse(
-            items=rows,
-            next_cursor=next_cursor,
-            prev_cursor=prev_cursor,
-            has_more=has_more,
-            has_previous=has_previous,
+            items=page.items,
+            next_cursor=page.next_cursor,
+            prev_cursor=page.prev_cursor,
+            has_more=page.has_more,
+            has_previous=page.has_previous,
         )
 
     async def batch_insert_rows(


### PR DESCRIPTION
## Summary

- migrate `CasesService.search_cases`, `TablesService.list_rows` / `search_rows`, and `CaseTableRowsService.list_rows` to the shared pagination utility
- preserve the existing service and HTTP signatures, including the compatibility `reverse` parameter, while making cursor direction authoritative
- add regressions proving that moving backward from page three returns page two, both cursor directions round-trip, and `MULTI_SELECT` ordering advances across pages

## Root cause

The affected services each implemented cursor pagination independently. Their reverse path inverted the query order but did not consistently reconstruct the returned page and cursors, so a request intended to move backward could return the wrong adjacent page.

The shared paginator encodes direction in signed cursors, applies the matching seek predicate and query order, then restores the caller-visible order before constructing the next and previous cursors.

## Stack

This is a child of #3256 and targets `alee/ENG-1531-pagination-api`. The parent PR introduces the shared pagination abstraction; this PR applies it only to the service implementations covered by [ENG-1531](https://linear.app/tracecat/issue/ENG-1531/reverse-cursor-pagination-returns-the-wrong-page-in-cases-tables-and).

## Compatibility

All existing service and HTTP method signatures remain unchanged. Clients continue to send `next_cursor` or `prev_cursor`; the legacy `reverse` parameter remains accepted for compatibility, while cursor direction is authoritative internally.

## Validation

- `uv run pytest tests/unit/test_pagination.py tests/unit/test_cases_service.py tests/unit/test_tables_service.py tests/unit/test_case_table_rows_service.py -q` — 231 passed
- affected API suites — 92 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- Required pre-commit hooks

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | +94 | -351 |
| Tests | +228 | -12 |
