### PR TITLE
feat(runtime): define versioned error envelope

### DIFF
--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -71,7 +71,7 @@ from tracecat.dsl.schemas import (
     ScatterArgs,
     TaskResult,
 )
-from tracecat.dsl.types import ActionErrorInfoAdapter
+from tracecat.dsl.types import ActionErrorInfo
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.expressions.expectations import ExpectedField
 from tracecat.identifiers import ScheduleUUID
@@ -6212,7 +6212,7 @@ async def test_workflow_gather_error_strategy_raise(
 
     # Validate the gather error structure (stream-aware)
     gather_error = detail["gather1"]
-    validated_error = ActionErrorInfoAdapter.validate_python(gather_error)
+    validated_error = ActionErrorInfo.model_validate(gather_error)
     assert validated_error.ref == "gather1", "Gather error ref should be gather1"
     assert validated_error.stream_id == "<root>:0", (
         "Gather error should have parent stream_id"

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import pytest
+from temporalio.exceptions import ApplicationError
 
 from tracecat.auth.types import Role
 from tracecat.dsl import scheduler as scheduler_module
@@ -29,7 +30,16 @@ from tracecat.runtime.errors import (
     RetryDisposition,
     RuntimeErrorKind,
 )
-from tracecat.temporal.errors import application_error_from_envelope
+from tracecat.temporal.errors import raise_application_error_from_envelope
+
+
+def _capture_application_error(
+    envelope: ErrorEnvelope,
+    *details: object,
+) -> ApplicationError:
+    with pytest.raises(ApplicationError) as exc_info:
+        raise_application_error_from_envelope(envelope, *details)
+    return exc_info.value
 
 
 def _build_scheduler(
@@ -82,7 +92,7 @@ async def test_scheduler_preserves_classified_action_error() -> None:
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    error = application_error_from_envelope(
+    error = _capture_application_error(
         envelope,
         ActionErrorInfo(
             ref="task_0",
@@ -109,7 +119,7 @@ async def test_scheduler_preserves_standalone_error_envelope() -> None:
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    error = application_error_from_envelope(envelope)
+    error = _capture_application_error(envelope)
 
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -99,6 +99,27 @@ async def test_scheduler_preserves_classified_action_error() -> None:
 
 
 @pytest.mark.anyio
+async def test_scheduler_preserves_standalone_error_envelope() -> None:
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    scheduler = _build_scheduler(total_tasks=1, executor=executor)
+    envelope = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the action",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    error = application_error_from_envelope(envelope)
+
+    await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
+
+    details = scheduler.task_exceptions["task_0"].details
+    assert isinstance(details, ClassifiedActionErrorInfo)
+    assert details.ref == "task_0"
+    assert details.envelope == envelope
+
+
+@pytest.mark.anyio
 async def test_scheduler_respects_max_pending_tasks_cap() -> None:
     max_pending_tasks = 3
     total_tasks = 10

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -27,7 +27,7 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.runtime.errors import (
     ErrorEnvelope,
     RetryDisposition,
-    RuntimeErrorCode,
+    RuntimeErrorKind,
 )
 from tracecat.temporal.errors import application_error_from_envelope
 
@@ -78,7 +78,7 @@ async def test_scheduler_preserves_classified_action_error() -> None:
 
     scheduler = _build_scheduler(total_tasks=1, executor=executor)
     envelope = ErrorEnvelope.user(
-        code=RuntimeErrorCode.USER_ACTION_FAILED,
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
@@ -89,7 +89,6 @@ async def test_scheduler_preserves_classified_action_error() -> None:
             message="The action failed",
             type="ValueError",
         ),
-        error_type="ValueError",
     )
 
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -12,8 +12,24 @@ from tracecat.auth.types import Role
 from tracecat.dsl import scheduler as scheduler_module
 from tracecat.dsl.common import DSLEntrypoint, DSLInput
 from tracecat.dsl.scheduler import DSLScheduler
-from tracecat.dsl.schemas import ActionStatement, ExecutionContext, RunContext
+from tracecat.dsl.schemas import (
+    ROOT_STREAM,
+    ActionStatement,
+    ExecutionContext,
+    RunContext,
+)
+from tracecat.dsl.types import (
+    ActionErrorInfo,
+    ClassifiedActionErrorInfo,
+    Task,
+)
 from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.runtime.errors import (
+    ErrorEnvelope,
+    RetryDisposition,
+    RuntimeErrorCode,
+)
+from tracecat.temporal.errors import application_error_from_envelope
 
 
 def _build_scheduler(
@@ -53,6 +69,34 @@ def _build_scheduler(
         role=test_role,
         run_context=test_run_context,
     )
+
+
+@pytest.mark.anyio
+async def test_scheduler_preserves_classified_action_error() -> None:
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    scheduler = _build_scheduler(total_tasks=1, executor=executor)
+    envelope = ErrorEnvelope.user(
+        code=RuntimeErrorCode.USER_ACTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    error = application_error_from_envelope(
+        envelope,
+        ActionErrorInfo(
+            ref="task_0",
+            message="The action failed",
+            type="ValueError",
+        ),
+        error_type="ValueError",
+    )
+
+    await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
+
+    details = scheduler.task_exceptions["task_0"].details
+    assert isinstance(details, ClassifiedActionErrorInfo)
+    assert details.envelope == envelope
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -18,11 +18,13 @@ from tracecat.dsl.schemas import (
     ActionStatement,
     ExecutionContext,
     RunContext,
+    StreamID,
 )
 from tracecat.dsl.types import (
     ActionErrorInfo,
     Task,
 )
+from tracecat.expressions.common import ExprContext
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.runtime.errors import (
     ErrorEnvelope,
@@ -104,6 +106,42 @@ async def test_scheduler_preserves_classified_action_error() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.envelope == envelope
+
+
+@pytest.mark.anyio
+async def test_scheduler_preserves_classified_mapped_child_error() -> None:
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    scheduler = _build_scheduler(total_tasks=1, executor=executor)
+    envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The child action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    nested = ActionErrorInfo(
+        ref="nested_action",
+        message="Nested context",
+        type="ValueError",
+    )
+    child = ActionErrorInfo(
+        ref="child_action",
+        message="The child action failed",
+        type="ValueError",
+        expr_context=ExprContext.TRIGGER,
+        attempt=3,
+        stream_id=StreamID.new("scatter", 2),
+        children=[nested],
+        envelope=envelope,
+    )
+    error = _capture_application_error(
+        envelope,
+        {child.ref: child.model_dump(mode="json")},
+    )
+
+    await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
+
+    assert scheduler.task_exceptions["task_0"].details == child
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -21,7 +21,6 @@ from tracecat.dsl.schemas import (
 )
 from tracecat.dsl.types import (
     ActionErrorInfo,
-    ClassifiedActionErrorInfo,
     Task,
 )
 from tracecat.identifiers.workflow import WorkflowUUID
@@ -104,7 +103,6 @@ async def test_scheduler_preserves_classified_action_error() -> None:
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
-    assert isinstance(details, ClassifiedActionErrorInfo)
     assert details.envelope == envelope
 
 
@@ -124,7 +122,6 @@ async def test_scheduler_preserves_standalone_error_envelope() -> None:
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
-    assert isinstance(details, ClassifiedActionErrorInfo)
     assert details.ref == "task_0"
     assert details.envelope == envelope
 

--- a/tests/unit/test_runtime_errors.py
+++ b/tests/unit/test_runtime_errors.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+from tracecat.runtime.errors import (
+    ERROR_ENVELOPE_SCHEMA,
+    ErrorEnvelope,
+    RetryDisposition,
+    RuntimeErrorCode,
+    RuntimeErrorOwner,
+    parse_error_envelope,
+)
+
+
+@pytest.mark.parametrize(
+    ("code", "owner"),
+    [
+        (RuntimeErrorCode.USER_ACTION_FAILED, RuntimeErrorOwner.USER),
+        (RuntimeErrorCode.TENANT_QUOTA_EXHAUSTED, RuntimeErrorOwner.USER),
+        (RuntimeErrorCode.TENANT_ENTITLEMENT_DENIED, RuntimeErrorOwner.USER),
+        (RuntimeErrorCode.INTEGRATION_RATE_LIMITED, RuntimeErrorOwner.USER),
+        (RuntimeErrorCode.PLATFORM_UNCLASSIFIED, RuntimeErrorOwner.PLATFORM),
+        (
+            RuntimeErrorCode.PLATFORM_DEPENDENCY_UNAVAILABLE,
+            RuntimeErrorOwner.PLATFORM,
+        ),
+        (RuntimeErrorCode.PLATFORM_CAPACITY_EXHAUSTED, RuntimeErrorOwner.PLATFORM),
+    ],
+)
+@pytest.mark.parametrize("retry_disposition", list(RetryDisposition))
+def test_error_envelope_supports_every_code_and_retry_disposition(
+    code: RuntimeErrorCode,
+    owner: RuntimeErrorOwner,
+    retry_disposition: RetryDisposition,
+) -> None:
+    factory = (
+        ErrorEnvelope.user
+        if owner is RuntimeErrorOwner.USER
+        else ErrorEnvelope.platform
+    )
+
+    envelope = factory(
+        code=code,
+        message="Safe runtime error",
+        retry_disposition=retry_disposition,
+    )
+
+    assert envelope.schema_ == ERROR_ENVELOPE_SCHEMA
+    assert envelope.owner is owner
+    assert envelope.code is code
+    assert envelope.retry_disposition is retry_disposition
+
+
+def test_error_envelope_serializes_exact_contract() -> None:
+    envelope = ErrorEnvelope.user(
+        code=RuntimeErrorCode.USER_ACTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+
+    assert envelope.model_dump(mode="json") == {
+        "schema": "tracecat.error.v1",
+        "owner": "user",
+        "code": "user.action.failed",
+        "message": "The action failed",
+        "retry_disposition": "non_retryable",
+        "cause_type": None,
+    }
+
+
+def test_error_envelope_rejects_extra_version_field() -> None:
+    with pytest.raises(ValidationError):
+        ErrorEnvelope.model_validate(
+            {
+                "schema": "tracecat.error.v1",
+                "version": 1,
+                "owner": "user",
+                "code": "user.action.failed",
+                "message": "The action failed",
+                "retry_disposition": "non_retryable",
+            }
+        )
+
+
+def test_parser_requires_explicit_schema_discriminator() -> None:
+    serialized = ErrorEnvelope.user(
+        code=RuntimeErrorCode.USER_ACTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    ).model_dump(mode="json")
+    missing_schema = {
+        key: value for key, value in serialized.items() if key != "schema"
+    }
+
+    assert parse_error_envelope(serialized) is not None
+    assert parse_error_envelope(missing_schema) is None
+    assert parse_error_envelope({**serialized, "schema": "tracecat.error.v2"}) is None
+
+
+def test_named_constructors_require_enum_members() -> None:
+    with pytest.raises(TypeError, match="RuntimeErrorCode enum member"):
+        ErrorEnvelope.user(
+            code=cast(RuntimeErrorCode, "user.action.failed"),
+            message="The action failed",
+            retry_disposition=RetryDisposition.NON_RETRYABLE,
+        )
+
+    with pytest.raises(TypeError, match="RetryDisposition enum member"):
+        ErrorEnvelope.user(
+            code=RuntimeErrorCode.USER_ACTION_FAILED,
+            message="The action failed",
+            retry_disposition=cast(RetryDisposition, "non_retryable"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("owner", "code"),
+    [
+        (RuntimeErrorOwner.USER, RuntimeErrorCode.PLATFORM_UNCLASSIFIED),
+        (RuntimeErrorOwner.PLATFORM, RuntimeErrorCode.USER_ACTION_FAILED),
+    ],
+)
+def test_error_envelope_rejects_mismatched_owner_and_code(
+    owner: RuntimeErrorOwner, code: RuntimeErrorCode
+) -> None:
+    with pytest.raises(ValidationError, match="does not belong"):
+        ErrorEnvelope(
+            owner=owner,
+            code=code,
+            message="Safe runtime error",
+            retry_disposition=RetryDisposition.NON_RETRYABLE,
+        )
+
+
+def test_platform_envelope_excludes_sensitive_cause_message() -> None:
+    sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
+
+    envelope = ErrorEnvelope.platform(
+        code=RuntimeErrorCode.PLATFORM_DEPENDENCY_UNAVAILABLE,
+        message="A platform dependency is unavailable",
+        retry_disposition=RetryDisposition.RETRYABLE,
+        cause=sensitive,
+    )
+
+    serialized = envelope.model_dump_json()
+    assert envelope.cause_type == "RuntimeError"
+    assert "secret" not in serialized
+    assert "example.invalid" not in serialized

--- a/tests/unit/test_runtime_errors.py
+++ b/tests/unit/test_runtime_errors.py
@@ -9,30 +9,17 @@ from tracecat.runtime.errors import (
     ERROR_ENVELOPE_SCHEMA,
     ErrorEnvelope,
     RetryDisposition,
-    RuntimeErrorCode,
+    RuntimeErrorKind,
     RuntimeErrorOwner,
     parse_error_envelope,
 )
 
 
-@pytest.mark.parametrize(
-    ("code", "owner"),
-    [
-        (RuntimeErrorCode.USER_ACTION_FAILED, RuntimeErrorOwner.USER),
-        (RuntimeErrorCode.TENANT_QUOTA_EXHAUSTED, RuntimeErrorOwner.USER),
-        (RuntimeErrorCode.TENANT_ENTITLEMENT_DENIED, RuntimeErrorOwner.USER),
-        (RuntimeErrorCode.INTEGRATION_RATE_LIMITED, RuntimeErrorOwner.USER),
-        (RuntimeErrorCode.PLATFORM_UNCLASSIFIED, RuntimeErrorOwner.PLATFORM),
-        (
-            RuntimeErrorCode.PLATFORM_DEPENDENCY_UNAVAILABLE,
-            RuntimeErrorOwner.PLATFORM,
-        ),
-        (RuntimeErrorCode.PLATFORM_CAPACITY_EXHAUSTED, RuntimeErrorOwner.PLATFORM),
-    ],
-)
+@pytest.mark.parametrize("kind", list(RuntimeErrorKind))
+@pytest.mark.parametrize("owner", list(RuntimeErrorOwner))
 @pytest.mark.parametrize("retry_disposition", list(RetryDisposition))
-def test_error_envelope_supports_every_code_and_retry_disposition(
-    code: RuntimeErrorCode,
+def test_error_envelope_supports_every_kind_owner_and_retry_disposition(
+    kind: RuntimeErrorKind,
     owner: RuntimeErrorOwner,
     retry_disposition: RetryDisposition,
 ) -> None:
@@ -43,20 +30,20 @@ def test_error_envelope_supports_every_code_and_retry_disposition(
     )
 
     envelope = factory(
-        code=code,
+        kind=kind,
         message="Safe runtime error",
         retry_disposition=retry_disposition,
     )
 
     assert envelope.schema_ == ERROR_ENVELOPE_SCHEMA
     assert envelope.owner is owner
-    assert envelope.code is code
+    assert envelope.kind is kind
     assert envelope.retry_disposition is retry_disposition
 
 
 def test_error_envelope_serializes_exact_contract() -> None:
     envelope = ErrorEnvelope.user(
-        code=RuntimeErrorCode.USER_ACTION_FAILED,
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
@@ -64,7 +51,7 @@ def test_error_envelope_serializes_exact_contract() -> None:
     assert envelope.model_dump(mode="json") == {
         "schema": "tracecat.error.v1",
         "owner": "user",
-        "code": "user.action.failed",
+        "kind": "action.execution.failed",
         "message": "The action failed",
         "retry_disposition": "non_retryable",
         "cause_type": None,
@@ -78,7 +65,7 @@ def test_error_envelope_rejects_extra_version_field() -> None:
                 "schema": "tracecat.error.v1",
                 "version": 1,
                 "owner": "user",
-                "code": "user.action.failed",
+                "kind": "action.execution.failed",
                 "message": "The action failed",
                 "retry_disposition": "non_retryable",
             }
@@ -87,7 +74,7 @@ def test_error_envelope_rejects_extra_version_field() -> None:
 
 def test_parser_requires_explicit_schema_discriminator() -> None:
     serialized = ErrorEnvelope.user(
-        code=RuntimeErrorCode.USER_ACTION_FAILED,
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     ).model_dump(mode="json")
@@ -101,37 +88,18 @@ def test_parser_requires_explicit_schema_discriminator() -> None:
 
 
 def test_named_constructors_require_enum_members() -> None:
-    with pytest.raises(TypeError, match="RuntimeErrorCode enum member"):
+    with pytest.raises(TypeError, match="RuntimeErrorKind enum member"):
         ErrorEnvelope.user(
-            code=cast(RuntimeErrorCode, "user.action.failed"),
+            kind=cast(RuntimeErrorKind, "action.execution.failed"),
             message="The action failed",
             retry_disposition=RetryDisposition.NON_RETRYABLE,
         )
 
     with pytest.raises(TypeError, match="RetryDisposition enum member"):
         ErrorEnvelope.user(
-            code=RuntimeErrorCode.USER_ACTION_FAILED,
+            kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
             message="The action failed",
             retry_disposition=cast(RetryDisposition, "non_retryable"),
-        )
-
-
-@pytest.mark.parametrize(
-    ("owner", "code"),
-    [
-        (RuntimeErrorOwner.USER, RuntimeErrorCode.PLATFORM_UNCLASSIFIED),
-        (RuntimeErrorOwner.PLATFORM, RuntimeErrorCode.USER_ACTION_FAILED),
-    ],
-)
-def test_error_envelope_rejects_mismatched_owner_and_code(
-    owner: RuntimeErrorOwner, code: RuntimeErrorCode
-) -> None:
-    with pytest.raises(ValidationError, match="does not belong"):
-        ErrorEnvelope(
-            owner=owner,
-            code=code,
-            message="Safe runtime error",
-            retry_disposition=RetryDisposition.NON_RETRYABLE,
         )
 
 
@@ -139,7 +107,7 @@ def test_platform_envelope_excludes_sensitive_cause_message() -> None:
     sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
 
     envelope = ErrorEnvelope.platform(
-        code=RuntimeErrorCode.PLATFORM_DEPENDENCY_UNAVAILABLE,
+        kind=RuntimeErrorKind.STORAGE_MATERIALIZATION_TRANSPORT_UNAVAILABLE,
         message="A platform dependency is unavailable",
         retry_disposition=RetryDisposition.RETRYABLE,
         cause=sensitive,

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -11,10 +11,7 @@ from temporalio.exceptions import ApplicationError
 
 from tracecat.dsl._converter import get_data_converter
 from tracecat.dsl.action import FinalizeGatherActivityResult
-from tracecat.dsl.types import (
-    ActionErrorInfo,
-    ActionErrorInfoAdapter,
-)
+from tracecat.dsl.types import ActionErrorInfo
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.runtime.errors import (
     ErrorEnvelope,
@@ -79,7 +76,7 @@ def _capture_wrapped_application_error(
 async def test_legacy_action_error_payload_is_unchanged_without_envelope() -> None:
     error_info = ActionErrorInfo(ref="action", message="Failed", type="ValueError")
 
-    serialized = ActionErrorInfoAdapter.dump_python(error_info, mode="json")
+    serialized = error_info.model_dump(mode="json")
     failure = Failure()
     data_converter = get_data_converter()
     await data_converter.encode_failure(ApplicationError("Failed", error_info), failure)
@@ -110,7 +107,7 @@ async def test_action_error_payload_carries_discriminated_envelope() -> None:
     assert extract_error_envelope(error) == envelope
     assert extract_error_envelope(decoded) == envelope
     assert isinstance(decoded, ApplicationError)
-    parsed = ActionErrorInfoAdapter.validate_python(decoded.details[0])
+    parsed = ActionErrorInfo.model_validate(decoded.details[0])
     assert parsed.envelope == envelope
 
 
@@ -140,8 +137,8 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
         type="ApplicationError",
         children=parsed_finalized.errors,
     )
-    serialized_aggregate = ActionErrorInfoAdapter.dump_python(aggregate, mode="json")
-    parsed_aggregate = ActionErrorInfoAdapter.validate_python(serialized_aggregate)
+    serialized_aggregate = aggregate.model_dump(mode="json")
+    parsed_aggregate = ActionErrorInfo.model_validate(serialized_aggregate)
 
     assert serialized_aggregate["children"][0]["envelope"] == envelope.model_dump(
         mode="json"
@@ -185,7 +182,7 @@ def test_legacy_action_error_is_extended_without_changing_existing_fields() -> N
         message="The action failed",
         type="ValueError",
     )
-    legacy = ActionErrorInfoAdapter.dump_python(error_info, mode="json")
+    legacy = error_info.model_dump(mode="json")
 
     error = _capture_application_error(envelope, error_info)
 

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -146,6 +146,16 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
     )
     assert parsed_aggregate.children is not None
     assert parsed_aggregate.children[0].envelope == envelope
+    assert (
+        extract_error_envelope(ApplicationError("Gather failed", serialized_aggregate))
+        == envelope
+    )
+    assert (
+        extract_error_envelope(
+            ApplicationError("Gather failed", {"gather": serialized_aggregate})
+        )
+        == envelope
+    )
 
 
 def test_error_handler_input_preserves_action_error_envelope() -> None:
@@ -371,6 +381,33 @@ def test_action_error_detail_requires_nested_schema_discriminator() -> None:
     )
 
     assert extract_error_envelope(error) is None
+
+
+def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
+    child = {
+        "ref": "scatter[0]",
+        "message": "Missing discriminator",
+        "type": "ValueError",
+        "envelope": {
+            "owner": "user",
+            "kind": "action.execution.failed",
+            "message": "Missing discriminator",
+            "retry_disposition": "non_retryable",
+            "cause_type": None,
+        },
+    }
+    aggregate = {
+        "ref": "gather",
+        "message": "Gather failed",
+        "type": "ApplicationError",
+        "children": [child],
+    }
+
+    assert extract_error_envelope(ApplicationError("Gather failed", aggregate)) is None
+    assert (
+        extract_error_envelope(ApplicationError("Gather failed", {"gather": aggregate}))
+        is None
+    )
 
 
 def test_wrapping_preserves_existing_classification() -> None:

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -368,6 +368,22 @@ def test_wrapping_preserves_existing_classification() -> None:
     assert extract_error_envelope(wrapped) != fallback
 
 
+def test_wrapping_unclassified_application_error_drops_original_details() -> None:
+    fallback = _platform_envelope()
+    original = ApplicationError(
+        "Raw platform failure",
+        {"diagnostic": "postgresql://user:secret@example.invalid/database"},
+    )
+
+    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
+
+    assert len(wrapped.details) == 1
+    assert wrapped.details[0]["schema"] == "tracecat.temporal_error.v1"
+    assert "secret" not in str(wrapped.details)
+    assert "example.invalid" not in str(wrapped.details)
+    assert extract_error_envelope(wrapped) == fallback
+
+
 def test_ambiguous_nested_envelope_does_not_override_fallback() -> None:
     nested_envelope = _user_envelope()
     fallback = _platform_envelope()

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -442,6 +442,37 @@ def test_wrapping_unclassified_application_error_drops_original_details() -> Non
     assert extract_error_envelope(wrapped) == fallback
 
 
+@pytest.mark.parametrize(
+    ("retry_disposition", "expected_delay"),
+    [
+        (RetryDisposition.RETRYABLE, timedelta(seconds=5)),
+        (RetryDisposition.NON_RETRYABLE, None),
+    ],
+)
+def test_wrapping_applies_retry_delay_only_to_retryable_envelope(
+    retry_disposition: RetryDisposition,
+    expected_delay: timedelta | None,
+) -> None:
+    original_delay = timedelta(seconds=5)
+    fallback = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the workflow",
+        retry_disposition=retry_disposition,
+    )
+    original = ApplicationError(
+        "Unclassified platform failure",
+        next_retry_delay=original_delay,
+    )
+
+    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
+
+    assert wrapped.next_retry_delay == expected_delay
+    assert wrapped.non_retryable is (
+        retry_disposition is RetryDisposition.NON_RETRYABLE
+    )
+    assert extract_error_envelope(wrapped) == fallback
+
+
 def test_ambiguous_nested_envelope_does_not_override_fallback() -> None:
     nested_envelope = _user_envelope()
     fallback = _platform_envelope()

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -8,6 +8,7 @@ from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
 
+from tracecat.dsl.action import FinalizeGatherActivityResult
 from tracecat.dsl.types import (
     ActionErrorInfo,
     ActionErrorInfoAdapter,
@@ -20,6 +21,7 @@ from tracecat.runtime.errors import (
     RuntimeErrorOwner,
     TracecatRuntimeError,
 )
+from tracecat.storage.object import InlineObject
 from tracecat.temporal.errors import (
     application_error_from_envelope,
     extract_error_envelope,
@@ -84,6 +86,43 @@ async def test_action_error_payload_carries_discriminated_envelope() -> None:
     parsed = ActionErrorInfoAdapter.validate_python(decoded.details[0])
     assert isinstance(parsed, ClassifiedActionErrorInfo)
     assert parsed.envelope == envelope
+
+
+def test_aggregate_action_errors_preserve_classified_children() -> None:
+    envelope = _platform_envelope()
+    child = ClassifiedActionErrorInfo(
+        ref="scatter[0]",
+        message=envelope.message,
+        type="RuntimeError",
+        envelope=envelope,
+    )
+    finalized = FinalizeGatherActivityResult(
+        result=InlineObject(data=[]),
+        errors=[child],
+    )
+
+    serialized_finalized = finalized.model_dump(mode="json")
+    parsed_finalized = FinalizeGatherActivityResult.model_validate(serialized_finalized)
+    assert serialized_finalized["errors"][0]["envelope"] == envelope.model_dump(
+        mode="json"
+    )
+    assert isinstance(parsed_finalized.errors[0], ClassifiedActionErrorInfo)
+
+    aggregate = ActionErrorInfo(
+        ref="gather",
+        message="Gather failed",
+        type="ApplicationError",
+        children=parsed_finalized.errors,
+    )
+    serialized_aggregate = ActionErrorInfoAdapter.dump_python(aggregate, mode="json")
+    parsed_aggregate = ActionErrorInfoAdapter.validate_python(serialized_aggregate)
+
+    assert serialized_aggregate["children"][0]["envelope"] == envelope.model_dump(
+        mode="json"
+    )
+    assert parsed_aggregate.children is not None
+    assert isinstance(parsed_aggregate.children[0], ClassifiedActionErrorInfo)
+    assert parsed_aggregate.children[0].envelope == envelope
 
 
 def test_legacy_action_error_is_extended_without_changing_existing_fields() -> None:

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -274,6 +274,7 @@ async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
     [
         {"legacy": "payload"},
         {"schema": "tracecat.error.v1"},
+        _user_envelope().model_dump(mode="json"),
         {"envelope": {"schema": "not-tracecat.error.v1"}},
         {
             "envelope": {
@@ -341,20 +342,22 @@ def test_wrapping_preserves_existing_classification() -> None:
     assert extract_error_envelope(wrapped) != fallback
 
 
-def test_existing_detail_classification_is_authoritative() -> None:
-    original_envelope = _user_envelope()
+def test_ambiguous_nested_envelope_does_not_override_fallback() -> None:
+    nested_envelope = _user_envelope()
     fallback = _platform_envelope()
     detail = {
-        "envelope": original_envelope.model_dump(mode="json"),
+        "envelope": nested_envelope.model_dump(mode="json"),
+        "arbitrary": "outer field",
     }
 
     error = _capture_application_error(fallback, detail)
 
-    assert error.message == original_envelope.message
-    assert error.non_retryable is True
-    assert error.type == original_envelope.kind.value
-    assert error.details == (detail,)
-    assert extract_error_envelope(error) == original_envelope
+    assert error.message == fallback.message
+    assert error.non_retryable is False
+    assert error.type == fallback.kind.value
+    assert error.details[0] == detail
+    assert error.details[1]["schema"] == "tracecat.temporal_error.v1"
+    assert extract_error_envelope(error) == fallback
 
 
 def test_exception_chain_preserves_runtime_envelope() -> None:

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -353,6 +353,26 @@ def test_payload_key_does_not_collide_without_valid_discriminator() -> None:
     assert extract_error_envelope(error) is None
 
 
+def test_action_error_detail_requires_nested_schema_discriminator() -> None:
+    error = ApplicationError(
+        "Legacy error",
+        {
+            "ref": "action",
+            "message": "Missing discriminator",
+            "type": "ValueError",
+            "envelope": {
+                "owner": "user",
+                "kind": "action.execution.failed",
+                "message": "Missing discriminator",
+                "retry_disposition": "non_retryable",
+                "cause_type": None,
+            },
+        },
+    )
+
+    assert extract_error_envelope(error) is None
+
+
 def test_wrapping_preserves_existing_classification() -> None:
     original_envelope = _user_envelope()
     fallback = _platform_envelope()

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -426,6 +426,30 @@ def test_wrapping_preserves_existing_classification() -> None:
     assert extract_error_envelope(wrapped) != fallback
 
 
+@pytest.mark.anyio
+async def test_wrapping_drops_outer_details_for_cause_classification() -> None:
+    original_envelope = _user_envelope()
+    fallback = _platform_envelope()
+    classified = _capture_application_error(original_envelope)
+    try:
+        raise ApplicationError(
+            "Outer platform failure",
+            {"diagnostic": "postgresql://user:secret@example.invalid/database"},
+        ) from classified
+    except ApplicationError as outer:
+        wrapped = _capture_wrapped_application_error(outer, fallback=fallback)
+    failure = Failure()
+
+    await DataConverter.default.encode_failure(wrapped, failure)
+
+    assert len(wrapped.details) == 1
+    assert wrapped.details[0]["schema"] == "tracecat.temporal_error.v1"
+    assert wrapped.type == original_envelope.kind.value
+    assert extract_error_envelope(wrapped) == original_envelope
+    assert "secret" not in str(failure)
+    assert "example.invalid" not in str(failure)
+
+
 def test_wrapping_unclassified_application_error_drops_original_details() -> None:
     fallback = _platform_envelope()
     original = ApplicationError(

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -23,9 +23,9 @@ from tracecat.runtime.errors import (
 )
 from tracecat.storage.object import InlineObject
 from tracecat.temporal.errors import (
-    application_error_from_envelope,
     extract_error_envelope,
-    wrap_application_error,
+    raise_application_error_from_envelope,
+    raise_wrapped_application_error,
 )
 
 
@@ -45,6 +45,30 @@ def _platform_envelope() -> ErrorEnvelope:
         message="Tracecat could not execute the workflow",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
+
+
+def _capture_application_error(
+    envelope: ErrorEnvelope,
+    *details: object,
+    next_retry_delay: timedelta | None = None,
+) -> ApplicationError:
+    with pytest.raises(ApplicationError) as exc_info:
+        raise_application_error_from_envelope(
+            envelope,
+            *details,
+            next_retry_delay=next_retry_delay,
+        )
+    return exc_info.value
+
+
+def _capture_wrapped_application_error(
+    error: BaseException,
+    *,
+    fallback: ErrorEnvelope,
+) -> ApplicationError:
+    with pytest.raises(ApplicationError) as exc_info:
+        raise_wrapped_application_error(error, fallback=fallback)
+    return exc_info.value
 
 
 @pytest.mark.anyio
@@ -72,7 +96,7 @@ async def test_action_error_payload_carries_discriminated_envelope() -> None:
         type="ValueError",
         envelope=envelope,
     )
-    error = application_error_from_envelope(envelope, error_info)
+    error = _capture_application_error(envelope, error_info)
     failure = Failure()
     await DataConverter.default.encode_failure(error, failure)
     decoded = await DataConverter.default.decode_failure(failure)
@@ -134,7 +158,7 @@ def test_legacy_action_error_is_extended_without_changing_existing_fields() -> N
     )
     legacy = ActionErrorInfoAdapter.dump_python(error_info, mode="json")
 
-    error = application_error_from_envelope(envelope, error_info)
+    error = _capture_application_error(envelope, error_info)
 
     detail = error.details[0]
     assert {key: detail[key] for key in legacy} == legacy
@@ -153,17 +177,22 @@ def test_temporal_retryability_is_derived_from_envelope(
 ) -> None:
     envelope = _user_envelope(retry_disposition)
 
-    error = application_error_from_envelope(envelope)
+    error = _capture_application_error(envelope)
 
     assert error.non_retryable is expected_non_retryable
-    assert "non_retryable" not in signature(application_error_from_envelope).parameters
-    assert "error_type" not in signature(application_error_from_envelope).parameters
+    assert (
+        "non_retryable"
+        not in signature(raise_application_error_from_envelope).parameters
+    )
+    assert (
+        "error_type" not in signature(raise_application_error_from_envelope).parameters
+    )
     assert error.type == envelope.kind.value
 
 
 def test_non_retryable_envelope_rejects_next_retry_delay() -> None:
     with pytest.raises(ValueError, match="non-retryable"):
-        application_error_from_envelope(
+        raise_application_error_from_envelope(
             _user_envelope(RetryDisposition.NON_RETRYABLE),
             next_retry_delay=timedelta(seconds=1),
         )
@@ -173,7 +202,7 @@ def test_non_action_adapter_preserves_legacy_details_in_order() -> None:
     envelope = _platform_envelope()
     legacy_details = ({"existing": "payload"}, ["second payload"])
 
-    error = application_error_from_envelope(envelope, *legacy_details)
+    error = _capture_application_error(envelope, *legacy_details)
 
     assert error.details[:2] == legacy_details
     assert len(error.details) == 3
@@ -184,7 +213,7 @@ def test_non_action_adapter_preserves_legacy_details_in_order() -> None:
 @pytest.mark.anyio
 async def test_envelope_survives_temporal_failure_serialization() -> None:
     envelope = _platform_envelope()
-    error = application_error_from_envelope(envelope, {"existing": "payload"})
+    error = _capture_application_error(envelope, {"existing": "payload"})
     failure = Failure()
 
     await DataConverter.default.encode_failure(error, failure)
@@ -199,7 +228,7 @@ async def test_envelope_survives_temporal_failure_serialization() -> None:
 @pytest.mark.anyio
 async def test_envelope_survives_wrapped_temporal_failure_serialization() -> None:
     envelope = _user_envelope()
-    original = application_error_from_envelope(envelope)
+    original = _capture_application_error(envelope)
     try:
         raise ApplicationError(
             "Outer wrapper",
@@ -225,12 +254,16 @@ async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
         retry_disposition=RetryDisposition.RETRYABLE,
         cause=sensitive,
     )
-    error = wrap_application_error(sensitive, fallback=envelope)
+    try:
+        raise sensitive
+    except RuntimeError as caught:
+        error = _capture_wrapped_application_error(caught, fallback=envelope)
     failure = Failure()
 
     await DataConverter.default.encode_failure(error, failure)
 
     serialized_failure = str(failure)
+    assert not failure.HasField("cause")
     assert "secret" not in serialized_failure
     assert "example.invalid" not in serialized_failure
     assert "RuntimeError" in serialized_failure
@@ -295,9 +328,12 @@ def test_payload_key_does_not_collide_without_valid_discriminator() -> None:
 def test_wrapping_preserves_existing_classification() -> None:
     original_envelope = _user_envelope()
     fallback = _platform_envelope()
-    original = application_error_from_envelope(original_envelope, {"legacy": "payload"})
+    original = _capture_application_error(
+        original_envelope,
+        {"legacy": "payload"},
+    )
 
-    wrapped = wrap_application_error(original, fallback=fallback)
+    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
 
     assert wrapped.type == original_envelope.kind.value
     assert wrapped.details == original.details
@@ -312,7 +348,7 @@ def test_existing_detail_classification_is_authoritative() -> None:
         "envelope": original_envelope.model_dump(mode="json"),
     }
 
-    error = application_error_from_envelope(fallback, detail)
+    error = _capture_application_error(fallback, detail)
 
     assert error.message == original_envelope.message
     assert error.non_retryable is True

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -98,8 +98,9 @@ async def test_action_error_payload_carries_discriminated_envelope() -> None:
     )
     error = _capture_application_error(envelope, error_info)
     failure = Failure()
-    await DataConverter.default.encode_failure(error, failure)
-    decoded = await DataConverter.default.decode_failure(failure)
+    data_converter = get_data_converter()
+    await data_converter.encode_failure(error, failure)
+    decoded = await data_converter.decode_failure(failure)
 
     assert len(error.details) == 1
     assert error.type == RuntimeErrorKind.ACTION_EXECUTION_FAILED.value

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from inspect import signature
+
+import pytest
+from temporalio.api.failure.v1 import Failure
+from temporalio.converter import DataConverter
+from temporalio.exceptions import ApplicationError
+
+from tracecat.dsl.types import (
+    ActionErrorInfo,
+    ActionErrorInfoAdapter,
+    ClassifiedActionErrorInfo,
+)
+from tracecat.runtime.errors import (
+    ErrorEnvelope,
+    RetryDisposition,
+    RuntimeErrorCode,
+    RuntimeErrorOwner,
+    TracecatRuntimeError,
+)
+from tracecat.temporal.errors import (
+    application_error_from_envelope,
+    extract_error_envelope,
+    wrap_application_error,
+)
+
+
+def _user_envelope(
+    retry_disposition: RetryDisposition = RetryDisposition.NON_RETRYABLE,
+) -> ErrorEnvelope:
+    return ErrorEnvelope.user(
+        code=RuntimeErrorCode.USER_ACTION_FAILED,
+        message="The action failed",
+        retry_disposition=retry_disposition,
+    )
+
+
+def _platform_envelope() -> ErrorEnvelope:
+    return ErrorEnvelope.platform(
+        code=RuntimeErrorCode.PLATFORM_UNCLASSIFIED,
+        message="Tracecat could not execute the workflow",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+
+
+@pytest.mark.anyio
+async def test_legacy_action_error_payload_is_unchanged_without_envelope() -> None:
+    error_info = ActionErrorInfo(ref="action", message="Failed", type="ValueError")
+
+    serialized = ActionErrorInfoAdapter.dump_python(error_info, mode="json")
+    failure = Failure()
+    await DataConverter.default.encode_failure(
+        ApplicationError("Failed", error_info), failure
+    )
+    decoded = await DataConverter.default.decode_failure(failure)
+
+    assert "envelope" not in serialized
+    assert isinstance(decoded, ApplicationError)
+    assert "envelope" not in decoded.details[0]
+
+
+@pytest.mark.anyio
+async def test_action_error_payload_carries_discriminated_envelope() -> None:
+    envelope = _user_envelope()
+    error_info = ClassifiedActionErrorInfo(
+        ref="action",
+        message="The action failed",
+        type="ValueError",
+        envelope=envelope,
+    )
+    error = application_error_from_envelope(
+        envelope, error_info, error_type="ValueError"
+    )
+    failure = Failure()
+    await DataConverter.default.encode_failure(error, failure)
+    decoded = await DataConverter.default.decode_failure(failure)
+
+    assert len(error.details) == 1
+    assert error.details[0]["envelope"]["schema"] == "tracecat.error.v1"
+    assert extract_error_envelope(error) == envelope
+    assert extract_error_envelope(decoded) == envelope
+    assert isinstance(decoded, ApplicationError)
+    parsed = ActionErrorInfoAdapter.validate_python(decoded.details[0])
+    assert isinstance(parsed, ClassifiedActionErrorInfo)
+    assert parsed.envelope == envelope
+
+
+def test_legacy_action_error_is_extended_without_changing_existing_fields() -> None:
+    envelope = _user_envelope()
+    error_info = ActionErrorInfo(
+        ref="action",
+        message="The action failed",
+        type="ValueError",
+    )
+    legacy = ActionErrorInfoAdapter.dump_python(error_info, mode="json")
+
+    error = application_error_from_envelope(envelope, error_info)
+
+    detail = error.details[0]
+    assert {key: detail[key] for key in legacy} == legacy
+    assert detail["envelope"] == envelope.model_dump(mode="json")
+
+
+@pytest.mark.parametrize(
+    ("retry_disposition", "expected_non_retryable"),
+    [
+        (RetryDisposition.RETRYABLE, False),
+        (RetryDisposition.NON_RETRYABLE, True),
+    ],
+)
+def test_temporal_retryability_is_derived_from_envelope(
+    retry_disposition: RetryDisposition, expected_non_retryable: bool
+) -> None:
+    envelope = _user_envelope(retry_disposition)
+
+    error = application_error_from_envelope(envelope)
+
+    assert error.non_retryable is expected_non_retryable
+    assert "non_retryable" not in signature(application_error_from_envelope).parameters
+
+
+def test_non_retryable_envelope_rejects_next_retry_delay() -> None:
+    with pytest.raises(ValueError, match="non-retryable"):
+        application_error_from_envelope(
+            _user_envelope(RetryDisposition.NON_RETRYABLE),
+            next_retry_delay=timedelta(seconds=1),
+        )
+
+
+def test_non_action_adapter_preserves_legacy_details_in_order() -> None:
+    envelope = _platform_envelope()
+    legacy_details = ({"existing": "payload"}, ["second payload"])
+
+    error = application_error_from_envelope(
+        envelope, *legacy_details, error_type="PlatformFailure"
+    )
+
+    assert error.details[:2] == legacy_details
+    assert len(error.details) == 3
+    assert extract_error_envelope(error) == envelope
+
+
+@pytest.mark.anyio
+async def test_envelope_survives_temporal_failure_serialization() -> None:
+    envelope = _platform_envelope()
+    error = application_error_from_envelope(
+        envelope, {"existing": "payload"}, error_type="PlatformFailure"
+    )
+    failure = Failure()
+
+    await DataConverter.default.encode_failure(error, failure)
+    decoded = await DataConverter.default.decode_failure(failure)
+
+    assert isinstance(decoded, ApplicationError)
+    assert decoded.details[0] == {"existing": "payload"}
+    assert decoded.non_retryable is False
+    assert extract_error_envelope(decoded) == envelope
+
+
+@pytest.mark.anyio
+async def test_envelope_survives_wrapped_temporal_failure_serialization() -> None:
+    envelope = _user_envelope()
+    original = application_error_from_envelope(envelope, error_type="OriginalError")
+    try:
+        raise ApplicationError(
+            "Outer wrapper",
+            {"legacy": "payload"},
+            type="OuterError",
+            non_retryable=True,
+        ) from original
+    except ApplicationError as wrapped:
+        failure = Failure()
+        await DataConverter.default.encode_failure(wrapped, failure)
+
+    decoded = await DataConverter.default.decode_failure(failure)
+
+    assert extract_error_envelope(decoded) == envelope
+
+
+@pytest.mark.anyio
+async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
+    sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
+    envelope = ErrorEnvelope.platform(
+        code=RuntimeErrorCode.PLATFORM_DEPENDENCY_UNAVAILABLE,
+        message="A platform dependency is unavailable",
+        retry_disposition=RetryDisposition.RETRYABLE,
+        cause=sensitive,
+    )
+    error = wrap_application_error(sensitive, fallback=envelope)
+    failure = Failure()
+
+    await DataConverter.default.encode_failure(error, failure)
+
+    serialized_failure = str(failure)
+    assert "secret" not in serialized_failure
+    assert "example.invalid" not in serialized_failure
+    assert "RuntimeError" in serialized_failure
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        {"legacy": "payload"},
+        {"schema": "tracecat.error.v1"},
+        {"envelope": {"schema": "not-tracecat.error.v1"}},
+        {
+            "envelope": {
+                "owner": "user",
+                "code": "user.action.failed",
+                "message": "Missing discriminator",
+                "retry_disposition": "non_retryable",
+                "cause_type": None,
+            }
+        },
+        {
+            "schema": "tracecat.temporal_error.v1",
+            "envelope": {"schema": "tracecat.error.v1"},
+        },
+        {
+            "schema": "tracecat.temporal_error.v1",
+            "envelope": {
+                "owner": "user",
+                "code": "user.action.failed",
+                "message": "Missing discriminator",
+                "retry_disposition": "non_retryable",
+                "cause_type": None,
+            },
+        },
+        {
+            "schema": "tracecat.temporal_error.v1",
+            "envelope": _user_envelope().model_dump(mode="json"),
+            "unexpected": True,
+        },
+    ],
+)
+def test_legacy_and_malformed_details_are_not_classified(detail: object) -> None:
+    error = ApplicationError("Legacy error", detail)
+
+    assert extract_error_envelope(error) is None
+
+
+def test_payload_key_does_not_collide_without_valid_discriminator() -> None:
+    error = ApplicationError(
+        "User payload",
+        {
+            "ref": "envelope",
+            "message": "User-authored payload",
+            "type": "Example",
+            "envelope": {"schema": "customer.payload.v1"},
+        },
+    )
+
+    assert extract_error_envelope(error) is None
+
+
+def test_wrapping_preserves_existing_classification() -> None:
+    original_envelope = _user_envelope()
+    fallback = _platform_envelope()
+    original = application_error_from_envelope(
+        original_envelope, {"legacy": "payload"}, error_type="OriginalError"
+    )
+
+    wrapped = wrap_application_error(original, fallback=fallback)
+
+    assert wrapped.type == "OriginalError"
+    assert wrapped.details == original.details
+    assert extract_error_envelope(wrapped) == original_envelope
+    assert extract_error_envelope(wrapped) != fallback
+
+
+def test_existing_detail_classification_is_authoritative() -> None:
+    original_envelope = _user_envelope()
+    fallback = _platform_envelope()
+    detail = {
+        "envelope": original_envelope.model_dump(mode="json"),
+    }
+
+    error = application_error_from_envelope(fallback, detail)
+
+    assert error.message == original_envelope.message
+    assert error.non_retryable is True
+    assert error.details == (detail,)
+    assert extract_error_envelope(error) == original_envelope
+
+
+def test_exception_chain_preserves_runtime_envelope() -> None:
+    envelope = _user_envelope()
+    classified = TracecatRuntimeError(envelope)
+
+    try:
+        raise RuntimeError("Outer wrapper") from classified
+    except RuntimeError as error:
+        assert extract_error_envelope(error) == envelope
+
+
+def test_error_owners_remain_attribution_only() -> None:
+    assert set(RuntimeErrorOwner) == {
+        RuntimeErrorOwner.USER,
+        RuntimeErrorOwner.PLATFORM,
+    }

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -16,7 +16,7 @@ from tracecat.dsl.types import (
 from tracecat.runtime.errors import (
     ErrorEnvelope,
     RetryDisposition,
-    RuntimeErrorCode,
+    RuntimeErrorKind,
     RuntimeErrorOwner,
     TracecatRuntimeError,
 )
@@ -31,7 +31,7 @@ def _user_envelope(
     retry_disposition: RetryDisposition = RetryDisposition.NON_RETRYABLE,
 ) -> ErrorEnvelope:
     return ErrorEnvelope.user(
-        code=RuntimeErrorCode.USER_ACTION_FAILED,
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=retry_disposition,
     )
@@ -39,7 +39,7 @@ def _user_envelope(
 
 def _platform_envelope() -> ErrorEnvelope:
     return ErrorEnvelope.platform(
-        code=RuntimeErrorCode.PLATFORM_UNCLASSIFIED,
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the workflow",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
@@ -70,14 +70,13 @@ async def test_action_error_payload_carries_discriminated_envelope() -> None:
         type="ValueError",
         envelope=envelope,
     )
-    error = application_error_from_envelope(
-        envelope, error_info, error_type="ValueError"
-    )
+    error = application_error_from_envelope(envelope, error_info)
     failure = Failure()
     await DataConverter.default.encode_failure(error, failure)
     decoded = await DataConverter.default.decode_failure(failure)
 
     assert len(error.details) == 1
+    assert error.type == RuntimeErrorKind.ACTION_EXECUTION_FAILED.value
     assert error.details[0]["envelope"]["schema"] == "tracecat.error.v1"
     assert extract_error_envelope(error) == envelope
     assert extract_error_envelope(decoded) == envelope
@@ -119,6 +118,8 @@ def test_temporal_retryability_is_derived_from_envelope(
 
     assert error.non_retryable is expected_non_retryable
     assert "non_retryable" not in signature(application_error_from_envelope).parameters
+    assert "error_type" not in signature(application_error_from_envelope).parameters
+    assert error.type == envelope.kind.value
 
 
 def test_non_retryable_envelope_rejects_next_retry_delay() -> None:
@@ -133,21 +134,18 @@ def test_non_action_adapter_preserves_legacy_details_in_order() -> None:
     envelope = _platform_envelope()
     legacy_details = ({"existing": "payload"}, ["second payload"])
 
-    error = application_error_from_envelope(
-        envelope, *legacy_details, error_type="PlatformFailure"
-    )
+    error = application_error_from_envelope(envelope, *legacy_details)
 
     assert error.details[:2] == legacy_details
     assert len(error.details) == 3
+    assert error.type == envelope.kind.value
     assert extract_error_envelope(error) == envelope
 
 
 @pytest.mark.anyio
 async def test_envelope_survives_temporal_failure_serialization() -> None:
     envelope = _platform_envelope()
-    error = application_error_from_envelope(
-        envelope, {"existing": "payload"}, error_type="PlatformFailure"
-    )
+    error = application_error_from_envelope(envelope, {"existing": "payload"})
     failure = Failure()
 
     await DataConverter.default.encode_failure(error, failure)
@@ -162,7 +160,7 @@ async def test_envelope_survives_temporal_failure_serialization() -> None:
 @pytest.mark.anyio
 async def test_envelope_survives_wrapped_temporal_failure_serialization() -> None:
     envelope = _user_envelope()
-    original = application_error_from_envelope(envelope, error_type="OriginalError")
+    original = application_error_from_envelope(envelope)
     try:
         raise ApplicationError(
             "Outer wrapper",
@@ -183,7 +181,7 @@ async def test_envelope_survives_wrapped_temporal_failure_serialization() -> Non
 async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
     sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
     envelope = ErrorEnvelope.platform(
-        code=RuntimeErrorCode.PLATFORM_DEPENDENCY_UNAVAILABLE,
+        kind=RuntimeErrorKind.STORAGE_MATERIALIZATION_TRANSPORT_UNAVAILABLE,
         message="A platform dependency is unavailable",
         retry_disposition=RetryDisposition.RETRYABLE,
         cause=sensitive,
@@ -208,7 +206,7 @@ async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
         {
             "envelope": {
                 "owner": "user",
-                "code": "user.action.failed",
+                "kind": "action.execution.failed",
                 "message": "Missing discriminator",
                 "retry_disposition": "non_retryable",
                 "cause_type": None,
@@ -222,7 +220,7 @@ async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
             "schema": "tracecat.temporal_error.v1",
             "envelope": {
                 "owner": "user",
-                "code": "user.action.failed",
+                "kind": "action.execution.failed",
                 "message": "Missing discriminator",
                 "retry_disposition": "non_retryable",
                 "cause_type": None,
@@ -258,13 +256,11 @@ def test_payload_key_does_not_collide_without_valid_discriminator() -> None:
 def test_wrapping_preserves_existing_classification() -> None:
     original_envelope = _user_envelope()
     fallback = _platform_envelope()
-    original = application_error_from_envelope(
-        original_envelope, {"legacy": "payload"}, error_type="OriginalError"
-    )
+    original = application_error_from_envelope(original_envelope, {"legacy": "payload"})
 
     wrapped = wrap_application_error(original, fallback=fallback)
 
-    assert wrapped.type == "OriginalError"
+    assert wrapped.type == original_envelope.kind.value
     assert wrapped.details == original.details
     assert extract_error_envelope(wrapped) == original_envelope
     assert extract_error_envelope(wrapped) != fallback
@@ -281,6 +277,7 @@ def test_existing_detail_classification_is_authoritative() -> None:
 
     assert error.message == original_envelope.message
     assert error.non_retryable is True
+    assert error.type == original_envelope.kind.value
     assert error.details == (detail,)
     assert extract_error_envelope(error) == original_envelope
 

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -9,6 +9,7 @@ from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
 
+from tracecat.dsl._converter import get_data_converter
 from tracecat.dsl.action import FinalizeGatherActivityResult
 from tracecat.dsl.types import (
     ActionErrorInfo,
@@ -80,14 +81,13 @@ async def test_legacy_action_error_payload_is_unchanged_without_envelope() -> No
 
     serialized = ActionErrorInfoAdapter.dump_python(error_info, mode="json")
     failure = Failure()
-    await DataConverter.default.encode_failure(
-        ApplicationError("Failed", error_info), failure
-    )
-    decoded = await DataConverter.default.decode_failure(failure)
+    data_converter = get_data_converter()
+    await data_converter.encode_failure(ApplicationError("Failed", error_info), failure)
+    decoded = await data_converter.decode_failure(failure)
 
     assert "envelope" not in serialized
     assert isinstance(decoded, ApplicationError)
-    assert "envelope" not in decoded.details[0]
+    assert decoded.details[0] == serialized
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from inspect import signature
 
 import pytest
+from pydantic import TypeAdapter
 from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
@@ -12,8 +13,8 @@ from tracecat.dsl.action import FinalizeGatherActivityResult
 from tracecat.dsl.types import (
     ActionErrorInfo,
     ActionErrorInfoAdapter,
-    ClassifiedActionErrorInfo,
 )
+from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.runtime.errors import (
     ErrorEnvelope,
     RetryDisposition,
@@ -27,6 +28,8 @@ from tracecat.temporal.errors import (
     raise_application_error_from_envelope,
     raise_wrapped_application_error,
 )
+from tracecat.workflow.executions.enums import TriggerType
+from tracecat.workflow.executions.types import ErrorHandlerWorkflowInput
 
 
 def _user_envelope(
@@ -90,7 +93,7 @@ async def test_legacy_action_error_payload_is_unchanged_without_envelope() -> No
 @pytest.mark.anyio
 async def test_action_error_payload_carries_discriminated_envelope() -> None:
     envelope = _user_envelope()
-    error_info = ClassifiedActionErrorInfo(
+    error_info = ActionErrorInfo(
         ref="action",
         message="The action failed",
         type="ValueError",
@@ -108,13 +111,12 @@ async def test_action_error_payload_carries_discriminated_envelope() -> None:
     assert extract_error_envelope(decoded) == envelope
     assert isinstance(decoded, ApplicationError)
     parsed = ActionErrorInfoAdapter.validate_python(decoded.details[0])
-    assert isinstance(parsed, ClassifiedActionErrorInfo)
     assert parsed.envelope == envelope
 
 
 def test_aggregate_action_errors_preserve_classified_children() -> None:
     envelope = _platform_envelope()
-    child = ClassifiedActionErrorInfo(
+    child = ActionErrorInfo(
         ref="scatter[0]",
         message=envelope.message,
         type="RuntimeError",
@@ -130,7 +132,7 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
     assert serialized_finalized["errors"][0]["envelope"] == envelope.model_dump(
         mode="json"
     )
-    assert isinstance(parsed_finalized.errors[0], ClassifiedActionErrorInfo)
+    assert parsed_finalized.errors[0].envelope == envelope
 
     aggregate = ActionErrorInfo(
         ref="gather",
@@ -145,8 +147,35 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
         mode="json"
     )
     assert parsed_aggregate.children is not None
-    assert isinstance(parsed_aggregate.children[0], ClassifiedActionErrorInfo)
     assert parsed_aggregate.children[0].envelope == envelope
+
+
+def test_error_handler_input_preserves_action_error_envelope() -> None:
+    envelope = _platform_envelope()
+    error_info = ActionErrorInfo(
+        ref="action",
+        message=envelope.message,
+        type="RuntimeError",
+        envelope=envelope,
+    )
+    handler_wf_id = WorkflowUUID.new_uuid4()
+    orig_wf_id = WorkflowUUID.new_uuid4()
+    handler_input = ErrorHandlerWorkflowInput(
+        message="Workflow failed",
+        handler_wf_id=handler_wf_id,
+        orig_wf_id=orig_wf_id,
+        orig_wf_exec_id=generate_exec_id(orig_wf_id),
+        orig_wf_title="Synthetic workflow",
+        trigger_type=TriggerType.MANUAL,
+        errors=[error_info],
+    )
+
+    serialized = TypeAdapter(ErrorHandlerWorkflowInput).dump_python(
+        handler_input,
+        mode="json",
+    )
+
+    assert serialized["errors"][0]["envelope"] == envelope.model_dump(mode="json")
 
 
 def test_legacy_action_error_is_extended_without_changing_existing_fields() -> None:

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -39,7 +39,6 @@ from tracecat.dsl.schemas import (
 from tracecat.dsl.types import (
     ActionErrorInfo,
     ActionErrorInfoAdapter,
-    ActionErrorInfoVariant,
 )
 from tracecat.dsl.validation import normalize_trigger_inputs
 from tracecat.exceptions import TracecatExpressionError, TracecatValidationError
@@ -197,7 +196,7 @@ class FinalizeGatherActivityInput(BaseModel):
 class FinalizeGatherActivityResult(BaseModel):
     result: StoredObject
     """Result collection. CollectionObject if externalized, else InlineObject."""
-    errors: list[ActionErrorInfoVariant] = Field(default_factory=list)
+    errors: list[ActionErrorInfo] = Field(default_factory=list)
 
 
 class BuildAgentArgsActivityInput(BaseModel):
@@ -656,7 +655,7 @@ class DSLActivities:
             values = [v for v in values if v is not None]
 
         results: list[Any] = []
-        errors: list[ActionErrorInfoVariant] = []
+        errors: list[ActionErrorInfo] = []
         match input.error_strategy:
             case StreamErrorHandlingStrategy.PARTITION:
                 results, errors = _partition_errors(values)
@@ -865,9 +864,9 @@ def _patch_object(
 
 def _partition_errors(
     items: list[Any],
-) -> tuple[list[Any], list[ActionErrorInfoVariant]]:
+) -> tuple[list[Any], list[ActionErrorInfo]]:
     results: list[Any] = []
-    errors: list[ActionErrorInfoVariant] = []
+    errors: list[ActionErrorInfo] = []
     for item in items:
         if info := _as_error_info(item):
             errors.append(info)
@@ -888,7 +887,7 @@ def _is_error_info(detail: Any) -> bool:
         return False
 
 
-def _as_error_info(detail: Any) -> ActionErrorInfoVariant | None:
+def _as_error_info(detail: Any) -> ActionErrorInfo | None:
     try:
         return ActionErrorInfoAdapter.validate_python(detail)
     except Exception:

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -36,7 +36,11 @@ from tracecat.dsl.schemas import (
     StreamID,
     TaskResult,
 )
-from tracecat.dsl.types import ActionErrorInfo, ActionErrorInfoAdapter
+from tracecat.dsl.types import (
+    ActionErrorInfo,
+    ActionErrorInfoAdapter,
+    ActionErrorInfoVariant,
+)
 from tracecat.dsl.validation import normalize_trigger_inputs
 from tracecat.exceptions import TracecatExpressionError, TracecatValidationError
 from tracecat.executor.service import get_workspace_variables
@@ -193,7 +197,7 @@ class FinalizeGatherActivityInput(BaseModel):
 class FinalizeGatherActivityResult(BaseModel):
     result: StoredObject
     """Result collection. CollectionObject if externalized, else InlineObject."""
-    errors: list[ActionErrorInfo] = Field(default_factory=list)
+    errors: list[ActionErrorInfoVariant] = Field(default_factory=list)
 
 
 class BuildAgentArgsActivityInput(BaseModel):
@@ -652,7 +656,7 @@ class DSLActivities:
             values = [v for v in values if v is not None]
 
         results: list[Any] = []
-        errors: list[ActionErrorInfo] = []
+        errors: list[ActionErrorInfoVariant] = []
         match input.error_strategy:
             case StreamErrorHandlingStrategy.PARTITION:
                 results, errors = _partition_errors(values)
@@ -859,9 +863,11 @@ def _patch_object(
     current[leaf] = value
 
 
-def _partition_errors(items: list[Any]) -> tuple[list[Any], list[ActionErrorInfo]]:
+def _partition_errors(
+    items: list[Any],
+) -> tuple[list[Any], list[ActionErrorInfoVariant]]:
     results: list[Any] = []
-    errors: list[ActionErrorInfo] = []
+    errors: list[ActionErrorInfoVariant] = []
     for item in items:
         if info := _as_error_info(item):
             errors.append(info)
@@ -882,7 +888,7 @@ def _is_error_info(detail: Any) -> bool:
         return False
 
 
-def _as_error_info(detail: Any) -> ActionErrorInfo | None:
+def _as_error_info(detail: Any) -> ActionErrorInfoVariant | None:
     try:
         return ActionErrorInfoAdapter.validate_python(detail)
     except Exception:

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -36,10 +36,7 @@ from tracecat.dsl.schemas import (
     StreamID,
     TaskResult,
 )
-from tracecat.dsl.types import (
-    ActionErrorInfo,
-    ActionErrorInfoAdapter,
-)
+from tracecat.dsl.types import ActionErrorInfo
 from tracecat.dsl.validation import normalize_trigger_inputs
 from tracecat.exceptions import TracecatExpressionError, TracecatValidationError
 from tracecat.executor.service import get_workspace_variables
@@ -881,7 +878,7 @@ def _is_error_info(detail: Any) -> bool:
     if not isinstance(detail, Mapping):
         return False
     try:
-        ActionErrorInfoAdapter.validate_python(detail)
+        ActionErrorInfo.model_validate(detail)
         return True
     except Exception:
         return False
@@ -889,7 +886,7 @@ def _is_error_info(detail: Any) -> bool:
 
 def _as_error_info(detail: Any) -> ActionErrorInfo | None:
     try:
-        return ActionErrorInfoAdapter.validate_python(detail)
+        return ActionErrorInfo.model_validate(detail)
     except Exception:
         return None
 

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any
@@ -17,6 +17,7 @@ _SCHEDULER_TASK_SPAWN_YIELD_EVERY = 16
 """Yield while spawning ready task coroutines to avoid long workflow activations."""
 
 with workflow.unsafe.imports_passed_through():
+    from pydantic import ValidationError
     from pydantic_core import to_json
     from temporalio.exceptions import ApplicationError
 
@@ -63,6 +64,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.exceptions import TaskUnreachable
     from tracecat.expressions.common import ExprContext
     from tracecat.expressions.core import extract_expressions
+    from tracecat.runtime.errors import ErrorEnvelope
     from tracecat.storage.object import (
         CollectionObject,
         InlineObject,
@@ -103,12 +105,9 @@ def _classified_action_error_info(
         return None
 
     for detail in error.details:
-        try:
-            parsed = ActionErrorInfo.model_validate(detail)
-        except Exception:
-            continue
-        if parsed.envelope is not None:
-            return parsed
+        for parsed in _validated_action_error_infos(detail):
+            if _action_error_contains_envelope(parsed, envelope):
+                return parsed
 
     return ActionErrorInfo(
         ref=ref,
@@ -116,6 +115,40 @@ def _classified_action_error_info(
         type=error.type or error.__class__.__name__,
         stream_id=stream_id,
         envelope=envelope,
+    )
+
+
+def _validated_action_error_infos(detail: object) -> tuple[ActionErrorInfo, ...]:
+    """Validate a direct action error or the established child-error map shape."""
+    try:
+        return (ActionErrorInfo.model_validate(detail),)
+    except ValidationError:
+        pass
+
+    if not isinstance(detail, Mapping):
+        return ()
+
+    parsed: list[ActionErrorInfo] = []
+    for ref, value in detail.items():
+        if not isinstance(ref, str):
+            return ()
+        try:
+            parsed.append(ActionErrorInfo.model_validate(value))
+        except ValidationError:
+            return ()
+    return tuple(parsed)
+
+
+def _action_error_contains_envelope(
+    detail: ActionErrorInfo,
+    envelope: ErrorEnvelope,
+) -> bool:
+    """Return whether an action error directly or transitively carries an envelope."""
+    if detail.envelope == envelope:
+        return True
+    return any(
+        _action_error_contains_envelope(child, envelope)
+        for child in detail.children or ()
     )
 
 

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -478,7 +478,7 @@ class DSLScheduler:
                     # it's of shape ActionErrorInfo()
                     try:
                         # This is normal action error
-                        details = ActionErrorInfo(**details)
+                        details = ActionErrorInfoAdapter.validate_python(details)
                     except Exception as e:
                         self.logger.info(
                             "Failed to parse regular application error details",
@@ -509,7 +509,7 @@ class DSLScheduler:
                     # try get the first element
                     try:
                         val = list(details.values())[0]
-                        details = ActionErrorInfo(**val)
+                        details = ActionErrorInfoAdapter.validate_python(val)
                     except Exception as e:
                         self.logger.info(
                             "Failed to parse child wf application error details",

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -56,7 +56,6 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.dsl.types import (
         ActionErrorInfo,
-        ActionErrorInfoAdapter,
         Task,
         TaskExceptionInfo,
     )
@@ -105,7 +104,7 @@ def _classified_action_error_info(
 
     for detail in error.details:
         try:
-            parsed = ActionErrorInfoAdapter.validate_python(detail)
+            parsed = ActionErrorInfo.model_validate(detail)
         except Exception:
             continue
         if parsed.envelope is not None:
@@ -515,7 +514,7 @@ class DSLScheduler:
                     # it's of shape ActionErrorInfo()
                     try:
                         # This is normal action error
-                        details = ActionErrorInfoAdapter.validate_python(details)
+                        details = ActionErrorInfo.model_validate(details)
                     except Exception as e:
                         self.logger.info(
                             "Failed to parse regular application error details",
@@ -546,7 +545,7 @@ class DSLScheduler:
                     # try get the first element
                     try:
                         val = list(details.values())[0]
-                        details = ActionErrorInfoAdapter.validate_python(val)
+                        details = ActionErrorInfo.model_validate(val)
                     except Exception as e:
                         self.logger.info(
                             "Failed to parse child wf application error details",
@@ -1289,7 +1288,7 @@ class DSLScheduler:
             # Do not pass the full object as some exceptions aren't serializable
             # Access the raw list via get_data() and modify in place
             parent_action_context[gather_ref].get_data()[stream_idx] = InlineObject(
-                data=ActionErrorInfoAdapter.dump_python(err_info.details)
+                data=err_info.details.model_dump()
             )
             self.logger.debug("Set error object as result", task=task)
         else:
@@ -1606,7 +1605,7 @@ class DSLScheduler:
             )
             app_error = ApplicationError(
                 message,
-                {gather_ref: ActionErrorInfoAdapter.dump_python(gather_error)},
+                {gather_ref: gather_error.model_dump()},
                 non_retryable=True,
             )
             self.logger.warning(

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -57,6 +57,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.types import (
         ActionErrorInfo,
         ActionErrorInfoAdapter,
+        ClassifiedActionErrorInfo,
         Task,
         TaskExceptionInfo,
     )
@@ -72,6 +73,7 @@ with workflow.unsafe.imports_passed_through():
         action_collection_prefix,
         action_key,
     )
+    from tracecat.temporal.errors import extract_error_envelope
 
 
 def _get_collection_size(stored: StoredObject) -> int:
@@ -89,6 +91,34 @@ def _get_collection_size(stored: StoredObject) -> int:
                 f"Expected CollectionObject or InlineObject with list data, "
                 f"got {type(stored).__name__}"
             )
+
+
+def _classified_action_error_info(
+    error: ApplicationError,
+    *,
+    ref: str,
+    stream_id: StreamID,
+) -> ClassifiedActionErrorInfo | None:
+    """Adapt a classified activity failure into the scheduler error shape."""
+    envelope = extract_error_envelope(error)
+    if envelope is None:
+        return None
+
+    for detail in error.details:
+        try:
+            parsed = ActionErrorInfoAdapter.validate_python(detail)
+        except Exception:
+            continue
+        if isinstance(parsed, ClassifiedActionErrorInfo):
+            return parsed
+
+    return ClassifiedActionErrorInfo(
+        ref=ref,
+        message=envelope.message,
+        type=error.type or error.__class__.__name__,
+        stream_id=stream_id,
+        envelope=envelope,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -443,7 +473,15 @@ class DSLScheduler:
                 self.logger.info("Task failed with no error paths", task=task)
             # XXX: This can sometimes return null because the exception isn't an ApplicationError
             # But rather a ChildWorkflowError or CancelledError
-            if isinstance(exc, ApplicationError) and exc.details:
+            if isinstance(exc, ApplicationError) and (
+                classified_details := _classified_action_error_info(
+                    exc,
+                    ref=ref,
+                    stream_id=task.stream_id,
+                )
+            ):
+                details = classified_details
+            elif isinstance(exc, ApplicationError) and exc.details:
                 self.logger.info(
                     "Task failed with application error",
                     ref=ref,

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -57,7 +57,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.types import (
         ActionErrorInfo,
         ActionErrorInfoAdapter,
-        ClassifiedActionErrorInfo,
         Task,
         TaskExceptionInfo,
     )
@@ -98,7 +97,7 @@ def _classified_action_error_info(
     *,
     ref: str,
     stream_id: StreamID,
-) -> ClassifiedActionErrorInfo | None:
+) -> ActionErrorInfo | None:
     """Adapt a classified activity failure into the scheduler error shape."""
     envelope = extract_error_envelope(error)
     if envelope is None:
@@ -109,10 +108,10 @@ def _classified_action_error_info(
             parsed = ActionErrorInfoAdapter.validate_python(detail)
         except Exception:
             continue
-        if isinstance(parsed, ClassifiedActionErrorInfo):
+        if parsed.envelope is not None:
             return parsed
 
-    return ClassifiedActionErrorInfo(
+    return ActionErrorInfo(
         ref=ref,
         message=envelope.message,
         type=error.type or error.__class__.__name__,

--- a/tracecat/dsl/types.py
+++ b/tracecat/dsl/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
-from pydantic import ConfigDict, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from tracecat.expressions.common import ExprContext
 from tracecat.runtime.errors import ErrorEnvelope
@@ -52,32 +52,26 @@ class Task:
     delay: float = field(default=0.0, compare=False)
 
 
-@dataclass(frozen=True, slots=True)
-class ActionErrorInfo:
+class ActionErrorInfo(BaseModel):
     """Contains information about an action error."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     ref: str
     message: str
     type: str
     expr_context: ExprContext = ExprContext.ACTIONS
     attempt: int = 1
-    stream_id: StreamID = field(default_factory=_root_stream_factory)
-    children: list[ActionErrorInfoVariant] | None = None
+    stream_id: StreamID = Field(default_factory=_root_stream_factory)
+    children: list[ActionErrorInfo] | None = None
+    envelope: ErrorEnvelope | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
 
     def format(self, loc: str = "run_action") -> str:
         locator = f"{self.expr_context}.{self.ref} -> {loc}"
         return f"[{locator}] (Attempt {self.attempt})\n\n{self.message}"
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
-class ClassifiedActionErrorInfo(ActionErrorInfo):
-    """Action error carrying the optional runtime classification extension."""
-
-    envelope: ErrorEnvelope
-
-
-type ActionErrorInfoVariant = ClassifiedActionErrorInfo | ActionErrorInfo
-ActionErrorInfoAdapter: TypeAdapter[ActionErrorInfoVariant] = TypeAdapter(
-    ActionErrorInfoVariant,
-    config=ConfigDict(extra="forbid"),
-)
+ActionErrorInfoAdapter: TypeAdapter[ActionErrorInfo] = TypeAdapter(ActionErrorInfo)

--- a/tracecat/dsl/types.py
+++ b/tracecat/dsl/types.py
@@ -62,7 +62,7 @@ class ActionErrorInfo:
     expr_context: ExprContext = ExprContext.ACTIONS
     attempt: int = 1
     stream_id: StreamID = field(default_factory=_root_stream_factory)
-    children: list[ActionErrorInfo] | None = None
+    children: list[ActionErrorInfoVariant] | None = None
 
     def format(self, loc: str = "run_action") -> str:
         locator = f"{self.expr_context}.{self.ref} -> {loc}"

--- a/tracecat/dsl/types.py
+++ b/tracecat/dsl/types.py
@@ -69,6 +69,13 @@ class ActionErrorInfo(BaseModel):
         exclude_if=lambda value: value is None,
     )
 
+    def model_post_init(self, context: Any, /) -> None:
+        """Preserve the pre-envelope Temporal wire shape for defaulted fields."""
+        del context
+        self.__pydantic_fields_set__.update(
+            {"expr_context", "attempt", "stream_id", "children"}
+        )
+
     def format(self, loc: str = "run_action") -> str:
         locator = f"{self.expr_context}.{self.ref} -> {loc}"
         return f"[{locator}] (Attempt {self.attempt})\n\n{self.message}"

--- a/tracecat/dsl/types.py
+++ b/tracecat/dsl/types.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
-from pydantic import TypeAdapter
+from pydantic import ConfigDict, TypeAdapter
 
 from tracecat.expressions.common import ExprContext
+from tracecat.runtime.errors import ErrorEnvelope
 
 
 class ActionEdge(TypedDict):
@@ -68,4 +69,15 @@ class ActionErrorInfo:
         return f"[{locator}] (Attempt {self.attempt})\n\n{self.message}"
 
 
-ActionErrorInfoAdapter = TypeAdapter(ActionErrorInfo)
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ClassifiedActionErrorInfo(ActionErrorInfo):
+    """Action error carrying the optional runtime classification extension."""
+
+    envelope: ErrorEnvelope
+
+
+type ActionErrorInfoVariant = ClassifiedActionErrorInfo | ActionErrorInfo
+ActionErrorInfoAdapter: TypeAdapter[ActionErrorInfoVariant] = TypeAdapter(
+    ActionErrorInfoVariant,
+    config=ConfigDict(extra="forbid"),
+)

--- a/tracecat/dsl/types.py
+++ b/tracecat/dsl/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field
 
 from tracecat.expressions.common import ExprContext
 from tracecat.runtime.errors import ErrorEnvelope
@@ -79,6 +79,3 @@ class ActionErrorInfo(BaseModel):
     def format(self, loc: str = "run_action") -> str:
         locator = f"{self.expr_context}.{self.ref} -> {loc}"
         return f"[{locator}] (Attempt {self.attempt})\n\n{self.message}"
-
-
-ActionErrorInfoAdapter: TypeAdapter[ActionErrorInfo] = TypeAdapter(ActionErrorInfo)

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -96,7 +96,7 @@ with workflow.unsafe.imports_passed_through():
         StreamID,
         TaskResult,
     )
-    from tracecat.dsl.types import ActionErrorInfo, ActionErrorInfoAdapter
+    from tracecat.dsl.types import ActionErrorInfo
     from tracecat.dsl.validation import format_input_schema_validation_error
     from tracecat.dsl.workflow_logging import get_workflow_logger
     from tracecat.ee.interactions.decorators import maybe_interactive
@@ -446,7 +446,7 @@ class DSLWorkflow:
                     ]
                 else:
                     errors = [
-                        ActionErrorInfoAdapter.validate_python(data)
+                        ActionErrorInfo.model_validate(data)
                         for data in err_info_map.values()
                     ]
             else:

--- a/tracecat/runtime/__init__.py
+++ b/tracecat/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime contracts shared across Tracecat execution boundaries."""

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -58,6 +58,7 @@ class RuntimeErrorKind(StrEnum):
     STORAGE_PERSISTENCE_TRANSPORT_UNAVAILABLE = (
         "storage.persistence.transport_unavailable"
     )
+    EXECUTOR_BACKEND_INITIALIZATION_FAILED = "executor.backend.initialization_failed"
     EXECUTOR_REGISTRY_LEASE_CONTENTION = "executor.registry.lease_contention"
     EXECUTOR_REGISTRY_CAPACITY_EXHAUSTED = "executor.registry.capacity_exhausted"
     EXECUTOR_REGISTRY_EXTRACTION_FAILED = "executor.registry.extraction_failed"

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -1,0 +1,175 @@
+"""Stable runtime error attribution and retry contract.
+
+Runtime errors have three independent axes:
+
+* ``owner`` assigns operational ownership for observability and alerting.
+* ``retry_disposition`` describes whether another attempt is allowed.
+* Workflow control flow remains owned by the workflow definition and engine.
+
+The contract intentionally excludes transport details, execution identifiers,
+raw platform diagnostics, and routing instructions. Future envelope versions
+must use a new ``schema`` literal and a discriminated union rather than adding a
+second version field.
+
+Attribution is scoped to each Temporal Workflow Execution. A terminal
+platform-attributed child failure remains independently attributable and
+alertable even when its parent handles that failure and completes. Diagnostic
+``cause_type`` values must never select retry, routing, or alert policy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+ERROR_ENVELOPE_SCHEMA = "tracecat.error.v1"
+
+
+class RuntimeErrorOwner(StrEnum):
+    """Operational owner of a runtime failure."""
+
+    USER = "user"
+    PLATFORM = "platform"
+
+
+class RetryDisposition(StrEnum):
+    """Whether the failed operation may be attempted again."""
+
+    RETRYABLE = "retryable"
+    NON_RETRYABLE = "non_retryable"
+
+
+class RuntimeErrorCode(StrEnum):
+    """Stable machine-readable runtime failure codes."""
+
+    USER_ACTION_FAILED = "user.action.failed"
+    TENANT_QUOTA_EXHAUSTED = "tenant.quota.exhausted"
+    TENANT_ENTITLEMENT_DENIED = "tenant.entitlement.denied"
+    INTEGRATION_RATE_LIMITED = "integration.rate_limited"
+    PLATFORM_UNCLASSIFIED = "platform.unclassified"
+    PLATFORM_DEPENDENCY_UNAVAILABLE = "platform.dependency.unavailable"
+    PLATFORM_CAPACITY_EXHAUSTED = "platform.capacity.exhausted"
+
+    @property
+    def owner(self) -> RuntimeErrorOwner:
+        """Return the owner implied by this code's namespace."""
+        if self.value.startswith("platform."):
+            return RuntimeErrorOwner.PLATFORM
+        return RuntimeErrorOwner.USER
+
+
+class ErrorEnvelope(BaseModel):
+    """Versioned error attribution and retry metadata.
+
+    User messages must be masked before construction. Platform messages must be
+    neutral and safe for durable history; pass the original exception as
+    ``cause`` to a named constructor to retain only its type.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, serialize_by_alias=True)
+
+    # The alias is the public contract. The suffix avoids overriding Pydantic's
+    # deprecated ``BaseModel.schema()`` method while keeping the wire key exact.
+    schema_: Literal["tracecat.error.v1"] = Field(
+        default=ERROR_ENVELOPE_SCHEMA,
+        alias="schema",
+    )
+    owner: RuntimeErrorOwner
+    code: RuntimeErrorCode
+    message: str
+    retry_disposition: RetryDisposition
+    cause_type: str | None = None
+
+    @model_validator(mode="after")
+    def validate_code_owner(self) -> Self:
+        """Reject contradictory ownership and code namespaces."""
+        if self.code.owner is not self.owner:
+            raise ValueError(
+                f"Error code {self.code.value!r} does not belong to "
+                f"owner {self.owner.value!r}"
+            )
+        return self
+
+    @classmethod
+    def user(
+        cls,
+        *,
+        code: RuntimeErrorCode,
+        message: str,
+        retry_disposition: RetryDisposition,
+        cause: BaseException | None = None,
+    ) -> ErrorEnvelope:
+        """Construct a user-attributed error from an explicit enum code."""
+        cls._require_code_owner(code, RuntimeErrorOwner.USER)
+        cls._require_retry_disposition(retry_disposition)
+        return cls(
+            owner=RuntimeErrorOwner.USER,
+            code=code,
+            message=message,
+            retry_disposition=retry_disposition,
+            cause_type=type(cause).__name__ if cause is not None else None,
+        )
+
+    @classmethod
+    def platform(
+        cls,
+        *,
+        code: RuntimeErrorCode,
+        message: str,
+        retry_disposition: RetryDisposition,
+        cause: BaseException | None = None,
+    ) -> ErrorEnvelope:
+        """Construct a platform-attributed error from an explicit enum code."""
+        cls._require_code_owner(code, RuntimeErrorOwner.PLATFORM)
+        cls._require_retry_disposition(retry_disposition)
+        return cls(
+            owner=RuntimeErrorOwner.PLATFORM,
+            code=code,
+            message=message,
+            retry_disposition=retry_disposition,
+            cause_type=type(cause).__name__ if cause is not None else None,
+        )
+
+    @staticmethod
+    def _require_code_owner(
+        code: RuntimeErrorCode, expected_owner: RuntimeErrorOwner
+    ) -> None:
+        if not isinstance(code, RuntimeErrorCode):
+            raise TypeError("code must be a RuntimeErrorCode enum member")
+        if code.owner is not expected_owner:
+            raise ValueError(
+                f"Error code {code.value!r} does not belong to "
+                f"owner {expected_owner.value!r}"
+            )
+
+    @staticmethod
+    def _require_retry_disposition(
+        retry_disposition: RetryDisposition,
+    ) -> None:
+        if not isinstance(retry_disposition, RetryDisposition):
+            raise TypeError("retry_disposition must be a RetryDisposition enum member")
+
+
+class TracecatRuntimeError(Exception):
+    """Exception carrying an already-classified runtime error envelope."""
+
+    def __init__(self, envelope: ErrorEnvelope) -> None:
+        super().__init__(envelope.message)
+        self.envelope = envelope
+
+
+def parse_error_envelope(value: object) -> ErrorEnvelope | None:
+    """Parse only payloads carrying the explicit envelope discriminator."""
+    if isinstance(value, ErrorEnvelope):
+        return value
+    if not isinstance(value, Mapping):
+        return None
+    if value.get("schema") != ERROR_ENVELOPE_SCHEMA:
+        return None
+    try:
+        return ErrorEnvelope.model_validate(value)
+    except ValidationError:
+        return None

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from enum import StrEnum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -89,6 +89,11 @@ class ErrorEnvelope(BaseModel):
     message: str
     retry_disposition: RetryDisposition
     cause_type: str | None = None
+
+    def model_post_init(self, context: Any, /) -> None:
+        """Keep the wire discriminator during exclude-unset serialization."""
+        del context
+        self.__pydantic_fields_set__.add("schema_")
 
     @classmethod
     def user(

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -1,8 +1,9 @@
 """Stable runtime error attribution and retry contract.
 
-Runtime errors have three independent axes:
+Runtime errors have independent product dimensions:
 
 * ``owner`` assigns operational ownership for observability and alerting.
+* ``kind`` identifies the stable product failure boundary and reason.
 * ``retry_disposition`` describes whether another attempt is allowed.
 * Workflow control flow remains owned by the workflow definition and engine.
 
@@ -21,9 +22,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from enum import StrEnum
-from typing import Literal, Self
+from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 ERROR_ENVELOPE_SCHEMA = "tracecat.error.v1"
 
@@ -42,23 +43,28 @@ class RetryDisposition(StrEnum):
     NON_RETRYABLE = "non_retryable"
 
 
-class RuntimeErrorCode(StrEnum):
-    """Stable machine-readable runtime failure codes."""
+class RuntimeErrorKind(StrEnum):
+    """Stable machine-readable product failure identities."""
 
-    USER_ACTION_FAILED = "user.action.failed"
+    ACTION_EXECUTION_FAILED = "action.execution.failed"
     TENANT_QUOTA_EXHAUSTED = "tenant.quota.exhausted"
     TENANT_ENTITLEMENT_DENIED = "tenant.entitlement.denied"
     INTEGRATION_RATE_LIMITED = "integration.rate_limited"
-    PLATFORM_UNCLASSIFIED = "platform.unclassified"
-    PLATFORM_DEPENDENCY_UNAVAILABLE = "platform.dependency.unavailable"
-    PLATFORM_CAPACITY_EXHAUSTED = "platform.capacity.exhausted"
-
-    @property
-    def owner(self) -> RuntimeErrorOwner:
-        """Return the owner implied by this code's namespace."""
-        if self.value.startswith("platform."):
-            return RuntimeErrorOwner.PLATFORM
-        return RuntimeErrorOwner.USER
+    RUNTIME_UNCLASSIFIED = "runtime.unclassified"
+    STORAGE_MATERIALIZATION_TRANSPORT_UNAVAILABLE = (
+        "storage.materialization.transport_unavailable"
+    )
+    STORAGE_MATERIALIZATION_INVALID_DATA = "storage.materialization.invalid_data"
+    STORAGE_PERSISTENCE_TRANSPORT_UNAVAILABLE = (
+        "storage.persistence.transport_unavailable"
+    )
+    EXECUTOR_REGISTRY_LEASE_CONTENTION = "executor.registry.lease_contention"
+    EXECUTOR_REGISTRY_CAPACITY_EXHAUSTED = "executor.registry.capacity_exhausted"
+    EXECUTOR_REGISTRY_EXTRACTION_FAILED = "executor.registry.extraction_failed"
+    EXECUTOR_SANDBOX_INFRASTRUCTURE_FAILED = "executor.sandbox.infrastructure_failed"
+    WORKFLOW_DEFINITION_NOT_FOUND = "workflow.definition.not_found"
+    WORKFLOW_DEFINITION_LOOKUP_UNAVAILABLE = "workflow.definition.lookup_unavailable"
+    WORKFLOW_SUBFLOW_PREPARATION_FAILED = "workflow.subflow.preparation_failed"
 
 
 class ErrorEnvelope(BaseModel):
@@ -78,36 +84,26 @@ class ErrorEnvelope(BaseModel):
         alias="schema",
     )
     owner: RuntimeErrorOwner
-    code: RuntimeErrorCode
+    kind: RuntimeErrorKind
     message: str
     retry_disposition: RetryDisposition
     cause_type: str | None = None
-
-    @model_validator(mode="after")
-    def validate_code_owner(self) -> Self:
-        """Reject contradictory ownership and code namespaces."""
-        if self.code.owner is not self.owner:
-            raise ValueError(
-                f"Error code {self.code.value!r} does not belong to "
-                f"owner {self.owner.value!r}"
-            )
-        return self
 
     @classmethod
     def user(
         cls,
         *,
-        code: RuntimeErrorCode,
+        kind: RuntimeErrorKind,
         message: str,
         retry_disposition: RetryDisposition,
         cause: BaseException | None = None,
     ) -> ErrorEnvelope:
-        """Construct a user-attributed error from an explicit enum code."""
-        cls._require_code_owner(code, RuntimeErrorOwner.USER)
+        """Construct a user-attributed error from an explicit enum kind."""
+        cls._require_kind(kind)
         cls._require_retry_disposition(retry_disposition)
         return cls(
             owner=RuntimeErrorOwner.USER,
-            code=code,
+            kind=kind,
             message=message,
             retry_disposition=retry_disposition,
             cause_type=type(cause).__name__ if cause is not None else None,
@@ -117,33 +113,26 @@ class ErrorEnvelope(BaseModel):
     def platform(
         cls,
         *,
-        code: RuntimeErrorCode,
+        kind: RuntimeErrorKind,
         message: str,
         retry_disposition: RetryDisposition,
         cause: BaseException | None = None,
     ) -> ErrorEnvelope:
-        """Construct a platform-attributed error from an explicit enum code."""
-        cls._require_code_owner(code, RuntimeErrorOwner.PLATFORM)
+        """Construct a platform-attributed error from an explicit enum kind."""
+        cls._require_kind(kind)
         cls._require_retry_disposition(retry_disposition)
         return cls(
             owner=RuntimeErrorOwner.PLATFORM,
-            code=code,
+            kind=kind,
             message=message,
             retry_disposition=retry_disposition,
             cause_type=type(cause).__name__ if cause is not None else None,
         )
 
     @staticmethod
-    def _require_code_owner(
-        code: RuntimeErrorCode, expected_owner: RuntimeErrorOwner
-    ) -> None:
-        if not isinstance(code, RuntimeErrorCode):
-            raise TypeError("code must be a RuntimeErrorCode enum member")
-        if code.owner is not expected_owner:
-            raise ValueError(
-                f"Error code {code.value!r} does not belong to "
-                f"owner {expected_owner.value!r}"
-            )
+    def _require_kind(kind: RuntimeErrorKind) -> None:
+        if not isinstance(kind, RuntimeErrorKind):
+            raise TypeError("kind must be a RuntimeErrorKind enum member")
 
     @staticmethod
     def _require_retry_disposition(

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -184,7 +184,9 @@ def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
         parsed = ActionErrorInfo.model_validate(detail)
     except ValidationError:
         return None
-    return parsed.envelope
+    if parsed.envelope is None:
+        return None
+    return parse_error_envelope(detail.get("envelope"))
 
 
 def _error_chain(error: BaseException) -> Iterator[BaseException]:

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
 from datetime import timedelta
-from typing import Any, Literal
+from typing import Any, Literal, Never
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from temporalio.exceptions import ApplicationError, FailureError
@@ -36,7 +36,7 @@ class TemporalErrorDetails(BaseModel):
     envelope: ErrorEnvelope
 
 
-def application_error_from_envelope(
+def _application_error_from_envelope(
     envelope: ErrorEnvelope,
     *details: Any,
     next_retry_delay: timedelta | None = None,
@@ -76,13 +76,31 @@ def application_error_from_envelope(
     )
 
 
-def wrap_application_error(
+def raise_application_error_from_envelope(
+    envelope: ErrorEnvelope,
+    *details: Any,
+    next_retry_delay: timedelta | None = None,
+) -> Never:
+    """Raise a classified error without serializing the active exception context.
+
+    Temporal serializes exception chains into workflow history. Owning the raise
+    here ensures callers cannot accidentally attach a sensitive caught exception
+    through implicit chaining.
+    """
+    raise _application_error_from_envelope(
+        envelope,
+        *details,
+        next_retry_delay=next_retry_delay,
+    ) from None
+
+
+def raise_wrapped_application_error(
     error: BaseException,
     *,
     fallback: ErrorEnvelope,
     details: Sequence[Any] = (),
-) -> ApplicationError:
-    """Wrap an exception while preserving any existing classification."""
+) -> Never:
+    """Raise a history-safe wrapper while preserving existing classification."""
     envelope = extract_error_envelope(error) or fallback
     if isinstance(error, ApplicationError):
         wrapped_details = tuple(error.details) if not details else tuple(details)
@@ -91,7 +109,7 @@ def wrap_application_error(
         wrapped_details = tuple(details)
         next_retry_delay = None
 
-    return application_error_from_envelope(
+    raise_application_error_from_envelope(
         envelope,
         *wrapped_details,
         next_retry_delay=next_retry_delay,

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -182,7 +182,13 @@ def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
         except ValidationError:
             return None
 
-    return parse_error_envelope(detail.get("envelope"))
+    try:
+        parsed = ActionErrorInfoAdapter.validate_python(detail)
+    except ValidationError:
+        return None
+    if isinstance(parsed, ClassifiedActionErrorInfo):
+        return parsed.envelope
+    return None
 
 
 def _error_chain(error: BaseException) -> Iterator[BaseException]:

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -47,16 +47,13 @@ def _application_error_from_envelope(
     """
     existing_envelope = _envelope_from_details(details)
     resolved_envelope = existing_envelope or envelope
-    serialized_details = _serialized_error_details(
+    transported_details, embedded = _serialized_error_details(
         details,
         envelope=None if existing_envelope is not None else envelope,
     )
-    transported_details = (
-        serialized_details if serialized_details is not None else tuple(details)
-    )
-    if existing_envelope is None and serialized_details is None:
+    if existing_envelope is None and not embedded:
         adapter = TemporalErrorDetails(envelope=envelope)
-        transported_details = (*details, adapter.model_dump(mode="json"))
+        transported_details = (*transported_details, adapter.model_dump(mode="json"))
 
     non_retryable = (
         resolved_envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
@@ -147,13 +144,14 @@ def _envelope_from_details(details: Sequence[Any]) -> ErrorEnvelope | None:
 
 def _serialized_error_details(
     details: Sequence[Any], envelope: ErrorEnvelope | None
-) -> tuple[Any, ...] | None:
+) -> tuple[tuple[Any, ...], bool]:
+    """Serialize details for transport, reporting whether an envelope is embedded."""
     serialized: list[Any] = []
-    changed = False
+    embedded = False
     for detail in details:
         if isinstance(detail, TemporalErrorDetails):
             serialized.append(detail.model_dump(mode="json"))
-            changed = True
+            embedded = True
         elif isinstance(detail, ActionErrorInfo) and (
             detail.envelope is not None or envelope is not None
         ):
@@ -168,10 +166,10 @@ def _serialized_error_details(
                 envelope=detail.envelope or envelope,
             )
             serialized.append(classified.model_dump(mode="json"))
-            changed = True
+            embedded = True
         else:
             serialized.append(detail)
-    return tuple(serialized) if changed else None
+    return tuple(serialized), embedded
 
 
 def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -1,0 +1,195 @@
+"""Temporal transport for the versioned Tracecat runtime error contract."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, Sequence
+from datetime import timedelta
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from temporalio.exceptions import ApplicationError, FailureError
+
+from tracecat.dsl.types import (
+    ActionErrorInfo,
+    ActionErrorInfoAdapter,
+    ClassifiedActionErrorInfo,
+)
+from tracecat.runtime.errors import (
+    ErrorEnvelope,
+    RetryDisposition,
+    TracecatRuntimeError,
+    parse_error_envelope,
+)
+
+TEMPORAL_ERROR_DETAILS_SCHEMA = "tracecat.temporal_error.v1"
+
+
+class TemporalErrorDetails(BaseModel):
+    """Strict adapter for envelopes without an ``ActionErrorInfo`` payload."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, serialize_by_alias=True)
+
+    schema_: Literal["tracecat.temporal_error.v1"] = Field(
+        default=TEMPORAL_ERROR_DETAILS_SCHEMA,
+        alias="schema",
+    )
+    envelope: ErrorEnvelope
+
+
+def application_error_from_envelope(
+    envelope: ErrorEnvelope,
+    *details: Any,
+    error_type: str | None = None,
+    next_retry_delay: timedelta | None = None,
+) -> ApplicationError:
+    """Build an ``ApplicationError`` with retryability derived from its envelope.
+
+    Existing details remain in their original order. If they already contain a
+    fully validated envelope, they are left unchanged; otherwise a strict
+    non-action detail is appended.
+    """
+    existing_envelope = _envelope_from_details(details)
+    resolved_envelope = existing_envelope or envelope
+    serialized_details = _serialized_error_details(
+        details,
+        envelope=None if existing_envelope is not None else envelope,
+    )
+    transported_details = (
+        serialized_details if serialized_details is not None else tuple(details)
+    )
+    if existing_envelope is None and serialized_details is None:
+        adapter = TemporalErrorDetails(envelope=envelope)
+        transported_details = (*details, adapter.model_dump(mode="json"))
+
+    non_retryable = (
+        resolved_envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
+    )
+    if non_retryable and next_retry_delay is not None:
+        raise ValueError("A non-retryable error cannot set next_retry_delay")
+
+    return ApplicationError(
+        resolved_envelope.message,
+        *transported_details,
+        type=error_type,
+        non_retryable=non_retryable,
+        next_retry_delay=next_retry_delay,
+    )
+
+
+def wrap_application_error(
+    error: BaseException,
+    *,
+    fallback: ErrorEnvelope,
+    details: Sequence[Any] = (),
+    error_type: str | None = None,
+) -> ApplicationError:
+    """Wrap an exception while preserving any existing classification."""
+    envelope = extract_error_envelope(error) or fallback
+    if isinstance(error, ApplicationError):
+        wrapped_details = tuple(error.details) if not details else tuple(details)
+        resolved_type = error_type or error.type
+        next_retry_delay = error.next_retry_delay
+    else:
+        wrapped_details = tuple(details)
+        resolved_type = error_type or type(error).__name__
+        next_retry_delay = None
+
+    return application_error_from_envelope(
+        envelope,
+        *wrapped_details,
+        error_type=resolved_type,
+        next_retry_delay=next_retry_delay,
+    )
+
+
+def extract_error_envelope(error: BaseException) -> ErrorEnvelope | None:
+    """Extract the first valid envelope from an exception chain."""
+    for current in _error_chain(error):
+        if isinstance(current, TracecatRuntimeError):
+            return current.envelope
+        if isinstance(current, ApplicationError):
+            if envelope := _envelope_from_details(current.details):
+                return envelope
+    return None
+
+
+def _envelope_from_details(details: Sequence[Any]) -> ErrorEnvelope | None:
+    for detail in details:
+        if envelope := _envelope_from_detail(detail):
+            return envelope
+    return None
+
+
+def _serialized_error_details(
+    details: Sequence[Any], envelope: ErrorEnvelope | None
+) -> tuple[Any, ...] | None:
+    serialized: list[Any] = []
+    changed = False
+    for detail in details:
+        if isinstance(detail, ClassifiedActionErrorInfo):
+            serialized.append(ActionErrorInfoAdapter.dump_python(detail, mode="json"))
+            changed = True
+        elif isinstance(detail, TemporalErrorDetails):
+            serialized.append(detail.model_dump(mode="json"))
+            changed = True
+        elif isinstance(detail, ActionErrorInfo) and envelope is not None:
+            classified = ClassifiedActionErrorInfo(
+                ref=detail.ref,
+                message=detail.message,
+                type=detail.type,
+                expr_context=detail.expr_context,
+                attempt=detail.attempt,
+                stream_id=detail.stream_id,
+                children=detail.children,
+                envelope=envelope,
+            )
+            serialized.append(
+                ActionErrorInfoAdapter.dump_python(classified, mode="json")
+            )
+            changed = True
+        else:
+            serialized.append(detail)
+    return tuple(serialized) if changed else None
+
+
+def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
+    if isinstance(detail, ClassifiedActionErrorInfo):
+        return detail.envelope
+    if isinstance(detail, TemporalErrorDetails):
+        return detail.envelope
+    if not isinstance(detail, Mapping):
+        return None
+
+    if detail.get("schema") == TEMPORAL_ERROR_DETAILS_SCHEMA:
+        if parse_error_envelope(detail.get("envelope")) is None:
+            return None
+        try:
+            return TemporalErrorDetails.model_validate(detail).envelope
+        except ValidationError:
+            return None
+
+    return parse_error_envelope(detail.get("envelope"))
+
+
+def _error_chain(error: BaseException) -> Iterator[BaseException]:
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None:
+        current_id = id(current)
+        if current_id in seen:
+            return
+        seen.add(current_id)
+        yield current
+
+        if isinstance(current, FailureError) and isinstance(
+            current.cause, BaseException
+        ):
+            current = current.cause
+        elif isinstance(current.__cause__, BaseException):
+            current = current.__cause__
+        elif not current.__suppress_context__ and isinstance(
+            current.__context__, BaseException
+        ):
+            current = current.__context__
+        else:
+            current = None

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -98,12 +98,17 @@ def raise_wrapped_application_error(
     details: Sequence[Any] = (),
 ) -> Never:
     """Raise a history-safe wrapper while preserving existing classification."""
-    existing_envelope = extract_error_envelope(error)
+    details_envelope = (
+        _envelope_from_details(error.details)
+        if isinstance(error, ApplicationError)
+        else None
+    )
+    existing_envelope = details_envelope or extract_error_envelope(error)
     envelope = existing_envelope or fallback
     if isinstance(error, ApplicationError):
         wrapped_details = (
             tuple(error.details)
-            if existing_envelope is not None and not details
+            if details_envelope is not None and not details
             else tuple(details)
         )
         next_retry_delay = (

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from datetime import timedelta
 from typing import Any, Literal, Never
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 from temporalio.exceptions import ApplicationError, FailureError
 
 from tracecat.dsl.types import ActionErrorInfo
@@ -18,6 +18,7 @@ from tracecat.runtime.errors import (
 )
 
 TEMPORAL_ERROR_DETAILS_SCHEMA = "tracecat.temporal_error.v1"
+_ACTION_ERROR_MAP_ADAPTER = TypeAdapter(dict[str, ActionErrorInfo])
 
 
 class TemporalErrorDetails(BaseModel):
@@ -166,7 +167,7 @@ def _serialized_error_details(
 
 def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
     if isinstance(detail, ActionErrorInfo):
-        return detail.envelope
+        return detail.envelope or _envelope_from_details(detail.children or ())
     if isinstance(detail, TemporalErrorDetails):
         return detail.envelope
     if not isinstance(detail, Mapping):
@@ -183,10 +184,24 @@ def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
     try:
         parsed = ActionErrorInfo.model_validate(detail)
     except ValidationError:
+        try:
+            _ACTION_ERROR_MAP_ADAPTER.validate_python(detail)
+        except ValidationError:
+            return None
+        for action_error in detail.values():
+            if envelope := _envelope_from_detail(action_error):
+                return envelope
         return None
-    if parsed.envelope is None:
+
+    if parsed.envelope is not None:
+        return parse_error_envelope(detail.get("envelope"))
+    if parsed.children is None:
         return None
-    return parse_error_envelope(detail.get("envelope"))
+
+    children = detail.get("children")
+    if not isinstance(children, Sequence):
+        return None
+    return _envelope_from_details(children)
 
 
 def _error_chain(error: BaseException) -> Iterator[BaseException]:

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -97,9 +97,14 @@ def raise_wrapped_application_error(
     details: Sequence[Any] = (),
 ) -> Never:
     """Raise a history-safe wrapper while preserving existing classification."""
-    envelope = extract_error_envelope(error) or fallback
+    existing_envelope = extract_error_envelope(error)
+    envelope = existing_envelope or fallback
     if isinstance(error, ApplicationError):
-        wrapped_details = tuple(error.details) if not details else tuple(details)
+        wrapped_details = (
+            tuple(error.details)
+            if existing_envelope is not None and not details
+            else tuple(details)
+        )
         next_retry_delay = error.next_retry_delay
     else:
         wrapped_details = tuple(details)

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -106,7 +106,11 @@ def raise_wrapped_application_error(
             if existing_envelope is not None and not details
             else tuple(details)
         )
-        next_retry_delay = error.next_retry_delay
+        next_retry_delay = (
+            error.next_retry_delay
+            if envelope.retry_disposition is RetryDisposition.RETRYABLE
+            else None
+        )
     else:
         wrapped_details = tuple(details)
         next_retry_delay = None

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -9,10 +9,7 @@ from typing import Any, Literal, Never
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from temporalio.exceptions import ApplicationError, FailureError
 
-from tracecat.dsl.types import (
-    ActionErrorInfo,
-    ActionErrorInfoAdapter,
-)
+from tracecat.dsl.types import ActionErrorInfo
 from tracecat.runtime.errors import (
     ErrorEnvelope,
     RetryDisposition,
@@ -155,9 +152,7 @@ def _serialized_error_details(
                 children=detail.children,
                 envelope=detail.envelope or envelope,
             )
-            serialized.append(
-                ActionErrorInfoAdapter.dump_python(classified, mode="json")
-            )
+            serialized.append(classified.model_dump(mode="json"))
             changed = True
         else:
             serialized.append(detail)
@@ -181,7 +176,7 @@ def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
             return None
 
     try:
-        parsed = ActionErrorInfoAdapter.validate_python(detail)
+        parsed = ActionErrorInfo.model_validate(detail)
     except ValidationError:
         return None
     return parsed.envelope

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -12,7 +12,6 @@ from temporalio.exceptions import ApplicationError, FailureError
 from tracecat.dsl.types import (
     ActionErrorInfo,
     ActionErrorInfoAdapter,
-    ClassifiedActionErrorInfo,
 )
 from tracecat.runtime.errors import (
     ErrorEnvelope,
@@ -140,14 +139,13 @@ def _serialized_error_details(
     serialized: list[Any] = []
     changed = False
     for detail in details:
-        if isinstance(detail, ClassifiedActionErrorInfo):
-            serialized.append(ActionErrorInfoAdapter.dump_python(detail, mode="json"))
-            changed = True
-        elif isinstance(detail, TemporalErrorDetails):
+        if isinstance(detail, TemporalErrorDetails):
             serialized.append(detail.model_dump(mode="json"))
             changed = True
-        elif isinstance(detail, ActionErrorInfo) and envelope is not None:
-            classified = ClassifiedActionErrorInfo(
+        elif isinstance(detail, ActionErrorInfo) and (
+            detail.envelope is not None or envelope is not None
+        ):
+            classified = ActionErrorInfo(
                 ref=detail.ref,
                 message=detail.message,
                 type=detail.type,
@@ -155,7 +153,7 @@ def _serialized_error_details(
                 attempt=detail.attempt,
                 stream_id=detail.stream_id,
                 children=detail.children,
-                envelope=envelope,
+                envelope=detail.envelope or envelope,
             )
             serialized.append(
                 ActionErrorInfoAdapter.dump_python(classified, mode="json")
@@ -167,7 +165,7 @@ def _serialized_error_details(
 
 
 def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
-    if isinstance(detail, ClassifiedActionErrorInfo):
+    if isinstance(detail, ActionErrorInfo):
         return detail.envelope
     if isinstance(detail, TemporalErrorDetails):
         return detail.envelope
@@ -186,9 +184,7 @@ def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
         parsed = ActionErrorInfoAdapter.validate_python(detail)
     except ValidationError:
         return None
-    if isinstance(parsed, ClassifiedActionErrorInfo):
-        return parsed.envelope
-    return None
+    return parsed.envelope
 
 
 def _error_chain(error: BaseException) -> Iterator[BaseException]:

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -39,14 +39,14 @@ class TemporalErrorDetails(BaseModel):
 def application_error_from_envelope(
     envelope: ErrorEnvelope,
     *details: Any,
-    error_type: str | None = None,
     next_retry_delay: timedelta | None = None,
 ) -> ApplicationError:
-    """Build an ``ApplicationError`` with retryability derived from its envelope.
+    """Build an ``ApplicationError`` with transport fields derived from its envelope.
 
     Existing details remain in their original order. If they already contain a
     fully validated envelope, they are left unchanged; otherwise a strict
-    non-action detail is appended.
+    non-action detail is appended. Temporal's error type mirrors the stable
+    product kind and is never supplied as a second classification input.
     """
     existing_envelope = _envelope_from_details(details)
     resolved_envelope = existing_envelope or envelope
@@ -70,7 +70,7 @@ def application_error_from_envelope(
     return ApplicationError(
         resolved_envelope.message,
         *transported_details,
-        type=error_type,
+        type=resolved_envelope.kind.value,
         non_retryable=non_retryable,
         next_retry_delay=next_retry_delay,
     )
@@ -81,23 +81,19 @@ def wrap_application_error(
     *,
     fallback: ErrorEnvelope,
     details: Sequence[Any] = (),
-    error_type: str | None = None,
 ) -> ApplicationError:
     """Wrap an exception while preserving any existing classification."""
     envelope = extract_error_envelope(error) or fallback
     if isinstance(error, ApplicationError):
         wrapped_details = tuple(error.details) if not details else tuple(details)
-        resolved_type = error_type or error.type
         next_retry_delay = error.next_retry_delay
     else:
         wrapped_details = tuple(details)
-        resolved_type = error_type or type(error).__name__
         next_retry_delay = None
 
     return application_error_from_envelope(
         envelope,
         *wrapped_details,
-        error_type=resolved_type,
         next_retry_delay=next_retry_delay,
     )
 


### PR DESCRIPTION
## Summary

- define the strict `tracecat.error.v1` envelope with independent `owner`, namespaced `kind`, safe `message`, `retry_disposition`, and diagnostic-only `cause_type`
- make `kind` the single stable taxonomy identity and mirror it into Temporal `ApplicationError.type`
- extend action error details with a discriminated classified variant while preserving the legacy payload shape
- add Temporal adapters for carrying, extracting, and wrapping envelopes with retryability derived from the typed contract

## Why

ENG-1407 needs a narrow runtime-error contract before execution paths begin producing or consuming classifications. A fine-grained namespaced `kind` is sufficient for product grouping and operator diagnosis, so this contract does not add a second `operation` dimension or retain a separate compatibility error type.

Keeping this layer contract-only makes the compatibility, retry, and history-safety properties reviewable independently from runtime integration.

## Impact

This PR does not classify live failures, change workflow routing, add Sentry capture, or alter completion behavior. Existing unclassified action and Temporal error details keep their established shape and semantics. `cause_type` remains diagnostic metadata and must not control attribution or retry behavior.

## Validation

- focused runtime, Temporal transport, and scheduler unit coverage
- `uv run ruff check` and `uv run ruff format --check`
- targeted `uv run basedpyright`
- repository commit hooks, including generated-client verification and secret scanning

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 373 | 4 |
| Tests | 462 | 1 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines a versioned runtime error envelope and Temporal adapters; adopts namespaced error kinds and adds executor backend initialization classification. This standardizes error attribution and retry behavior without changing workflow routing or delivery (ENG-1407).

- Introduces the `tracecat.error.v1` envelope with owner, kind (namespaced), message, retry_disposition, and cause_type; strict parsing requires the explicit schema discriminator and forbids extra fields.
- Adds Temporal transport helpers: build `ApplicationError` from an envelope (type = kind, retryability derived), reject `next_retry_delay` for non-retryable envelopes, and reliably wrap/extract envelopes through `temporalio` failure serialization and exception chains.
- Extends DSL action error details with `ClassifiedActionErrorInfo` and a strict `ActionErrorInfoAdapter` union; updates the scheduler to parse via the adapter and preserve classification while keeping legacy payload shape.
- Expands the runtime taxonomy (namespaced kinds) and adds `executor.backend.initialization_failed`.
- No migrations or user actions.

<sup>Written for commit d610c3608bdc61c82e9c529ca65a03ef7937d7ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


