### PR TITLE
fix(executor): recover stale loop device nodes

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -250,6 +250,8 @@ jobs:
           # Tests run on the host, so Temporal must be reachable via localhost
           TEMPORAL__CLUSTER_URL: "localhost:7233"
           TRACECAT__DISABLE_NSJAIL: "true"
+          # Privileged loop-device regression reuses the exact image built above.
+          TRACECAT__REGISTRY_LOOP_HOTPLUG_IMAGE: tracecat-ci:integration-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           # Skip pool integration tests for now.
           # Worker-specific task queues in conftest.py ensure isolation

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,15 @@ RUN git clone https://github.com/google/nsjail.git /tmp/nsjail && \
     install -m 0755 nsjail /usr/local/bin/nsjail && \
     rm -rf /tmp/nsjail
 
+COPY docker/loop-device-sync.cc /tmp/loop-device-sync.cc
+
+RUN g++ -std=c++20 -O2 -Wall -Wextra -Werror -Wformat=2 \
+        -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE -pie \
+        -Wl,-z,relro,-z,now \
+        /tmp/loop-device-sync.cc -o /usr/local/bin/tracecat-loop-device-sync && \
+    strip /usr/local/bin/tracecat-loop-device-sync && \
+    rm /tmp/loop-device-sync.cc
+
 # ====================
 # Stage 2: Create minimal sandbox rootfs
 # ====================
@@ -137,13 +146,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # extensions from this directory instead of autoinstalling over the network.
 ENV TRACECAT__DUCKDB_EXTENSION_DIRECTORY=/usr/local/lib/duckdb/extensions
 
-# Allow the non-root executor process to invoke mount/umount when the container
-# runtime grants the needed bounding capabilities. Without these file caps,
-# privileged Docker containers still run apiuser with no effective capabilities.
-RUN chmod u-s /usr/bin/mount /usr/bin/umount && \
-    setcap cap_sys_admin,cap_dac_override+ep /usr/bin/mount && \
-    setcap cap_sys_admin,cap_dac_override+ep /usr/bin/umount
-
 # Copy sandbox rootfs
 COPY --from=sandbox-rootfs /usr /var/lib/tracecat/sandbox-rootfs/usr
 
@@ -198,6 +200,16 @@ RUN groupadd -g 1001 apiuser && useradd -m -u 1001 -g apiuser apiuser && \
 
 # Create MCP socket directory for apiuser
 RUN mkdir -p /var/run/tracecat && chown 1001:1001 /var/run/tracecat
+
+# Allow the non-root executor process to invoke mount/umount and synchronize
+# kernel-confirmed loop nodes when the runtime grants the needed bounding
+# capabilities. The fixed-purpose sync helper cannot create arbitrary devices.
+COPY --from=nsjail-builder /usr/local/bin/tracecat-loop-device-sync /usr/local/bin/tracecat-loop-device-sync
+
+RUN chmod u-s /usr/bin/mount /usr/bin/umount && \
+    setcap cap_sys_admin,cap_dac_override+ep /usr/bin/mount && \
+    setcap cap_sys_admin,cap_dac_override+ep /usr/bin/umount && \
+    setcap cap_mknod,cap_dac_override+ep /usr/local/bin/tracecat-loop-device-sync
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -209,7 +209,7 @@ COPY --from=nsjail-builder /usr/local/bin/tracecat-loop-device-sync /usr/local/b
 RUN chmod u-s /usr/bin/mount /usr/bin/umount && \
     setcap cap_sys_admin,cap_dac_override+ep /usr/bin/mount && \
     setcap cap_sys_admin,cap_dac_override+ep /usr/bin/umount && \
-    setcap cap_mknod,cap_dac_override+ep /usr/local/bin/tracecat-loop-device-sync
+    setcap cap_mknod,cap_dac_override,cap_setuid+ep /usr/local/bin/tracecat-loop-device-sync
 
 WORKDIR /app
 

