### PR TITLE
fix(executor): preserve gateway during shutdown

### DIFF
--- a/tests/unit/executor/test_action_gateway_signal_lifecycle.py
+++ b/tests/unit/executor/test_action_gateway_signal_lifecycle.py
@@ -19,6 +19,8 @@ from tracecat.temporal.worker_lifecycle import (
     install_worker_shutdown_signal_handlers,
 )
 
+COLD_PROCESS_START_TIMEOUT_SECONDS = 60.0
+
 
 @pytest.fixture(autouse=True, scope="session")
 def default_org() -> Iterator[None]:
@@ -100,7 +102,9 @@ def test_sigterm_keeps_action_gateway_available_during_worker_drain() -> None:
         process.start()
         child_connection.close()
         try:
-            assert parent_connection.poll(15), "Action Gateway did not start"
+            assert parent_connection.poll(COLD_PROCESS_START_TIMEOUT_SECONDS), (
+                "Action Gateway did not start"
+            )
             status, detail = parent_connection.recv()
             if status == "error":
                 pytest.fail(detail)

--- a/tests/unit/executor/test_action_gateway_signal_lifecycle.py
+++ b/tests/unit/executor/test_action_gateway_signal_lifecycle.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+import os
+import signal
+import sys
+import tempfile
+import traceback
+from collections.abc import Iterator
+from multiprocessing.connection import Connection
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tracecat.executor.action_gateway.server import ActionGateway
+from tracecat.temporal.worker_lifecycle import (
+    install_worker_shutdown_signal_handlers,
+)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def default_org() -> Iterator[None]:
+    yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def workflow_bucket() -> Iterator[None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def clean_redis_db() -> Iterator[None]:
+    yield
+
+
+async def _gateway_is_reachable(socket_path: Path) -> bool:
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.AsyncHTTPTransport(uds=str(socket_path)),
+        ) as client:
+            response = await client.get("http://action-gateway/internal/health")
+    except httpx.ConnectError:
+        return False
+    return response.status_code == 200
+
+
+async def _run_signal_probe(
+    socket_path: Path,
+    result_connection: Connection,
+) -> None:
+    shutdown_event = asyncio.Event()
+    gateway = ActionGateway(socket_path=socket_path)
+
+    with install_worker_shutdown_signal_handlers(shutdown_event):
+        await gateway.start()
+        try:
+            result_connection.send(("ready", os.getpid()))
+            await asyncio.wait_for(shutdown_event.wait(), timeout=5)
+
+            # Give the embedded server time to react to SIGTERM. It must remain
+            # available until the executor explicitly stops it after draining.
+            await asyncio.sleep(0.25)
+            result_connection.send(
+                ("after-signal", await _gateway_is_reachable(socket_path))
+            )
+
+            loop = asyncio.get_running_loop()
+            command = await loop.run_in_executor(None, result_connection.recv)
+            if command != "stop":
+                raise RuntimeError(f"Unexpected parent command: {command!r}")
+        finally:
+            await gateway.stop()
+
+
+def _run_action_gateway_signal_probe(
+    socket_path: str,
+    result_connection: Connection,
+) -> None:
+    try:
+        asyncio.run(_run_signal_probe(Path(socket_path), result_connection))
+    except BaseException:
+        result_connection.send(("error", traceback.format_exc()))
+        raise
+    finally:
+        result_connection.close()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires POSIX signals")
+def test_sigterm_keeps_action_gateway_available_during_worker_drain() -> None:
+    context = multiprocessing.get_context("spawn")
+    parent_connection, child_connection = context.Pipe(duplex=True)
+    with tempfile.TemporaryDirectory(prefix="tc-gw-") as temp_dir:
+        process = context.Process(
+            target=_run_action_gateway_signal_probe,
+            args=(str(Path(temp_dir) / "gateway.sock"), child_connection),
+        )
+
+        process.start()
+        child_connection.close()
+        try:
+            assert parent_connection.poll(15), "Action Gateway did not start"
+            status, detail = parent_connection.recv()
+            if status == "error":
+                pytest.fail(detail)
+            assert status == "ready"
+
+            os.kill(detail, signal.SIGTERM)
+
+            assert parent_connection.poll(10), "Executor did not handle SIGTERM"
+            status, detail = parent_connection.recv()
+            if status == "error":
+                pytest.fail(detail)
+            assert status == "after-signal"
+            assert detail is True
+        finally:
+            if process.is_alive():
+                try:
+                    parent_connection.send("stop")
+                except (BrokenPipeError, EOFError, OSError):
+                    pass
+            process.join(timeout=10)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+            if process.is_alive():
+                process.kill()
+                process.join()
+            parent_connection.close()
+
+    assert process.exitcode == 0

