### PR TITLE
fix(executor): enforce registry cache capacity invariants

### DIFF
--- a/tests/unit/test_registry_artifacts.py
+++ b/tests/unit/test_registry_artifacts.py
@@ -30,6 +30,7 @@ from tracecat.executor.registry_artifacts import (
     SQUASHFS_MOUNT_OPTIONS,
     RegistryArtifactCache,
     RegistryArtifactCacheCapacityError,
+    RegistryArtifactCacheLeaseContentionError,
     RegistryArtifactCacheLoopError,
     RegistryArtifactEviction,
     RegistryArtifactExtractionError,
@@ -2365,6 +2366,120 @@ class TestRegistryArtifactCacheLease:
 
 class TestRegistryArtifactCacheEviction:
     """Tests for bounded eviction of registry artifact cache entries."""
+
+    @pytest.mark.anyio
+    async def test_capacity_blocked_only_by_active_lease_is_transient(
+        self, temp_cache_dir: Path
+    ) -> None:
+        """Admission identifies bytes that become available on lease release."""
+        cache = RegistryArtifactCache(temp_cache_dir)
+        busy_key = "busy"
+        _write_image_entry(temp_cache_dir, busy_key, size=4096, mtime=100.0)
+        snapshot = cache._scan_cache_snapshot()
+        additional_bytes = _filesystem_allocation_unit(temp_cache_dir)
+        fixed_bytes = (
+            snapshot.structural_bytes + snapshot.staging_bytes + snapshot.trash_bytes
+        )
+        cache._acquire_lease(busy_key)
+
+        try:
+            with pytest.raises(RegistryArtifactCacheLeaseContentionError) as raised:
+                async with cache._admission_lock:
+                    await cache._ensure_cache_capacity(
+                        additional_bytes=additional_bytes,
+                        protected_key="cold",
+                        max_bytes=fixed_bytes + additional_bytes,
+                    )
+        finally:
+            cache._release_lease(busy_key)
+
+        assert raised.value.current_bytes == (
+            fixed_bytes + snapshot.entries[busy_key].size_bytes
+        )
+        assert raised.value.additional_bytes == additional_bytes
+        assert raised.value.max_bytes == fixed_bytes + additional_bytes
+
+    @pytest.mark.anyio
+    async def test_capacity_pinned_by_current_attempt_is_permanent(
+        self, temp_cache_dir: Path
+    ) -> None:
+        """Reacquiring this attempt's own pins cannot relieve capacity pressure."""
+        cache = RegistryArtifactCache(temp_cache_dir)
+        attempt_key = "attempt"
+        _write_image_entry(temp_cache_dir, attempt_key, size=4096, mtime=100.0)
+        snapshot = cache._scan_cache_snapshot()
+        additional_bytes = _filesystem_allocation_unit(temp_cache_dir)
+        fixed_bytes = (
+            snapshot.structural_bytes + snapshot.staging_bytes + snapshot.trash_bytes
+        )
+        cache._acquire_lease(attempt_key)
+
+        try:
+            with pytest.raises(RegistryArtifactCacheCapacityError) as raised:
+                async with cache._admission_lock:
+                    await cache._ensure_cache_capacity(
+                        additional_bytes=additional_bytes,
+                        protected_key="cold",
+                        max_bytes=fixed_bytes + additional_bytes,
+                        attempt_cache_keys={attempt_key, "cold"},
+                    )
+        finally:
+            cache._release_lease(attempt_key)
+
+        assert type(raised.value) is RegistryArtifactCacheCapacityError
+        assert raised.value.current_bytes == (
+            fixed_bytes + snapshot.entries[attempt_key].size_bytes
+        )
+
+    @pytest.mark.anyio
+    async def test_capacity_rechecks_contention_after_eviction_yields(
+        self, temp_cache_dir: Path
+    ) -> None:
+        """A cache hit racing an eviction remains eligible for lease retry."""
+        cache = RegistryArtifactCache(temp_cache_dir)
+        oldest_key = "oldest"
+        newly_busy_key = "newly-busy"
+        _write_image_entry(temp_cache_dir, oldest_key, size=4096, mtime=100.0)
+        _write_image_entry(temp_cache_dir, newly_busy_key, size=4096, mtime=200.0)
+        snapshot = cache._scan_cache_snapshot()
+        additional_bytes = _filesystem_allocation_unit(temp_cache_dir)
+        fixed_bytes = (
+            snapshot.structural_bytes + snapshot.staging_bytes + snapshot.trash_bytes
+        )
+        original_evict = cache._evict_entry
+        evicted_keys: list[str] = []
+
+        async def evict_then_pin_remaining(cache_key: str) -> RegistryArtifactEviction:
+            eviction = await original_evict(cache_key)
+            evicted_keys.append(cache_key)
+            if len(evicted_keys) == 1:
+                cache._acquire_lease(newly_busy_key)
+            return eviction
+
+        try:
+            with (
+                patch.object(
+                    cache,
+                    "_evict_entry",
+                    side_effect=evict_then_pin_remaining,
+                ),
+                pytest.raises(RegistryArtifactCacheLeaseContentionError) as raised,
+            ):
+                async with cache._admission_lock:
+                    await cache._ensure_cache_capacity(
+                        additional_bytes=additional_bytes,
+                        protected_key="cold",
+                        max_bytes=fixed_bytes + additional_bytes,
+                    )
+        finally:
+            cache._release_lease(newly_busy_key)
+
+        assert evicted_keys == [oldest_key]
+        assert raised.value.current_bytes == (
+            snapshot.total_bytes - snapshot.entries[oldest_key].size_bytes
+        )
+        assert raised.value.additional_bytes == additional_bytes
+        assert raised.value.max_bytes == fixed_bytes + additional_bytes
 
     def test_snapshot_accounts_for_invalid_entry_children(
         self, temp_cache_dir: Path

--- a/tracecat/executor/registry_artifact_storage.py
+++ b/tracecat/executor/registry_artifact_storage.py
@@ -10,7 +10,7 @@ import shutil
 import stat
 import threading
 import time
-from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Collection, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -36,6 +36,7 @@ __all__ = (
     "CACHE_TRASH_DIR_NAME",
     "RegistryArtifactAdmission",
     "RegistryArtifactCacheCapacityError",
+    "RegistryArtifactCacheLeaseContentionError",
     "RegistryArtifactCacheLoopError",
     "RegistryArtifactCacheStorage",
     "RegistryArtifactEviction",
@@ -92,6 +93,10 @@ class RegistryArtifactCacheCapacityError(RuntimeError):
         self.current_bytes = current_bytes
         self.additional_bytes = additional_bytes
         self.max_bytes = max_bytes
+
+
+class RegistryArtifactCacheLeaseContentionError(RegistryArtifactCacheCapacityError):
+    """Active leases temporarily pin bytes needed by a cold artifact."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -572,7 +577,12 @@ class RegistryArtifactCacheStorage:
             admission=admission,
         )
 
-    def _admission_for(self, cache_key: str) -> RegistryArtifactAdmission | None:
+    def _admission_for(
+        self,
+        cache_key: str,
+        *,
+        attempt_cache_keys: Collection[str] = (),
+    ) -> RegistryArtifactAdmission | None:
         """Return byte-bound admission controls for one cold cache key."""
         max_bytes = config.TRACECAT__EXECUTOR_REGISTRY_CACHE_MAX_BYTES
         if max_bytes <= 0:
@@ -587,6 +597,7 @@ class RegistryArtifactCacheStorage:
                 ),
                 protected_key=cache_key,
                 max_bytes=max_bytes,
+                attempt_cache_keys=attempt_cache_keys,
             )
 
         return RegistryArtifactAdmission(
@@ -753,13 +764,23 @@ class RegistryArtifactCacheStorage:
         additional_bytes: int,
         protected_key: str,
         max_bytes: int,
+        attempt_cache_keys: Collection[str] = (),
     ) -> None:
         """Reserve peak bytes for one serialized cold writer."""
         if additional_bytes < 0:
             raise ValueError("additional_bytes must be non-negative")
 
-        def capacity_error(current_bytes: int) -> RegistryArtifactCacheCapacityError:
-            return RegistryArtifactCacheCapacityError(
+        def capacity_error(
+            current_bytes: int,
+            *,
+            lease_contention: bool = False,
+        ) -> RegistryArtifactCacheCapacityError:
+            error_type = (
+                RegistryArtifactCacheLeaseContentionError
+                if lease_contention
+                else RegistryArtifactCacheCapacityError
+            )
+            return error_type(
                 current_bytes=current_bytes,
                 additional_bytes=additional_bytes,
                 max_bytes=max_bytes,
@@ -769,23 +790,37 @@ class RegistryArtifactCacheStorage:
         snapshot = await asyncio.to_thread(self._scan_cache_snapshot)
         entries = snapshot.entries
         total_bytes = snapshot.total_bytes
-        non_evictable_bytes = (
-            snapshot.structural_bytes
-            + snapshot.staging_bytes
-            + snapshot.trash_bytes
-            + sum(
-                entry.size_bytes
-                for entry in entries.values()
-                if entry.cache_key == protected_key
-                or self._refcount(entry.cache_key) > 0
-                or (
-                    (runtime := self._runtime.get(entry.cache_key)) is not None
-                    and runtime.lock.locked()
-                )
-            )
+        fixed_bytes = (
+            snapshot.structural_bytes + snapshot.staging_bytes + snapshot.trash_bytes
         )
+        protected_bytes = sum(
+            entry.size_bytes
+            for entry in entries.values()
+            if entry.cache_key == protected_key
+        )
+        busy_entries = [
+            entry
+            for entry in entries.values()
+            if entry.cache_key != protected_key
+            and self._cache_entry_is_busy(entry.cache_key)
+        ]
+        busy_bytes = sum(entry.size_bytes for entry in busy_entries)
+        retryable_busy_bytes = sum(
+            entry.size_bytes
+            for entry in busy_entries
+            if entry.cache_key not in attempt_cache_keys
+        )
+        non_evictable_bytes = fixed_bytes + protected_bytes + busy_bytes
         if non_evictable_bytes + additional_bytes > max_bytes:
-            raise capacity_error(non_evictable_bytes)
+            fits_after_busy_entries_release = (
+                retryable_busy_bytes > 0
+                and non_evictable_bytes - retryable_busy_bytes + additional_bytes
+                <= max_bytes
+            )
+            raise capacity_error(
+                non_evictable_bytes,
+                lease_contention=fits_after_busy_entries_release,
+            )
         if (
             not (trash_clean and startup_clean)
             and total_bytes + additional_bytes > max_bytes
@@ -802,7 +837,30 @@ class RegistryArtifactCacheStorage:
             ),
         )
         if not eviction_pass.fits:
-            raise capacity_error(eviction_pass.total_bytes)
+            retryable_busy_bytes = sum(
+                entry.size_bytes
+                for entry in entries.values()
+                if entry.cache_key != protected_key
+                and entry.cache_key not in attempt_cache_keys
+                and self._cache_entry_is_busy(entry.cache_key)
+            )
+            fits_after_busy_entries_release = (
+                eviction_pass.exhausted_candidates
+                and retryable_busy_bytes > 0
+                and eviction_pass.total_bytes - retryable_busy_bytes + additional_bytes
+                <= max_bytes
+            )
+            raise capacity_error(
+                eviction_pass.total_bytes,
+                lease_contention=fits_after_busy_entries_release,
+            )
+
+    def _cache_entry_is_busy(self, cache_key: str) -> bool:
+        """Return whether process-local lease or lock state blocks eviction."""
+        if self._refcount(cache_key) > 0:
+            return True
+        runtime = self._runtime.get(cache_key)
+        return runtime is not None and runtime.lock.locked()
 
     async def _evict_until_fits(
         self,

--- a/tracecat/executor/registry_artifacts.py
+++ b/tracecat/executor/registry_artifacts.py
@@ -35,6 +35,7 @@ from tracecat.executor.registry_artifact_mounts import (
 from tracecat.executor.registry_artifact_storage import (
     RegistryArtifactAdmission,
     RegistryArtifactCacheCapacityError,
+    RegistryArtifactCacheLeaseContentionError,
     RegistryArtifactCacheLoopError,
     RegistryArtifactCacheStorage,
     RegistryArtifactEviction,
@@ -63,6 +64,7 @@ __all__ = (
     "RegistryArtifactAdmission",
     "RegistryArtifactCache",
     "RegistryArtifactCacheCapacityError",
+    "RegistryArtifactCacheLeaseContentionError",
     "RegistryArtifactExtractionError",
     "RegistryArtifactCacheLoopError",
     "RegistryArtifactEviction",


### PR DESCRIPTION
## Summary

Enforce registry-cache byte-budget invariants and distinguish temporary leased pressure from artifacts that can never fit.

## What changed

- Add the typed `RegistryArtifactCacheLeaseContentionError` subtype for active-lease pressure.
- Account for fixed, protected, and busy bytes separately during cold admission.
- Treat bytes pinned by the current multi-artifact attempt as permanent for that attempt.
- Classify contention as transient only when an unrelated busy entry releasing would make the request fit.
- Recheck typed capacity state after eviction yields so concurrent lock and lease changes are reflected.

Retry policy is intentionally left to #3264; this layer only establishes the capacity classification contract.

## Validation

- `uv run pytest --confcutdir=tests/unit tests/unit/test_registry_artifacts.py -q` — 129 passed
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run basedpyright ...`

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 80 | 20 |
| Tests | 115 | 0 |

## Stack

PR 2 of 4. Depends on #3261; followed by #3264 and #3265.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