--- a/docker/loop-device-sync.cc
+++ b/docker/loop-device-sync.cc
@@ -1,0 +1,215 @@
+#include <charconv>
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+
+// Synchronize loop block-device nodes visible to a running executor container.
+//
+// A container's /dev is normally a private tmpfs populated when the container
+// starts. The host kernel can create additional loop devices later, making
+// /sys/block/loopN visible in the container without adding the corresponding
+// /dev/loopN node. util-linux mount(8) may then select that free loop device but
+// fail to open it with ENOENT.
+//
+// This helper repairs only that visibility mismatch. It mirrors loop devices
+// already reported by the kernel into /dev; it does not allocate, configure,
+// attach, mount, unmount, or remove loop devices. It is installed with the
+// narrow CAP_MKNOD file capability because the main Python executor runs as an
+// unprivileged user.
+//
+// Security contract:
+//   * accept no caller-controlled paths or device numbers;
+//   * trust only kernel sysfs entries named loopN with Linux loop major 7;
+//   * reject any existing /dev/loopN path that is not the exact block device;
+//   * create nodes mode 0600, leaving access to the file-capability mount tool;
+//   * fail the entire synchronization on malformed or inconsistent state.
+//
+// stdout is a small machine-readable ABI consumed by registry_artifacts.py:
+//
+//     <kernel devices> <created nodes> <existing nodes>\n
+//
+// Diagnostics go to stderr and a nonzero exit status. Concurrent helper
+// processes are safe: only one mknod wins and the EEXIST loser revalidates the
+// winning node before accepting it.
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr unsigned int kLoopBlockMajor = 7;
+const fs::path kSysBlockPath{"/sys/block"};
+
+struct DeviceNumbers {
+    unsigned int major;
+    unsigned int minor;
+};
+
+struct SyncCounts {
+    std::uint64_t kernel_devices = 0;
+    std::uint64_t created_nodes = 0;
+    std::uint64_t existing_nodes = 0;
+};
+
+enum class NodeState { kMissing, kExisting };
+
+std::optional<unsigned int> parse_loop_minor(const fs::path& filename) {
+    const std::string name = filename.native();
+    constexpr std::string_view prefix{"loop"};
+    if (!name.starts_with(prefix) || name.size() == prefix.size()) {
+        return std::nullopt;
+    }
+
+    const std::string_view digits{name.data() + prefix.size(),
+                                  name.size() - prefix.size()};
+    unsigned int minor = 0;
+    const auto [end, error] =
+        std::from_chars(digits.data(), digits.data() + digits.size(), minor);
+    if (error != std::errc{} || end != digits.data() + digits.size()) {
+        return std::nullopt;
+    }
+    return minor;
+}
+
+unsigned int parse_device_number(std::string_view value,
+                                 const fs::path& source) {
+    unsigned int number = 0;
+    const auto [end, error] =
+        std::from_chars(value.data(), value.data() + value.size(), number);
+    if (error != std::errc{} || end != value.data() + value.size()) {
+        throw std::runtime_error("invalid device numbers in " + source.string());
+    }
+    return number;
+}
+
+DeviceNumbers read_device_numbers(const fs::path& sysfs_device,
+                                  unsigned int expected_minor) {
+    const fs::path source = sysfs_device / "dev";
+    std::ifstream input{source};
+    std::string value;
+    if (!input || !std::getline(input, value)) {
+        throw std::runtime_error("cannot read " + source.string());
+    }
+
+    const std::size_t separator = value.find(':');
+    if (separator == std::string::npos ||
+        value.find(':', separator + 1) != std::string::npos) {
+        throw std::runtime_error("invalid device numbers in " + source.string());
+    }
+
+    // Validate both halves of the mapping. The directory name supplies the
+    // destination /dev suffix, while the sysfs dev file supplies the block
+    // device identity used by mknod(2); they must describe the same loop node.
+    const DeviceNumbers numbers{
+        .major = parse_device_number(
+            std::string_view{value}.substr(0, separator), source),
+        .minor = parse_device_number(
+            std::string_view{value}.substr(separator + 1), source),
+    };
+    if (numbers.major != kLoopBlockMajor ||
+        numbers.minor != expected_minor) {
+        throw std::runtime_error("unexpected loop device numbers in " +
+                                 source.string());
+    }
+    return numbers;
+}
+
+NodeState validate_existing_node(const fs::path& device,
+                                 const DeviceNumbers& numbers) {
+    struct stat node_stat {};
+    // lstat(2), rather than stat(2), deliberately rejects a symlink occupying
+    // /dev/loopN instead of following it to an attacker-selected target.
+    if (::lstat(device.c_str(), &node_stat) != 0) {
+        if (errno == ENOENT) {
+            return NodeState::kMissing;
+        }
+        throw std::system_error(errno, std::generic_category(),
+                                "cannot inspect " + device.string());
+    }
+
+    if (!S_ISBLK(node_stat.st_mode) ||
+        ::major(node_stat.st_rdev) != numbers.major ||
+        ::minor(node_stat.st_rdev) != numbers.minor) {
+        throw std::runtime_error("refusing unexpected existing path " +
+                                 device.string());
+    }
+    return NodeState::kExisting;
+}
+
+bool create_device_node(const fs::path& device,
+                        const DeviceNumbers& numbers) {
+    if (::mknod(device.c_str(), S_IFBLK | 0600,
+                ::makedev(numbers.major, numbers.minor)) == 0) {
+        return true;
+    }
+
+    const int error = errno;
+    // Another executor thread or process may create this container-local node
+    // after our lstat and before mknod. Treat that race as success only after
+    // applying the same strict block-device validation as the fast path.
+    if (error == EEXIST &&
+        validate_existing_node(device, numbers) == NodeState::kExisting) {
+        return false;
+    }
+    throw std::system_error(error, std::generic_category(),
+                            "cannot create " + device.string());
+}
+
+SyncCounts synchronize_loop_devices() {
+    SyncCounts counts;
+    // /sys/block is the authoritative view of loop objects currently known to
+    // the shared kernel. Non-loop block devices are ignored by name.
+    for (const fs::directory_entry& entry :
+         fs::directory_iterator{kSysBlockPath}) {
+        const std::optional<unsigned int> minor =
+            parse_loop_minor(entry.path().filename());
+        if (!minor.has_value()) {
+            continue;
+        }
+        ++counts.kernel_devices;
+
+        const DeviceNumbers numbers =
+            read_device_numbers(entry.path(), minor.value());
+        const fs::path device =
+            fs::path{"/dev"} / ("loop" + std::to_string(numbers.minor));
+        if (validate_existing_node(device, numbers) == NodeState::kExisting) {
+            ++counts.existing_nodes;
+        } else if (create_device_node(device, numbers)) {
+            ++counts.created_nodes;
+        } else {
+            ++counts.existing_nodes;
+        }
+    }
+    return counts;
+}
+
+}  // namespace
+
+int main(int argc, char*[]) {
+    // A zero-argument interface keeps the capability-bearing helper
+    // fixed-purpose: callers cannot ask it to create an arbitrary device node.
+    if (argc != 1) {
+        std::cerr << "tracecat-loop-device-sync does not accept arguments\n";
+        return EXIT_FAILURE;
+    }
+
+    try {
+        const SyncCounts counts = synchronize_loop_devices();
+        std::cout << counts.kernel_devices << ' ' << counts.created_nodes << ' '
+                  << counts.existing_nodes << '\n';
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}

--- a/docker/loop-device-sync.cc
+++ b/docker/loop-device-sync.cc
@@ -11,8 +11,10 @@
 #include <string_view>
 #include <system_error>
 
+#include <sys/fsuid.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
+#include <sys/types.h>
 
 // Synchronize loop block-device nodes visible to a running executor container.
 //
@@ -25,14 +27,17 @@
 // This helper repairs only that visibility mismatch. It mirrors loop devices
 // already reported by the kernel into /dev; it does not allocate, configure,
 // attach, mount, unmount, or remove loop devices. It is installed with the
-// narrow CAP_MKNOD file capability because the main Python executor runs as an
-// unprivileged user.
+// narrow file capabilities because the main Python executor runs as an
+// unprivileged user. CAP_SETUID is used only to set the filesystem UID to root
+// before publishing nodes, so ordinary UID-1001 action subprocesses cannot open
+// node-global loop devices through owner permissions.
 //
 // Security contract:
 //   * accept no caller-controlled paths or device numbers;
 //   * trust only kernel sysfs entries named loopN with Linux loop major 7;
 //   * reject any existing /dev/loopN path that is not the exact block device;
-//   * create nodes mode 0600, leaving access to the file-capability mount tool;
+//   * create root-owned nodes mode 0600, leaving access only to the
+//     file-capability mount tool;
 //   * fail the entire synchronization on malformed or inconsistent state.
 //
 // stdout is a small machine-readable ABI consumed by registry_artifacts.py:
@@ -62,6 +67,26 @@ struct SyncCounts {
 };
 
 enum class NodeState { kMissing, kExisting };
+
+class ScopedRootFsuid {
+  public:
+    ScopedRootFsuid() : original_fsuid_(::setfsuid(0)) {
+        // setfsuid(2) reports the previous value even when it refuses a change.
+        // Setting the requested value a second time therefore verifies that the
+        // first call actually installed root as the filesystem UID.
+        if (::setfsuid(0) != 0) {
+            throw std::runtime_error("cannot set root filesystem uid");
+        }
+    }
+
+    ScopedRootFsuid(const ScopedRootFsuid&) = delete;
+    ScopedRootFsuid& operator=(const ScopedRootFsuid&) = delete;
+
+    ~ScopedRootFsuid() { static_cast<void>(::setfsuid(original_fsuid_)); }
+
+  private:
+    uid_t original_fsuid_;
+};
 
 std::optional<unsigned int> parse_loop_minor(const fs::path& filename) {
     const std::string name = filename.native();
@@ -204,6 +229,10 @@ int main(int argc, char*[]) {
     }
 
     try {
+        // mknod(2) assigns ownership from the caller's filesystem UID. Publish
+        // nodes as root from birth so there is no UID-1001 ownership window for
+        // a concurrent untrusted action to exploit.
+        const ScopedRootFsuid root_fsuid;
         const SyncCounts counts = synchronize_loop_devices();
         std::cout << counts.kernel_devices << ' ' << counts.created_nodes << ' '
                   << counts.existing_nodes << '\n';

--- a/tests/integration/test_registry_artifact_loop_hotplug.py
+++ b/tests/integration/test_registry_artifact_loop_hotplug.py
@@ -10,11 +10,13 @@ The companion regression exercises Tracecat's product mount path against the
 same condition as the real non-root ``apiuser``. It requires the product path
 to synchronize the missing node and successfully mount the second image.
 
-Build the normal executor image once, then run without database-backed parent
-fixtures. The test reuses that image and bind-mounts only this test source::
+Build the normal executor image once, resolve its immutable image ID, then run
+without database-backed parent fixtures::
 
     docker compose -f docker-compose.dev.yml build executor
-    uv run pytest --confcutdir=tests/integration \
+    TRACECAT__REGISTRY_LOOP_HOTPLUG_IMAGE=$(docker compose \
+        -f docker-compose.dev.yml images -q executor) \
+      uv run pytest --confcutdir=tests/integration \
         tests/integration/test_registry_artifact_loop_hotplug.py \
         -m integration -s
 """
@@ -23,7 +25,6 @@ from __future__ import annotations
 
 import asyncio
 import fcntl
-import functools
 import json
 import os
 import pwd
@@ -38,6 +39,7 @@ from pathlib import Path
 from typing import Self, cast
 
 _LOOP_HOTPLUG_CHILD_ENV = "TRACECAT__REGISTRY_LOOP_HOTPLUG_CHILD"
+_LOOP_HOTPLUG_IMAGE_ENV = "TRACECAT__REGISTRY_LOOP_HOTPLUG_IMAGE"
 _LOOP_HOTPLUG_FLAG = "--run-registry-loop-hotplug"
 _LOOP_HOTPLUG_RESULT = "TRACECAT_REGISTRY_LOOP_HOTPLUG_RESULT:"
 
@@ -63,6 +65,7 @@ class LoopHotplugPayload:
     product_mount_succeeded: bool
     product_error: str | None
     product_created_device_node: bool
+    product_device_inaccessible_to_apiuser: bool
     product_module_readable: bool
     cleanup_unmounted: bool
 
@@ -106,6 +109,9 @@ class LoopHotplugPayload:
             product_mount_succeeded=required_bool("product_mount_succeeded"),
             product_error=optional_str("product_error"),
             product_created_device_node=required_bool("product_created_device_node"),
+            product_device_inaccessible_to_apiuser=required_bool(
+                "product_device_inaccessible_to_apiuser"
+            ),
             product_module_readable=required_bool("product_module_readable"),
             cleanup_unmounted=required_bool("cleanup_unmounted"),
         )
@@ -123,6 +129,7 @@ def _empty_payload(*, skipped: str | None = None) -> LoopHotplugPayload:
         product_mount_succeeded=False,
         product_error=None,
         product_created_device_node=False,
+        product_device_inaccessible_to_apiuser=False,
         product_module_readable=False,
         cleanup_unmounted=False,
     )
@@ -147,78 +154,74 @@ def _run_loop_hotplug_in_docker_or_skip() -> LoopHotplugPayload:
         raise unittest.SkipTest("Docker daemon unavailable for registry loop hotplug")
 
     repo_root = Path(__file__).resolve().parents[2]
-    compose_env = os.environ.copy()
-    compose_env.setdefault(
-        "TRACECAT__LOCAL_REPOSITORY_PATH",
-        str(repo_root / "packages"),
+    configured_image = os.environ.get(_LOOP_HOTPLUG_IMAGE_ENV)
+    if not configured_image:
+        raise unittest.SkipTest(
+            f"{_LOOP_HOTPLUG_IMAGE_ENV} must name the prebuilt executor image"
+        )
+    inspect_result = subprocess.run(
+        ["docker", "image", "inspect", "--format", "{{.Id}}", configured_image],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
     )
-    compose_env.setdefault("PUBLIC_APP_PORT", "80")
-    compose_env.setdefault("BASE_DOMAIN", ":80")
-    compose_env.setdefault("ADDRESS", "0.0.0.0")
-    compose_env["LOG_LEVEL"] = "INFO"
-    compose_env["TRACECAT__APP_ENV"] = "development"
-    compose_env["TRACECAT__SERVICE_KEY"] = "test-service-key"
-    compose_env["TRACECAT__LOCAL_REPOSITORY_ENABLED"] = "false"
-    compose_env[_LOOP_HOTPLUG_CHILD_ENV] = "1"
-    compose_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    if inspect_result.returncode != 0:
+        raise AssertionError(
+            f"Configured loop hotplug image is unavailable: {configured_image!r}"
+            f"\n\nstderr:\n{inspect_result.stderr}"
+        )
+    image_id = inspect_result.stdout.strip()
+    if not image_id.startswith("sha256:"):
+        raise AssertionError(f"Docker returned an invalid image ID: {image_id!r}")
 
-    override_fd, override_name = tempfile.mkstemp(
-        prefix="tracecat-registry-loop-hotplug-",
-        suffix=".yml",
+    child_env = os.environ.copy()
+    child_env["LOG_LEVEL"] = "INFO"
+    child_env["TRACECAT__APP_ENV"] = "development"
+    child_env["TRACECAT__SERVICE_KEY"] = "test-service-key"
+    child_env["TRACECAT__LOCAL_REPOSITORY_ENABLED"] = "false"
+    child_env[_LOOP_HOTPLUG_CHILD_ENV] = "1"
+    child_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    forwarded_env = (
+        "LOG_LEVEL",
+        "TRACECAT__APP_ENV",
+        "TRACECAT__SERVICE_KEY",
+        "TRACECAT__LOCAL_REPOSITORY_ENABLED",
+        _LOOP_HOTPLUG_CHILD_ENV,
+        "PYTHONDONTWRITEBYTECODE",
     )
-    os.close(override_fd)
-    override_path = Path(override_name)
-    override_path.write_text(
-        "\n".join(
-            [
-                "services:",
-                "  executor:",
-                "    privileged: true",
-                '    user: "0:0"',
-                "    security_opt:",
-                "      - seccomp:unconfined",
-                "      - systempaths=unconfined",
-                "    volumes:",
-                f"      - {repo_root / 'tests'}:/app/tests:ro",
-                "    environment:",
-                f"      - {_LOOP_HOTPLUG_CHILD_ENV}",
-                "      - TRACECAT__APP_ENV",
-                "      - TRACECAT__SERVICE_KEY",
-                "      - TRACECAT__LOCAL_REPOSITORY_ENABLED",
-                "      - PYTHONDONTWRITEBYTECODE",
-                "",
-            ]
-        )
+    docker_env_args = [argument for key in forwarded_env for argument in ("--env", key)]
+
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--pull=never",
+            "--privileged",
+            "--user",
+            "0:0",
+            "--security-opt",
+            "seccomp=unconfined",
+            "--security-opt",
+            "systempaths=unconfined",
+            "--volume",
+            f"{repo_root / 'tests'}:/app/tests:ro",
+            *docker_env_args,
+            "--entrypoint",
+            "/app/.venv/bin/python",
+            image_id,
+            "-m",
+            "tests.integration.test_registry_artifact_loop_hotplug",
+            _LOOP_HOTPLUG_FLAG,
+        ],
+        cwd=repo_root,
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=900,
+        check=False,
     )
-    try:
-        result = subprocess.run(
-            [
-                "docker",
-                "compose",
-                "-f",
-                str(repo_root / "docker-compose.dev.yml"),
-                "-f",
-                str(override_path),
-                "run",
-                "--rm",
-                "--no-deps",
-                "-T",
-                "--entrypoint",
-                "/app/.venv/bin/python",
-                "executor",
-                "-m",
-                "tests.integration.test_registry_artifact_loop_hotplug",
-                _LOOP_HOTPLUG_FLAG,
-            ],
-            cwd=repo_root,
-            env=compose_env,
-            capture_output=True,
-            text=True,
-            timeout=900,
-            check=False,
-        )
-    finally:
-        override_path.unlink(missing_ok=True)
 
     if result.returncode != 0:
         raise AssertionError(
@@ -237,15 +240,9 @@ def _run_loop_hotplug_in_docker_or_skip() -> LoopHotplugPayload:
     )
 
 
-@functools.cache
-def _loop_hotplug_payload() -> LoopHotplugPayload:
-    """Run the isolated privileged-container scenario once."""
-    return _run_loop_hotplug_in_docker_or_skip()
-
-
-def test_legacy_mount_reproduces_missing_loop_device_node() -> None:
-    """Reproduce the production ``failed to setup loop device`` condition."""
-    payload = _loop_hotplug_payload()
+def test_registry_loop_hotplug_recovery() -> None:
+    """Reproduce the legacy failure and require secure product recovery."""
+    payload = _run_loop_hotplug_in_docker_or_skip()
     if payload.skipped:
         raise unittest.SkipTest(payload.skipped)
 
@@ -253,17 +250,10 @@ def test_legacy_mount_reproduces_missing_loop_device_node() -> None:
     assert payload.legacy_probe_failed is True
     assert "failed to setup loop device" in payload.legacy_error
     assert payload.kernel_device_exists_without_container_node is True
-
-
-def test_product_mount_synchronizes_missing_loop_device_node() -> None:
-    """Require Tracecat's non-root mount path to recover from stale ``/dev``."""
-    payload = _loop_hotplug_payload()
-    if payload.skipped:
-        raise unittest.SkipTest(payload.skipped)
-
     assert payload.product_ran_as_apiuser is True
     assert payload.product_mount_succeeded is True, payload.product_error
     assert payload.product_created_device_node is True
+    assert payload.product_device_inaccessible_to_apiuser is True
     assert payload.product_module_readable is True
     assert payload.cleanup_unmounted is True
 
@@ -311,6 +301,17 @@ def _create_local_loop_node(minor: int) -> Path:
         os.makedev(_LOOP_BLOCK_MAJOR, minor),
     )
     return path
+
+
+def _device_is_read_protected(path: Path) -> bool:
+    """Return whether the current unprivileged user cannot open a block node."""
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC)
+    except PermissionError:
+        return True
+    else:
+        os.close(descriptor)
+        return False
 
 
 def _build_squashfs_image(source_dir: Path, image_path: Path) -> None:
@@ -409,6 +410,7 @@ async def _run_loop_hotplug_child() -> None:
     product_mount_succeeded = False
     product_error: str | None = None
     product_created_device_node = False
+    product_device_inaccessible_to_apiuser = False
     product_module_readable = False
     cleanup_unmounted = False
 
@@ -473,6 +475,11 @@ async def _run_loop_hotplug_child() -> None:
                     and os.major(probe_stat.st_rdev) == _LOOP_BLOCK_MAJOR
                     and os.minor(probe_stat.st_rdev) == probe_minor
                 )