--- a/tracecat/executor/action_gateway/server.py
+++ b/tracecat/executor/action_gateway/server.py
@@ -4,12 +4,26 @@ from __future__ import annotations
 
 import asyncio
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+
+import uvicorn
 
 from tracecat.executor.action_gateway.app import create_app
 from tracecat.executor.action_gateway.config import action_gateway_socket_path
 from tracecat.logger import logger
+
+
+class _ExecutorOwnedSignalServer(uvicorn.Server):
+    """Uvicorn server that leaves process signal handling to the executor."""
+
+    @contextmanager
+    def capture_signals(self) -> Iterator[None]:
+        # The executor must stop Temporal intake and drain active activities
+        # before this gateway closes. Uvicorn's default signal capture would
+        # close the socket first and make in-flight SDK calls fail.
+        yield
 
 
 class ActionGateway:
@@ -17,7 +31,7 @@ class ActionGateway:
 
     def __init__(self, *, socket_path: Path | None = None) -> None:
         self._configured_socket_path = socket_path
-        self._server: Any | None = None
+        self._server: uvicorn.Server | None = None
         self._task: asyncio.Task[None] | None = None
         self._socket_path: Path | None = None
 
@@ -25,8 +39,6 @@ class ActionGateway:
         """Start the action gateway for this executor process."""
         if self._task is not None:
             return
-
-        import uvicorn
 
         socket_path = self._configured_socket_path or action_gateway_socket_path()
         socket_path.parent.mkdir(parents=True, exist_ok=True)
@@ -38,7 +50,7 @@ class ActionGateway:
             log_level="warning",
             lifespan="on",
         )
-        server = uvicorn.Server(uvicorn_config)
+        server = _ExecutorOwnedSignalServer(uvicorn_config)
         self._server = server
         self._socket_path = socket_path
         self._task = asyncio.create_task(server.serve())
@@ -69,7 +81,7 @@ class ActionGateway:
         if task is None:
             return
 
-        if server is not None and hasattr(server, "should_exit"):
+        if server is not None:
             server.should_exit = True
         try:
             await asyncio.wait_for(task, timeout=5)


### PR DESCRIPTION
## Summary

- Keep the embedded Action Gateway from installing Uvicorn signal handlers so the executor owns the SIGTERM shutdown order.
- Retain explicit gateway shutdown through `ActionGateway.stop()`.
- Add a process-level regression test proving the Unix-socket health endpoint remains available after SIGTERM until the executor explicitly stops the gateway.

## Root cause

Uvicorn captured SIGTERM inside the executor process and began shutting down the embedded gateway immediately. That closed the Unix socket while the Temporal worker could still be draining in-flight activities, causing their SDK calls to fail.

## Impact

The Action Gateway now remains available throughout worker drain and closes only when the executor reaches its explicit gateway shutdown step.

## Validation

- `uv run pytest tests/unit/executor/test_action_gateway_signal_lifecycle.py -q`
- `uv run ruff check tracecat/executor/action_gateway/server.py tests/unit/executor/test_action_gateway_signal_lifecycle.py`
- `uv run ruff format --check tracecat/executor/action_gateway/server.py tests/unit/executor/test_action_gateway_signal_lifecycle.py`
- `uv run basedpyright tracecat/executor/action_gateway/server.py tests/unit/executor/test_action_gateway_signal_lifecycle.py`
- `git diff --check`
- Full pre-commit hook suite, including client generation and Python type checking

## LOC breakdown

| Category | + | - |
|---|---:|---:|
| Logic | 18 | 6 |
| Tests | 132 | 0 |
| **Total** | **150** | **6** |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the embedded Action Gateway available during executor shutdown by preventing `uvicorn` from installing signal handlers. Before: SIGTERM closed the gateway’s Unix socket while the worker drained; After: the executor handles SIGTERM and closes the gateway only when it calls `ActionGateway.stop()`.

- Introduces `_ExecutorOwnedSignalServer` that no-ops `capture_signals`.
- Retains explicit shutdown via `ActionGateway.stop()`.
- Adds a process-level regression test that verifies the Unix-socket health endpoint stays reachable after SIGTERM until explicit stop, and increases cold-start allowance to 60s to avoid flakiness.
- No external API or config changes; no migration required.

<sup>Written for commit 3855ae7f8e912180f83d746c45c46f96608102da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

