### PR TITLE
fix: retry actions after heartbeat timeouts

### DIFF
--- a/tests/unit/test_dsl_workflow_activity_retry.py
+++ b/tests/unit/test_dsl_workflow_activity_retry.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+    TimeoutType,
+)
+from temporalio.exceptions import (
+    TimeoutError as TemporalTimeoutError,
+)
+
+from tracecat.dsl.schemas import ActionRetryPolicy, ActionStatement, RunActionInput
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.storage.object import InlineObject
+
+
+def _activity_error_from(cause: Exception) -> ActivityError:
+    try:
+        raise ActivityError(
+            "Activity failed",
+            scheduled_event_id=1,
+            started_event_id=2,
+            identity="test-executor",
+            activity_type="execute_action_activity",
+            activity_id="execute_action_activity",
+            retry_state=None,
+        ) from cause
+    except ActivityError as exc:
+        return exc
+
+
+def _timeout_error(timeout_type: TimeoutType) -> ActivityError:
+    return _activity_error_from(
+        TemporalTimeoutError(
+            "Activity timed out",
+            type=timeout_type,
+            last_heartbeat_details=[],
+        )
+    )
+
+
+def _workflow() -> DSLWorkflow:
+    dsl_workflow = object.__new__(DSLWorkflow)
+    dsl_workflow.role = cast(Any, object())
+    dsl_workflow.logger = Mock()
+    return dsl_workflow
+
+
+def _task(*, max_attempts: int = 1) -> ActionStatement:
+    return ActionStatement(
+        ref="test_action",
+        action="core.transform.reshape",
+        retry_policy=ActionRetryPolicy(max_attempts=max_attempts),
+    )
+
+
+@pytest.mark.anyio
+async def test_action_retries_once_after_heartbeat_timeout() -> None:
+    dsl_workflow = _workflow()
+    execute_activity = AsyncMock(
+        side_effect=[
+            _timeout_error(TimeoutType.HEARTBEAT),
+            InlineObject(data={"ok": True}),
+        ]
+    )
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.execute_activity", new=execute_activity),
+        patch("tracecat.dsl.workflow.workflow.patched", return_value=True),
+    ):
+        result = await dsl_workflow._execute_action_activity(
+            _task(), cast(RunActionInput, object())
+        )
+
+    assert result == InlineObject(data={"ok": True})
+    assert execute_activity.await_count == 2
+    cast(Any, dsl_workflow.logger.warning).assert_called_once_with(
+        "Retrying action after activity heartbeat timeout",
+        task_ref="test_action",
+    )
+
+
+@pytest.mark.anyio
+async def test_action_propagates_second_heartbeat_timeout() -> None:
+    dsl_workflow = _workflow()
+    second_timeout = _timeout_error(TimeoutType.HEARTBEAT)
+    execute_activity = AsyncMock(
+        side_effect=[_timeout_error(TimeoutType.HEARTBEAT), second_timeout]
+    )
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.execute_activity", new=execute_activity),
+        patch("tracecat.dsl.workflow.workflow.patched", return_value=True),
+        pytest.raises(ActivityError) as raised,
+    ):
+        await dsl_workflow._execute_action_activity(
+            _task(), cast(RunActionInput, object())
+        )
+
+    assert raised.value is second_timeout
+    assert execute_activity.await_count == 2
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        _timeout_error(TimeoutType.START_TO_CLOSE),
+        _activity_error_from(ApplicationError("Action failed")),
+    ],
+    ids=["start-to-close-timeout", "application-error"],
+)
+async def test_action_does_not_retry_other_failures(failure: ActivityError) -> None:
+    dsl_workflow = _workflow()
+    execute_activity = AsyncMock(side_effect=failure)
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.execute_activity", new=execute_activity),
+        pytest.raises(ActivityError) as raised,
+    ):
+        await dsl_workflow._execute_action_activity(
+            _task(), cast(RunActionInput, object())
+        )
+
+    assert raised.value is failure
+    assert execute_activity.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_action_with_configured_retries_has_no_extra_heartbeat_retry() -> None:
+    dsl_workflow = _workflow()
+    heartbeat_timeout = _timeout_error(TimeoutType.HEARTBEAT)
+    execute_activity = AsyncMock(side_effect=heartbeat_timeout)
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.execute_activity", new=execute_activity),
+        pytest.raises(ActivityError) as raised,
+    ):
+        await dsl_workflow._execute_action_activity(
+            _task(max_attempts=2), cast(RunActionInput, object())
+        )
+
+    assert raised.value is heartbeat_timeout
+    assert execute_activity.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_action_preserves_legacy_path_without_retry_patch_marker() -> None:
+    dsl_workflow = _workflow()
+    heartbeat_timeout = _timeout_error(TimeoutType.HEARTBEAT)
+    execute_activity = AsyncMock(side_effect=heartbeat_timeout)
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.execute_activity", new=execute_activity),
+        patch("tracecat.dsl.workflow.workflow.patched", return_value=False),
+        pytest.raises(ActivityError) as raised,
+    ):
+        await dsl_workflow._execute_action_activity(
+            _task(), cast(RunActionInput, object())
+        )
+
+    assert raised.value is heartbeat_timeout
+    assert execute_activity.await_count == 1

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -18,7 +18,11 @@ from temporalio.exceptions import (
     ApplicationError,
     ChildWorkflowError,
     FailureError,
+    TimeoutType,
     is_cancelled_exception,
+)
+from temporalio.exceptions import (
+    TimeoutError as TemporalTimeoutError,
 )
 
 with workflow.unsafe.imports_passed_through():