+                product_device_inaccessible_to_apiuser = (
+                    probe_stat.st_uid == 0
+                    and stat.S_IMODE(probe_stat.st_mode) == 0o600
+                    and _device_is_read_protected(probe_device)
+                )
             product_module_readable = (
                 product_mount_succeeded
                 and (probe_target / "probe.py").read_text() == "VALUE = 1\n"
@@ -496,6 +503,7 @@ async def _run_loop_hotplug_child() -> None:
         product_mount_succeeded=product_mount_succeeded,
         product_error=product_error,
         product_created_device_node=product_created_device_node,
+        product_device_inaccessible_to_apiuser=(product_device_inaccessible_to_apiuser),
         product_module_readable=product_module_readable,
         cleanup_unmounted=cleanup_unmounted,
     )

--- a/tests/integration/test_registry_artifact_loop_hotplug.py
+++ b/tests/integration/test_registry_artifact_loop_hotplug.py
@@ -1,0 +1,511 @@
+"""Reproduce stale loop-device visibility inside an executor container.
+
+Linux can create a new loop object through ``/dev/loop-control`` while the
+matching ``/dev/loopN`` block node remains absent from a running container's
+private ``/dev``. This privileged integration test constrains a disposable
+executor container to one visible loop block node, occupies it, and proves
+that the legacy ``mount -o loop`` path fails for a second image.
+
+The companion regression exercises Tracecat's product mount path against the
+same condition as the real non-root ``apiuser``. It requires the product path
+to synchronize the missing node and successfully mount the second image.
+
+Build the normal executor image once, then run without database-backed parent
+fixtures. The test reuses that image and bind-mounts only this test source::
+
+    docker compose -f docker-compose.dev.yml build executor
+    uv run pytest --confcutdir=tests/integration \
+        tests/integration/test_registry_artifact_loop_hotplug.py \
+        -m integration -s
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import functools
+import json
+import os
+import pwd
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Self, cast
+
+_LOOP_HOTPLUG_CHILD_ENV = "TRACECAT__REGISTRY_LOOP_HOTPLUG_CHILD"
+_LOOP_HOTPLUG_FLAG = "--run-registry-loop-hotplug"
+_LOOP_HOTPLUG_RESULT = "TRACECAT_REGISTRY_LOOP_HOTPLUG_RESULT:"
+
+_LOOP_BLOCK_MAJOR = 7
+_LOOP_CTL_GET_FREE = 0x4C82
+
+if os.environ.get(_LOOP_HOTPLUG_CHILD_ENV) != "1":
+    import pytest
+
+    pytestmark = pytest.mark.integration
+
+
+@dataclass(frozen=True, slots=True)
+class LoopHotplugPayload:
+    """Observable outcomes from the disposable privileged container."""
+
+    skipped: str | None
+    legacy_holder_mounted: bool
+    legacy_probe_failed: bool
+    legacy_error: str
+    kernel_device_exists_without_container_node: bool
+    product_ran_as_apiuser: bool
+    product_mount_succeeded: bool
+    product_error: str | None
+    product_created_device_node: bool
+    product_module_readable: bool
+    cleanup_unmounted: bool
+
+    @classmethod
+    def from_json(cls, raw: str) -> Self:
+        """Validate and decode the child-process result payload."""
+        decoded: object = json.loads(raw)
+        if not isinstance(decoded, dict):
+            raise TypeError("Loop hotplug payload must be a JSON object")
+        data = cast(dict[str, object], decoded)
+
+        def required_bool(key: str) -> bool:
+            value = data.get(key)
+            if not isinstance(value, bool):
+                raise TypeError(f"Loop hotplug payload field {key!r} must be bool")
+            return value
+
+        def required_str(key: str) -> str:
+            value = data.get(key)
+            if not isinstance(value, str):
+                raise TypeError(f"Loop hotplug payload field {key!r} must be str")
+            return value
+
+        def optional_str(key: str) -> str | None:
+            value = data.get(key)
+            if value is not None and not isinstance(value, str):
+                raise TypeError(
+                    f"Loop hotplug payload field {key!r} must be str or null"
+                )
+            return value
+
+        return cls(
+            skipped=optional_str("skipped"),
+            legacy_holder_mounted=required_bool("legacy_holder_mounted"),
+            legacy_probe_failed=required_bool("legacy_probe_failed"),
+            legacy_error=required_str("legacy_error"),
+            kernel_device_exists_without_container_node=required_bool(
+                "kernel_device_exists_without_container_node"
+            ),
+            product_ran_as_apiuser=required_bool("product_ran_as_apiuser"),
+            product_mount_succeeded=required_bool("product_mount_succeeded"),
+            product_error=optional_str("product_error"),
+            product_created_device_node=required_bool("product_created_device_node"),
+            product_module_readable=required_bool("product_module_readable"),
+            cleanup_unmounted=required_bool("cleanup_unmounted"),
+        )
+
+
+def _empty_payload(*, skipped: str | None = None) -> LoopHotplugPayload:
+    """Return a result with every probe false."""
+    return LoopHotplugPayload(
+        skipped=skipped,
+        legacy_holder_mounted=False,
+        legacy_probe_failed=False,
+        legacy_error="",
+        kernel_device_exists_without_container_node=False,
+        product_ran_as_apiuser=False,
+        product_mount_succeeded=False,
+        product_error=None,
+        product_created_device_node=False,
+        product_module_readable=False,
+        cleanup_unmounted=False,
+    )
+
+
+def _run_loop_hotplug_in_docker_or_skip() -> LoopHotplugPayload:
+    """Run the loop-device hotplug scenario in a disposable executor."""
+    if os.environ.get(_LOOP_HOTPLUG_CHILD_ENV) == "1":
+        raise unittest.SkipTest("already inside registry loop hotplug Docker child")
+    if shutil.which("docker") is None:
+        raise unittest.SkipTest("Docker CLI unavailable for registry loop hotplug")
+    if (
+        subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        ).returncode
+        != 0
+    ):
+        raise unittest.SkipTest("Docker daemon unavailable for registry loop hotplug")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    compose_env = os.environ.copy()
+    compose_env.setdefault(
+        "TRACECAT__LOCAL_REPOSITORY_PATH",
+        str(repo_root / "packages"),
+    )
+    compose_env.setdefault("PUBLIC_APP_PORT", "80")
+    compose_env.setdefault("BASE_DOMAIN", ":80")
+    compose_env.setdefault("ADDRESS", "0.0.0.0")
+    compose_env["LOG_LEVEL"] = "INFO"
+    compose_env["TRACECAT__APP_ENV"] = "development"
+    compose_env["TRACECAT__SERVICE_KEY"] = "test-service-key"
+    compose_env["TRACECAT__LOCAL_REPOSITORY_ENABLED"] = "false"
+    compose_env[_LOOP_HOTPLUG_CHILD_ENV] = "1"
+    compose_env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+    override_fd, override_name = tempfile.mkstemp(
+        prefix="tracecat-registry-loop-hotplug-",
+        suffix=".yml",
+    )
+    os.close(override_fd)
+    override_path = Path(override_name)
+    override_path.write_text(
+        "\n".join(
+            [
+                "services:",
+                "  executor:",
+                "    privileged: true",
+                '    user: "0:0"',
+                "    security_opt:",
+                "      - seccomp:unconfined",
+                "      - systempaths=unconfined",
+                "    volumes:",
+                f"      - {repo_root / 'tests'}:/app/tests:ro",
+                "    environment:",
+                f"      - {_LOOP_HOTPLUG_CHILD_ENV}",
+                "      - TRACECAT__APP_ENV",
+                "      - TRACECAT__SERVICE_KEY",
+                "      - TRACECAT__LOCAL_REPOSITORY_ENABLED",
+                "      - PYTHONDONTWRITEBYTECODE",
+                "",
+            ]
+        )
+    )
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                str(repo_root / "docker-compose.dev.yml"),
+                "-f",
+                str(override_path),
+                "run",
+                "--rm",
+                "--no-deps",
+                "-T",
+                "--entrypoint",
+                "/app/.venv/bin/python",
+                "executor",
+                "-m",
+                "tests.integration.test_registry_artifact_loop_hotplug",
+                _LOOP_HOTPLUG_FLAG,
+            ],
+            cwd=repo_root,
+            env=compose_env,
+            capture_output=True,
+            text=True,
+            timeout=900,
+            check=False,
+        )
+    finally:
+        override_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        raise AssertionError(
+            "Dockerized registry loop hotplug scenario failed."
+            f"\n\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    for line in output.splitlines():
+        if line.startswith(_LOOP_HOTPLUG_RESULT):
+            return LoopHotplugPayload.from_json(line.removeprefix(_LOOP_HOTPLUG_RESULT))
+
+    raise AssertionError(
+        "Dockerized registry loop hotplug scenario did not emit a result."
+        f"\n\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )
+
+
+@functools.cache
+def _loop_hotplug_payload() -> LoopHotplugPayload:
+    """Run the isolated privileged-container scenario once."""
+    return _run_loop_hotplug_in_docker_or_skip()
+
+
+def test_legacy_mount_reproduces_missing_loop_device_node() -> None:
+    """Reproduce the production ``failed to setup loop device`` condition."""
+    payload = _loop_hotplug_payload()
+    if payload.skipped:
+        raise unittest.SkipTest(payload.skipped)
+
+    assert payload.legacy_holder_mounted is True
+    assert payload.legacy_probe_failed is True
+    assert "failed to setup loop device" in payload.legacy_error
+    assert payload.kernel_device_exists_without_container_node is True
+
+
+def test_product_mount_synchronizes_missing_loop_device_node() -> None:
+    """Require Tracecat's non-root mount path to recover from stale ``/dev``."""
+    payload = _loop_hotplug_payload()
+    if payload.skipped:
+        raise unittest.SkipTest(payload.skipped)
+
+    assert payload.product_ran_as_apiuser is True
+    assert payload.product_mount_succeeded is True, payload.product_error
+    assert payload.product_created_device_node is True
+    assert payload.product_module_readable is True
+    assert payload.cleanup_unmounted is True
+
+
+def _dev_filesystem_type() -> str | None:
+    """Return the filesystem type mounted at ``/dev`` in this container."""
+    for line in Path("/proc/self/mountinfo").read_text().splitlines():
+        fields = line.split()
+        if len(fields) < 10 or fields[4] != "/dev":
+            continue
+        separator = fields.index("-")
+        return fields[separator + 1]
+    return None
+
+
+def _remove_local_loop_block_nodes() -> None:
+    """Remove loop block nodes only from the disposable container's ``/dev``."""
+    for path in Path("/dev").iterdir():
+        suffix = path.name.removeprefix("loop")
+        if not path.name.startswith("loop") or not suffix.isdigit():
+            continue
+        path_stat = path.lstat()
+        if not stat.S_ISBLK(path_stat.st_mode):
+            raise RuntimeError(f"Refusing to remove non-block loop path: {path}")
+        if os.major(path_stat.st_rdev) != _LOOP_BLOCK_MAJOR:
+            raise RuntimeError(f"Refusing to remove unexpected loop device: {path}")
+        path.unlink()
+
+
+def _get_free_loop_minor() -> int:
+    """Ask the shared kernel loop driver for an unbound loop minor."""
+    control_fd = os.open("/dev/loop-control", os.O_RDWR | os.O_CLOEXEC)
+    try:
+        return fcntl.ioctl(control_fd, _LOOP_CTL_GET_FREE, 0)
+    finally:
+        os.close(control_fd)
+
+
+def _create_local_loop_node(minor: int) -> Path:
+    """Create exactly one loop block node in the container's private ``/dev``."""
+    path = Path(f"/dev/loop{minor}")
+    os.mknod(
+        path,
+        stat.S_IFBLK | 0o600,
+        os.makedev(_LOOP_BLOCK_MAJOR, minor),
+    )
+    return path
+
+
+def _build_squashfs_image(source_dir: Path, image_path: Path) -> None:
+    """Build a tiny readable SquashFS image for a real mount."""
+    source_dir.mkdir(parents=True)
+    (source_dir / "probe.py").write_text("VALUE = 1\n")
+    subprocess.run(
+        ["mksquashfs", str(source_dir), str(image_path), "-noappend", "-quiet"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _legacy_mount(
+    image_path: Path, target_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the legacy auto-loop mount behavior under test."""
+    target_dir.mkdir(exist_ok=True)
+    return subprocess.run(
+        [
+            "mount",
+            "-t",
+            "squashfs",
+            "-o",
+            "loop,ro,nodev,nosuid",
+            str(image_path),
+            str(target_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _is_mounted(target_dir: Path) -> bool:
+    """Return whether the exact target occurs in the process mount table."""
+    target = str(target_dir)
+    return any(
+        len(fields := line.split()) >= 3 and fields[1] == target
+        for line in Path("/proc/mounts").read_text().splitlines()
+    )
+
+
+def _unmount_if_mounted(target_dir: Path) -> None:
+    """Best-effort cleanup for a mount owned by the disposable container."""
+    if not _is_mounted(target_dir):
+        return
+    subprocess.run(
+        ["umount", str(target_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _chown_tree(root: Path, uid: int, gid: int) -> None:
+    """Make the completed fixture tree removable after dropping privileges."""
+    os.chown(root, uid, gid)
+    for path in root.rglob("*"):
+        os.chown(path, uid, gid)
+
+
+async def _run_loop_hotplug_child() -> None:
+    """Reproduce the missing-node failure and probe Tracecat's mount path."""
+    if _dev_filesystem_type() != "tmpfs":
+        payload = _empty_payload(
+            skipped="container /dev is not an isolated tmpfs; refusing to modify it"
+        )
+        print(f"{_LOOP_HOTPLUG_RESULT}{json.dumps(asdict(payload), sort_keys=True)}")
+        return
+
+    required_paths = (
+        "/dev/loop-control",
+        shutil.which("mount"),
+        shutil.which("umount"),
+    )
+    if any(path is None or not os.path.exists(path) for path in required_paths):
+        payload = _empty_payload(skipped="loop-control, mount, or umount unavailable")
+        print(f"{_LOOP_HOTPLUG_RESULT}{json.dumps(asdict(payload), sort_keys=True)}")
+        return
+    if shutil.which("mksquashfs") is None:
+        payload = _empty_payload(skipped="mksquashfs unavailable")
+        print(f"{_LOOP_HOTPLUG_RESULT}{json.dumps(asdict(payload), sort_keys=True)}")
+        return
+
+    _remove_local_loop_block_nodes()
+    holder_minor = _get_free_loop_minor()
+    _create_local_loop_node(holder_minor)
+
+    legacy_holder_mounted = False
+    legacy_probe_failed = False
+    legacy_error = ""
+    kernel_device_exists_without_container_node = False
+    product_ran_as_apiuser = False
+    product_mount_succeeded = False
+    product_error: str | None = None
+    product_created_device_node = False
+    product_module_readable = False
+    cleanup_unmounted = False
+
+    with tempfile.TemporaryDirectory(prefix="registry-loop-hotplug-") as tmp:
+        root = Path(tmp)
+        holder_image = root / "holder.squashfs"
+        probe_image = root / "probe.squashfs"
+        holder_target = root / "holder-mount"
+        probe_target = root / "probe-mount"
+        _build_squashfs_image(root / "holder-source", holder_image)
+        _build_squashfs_image(root / "probe-source", probe_image)
+        holder_target.mkdir()
+        probe_target.mkdir()
+
+        apiuser = pwd.getpwnam("apiuser")
+        _chown_tree(root, apiuser.pw_uid, apiuser.pw_gid)
+
+        try:
+            holder_result = _legacy_mount(holder_image, holder_target)
+            if holder_result.returncode != 0:
+                raise RuntimeError(
+                    "Could not establish the single visible loop holder: "
+                    f"{holder_result.stderr or holder_result.stdout}"
+                )
+            legacy_holder_mounted = _is_mounted(holder_target)
+
+            probe_minor = _get_free_loop_minor()
+            probe_device = Path(f"/dev/loop{probe_minor}")
+            probe_kernel_device = Path(f"/sys/block/loop{probe_minor}")
+
+            legacy_result = _legacy_mount(probe_image, probe_target)
+            legacy_probe_failed = legacy_result.returncode != 0
+            legacy_error = (legacy_result.stderr or legacy_result.stdout).strip()
+            kernel_device_exists_without_container_node = (
+                probe_kernel_device.exists() and not probe_device.exists()
+            )
+
+            os.setgroups([])
+            os.setgid(apiuser.pw_gid)
+            os.setuid(apiuser.pw_uid)
+            product_ran_as_apiuser = (
+                os.getuid() == apiuser.pw_uid and os.geteuid() == apiuser.pw_uid
+            )
+
+            from tracecat.executor.registry_artifacts import SquashfsArtifact
+
+            artifact = SquashfsArtifact(
+                uri="s3://example/registry/site-packages.squashfs",
+                cache_key="loop-hotplug-probe",
+            )
+            try:
+                await artifact._mount_image(probe_image, probe_target)
+            except Exception as error:
+                product_error = f"{type(error).__name__}: {error}"
+            else:
+                product_mount_succeeded = _is_mounted(probe_target)
+
+            if probe_device.exists():
+                probe_stat = probe_device.lstat()
+                product_created_device_node = (
+                    stat.S_ISBLK(probe_stat.st_mode)
+                    and os.major(probe_stat.st_rdev) == _LOOP_BLOCK_MAJOR
+                    and os.minor(probe_stat.st_rdev) == probe_minor
+                )
+            product_module_readable = (
+                product_mount_succeeded
+                and (probe_target / "probe.py").read_text() == "VALUE = 1\n"
+            )
+        finally:
+            _unmount_if_mounted(probe_target)
+            _unmount_if_mounted(holder_target)
+            cleanup_unmounted = not _is_mounted(probe_target) and not _is_mounted(
+                holder_target
+            )
+
+    payload = LoopHotplugPayload(
+        skipped=None,
+        legacy_holder_mounted=legacy_holder_mounted,
+        legacy_probe_failed=legacy_probe_failed,
+        legacy_error=legacy_error,
+        kernel_device_exists_without_container_node=(
+            kernel_device_exists_without_container_node
+        ),
+        product_ran_as_apiuser=product_ran_as_apiuser,
+        product_mount_succeeded=product_mount_succeeded,
+        product_error=product_error,
+        product_created_device_node=product_created_device_node,
+        product_module_readable=product_module_readable,
+        cleanup_unmounted=cleanup_unmounted,
+    )
+    print(f"{_LOOP_HOTPLUG_RESULT}{json.dumps(asdict(payload), sort_keys=True)}")
+
+
+if __name__ == "__main__":
+    if os.environ.get(_LOOP_HOTPLUG_CHILD_ENV) == "1" and sys.argv[1:] == [
+        _LOOP_HOTPLUG_FLAG
+    ]:
+        asyncio.run(_run_loop_hotplug_child())
+    else:
+        raise SystemExit("Refusing to run loop hotplug child without its guard")

--- a/tests/unit/test_registry_artifact_mounts.py
+++ b/tests/unit/test_registry_artifact_mounts.py
@@ -1,0 +1,244 @@
+"""Tests for SquashFS mount recovery and helper protocol handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tracecat.executor import registry_artifact_mounts
+
+
+def _process(*, returncode: int) -> AsyncMock:
+    process = AsyncMock()
+    process.returncode = returncode
+    return process
+
+
+@pytest.mark.anyio
+async def test_sync_loop_device_nodes_parses_valid_counts() -> None:
+    """The helper's three-field output is converted to a typed result."""
+    process = _process(returncode=0)
+
+    with (
+        patch(
+            "tracecat.executor.registry_artifact_mounts.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=process,
+        ) as create_subprocess_exec,
+        patch(
+            "tracecat.executor.registry_artifact_mounts.communicate_process_group",
+            new_callable=AsyncMock,
+            return_value=(b"7 2 5\n", b""),
+        ),
+    ):
+        result = await registry_artifact_mounts._sync_loop_device_nodes()
+
+    assert result == registry_artifact_mounts.LoopDeviceSyncResult(
+        kernel_devices=7,
+        created_nodes=2,
+        existing_nodes=5,
+    )
+    create_subprocess_exec.assert_awaited_once_with(
+        registry_artifact_mounts.LOOP_DEVICE_SYNC_HELPER,
+        stdout=registry_artifact_mounts.asyncio.subprocess.PIPE,
+        stderr=registry_artifact_mounts.asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "stderr", "message"),
+    [
+        (1, b"", b"permission denied", "permission denied"),
+        (0, b"1 1\n", b"", "invalid result"),
+        (0, b"one two three\n", b"", "invalid result"),
+        (0, b"2 2 1\n", b"", "inconsistent counts"),
+        (0, b"-1 0 -1\n", b"", "inconsistent counts"),
+    ],
+)
+@pytest.mark.anyio
+async def test_sync_loop_device_nodes_rejects_helper_failures(
+    returncode: int,
+    stdout: bytes,
+    stderr: bytes,
+    message: str,
+) -> None:
+    """Nonzero, malformed, and inconsistent helper results fail closed."""
+    process = _process(returncode=returncode)
+
+    with (
+        patch(
+            "tracecat.executor.registry_artifact_mounts.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=process,
+        ),
+        patch(
+            "tracecat.executor.registry_artifact_mounts.communicate_process_group",
+            new_callable=AsyncMock,
+            return_value=(stdout, stderr),
+        ),
+        pytest.raises(
+            registry_artifact_mounts.LoopDeviceSyncCommandError,
+            match=message,
+        ),
+    ):
+        await registry_artifact_mounts._sync_loop_device_nodes()
+
+
+@pytest.mark.anyio
+async def test_sync_loop_device_nodes_wraps_startup_failure() -> None:
+    """An unavailable capability helper becomes a structured sync failure."""
+    with (
+        patch(
+            "tracecat.executor.registry_artifact_mounts.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            side_effect=PermissionError("not permitted"),
+        ),
+        pytest.raises(
+            registry_artifact_mounts.LoopDeviceSyncCommandError,
+            match="could not start",
+        ) as raised,
+    ):
+        await registry_artifact_mounts._sync_loop_device_nodes()
+
+    assert isinstance(raised.value.__cause__, PermissionError)
+
+
+@pytest.mark.anyio
+async def test_mount_squashfs_recovers_after_synchronizing_nodes(
+    tmp_path: Path,
+) -> None:
+    """A failed mount synchronizes nodes, waits briefly, and then succeeds."""
+    image_path = tmp_path / "image.squashfs"
+    target_dir = tmp_path / "mount"
+    processes = [_process(returncode=1), _process(returncode=0)]
+    sync_result = registry_artifact_mounts.LoopDeviceSyncResult(3, 1, 2)
+
+    with (
+        patch(
+            "tracecat.executor.registry_artifact_mounts.is_mount",
+            return_value=False,
+        ),
+        patch(
+            "tracecat.executor.registry_artifact_mounts.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            side_effect=processes,
+        ) as create_subprocess_exec,
+        patch(
+            "tracecat.executor.registry_artifact_mounts.communicate_process_group",
+            new_callable=AsyncMock,
+            side_effect=[(b"", b"failed"), (b"", b"")],
+        ),
+        patch(
+            "tracecat.executor.registry_artifact_mounts._sync_loop_device_nodes",
+            new_callable=AsyncMock,
+            return_value=sync_result,
+        ) as sync_nodes,
+        patch(
+            "tracecat.executor.registry_artifact_mounts.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep,
+    ):
+        await registry_artifact_mounts.mount_squashfs(image_path, target_dir)
+
+    assert create_subprocess_exec.await_count == 2
+    sync_nodes.assert_awaited_once_with()
+    sleep.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_mount_squashfs_preserves_mount_error_when_sync_fails(
+    tmp_path: Path,
+) -> None:
+    """A helper failure keeps the original mount diagnostic and stops retrying."""
+    process = _process(returncode=1)
+    sync_error = registry_artifact_mounts.LoopDeviceSyncCommandError("sync failed")
+
+    with (
+        patch(
+            "tracecat.executor.registry_artifact_mounts.is_mount",
+            return_value=False,
+        ),
+        patch(
+            "tracecat.executor.registry_artifact_mounts.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=process,
+        ) as create_subprocess_exec,
+        patch(
+            "tracecat.executor.registry_artifact_mounts.communicate_process_group",
+            new_callable=AsyncMock,
+            return_value=(b"", b"mount failed"),
+        ),
+        patch(
+            "tracecat.executor.registry_artifact_mounts._sync_loop_device_nodes",
+            new_callable=AsyncMock,
+            side_effect=sync_error,
+        ),
+        pytest.raises(
+            registry_artifact_mounts.SquashfsMountCommandError,
+            match="mount failed",
+        ) as raised,
+    ):
+        await registry_artifact_mounts.mount_squashfs(
+            tmp_path / "image.squashfs",
+            tmp_path / "mount",
+        )
+
+    create_subprocess_exec.assert_awaited_once()
+    assert raised.value.__cause__ is sync_error
+
+
+@pytest.mark.anyio
+async def test_mount_squashfs_stops_after_bounded_retries(tmp_path: Path) -> None:
+    """Persistent mount failure performs exactly the configured attempt count."""
+    processes = [
+        _process(returncode=1)
+        for _ in range(registry_artifact_mounts.SQUASHFS_MOUNT_MAX_ATTEMPTS)
+    ]
+    sync_result = registry_artifact_mounts.LoopDeviceSyncResult(1, 0, 1)
+
+    with (
+        patch(
+            "tracecat.executor.registry_artifact_mounts.is_mount",
+            return_value=False,
+        ),
+        patch(
+            "tracecat.executor.registry_artifact_mounts.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            side_effect=processes,
+        ) as create_subprocess_exec,
+        patch(
+            "tracecat.executor.registry_artifact_mounts.communicate_process_group",
+            new_callable=AsyncMock,
+            return_value=(b"", b"still failing"),
+        ),
+        patch(
+            "tracecat.executor.registry_artifact_mounts._sync_loop_device_nodes",
+            new_callable=AsyncMock,
+            return_value=sync_result,
+        ) as sync_nodes,
+        patch(
+            "tracecat.executor.registry_artifact_mounts.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep,
+        pytest.raises(
+            registry_artifact_mounts.SquashfsMountCommandError,
+            match="still failing",
+        ),
+    ):
+        await registry_artifact_mounts.mount_squashfs(
+            tmp_path / "image.squashfs",
+            tmp_path / "mount",
+        )
+
+    assert (
+        create_subprocess_exec.await_count
+        == registry_artifact_mounts.SQUASHFS_MOUNT_MAX_ATTEMPTS
+    )
+    assert (
+        sync_nodes.await_count
+        == registry_artifact_mounts.SQUASHFS_MOUNT_MAX_ATTEMPTS - 1
+    )
+    assert sleep.await_count == registry_artifact_mounts.SQUASHFS_MOUNT_MAX_ATTEMPTS - 1

--- a/tests/unit/test_registry_artifacts.py
+++ b/tests/unit/test_registry_artifacts.py
@@ -859,7 +859,7 @@ class TestRegistryArtifactCache:
 
         with (
             patch(
-                "tracecat.executor.registry_artifacts.asyncio.create_subprocess_exec",
+                "tracecat.executor.registry_artifact_mounts.asyncio.create_subprocess_exec",
                 new_callable=AsyncMock,
                 return_value=process,
             ) as create_subprocess_exec,
@@ -903,7 +903,7 @@ class TestRegistryArtifactCache:
 
         with (
             patch(
-                "tracecat.executor.registry_artifacts.asyncio.create_subprocess_exec",
+                "tracecat.executor.registry_artifact_mounts.asyncio.create_subprocess_exec",
                 new_callable=AsyncMock,
                 return_value=process,
             ) as create_subprocess_exec,

--- a/tracecat/executor/registry_artifact_mounts.py
+++ b/tracecat/executor/registry_artifact_mounts.py
@@ -1,10 +1,53 @@
-"""Fail-closed mount-state inspection for registry artifact caches."""
+"""SquashFS mount lifecycle and loop-device recovery."""
 
 from __future__ import annotations
 
+import asyncio
 import os
+import random
 import stat
+from dataclasses import dataclass
 from pathlib import Path
+
+from tracecat.logger import logger
+from tracecat.sandbox.utils import communicate_process_group
+
+SQUASHFS_MOUNT_OPTIONS = "loop,ro,nodev,nosuid"
+"""Mount options for executor-managed SquashFS registry artifacts.
+
+The image must stay read-only and should not expose device nodes or setuid bits
+from registry package contents. Avoid ``noexec`` because Python packages may
+include native extension modules loaded from the mounted artifact.
+"""
+
+LOOP_DEVICE_SYNC_HELPER = "/usr/local/bin/tracecat-loop-device-sync"
+"""Fixed-purpose helper that mirrors kernel-confirmed loop nodes into ``/dev``."""
+
+SQUASHFS_MOUNT_MAX_ATTEMPTS = 3
+SQUASHFS_MOUNT_RETRY_MIN_SECONDS = 0.05
+SQUASHFS_MOUNT_RETRY_MAX_SECONDS = 0.2
+
+
+class SquashfsMountCommandError(RuntimeError):
+    """The ``mount`` command itself failed for a SquashFS registry artifact.
+
+    Only this error drives SquashFS mount policy. Download, directory creation,
+    and other preparation failures must not be mistaken for a missing mount
+    capability or loop-device exhaustion.
+    """
+
+
+class LoopDeviceSyncCommandError(RuntimeError):
+    """The restricted loop-device synchronization helper failed."""
+
+
+@dataclass(frozen=True, slots=True)
+class LoopDeviceSyncResult:
+    """Counts reported after synchronizing kernel loop devices into ``/dev``."""
+
+    kernel_devices: int
+    created_nodes: int
+    existing_nodes: int
 
 
 def is_mount(path: Path) -> bool:
@@ -22,3 +65,117 @@ def is_mount(path: Path) -> bool:
     return (
         path_stat.st_dev != parent_stat.st_dev or path_stat.st_ino == parent_stat.st_ino
     )
+
+
+async def _sync_loop_device_nodes() -> LoopDeviceSyncResult:
+    """Create missing ``/dev/loopN`` nodes already present in kernel sysfs."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            LOOP_DEVICE_SYNC_HELPER,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+    except OSError as error:
+        raise LoopDeviceSyncCommandError(
+            "loop-device synchronization helper could not start"
+        ) from error
+
+    stdout, stderr = await communicate_process_group(proc)
+    if proc.returncode != 0:
+        output = (stderr or stdout).decode(errors="replace").strip()
+        raise LoopDeviceSyncCommandError(
+            output or "loop-device synchronization helper failed"
+        )
+
+    fields = stdout.decode(errors="replace").split()
+    if len(fields) != 3:
+        raise LoopDeviceSyncCommandError(
+            "loop-device synchronization helper returned an invalid result"
+        )
+    try:
+        kernel_devices, created_nodes, existing_nodes = map(int, fields)
+    except ValueError as error:
+        raise LoopDeviceSyncCommandError(
+            "loop-device synchronization helper returned an invalid result"
+        ) from error
+    if (
+        min(kernel_devices, created_nodes, existing_nodes) < 0
+        or created_nodes + existing_nodes != kernel_devices
+    ):
+        raise LoopDeviceSyncCommandError(
+            "loop-device synchronization helper returned inconsistent counts"
+        )
+
+    return LoopDeviceSyncResult(
+        kernel_devices=kernel_devices,
+        created_nodes=created_nodes,
+        existing_nodes=existing_nodes,
+    )
+
+
+async def mount_squashfs(image_path: Path, target_dir: Path) -> None:
+    """Mount a SquashFS image, repairing stale container loop nodes on failure.
+
+    The first attempt preserves the normal fast path. A failed attempt invokes
+    the fixed-purpose helper and retries with short jitter, covering both stale
+    ``/dev`` snapshots and concurrent node-level loop allocation.
+
+    Raises:
+        SquashfsMountCommandError: The mount command failed after recovery.
+    """
+    for attempt in range(1, SQUASHFS_MOUNT_MAX_ATTEMPTS + 1):
+        if is_mount(target_dir):
+            return
+
+        proc = await asyncio.create_subprocess_exec(
+            "mount",
+            "-t",
+            "squashfs",
+            "-o",
+            SQUASHFS_MOUNT_OPTIONS,
+            str(image_path),
+            str(target_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        stdout, stderr = await communicate_process_group(proc)
+
+        if proc.returncode == 0 or is_mount(target_dir):
+            return
+
+        output = (stderr or stdout).decode(errors="replace").strip()
+        mount_error = SquashfsMountCommandError(output or "mount command failed")
+        if attempt == SQUASHFS_MOUNT_MAX_ATTEMPTS:
+            raise mount_error
+
+        try:
+            sync_result = await _sync_loop_device_nodes()
+        except LoopDeviceSyncCommandError as sync_error:
+            logger.warning(
+                "Failed to synchronize loop device nodes after mount failure",
+                mount_attempt=attempt,
+                mount_attempts=SQUASHFS_MOUNT_MAX_ATTEMPTS,
+                mount_error=str(mount_error),
+                error=str(sync_error),
+            )
+            raise mount_error from sync_error
+
+        retry_delay = random.uniform(
+            SQUASHFS_MOUNT_RETRY_MIN_SECONDS,
+            SQUASHFS_MOUNT_RETRY_MAX_SECONDS,
+        )
+        logger.warning(
+            "Retrying SquashFS mount after synchronizing loop device nodes",
+            mount_attempt=attempt,
+            mount_attempts=SQUASHFS_MOUNT_MAX_ATTEMPTS,
+            mount_error=str(mount_error),
+            kernel_loop_devices=sync_result.kernel_devices,
+            created_loop_nodes=sync_result.created_nodes,
+            existing_loop_nodes=sync_result.existing_nodes,
+            retry_delay_ms=f"{retry_delay * 1000:.1f}",
+        )
+        await asyncio.sleep(retry_delay)
+
+    raise AssertionError("SquashFS mount retry loop exhausted unexpectedly")

--- a/tracecat/executor/registry_artifacts.py
+++ b/tracecat/executor/registry_artifacts.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import hashlib
 import os
+import random
 import shutil
 import sysconfig
 import tarfile
@@ -89,6 +90,13 @@ from registry package contents. Avoid noexec because Python packages may include
 native extension modules that need to be loaded from the mounted artifact.
 """
 
+LOOP_DEVICE_SYNC_HELPER = "/usr/local/bin/tracecat-loop-device-sync"
+"""Fixed-purpose helper that mirrors kernel-confirmed loop nodes into ``/dev``."""
+
+SQUASHFS_MOUNT_MAX_ATTEMPTS = 3
+SQUASHFS_MOUNT_RETRY_MIN_SECONDS = 0.05
+SQUASHFS_MOUNT_RETRY_MAX_SECONDS = 0.2
+
 BUNDLED_BUILTIN_REGISTRY_URI_PREFIX = f"tracecat-builtin://{DEFAULT_REGISTRY_ORIGIN}/"
 """Pseudo-URI for the builtin registry already installed in the executor image."""
 
@@ -102,6 +110,10 @@ class SquashfsMountCommandError(RuntimeError):
     """
 
 
+class LoopDeviceSyncCommandError(RuntimeError):
+    """The restricted loop-device synchronization helper failed."""
+
+
 class RegistryArtifactUriError(ValueError):
     """A registry artifact URI is malformed, with identifiers suppressed."""
 
@@ -111,6 +123,15 @@ class RegistryArtifactExtractionError(RuntimeError):
 
     def __init__(self) -> None:
         super().__init__("Registry artifact extraction failed")
+
+
+@dataclass(frozen=True, slots=True)
+class LoopDeviceSyncResult:
+    """Counts reported after synchronizing kernel loop devices into ``/dev``."""
+
+    kernel_devices: int
+    created_nodes: int
+    existing_nodes: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,6 +192,53 @@ class BuiltinArtifact(RegistryArtifact):
             paths=[str(p) for p in import_paths],
         )
         return import_paths
+
+
+async def _sync_loop_device_nodes() -> LoopDeviceSyncResult:
+    """Create missing ``/dev/loopN`` nodes already present in kernel sysfs."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            LOOP_DEVICE_SYNC_HELPER,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+    except OSError as error:
+        raise LoopDeviceSyncCommandError(
+            "loop-device synchronization helper could not start"
+        ) from error
+
+    stdout, stderr = await communicate_process_group(proc)
+    if proc.returncode != 0:
+        output = (stderr or stdout).decode(errors="replace").strip()
+        raise LoopDeviceSyncCommandError(
+            output or "loop-device synchronization helper failed"
+        )
+
+    fields = stdout.decode(errors="replace").split()
+    if len(fields) != 3:
+        raise LoopDeviceSyncCommandError(
+            "loop-device synchronization helper returned an invalid result"
+        )
+    try:
+        kernel_devices, created_nodes, existing_nodes = map(int, fields)
+    except ValueError as error:
+        raise LoopDeviceSyncCommandError(
+            "loop-device synchronization helper returned an invalid result"
+        ) from error
+    if (
+        min(kernel_devices, created_nodes, existing_nodes) < 0
+        or created_nodes + existing_nodes != kernel_devices
+    ):
+        raise LoopDeviceSyncCommandError(
+            "loop-device synchronization helper returned inconsistent counts"
+        )
+
+    return LoopDeviceSyncResult(
+        kernel_devices=kernel_devices,
+        created_nodes=created_nodes,
+        existing_nodes=existing_nodes,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -413,28 +481,61 @@ class SquashfsArtifact(RegistryArtifact):
         Raises:
             SquashfsMountCommandError: The ``mount`` command failed.
         """
-        if registry_artifact_mounts.is_mount(target_dir):
-            return
+        for attempt in range(1, SQUASHFS_MOUNT_MAX_ATTEMPTS + 1):
+            if registry_artifact_mounts.is_mount(target_dir):
+                return
 
-        proc = await asyncio.create_subprocess_exec(
-            "mount",
-            "-t",
-            "squashfs",
-            "-o",
-            SQUASHFS_MOUNT_OPTIONS,
-            str(image_path),
-            str(target_dir),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,
-        )
-        stdout, stderr = await communicate_process_group(proc)
+            proc = await asyncio.create_subprocess_exec(
+                "mount",
+                "-t",
+                "squashfs",
+                "-o",
+                SQUASHFS_MOUNT_OPTIONS,
+                str(image_path),
+                str(target_dir),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+            )
+            stdout, stderr = await communicate_process_group(proc)
 
-        if proc.returncode == 0 or registry_artifact_mounts.is_mount(target_dir):
-            return
+            if proc.returncode == 0 or registry_artifact_mounts.is_mount(target_dir):
+                return
 
-        output = (stderr or stdout).decode(errors="replace").strip()
-        raise SquashfsMountCommandError(output or "mount command failed")
+            output = (stderr or stdout).decode(errors="replace").strip()
+            mount_error = SquashfsMountCommandError(output or "mount command failed")
+            if attempt == SQUASHFS_MOUNT_MAX_ATTEMPTS:
+                raise mount_error
+
+            try:
+                sync_result = await _sync_loop_device_nodes()
+            except LoopDeviceSyncCommandError as sync_error:
+                logger.warning(
+                    "Failed to synchronize loop device nodes after mount failure",
+                    mount_attempt=attempt,
+                    mount_attempts=SQUASHFS_MOUNT_MAX_ATTEMPTS,
+                    mount_error=str(mount_error),
+                    error=str(sync_error),
+                )
+                raise mount_error from sync_error
+
+            retry_delay = random.uniform(
+                SQUASHFS_MOUNT_RETRY_MIN_SECONDS,
+                SQUASHFS_MOUNT_RETRY_MAX_SECONDS,
+            )
+            logger.warning(
+                "Retrying SquashFS mount after synchronizing loop device nodes",
+                mount_attempt=attempt,
+                mount_attempts=SQUASHFS_MOUNT_MAX_ATTEMPTS,
+                mount_error=str(mount_error),
+                kernel_loop_devices=sync_result.kernel_devices,
+                created_loop_nodes=sync_result.created_nodes,
+                existing_loop_nodes=sync_result.existing_nodes,
+                retry_delay_ms=f"{retry_delay * 1000:.1f}",
+            )
+            await asyncio.sleep(retry_delay)
+
+        raise AssertionError("SquashFS mount retry loop exhausted unexpectedly")
 
     async def _extract_image(self, image_path: Path, target_dir: Path) -> None:
         """Extract a SquashFS image to target_dir using unsquashfs.

--- a/tracecat/executor/registry_artifacts.py
+++ b/tracecat/executor/registry_artifacts.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import hashlib
 import os
-import random
 import shutil
 import sysconfig
 import tarfile
@@ -29,6 +28,10 @@ from tracecat.concurrency import (
     run_blocking_rejoin_on_cancel,
 )
 from tracecat.executor import registry_artifact_mounts
+from tracecat.executor.registry_artifact_mounts import (
+    SQUASHFS_MOUNT_OPTIONS,
+    SquashfsMountCommandError,
+)
 from tracecat.executor.registry_artifact_storage import (
     RegistryArtifactAdmission,
     RegistryArtifactCacheCapacityError,
@@ -82,36 +85,8 @@ class RegistryArtifactFormat(StrEnum):
     TAR_GZ = "tar.gz"
 
 
-SQUASHFS_MOUNT_OPTIONS = "loop,ro,nodev,nosuid"
-"""Mount options for executor-managed SquashFS registry artifacts.
-
-The image must stay read-only and should not expose device nodes or setuid bits
-from registry package contents. Avoid noexec because Python packages may include
-native extension modules that need to be loaded from the mounted artifact.
-"""
-
-LOOP_DEVICE_SYNC_HELPER = "/usr/local/bin/tracecat-loop-device-sync"
-"""Fixed-purpose helper that mirrors kernel-confirmed loop nodes into ``/dev``."""
-
-SQUASHFS_MOUNT_MAX_ATTEMPTS = 3
-SQUASHFS_MOUNT_RETRY_MIN_SECONDS = 0.05
-SQUASHFS_MOUNT_RETRY_MAX_SECONDS = 0.2
-
 BUNDLED_BUILTIN_REGISTRY_URI_PREFIX = f"tracecat-builtin://{DEFAULT_REGISTRY_ORIGIN}/"
 """Pseudo-URI for the builtin registry already installed in the executor image."""
-
-
-class SquashfsMountCommandError(RuntimeError):
-    """The ``mount`` command itself failed for a SquashFS registry artifact.
-
-    Only this error drives SquashFS mount policy. Download, mkdir, and other
-    preparation failures must not be mistaken for a missing mount capability or
-    for loop-device exhaustion.
-    """
-
-
-class LoopDeviceSyncCommandError(RuntimeError):
-    """The restricted loop-device synchronization helper failed."""
 
 
 class RegistryArtifactUriError(ValueError):
@@ -123,15 +98,6 @@ class RegistryArtifactExtractionError(RuntimeError):
 
     def __init__(self) -> None:
         super().__init__("Registry artifact extraction failed")
-
-
-@dataclass(frozen=True, slots=True)
-class LoopDeviceSyncResult:
-    """Counts reported after synchronizing kernel loop devices into ``/dev``."""
-
-    kernel_devices: int
-    created_nodes: int
-    existing_nodes: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,53 +158,6 @@ class BuiltinArtifact(RegistryArtifact):
             paths=[str(p) for p in import_paths],
         )
         return import_paths
-
-
-async def _sync_loop_device_nodes() -> LoopDeviceSyncResult:
-    """Create missing ``/dev/loopN`` nodes already present in kernel sysfs."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            LOOP_DEVICE_SYNC_HELPER,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,
-        )
-    except OSError as error:
-        raise LoopDeviceSyncCommandError(
-            "loop-device synchronization helper could not start"
-        ) from error
-
-    stdout, stderr = await communicate_process_group(proc)
-    if proc.returncode != 0:
-        output = (stderr or stdout).decode(errors="replace").strip()
-        raise LoopDeviceSyncCommandError(
-            output or "loop-device synchronization helper failed"
-        )
-
-    fields = stdout.decode(errors="replace").split()
-    if len(fields) != 3:
-        raise LoopDeviceSyncCommandError(
-            "loop-device synchronization helper returned an invalid result"
-        )
-    try:
-        kernel_devices, created_nodes, existing_nodes = map(int, fields)
-    except ValueError as error:
-        raise LoopDeviceSyncCommandError(
-            "loop-device synchronization helper returned an invalid result"
-        ) from error
-    if (
-        min(kernel_devices, created_nodes, existing_nodes) < 0
-        or created_nodes + existing_nodes != kernel_devices
-    ):
-        raise LoopDeviceSyncCommandError(
-            "loop-device synchronization helper returned inconsistent counts"
-        )
-
-    return LoopDeviceSyncResult(
-        kernel_devices=kernel_devices,
-        created_nodes=created_nodes,
-        existing_nodes=existing_nodes,
-    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -481,61 +400,7 @@ class SquashfsArtifact(RegistryArtifact):
         Raises:
             SquashfsMountCommandError: The ``mount`` command failed.
         """
-        for attempt in range(1, SQUASHFS_MOUNT_MAX_ATTEMPTS + 1):
-            if registry_artifact_mounts.is_mount(target_dir):
-                return
-
-            proc = await asyncio.create_subprocess_exec(
-                "mount",
-                "-t",
-                "squashfs",
-                "-o",
-                SQUASHFS_MOUNT_OPTIONS,
-                str(image_path),
-                str(target_dir),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                start_new_session=True,
-            )
-            stdout, stderr = await communicate_process_group(proc)
-
-            if proc.returncode == 0 or registry_artifact_mounts.is_mount(target_dir):
-                return
-
-            output = (stderr or stdout).decode(errors="replace").strip()
-            mount_error = SquashfsMountCommandError(output or "mount command failed")
-            if attempt == SQUASHFS_MOUNT_MAX_ATTEMPTS:
-                raise mount_error
-
-            try:
-                sync_result = await _sync_loop_device_nodes()
-            except LoopDeviceSyncCommandError as sync_error:
-                logger.warning(
-                    "Failed to synchronize loop device nodes after mount failure",
-                    mount_attempt=attempt,
-                    mount_attempts=SQUASHFS_MOUNT_MAX_ATTEMPTS,
-                    mount_error=str(mount_error),
-                    error=str(sync_error),
-                )
-                raise mount_error from sync_error
-
-            retry_delay = random.uniform(
-                SQUASHFS_MOUNT_RETRY_MIN_SECONDS,
-                SQUASHFS_MOUNT_RETRY_MAX_SECONDS,
-            )
-            logger.warning(
-                "Retrying SquashFS mount after synchronizing loop device nodes",
-                mount_attempt=attempt,
-                mount_attempts=SQUASHFS_MOUNT_MAX_ATTEMPTS,
-                mount_error=str(mount_error),
-                kernel_loop_devices=sync_result.kernel_devices,
-                created_loop_nodes=sync_result.created_nodes,
-                existing_loop_nodes=sync_result.existing_nodes,
-                retry_delay_ms=f"{retry_delay * 1000:.1f}",
-            )
-            await asyncio.sleep(retry_delay)
-
-        raise AssertionError("SquashFS mount retry loop exhausted unexpectedly")
+        await registry_artifact_mounts.mount_squashfs(image_path, target_dir)
 
     async def _extract_image(self, image_path: Path, target_dir: Path) -> None:
         """Extract a SquashFS image to target_dir using unsquashfs.


### PR DESCRIPTION
## Summary

Repair executor containers whose `/dev` view is missing loop devices created by the shared node kernel after the container started, without exposing node-global block devices to action subprocesses.

## Root cause

Kubernetes containers have a private `/dev` populated at startup, while loop devices are allocated in the node kernel. A later `mount -o loop` can select a kernel loop device visible in `/sys/block` whose `/dev/loopN` node is absent inside an older executor pod, causing `failed to setup loop device` even though the kernel device exists.

## What changed

- Add a fixed-purpose C++ helper that mirrors validated kernel loop devices from `/sys/block/loopN/dev` into the container's `/dev`.
- Create repaired nodes as root-owned mode `0600` from birth, so UID-1001 action subprocesses cannot read, write, or chmod node-global loop devices.
- Keep the Python executor unprivileged; only the fixed-purpose helper receives `CAP_MKNOD`, `CAP_DAC_OVERRIDE`, and `CAP_SETUID`.
- Preserve the normal first mount attempt, then synchronize stale loop-device nodes and retry up to three times with short jitter after failure.
- Isolate mount/recovery policy in `registry_artifact_mounts.py` and cover helper protocol, retry, and failure behavior with fast unit tests.
- Run one xdist-safe privileged Docker regression against an explicitly supplied image resolved to its immutable ID. It reproduces the exact missing-node failure, mounts through the executor path, asserts UID 1001 cannot open the repaired node, and verifies cleanup.
- Reuse the exact executor image already built by scheduled integration CI rather than a possibly stale Compose image.

## Impact

No configuration or manifest changes are required. Existing executor images gain the helper in every environment, including `tracecat-ci`, and normal `mount -o loop` allocation remains kernel-managed.

## Validation

- `uv run pytest --confcutdir=tests/unit tests/unit/test_registry_artifact_mounts.py tests/unit/test_registry_artifacts.py -q` (`136 passed`)
- `TRACECAT__REGISTRY_LOOP_HOTPLUG_IMAGE=sha256:710e5c066b7baac344c2f0828a41321108effa2b3d2c9c713f8b5d171d4e4e39 uv run pytest --confcutdir=tests/integration tests/integration/test_registry_artifact_loop_hotplug.py -m integration -q -s` (`1 passed`)
- `uv run ruff check ...` and `uv run ruff format --check ...`
- `uv run pyright ...` (`0 errors, 0 warnings`)
- Workflow YAML parsed successfully.
- The C++ helper and full executor image built successfully with warnings treated as errors.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 407 | 40 |
| Tests | 765 | 2 |
| Infra/config | 21 | 7 |

## Stack

PR 1 of 4. Followed by #3262, #3264, and #3265.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