@@ -163,6 +167,7 @@ with workflow.unsafe.imports_passed_through():
 
 
 _CHILD_RUN_ARG_PREP_YIELD_EVERY = 8
+ACTION_HEARTBEAT_TIMEOUT_RETRY_PATCH = "dsl-action-heartbeat-timeout-retry-v1"
 
 
 def _inherit_search_attributes_with_alias(
@@ -1795,9 +1800,39 @@ class DSLWorkflow:
             registry_lock=self.registry_lock,
         )
 
+        return await self._execute_action_activity(task, arg)
+
+    async def _execute_action_activity(
+        self, task: ActionStatement, arg: RunActionInput
+    ) -> StoredObject:
+        """Dispatch an action, retrying one executor heartbeat interruption."""
+        try:
+            stored = await self._execute_action_activity_once(task, arg)
+        except ActivityError as exc:
+            cause = exc.cause
+            should_retry_heartbeat = (
+                task.retry_policy.max_attempts == 1
+                and isinstance(cause, TemporalTimeoutError)
+                and cause.type is TimeoutType.HEARTBEAT
+                and workflow.patched(ACTION_HEARTBEAT_TIMEOUT_RETRY_PATCH)
+            )
+            if not should_retry_heartbeat:
+                raise
+
+            self.logger.warning(
+                "Retrying action after activity heartbeat timeout",
+                task_ref=task.ref,
+            )
+            stored = await self._execute_action_activity_once(task, arg)
+
+        return StoredObjectValidator.validate_python(stored)
+
+    async def _execute_action_activity_once(
+        self, task: ActionStatement, arg: RunActionInput
+    ) -> Any:
         # Dispatch to ExecutorWorker on shared-action-queue
         # Using string activity name since it's registered on a different worker
-        stored = await workflow.execute_activity(
+        return await workflow.execute_activity(
             "execute_action_activity",
             args=(arg, self.role),
             task_queue=config.TRACECAT__EXECUTOR_QUEUE,
@@ -1813,7 +1848,6 @@ class DSLWorkflow:
                 maximum_attempts=task.retry_policy.max_attempts,
             ),
         )
-        return StoredObjectValidator.validate_python(stored)
 
     async def _run_child_workflow(
         self, task: ActionStatement, run_args: DSLRunArgs, loop_index: int | None = None


### PR DESCRIPTION
## Summary

- retry an action once when Temporal reports a typed activity heartbeat timeout
- preserve existing action retry budgets and propagate application and non-heartbeat failures unchanged
- guard the new command-producing path with a Temporal patch marker for replay compatibility
- add focused regression coverage for the retry and non-retry boundaries

## Root cause

An executor pod can disappear while running an activity, including during node or ephemeral-storage eviction. Temporal detects the lost worker through the heartbeat timeout and fails the workflow even when another healthy executor is available.

The heartbeat timeout is an infrastructure interruption with unknown completion state. This change therefore adds one bounded redispatch for default single-attempt actions instead of broadly increasing every action's retry policy.

## Impact

Workflows can recover from a single executor loss without retrying application failures or multiplying explicit action retry budgets. A second heartbeat timeout still fails normally.

Linear: [ENG-1668](https://linear.app/tracecat/issue/ENG-1668/retry-actions-once-after-a-temporal-heartbeat-timeout)

## Validation

- `uv run pytest --confcutdir=tests/unit tests/unit/test_dsl_workflow_concurrency.py tests/unit/test_dsl_workflow_activity_retry.py -q` — 26 passed
- `uv run ruff check tracecat/dsl/workflow.py tests/unit/test_dsl_workflow_activity_retry.py`
- `uv run pyright tracecat/dsl/workflow.py tests/unit/test_dsl_workflow_activity_retry.py`
- signed commit verified after rebasing onto current `origin/main`

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 36 | 2 |
| Tests | 167 | 0 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry actions once after a Temporal activity heartbeat timeout so workflows can recover from a lost executor. Previously, a heartbeat timeout failed the workflow; now single‑attempt actions get one bounded redispatch, while other failures and explicit retry budgets remain unchanged.

- Retries only when the cause is a heartbeat timeout, the task has `max_attempts == 1`, and the `dsl-action-heartbeat-timeout-retry-v1` patch is active; logs a warning and still fails on a second heartbeat timeout.
- Preserves application error propagation and non‑heartbeat timeouts; tasks with `max_attempts > 1` do not get an extra retry.
- Extracts `_execute_action_activity` and guards the new path with `workflow.patched` for replay compatibility; adds focused unit tests for retry and non‑retry boundaries.
- Addresses Linear ENG-1668.

<sup>Written for commit b379e52b4ce751e9a8dd398818094f12c0dfc4f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

