### PR TITLE
feat(runtime): thread error envelopes through workflows

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -177,6 +177,7 @@ jobs:
             TracecatAlias
             TracecatCorrelationId
             TracecatExecutionType
+            TracecatErrorOwner
           )
 
           add_args=()

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -228,7 +228,14 @@ jobs:
             TRACECAT_TEST_API_MODE=inprocess \
             TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
             TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
-            uv run pytest tests/temporal -m "not live_secret and not requires_api" -n auto -ra -o faulthandler_timeout=300
+            uv run pytest tests/temporal -m "not live_secret and not requires_api and not serial" -n auto -ra -o faulthandler_timeout=300
+
+            # Some Temporal failure-path regressions exercise worker shutdown
+            # behavior that is not safe inside a long-lived xdist process.
+            TRACECAT_TEST_API_MODE=inprocess \
+            TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
+            TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
+            uv run pytest tests/temporal -m "serial and not live_secret and not requires_api" -ra -o faulthandler_timeout=300
 
             # API-backed temporal tests start a local API process against the
             # test DB. Run them serially to avoid startup races under xdist,

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -228,14 +228,7 @@ jobs:
             TRACECAT_TEST_API_MODE=inprocess \
             TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
             TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
-            uv run pytest tests/temporal -m "not live_secret and not requires_api and not serial" -n auto -ra -o faulthandler_timeout=300
-
-            # Some Temporal failure-path regressions exercise worker shutdown
-            # behavior that is not safe inside a long-lived xdist process.
-            TRACECAT_TEST_API_MODE=inprocess \
-            TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
-            TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
-            uv run pytest tests/temporal -m "serial and not live_secret and not requires_api" -ra -o faulthandler_timeout=300
+            uv run pytest tests/temporal -m "not live_secret and not requires_api" -n auto -ra -o faulthandler_timeout=300
 
             # API-backed temporal tests start a local API process against the
             # test DB. Run them serially to avoid startup races under xdist,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,6 @@ markers = [
     "ollama: mark tests that require Ollama",
     "temporal: marks tests that require Temporal server",
     "requires_api: marks tests that require a live Tracecat API endpoint",
-    "serial: marks tests that must not run under pytest-xdist",
     "regression: marks regression tests",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ markers = [
     "ollama: mark tests that require Ollama",
     "temporal: marks tests that require Temporal server",
     "requires_api: marks tests that require a live Tracecat API endpoint",
+    "serial: marks tests that must not run under pytest-xdist",
     "regression: marks regression tests",
 ]
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -3,17 +3,23 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
+from datetime import timedelta
 from pathlib import Path
 from types import ModuleType
 from typing import Any, TypeGuard
 
 import httpx
+import pytest
 import yaml
 from pydantic import ValidationError
+from temporalio.client import Client, WorkflowHistory
+from temporalio.exceptions import ApplicationError
 
 from tracecat.identifiers.action import ref
 from tracecat.identifiers.workflow import EXEC_ID_PREFIX, WorkflowUUID
 from tracecat.registry.actions.schemas import TemplateAction
+from tracecat.runtime.errors import ErrorEnvelope
 from tracecat.storage.object import (
     CollectionObject,
     ExternalObject,
@@ -22,6 +28,7 @@ from tracecat.storage.object import (
     StoredObjectValidator,
     get_object_storage,
 )
+from tracecat.temporal.errors import raise_application_error_from_envelope
 
 
 def user_client() -> httpx.AsyncClient:
@@ -33,6 +40,43 @@ def user_client() -> httpx.AsyncClient:
 
 
 TEST_WF_ID = WorkflowUUID(int=0)
+
+
+def capture_application_error(
+    envelope: ErrorEnvelope,
+    *details: object,
+    next_retry_delay: timedelta | None = None,
+) -> ApplicationError:
+    """Capture a classified Temporal application error raised by the helper."""
+    with pytest.raises(ApplicationError) as exc_info:
+        raise_application_error_from_envelope(
+            envelope,
+            *details,
+            next_retry_delay=next_retry_delay,
+        )
+    return exc_info.value
+
+
+async def recorded_patch_ids(
+    temporal_client: Client,
+    history: WorkflowHistory,
+) -> set[str]:
+    """Decode patch IDs recorded in a workflow history."""
+    patch_ids: set[str] = set()
+    for event in history.events:
+        if not event.HasField("marker_recorded_event_attributes"):
+            continue
+        attributes = event.marker_recorded_event_attributes
+        if attributes.marker_name != "core_patch":
+            continue
+        patch_payload = attributes.details.get("patch-data")
+        if patch_payload is None:
+            continue
+        patch_data = await temporal_client.data_converter.decode(patch_payload.payloads)
+        for data in patch_data:
+            if isinstance(data, Mapping) and isinstance(data.get("id"), str):
+                patch_ids.add(data["id"])
+    return patch_ids
 
 
 def generate_test_exec_id(name: str) -> str:

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -19,7 +19,7 @@ from temporalio.exceptions import ApplicationError
 from tracecat.identifiers.action import ref
 from tracecat.identifiers.workflow import EXEC_ID_PREFIX, WorkflowUUID
 from tracecat.registry.actions.schemas import TemplateAction
-from tracecat.runtime.errors import ErrorEnvelope
+from tracecat.runtime.errors import RuntimeErrorClassification
 from tracecat.storage.object import (
     CollectionObject,
     ExternalObject,
@@ -28,7 +28,7 @@ from tracecat.storage.object import (
     StoredObjectValidator,
     get_object_storage,
 )
-from tracecat.temporal.errors import raise_application_error_from_envelope
+from tracecat.temporal.errors import raise_application_error_from_classification
 
 
 def user_client() -> httpx.AsyncClient:
@@ -43,14 +43,14 @@ TEST_WF_ID = WorkflowUUID(int=0)
 
 
 def capture_application_error(
-    envelope: ErrorEnvelope,
+    classification: RuntimeErrorClassification,
     *details: object,
     next_retry_delay: timedelta | None = None,
 ) -> ApplicationError:
     """Capture a classified Temporal application error raised by the helper."""
     with pytest.raises(ApplicationError) as exc_info:
-        raise_application_error_from_envelope(
-            envelope,
+        raise_application_error_from_classification(
+            classification,
             *details,
             next_retry_delay=next_retry_delay,
         )

--- a/tests/temporal/test_dsl_workflow_replay.py
+++ b/tests/temporal/test_dsl_workflow_replay.py
@@ -9,10 +9,11 @@ from typing import Never
 
 import pytest
 from temporalio import activity
-from temporalio.client import Client, WorkflowFailureError, WorkflowHistory
+from temporalio.client import Client, WorkflowFailureError
 from temporalio.exceptions import ApplicationError
 from temporalio.worker import Replayer, Worker
 
+from tests.shared import recorded_patch_ids
 from tracecat.auth.types import Role
 from tracecat.dsl import workflow as workflow_module
 from tracecat.dsl.action import DSLActivities, PrepareSubflowActivityInput
@@ -78,28 +79,6 @@ def _raise_legacy_workflow_application_error(
 
 def _ignore_terminal_error_owner(_error: ApplicationError) -> None:
     """Reproduce the absence of terminal owner attribution before ENG-1407."""
-
-
-async def _recorded_patch_ids(
-    temporal_client: Client,
-    history: WorkflowHistory,
-) -> set[str]:
-    """Decode patch IDs recorded in a workflow history."""
-    patch_ids: set[str] = set()
-    for event in history.events:
-        if not event.HasField("marker_recorded_event_attributes"):
-            continue
-        attributes = event.marker_recorded_event_attributes
-        if attributes.marker_name != "core_patch":
-            continue
-        patch_payload = attributes.details.get("patch-data")
-        if patch_payload is None:
-            continue
-        patch_data = await temporal_client.data_converter.decode(patch_payload.payloads)
-        for data in patch_data:
-            if isinstance(data, Mapping) and isinstance(data.get("id"), str):
-                patch_ids.add(data["id"])
-    return patch_ids
 
 
 @pytest.mark.anyio
@@ -181,9 +160,9 @@ async def test_dsl_workflow_replays_legacy_subflow_failure_history(
 
     history = await handle.fetch_history()
     assert extract_error_envelope(exc_info.value) is None
-    recorded_patch_ids = await _recorded_patch_ids(temporal_client, history)
-    assert ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH not in recorded_patch_ids
-    assert ERROR_OWNER_AFTER_HANDLER_PATCH not in recorded_patch_ids
+    patch_ids = await recorded_patch_ids(temporal_client, history)
+    assert ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH not in patch_ids
+    assert ERROR_OWNER_AFTER_HANDLER_PATCH not in patch_ids
 
     replay_result = await Replayer(
         workflows=[DSLWorkflow],

--- a/tests/temporal/test_dsl_workflow_replay.py
+++ b/tests/temporal/test_dsl_workflow_replay.py
@@ -32,7 +32,7 @@ from tracecat.dsl.workflow import (
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.object import InlineObject
-from tracecat.temporal.errors import extract_error_envelope
+from tracecat.temporal.errors import extract_error_classification
 from tracecat.workflow.management.management import WorkflowsManagementService
 
 pytestmark = [pytest.mark.temporal, pytest.mark.integration]
@@ -159,7 +159,7 @@ async def test_dsl_workflow_replays_legacy_subflow_failure_history(
                 await handle.result()
 
     history = await handle.fetch_history()
-    assert extract_error_envelope(exc_info.value) is None
+    assert extract_error_classification(exc_info.value) is None
     patch_ids = await recorded_patch_ids(temporal_client, history)
     assert ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH not in patch_ids
     assert ERROR_OWNER_AFTER_HANDLER_PATCH not in patch_ids

--- a/tests/temporal/test_dsl_workflow_replay.py
+++ b/tests/temporal/test_dsl_workflow_replay.py
@@ -1,0 +1,193 @@
+"""Replay compatibility tests for DSLWorkflow histories."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Never
+
+import pytest
+from temporalio import activity
+from temporalio.client import Client, WorkflowFailureError, WorkflowHistory
+from temporalio.exceptions import ApplicationError
+from temporalio.worker import Replayer, Worker
+
+from tracecat.auth.types import Role
+from tracecat.dsl import workflow as workflow_module
+from tracecat.dsl.action import DSLActivities, PrepareSubflowActivityInput
+from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.init_activities import (
+    resolve_workflow_concurrency_limits_enabled_activity,
+)
+from tracecat.dsl.schemas import ActionStatement
+from tracecat.dsl.types import TaskExceptionInfo
+from tracecat.dsl.worker import new_sandbox_runner
+from tracecat.dsl.workflow import (
+    ERROR_OWNER_AFTER_HANDLER_PATCH,
+    ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH,
+    DSLWorkflow,
+)
+from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
+from tracecat.registry.lock.types import RegistryLock
+from tracecat.storage.object import InlineObject
+from tracecat.temporal.errors import extract_error_envelope
+from tracecat.workflow.management.management import WorkflowsManagementService
+
+pytestmark = [pytest.mark.temporal, pytest.mark.integration]
+
+
+def _activity_name(activity_def: object) -> str:
+    """Read the name Temporal attaches dynamically to an activity definition."""
+    return getattr(activity_def, "__temporal_activity_definition").name
+
+
+@activity.defn(
+    name=_activity_name(resolve_workflow_concurrency_limits_enabled_activity)
+)
+async def _disable_workflow_concurrency_limits() -> bool:
+    """Keep the replay history focused on the terminal failure boundary."""
+    return False
+
+
+@activity.defn(name=_activity_name(DSLActivities.prepare_subflow_activity))
+async def _legacy_prepare_subflow_activity(
+    _input: PrepareSubflowActivityInput,
+) -> None:
+    """Reproduce the unclassified activity failure emitted before ENG-1407."""
+    raise RuntimeError("synthetic legacy subflow preparation failure")
+
+
+def _raise_legacy_workflow_application_error(
+    task_exceptions: Mapping[str, TaskExceptionInfo],
+) -> Never:
+    """Reproduce the terminal ApplicationError emitted before ENG-1407."""
+    n_exceptions = len(task_exceptions)
+    formatted_exceptions = "\n".join(
+        f"{'=' * 10} ({i + 1}/{n_exceptions}) {details.expr_context}.{ref} {'=' * 10}\n\n{info.exception!s}"
+        for i, (ref, info) in enumerate(task_exceptions.items())
+        if (details := info.details)
+    )
+    raise ApplicationError(
+        f"Workflow failed with {n_exceptions} error(s)\n\n{formatted_exceptions}",
+        {ref: info.details for ref, info in task_exceptions.items()},
+        non_retryable=True,
+        type=ApplicationError.__name__,
+    ) from None
+
+
+def _ignore_terminal_error_owner(_error: ApplicationError) -> None:
+    """Reproduce the absence of terminal owner attribution before ENG-1407."""
+
+
+async def _recorded_patch_ids(
+    temporal_client: Client,
+    history: WorkflowHistory,
+) -> set[str]:
+    """Decode patch IDs recorded in a workflow history."""
+    patch_ids: set[str] = set()
+    for event in history.events:
+        if not event.HasField("marker_recorded_event_attributes"):
+            continue
+        attributes = event.marker_recorded_event_attributes
+        if attributes.marker_name != "core_patch":
+            continue
+        patch_payload = attributes.details.get("patch-data")
+        if patch_payload is None:
+            continue
+        patch_data = await temporal_client.data_converter.decode(patch_payload.payloads)
+        for data in patch_data:
+            if isinstance(data, Mapping) and isinstance(data.get("id"), str):
+                patch_ids.add(data["id"])
+    return patch_ids
+
+
+@pytest.mark.anyio
+async def test_dsl_workflow_replays_legacy_subflow_failure_history(
+    temporal_client: Client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay a marker-free, pre-classification activity failure history."""
+    task_queue = f"dsl-workflow-replay-{uuid.uuid4()}"
+    wf_id = WorkflowUUID.new_uuid4()
+    run_args = DSLRunArgs(
+        role=Role(
+            type="service",
+            service_id="tracecat-runner",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+        wf_id=wf_id,
+        dsl=DSLInput(
+            title="Legacy replay probe",
+            description="Capture an unclassified subflow preparation failure",
+            entrypoint=DSLEntrypoint(ref="call_child"),
+            actions=[
+                ActionStatement(
+                    ref="call_child",
+                    action="core.workflow.execute",
+                    args={"workflow_alias": "missing-child"},
+                )
+            ],
+        ),
+        trigger_inputs=InlineObject(data={"source": "replay-test"}),
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test"},
+            actions={},
+        ),
+        time_anchor=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    current_patched = workflow_module.workflow.patched
+
+    def legacy_patched(patch_id: str) -> bool:
+        """Keep the captured history older than the owner-timing patch."""
+        if patch_id == ERROR_OWNER_AFTER_HANDLER_PATCH:
+            return False
+        return current_patched(patch_id)
+
+    with monkeypatch.context() as legacy_worker:
+        legacy_worker.setattr(workflow_module.workflow, "patched", legacy_patched)
+        legacy_worker.setattr(
+            workflow_module,
+            "_raise_workflow_application_error",
+            _raise_legacy_workflow_application_error,
+        )
+        legacy_worker.setattr(
+            DSLWorkflow,
+            "_upsert_terminal_error_owner",
+            staticmethod(_ignore_terminal_error_owner),
+        )
+        async with Worker(
+            client=temporal_client,
+            task_queue=task_queue,
+            activities=[
+                _disable_workflow_concurrency_limits,
+                _legacy_prepare_subflow_activity,
+                WorkflowsManagementService.get_error_handler_workflow_id,
+            ],
+            workflows=[DSLWorkflow],
+            workflow_runner=new_sandbox_runner(),
+        ):
+            handle = await temporal_client.start_workflow(
+                DSLWorkflow.run,
+                run_args,
+                id=generate_exec_id(wf_id),
+                task_queue=task_queue,
+                execution_timeout=timedelta(seconds=30),
+            )
+            with pytest.raises(WorkflowFailureError) as exc_info:
+                await handle.result()
+
+    history = await handle.fetch_history()
+    assert extract_error_envelope(exc_info.value) is None
+    recorded_patch_ids = await _recorded_patch_ids(temporal_client, history)
+    assert ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH not in recorded_patch_ids
+    assert ERROR_OWNER_AFTER_HANDLER_PATCH not in recorded_patch_ids
+
+    replay_result = await Replayer(
+        workflows=[DSLWorkflow],
+        workflow_runner=new_sandbox_runner(),
+        data_converter=temporal_client.data_converter,
+    ).replay_workflow(history, raise_on_replay_failure=False)
+    assert replay_result.replay_failure is None

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -11,7 +11,7 @@ import asyncio
 import os
 import uuid
 from collections.abc import Callable, Mapping, Sequence
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 import orjson
@@ -67,7 +67,6 @@ from tracecat.agent.executor.activity import (
     AgentExecutorResult,
     ToolExecutionResult,
 )
-from tracecat.agent.executor.schemas import ApprovedToolCall
 from tracecat.agent.preset.activities import ResolveAgentsConfigActivityInput
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
@@ -2715,46 +2714,6 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         legacy_sdk_session_data,
         None,
     ]
-
-
-def test_agent_workflow_does_not_retry_approved_tool_failures(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured_activity_options: dict[str, Any] = {}
-    service_role = Role(
-        type="user",
-        workspace_id=uuid.uuid4(),
-        organization_id=uuid.uuid4(),
-        user_id=uuid.uuid4(),
-        service_id="tracecat-api",
-    )
-
-    def mock_start_activity(*args: Any, **kwargs: Any) -> Any:
-        del args
-        captured_activity_options.update(kwargs)
-        return object()
-
-    monkeypatch.setattr(temporal_workflow, "uuid4", uuid.uuid4)
-    monkeypatch.setattr(temporal_workflow, "start_activity", mock_start_activity)
-
-    durable_workflow_module._start_registry_tool_call(
-        ApprovedToolCall(
-            tool_call_id="call_123",
-            tool_name="core__http_request",
-            args={"url": "https://example.com", "method": "GET"},
-        ),
-        registry_lock=RegistryLock(
-            origins={"tracecat_registry": "test-version"},
-            actions={"core.http_request": "tracecat_registry"},
-        ),
-        service_role=service_role,
-        logical_time=datetime(2026, 3, 18, tzinfo=UTC),
-    )
-
-    retry_policy = captured_activity_options["retry_policy"]
-    assert retry_policy == RETRY_POLICIES["activity:fail_fast"]
-    assert retry_policy.maximum_attempts == 1
-    assert captured_activity_options["task_queue"] == config.TRACECAT__EXECUTOR_QUEUE
 
 
 # =============================================================================

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -2942,6 +2942,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
             mock_record_approval_requests,
             mock_apply_approval_decisions,
             mock_emit_session_done,
+            create_mock_finalize_turn_activity(),
         ],
         workflows=[DurableAgentWorkflow],
         workflow_runner=UnsandboxedWorkflowRunner(),

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -10,7 +10,7 @@ These tests verify the end-to-end workflow behavior including:
 import asyncio
 import os
 import uuid
-from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from typing import Any
@@ -59,6 +59,7 @@ from tracecat_ee.agent.workflows.durable import (
     WorkflowCancelRequest,
 )
 
+from tests.shared import recorded_patch_ids
 from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.common.stream_types import ToolCallContent
@@ -415,29 +416,6 @@ async def replay_durable_agent_workflow_history(
             data_converter=temporal_client.data_converter,
         ).replay_workflows(histories(), raise_on_replay_failure=False)
     assert not replay_results.replay_failures
-
-
-async def recorded_patch_ids(
-    temporal_client: Client,
-    history: WorkflowHistory,
-) -> set[str]:
-    """Decode patch IDs recorded in a workflow history."""
-    patch_ids: set[str] = set()
-    for event in history.events:
-        if not event.HasField("marker_recorded_event_attributes"):
-            continue
-        attributes = event.marker_recorded_event_attributes
-        if attributes.marker_name != "core_patch":
-            continue
-        if "patch-data" not in attributes.details:
-            continue
-        patch_data = await temporal_client.data_converter.decode(
-            attributes.details["patch-data"].payloads
-        )
-        for data in patch_data:
-            if isinstance(data, Mapping) and isinstance(data.get("id"), str):
-                patch_ids.add(data["id"])
-    return patch_ids
 
 
 async def fetch_history_after_completed_workflow_task(

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -2589,17 +2589,10 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         input: LoadSessionInput,
     ) -> LoadSessionResult:
         assert input.session_id == mock_session_id
-        if len(captured_agent_inputs) == 0:
-            return LoadSessionResult(
-                found=True,
-                sdk_session_id="legacy-sdk-session",
-                sdk_session_data=legacy_sdk_session_data,
-                is_fork=False,
-            )
         return LoadSessionResult(
             found=True,
             sdk_session_id="legacy-sdk-session",
-            sdk_session_data=None,
+            sdk_session_data=legacy_sdk_session_data,
             is_fork=False,
         )
 
@@ -2608,29 +2601,19 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         input: AgentExecutorInput,
     ) -> AgentExecutorResult:
         captured_agent_inputs.append(input)
-        if len(captured_agent_inputs) == 1:
-            assert input.sdk_session_id == "legacy-sdk-session"
-            assert input.sdk_session_data == legacy_sdk_session_data
-            assert input.is_approval_continuation is False
-            return AgentExecutorResult(
-                success=True,
-                approval_requested=True,
-                approval_items=[
-                    ToolCallContent(
-                        id="call_123",
-                        name="core__http_request",
-                        input={"url": "https://example.com", "method": "GET"},
-                    )
-                ],
-            )
-
         assert input.sdk_session_id == "legacy-sdk-session"
-        assert input.sdk_session_data is None
-        assert input.is_approval_continuation is True
+        assert input.sdk_session_data == legacy_sdk_session_data
+        assert input.is_approval_continuation is False
         return AgentExecutorResult(
             success=True,
-            approval_requested=False,
-            output={"status": "continued"},
+            approval_requested=True,
+            approval_items=[
+                ToolCallContent(
+                    id="call_123",
+                    name="core__http_request",
+                    input={"url": "https://example.com", "method": "GET"},
+                )
+            ],
         )
 
     @activity.defn(name="record_approval_requests")
@@ -2640,12 +2623,6 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         assert [approval.tool_call_id for approval in input.approvals] == ["call_123"]
         approval_pause_call_order.append("record_approval_requests")
         approval_request_recorded.set()
-
-    @activity.defn(name="apply_approval_decisions")
-    async def mock_apply_approval_decisions(
-        input: ApplyApprovalResultsActivityInputs,
-    ) -> None:
-        assert [decision.tool_call_id for decision in input.decisions] == ["call_123"]
 
     workflow_args = AgentWorkflowArgs(
         role=svc_role,
@@ -2664,15 +2641,11 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         create_mock_load_session_messages_activity(),
         create_mock_build_tool_definitions_activity(),
         mock_run_agent_activity,
-        create_mock_execute_action_activity(),
-        create_mock_reconcile_tool_results_activity(),
         mock_record_approval_requests,
-        mock_apply_approval_decisions,
         create_mock_emit_session_done_activity(
             call_order=approval_pause_call_order,
             done_event=approval_done_emitted,
         ),
-        create_mock_finalize_turn_activity(),
     ]
 
     async with agent_worker_factory(
@@ -2694,25 +2667,12 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
             "emit_session_done",
         ]
         suspended_history = await fetch_history_after_completed_workflow_task(wf_handle)
-        await replay_durable_agent_workflow_history(temporal_client, suspended_history)
 
-        await wf_handle.execute_update(
-            DurableAgentWorkflow.set_approvals,
-            WorkflowApprovalSubmission(
-                approvals={"call_123": True},
-                approved_by=svc_role.user_id,
-            ),
-        )
+    await wf_handle.terminate(reason="Replay regression history captured")
+    await replay_durable_agent_workflow_history(temporal_client, suspended_history)
 
-        result = await wf_handle.result()
-        completed_history = await wf_handle.fetch_history()
-        await replay_durable_agent_workflow_history(temporal_client, completed_history)
-
-    assert result.session_id == mock_session_id
-    assert result.output == {"status": "continued"}
     assert [input.sdk_session_data for input in captured_agent_inputs] == [
-        legacy_sdk_session_data,
-        None,
+        legacy_sdk_session_data
     ]
 
 

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -11,7 +11,7 @@ import asyncio
 import os
 import uuid
 from collections.abc import Callable, Mapping, Sequence
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import orjson
@@ -67,6 +67,7 @@ from tracecat.agent.executor.activity import (
     AgentExecutorResult,
     ToolExecutionResult,
 )
+from tracecat.agent.executor.schemas import ApprovedToolCall
 from tracecat.agent.preset.activities import ResolveAgentsConfigActivityInput
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
@@ -2716,171 +2717,44 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
     ]
 
 
-@pytest.mark.anyio
-@pytest.mark.integration
-async def test_agent_workflow_does_not_retry_approved_tool_failures(
-    svc_role: Role,
-    temporal_client: Client,
-    agent_worker_factory,
-    mock_session_id: uuid.UUID,
-    agent_config_with_approvals: AgentConfig,
+def test_agent_workflow_does_not_retry_approved_tool_failures(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    agent_queue = f"test-agent-queue-{mock_session_id}"
-
-    approval_request_recorded = asyncio.Event()
-    approval_done_emitted = asyncio.Event()
-    approval_pause_call_order: list[str] = []
-    resumed_after_approval = asyncio.Event()
-    reconcile_inputs: list[ReconcileToolResultsInput] = []
-    executor_attempts = 0
-    run_agent_call_count = 0
-
-    @activity.defn(name="run_agent_activity")
-    async def mock_run_agent_activity(
-        input: AgentExecutorInput,
-    ) -> AgentExecutorResult:
-        nonlocal run_agent_call_count
-        activity.heartbeat("Mock agent running")
-
-        if run_agent_call_count == 0:
-            run_agent_call_count += 1
-            return AgentExecutorResult(
-                success=True,
-                approval_requested=True,
-                approval_items=[
-                    ToolCallContent(
-                        id="call_123",
-                        name="core__http_request",
-                        input={"url": "https://example.com", "method": "GET"},
-                    )
-                ],
-            )
-
-        assert input.is_approval_continuation is True
-
-        resumed_after_approval.set()
-        run_agent_call_count += 1
-        return AgentExecutorResult(
-            success=True,
-            approval_requested=False,
-            output={"status": "done"},
-        )
-
-    @activity.defn(name="record_approval_requests")
-    async def mock_record_approval_requests(input: Any) -> None:
-        del input
-        approval_pause_call_order.append("record_approval_requests")
-        approval_request_recorded.set()
-
-    @activity.defn(name="apply_approval_decisions")
-    async def mock_apply_approval_decisions(input: Any) -> None:
-        del input
-
-    @activity.defn(name="execute_action_activity")
-    async def mock_execute_action_activity(
-        input: RunActionInput,
-        role: Role,
-    ) -> InlineObject[dict[str, str]]:
-        del input, role
-        nonlocal executor_attempts
-        executor_attempts += 1
-        if executor_attempts == 1:
-            raise ApplicationError("transient tool failure")
-        return InlineObject(data={"status": "success"})
-
-    @activity.defn(name="reconcile_tool_results_activity")
-    async def mock_reconcile_tool_results_activity(
-        input: ReconcileToolResultsInput,
-    ) -> ReconcileToolResultsResult:
-        reconcile_inputs.append(input)
-        return ReconcileToolResultsResult(
-            results=[
-                ToolExecutionResult(
-                    tool_call_id=pending.tool_call_id,
-                    tool_name=pending.tool_name,
-                    result=pending.raw_result,
-                    is_error=pending.is_error,
-                )
-                for pending in input.pending_results
-            ]
-        )
-
-    mock_emit_session_done = create_mock_emit_session_done_activity(
-        call_order=approval_pause_call_order,
-        done_event=approval_done_emitted,
+    captured_activity_options: dict[str, Any] = {}
+    service_role = Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
     )
 
-    workflow_args = AgentWorkflowArgs(
-        role=svc_role,
-        agent_args=RunAgentArgs(
-            session_id=mock_session_id,
-            user_prompt="Make a test HTTP request",
-            config=agent_config_with_approvals,
+    def mock_start_activity(*args: Any, **kwargs: Any) -> Any:
+        del args
+        captured_activity_options.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(temporal_workflow, "uuid4", uuid.uuid4)
+    monkeypatch.setattr(temporal_workflow, "start_activity", mock_start_activity)
+
+    durable_workflow_module._start_registry_tool_call(
+        ApprovedToolCall(
+            tool_call_id="call_123",
+            tool_name="core__http_request",
+            args={"url": "https://example.com", "method": "GET"},
         ),
-        entity_type=AgentSessionEntity.WORKFLOW,
-        entity_id=uuid.uuid4(),
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test-version"},
+            actions={"core.http_request": "tracecat_registry"},
+        ),
+        service_role=service_role,
+        logical_time=datetime(2026, 3, 18, tzinfo=UTC),
     )
 
-    activities = [
-        create_mock_create_session_activity(),
-        create_mock_load_session_activity(),
-        create_mock_load_session_messages_activity(),
-        create_mock_build_tool_definitions_activity(),
-        mock_run_agent_activity,
-        mock_record_approval_requests,
-        mock_apply_approval_decisions,
-        mock_emit_session_done,
-        mock_execute_action_activity,
-        mock_reconcile_tool_results_activity,
-        create_mock_finalize_turn_activity(),
-    ]
-
-    agent_worker = agent_worker_factory(
-        temporal_client, task_queue=agent_queue, custom_activities=activities
-    )
-    async with asyncio.timeout(30):
-        await agent_worker.__aenter__()
-    try:
-        async with asyncio.timeout(30):
-            wf_handle = await temporal_client.start_workflow(
-                DurableAgentWorkflow.run,
-                workflow_args,
-                id=AgentWorkflowID(mock_session_id),
-                task_queue=agent_queue,
-                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-                execution_timeout=timedelta(seconds=60),
-            )
-
-        await asyncio.wait_for(approval_request_recorded.wait(), timeout=10)
-        await asyncio.wait_for(approval_done_emitted.wait(), timeout=10)
-        assert approval_pause_call_order == [
-            "record_approval_requests",
-            "emit_session_done",
-        ]
-        async with asyncio.timeout(30):
-            await wf_handle.execute_update(
-                DurableAgentWorkflow.set_approvals,
-                WorkflowApprovalSubmission(
-                    approvals={"call_123": True},
-                    approved_by=svc_role.user_id,
-                ),
-            )
-
-        async with asyncio.timeout(30):
-            result = await wf_handle.result()
-    finally:
-        async with asyncio.timeout(30):
-            await agent_worker.__aexit__(None, None, None)
-
-    assert result.session_id == mock_session_id
-    assert executor_attempts == 1
-    assert resumed_after_approval.is_set()
-    assert len(reconcile_inputs) == 1
-    [pending_result] = reconcile_inputs[0].pending_results
-    assert pending_result.tool_call_id == "call_123"
-    assert pending_result.is_error is True
-    assert pending_result.raw_result is not None
-    assert "Tool execution failed:" in pending_result.raw_result
+    retry_policy = captured_activity_options["retry_policy"]
+    assert retry_policy == RETRY_POLICIES["activity:fail_fast"]
+    assert retry_policy.maximum_attempts == 1
+    assert captured_activity_options["task_queue"] == config.TRACECAT__EXECUTOR_QUEUE
 
 
 # =============================================================================

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -2579,7 +2579,7 @@ async def test_agent_workflow_routes_approved_user_mcp_tool_to_remote_activity(
 async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
     svc_role: Role,
     temporal_client: Client,
-    agent_worker_factory,
+    monkeypatch: pytest.MonkeyPatch,
     mock_session_id: uuid.UUID,
     agent_config_with_approvals: AgentConfig,
 ) -> None:
@@ -2658,8 +2658,19 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         ),
     ]
 
-    async with agent_worker_factory(
-        temporal_client, task_queue=queue, custom_activities=activities
+    monkeypatch.setattr(config, "TRACECAT__AGENT_EXECUTOR_QUEUE", queue)
+    monkeypatch.setattr(config, "TRACECAT__EXECUTOR_QUEUE", queue)
+
+    # Every activity registered by this regression is async, so it does not
+    # need the shared activity executor. Keeping that executor alive while the
+    # suspended history is replayed can strand an xdist worker in AnyIO test
+    # teardown after the test call itself has passed.
+    async with Worker(
+        client=temporal_client,
+        task_queue=queue,
+        activities=activities,
+        workflows=[DurableAgentWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
     ):
         wf_handle = await temporal_client.start_workflow(
             DurableAgentWorkflow.run,

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -2672,6 +2672,7 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
             call_order=approval_pause_call_order,
             done_event=approval_done_emitted,
         ),
+        create_mock_finalize_turn_activity(),
     ]
 
     async with agent_worker_factory(
@@ -2720,77 +2721,19 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
 async def test_agent_workflow_does_not_retry_approved_tool_failures(
     svc_role: Role,
     temporal_client: Client,
+    agent_worker_factory,
     mock_session_id: uuid.UUID,
     agent_config_with_approvals: AgentConfig,
-    test_user: User,
-    monkeypatch: pytest.MonkeyPatch,
-    threadpool,
 ) -> None:
-    del test_user
     agent_queue = f"test-agent-queue-{mock_session_id}"
-    agent_executor_queue = f"test-agent-executor-queue-{mock_session_id}"
-    executor_queue = f"test-executor-queue-{mock_session_id}"
-
-    monkeypatch.setattr(config, "TRACECAT__AGENT_QUEUE", agent_queue)
-    monkeypatch.setattr(config, "TRACECAT__AGENT_EXECUTOR_QUEUE", agent_executor_queue)
-    monkeypatch.setattr(config, "TRACECAT__EXECUTOR_QUEUE", executor_queue)
 
     approval_request_recorded = asyncio.Event()
     approval_done_emitted = asyncio.Event()
     approval_pause_call_order: list[str] = []
     resumed_after_approval = asyncio.Event()
+    reconcile_inputs: list[ReconcileToolResultsInput] = []
     executor_attempts = 0
     run_agent_call_count = 0
-
-    class _FakeStream:
-        async def append(self, event: Any) -> None:
-            del event
-
-        async def clear_buffer(self) -> None:
-            return None
-
-    async def fake_agent_stream_new(
-        *,
-        session_id: uuid.UUID,
-        workspace_id: uuid.UUID,
-        stream_id: uuid.UUID | None = None,
-    ) -> _FakeStream:
-        del session_id, workspace_id, stream_id
-        return _FakeStream()
-
-    monkeypatch.setattr(
-        "tracecat.agent.session.activities.AgentStream.new",
-        fake_agent_stream_new,
-    )
-
-    @activity.defn(name="build_agent_tool_definitions")
-    async def mock_build_tool_definitions(
-        args: BuildAgentToolDefsArgs,
-    ) -> BuildAgentToolDefsResult:
-        tool_result = BuildToolDefsResult(
-            tool_definitions={
-                "core.http_request": MCPToolDefinition(
-                    name="core__http_request",
-                    description="HTTP request",
-                    parameters_json_schema={
-                        "type": "object",
-                        "properties": {
-                            "url": {"type": "string"},
-                            "method": {"type": "string"},
-                        },
-                        "required": ["url", "method"],
-                        "additionalProperties": False,
-                    },
-                )
-            },
-            registry_lock=RegistryLock(
-                origins={"tracecat_registry": "test-version"},
-                actions={"core.http_request": "tracecat_registry"},
-            ),
-        )
-        return BuildAgentToolDefsResult(
-            scopes={scope.scope: tool_result for scope in args.scopes}
-        )
 
     @activity.defn(name="run_agent_activity")
     async def mock_run_agent_activity(
@@ -2800,73 +2743,6 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         activity.heartbeat("Mock agent running")
 
         if run_agent_call_count == 0:
-            assistant_uuid = str(uuid.uuid4())
-            async with AgentSessionService.with_session(role=input.role) as service:
-                session = await service.get_session(input.session_id)
-                assert session is not None
-                session.sdk_session_id = "sdk-session"
-                service.session.add(session)
-                service.session.add(
-                    AgentSessionHistory(
-                        session_id=input.session_id,
-                        workspace_id=input.workspace_id,
-                        kind="chat-message",
-                        content={
-                            "uuid": assistant_uuid,
-                            "sessionId": "sdk-session",
-                            "type": "assistant",
-                            "timestamp": "2026-03-18T00:00:00Z",
-                            "cwd": "/home/agent",
-                            "version": "2.0.72",
-                            "message": {
-                                "role": "assistant",
-                                "content": [
-                                    {
-                                        "type": "tool_use",
-                                        "id": "call_123",
-                                        "name": "core__http_request",
-                                        "input": {
-                                            "url": "https://example.com",
-                                            "method": "GET",
-                                        },
-                                    }
-                                ],
-                            },
-                        },
-                    )
-                )
-                service.session.add(
-                    AgentSessionHistory(
-                        session_id=input.session_id,
-                        workspace_id=input.workspace_id,
-                        kind="chat-message",
-                        content={
-                            "uuid": str(uuid.uuid4()),
-                            "parentUuid": assistant_uuid,
-                            "sessionId": "sdk-session",
-                            "type": "user",
-                            "timestamp": "2026-03-18T00:00:01Z",
-                            "cwd": "/home/agent",
-                            "version": "2.0.72",
-                            "userType": "external",
-                            "gitBranch": "",
-                            "isSidechain": False,
-                            "message": {
-                                "role": "user",
-                                "content": [
-                                    {
-                                        "type": "tool_result",
-                                        "tool_use_id": "call_123",
-                                        "content": "interrupted",
-                                        "is_error": True,
-                                    }
-                                ],
-                            },
-                        },
-                    )
-                )
-                await service.session.commit()
-
             run_agent_call_count += 1
             return AgentExecutorResult(
                 success=True,
@@ -2881,8 +2757,6 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
             )
 
         assert input.is_approval_continuation is True
-        assert input.sdk_session_id == "sdk-session"
-        assert input.sdk_session_data is None
 
         resumed_after_approval.set()
         run_agent_call_count += 1
@@ -2914,6 +2788,23 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
             raise ApplicationError("transient tool failure")
         return InlineObject(data={"status": "success"})
 
+    @activity.defn(name="reconcile_tool_results_activity")
+    async def mock_reconcile_tool_results_activity(
+        input: ReconcileToolResultsInput,
+    ) -> ReconcileToolResultsResult:
+        reconcile_inputs.append(input)
+        return ReconcileToolResultsResult(
+            results=[
+                ToolExecutionResult(
+                    tool_call_id=pending.tool_call_id,
+                    tool_name=pending.tool_name,
+                    result=pending.raw_result,
+                    is_error=pending.is_error,
+                )
+                for pending in input.pending_results
+            ]
+        )
+
     mock_emit_session_done = create_mock_emit_session_done_activity(
         call_order=approval_pause_call_order,
         done_event=approval_done_emitted,
@@ -2930,40 +2821,23 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         entity_id=uuid.uuid4(),
     )
 
-    workflow_worker = Worker(
-        client=temporal_client,
-        task_queue=agent_queue,
-        activities=[
-            create_session_activity,
-            load_session_activity,
-            load_session_messages_activity,
-            reconcile_tool_results_activity,
-            mock_build_tool_definitions,
-            mock_record_approval_requests,
-            mock_apply_approval_decisions,
-            mock_emit_session_done,
-            create_mock_finalize_turn_activity(),
-        ],
-        workflows=[DurableAgentWorkflow],
-        workflow_runner=UnsandboxedWorkflowRunner(),
-        activity_executor=threadpool,
-    )
-    agent_executor_worker = Worker(
-        client=temporal_client,
-        task_queue=agent_executor_queue,
-        activities=[mock_run_agent_activity],
-        workflows=[],
-        activity_executor=threadpool,
-    )
-    executor_worker = Worker(
-        client=temporal_client,
-        task_queue=executor_queue,
-        activities=[mock_execute_action_activity],
-        workflows=[],
-        activity_executor=threadpool,
-    )
+    activities = [
+        create_mock_create_session_activity(),
+        create_mock_load_session_activity(),
+        create_mock_load_session_messages_activity(),
+        create_mock_build_tool_definitions_activity(),
+        mock_run_agent_activity,
+        mock_record_approval_requests,
+        mock_apply_approval_decisions,
+        mock_emit_session_done,
+        mock_execute_action_activity,
+        mock_reconcile_tool_results_activity,
+        create_mock_finalize_turn_activity(),
+    ]
 
-    async with workflow_worker, agent_executor_worker, executor_worker:
+    async with agent_worker_factory(
+        temporal_client, task_queue=agent_queue, custom_activities=activities
+    ):
         wf_handle = await temporal_client.start_workflow(
             DurableAgentWorkflow.run,
             workflow_args,
@@ -2992,21 +2866,12 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
     assert result.session_id == mock_session_id
     assert executor_attempts == 1
     assert resumed_after_approval.is_set()
-
-    async with AgentSessionService.with_session(role=svc_role) as service:
-        history = await service.get_session_history(mock_session_id)
-
-    tool_result_blocks = [
-        block
-        for entry in history
-        for block in entry.content.get("message", {}).get("content", [])
-        if isinstance(block, dict) and block.get("type") == "tool_result"
-    ]
-    inserted_block = next(
-        block for block in tool_result_blocks if block.get("tool_use_id") == "call_123"
-    )
-    assert inserted_block["is_error"] is True
-    assert "Tool execution failed:" in inserted_block["content"]
+    assert len(reconcile_inputs) == 1
+    [pending_result] = reconcile_inputs[0].pending_results
+    assert pending_result.tool_call_id == "call_123"
+    assert pending_result.is_error is True
+    assert pending_result.raw_result is not None
+    assert "Tool execution failed:" in pending_result.raw_result
 
 
 # =============================================================================

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -10,7 +10,7 @@ These tests verify the end-to-end workflow behavior including:
 import asyncio
 import os
 import uuid
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from datetime import timedelta
 from typing import Any
 
@@ -399,12 +399,16 @@ async def replay_durable_agent_workflow_history(
     history: WorkflowHistory,
 ) -> None:
     """Replay a fetched durable-agent history against the current workflow code."""
-    replay_result = await Replayer(
+
+    async def histories() -> AsyncIterator[WorkflowHistory]:
+        yield history
+
+    replay_results = await Replayer(
         workflows=[DurableAgentWorkflow],
         workflow_runner=UnsandboxedWorkflowRunner(),
         data_converter=temporal_client.data_converter,
-    ).replay_workflow(history, raise_on_replay_failure=False)
-    assert replay_result.replay_failure is None
+    ).replay_workflows(histories(), raise_on_replay_failure=False)
+    assert not replay_results.replay_failures
 
 
 async def recorded_patch_ids(

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -2835,17 +2835,21 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         create_mock_finalize_turn_activity(),
     ]
 
-    async with agent_worker_factory(
+    agent_worker = agent_worker_factory(
         temporal_client, task_queue=agent_queue, custom_activities=activities
-    ):
-        wf_handle = await temporal_client.start_workflow(
-            DurableAgentWorkflow.run,
-            workflow_args,
-            id=AgentWorkflowID(mock_session_id),
-            task_queue=agent_queue,
-            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-            execution_timeout=timedelta(seconds=60),
-        )
+    )
+    async with asyncio.timeout(30):
+        await agent_worker.__aenter__()
+    try:
+        async with asyncio.timeout(30):
+            wf_handle = await temporal_client.start_workflow(
+                DurableAgentWorkflow.run,
+                workflow_args,
+                id=AgentWorkflowID(mock_session_id),
+                task_queue=agent_queue,
+                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+                execution_timeout=timedelta(seconds=60),
+            )
 
         await asyncio.wait_for(approval_request_recorded.wait(), timeout=10)
         await asyncio.wait_for(approval_done_emitted.wait(), timeout=10)
@@ -2853,15 +2857,20 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
             "record_approval_requests",
             "emit_session_done",
         ]
-        await wf_handle.execute_update(
-            DurableAgentWorkflow.set_approvals,
-            WorkflowApprovalSubmission(
-                approvals={"call_123": True},
-                approved_by=svc_role.user_id,
-            ),
-        )
+        async with asyncio.timeout(30):
+            await wf_handle.execute_update(
+                DurableAgentWorkflow.set_approvals,
+                WorkflowApprovalSubmission(
+                    approvals={"call_123": True},
+                    approved_by=svc_role.user_id,
+                ),
+            )
 
-        result = await wf_handle.result()
+        async with asyncio.timeout(30):
+            result = await wf_handle.result()
+    finally:
+        async with asyncio.timeout(30):
+            await agent_worker.__aexit__(None, None, None)
 
     assert result.session_id == mock_session_id
     assert executor_attempts == 1

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -11,6 +11,7 @@ import asyncio
 import os
 import uuid
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from typing import Any
 
@@ -403,11 +404,16 @@ async def replay_durable_agent_workflow_history(
     async def histories() -> AsyncIterator[WorkflowHistory]:
         yield history
 
-    replay_results = await Replayer(
-        workflows=[DurableAgentWorkflow],
-        workflow_runner=UnsandboxedWorkflowRunner(),
-        data_converter=temporal_client.data_converter,
-    ).replay_workflows(histories(), raise_on_replay_failure=False)
+    # Replayer creates an executor that it intentionally never shuts down when
+    # none is supplied. Repeated replays would therefore keep xdist workers
+    # alive after their final test.
+    with ThreadPoolExecutor() as workflow_task_executor:
+        replay_results = await Replayer(
+            workflows=[DurableAgentWorkflow],
+            workflow_task_executor=workflow_task_executor,
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            data_converter=temporal_client.data_converter,
+        ).replay_workflows(histories(), raise_on_replay_failure=False)
     assert not replay_results.replay_failures
 
 

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -2579,7 +2579,7 @@ async def test_agent_workflow_routes_approved_user_mcp_tool_to_remote_activity(
 async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
     svc_role: Role,
     temporal_client: Client,
-    monkeypatch: pytest.MonkeyPatch,
+    agent_worker_factory,
     mock_session_id: uuid.UUID,
     agent_config_with_approvals: AgentConfig,
 ) -> None:
@@ -2658,19 +2658,8 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
         ),
     ]
 
-    monkeypatch.setattr(config, "TRACECAT__AGENT_EXECUTOR_QUEUE", queue)
-    monkeypatch.setattr(config, "TRACECAT__EXECUTOR_QUEUE", queue)
-
-    # Every activity registered by this regression is async, so it does not
-    # need the shared activity executor. Keeping that executor alive while the
-    # suspended history is replayed can strand an xdist worker in AnyIO test
-    # teardown after the test call itself has passed.
-    async with Worker(
-        client=temporal_client,
-        task_queue=queue,
-        activities=activities,
-        workflows=[DurableAgentWorkflow],
-        workflow_runner=UnsandboxedWorkflowRunner(),
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
     ):
         wf_handle = await temporal_client.start_workflow(
             DurableAgentWorkflow.run,

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -1393,6 +1393,7 @@ async def test_single_child_workflow_alias(
 
 
 @pytest.mark.anyio
+@pytest.mark.serial
 async def test_child_workflow_alias_not_found_surfaces_detail(
     test_role: Role,
     temporal_client: Client,

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -1393,7 +1393,6 @@ async def test_single_child_workflow_alias(
 
 
 @pytest.mark.anyio
-@pytest.mark.serial
 async def test_child_workflow_alias_not_found_surfaces_detail(
     test_role: Role,
     temporal_client: Client,

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -1397,7 +1397,6 @@ async def test_child_workflow_alias_not_found_surfaces_detail(
     test_role: Role,
     temporal_client: Client,
     test_worker_factory: WorkerFactory,
-    test_executor_worker_factory: WorkerFactory,
 ):
     test_name = test_child_workflow_alias_not_found_surfaces_detail.__name__
     wf_exec_id = generate_test_exec_id(test_name)
@@ -1434,9 +1433,8 @@ async def test_child_workflow_alias_not_found_surfaces_detail(
     )
 
     worker = test_worker_factory(temporal_client)
-    executor_worker = test_executor_worker_factory(temporal_client)
     with pytest.raises(WorkflowFailureError) as exc_info:
-        _ = await _run_workflow(wf_exec_id, run_args, worker, executor_worker)
+        _ = await _run_workflow(wf_exec_id, run_args, worker)
 
     assert str(exc_info.value) == "Workflow execution failed"
     cause = exc_info.value.cause

--- a/tests/unit/test_build_agent_args.py
+++ b/tests/unit/test_build_agent_args.py
@@ -24,7 +24,6 @@ from tracecat.agent.common.types import MCPHttpServerConfig, MCPStdioServerConfi
 from tracecat.auth.types import Role
 from tracecat.dsl.action import (
     BuildAgentArgsActivityInput,
-    BuildPresetAgentArgsActivityInput,
     DSLActivities,
 )
 from tracecat.dsl.schemas import ExecutionContext, TaskResult
@@ -608,7 +607,7 @@ class TestBuildPresetAgentArgsActivity:
             "preset": "my-preset",
             "user_prompt": "${{ VARS.prompts.default }}",
         }
-        input = BuildPresetAgentArgsActivityInput(
+        input = BuildAgentArgsActivityInput(
             args=args,
             operand=_make_context(),
             role=role,
@@ -634,7 +633,7 @@ class TestBuildPresetAgentArgsActivity:
             "preset": "my-preset",
             "user_prompt": "Hello",
         }
-        input = BuildPresetAgentArgsActivityInput(
+        input = BuildAgentArgsActivityInput(
             args=args,
             operand=_make_context(),
             role=role,
@@ -658,7 +657,7 @@ class TestBuildPresetAgentArgsActivity:
             "preset": "my-preset",
             "user_prompt": "${{ VARS.prompts.default }}",
         }
-        input = BuildPresetAgentArgsActivityInput(
+        input = BuildAgentArgsActivityInput(
             args=args,
             operand=_make_context(),
             role=role,

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -179,6 +179,38 @@ async def test_scheduler_preserves_standalone_error_envelope() -> None:
 
 
 @pytest.mark.anyio
+async def test_scheduler_rejects_defaulted_unversioned_envelope() -> None:
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    scheduler = _build_scheduler(total_tasks=1, executor=executor)
+    invalid_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="Invalid unversioned classification",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    fallback_envelope = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the action",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    invalid_detail = ActionErrorInfo(
+        ref="forged_action",
+        message=invalid_envelope.message,
+        type="UserError",
+        envelope=invalid_envelope,
+    ).model_dump(mode="json")
+    invalid_detail["envelope"].pop("schema")
+    error = _capture_application_error(fallback_envelope, invalid_detail)
+
+    await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
+
+    details = scheduler.task_exceptions["task_0"].details
+    assert details.ref == "task_0"
+    assert details.envelope == fallback_envelope
+
+
+@pytest.mark.anyio
 async def test_scheduler_respects_max_pending_tasks_cap() -> None:
     max_pending_tasks = 3
     total_tasks = 10

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -18,13 +18,11 @@ from tracecat.dsl.schemas import (
     ActionStatement,
     ExecutionContext,
     RunContext,
-    StreamID,
 )
 from tracecat.dsl.types import (
     ActionErrorInfo,
     Task,
 )
-from tracecat.expressions.common import ExprContext
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.runtime.errors import (
     ErrorEnvelope,
@@ -106,42 +104,6 @@ async def test_scheduler_preserves_classified_action_error() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.envelope == envelope
-
-
-@pytest.mark.anyio
-async def test_scheduler_preserves_classified_mapped_child_error() -> None:
-    async def executor(_: ActionStatement) -> None:
-        return None
-
-    scheduler = _build_scheduler(total_tasks=1, executor=executor)
-    envelope = ErrorEnvelope.user(
-        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
-        message="The child action failed",
-        retry_disposition=RetryDisposition.NON_RETRYABLE,
-    )
-    nested = ActionErrorInfo(
-        ref="nested_action",
-        message="Nested context",
-        type="ValueError",
-    )
-    child = ActionErrorInfo(
-        ref="child_action",
-        message="The child action failed",
-        type="ValueError",
-        expr_context=ExprContext.TRIGGER,
-        attempt=3,
-        stream_id=StreamID.new("scatter", 2),
-        children=[nested],
-        envelope=envelope,
-    )
-    error = _capture_application_error(
-        envelope,
-        {child.ref: child.model_dump(mode="json")},
-    )
-
-    await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
-
-    assert scheduler.task_exceptions["task_0"].details == child
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -7,8 +7,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 import pytest
-from temporalio.exceptions import ApplicationError
 
+from tests.shared import capture_application_error as _capture_application_error
 from tracecat.auth.types import Role
 from tracecat.dsl import scheduler as scheduler_module
 from tracecat.dsl.common import DSLEntrypoint, DSLInput
@@ -32,17 +32,7 @@ from tracecat.runtime.errors import (
 )
 from tracecat.temporal.errors import (
     extract_error_envelopes,
-    raise_application_error_from_envelope,
 )
-
-
-def _capture_application_error(
-    envelope: ErrorEnvelope,
-    *details: object,
-) -> ApplicationError:
-    with pytest.raises(ApplicationError) as exc_info:
-        raise_application_error_from_envelope(envelope, *details)
-    return exc_info.value
 
 
 def _build_scheduler(

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -18,6 +18,7 @@ from tracecat.dsl.schemas import (
     ActionStatement,
     ExecutionContext,
     RunContext,
+    StreamID,
 )
 from tracecat.dsl.types import (
     ActionErrorInfo,
@@ -106,6 +107,36 @@ async def test_scheduler_preserves_classified_action_error() -> None:
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
+    assert details.envelope == envelope
+
+
+@pytest.mark.anyio
+async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> None:
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    scheduler = _build_scheduler(total_tasks=1, executor=executor)
+    stream_id = StreamID.new("task_0", 2)
+    envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    error = _capture_application_error(
+        envelope,
+        ActionErrorInfo(
+            ref="legacy_ref",
+            message=envelope.message,
+            type="ValueError",
+            envelope=envelope,
+        ),
+    )
+
+    await scheduler._handle_error_path(Task(ref="task_0", stream_id=stream_id), error)
+
+    details = scheduler.stream_exceptions[stream_id].details
+    assert details.ref == "task_0"
+    assert details.stream_id == stream_id
     assert details.envelope == envelope
 
 

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -26,14 +26,14 @@ from tracecat.dsl.types import (
 )
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.runtime.errors import (
-    ErrorEnvelope,
     RetryDisposition,
+    RuntimeErrorClassification,
     RuntimeErrorKind,
 )
 from tracecat.temporal.errors import (
-    extract_error_envelopes,
-    parse_classified_detail,
-    wrap_error,
+    build_error_transport_detail,
+    extract_error_classifications,
+    parse_classified_error_payload,
 )
 
 
@@ -78,13 +78,13 @@ def _build_scheduler(
 
 @pytest.mark.anyio
 async def test_scheduler_unwraps_classified_action_error_payload() -> None:
-    """A wrapper's payload becomes the task error info and its envelope is recorded."""
+    """Transported diagnostics become task error info and retain classification."""
 
     async def executor(_: ActionStatement) -> None:
         return None
 
     scheduler = _build_scheduler(total_tasks=1, executor=executor)
-    envelope = ErrorEnvelope.user(
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
@@ -94,13 +94,15 @@ async def test_scheduler_unwraps_classified_action_error_payload() -> None:
         message="The action failed",
         type="ValueError",
     )
-    error = _capture_application_error(envelope, wrap_error(envelope, payload))
+    error = _capture_application_error(
+        classification, build_error_transport_detail(classification, payload)
+    )
 
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
     assert details == payload
-    assert scheduler.stream_error_envelopes[ROOT_STREAM] == envelope
+    assert scheduler.stream_error_classifications[ROOT_STREAM] == classification
 
 
 @pytest.mark.anyio
@@ -112,18 +114,18 @@ async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> 
 
     scheduler = _build_scheduler(total_tasks=1, executor=executor)
     stream_id = StreamID.new("task_0", 2)
-    envelope = ErrorEnvelope.user(
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
     error = _capture_application_error(
-        envelope,
-        wrap_error(
-            envelope,
+        classification,
+        build_error_transport_detail(
+            classification,
             ActionErrorInfo(
                 ref="legacy_ref",
-                message=envelope.message,
+                message=classification.message,
                 type="ValueError",
             ),
         ),
@@ -134,13 +136,13 @@ async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> 
     details = scheduler.stream_exceptions[stream_id].details
     assert details.ref == "task_0"
     assert details.stream_id == stream_id
-    assert details.message == envelope.message
-    assert scheduler.stream_error_envelopes[stream_id] == envelope
+    assert details.message == classification.message
+    assert scheduler.stream_error_classifications[stream_id] == classification
 
 
 @pytest.mark.anyio
 async def test_scheduler_unwraps_classified_child_workflow_error_map() -> None:
-    """A child's terminal wrapper map becomes children payloads; ownership
+    """A child's terminal transport map becomes children payloads; ownership
     aggregates platform-wins across entries, so a platform-owned entry after a
     user-owned one still attributes the stream to the platform."""
 
@@ -148,34 +150,34 @@ async def test_scheduler_unwraps_classified_child_workflow_error_map() -> None:
         return None
 
     scheduler = _build_scheduler(total_tasks=1, executor=executor)
-    user_envelope = ErrorEnvelope.user(
+    user_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The child action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    platform_envelope = ErrorEnvelope.platform(
+    platform_classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the child action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
     user_detail = ActionErrorInfo(
         ref="user_action",
-        message=user_envelope.message,
+        message=user_classification.message,
         type="UserError",
     )
     platform_detail = ActionErrorInfo(
         ref="platform_action",
-        message=platform_envelope.message,
+        message=platform_classification.message,
         type="RuntimeError",
     )
     error = _capture_application_error(
-        user_envelope,
+        user_classification,
         {
-            user_detail.ref: wrap_error(user_envelope, user_detail).model_dump(
-                mode="json"
-            ),
-            platform_detail.ref: wrap_error(
-                platform_envelope, platform_detail
+            user_detail.ref: build_error_transport_detail(
+                user_classification, user_detail
+            ).model_dump(mode="json"),
+            platform_detail.ref: build_error_transport_detail(
+                platform_classification, platform_detail
             ).model_dump(mode="json"),
         },
     )
@@ -184,14 +186,19 @@ async def test_scheduler_unwraps_classified_child_workflow_error_map() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.ref == "task_0"
-    assert details.message == platform_envelope.message
+    assert details.message == platform_classification.message
     assert details.children == [user_detail, platform_detail]
-    assert scheduler.stream_error_envelopes[ROOT_STREAM] == platform_envelope
-    assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
+    assert (
+        scheduler.stream_error_classifications[ROOT_STREAM] == platform_classification
+    )
+    assert extract_error_classifications(error) == (
+        user_classification,
+        platform_classification,
+    )
 
 
 @pytest.mark.anyio
-async def test_scheduler_child_workflow_error_map_all_user_keeps_first_envelope() -> (
+async def test_scheduler_child_workflow_error_map_all_user_keeps_first_classification() -> (
     None
 ):
     """An all-user terminal map still attributes the stream to the first entry."""
@@ -200,32 +207,32 @@ async def test_scheduler_child_workflow_error_map_all_user_keeps_first_envelope(
         return None
 
     scheduler = _build_scheduler(total_tasks=1, executor=executor)
-    first_envelope = ErrorEnvelope.user(
+    first_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The first child action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    second_envelope = ErrorEnvelope.user(
+    second_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The second child action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
     error = _capture_application_error(
-        first_envelope,
+        first_classification,
         {
-            "first_action": wrap_error(
-                first_envelope,
+            "first_action": build_error_transport_detail(
+                first_classification,
                 ActionErrorInfo(
                     ref="first_action",
-                    message=first_envelope.message,
+                    message=first_classification.message,
                     type="UserError",
                 ),
             ).model_dump(mode="json"),
-            "second_action": wrap_error(
-                second_envelope,
+            "second_action": build_error_transport_detail(
+                second_classification,
                 ActionErrorInfo(
                     ref="second_action",
-                    message=second_envelope.message,
+                    message=second_classification.message,
                     type="UserError",
                 ),
             ).model_dump(mode="json"),
@@ -235,70 +242,72 @@ async def test_scheduler_child_workflow_error_map_all_user_keeps_first_envelope(
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
-    assert details.message == first_envelope.message
-    assert scheduler.stream_error_envelopes[ROOT_STREAM] == first_envelope
+    assert details.message == first_classification.message
+    assert scheduler.stream_error_classifications[ROOT_STREAM] == first_classification
 
 
 @pytest.mark.anyio
-async def test_scheduler_synthesizes_info_from_bare_envelope_wrapper() -> None:
-    """A payload-free wrapper still yields a task error info built from its envelope."""
+async def test_scheduler_synthesizes_info_from_bare_transport_detail() -> None:
+    """A detail without diagnostics still yields synthesized task error info."""
 
     async def executor(_: ActionStatement) -> None:
         return None
 
     scheduler = _build_scheduler(total_tasks=1, executor=executor)
-    envelope = ErrorEnvelope.platform(
+    classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    error = _capture_application_error(envelope)
+    error = _capture_application_error(classification)
 
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.ref == "task_0"
-    assert details.message == envelope.message
+    assert details.message == classification.message
     assert details.children is None
-    assert scheduler.stream_error_envelopes[ROOT_STREAM] == envelope
+    assert scheduler.stream_error_classifications[ROOT_STREAM] == classification
 
 
 @pytest.mark.anyio
-async def test_scheduler_rejects_wrapper_with_undiscriminated_envelope() -> None:
-    """A wrapper whose envelope lacks the discriminator never classifies the failure."""
+async def test_scheduler_rejects_undiscriminated_classification() -> None:
+    """An undiscriminated classification never classifies the failure."""
 
     async def executor(_: ActionStatement) -> None:
         return None
 
     scheduler = _build_scheduler(total_tasks=1, executor=executor)
-    invalid_envelope = ErrorEnvelope.user(
+    invalid_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="Invalid unversioned classification",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    fallback_envelope = ErrorEnvelope.platform(
+    fallback_classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    invalid_detail = wrap_error(
-        invalid_envelope,
+    invalid_detail = build_error_transport_detail(
+        invalid_classification,
         ActionErrorInfo(
             ref="forged_action",
-            message=invalid_envelope.message,
+            message=invalid_classification.message,
             type="UserError",
         ),
     ).model_dump(mode="json")
-    invalid_detail["envelope"].pop("schema")
-    error = _capture_application_error(fallback_envelope, invalid_detail)
+    invalid_detail["classification"].pop("schema")
+    error = _capture_application_error(fallback_classification, invalid_detail)
 
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
-    assert parse_classified_detail(invalid_detail) is None
+    assert parse_classified_error_payload(invalid_detail) is None
     assert details.ref == "task_0"
-    assert details.message == fallback_envelope.message
-    assert scheduler.stream_error_envelopes[ROOT_STREAM] == fallback_envelope
+    assert details.message == fallback_classification.message
+    assert (
+        scheduler.stream_error_classifications[ROOT_STREAM] == fallback_classification
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -12,6 +12,7 @@ from tests.shared import capture_application_error as _capture_application_error
 from tracecat.auth.types import Role
 from tracecat.dsl import scheduler as scheduler_module
 from tracecat.dsl.common import DSLEntrypoint, DSLInput
+from tracecat.dsl.error_transport import parse_classified_action_error_payload
 from tracecat.dsl.scheduler import DSLScheduler
 from tracecat.dsl.schemas import (
     ROOT_STREAM,
@@ -33,7 +34,6 @@ from tracecat.runtime.errors import (
 from tracecat.temporal.errors import (
     build_error_transport_detail,
     extract_error_classifications,
-    parse_classified_error_payload,
 )
 
 
@@ -302,7 +302,7 @@ async def test_scheduler_rejects_undiscriminated_classification() -> None:
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
-    assert parse_classified_error_payload(invalid_detail) is None
+    assert parse_classified_action_error_payload(invalid_detail) is None
     assert details.ref == "task_0"
     assert details.message == fallback_classification.message
     assert (

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -29,7 +29,10 @@ from tracecat.runtime.errors import (
     RetryDisposition,
     RuntimeErrorKind,
 )
-from tracecat.temporal.errors import raise_application_error_from_envelope
+from tracecat.temporal.errors import (
+    extract_error_envelopes,
+    raise_application_error_from_envelope,
+)
 
 
 def _capture_application_error(
@@ -104,6 +107,55 @@ async def test_scheduler_preserves_classified_action_error() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.envelope == envelope
+
+
+@pytest.mark.anyio
+async def test_scheduler_preserves_all_classified_mapped_child_errors() -> None:
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    scheduler = _build_scheduler(total_tasks=1, executor=executor)
+    user_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The child action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    platform_envelope = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the child action",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    user_detail = ActionErrorInfo(
+        ref="user_action",
+        message=user_envelope.message,
+        type="UserError",
+        envelope=user_envelope,
+    )
+    platform_detail = ActionErrorInfo(
+        ref="platform_action",
+        message=platform_envelope.message,
+        type="RuntimeError",
+        envelope=platform_envelope,
+    )
+    error = _capture_application_error(
+        user_envelope,
+        {
+            user_detail.ref: user_detail.model_dump(mode="json"),
+            platform_detail.ref: platform_detail.model_dump(mode="json"),
+        },
+    )
+
+    await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
+
+    details = scheduler.task_exceptions["task_0"].details
+    assert details.ref == "task_0"
+    assert details.envelope == user_envelope
+    assert details.children == [user_detail, platform_detail]
+    retransported = _capture_application_error(user_envelope, details)
+    assert extract_error_envelopes(retransported) == (
+        user_envelope,
+        platform_envelope,
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -32,6 +32,8 @@ from tracecat.runtime.errors import (
 )
 from tracecat.temporal.errors import (
     extract_error_envelopes,
+    parse_classified_detail,
+    wrap_error,
 )
 
 
@@ -75,7 +77,9 @@ def _build_scheduler(
 
 
 @pytest.mark.anyio
-async def test_scheduler_preserves_classified_action_error() -> None:
+async def test_scheduler_unwraps_classified_action_error_payload() -> None:
+    """A wrapper's payload becomes the task error info and its envelope is recorded."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -85,23 +89,24 @@ async def test_scheduler_preserves_classified_action_error() -> None:
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    error = _capture_application_error(
-        envelope,
-        ActionErrorInfo(
-            ref="task_0",
-            message="The action failed",
-            type="ValueError",
-        ),
+    payload = ActionErrorInfo(
+        ref="task_0",
+        message="The action failed",
+        type="ValueError",
     )
+    error = _capture_application_error(envelope, wrap_error(envelope, payload))
 
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
-    assert details.envelope == envelope
+    assert details == payload
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == envelope
 
 
 @pytest.mark.anyio
 async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> None:
+    """An unwrapped payload is rebound to the failing task's ref and stream."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -114,11 +119,13 @@ async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> 
     )
     error = _capture_application_error(
         envelope,
-        ActionErrorInfo(
-            ref="legacy_ref",
-            message=envelope.message,
-            type="ValueError",
-            envelope=envelope,
+        wrap_error(
+            envelope,
+            ActionErrorInfo(
+                ref="legacy_ref",
+                message=envelope.message,
+                type="ValueError",
+            ),
         ),
     )
 
@@ -127,11 +134,14 @@ async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> 
     details = scheduler.stream_exceptions[stream_id].details
     assert details.ref == "task_0"
     assert details.stream_id == stream_id
-    assert details.envelope == envelope
+    assert details.message == envelope.message
+    assert scheduler.stream_error_envelopes[stream_id] == envelope
 
 
 @pytest.mark.anyio
-async def test_scheduler_preserves_all_classified_mapped_child_errors() -> None:
+async def test_scheduler_unwraps_classified_child_workflow_error_map() -> None:
+    """A child's terminal wrapper map becomes children payloads; envelopes stay on it."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -150,19 +160,21 @@ async def test_scheduler_preserves_all_classified_mapped_child_errors() -> None:
         ref="user_action",
         message=user_envelope.message,
         type="UserError",
-        envelope=user_envelope,
     )
     platform_detail = ActionErrorInfo(
         ref="platform_action",
         message=platform_envelope.message,
         type="RuntimeError",
-        envelope=platform_envelope,
     )
     error = _capture_application_error(
         user_envelope,
         {
-            user_detail.ref: user_detail.model_dump(mode="json"),
-            platform_detail.ref: platform_detail.model_dump(mode="json"),
+            user_detail.ref: wrap_error(user_envelope, user_detail).model_dump(
+                mode="json"
+            ),
+            platform_detail.ref: wrap_error(
+                platform_envelope, platform_detail
+            ).model_dump(mode="json"),
         },
     )
 
@@ -170,17 +182,16 @@ async def test_scheduler_preserves_all_classified_mapped_child_errors() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.ref == "task_0"
-    assert details.envelope == user_envelope
+    assert details.message == user_envelope.message
     assert details.children == [user_detail, platform_detail]
-    retransported = _capture_application_error(user_envelope, details)
-    assert extract_error_envelopes(retransported) == (
-        user_envelope,
-        platform_envelope,
-    )
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == user_envelope
+    assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
 
 
 @pytest.mark.anyio
-async def test_scheduler_preserves_standalone_error_envelope() -> None:
+async def test_scheduler_synthesizes_info_from_bare_envelope_wrapper() -> None:
+    """A payload-free wrapper still yields a task error info built from its envelope."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -196,11 +207,15 @@ async def test_scheduler_preserves_standalone_error_envelope() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.ref == "task_0"
-    assert details.envelope == envelope
+    assert details.message == envelope.message
+    assert details.children is None
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == envelope
 
 
 @pytest.mark.anyio
-async def test_scheduler_rejects_defaulted_unversioned_envelope() -> None:
+async def test_scheduler_rejects_wrapper_with_undiscriminated_envelope() -> None:
+    """A wrapper whose envelope lacks the discriminator never classifies the failure."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -215,11 +230,13 @@ async def test_scheduler_rejects_defaulted_unversioned_envelope() -> None:
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    invalid_detail = ActionErrorInfo(
-        ref="forged_action",
-        message=invalid_envelope.message,
-        type="UserError",
-        envelope=invalid_envelope,
+    invalid_detail = wrap_error(
+        invalid_envelope,
+        ActionErrorInfo(
+            ref="forged_action",
+            message=invalid_envelope.message,
+            type="UserError",
+        ),
     ).model_dump(mode="json")
     invalid_detail["envelope"].pop("schema")
     error = _capture_application_error(fallback_envelope, invalid_detail)
@@ -227,8 +244,10 @@ async def test_scheduler_rejects_defaulted_unversioned_envelope() -> None:
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
+    assert parse_classified_detail(invalid_detail) is None
     assert details.ref == "task_0"
-    assert details.envelope == fallback_envelope
+    assert details.message == fallback_envelope.message
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == fallback_envelope
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -140,7 +140,9 @@ async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> 
 
 @pytest.mark.anyio
 async def test_scheduler_unwraps_classified_child_workflow_error_map() -> None:
-    """A child's terminal wrapper map becomes children payloads; envelopes stay on it."""
+    """A child's terminal wrapper map becomes children payloads; ownership
+    aggregates platform-wins across entries, so a platform-owned entry after a
+    user-owned one still attributes the stream to the platform."""
 
     async def executor(_: ActionStatement) -> None:
         return None
@@ -182,10 +184,59 @@ async def test_scheduler_unwraps_classified_child_workflow_error_map() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.ref == "task_0"
-    assert details.message == user_envelope.message
+    assert details.message == platform_envelope.message
     assert details.children == [user_detail, platform_detail]
-    assert scheduler.stream_error_envelopes[ROOT_STREAM] == user_envelope
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == platform_envelope
     assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
+
+
+@pytest.mark.anyio
+async def test_scheduler_child_workflow_error_map_all_user_keeps_first_envelope() -> (
+    None
+):
+    """An all-user terminal map still attributes the stream to the first entry."""
+
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    scheduler = _build_scheduler(total_tasks=1, executor=executor)
+    first_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The first child action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    second_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The second child action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    error = _capture_application_error(
+        first_envelope,
+        {
+            "first_action": wrap_error(
+                first_envelope,
+                ActionErrorInfo(
+                    ref="first_action",
+                    message=first_envelope.message,
+                    type="UserError",
+                ),
+            ).model_dump(mode="json"),
+            "second_action": wrap_error(
+                second_envelope,
+                ActionErrorInfo(
+                    ref="second_action",
+                    message=second_envelope.message,
+                    type="UserError",
+                ),
+            ).model_dump(mode="json"),
+        },
+    )
+
+    await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
+
+    details = scheduler.task_exceptions["task_0"].details
+    assert details.message == first_envelope.message
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == first_envelope
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -27,7 +27,7 @@ from tracecat.dsl.schemas import (
     RunContext,
     TaskResult,
 )
-from tracecat.dsl.workflow import ERROR_OWNER_CONTROL_FLOW_PATCH, DSLWorkflow
+from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.dsl.workflow_logging import get_workflow_logger
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.registry.lock.types import RegistryLock
@@ -559,10 +559,6 @@ async def test_run_skips_tier_limit_enforcement_when_flag_disabled() -> None:
     acquire_permit_mock = AsyncMock()
 
     with (
-        patch(
-            "tracecat.dsl.workflow.workflow.patched",
-            return_value=True,
-        ) as patched_mock,
         patch.object(
             workflow,
             "_resolve_organization_id",
@@ -581,8 +577,6 @@ async def test_run_skips_tier_limit_enforcement_when_flag_disabled() -> None:
     ):
         result = await workflow.run(run_args)
 
-    patched_mock.assert_called_once_with(ERROR_OWNER_CONTROL_FLOW_PATCH)
-    assert workflow.error_owner_control_flow_enabled is True
     assert workflow.workflow_concurrency_limits_enabled is False
     execute_activity_mock.assert_not_awaited()
     acquire_permit_mock.assert_not_awaited()

--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -27,7 +27,7 @@ from tracecat.dsl.schemas import (
     RunContext,
     TaskResult,
 )
-from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.dsl.workflow import ERROR_OWNER_CONTROL_FLOW_PATCH, DSLWorkflow
 from tracecat.dsl.workflow_logging import get_workflow_logger
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.registry.lock.types import RegistryLock
@@ -559,6 +559,10 @@ async def test_run_skips_tier_limit_enforcement_when_flag_disabled() -> None:
     acquire_permit_mock = AsyncMock()
 
     with (
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ) as patched_mock,
         patch.object(
             workflow,
             "_resolve_organization_id",
@@ -577,6 +581,8 @@ async def test_run_skips_tier_limit_enforcement_when_flag_disabled() -> None:
     ):
         result = await workflow.run(run_args)
 
+    patched_mock.assert_called_once_with(ERROR_OWNER_CONTROL_FLOW_PATCH)
+    assert workflow.error_owner_control_flow_enabled is True
     assert workflow.workflow_concurrency_limits_enabled is False
     execute_activity_mock.assert_not_awaited()
     acquire_permit_mock.assert_not_awaited()

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -27,8 +27,10 @@ from tracecat_ee.agent.workflows.durable import (
     _apply_configured_timeout,
     _approved_user_mcp_tool_name,
     _build_approved_tool_run_input,
+    _start_registry_tool_call,
 )
 
+from tracecat import config
 from tracecat.agent.common.types import MCPToolDefinition
 from tracecat.agent.executor.activity import AgentExecutorInput, AgentExecutorResult
 from tracecat.agent.executor.schemas import ApprovedToolCall
@@ -40,6 +42,7 @@ from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.auth.types import Role
 from tracecat.dsl._converter import _serializer
+from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.identifiers.workflow import ExecutionUUID, WorkflowUUID
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.workflow.executions.correlation import build_agent_session_correlation_id
@@ -907,6 +910,47 @@ def test_build_approved_tool_run_input_is_deterministic() -> None:
     )
     assert result.run_context.logical_time == logical_time
     assert result.agent_session_id == agent_session_id
+
+
+def test_approved_registry_tool_failures_are_not_retried() -> None:
+    role = Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+    registry_lock = RegistryLock(
+        origins={"tracecat_registry": "test-version"},
+        actions={"core.http_request": "tracecat_registry"},
+    )
+
+    with (
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.uuid4",
+            side_effect=[uuid.uuid4(), uuid.uuid4(), uuid.uuid4()],
+        ),
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.start_activity"
+        ) as start_activity_mock,
+    ):
+        _start_registry_tool_call(
+            ApprovedToolCall(
+                tool_call_id="call_123",
+                tool_name="core__http_request",
+                args={"url": "https://example.com", "method": "GET"},
+            ),
+            registry_lock=registry_lock,
+            service_role=role,
+            logical_time=datetime(2026, 3, 18, tzinfo=UTC),
+        )
+
+    retry_policy = start_activity_mock.call_args.kwargs["retry_policy"]
+    assert retry_policy == RETRY_POLICIES["activity:fail_fast"]
+    assert retry_policy.maximum_attempts == 1
+    assert start_activity_mock.call_args.kwargs["task_queue"] == (
+        config.TRACECAT__EXECUTOR_QUEUE
+    )
 
 
 def test_build_approved_tool_run_input_strips_proxy_metadata() -> None:

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -943,6 +943,7 @@ def test_approved_registry_tool_failures_are_not_retried() -> None:
             registry_lock=registry_lock,
             service_role=role,
             logical_time=datetime(2026, 3, 18, tzinfo=UTC),
+            agent_session_id=uuid.uuid4(),
         )
 
     retry_policy = start_activity_mock.call_args.kwargs["retry_policy"]

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -430,6 +430,60 @@ def test_workflow_error_preserves_all_action_envelopes() -> None:
     )
 
 
+def test_workflow_error_map_platform_entry_survives_terminal_aggregation() -> None:
+    """A platform-owned entry in a task's child terminal map wins re-extraction.
+
+    The scheduler selects platform-wins for mixed child maps; the terminal
+    aggregation must retain that ownership instead of collapsing to the first
+    (user) envelope in transport order.
+    """
+    user_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The child action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    platform_envelope = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the child action",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    user_detail = _action_error_info(user_envelope, ref="user_child")
+    platform_detail = _action_error_info(platform_envelope, ref="platform_child")
+    child_error = _capture_application_error(
+        user_envelope,
+        {
+            "user_child": wrap_error(user_envelope, user_detail).model_dump(
+                mode="json"
+            ),
+            "platform_child": wrap_error(platform_envelope, platform_detail).model_dump(
+                mode="json"
+            ),
+        },
+    )
+    aggregate_detail = ActionErrorInfo(
+        ref="call_child",
+        message=platform_envelope.message,
+        type="ApplicationError",
+        children=[user_detail, platform_detail],
+    )
+
+    error = _capture_workflow_application_error(
+        {
+            "call_child": TaskExceptionInfo(
+                exception=child_error, details=aggregate_detail
+            )
+        }
+    )
+
+    assert extract_error_envelopes(error) == (platform_envelope,)
+    assert error.details[0]["call_child"]["envelope"] == platform_envelope.model_dump(
+        mode="json"
+    )
+    assert error.details[0]["call_child"]["error"] == aggregate_detail.model_dump(
+        mode="json"
+    )
+
+
 def test_legacy_workflow_error_shape_is_unchanged() -> None:
     detail = ActionErrorInfo(ref="action", message="Failed", type="ValueError")
     error = _capture_workflow_application_error(

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -35,17 +35,17 @@ from tracecat.dsl.workflow import (
 )
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.runtime.errors import (
-    ErrorEnvelope,
     RetryDisposition,
+    RuntimeErrorClassification,
     RuntimeErrorKind,
     RuntimeErrorOwner,
 )
 from tracecat.temporal.errors import (
-    ClassifiedErrorDetail,
-    extract_error_envelope,
-    extract_error_envelopes,
-    parse_classified_detail,
-    wrap_error,
+    ErrorTransportDetail,
+    build_error_transport_detail,
+    extract_error_classification,
+    extract_error_classifications,
+    parse_classified_error_payload,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.workflow.executions.enums import TemporalSearchAttr, TriggerType
@@ -69,20 +69,24 @@ def _prepare_subflow_input() -> PrepareSubflowActivityInput:
     )
 
 
-def _action_error_info(envelope: ErrorEnvelope, *, ref: str) -> ActionErrorInfo:
-    """Build the envelope-free payload an envelope's failure would carry."""
+def _action_error_info(
+    classification: RuntimeErrorClassification, *, ref: str
+) -> ActionErrorInfo:
+    """Build the classification-free payload for a classified failure."""
     return ActionErrorInfo(
         ref=ref,
-        message=envelope.message,
-        type=envelope.cause_type or "ApplicationError",
+        message=classification.message,
+        type=classification.cause_type or "ApplicationError",
     )
 
 
-def _wrapped_error_detail(envelope: ErrorEnvelope, *, ref: str) -> dict[str, Any]:
-    """Serialize the classified wrapper that transports an envelope and its payload."""
-    return wrap_error(envelope, _action_error_info(envelope, ref=ref)).model_dump(
-        mode="json"
-    )
+def _error_transport_detail(
+    classification: RuntimeErrorClassification, *, ref: str
+) -> dict[str, Any]:
+    """Serialize the detail transporting a classification and action diagnostics."""
+    return build_error_transport_detail(
+        classification, _action_error_info(classification, ref=ref)
+    ).model_dump(mode="json")
 
 
 def _capture_workflow_application_error(
@@ -113,7 +117,7 @@ def _error_handler_workflow() -> tuple[DSLWorkflow, DSLRunArgs]:
 async def test_prepare_subflow_platform_failure_is_classified_and_history_safe() -> (
     None
 ):
-    """The failure travels as a wrapper whose envelope keeps diagnostics out of history."""
+    """The failure's classification keeps diagnostics out of durable history."""
     sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
 
     with (
@@ -127,22 +131,22 @@ async def test_prepare_subflow_platform_failure_is_classified_and_history_safe()
         await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
 
     error = exc_info.value
-    envelope = extract_error_envelope(error)
-    assert envelope is not None
-    assert envelope.owner is RuntimeErrorOwner.PLATFORM
-    assert envelope.kind is RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED
-    assert envelope.retry_disposition is RetryDisposition.RETRYABLE
-    assert envelope.cause_type == "RuntimeError"
+    classification = extract_error_classification(error)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.kind is RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED
+    assert classification.retry_disposition is RetryDisposition.RETRYABLE
+    assert classification.cause_type == "RuntimeError"
     assert error.non_retryable is False
-    assert error.type == envelope.kind.value
+    assert error.type == classification.kind.value
     assert error.__cause__ is None
 
-    detail = parse_classified_detail(error.details[0])
-    assert isinstance(detail, ClassifiedErrorDetail)
-    assert detail.envelope == envelope
-    assert detail.error == ActionErrorInfo(
+    detail = parse_classified_error_payload(error.details[0])
+    assert isinstance(detail, ErrorTransportDetail)
+    assert detail.classification == classification
+    assert detail.action_error == ActionErrorInfo(
         ref="call_child",
-        message=envelope.message,
+        message=classification.message,
         type="RuntimeError",
     )
 
@@ -155,7 +159,7 @@ async def test_prepare_subflow_platform_failure_is_classified_and_history_safe()
     log_fields = logger_error_mock.call_args.kwargs
     assert "error" not in log_fields
     assert log_fields["error_type"] == "RuntimeError"
-    assert log_fields["error_kind"] == envelope.kind.value
+    assert log_fields["error_kind"] == classification.kind.value
     assert "secret" not in str(logger_error_mock.call_args)
 
 
@@ -173,14 +177,14 @@ async def test_prepare_subflow_input_failure_keeps_user_semantics() -> None:
         await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
 
     error = exc_info.value
-    envelope = extract_error_envelope(error)
-    assert envelope is not None
-    assert envelope.owner is RuntimeErrorOwner.USER
-    assert envelope.kind is RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID
-    assert envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
-    assert envelope.message == user_error.message
+    classification = extract_error_classification(error)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert classification.message == user_error.message
     assert error.non_retryable is True
-    assert error.type == envelope.kind.value
+    assert error.type == classification.kind.value
 
 
 @pytest.mark.anyio
@@ -198,22 +202,22 @@ async def test_prepare_subflow_missing_definition_uses_not_found_kind() -> None:
     ):
         await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
 
-    envelope = extract_error_envelope(exc_info.value)
-    assert envelope is not None
-    assert envelope.owner is RuntimeErrorOwner.USER
-    assert envelope.kind is RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND
 
 
-def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
+def test_subflow_user_classification_control_flow_is_replay_gated() -> None:
     """A wholly user-owned classified failure only steers control flow behind the patch."""
-    envelope = ErrorEnvelope.user(
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
         message="The child workflow could not be found",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
     error = _capture_application_error(
-        envelope,
-        _wrapped_error_detail(envelope, ref="call_child"),
+        classification,
+        _error_transport_detail(classification, ref="call_child"),
     )
 
     with patch(
@@ -233,12 +237,12 @@ def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
 
 @pytest.mark.anyio
 async def test_prepare_subflow_keeps_existing_classification_authoritative() -> None:
-    original_envelope = ErrorEnvelope.user(
+    original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    original_error = _capture_application_error(original_envelope)
+    original_error = _capture_application_error(original_classification)
 
     with (
         patch(
@@ -250,9 +254,9 @@ async def test_prepare_subflow_keeps_existing_classification_authoritative() -> 
         await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
 
     error = exc_info.value
-    assert extract_error_envelope(error) == original_envelope
+    assert extract_error_classification(error) == original_classification
     assert error.non_retryable is False
-    assert error.type == original_envelope.kind.value
+    assert error.type == original_classification.kind.value
 
 
 @pytest.mark.anyio
@@ -273,12 +277,12 @@ async def test_prepare_subflow_keeps_existing_non_retryable_semantics() -> None:
         await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
 
     error = exc_info.value
-    envelope = extract_error_envelope(error)
-    assert envelope is not None
-    assert envelope.owner is RuntimeErrorOwner.PLATFORM
-    assert envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
+    classification = extract_error_classification(error)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
     assert error.non_retryable is True
-    assert error.type == envelope.kind.value
+    assert error.type == classification.kind.value
 
 
 @pytest.mark.anyio
@@ -309,12 +313,12 @@ async def test_prepare_subflow_drops_unclassified_application_error_details() ->
 @pytest.mark.anyio
 async def test_prepare_subflow_filters_unclassified_sibling_details() -> None:
     sensitive = "SENSITIVE_MARKER"
-    envelope = ErrorEnvelope.user(
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    classified = _capture_application_error(envelope)
+    classified = _capture_application_error(classification)
     original_error = ApplicationError(
         classified.message,
         *classified.details,
@@ -335,19 +339,21 @@ async def test_prepare_subflow_filters_unclassified_sibling_details() -> None:
 
     failure = Failure()
     await DataConverter.default.encode_failure(exc_info.value, failure)
-    assert extract_error_envelope(exc_info.value) == envelope
+    assert extract_error_classification(exc_info.value) == classification
     assert sensitive not in str(exc_info.value.details)
     assert sensitive not in str(failure)
 
 
 @pytest.mark.anyio
-async def test_prepare_subflow_clears_retry_delay_for_non_retryable_envelope() -> None:
-    envelope = ErrorEnvelope.user(
+async def test_prepare_subflow_clears_retry_delay_for_non_retryable_classification() -> (
+    None
+):
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    classified = _capture_application_error(envelope)
+    classified = _capture_application_error(classification)
     original_error = ApplicationError(
         classified.message,
         *classified.details,
@@ -367,7 +373,7 @@ async def test_prepare_subflow_clears_retry_delay_for_non_retryable_envelope() -
 
     assert exc_info.value.non_retryable is True
     assert exc_info.value.next_retry_delay is None
-    assert extract_error_envelope(exc_info.value) == envelope
+    assert extract_error_classification(exc_info.value) == classification
 
 
 @pytest.mark.anyio
@@ -382,31 +388,33 @@ async def test_prepare_subflow_cancellation_keeps_native_semantics() -> None:
         await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
 
 
-def test_workflow_error_preserves_all_action_envelopes() -> None:
+def test_workflow_error_preserves_all_action_classifications() -> None:
     """The terminal map wraps every task; the platform-wins selection stamps the
     outer error's message, type, and retryability regardless of task order."""
-    user_envelope = ErrorEnvelope.user(
+    user_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    platform_envelope = ErrorEnvelope.platform(
+    platform_classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    user_detail = _action_error_info(user_envelope, ref="user_action")
-    platform_detail = _action_error_info(platform_envelope, ref="platform_action")
+    user_detail = _action_error_info(user_classification, ref="user_action")
+    platform_detail = _action_error_info(platform_classification, ref="platform_action")
     task_exceptions = {
         "user_action": TaskExceptionInfo(
             exception=_capture_application_error(
-                user_envelope, wrap_error(user_envelope, user_detail)
+                user_classification,
+                build_error_transport_detail(user_classification, user_detail),
             ),
             details=user_detail,
         ),
         "platform_action": TaskExceptionInfo(
             exception=_capture_application_error(
-                platform_envelope, wrap_error(platform_envelope, platform_detail)
+                platform_classification,
+                build_error_transport_detail(platform_classification, platform_detail),
             ),
             details=platform_detail,
         ),
@@ -414,22 +422,25 @@ def test_workflow_error_preserves_all_action_envelopes() -> None:
 
     error = _capture_workflow_application_error(task_exceptions)
 
-    assert error.message == platform_envelope.message
-    assert error.type == platform_envelope.kind.value
+    assert error.message == platform_classification.message
+    assert error.type == platform_classification.kind.value
     assert error.non_retryable is False
-    assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
-    assert error.details[0]["user_action"]["envelope"] == user_envelope.model_dump(
-        mode="json"
+    assert extract_error_classifications(error) == (
+        user_classification,
+        platform_classification,
     )
-    assert error.details[0]["user_action"]["error"] == user_detail.model_dump(
+    assert error.details[0]["user_action"][
+        "classification"
+    ] == user_classification.model_dump(mode="json")
+    assert error.details[0]["user_action"]["action_error"] == user_detail.model_dump(
         mode="json"
     )
     assert error.details[0]["platform_action"][
-        "envelope"
-    ] == platform_envelope.model_dump(mode="json")
-    assert error.details[0]["platform_action"]["error"] == platform_detail.model_dump(
-        mode="json"
-    )
+        "classification"
+    ] == platform_classification.model_dump(mode="json")
+    assert error.details[0]["platform_action"][
+        "action_error"
+    ] == platform_detail.model_dump(mode="json")
 
 
 def test_workflow_error_map_platform_entry_survives_terminal_aggregation() -> None:
@@ -437,34 +448,34 @@ def test_workflow_error_map_platform_entry_survives_terminal_aggregation() -> No
 
     The scheduler selects platform-wins for mixed child maps; the terminal
     aggregation must retain that ownership instead of collapsing to the first
-    (user) envelope in transport order.
+    (user) classification in transport order.
     """
-    user_envelope = ErrorEnvelope.user(
+    user_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The child action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    platform_envelope = ErrorEnvelope.platform(
+    platform_classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the child action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    user_detail = _action_error_info(user_envelope, ref="user_child")
-    platform_detail = _action_error_info(platform_envelope, ref="platform_child")
+    user_detail = _action_error_info(user_classification, ref="user_child")
+    platform_detail = _action_error_info(platform_classification, ref="platform_child")
     child_error = _capture_application_error(
-        user_envelope,
+        user_classification,
         {
-            "user_child": wrap_error(user_envelope, user_detail).model_dump(
-                mode="json"
-            ),
-            "platform_child": wrap_error(platform_envelope, platform_detail).model_dump(
-                mode="json"
-            ),
+            "user_child": build_error_transport_detail(
+                user_classification, user_detail
+            ).model_dump(mode="json"),
+            "platform_child": build_error_transport_detail(
+                platform_classification, platform_detail
+            ).model_dump(mode="json"),
         },
     )
     aggregate_detail = ActionErrorInfo(
         ref="call_child",
-        message=platform_envelope.message,
+        message=platform_classification.message,
         type="ApplicationError",
         children=[user_detail, platform_detail],
     )
@@ -477,16 +488,16 @@ def test_workflow_error_map_platform_entry_survives_terminal_aggregation() -> No
         }
     )
 
-    assert error.message == platform_envelope.message
-    assert error.type == platform_envelope.kind.value
+    assert error.message == platform_classification.message
+    assert error.type == platform_classification.kind.value
     assert error.non_retryable is False
-    assert extract_error_envelopes(error) == (platform_envelope,)
-    assert error.details[0]["call_child"]["envelope"] == platform_envelope.model_dump(
-        mode="json"
-    )
-    assert error.details[0]["call_child"]["error"] == aggregate_detail.model_dump(
-        mode="json"
-    )
+    assert extract_error_classifications(error) == (platform_classification,)
+    assert error.details[0]["call_child"][
+        "classification"
+    ] == platform_classification.model_dump(mode="json")
+    assert error.details[0]["call_child"][
+        "action_error"
+    ] == aggregate_detail.model_dump(mode="json")
 
 
 def test_legacy_workflow_error_shape_is_unchanged() -> None:
@@ -502,17 +513,17 @@ def test_legacy_workflow_error_shape_is_unchanged() -> None:
 
     assert error.non_retryable is True
     assert error.details == ({"action": detail},)
-    assert extract_error_envelope(error) is None
+    assert extract_error_classification(error) is None
 
 
 def test_mixed_workflow_errors_use_the_unclassified_terminal_raise() -> None:
     """One unclassified task keeps the whole terminal raise on the legacy shape."""
-    user_envelope = ErrorEnvelope.user(
+    user_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    user_detail = _action_error_info(user_envelope, ref="user_action")
+    user_detail = _action_error_info(user_classification, ref="user_action")
     legacy_detail = ActionErrorInfo(
         ref="legacy_action",
         message="Legacy failure",
@@ -522,7 +533,8 @@ def test_mixed_workflow_errors_use_the_unclassified_terminal_raise() -> None:
         {
             "user_action": TaskExceptionInfo(
                 exception=_capture_application_error(
-                    user_envelope, wrap_error(user_envelope, user_detail)
+                    user_classification,
+                    build_error_transport_detail(user_classification, user_detail),
                 ),
                 details=user_detail,
             ),
@@ -537,7 +549,7 @@ def test_mixed_workflow_errors_use_the_unclassified_terminal_raise() -> None:
     assert error.details == (
         {"user_action": user_detail, "legacy_action": legacy_detail},
     )
-    assert extract_error_envelopes(error) == ()
+    assert extract_error_classifications(error) == ()
     with patch("tracecat.dsl.workflow.workflow.patched") as patched_mock:
         assert DSLWorkflow._has_user_error_cause(error) is False
     patched_mock.assert_not_called()
@@ -547,14 +559,14 @@ def test_mixed_workflow_errors_use_the_unclassified_terminal_raise() -> None:
 async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
     """The handler completes before the original error's owner is stamped."""
     instance, args = _error_handler_workflow()
-    envelope = ErrorEnvelope.user(
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
     error = _capture_application_error(
-        envelope,
-        {"action": _wrapped_error_detail(envelope, ref="action")},
+        classification,
+        {"action": _error_transport_detail(classification, ref="action")},
     )
     events: list[str] = []
 
@@ -605,21 +617,21 @@ async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
 async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
     """A failing handler becomes the terminal error and owns the stamped attribution."""
     instance, args = _error_handler_workflow()
-    original_envelope = ErrorEnvelope.user(
+    original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    handler_envelope = ErrorEnvelope.platform(
+    handler_classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not run the error handler",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
     original_error = _capture_application_error(
-        original_envelope,
-        {"action": _wrapped_error_detail(original_envelope, ref="action")},
+        original_classification,
+        {"action": _error_transport_detail(original_classification, ref="action")},
     )
-    handler_error = _capture_application_error(handler_envelope)
+    handler_error = _capture_application_error(handler_classification)
 
     with (
         patch.object(
@@ -672,12 +684,12 @@ async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
 async def test_unclassified_handler_failure_does_not_inherit_original_owner() -> None:
     """Incidental exception context cannot classify an unclassified handler failure."""
     instance, args = _error_handler_workflow()
-    original_envelope = ErrorEnvelope.user(
+    original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    original_error = _capture_application_error(original_envelope)
+    original_error = _capture_application_error(original_classification)
     handler_error = RuntimeError("Handler lookup failed")
 
     with (
@@ -708,18 +720,18 @@ async def test_unclassified_handler_failure_does_not_inherit_original_owner() ->
 @pytest.mark.anyio
 async def test_error_handler_lookup_failure_stamps_escaping_error() -> None:
     instance, args = _error_handler_workflow()
-    original_envelope = ErrorEnvelope.user(
+    original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    lookup_envelope = ErrorEnvelope.platform(
+    lookup_classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not resolve the error handler",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    original_error = _capture_application_error(original_envelope)
-    lookup_error = _capture_application_error(lookup_envelope)
+    original_error = _capture_application_error(original_classification)
+    lookup_error = _capture_application_error(lookup_classification)
 
     with (
         patch.object(
@@ -746,13 +758,13 @@ async def test_error_handler_lookup_failure_stamps_escaping_error() -> None:
 @pytest.mark.anyio
 async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -> None:
     instance, args = _error_handler_workflow()
-    original_envelope = ErrorEnvelope.user(
+    original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
     original_error = _capture_application_error(
-        original_envelope,
+        original_classification,
         {"action": {"invalid": "detail"}},
     )
 
@@ -778,21 +790,21 @@ async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -
 
 
 def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
-    """One platform-owned wrapper in the terminal map stamps the workflow as platform."""
-    user_envelope = ErrorEnvelope.user(
+    """One platform classification in the terminal map stamps platform ownership."""
+    user_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    platform_envelope = ErrorEnvelope.platform(
+    platform_classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
     details = {
-        "user_action": _wrapped_error_detail(user_envelope, ref="user_action"),
-        "platform_action": _wrapped_error_detail(
-            platform_envelope, ref="platform_action"
+        "user_action": _error_transport_detail(user_classification, ref="user_action"),
+        "platform_action": _error_transport_detail(
+            platform_classification, ref="platform_action"
         ),
     }
     error = ApplicationError("Workflow failed", details, non_retryable=True)
@@ -815,12 +827,12 @@ def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
 
 
 def test_terminal_owner_upsert_is_replay_gated() -> None:
-    envelope = ErrorEnvelope.user(
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    error = _capture_application_error(envelope)
+    error = _capture_application_error(classification)
 
     with (
         patch(

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -637,25 +637,72 @@ async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
             "_run_error_handler_workflow",
             new=AsyncMock(side_effect=handler_error),
         ),
-        patch.object(
-            DSLWorkflow,
-            "_upsert_terminal_error_owner",
-        ) as upsert_mock,
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ) as patched_mock,
+        patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
         patch("tracecat.dsl.workflow.workflow.info"),
         patch(
             "tracecat.dsl.workflow.get_trigger_type",
             return_value=TriggerType.MANUAL,
         ),
-        pytest.raises(ApplicationError) as exc_info,
     ):
-        await instance._handle_application_error(
-            args,
-            original_error,
-            stamp_terminal_owner=True,
-        )
+        try:
+            raise original_error
+        except ApplicationError as active_error:
+            with pytest.raises(ApplicationError) as exc_info:
+                await instance._handle_application_error(
+                    args,
+                    active_error,
+                    stamp_terminal_owner=True,
+                )
 
     assert exc_info.value is handler_error
-    upsert_mock.assert_called_once_with(handler_error)
+    assert handler_error.__context__ is original_error
+    patched_mock.assert_called_once_with(ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH)
+    upsert_mock.assert_called_once()
+    updates = upsert_mock.call_args.args[0]
+    assert len(updates) == 1
+    assert updates[0].key.name == TemporalSearchAttr.ERROR_OWNER.value
+    assert updates[0].value == RuntimeErrorOwner.PLATFORM.value
+
+
+@pytest.mark.anyio
+async def test_unclassified_handler_failure_does_not_inherit_original_owner() -> None:
+    """Incidental exception context cannot classify an unclassified handler failure."""
+    instance, args = _error_handler_workflow()
+    original_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    original_error = _capture_application_error(original_envelope)
+    handler_error = RuntimeError("Handler lookup failed")
+
+    with (
+        patch.object(
+            instance,
+            "_get_error_handler_workflow_id",
+            new=AsyncMock(side_effect=handler_error),
+        ),
+        patch("tracecat.dsl.workflow.workflow.patched") as patched_mock,
+        patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
+    ):
+        try:
+            raise original_error
+        except ApplicationError as active_error:
+            with pytest.raises(RuntimeError) as exc_info:
+                await instance._handle_application_error(
+                    args,
+                    active_error,
+                    stamp_terminal_owner=True,
+                )
+
+    assert exc_info.value is handler_error
+    assert handler_error.__context__ is original_error
+    patched_mock.assert_not_called()
+    upsert_mock.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -21,6 +21,10 @@ from tracecat.dsl.action import (
 )
 from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.enums import PlatformAction
+from tracecat.dsl.error_transport import (
+    ActionErrorTransportDetail,
+    parse_classified_action_error_payload,
+)
 from tracecat.dsl.schemas import ActionStatement, ExecutionContext
 from tracecat.dsl.types import (
     ActionErrorInfo,
@@ -41,11 +45,9 @@ from tracecat.runtime.errors import (
     RuntimeErrorOwner,
 )
 from tracecat.temporal.errors import (
-    ErrorTransportDetail,
     build_error_transport_detail,
     extract_error_classification,
     extract_error_classifications,
-    parse_classified_error_payload,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.workflow.executions.enums import TemporalSearchAttr, TriggerType
@@ -141,10 +143,10 @@ async def test_prepare_subflow_platform_failure_is_classified_and_history_safe()
     assert error.type == classification.kind.value
     assert error.__cause__ is None
 
-    detail = parse_classified_error_payload(error.details[0])
-    assert isinstance(detail, ErrorTransportDetail)
+    detail = parse_classified_action_error_payload(error.details[0])
+    assert isinstance(detail, ActionErrorTransportDetail)
     assert detail.classification == classification
-    assert detail.action_error == ActionErrorInfo(
+    assert detail.diagnostic == ActionErrorInfo(
         ref="call_child",
         message=classification.message,
         type="RuntimeError",
@@ -432,14 +434,14 @@ def test_workflow_error_preserves_all_action_classifications() -> None:
     assert error.details[0]["user_action"][
         "classification"
     ] == user_classification.model_dump(mode="json")
-    assert error.details[0]["user_action"]["action_error"] == user_detail.model_dump(
+    assert error.details[0]["user_action"]["diagnostic"] == user_detail.model_dump(
         mode="json"
     )
     assert error.details[0]["platform_action"][
         "classification"
     ] == platform_classification.model_dump(mode="json")
     assert error.details[0]["platform_action"][
-        "action_error"
+        "diagnostic"
     ] == platform_detail.model_dump(mode="json")
 
 
@@ -495,9 +497,9 @@ def test_workflow_error_map_platform_entry_survives_terminal_aggregation() -> No
     assert error.details[0]["call_child"][
         "classification"
     ] == platform_classification.model_dump(mode="json")
-    assert error.details[0]["call_child"][
-        "action_error"
-    ] == aggregate_detail.model_dump(mode="json")
+    assert error.details[0]["call_child"]["diagnostic"] == aggregate_detail.model_dump(
+        mode="json"
+    )
 
 
 def test_legacy_workflow_error_shape_is_unchanged() -> None:

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -24,6 +24,7 @@ from tracecat.dsl.types import (
     TaskExceptionInfo,
 )
 from tracecat.dsl.workflow import (
+    ERROR_OWNER_AFTER_HANDLER_PATCH,
     ERROR_OWNER_CONTROL_FLOW_PATCH,
     ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH,
     DSLWorkflow,
@@ -470,7 +471,11 @@ async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
         ),
         pytest.raises(ApplicationError) as exc_info,
     ):
-        await instance._handle_application_error(args, error)
+        await instance._handle_application_error(
+            args,
+            error,
+            stamp_terminal_owner=True,
+        )
 
     assert exc_info.value is error
     run_handler_mock.assert_awaited_once_with(args)
@@ -528,7 +533,11 @@ async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
         ),
         pytest.raises(ApplicationError) as exc_info,
     ):
-        await instance._handle_application_error(args, original_error)
+        await instance._handle_application_error(
+            args,
+            original_error,
+            stamp_terminal_owner=True,
+        )
 
     assert exc_info.value is handler_error
     upsert_mock.assert_called_once_with(handler_error)
@@ -591,6 +600,13 @@ def test_terminal_owner_upsert_is_replay_gated() -> None:
 
     patched_mock.assert_called_once_with(ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH)
     upsert_mock.assert_not_called()
+
+
+def test_error_handler_owner_timing_has_distinct_replay_patch() -> None:
+    assert ERROR_OWNER_AFTER_HANDLER_PATCH not in {
+        ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH,
+        ERROR_OWNER_CONTROL_FLOW_PATCH,
+    }
 
 
 def test_legacy_terminal_error_does_not_add_patch_marker_or_owner() -> None:

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -18,6 +18,7 @@ from tracecat.dsl.types import (
     TaskExceptionInfo,
 )
 from tracecat.dsl.workflow import (
+    ERROR_OWNER_CONTROL_FLOW_PATCH,
     ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH,
     DSLWorkflow,
     _raise_workflow_application_error,
@@ -152,12 +153,19 @@ def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
         _classified_error_info(envelope, ref="call_child"),
     )
 
-    workflow = object.__new__(DSLWorkflow)
-    workflow.error_owner_control_flow_enabled = False
-    assert workflow._has_user_error_cause(error) is False
+    with patch(
+        "tracecat.dsl.workflow.workflow.patched",
+        return_value=False,
+    ) as patched_mock:
+        assert DSLWorkflow._has_user_error_cause(error) is False
+        patched_mock.assert_called_once_with(ERROR_OWNER_CONTROL_FLOW_PATCH)
 
-    workflow.error_owner_control_flow_enabled = True
-    assert workflow._has_user_error_cause(error) is True
+    with patch(
+        "tracecat.dsl.workflow.workflow.patched",
+        return_value=True,
+    ) as patched_mock:
+        assert DSLWorkflow._has_user_error_cause(error) is True
+        patched_mock.assert_called_once_with(ERROR_OWNER_CONTROL_FLOW_PATCH)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -11,6 +11,7 @@ from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
 
+from tests.shared import capture_application_error as _capture_application_error
 from tracecat.auth.types import Role
 from tracecat.dsl.action import (
     DSLActivities,
@@ -41,7 +42,6 @@ from tracecat.runtime.errors import (
 from tracecat.temporal.errors import (
     extract_error_envelope,
     extract_error_envelopes,
-    raise_application_error_from_envelope,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.workflow.executions.enums import TemporalSearchAttr, TriggerType
@@ -72,15 +72,6 @@ def _classified_error_info(envelope: ErrorEnvelope, *, ref: str) -> ActionErrorI
         type=envelope.cause_type or "ApplicationError",
         envelope=envelope,
     )
-
-
-def _capture_application_error(
-    envelope: ErrorEnvelope,
-    *details: object,
-) -> ApplicationError:
-    with pytest.raises(ApplicationError) as exc_info:
-        raise_application_error_from_envelope(envelope, *details)
-    return exc_info.value
 
 
 def _capture_workflow_application_error(

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from datetime import timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -40,8 +41,11 @@ from tracecat.runtime.errors import (
     RuntimeErrorOwner,
 )
 from tracecat.temporal.errors import (
+    ClassifiedErrorDetail,
     extract_error_envelope,
     extract_error_envelopes,
+    parse_classified_detail,
+    wrap_error,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.workflow.executions.enums import TemporalSearchAttr, TriggerType
@@ -65,12 +69,19 @@ def _prepare_subflow_input() -> PrepareSubflowActivityInput:
     )
 
 
-def _classified_error_info(envelope: ErrorEnvelope, *, ref: str) -> ActionErrorInfo:
+def _action_error_info(envelope: ErrorEnvelope, *, ref: str) -> ActionErrorInfo:
+    """Build the envelope-free payload an envelope's failure would carry."""
     return ActionErrorInfo(
         ref=ref,
         message=envelope.message,
         type=envelope.cause_type or "ApplicationError",
-        envelope=envelope,
+    )
+
+
+def _wrapped_error_detail(envelope: ErrorEnvelope, *, ref: str) -> dict[str, Any]:
+    """Serialize the classified wrapper that transports an envelope and its payload."""
+    return wrap_error(envelope, _action_error_info(envelope, ref=ref)).model_dump(
+        mode="json"
     )
 
 
@@ -102,6 +113,7 @@ def _error_handler_workflow() -> tuple[DSLWorkflow, DSLRunArgs]:
 async def test_prepare_subflow_platform_failure_is_classified_and_history_safe() -> (
     None
 ):
+    """The failure travels as a wrapper whose envelope keeps diagnostics out of history."""
     sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
 
     with (
@@ -125,8 +137,14 @@ async def test_prepare_subflow_platform_failure_is_classified_and_history_safe()
     assert error.type == envelope.kind.value
     assert error.__cause__ is None
 
-    detail = ActionErrorInfo.model_validate(error.details[0])
+    detail = parse_classified_detail(error.details[0])
+    assert isinstance(detail, ClassifiedErrorDetail)
     assert detail.envelope == envelope
+    assert detail.error == ActionErrorInfo(
+        ref="call_child",
+        message=envelope.message,
+        type="RuntimeError",
+    )
 
     failure = Failure()
     await DataConverter.default.encode_failure(error, failure)
@@ -187,6 +205,7 @@ async def test_prepare_subflow_missing_definition_uses_not_found_kind() -> None:
 
 
 def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
+    """A wholly user-owned classified failure only steers control flow behind the patch."""
     envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
         message="The child workflow could not be found",
@@ -194,7 +213,7 @@ def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
     )
     error = _capture_application_error(
         envelope,
-        _classified_error_info(envelope, ref="call_child"),
+        _wrapped_error_detail(envelope, ref="call_child"),
     )
 
     with patch(
@@ -364,6 +383,7 @@ async def test_prepare_subflow_cancellation_keeps_native_semantics() -> None:
 
 
 def test_workflow_error_preserves_all_action_envelopes() -> None:
+    """The terminal map wraps every task: envelope on the wrapper, payload beneath it."""
     user_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
@@ -374,15 +394,19 @@ def test_workflow_error_preserves_all_action_envelopes() -> None:
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    user_detail = _classified_error_info(user_envelope, ref="user_action")
-    platform_detail = _classified_error_info(platform_envelope, ref="platform_action")
+    user_detail = _action_error_info(user_envelope, ref="user_action")
+    platform_detail = _action_error_info(platform_envelope, ref="platform_action")
     task_exceptions = {
         "user_action": TaskExceptionInfo(
-            exception=_capture_application_error(user_envelope, user_detail),
+            exception=_capture_application_error(
+                user_envelope, wrap_error(user_envelope, user_detail)
+            ),
             details=user_detail,
         ),
         "platform_action": TaskExceptionInfo(
-            exception=_capture_application_error(platform_envelope, platform_detail),
+            exception=_capture_application_error(
+                platform_envelope, wrap_error(platform_envelope, platform_detail)
+            ),
             details=platform_detail,
         ),
     }
@@ -392,11 +416,17 @@ def test_workflow_error_preserves_all_action_envelopes() -> None:
     assert error.message == user_envelope.message
     assert error.non_retryable is True
     assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
-    assert error.details[0]["user_action"]["envelope"]["schema"] == (
-        "tracecat.error.v1"
+    assert error.details[0]["user_action"]["envelope"] == user_envelope.model_dump(
+        mode="json"
     )
-    assert error.details[0]["platform_action"]["envelope"]["schema"] == (
-        "tracecat.error.v1"
+    assert error.details[0]["user_action"]["error"] == user_detail.model_dump(
+        mode="json"
+    )
+    assert error.details[0]["platform_action"][
+        "envelope"
+    ] == platform_envelope.model_dump(mode="json")
+    assert error.details[0]["platform_action"]["error"] == platform_detail.model_dump(
+        mode="json"
     )
 
 
@@ -416,13 +446,14 @@ def test_legacy_workflow_error_shape_is_unchanged() -> None:
     assert extract_error_envelope(error) is None
 
 
-def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
+def test_mixed_workflow_errors_use_the_unclassified_terminal_raise() -> None:
+    """One unclassified task keeps the whole terminal raise on the legacy shape."""
     user_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    user_detail = _classified_error_info(user_envelope, ref="user_action")
+    user_detail = _action_error_info(user_envelope, ref="user_action")
     legacy_detail = ActionErrorInfo(
         ref="legacy_action",
         message="Legacy failure",
@@ -431,7 +462,9 @@ def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
     error = _capture_workflow_application_error(
         {
             "user_action": TaskExceptionInfo(
-                exception=_capture_application_error(user_envelope, user_detail),
+                exception=_capture_application_error(
+                    user_envelope, wrap_error(user_envelope, user_detail)
+                ),
                 details=user_detail,
             ),
             "legacy_action": TaskExceptionInfo(
@@ -442,6 +475,9 @@ def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
     )
 
     assert error.message.startswith("Workflow failed with 2 error(s)")
+    assert error.details == (
+        {"user_action": user_detail, "legacy_action": legacy_detail},
+    )
     assert extract_error_envelopes(error) == ()
     with patch("tracecat.dsl.workflow.workflow.patched") as patched_mock:
         assert DSLWorkflow._has_user_error_cause(error) is False
@@ -450,6 +486,7 @@ def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
 
 @pytest.mark.anyio
 async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
+    """The handler completes before the original error's owner is stamped."""
     instance, args = _error_handler_workflow()
     envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -458,11 +495,7 @@ async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
     )
     error = _capture_application_error(
         envelope,
-        {
-            "action": _classified_error_info(envelope, ref="action").model_dump(
-                mode="json"
-            )
-        },
+        {"action": _wrapped_error_detail(envelope, ref="action")},
     )
     events: list[str] = []
 
@@ -511,6 +544,7 @@ async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
 
 @pytest.mark.anyio
 async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
+    """A failing handler becomes the terminal error and owns the stamped attribution."""
     instance, args = _error_handler_workflow()
     original_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -524,11 +558,7 @@ async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
     )
     original_error = _capture_application_error(
         original_envelope,
-        {
-            "action": _classified_error_info(
-                original_envelope, ref="action"
-            ).model_dump(mode="json")
-        },
+        {"action": _wrapped_error_detail(original_envelope, ref="action")},
     )
     handler_error = _capture_application_error(handler_envelope)
 
@@ -642,6 +672,7 @@ async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -
 
 
 def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
+    """One platform-owned wrapper in the terminal map stamps the workflow as platform."""
     user_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
@@ -653,12 +684,10 @@ def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
         retry_disposition=RetryDisposition.RETRYABLE,
     )
     details = {
-        "user_action": _classified_error_info(
-            user_envelope, ref="user_action"
-        ).model_dump(mode="json"),
-        "platform_action": _classified_error_info(
+        "user_action": _wrapped_error_detail(user_envelope, ref="user_action"),
+        "platform_action": _wrapped_error_detail(
             platform_envelope, ref="platform_action"
-        ).model_dump(mode="json"),
+        ),
     }
     error = ApplicationError("Workflow failed", details, non_retryable=True)
 

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -18,7 +18,6 @@ from tracecat.dsl.types import (
     TaskExceptionInfo,
 )
 from tracecat.dsl.workflow import (
-    ERROR_OWNER_CONTROL_FLOW_PATCH,
     ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH,
     DSLWorkflow,
     _raise_workflow_application_error,
@@ -153,19 +152,12 @@ def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
         _classified_error_info(envelope, ref="call_child"),
     )
 
-    with patch(
-        "tracecat.dsl.workflow.workflow.patched",
-        return_value=False,
-    ) as patched_mock:
-        assert DSLWorkflow._has_user_error_cause(error) is False
-        patched_mock.assert_called_once_with(ERROR_OWNER_CONTROL_FLOW_PATCH)
+    workflow = object.__new__(DSLWorkflow)
+    workflow.error_owner_control_flow_enabled = False
+    assert workflow._has_user_error_cause(error) is False
 
-    with patch(
-        "tracecat.dsl.workflow.workflow.patched",
-        return_value=True,
-    ) as patched_mock:
-        assert DSLWorkflow._has_user_error_cause(error) is True
-        patched_mock.assert_called_once_with(ERROR_OWNER_CONTROL_FLOW_PATCH)
+    workflow.error_owner_control_flow_enabled = True
+    assert workflow._has_user_error_cause(error) is True
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -10,7 +11,11 @@ from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
 
 from tracecat.auth.types import Role
-from tracecat.dsl.action import DSLActivities, PrepareSubflowActivityInput
+from tracecat.dsl.action import (
+    DSLActivities,
+    PrepareSubflowActivityInput,
+    SubflowDefinitionNotFoundError,
+)
 from tracecat.dsl.enums import PlatformAction
 from tracecat.dsl.schemas import ActionStatement, ExecutionContext
 from tracecat.dsl.types import (
@@ -93,6 +98,7 @@ async def test_prepare_subflow_platform_failure_is_classified_and_history_safe()
             "tracecat.dsl.action._prepare_subflow",
             new=AsyncMock(side_effect=sensitive),
         ),
+        patch("tracecat.dsl.action.logger.error") as logger_error_mock,
         pytest.raises(ApplicationError) as exc_info,
     ):
         await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
@@ -116,11 +122,17 @@ async def test_prepare_subflow_platform_failure_is_classified_and_history_safe()
     serialized_failure = str(failure)
     assert "secret" not in serialized_failure
     assert "example.invalid" not in serialized_failure
+    logger_error_mock.assert_called_once()
+    log_fields = logger_error_mock.call_args.kwargs
+    assert "error" not in log_fields
+    assert log_fields["error_type"] == "RuntimeError"
+    assert log_fields["error_kind"] == envelope.kind.value
+    assert "secret" not in str(logger_error_mock.call_args)
 
 
 @pytest.mark.anyio
-async def test_prepare_subflow_user_failure_keeps_user_semantics() -> None:
-    user_error = UserError("Workflow alias 'child' was not found")
+async def test_prepare_subflow_input_failure_keeps_user_semantics() -> None:
+    user_error = UserError("Invalid child workflow arguments")
 
     with (
         patch(
@@ -135,11 +147,32 @@ async def test_prepare_subflow_user_failure_keeps_user_semantics() -> None:
     envelope = extract_error_envelope(error)
     assert envelope is not None
     assert envelope.owner is RuntimeErrorOwner.USER
-    assert envelope.kind is RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND
+    assert envelope.kind is RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID
     assert envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
     assert envelope.message == user_error.message
     assert error.non_retryable is True
     assert error.type == envelope.kind.value
+
+
+@pytest.mark.anyio
+async def test_prepare_subflow_missing_definition_uses_not_found_kind() -> None:
+    user_error = SubflowDefinitionNotFoundError(
+        "The child workflow definition could not be found"
+    )
+
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=user_error),
+        ),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+    envelope = extract_error_envelope(exc_info.value)
+    assert envelope is not None
+    assert envelope.owner is RuntimeErrorOwner.USER
+    assert envelope.kind is RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND
 
 
 def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
@@ -216,6 +249,61 @@ async def test_prepare_subflow_keeps_existing_non_retryable_semantics() -> None:
     assert envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
     assert error.non_retryable is True
     assert error.type == envelope.kind.value
+
+
+@pytest.mark.anyio
+async def test_prepare_subflow_drops_unclassified_application_error_details() -> None:
+    sensitive = "postgresql://user:secret@example.invalid/database"
+    original_error = ApplicationError(
+        "Dependency failed",
+        {"diagnostic": sensitive},
+        type="DependencyError",
+        non_retryable=True,
+    )
+
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=original_error),
+        ),
+        patch("tracecat.dsl.action.logger.error"),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+    failure = Failure()
+    await DataConverter.default.encode_failure(exc_info.value, failure)
+    assert sensitive not in str(failure)
+
+
+@pytest.mark.anyio
+async def test_prepare_subflow_clears_retry_delay_for_non_retryable_envelope() -> None:
+    envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    classified = _capture_application_error(envelope)
+    original_error = ApplicationError(
+        classified.message,
+        *classified.details,
+        type=classified.type,
+        non_retryable=True,
+        next_retry_delay=timedelta(seconds=5),
+    )
+
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=original_error),
+        ),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+    assert exc_info.value.non_retryable is True
+    assert exc_info.value.next_retry_delay is None
+    assert extract_error_envelope(exc_info.value) == envelope
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
@@ -575,6 +576,78 @@ async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
 
     assert exc_info.value is handler_error
     upsert_mock.assert_called_once_with(handler_error)
+
+
+@pytest.mark.anyio
+async def test_error_handler_lookup_failure_stamps_escaping_error() -> None:
+    instance, args = _error_handler_workflow()
+    original_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    lookup_envelope = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not resolve the error handler",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    original_error = _capture_application_error(original_envelope)
+    lookup_error = _capture_application_error(lookup_envelope)
+
+    with (
+        patch.object(
+            instance,
+            "_get_error_handler_workflow_id",
+            new=AsyncMock(side_effect=lookup_error),
+        ),
+        patch.object(
+            DSLWorkflow,
+            "_upsert_terminal_error_owner",
+        ) as upsert_mock,
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await instance._handle_application_error(
+            args,
+            original_error,
+            stamp_terminal_owner=True,
+        )
+
+    assert exc_info.value is lookup_error
+    upsert_mock.assert_called_once_with(lookup_error)
+
+
+@pytest.mark.anyio
+async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -> None:
+    instance, args = _error_handler_workflow()
+    original_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    original_error = _capture_application_error(
+        original_envelope,
+        {"action": {"invalid": "detail"}},
+    )
+
+    with (
+        patch.object(
+            instance,
+            "_get_error_handler_workflow_id",
+            new=AsyncMock(return_value=args.wf_id),
+        ),
+        patch.object(
+            DSLWorkflow,
+            "_upsert_terminal_error_owner",
+        ) as upsert_mock,
+        pytest.raises(ValidationError) as exc_info,
+    ):
+        await instance._handle_application_error(
+            args,
+            original_error,
+            stamp_terminal_owner=True,
+        )
+
+    upsert_mock.assert_called_once_with(exc_info.value)
 
 
 def test_terminal_platform_owner_wins_for_alert_attribution() -> None:

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio.api.failure.v1 import Failure
+from temporalio.converter import DataConverter
+from temporalio.exceptions import ApplicationError
+
+from tracecat.auth.types import Role
+from tracecat.dsl.action import DSLActivities, PrepareSubflowActivityInput
+from tracecat.dsl.enums import PlatformAction
+from tracecat.dsl.schemas import ActionStatement, ExecutionContext
+from tracecat.dsl.types import (
+    ActionErrorInfo,
+    TaskExceptionInfo,
+)
+from tracecat.dsl.workflow import (
+    ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH,
+    DSLWorkflow,
+    _raise_workflow_application_error,
+)
+from tracecat.runtime.errors import (
+    ErrorEnvelope,
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
+from tracecat.temporal.errors import (
+    extract_error_envelope,
+    extract_error_envelopes,
+    raise_application_error_from_envelope,
+)
+from tracecat.temporal.exceptions import UserError
+from tracecat.workflow.executions.enums import TemporalSearchAttr
+
+
+def _prepare_subflow_input() -> PrepareSubflowActivityInput:
+    return PrepareSubflowActivityInput(
+        role=Role(
+            type="service",
+            service_id="tracecat-runner",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+        task=ActionStatement(
+            ref="call_child",
+            action=PlatformAction.CHILD_WORKFLOW_EXECUTE,
+            args={"workflow_alias": "child"},
+        ),
+        operand=ExecutionContext(ACTIONS={}, TRIGGER=None),
+        key="test/subflow",
+    )
+
+
+def _classified_error_info(envelope: ErrorEnvelope, *, ref: str) -> ActionErrorInfo:
+    return ActionErrorInfo(
+        ref=ref,
+        message=envelope.message,
+        type=envelope.cause_type or "ApplicationError",
+        envelope=envelope,
+    )
+
+
+def _capture_application_error(
+    envelope: ErrorEnvelope,
+    *details: object,
+) -> ApplicationError:
+    with pytest.raises(ApplicationError) as exc_info:
+        raise_application_error_from_envelope(envelope, *details)
+    return exc_info.value
+
+
+def _capture_workflow_application_error(
+    task_exceptions: dict[str, TaskExceptionInfo],
+) -> ApplicationError:
+    with pytest.raises(ApplicationError) as exc_info:
+        _raise_workflow_application_error(task_exceptions)
+    return exc_info.value
+
+
+@pytest.mark.anyio
+async def test_prepare_subflow_platform_failure_is_classified_and_history_safe() -> (
+    None
+):
+    sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
+
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=sensitive),
+        ),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+    error = exc_info.value
+    envelope = extract_error_envelope(error)
+    assert envelope is not None
+    assert envelope.owner is RuntimeErrorOwner.PLATFORM
+    assert envelope.kind is RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED
+    assert envelope.retry_disposition is RetryDisposition.RETRYABLE
+    assert envelope.cause_type == "RuntimeError"
+    assert error.non_retryable is False
+    assert error.type == envelope.kind.value
+    assert error.__cause__ is None
+
+    detail = ActionErrorInfo.model_validate(error.details[0])
+    assert detail.envelope == envelope
+
+    failure = Failure()
+    await DataConverter.default.encode_failure(error, failure)
+    serialized_failure = str(failure)
+    assert "secret" not in serialized_failure
+    assert "example.invalid" not in serialized_failure
+
+
+@pytest.mark.anyio
+async def test_prepare_subflow_user_failure_keeps_user_semantics() -> None:
+    user_error = UserError("Workflow alias 'child' was not found")
+
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=user_error),
+        ),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+    error = exc_info.value
+    envelope = extract_error_envelope(error)
+    assert envelope is not None
+    assert envelope.owner is RuntimeErrorOwner.USER
+    assert envelope.kind is RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND
+    assert envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert envelope.message == user_error.message
+    assert error.non_retryable is True
+    assert error.type == envelope.kind.value
+
+
+@pytest.mark.anyio
+async def test_prepare_subflow_keeps_existing_classification_authoritative() -> None:
+    original_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    original_error = _capture_application_error(original_envelope)
+
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=original_error),
+        ),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+    error = exc_info.value
+    assert extract_error_envelope(error) == original_envelope
+    assert error.non_retryable is False
+    assert error.type == original_envelope.kind.value
+
+
+@pytest.mark.anyio
+async def test_prepare_subflow_keeps_existing_non_retryable_semantics() -> None:
+    original_error = ApplicationError(
+        "Do not retry this operation",
+        type="DependencyRejectedRequest",
+        non_retryable=True,
+    )
+
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=original_error),
+        ),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+    error = exc_info.value
+    envelope = extract_error_envelope(error)
+    assert envelope is not None
+    assert envelope.owner is RuntimeErrorOwner.PLATFORM
+    assert envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert error.non_retryable is True
+    assert error.type == envelope.kind.value
+
+
+@pytest.mark.anyio
+async def test_prepare_subflow_cancellation_keeps_native_semantics() -> None:
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+
+def test_workflow_error_preserves_all_action_envelopes() -> None:
+    user_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    platform_envelope = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the action",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    user_detail = _classified_error_info(user_envelope, ref="user_action")
+    platform_detail = _classified_error_info(platform_envelope, ref="platform_action")
+    task_exceptions = {
+        "user_action": TaskExceptionInfo(
+            exception=_capture_application_error(user_envelope, user_detail),
+            details=user_detail,
+        ),
+        "platform_action": TaskExceptionInfo(
+            exception=_capture_application_error(platform_envelope, platform_detail),
+            details=platform_detail,
+        ),
+    }
+
+    error = _capture_workflow_application_error(task_exceptions)
+
+    assert error.message == user_envelope.message
+    assert error.non_retryable is True
+    assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
+    assert error.details[0]["user_action"]["envelope"]["schema"] == (
+        "tracecat.error.v1"
+    )
+    assert error.details[0]["platform_action"]["envelope"]["schema"] == (
+        "tracecat.error.v1"
+    )
+
+
+def test_legacy_workflow_error_shape_is_unchanged() -> None:
+    detail = ActionErrorInfo(ref="action", message="Failed", type="ValueError")
+    error = _capture_workflow_application_error(
+        {
+            "action": TaskExceptionInfo(
+                exception=ApplicationError("Failed", non_retryable=True),
+                details=detail,
+            )
+        }
+    )
+
+    assert error.non_retryable is True
+    assert error.details == ({"action": detail},)
+    assert extract_error_envelope(error) is None
+
+
+def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
+    user_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    platform_envelope = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the action",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    details = {
+        "user_action": _classified_error_info(
+            user_envelope, ref="user_action"
+        ).model_dump(mode="json"),
+        "platform_action": _classified_error_info(
+            platform_envelope, ref="platform_action"
+        ).model_dump(mode="json"),
+    }
+    error = ApplicationError("Workflow failed", details, non_retryable=True)
+
+    with (
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ) as patched_mock,
+        patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
+    ):
+        DSLWorkflow._upsert_terminal_error_owner(error)
+
+    patched_mock.assert_called_once_with(ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH)
+    upsert_mock.assert_called_once()
+    updates = upsert_mock.call_args.args[0]
+    assert len(updates) == 1
+    assert updates[0].key.name == TemporalSearchAttr.ERROR_OWNER.value
+    assert updates[0].value == RuntimeErrorOwner.PLATFORM.value
+
+
+def test_terminal_owner_upsert_is_replay_gated() -> None:
+    envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    error = _capture_application_error(envelope)
+
+    with (
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=False,
+        ) as patched_mock,
+        patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
+    ):
+        DSLWorkflow._upsert_terminal_error_owner(error)
+
+    patched_mock.assert_called_once_with(ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH)
+    upsert_mock.assert_not_called()
+
+
+def test_legacy_terminal_error_does_not_add_patch_marker_or_owner() -> None:
+    error = ApplicationError("Legacy failure", non_retryable=True)
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.patched") as patched_mock,
+        patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
+    ):
+        DSLWorkflow._upsert_terminal_error_owner(error)
+
+    patched_mock.assert_not_called()
+    upsert_mock.assert_not_called()

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -283,6 +283,38 @@ def test_legacy_workflow_error_shape_is_unchanged() -> None:
     assert extract_error_envelope(error) is None
 
 
+def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
+    user_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    user_detail = _classified_error_info(user_envelope, ref="user_action")
+    legacy_detail = ActionErrorInfo(
+        ref="legacy_action",
+        message="Legacy failure",
+        type="RuntimeError",
+    )
+    error = _capture_workflow_application_error(
+        {
+            "user_action": TaskExceptionInfo(
+                exception=_capture_application_error(user_envelope, user_detail),
+                details=user_detail,
+            ),
+            "legacy_action": TaskExceptionInfo(
+                exception=ApplicationError("Legacy failure", non_retryable=True),
+                details=legacy_detail,
+            ),
+        }
+    )
+
+    assert error.message.startswith("Workflow failed with 2 error(s)")
+    assert extract_error_envelopes(error) == ()
+    with patch("tracecat.dsl.workflow.workflow.patched") as patched_mock:
+        assert DSLWorkflow._has_user_error_cause(error) is False
+    patched_mock.assert_not_called()
+
+
 def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
     user_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -296,6 +296,40 @@ async def test_prepare_subflow_drops_unclassified_application_error_details() ->
 
 
 @pytest.mark.anyio
+async def test_prepare_subflow_filters_unclassified_sibling_details() -> None:
+    sensitive = "SENSITIVE_MARKER"
+    envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    classified = _capture_application_error(envelope)
+    original_error = ApplicationError(
+        classified.message,
+        *classified.details,
+        {"diagnostic": sensitive},
+        type=classified.type,
+        non_retryable=classified.non_retryable,
+    )
+
+    with (
+        patch(
+            "tracecat.dsl.action._prepare_subflow",
+            new=AsyncMock(side_effect=original_error),
+        ),
+        patch("tracecat.dsl.action.logger.error"),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await DSLActivities.prepare_subflow_activity(_prepare_subflow_input())
+
+    failure = Failure()
+    await DataConverter.default.encode_failure(exc_info.value, failure)
+    assert extract_error_envelope(exc_info.value) == envelope
+    assert sensitive not in str(exc_info.value.details)
+    assert sensitive not in str(failure)
+
+
+@pytest.mark.anyio
 async def test_prepare_subflow_clears_retry_delay_for_non_retryable_envelope() -> None:
     envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from temporalio.api.failure.v1 import Failure
@@ -16,6 +16,7 @@ from tracecat.dsl.action import (
     PrepareSubflowActivityInput,
     SubflowDefinitionNotFoundError,
 )
+from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.enums import PlatformAction
 from tracecat.dsl.schemas import ActionStatement, ExecutionContext
 from tracecat.dsl.types import (
@@ -28,6 +29,7 @@ from tracecat.dsl.workflow import (
     DSLWorkflow,
     _raise_workflow_application_error,
 )
+from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.runtime.errors import (
     ErrorEnvelope,
     RetryDisposition,
@@ -40,7 +42,7 @@ from tracecat.temporal.errors import (
     raise_application_error_from_envelope,
 )
 from tracecat.temporal.exceptions import UserError
-from tracecat.workflow.executions.enums import TemporalSearchAttr
+from tracecat.workflow.executions.enums import TemporalSearchAttr, TriggerType
 
 
 def _prepare_subflow_input() -> PrepareSubflowActivityInput:
@@ -85,6 +87,22 @@ def _capture_workflow_application_error(
     with pytest.raises(ApplicationError) as exc_info:
         _raise_workflow_application_error(task_exceptions)
     return exc_info.value
+
+
+def _error_handler_workflow() -> tuple[DSLWorkflow, DSLRunArgs]:
+    instance = object.__new__(DSLWorkflow)
+    role = _prepare_subflow_input().role
+    dsl = DSLInput(
+        title="Error handler source",
+        description="Error handler ownership test",
+        entrypoint=DSLEntrypoint(ref="noop"),
+        actions=[ActionStatement(ref="noop", action="core.noop")],
+    )
+    args = DSLRunArgs(role=role, dsl=dsl, wf_id=WorkflowUUID.new_uuid4())
+    instance.logger = MagicMock()
+    instance.dsl = dsl
+    instance.wf_exec_id = f"{args.wf_id.short()}/exec_test"
+    return instance, args
 
 
 @pytest.mark.anyio
@@ -401,6 +419,119 @@ def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
     with patch("tracecat.dsl.workflow.workflow.patched") as patched_mock:
         assert DSLWorkflow._has_user_error_cause(error) is False
     patched_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
+    instance, args = _error_handler_workflow()
+    envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    error = _capture_application_error(
+        envelope,
+        {
+            "action": _classified_error_info(envelope, ref="action").model_dump(
+                mode="json"
+            )
+        },
+    )
+    events: list[str] = []
+
+    async def run_handler(_: DSLRunArgs) -> None:
+        events.append("handler")
+
+    with (
+        patch.object(
+            instance,
+            "_get_error_handler_workflow_id",
+            new=AsyncMock(return_value=args.wf_id),
+        ),
+        patch.object(
+            instance,
+            "_prepare_error_handler_workflow",
+            new=AsyncMock(return_value=args),
+        ),
+        patch.object(
+            instance,
+            "_run_error_handler_workflow",
+            new=AsyncMock(side_effect=run_handler),
+        ) as run_handler_mock,
+        patch.object(
+            DSLWorkflow,
+            "_upsert_terminal_error_owner",
+            side_effect=lambda _: events.append("upsert"),
+        ) as upsert_mock,
+        patch("tracecat.dsl.workflow.workflow.info"),
+        patch(
+            "tracecat.dsl.workflow.get_trigger_type",
+            return_value=TriggerType.MANUAL,
+        ),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await instance._handle_application_error(args, error)
+
+    assert exc_info.value is error
+    run_handler_mock.assert_awaited_once_with(args)
+    upsert_mock.assert_called_once_with(error)
+    assert events == ["handler", "upsert"]
+
+
+@pytest.mark.anyio
+async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
+    instance, args = _error_handler_workflow()
+    original_envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    handler_envelope = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not run the error handler",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    original_error = _capture_application_error(
+        original_envelope,
+        {
+            "action": _classified_error_info(
+                original_envelope, ref="action"
+            ).model_dump(mode="json")
+        },
+    )
+    handler_error = _capture_application_error(handler_envelope)
+
+    with (
+        patch.object(
+            instance,
+            "_get_error_handler_workflow_id",
+            new=AsyncMock(return_value=args.wf_id),
+        ),
+        patch.object(
+            instance,
+            "_prepare_error_handler_workflow",
+            new=AsyncMock(return_value=args),
+        ),
+        patch.object(
+            instance,
+            "_run_error_handler_workflow",
+            new=AsyncMock(side_effect=handler_error),
+        ),
+        patch.object(
+            DSLWorkflow,
+            "_upsert_terminal_error_owner",
+        ) as upsert_mock,
+        patch("tracecat.dsl.workflow.workflow.info"),
+        patch(
+            "tracecat.dsl.workflow.get_trigger_type",
+            return_value=TriggerType.MANUAL,
+        ),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await instance._handle_application_error(args, original_error)
+
+    assert exc_info.value is handler_error
+    upsert_mock.assert_called_once_with(handler_error)
 
 
 def test_terminal_platform_owner_wins_for_alert_attribution() -> None:

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -383,7 +383,8 @@ async def test_prepare_subflow_cancellation_keeps_native_semantics() -> None:
 
 
 def test_workflow_error_preserves_all_action_envelopes() -> None:
-    """The terminal map wraps every task: envelope on the wrapper, payload beneath it."""
+    """The terminal map wraps every task; the platform-wins selection stamps the
+    outer error's message, type, and retryability regardless of task order."""
     user_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
@@ -413,8 +414,9 @@ def test_workflow_error_preserves_all_action_envelopes() -> None:
 
     error = _capture_workflow_application_error(task_exceptions)
 
-    assert error.message == user_envelope.message
-    assert error.non_retryable is True
+    assert error.message == platform_envelope.message
+    assert error.type == platform_envelope.kind.value
+    assert error.non_retryable is False
     assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
     assert error.details[0]["user_action"]["envelope"] == user_envelope.model_dump(
         mode="json"
@@ -475,6 +477,9 @@ def test_workflow_error_map_platform_entry_survives_terminal_aggregation() -> No
         }
     )
 
+    assert error.message == platform_envelope.message
+    assert error.type == platform_envelope.kind.value
+    assert error.non_retryable is False
     assert extract_error_envelopes(error) == (platform_envelope,)
     assert error.details[0]["call_child"]["envelope"] == platform_envelope.model_dump(
         mode="json"

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -18,6 +18,7 @@ from tracecat.dsl.types import (
     TaskExceptionInfo,
 )
 from tracecat.dsl.workflow import (
+    ERROR_OWNER_CONTROL_FLOW_PATCH,
     ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH,
     DSLWorkflow,
     _raise_workflow_application_error,
@@ -139,6 +140,32 @@ async def test_prepare_subflow_user_failure_keeps_user_semantics() -> None:
     assert envelope.message == user_error.message
     assert error.non_retryable is True
     assert error.type == envelope.kind.value
+
+
+def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
+    envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
+        message="The child workflow could not be found",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    error = _capture_application_error(
+        envelope,
+        _classified_error_info(envelope, ref="call_child"),
+    )
+
+    with patch(
+        "tracecat.dsl.workflow.workflow.patched",
+        return_value=False,
+    ) as patched_mock:
+        assert DSLWorkflow._has_user_error_cause(error) is False
+        patched_mock.assert_called_once_with(ERROR_OWNER_CONTROL_FLOW_PATCH)
+
+    with patch(
+        "tracecat.dsl.workflow.workflow.patched",
+        return_value=True,
+    ) as patched_mock:
+        assert DSLWorkflow._has_user_error_cause(error) is True
+        patched_mock.assert_called_once_with(ERROR_OWNER_CONTROL_FLOW_PATCH)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_runtime_errors.py
+++ b/tests/unit/test_runtime_errors.py
@@ -58,6 +58,18 @@ def test_error_envelope_serializes_exact_contract() -> None:
     }
 
 
+def test_named_constructor_keeps_schema_when_excluding_unset_fields() -> None:
+    envelope = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+
+    assert envelope.model_dump(mode="json", exclude_unset=True)["schema"] == (
+        ERROR_ENVELOPE_SCHEMA
+    )
+
+
 def test_error_envelope_rejects_extra_version_field() -> None:
     with pytest.raises(ValidationError):
         ErrorEnvelope.model_validate(

--- a/tests/unit/test_runtime_errors.py
+++ b/tests/unit/test_runtime_errors.py
@@ -6,50 +6,50 @@ import pytest
 from pydantic import ValidationError
 
 from tracecat.runtime.errors import (
-    ERROR_ENVELOPE_SCHEMA,
-    ErrorEnvelope,
+    RUNTIME_ERROR_CLASSIFICATION_SCHEMA,
     RetryDisposition,
+    RuntimeErrorClassification,
     RuntimeErrorKind,
     RuntimeErrorOwner,
-    parse_error_envelope,
-    select_error_envelope,
+    parse_error_classification,
+    select_error_classification,
 )
 
 
 @pytest.mark.parametrize("kind", list(RuntimeErrorKind))
 @pytest.mark.parametrize("owner", list(RuntimeErrorOwner))
 @pytest.mark.parametrize("retry_disposition", list(RetryDisposition))
-def test_error_envelope_supports_every_kind_owner_and_retry_disposition(
+def test_error_classification_supports_every_kind_owner_and_retry_disposition(
     kind: RuntimeErrorKind,
     owner: RuntimeErrorOwner,
     retry_disposition: RetryDisposition,
 ) -> None:
     factory = (
-        ErrorEnvelope.user
+        RuntimeErrorClassification.user
         if owner is RuntimeErrorOwner.USER
-        else ErrorEnvelope.platform
+        else RuntimeErrorClassification.platform
     )
 
-    envelope = factory(
+    classification = factory(
         kind=kind,
         message="Safe runtime error",
         retry_disposition=retry_disposition,
     )
 
-    assert envelope.schema_ == ERROR_ENVELOPE_SCHEMA
-    assert envelope.owner is owner
-    assert envelope.kind is kind
-    assert envelope.retry_disposition is retry_disposition
+    assert classification.schema_ == RUNTIME_ERROR_CLASSIFICATION_SCHEMA
+    assert classification.owner is owner
+    assert classification.kind is kind
+    assert classification.retry_disposition is retry_disposition
 
 
-def test_error_envelope_serializes_exact_contract() -> None:
-    envelope = ErrorEnvelope.user(
+def test_error_classification_serializes_exact_contract() -> None:
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
 
-    assert envelope.model_dump(mode="json") == {
+    assert classification.model_dump(mode="json") == {
         "schema": "tracecat.error.v1",
         "owner": "user",
         "kind": "action.execution.failed",
@@ -60,20 +60,20 @@ def test_error_envelope_serializes_exact_contract() -> None:
 
 
 def test_named_constructor_keeps_schema_when_excluding_unset_fields() -> None:
-    envelope = ErrorEnvelope.user(
+    classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
 
-    assert envelope.model_dump(mode="json", exclude_unset=True)["schema"] == (
-        ERROR_ENVELOPE_SCHEMA
+    assert classification.model_dump(mode="json", exclude_unset=True)["schema"] == (
+        RUNTIME_ERROR_CLASSIFICATION_SCHEMA
     )
 
 
-def test_error_envelope_rejects_extra_version_field() -> None:
+def test_error_classification_rejects_extra_version_field() -> None:
     with pytest.raises(ValidationError):
-        ErrorEnvelope.model_validate(
+        RuntimeErrorClassification.model_validate(
             {
                 "schema": "tracecat.error.v1",
                 "version": 1,
@@ -86,7 +86,7 @@ def test_error_envelope_rejects_extra_version_field() -> None:
 
 
 def test_parser_requires_explicit_schema_discriminator() -> None:
-    serialized = ErrorEnvelope.user(
+    serialized = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
@@ -95,81 +95,84 @@ def test_parser_requires_explicit_schema_discriminator() -> None:
         key: value for key, value in serialized.items() if key != "schema"
     }
 
-    assert parse_error_envelope(serialized) is not None
-    assert parse_error_envelope(missing_schema) is None
-    assert parse_error_envelope({**serialized, "schema": "tracecat.error.v2"}) is None
+    assert parse_error_classification(serialized) is not None
+    assert parse_error_classification(missing_schema) is None
+    assert (
+        parse_error_classification({**serialized, "schema": "tracecat.error.v2"})
+        is None
+    )
 
 
 def test_named_constructors_require_enum_members() -> None:
     with pytest.raises(TypeError, match="RuntimeErrorKind enum member"):
-        ErrorEnvelope.user(
+        RuntimeErrorClassification.user(
             kind=cast(RuntimeErrorKind, "action.execution.failed"),
             message="The action failed",
             retry_disposition=RetryDisposition.NON_RETRYABLE,
         )
 
     with pytest.raises(TypeError, match="RetryDisposition enum member"):
-        ErrorEnvelope.user(
+        RuntimeErrorClassification.user(
             kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
             message="The action failed",
             retry_disposition=cast(RetryDisposition, "non_retryable"),
         )
 
 
-def test_select_error_envelope_prefers_first_platform_envelope() -> None:
-    first_user = ErrorEnvelope.user(
+def test_select_error_classification_prefers_first_platform_classification() -> None:
+    first_user = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="First user error",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    first_platform = ErrorEnvelope.platform(
+    first_platform = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="First platform error",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    second_platform = ErrorEnvelope.platform(
+    second_platform = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED,
         message="Second platform error",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
 
     assert (
-        select_error_envelope((first_user, first_platform, second_platform))
+        select_error_classification((first_user, first_platform, second_platform))
         is first_platform
     )
 
 
-def test_select_error_envelope_keeps_first_user_without_platform() -> None:
-    first_user = ErrorEnvelope.user(
+def test_select_error_classification_keeps_first_user_without_platform() -> None:
+    first_user = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="First user error",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    second_user = ErrorEnvelope.user(
+    second_user = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID,
         message="Second user error",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
 
-    assert select_error_envelope((first_user, second_user)) is first_user
+    assert select_error_classification((first_user, second_user)) is first_user
 
 
-def test_select_error_envelope_rejects_empty_collection() -> None:
-    with pytest.raises(ValueError, match="empty error envelope collection"):
-        select_error_envelope(())
+def test_select_error_classification_rejects_empty_collection() -> None:
+    with pytest.raises(ValueError, match="empty error classification collection"):
+        select_error_classification(())
 
 
-def test_platform_envelope_excludes_sensitive_cause_message() -> None:
+def test_platform_classification_excludes_sensitive_cause_message() -> None:
     sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
 
-    envelope = ErrorEnvelope.platform(
+    classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.STORAGE_MATERIALIZATION_TRANSPORT_UNAVAILABLE,
         message="A platform dependency is unavailable",
         retry_disposition=RetryDisposition.RETRYABLE,
         cause=sensitive,
     )
 
-    serialized = envelope.model_dump_json()
-    assert envelope.cause_type == "RuntimeError"
+    serialized = classification.model_dump_json()
+    assert classification.cause_type == "RuntimeError"
     assert "secret" not in serialized
     assert "example.invalid" not in serialized

--- a/tests/unit/test_runtime_errors.py
+++ b/tests/unit/test_runtime_errors.py
@@ -12,6 +12,7 @@ from tracecat.runtime.errors import (
     RuntimeErrorKind,
     RuntimeErrorOwner,
     parse_error_envelope,
+    select_error_envelope,
 )
 
 
@@ -113,6 +114,49 @@ def test_named_constructors_require_enum_members() -> None:
             message="The action failed",
             retry_disposition=cast(RetryDisposition, "non_retryable"),
         )
+
+
+def test_select_error_envelope_prefers_first_platform_envelope() -> None:
+    first_user = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="First user error",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    first_platform = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="First platform error",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    second_platform = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED,
+        message="Second platform error",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+
+    assert (
+        select_error_envelope((first_user, first_platform, second_platform))
+        is first_platform
+    )
+
+
+def test_select_error_envelope_keeps_first_user_without_platform() -> None:
+    first_user = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="First user error",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    second_user = ErrorEnvelope.user(
+        kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID,
+        message="Second user error",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+
+    assert select_error_envelope((first_user, second_user)) is first_user
+
+
+def test_select_error_envelope_rejects_empty_collection() -> None:
+    with pytest.raises(ValueError, match="empty error envelope collection"):
+        select_error_envelope(())
 
 
 def test_platform_envelope_excludes_sensitive_cause_message() -> None:

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -514,6 +514,56 @@ def test_wrapping_unclassified_application_error_drops_original_details() -> Non
     assert extract_error_envelope(wrapped) == fallback
 
 
+@pytest.mark.parametrize(
+    ("retry_disposition", "expected_delay"),
+    [
+        (RetryDisposition.RETRYABLE, timedelta(seconds=5)),
+        (RetryDisposition.NON_RETRYABLE, None),
+    ],
+)
+def test_wrapping_applies_retry_delay_only_to_retryable_fallback(
+    retry_disposition: RetryDisposition,
+    expected_delay: timedelta | None,
+) -> None:
+    original_delay = timedelta(seconds=5)
+    fallback = ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the workflow",
+        retry_disposition=retry_disposition,
+    )
+    original = ApplicationError(
+        "Unclassified platform failure",
+        next_retry_delay=original_delay,
+    )
+
+    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
+
+    assert wrapped.next_retry_delay == expected_delay
+    assert wrapped.non_retryable is (
+        retry_disposition is RetryDisposition.NON_RETRYABLE
+    )
+    assert extract_error_envelope(wrapped) == fallback
+
+
+def test_wrapping_clears_retry_delay_for_non_retryable_cause() -> None:
+    envelope = _user_envelope(RetryDisposition.NON_RETRYABLE)
+    classified = _capture_application_error(envelope)
+    try:
+        raise ApplicationError(
+            "Outer wrapper",
+            next_retry_delay=timedelta(seconds=5),
+        ) from classified
+    except ApplicationError as outer:
+        wrapped = _capture_wrapped_application_error(
+            outer,
+            fallback=_platform_envelope(),
+        )
+
+    assert wrapped.next_retry_delay is None
+    assert wrapped.non_retryable is True
+    assert extract_error_envelope(wrapped) == envelope
+
+
 def test_ambiguous_nested_envelope_does_not_override_fallback() -> None:
     nested_envelope = _user_envelope()
     fallback = _platform_envelope()

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -180,6 +180,40 @@ def test_aggregate_action_error_rejects_partially_classified_children(
     assert extract_error_envelopes(ApplicationError("Gather failed", detail)) == ()
 
 
+@pytest.mark.anyio
+async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -> None:
+    user_envelope = _user_envelope()
+    fallback = _platform_envelope()
+    aggregate = ActionErrorInfo(
+        ref="gather",
+        message="Gather failed",
+        type="ApplicationError",
+        children=[
+            ActionErrorInfo(
+                ref="scatter[0]",
+                message=user_envelope.message,
+                type="ValueError",
+                envelope=user_envelope,
+            ),
+            ActionErrorInfo(
+                ref="scatter[1]",
+                message="Legacy failure",
+                type="RuntimeError",
+            ),
+        ],
+    )
+
+    error = _capture_application_error(fallback, aggregate)
+    failure = Failure()
+    await DataConverter.default.encode_failure(error, failure)
+    decoded = await DataConverter.default.decode_failure(failure)
+
+    assert error.type == fallback.kind.value
+    assert error.non_retryable is False
+    assert extract_error_envelopes(error) == (fallback,)
+    assert extract_error_envelopes(decoded) == (fallback,)
+
+
 def test_error_handler_input_preserves_action_error_envelope() -> None:
     envelope = _platform_envelope()
     error_info = ActionErrorInfo(

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -15,39 +15,39 @@ from tracecat.dsl.action import FinalizeGatherActivityResult
 from tracecat.dsl.types import ActionErrorInfo
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.runtime.errors import (
-    ErrorEnvelope,
     RetryDisposition,
+    RuntimeErrorClassification,
     RuntimeErrorKind,
     RuntimeErrorOwner,
     TracecatRuntimeError,
 )
 from tracecat.storage.object import InlineObject
 from tracecat.temporal.errors import (
-    TEMPORAL_ERROR_DETAILS_SCHEMA,
-    ClassifiedErrorDetail,
-    extract_error_envelope,
-    extract_error_envelopes,
-    parse_classified_detail,
-    raise_application_error_from_envelope,
+    ERROR_TRANSPORT_DETAIL_SCHEMA,
+    ErrorTransportDetail,
+    build_error_transport_detail,
+    extract_error_classification,
+    extract_error_classifications,
+    parse_classified_error_payload,
+    raise_application_error_from_classification,
     raise_wrapped_application_error,
-    wrap_error,
 )
 from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.executions.types import ErrorHandlerWorkflowInput
 
 
-def _user_envelope(
+def _user_classification(
     retry_disposition: RetryDisposition = RetryDisposition.NON_RETRYABLE,
-) -> ErrorEnvelope:
-    return ErrorEnvelope.user(
+) -> RuntimeErrorClassification:
+    return RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=retry_disposition,
     )
 
 
-def _platform_envelope() -> ErrorEnvelope:
-    return ErrorEnvelope.platform(
+def _platform_classification() -> RuntimeErrorClassification:
+    return RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the workflow",
         retry_disposition=RetryDisposition.RETRYABLE,
@@ -57,15 +57,20 @@ def _platform_envelope() -> ErrorEnvelope:
 def _capture_wrapped_application_error(
     error: BaseException,
     *,
-    fallback: ErrorEnvelope,
+    fallback_classification: RuntimeErrorClassification,
 ) -> ApplicationError:
     with pytest.raises(ApplicationError) as exc_info:
-        raise_wrapped_application_error(error, fallback=fallback)
+        raise_wrapped_application_error(
+            error,
+            fallback_classification=fallback_classification,
+        )
     return exc_info.value
 
 
 @pytest.mark.anyio
-async def test_legacy_action_error_payload_is_unchanged_without_envelope() -> None:
+async def test_legacy_action_error_payload_is_unchanged_without_classification() -> (
+    None
+):
     error_info = ActionErrorInfo(ref="action", message="Failed", type="ValueError")
 
     serialized = error_info.model_dump(mode="json")
@@ -74,45 +79,47 @@ async def test_legacy_action_error_payload_is_unchanged_without_envelope() -> No
     await data_converter.encode_failure(ApplicationError("Failed", error_info), failure)
     decoded = await data_converter.decode_failure(failure)
 
-    assert "envelope" not in serialized
+    assert "classification" not in serialized
     assert isinstance(decoded, ApplicationError)
     assert decoded.details[0] == serialized
 
 
 @pytest.mark.anyio
-async def test_classified_wrapper_carries_envelope_and_preserves_payload() -> None:
-    """The wrapper carries the envelope; its payload survives unwrapping intact."""
-    envelope = _user_envelope()
+async def test_transport_detail_carries_classification_and_preserves_payload() -> None:
+    """The transport detail preserves classification and action diagnostics."""
+    classification = _user_classification()
     error_info = ActionErrorInfo(
         ref="action",
         message="The action failed",
         type="ValueError",
     )
-    error = _capture_application_error(envelope, wrap_error(envelope, error_info))
+    error = _capture_application_error(
+        classification, build_error_transport_detail(classification, error_info)
+    )
     failure = Failure()
     await DataConverter.default.encode_failure(error, failure)
     decoded = await DataConverter.default.decode_failure(failure)
 
     assert len(error.details) == 1
     assert error.type == RuntimeErrorKind.ACTION_EXECUTION_FAILED.value
-    assert error.details[0]["schema"] == TEMPORAL_ERROR_DETAILS_SCHEMA
-    assert error.details[0]["envelope"]["schema"] == "tracecat.error.v1"
-    assert error.details[0]["error"] == error_info.model_dump(mode="json")
-    assert extract_error_envelope(error) == envelope
-    assert extract_error_envelope(decoded) == envelope
+    assert error.details[0]["schema"] == ERROR_TRANSPORT_DETAIL_SCHEMA
+    assert error.details[0]["classification"]["schema"] == "tracecat.error.v1"
+    assert error.details[0]["action_error"] == error_info.model_dump(mode="json")
+    assert extract_error_classification(error) == classification
+    assert extract_error_classification(decoded) == classification
     assert isinstance(decoded, ApplicationError)
-    parsed = parse_classified_detail(decoded.details[0])
-    assert isinstance(parsed, ClassifiedErrorDetail)
-    assert parsed.envelope == envelope
-    assert parsed.error == error_info
+    parsed = parse_classified_error_payload(decoded.details[0])
+    assert isinstance(parsed, ErrorTransportDetail)
+    assert parsed.classification == classification
+    assert parsed.action_error == error_info
 
 
-def test_aggregate_action_error_attribution_lives_on_the_wrapper() -> None:
-    """Gather payloads stay envelope-free; the wrapper alone carries attribution."""
-    envelope = _platform_envelope()
+def test_aggregate_action_error_attribution_lives_on_transport_detail() -> None:
+    """Gather diagnostics stay classification-free; the transport carries it."""
+    classification = _platform_classification()
     child = ActionErrorInfo(
         ref="scatter[0]",
-        message=envelope.message,
+        message=classification.message,
         type="RuntimeError",
     )
     finalized = FinalizeGatherActivityResult(
@@ -122,7 +129,7 @@ def test_aggregate_action_error_attribution_lives_on_the_wrapper() -> None:
 
     serialized_finalized = finalized.model_dump(mode="json")
     parsed_finalized = FinalizeGatherActivityResult.model_validate(serialized_finalized)
-    assert "envelope" not in serialized_finalized["errors"][0]
+    assert "classification" not in serialized_finalized["errors"][0]
     assert parsed_finalized.errors == [child]
 
     aggregate = ActionErrorInfo(
@@ -132,32 +139,36 @@ def test_aggregate_action_error_attribution_lives_on_the_wrapper() -> None:
         children=parsed_finalized.errors,
     )
     serialized_aggregate = aggregate.model_dump(mode="json")
-    assert "envelope" not in serialized_aggregate
-    assert "envelope" not in serialized_aggregate["children"][0]
+    assert "classification" not in serialized_aggregate
+    assert "classification" not in serialized_aggregate["children"][0]
 
     error = ApplicationError(
         "Gather failed",
-        {"gather": wrap_error(envelope, aggregate).model_dump(mode="json")},
+        {
+            "gather": build_error_transport_detail(
+                classification, aggregate
+            ).model_dump(mode="json")
+        },
     )
-    parsed = parse_classified_detail(error.details[0])
+    parsed = parse_classified_error_payload(error.details[0])
 
-    assert extract_error_envelopes(error) == (envelope,)
+    assert extract_error_classifications(error) == (classification,)
     assert isinstance(parsed, dict)
-    assert parsed["gather"].error == aggregate
+    assert parsed["gather"].action_error == aggregate
 
 
 @pytest.mark.parametrize("mapped", [False, True])
-def test_embedded_payload_envelopes_never_classify(mapped: bool) -> None:
-    """Envelope keys inside a payload fail validation, so the detail is unclassified."""
-    envelope = _user_envelope()
-    serialized_envelope = envelope.model_dump(mode="json")
+def test_embedded_payload_classifications_never_classify(mapped: bool) -> None:
+    """Classification keys inside a payload fail validation, so the detail is unclassified."""
+    classification = _user_classification()
+    serialized_classification = classification.model_dump(mode="json")
     with pytest.raises(ValidationError):
         ActionErrorInfo.model_validate(
             {
                 "ref": "scatter[0]",
-                "message": envelope.message,
+                "message": classification.message,
                 "type": "ValueError",
-                "envelope": serialized_envelope,
+                "classification": serialized_classification,
             }
         )
 
@@ -165,13 +176,13 @@ def test_embedded_payload_envelopes_never_classify(mapped: bool) -> None:
         "ref": "gather",
         "message": "Gather failed",
         "type": "ApplicationError",
-        "envelope": serialized_envelope,
+        "classification": serialized_classification,
         "children": [
             {
                 "ref": "scatter[0]",
-                "message": envelope.message,
+                "message": classification.message,
                 "type": "ValueError",
-                "envelope": serialized_envelope,
+                "classification": serialized_classification,
             },
             {
                 "ref": "scatter[1]",
@@ -182,15 +193,17 @@ def test_embedded_payload_envelopes_never_classify(mapped: bool) -> None:
     }
     detail = {"gather": aggregate} if mapped else aggregate
 
-    assert extract_error_envelopes(ApplicationError("Gather failed", detail)) == ()
+    assert (
+        extract_error_classifications(ApplicationError("Gather failed", detail)) == ()
+    )
 
 
 @pytest.mark.anyio
-async def test_unclassified_aggregate_keeps_fallback_envelope_after_serialization() -> (
+async def test_unclassified_aggregate_keeps_fallback_classification_after_serialization() -> (
     None
 ):
     """An unclassified aggregate detail leaves the appended fallback authoritative."""
-    fallback = _platform_envelope()
+    fallback = _platform_classification()
     aggregate = ActionErrorInfo(
         ref="gather",
         message="Gather failed",
@@ -217,25 +230,25 @@ async def test_unclassified_aggregate_keeps_fallback_envelope_after_serializatio
     assert error.type == fallback.kind.value
     assert error.non_retryable is False
     assert error.details[0] == aggregate
-    assert extract_error_envelopes(error) == (fallback,)
-    assert extract_error_envelopes(decoded) == (fallback,)
+    assert extract_error_classifications(error) == (fallback,)
+    assert extract_error_classifications(decoded) == (fallback,)
 
 
 def test_error_handler_input_carries_unwrapped_action_errors() -> None:
-    """Handler input carries envelope-free payloads identical to the unwrapped ones."""
-    envelope = _platform_envelope()
+    """Handler input carries classification-free payloads identical to the unwrapped ones."""
+    classification = _platform_classification()
     error_info = ActionErrorInfo(
         ref="action",
-        message=envelope.message,
+        message=classification.message,
         type="RuntimeError",
     )
-    wrapped = parse_classified_detail(
-        wrap_error(envelope, error_info).model_dump(mode="json")
+    transport_detail = parse_classified_error_payload(
+        build_error_transport_detail(classification, error_info).model_dump(mode="json")
     )
-    assert isinstance(wrapped, ClassifiedErrorDetail)
-    assert isinstance(wrapped.error, ActionErrorInfo)
-    assert wrapped.envelope == envelope
-    assert wrapped.error == error_info
+    assert isinstance(transport_detail, ErrorTransportDetail)
+    assert isinstance(transport_detail.action_error, ActionErrorInfo)
+    assert transport_detail.classification == classification
+    assert transport_detail.action_error == error_info
 
     handler_wf_id = WorkflowUUID.new_uuid4()
     orig_wf_id = WorkflowUUID.new_uuid4()
@@ -246,7 +259,7 @@ def test_error_handler_input_carries_unwrapped_action_errors() -> None:
         orig_wf_exec_id=generate_exec_id(orig_wf_id),
         orig_wf_title="Synthetic workflow",
         trigger_type=TriggerType.MANUAL,
-        errors=[wrapped.error],
+        errors=[transport_detail.action_error],
     )
 
     serialized = TypeAdapter(ErrorHandlerWorkflowInput).dump_python(
@@ -255,25 +268,27 @@ def test_error_handler_input_carries_unwrapped_action_errors() -> None:
     )
 
     assert serialized["errors"][0] == error_info.model_dump(mode="json")
-    assert "envelope" not in serialized["errors"][0]
+    assert "classification" not in serialized["errors"][0]
 
 
-def test_legacy_action_error_is_transported_verbatim_beside_the_wrapper() -> None:
-    """A legacy payload travels unchanged; classification rides an appended wrapper."""
-    envelope = _user_envelope()
+def test_legacy_action_error_is_transported_beside_classification_detail() -> None:
+    """Legacy diagnostics remain unchanged beside the appended classification."""
+    classification = _user_classification()
     legacy = ActionErrorInfo(
         ref="action",
         message="The action failed",
         type="ValueError",
     ).model_dump(mode="json")
 
-    error = _capture_application_error(envelope, legacy)
+    error = _capture_application_error(classification, legacy)
 
     assert len(error.details) == 2
     assert error.details[0] == legacy
-    assert error.details[1] == wrap_error(envelope).model_dump(mode="json")
-    assert error.details[1]["error"] is None
-    assert extract_error_envelope(error) == envelope
+    assert error.details[1] == build_error_transport_detail(classification).model_dump(
+        mode="json"
+    )
+    assert error.details[1]["action_error"] is None
+    assert extract_error_classification(error) == classification
 
 
 @pytest.mark.parametrize(
@@ -283,48 +298,49 @@ def test_legacy_action_error_is_transported_verbatim_beside_the_wrapper() -> Non
         (RetryDisposition.NON_RETRYABLE, True),
     ],
 )
-def test_temporal_retryability_is_derived_from_envelope(
+def test_temporal_retryability_is_derived_from_classification(
     retry_disposition: RetryDisposition, expected_non_retryable: bool
 ) -> None:
-    envelope = _user_envelope(retry_disposition)
+    classification = _user_classification(retry_disposition)
 
-    error = _capture_application_error(envelope)
+    error = _capture_application_error(classification)
 
     assert error.non_retryable is expected_non_retryable
     assert (
         "non_retryable"
-        not in signature(raise_application_error_from_envelope).parameters
+        not in signature(raise_application_error_from_classification).parameters
     )
     assert (
-        "error_type" not in signature(raise_application_error_from_envelope).parameters
+        "error_type"
+        not in signature(raise_application_error_from_classification).parameters
     )
-    assert error.type == envelope.kind.value
+    assert error.type == classification.kind.value
 
 
-def test_non_retryable_envelope_rejects_next_retry_delay() -> None:
+def test_non_retryable_classification_rejects_next_retry_delay() -> None:
     with pytest.raises(ValueError, match="non-retryable"):
-        raise_application_error_from_envelope(
-            _user_envelope(RetryDisposition.NON_RETRYABLE),
+        raise_application_error_from_classification(
+            _user_classification(RetryDisposition.NON_RETRYABLE),
             next_retry_delay=timedelta(seconds=1),
         )
 
 
 def test_non_action_adapter_preserves_legacy_details_in_order() -> None:
-    envelope = _platform_envelope()
+    classification = _platform_classification()
     legacy_details = ({"existing": "payload"}, ["second payload"])
 
-    error = _capture_application_error(envelope, *legacy_details)
+    error = _capture_application_error(classification, *legacy_details)
 
     assert error.details[:2] == legacy_details
     assert len(error.details) == 3
-    assert error.type == envelope.kind.value
-    assert extract_error_envelope(error) == envelope
+    assert error.type == classification.kind.value
+    assert extract_error_classification(error) == classification
 
 
 @pytest.mark.anyio
-async def test_envelope_survives_temporal_failure_serialization() -> None:
-    envelope = _platform_envelope()
-    error = _capture_application_error(envelope, {"existing": "payload"})
+async def test_classification_survives_temporal_failure_serialization() -> None:
+    classification = _platform_classification()
+    error = _capture_application_error(classification, {"existing": "payload"})
     failure = Failure()
 
     await DataConverter.default.encode_failure(error, failure)
@@ -333,13 +349,13 @@ async def test_envelope_survives_temporal_failure_serialization() -> None:
     assert isinstance(decoded, ApplicationError)
     assert decoded.details[0] == {"existing": "payload"}
     assert decoded.non_retryable is False
-    assert extract_error_envelope(decoded) == envelope
+    assert extract_error_classification(decoded) == classification
 
 
 @pytest.mark.anyio
-async def test_envelope_survives_wrapped_temporal_failure_serialization() -> None:
-    envelope = _user_envelope()
-    original = _capture_application_error(envelope)
+async def test_classification_survives_wrapped_temporal_failure_serialization() -> None:
+    classification = _user_classification()
+    original = _capture_application_error(classification)
     try:
         raise ApplicationError(
             "Outer wrapper",
@@ -353,13 +369,13 @@ async def test_envelope_survives_wrapped_temporal_failure_serialization() -> Non
 
     decoded = await DataConverter.default.decode_failure(failure)
 
-    assert extract_error_envelope(decoded) == envelope
+    assert extract_error_classification(decoded) == classification
 
 
 @pytest.mark.anyio
 async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
     sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
-    envelope = ErrorEnvelope.platform(
+    classification = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.STORAGE_MATERIALIZATION_TRANSPORT_UNAVAILABLE,
         message="A platform dependency is unavailable",
         retry_disposition=RetryDisposition.RETRYABLE,
@@ -368,7 +384,10 @@ async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
     try:
         raise sensitive
     except RuntimeError as caught:
-        error = _capture_wrapped_application_error(caught, fallback=envelope)
+        error = _capture_wrapped_application_error(
+            caught,
+            fallback_classification=classification,
+        )
     failure = Failure()
 
     await DataConverter.default.encode_failure(error, failure)
@@ -385,24 +404,19 @@ async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
     [
         {"legacy": "payload"},
         {"schema": "tracecat.error.v1"},
-        _user_envelope().model_dump(mode="json"),
+        _user_classification().model_dump(mode="json"),
+        # The superseded transport key remains unclassified.
         {"envelope": {"schema": "not-tracecat.error.v1"}},
         {
-            "envelope": {
-                "owner": "user",
-                "kind": "action.execution.failed",
-                "message": "Missing discriminator",
-                "retry_disposition": "non_retryable",
-                "cause_type": None,
-            }
+            "classification": _user_classification().model_dump(mode="json"),
         },
         {
             "schema": "tracecat.temporal_error.v1",
-            "envelope": {"schema": "tracecat.error.v1"},
+            "classification": {"schema": "tracecat.error.v1"},
         },
         {
             "schema": "tracecat.temporal_error.v1",
-            "envelope": {
+            "classification": {
                 "owner": "user",
                 "kind": "action.execution.failed",
                 "message": "Missing discriminator",
@@ -412,7 +426,7 @@ async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
         },
         {
             "schema": "tracecat.temporal_error.v1",
-            "envelope": _user_envelope().model_dump(mode="json"),
+            "classification": _user_classification().model_dump(mode="json"),
             "unexpected": True,
         },
     ],
@@ -420,41 +434,44 @@ async def test_platform_diagnostics_do_not_enter_temporal_history() -> None:
 def test_legacy_and_malformed_details_are_not_classified(detail: object) -> None:
     error = ApplicationError("Legacy error", detail)
 
-    assert extract_error_envelope(error) is None
+    assert extract_error_classification(error) is None
 
 
 def test_payload_key_does_not_collide_without_valid_discriminator() -> None:
     error = ApplicationError(
         "User payload",
         {
-            "ref": "envelope",
+            "ref": "classification",
             "message": "User-authored payload",
             "type": "Example",
-            "envelope": {"schema": "customer.payload.v1"},
+            "classification": {"schema": "customer.payload.v1"},
         },
     )
 
-    assert extract_error_envelope(error) is None
+    assert extract_error_classification(error) is None
 
 
 def test_action_error_detail_requires_nested_schema_discriminator() -> None:
     error = ApplicationError(
         "Legacy error",
         {
-            "ref": "action",
-            "message": "Missing discriminator",
-            "type": "ValueError",
-            "envelope": {
+            "schema": "tracecat.temporal_error.v1",
+            "classification": {
                 "owner": "user",
                 "kind": "action.execution.failed",
                 "message": "Missing discriminator",
                 "retry_disposition": "non_retryable",
                 "cause_type": None,
             },
+            "action_error": {
+                "ref": "action",
+                "message": "Missing discriminator",
+                "type": "ValueError",
+            },
         },
     )
 
-    assert extract_error_envelope(error) is None
+    assert extract_error_classification(error) is None
 
 
 def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
@@ -462,13 +479,6 @@ def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
         "ref": "scatter[0]",
         "message": "Missing discriminator",
         "type": "ValueError",
-        "envelope": {
-            "owner": "user",
-            "kind": "action.execution.failed",
-            "message": "Missing discriminator",
-            "retry_disposition": "non_retryable",
-            "cause_type": None,
-        },
     }
     aggregate = {
         "ref": "gather",
@@ -477,44 +487,66 @@ def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
         "children": [child],
     }
 
-    assert extract_error_envelope(ApplicationError("Gather failed", aggregate)) is None
+    malformed_transport = {
+        "schema": "tracecat.temporal_error.v1",
+        "classification": {
+            "owner": "user",
+            "kind": "action.execution.failed",
+            "message": "Missing discriminator",
+            "retry_disposition": "non_retryable",
+            "cause_type": None,
+        },
+        "action_error": aggregate,
+    }
+
     assert (
-        extract_error_envelope(ApplicationError("Gather failed", {"gather": aggregate}))
+        extract_error_classification(
+            ApplicationError("Gather failed", malformed_transport)
+        )
+        is None
+    )
+    assert (
+        extract_error_classification(
+            ApplicationError("Gather failed", {"gather": malformed_transport})
+        )
         is None
     )
 
 
-def test_wrapper_map_extracts_every_classified_envelope() -> None:
-    """A terminal ``{ref: wrapper}`` map yields each wrapper's envelope in order."""
-    user_envelope = _user_envelope()
-    platform_envelope = _platform_envelope()
+def test_transport_map_extracts_every_classification() -> None:
+    """A terminal transport map yields each classification in order."""
+    user_classification = _user_classification()
+    platform_classification = _platform_classification()
     details = {
-        "user_action": wrap_error(
-            user_envelope,
+        "user_action": build_error_transport_detail(
+            user_classification,
             ActionErrorInfo(
                 ref="user_action",
-                message=user_envelope.message,
+                message=user_classification.message,
                 type="ValueError",
             ),
         ).model_dump(mode="json"),
-        "platform_action": wrap_error(
-            platform_envelope,
+        "platform_action": build_error_transport_detail(
+            platform_classification,
             ActionErrorInfo(
                 ref="platform_action",
-                message=platform_envelope.message,
+                message=platform_classification.message,
                 type="RuntimeError",
             ),
         ).model_dump(mode="json"),
     }
     error = ApplicationError("Workflow failed", details)
 
-    assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
+    assert extract_error_classifications(error) == (
+        user_classification,
+        platform_classification,
+    )
 
 
-def test_envelope_extraction_can_ignore_only_implicit_context() -> None:
+def test_classification_extraction_can_ignore_only_implicit_context() -> None:
     """Boundary extraction skips incidental context but keeps deliberate causes."""
-    envelope = _user_envelope()
-    classified_error = _capture_application_error(envelope)
+    classification = _user_classification()
+    classified_error = _capture_application_error(classification)
 
     try:
         raise classified_error
@@ -523,9 +555,9 @@ def test_envelope_extraction_can_ignore_only_implicit_context() -> None:
             raise RuntimeError("Handler failed")
         except RuntimeError as implicit_error:
             assert implicit_error.__context__ is classified_error
-            assert extract_error_envelopes(implicit_error) == (envelope,)
+            assert extract_error_classifications(implicit_error) == (classification,)
             assert (
-                extract_error_envelopes(
+                extract_error_classifications(
                     implicit_error,
                     include_implicit_context=False,
                 )
@@ -534,31 +566,33 @@ def test_envelope_extraction_can_ignore_only_implicit_context() -> None:
 
     explicit_error = RuntimeError("Explicit wrapper")
     explicit_error.__cause__ = classified_error
-    assert extract_error_envelopes(
+    assert extract_error_classifications(
         explicit_error,
         include_implicit_context=False,
-    ) == (envelope,)
+    ) == (classification,)
 
 
-def test_arbitrary_nested_envelope_does_not_collide_with_action_error_map() -> None:
-    envelope = _user_envelope()
+def test_arbitrary_nested_classification_does_not_collide_with_action_error_map() -> (
+    None
+):
+    classification = _user_classification()
     error = ApplicationError(
         "User payload",
         {
             "arbitrary": {
                 "payload": "not an action error",
-                "envelope": envelope.model_dump(mode="json"),
+                "classification": classification.model_dump(mode="json"),
             }
         },
     )
 
-    assert extract_error_envelopes(error) == ()
+    assert extract_error_classifications(error) == ()
 
 
 @pytest.mark.parametrize("companion", ["arbitrary", "legacy"])
 def test_map_with_any_unwrapped_value_is_unclassified(companion: str) -> None:
     """Classification is all-or-nothing on the map: one unwrapped value voids it."""
-    envelope = _user_envelope()
+    classification = _user_classification()
     legacy_payload = ActionErrorInfo(
         ref="legacy_action",
         message="Legacy failure",
@@ -572,11 +606,11 @@ def test_map_with_any_unwrapped_value_is_unclassified(companion: str) -> None:
     error = ApplicationError(
         "Mixed payload",
         {
-            "action": wrap_error(
-                envelope,
+            "action": build_error_transport_detail(
+                classification,
                 ActionErrorInfo(
                     ref="action",
-                    message=envelope.message,
+                    message=classification.message,
                     type="ValueError",
                 ),
             ).model_dump(mode="json"),
@@ -584,63 +618,72 @@ def test_map_with_any_unwrapped_value_is_unclassified(companion: str) -> None:
         },
     )
 
-    assert extract_error_envelopes(error) == ()
+    assert extract_error_classifications(error) == ()
 
 
 def test_wrapping_preserves_existing_classification() -> None:
-    original_envelope = _user_envelope()
-    fallback = _platform_envelope()
+    original_classification = _user_classification()
+    fallback = _platform_classification()
     original = _capture_application_error(
-        original_envelope,
+        original_classification,
         {"legacy": "payload"},
     )
 
-    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
+    wrapped = _capture_wrapped_application_error(
+        original,
+        fallback_classification=fallback,
+    )
 
-    assert wrapped.type == original_envelope.kind.value
+    assert wrapped.type == original_classification.kind.value
     assert wrapped.details == original.details
-    assert extract_error_envelope(wrapped) == original_envelope
-    assert extract_error_envelope(wrapped) != fallback
+    assert extract_error_classification(wrapped) == original_classification
+    assert extract_error_classification(wrapped) != fallback
 
 
 @pytest.mark.anyio
 async def test_wrapping_drops_outer_details_for_cause_classification() -> None:
-    original_envelope = _user_envelope()
-    fallback = _platform_envelope()
-    classified = _capture_application_error(original_envelope)
+    original_classification = _user_classification()
+    fallback = _platform_classification()
+    classified = _capture_application_error(original_classification)
     try:
         raise ApplicationError(
             "Outer platform failure",
             {"diagnostic": "postgresql://user:secret@example.invalid/database"},
         ) from classified
     except ApplicationError as outer:
-        wrapped = _capture_wrapped_application_error(outer, fallback=fallback)
+        wrapped = _capture_wrapped_application_error(
+            outer,
+            fallback_classification=fallback,
+        )
     failure = Failure()
 
     await DataConverter.default.encode_failure(wrapped, failure)
 
     assert len(wrapped.details) == 1
     assert wrapped.details[0]["schema"] == "tracecat.temporal_error.v1"
-    assert wrapped.type == original_envelope.kind.value
-    assert extract_error_envelope(wrapped) == original_envelope
+    assert wrapped.type == original_classification.kind.value
+    assert extract_error_classification(wrapped) == original_classification
     assert "secret" not in str(failure)
     assert "example.invalid" not in str(failure)
 
 
 def test_wrapping_unclassified_application_error_drops_original_details() -> None:
-    fallback = _platform_envelope()
+    fallback = _platform_classification()
     original = ApplicationError(
         "Raw platform failure",
         {"diagnostic": "postgresql://user:secret@example.invalid/database"},
     )
 
-    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
+    wrapped = _capture_wrapped_application_error(
+        original,
+        fallback_classification=fallback,
+    )
 
     assert len(wrapped.details) == 1
     assert wrapped.details[0]["schema"] == "tracecat.temporal_error.v1"
     assert "secret" not in str(wrapped.details)
     assert "example.invalid" not in str(wrapped.details)
-    assert extract_error_envelope(wrapped) == fallback
+    assert extract_error_classification(wrapped) == fallback
 
 
 @pytest.mark.parametrize(
@@ -655,7 +698,7 @@ def test_wrapping_applies_retry_delay_only_to_retryable_fallback(
     expected_delay: timedelta | None,
 ) -> None:
     original_delay = timedelta(seconds=5)
-    fallback = ErrorEnvelope.platform(
+    fallback = RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the workflow",
         retry_disposition=retry_disposition,
@@ -665,18 +708,21 @@ def test_wrapping_applies_retry_delay_only_to_retryable_fallback(
         next_retry_delay=original_delay,
     )
 
-    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
+    wrapped = _capture_wrapped_application_error(
+        original,
+        fallback_classification=fallback,
+    )
 
     assert wrapped.next_retry_delay == expected_delay
     assert wrapped.non_retryable is (
         retry_disposition is RetryDisposition.NON_RETRYABLE
     )
-    assert extract_error_envelope(wrapped) == fallback
+    assert extract_error_classification(wrapped) == fallback
 
 
 def test_wrapping_clears_retry_delay_for_non_retryable_cause() -> None:
-    envelope = _user_envelope(RetryDisposition.NON_RETRYABLE)
-    classified = _capture_application_error(envelope)
+    classification = _user_classification(RetryDisposition.NON_RETRYABLE)
+    classified = _capture_application_error(classification)
     try:
         raise ApplicationError(
             "Outer wrapper",
@@ -685,19 +731,19 @@ def test_wrapping_clears_retry_delay_for_non_retryable_cause() -> None:
     except ApplicationError as outer:
         wrapped = _capture_wrapped_application_error(
             outer,
-            fallback=_platform_envelope(),
+            fallback_classification=_platform_classification(),
         )
 
     assert wrapped.next_retry_delay is None
     assert wrapped.non_retryable is True
-    assert extract_error_envelope(wrapped) == envelope
+    assert extract_error_classification(wrapped) == classification
 
 
-def test_ambiguous_nested_envelope_does_not_override_fallback() -> None:
-    nested_envelope = _user_envelope()
-    fallback = _platform_envelope()
+def test_ambiguous_nested_classification_does_not_override_fallback() -> None:
+    nested_classification = _user_classification()
+    fallback = _platform_classification()
     detail = {
-        "envelope": nested_envelope.model_dump(mode="json"),
+        "classification": nested_classification.model_dump(mode="json"),
         "arbitrary": "outer field",
     }
 
@@ -708,17 +754,17 @@ def test_ambiguous_nested_envelope_does_not_override_fallback() -> None:
     assert error.type == fallback.kind.value
     assert error.details[0] == detail
     assert error.details[1]["schema"] == "tracecat.temporal_error.v1"
-    assert extract_error_envelope(error) == fallback
+    assert extract_error_classification(error) == fallback
 
 
-def test_exception_chain_preserves_runtime_envelope() -> None:
-    envelope = _user_envelope()
-    classified = TracecatRuntimeError(envelope)
+def test_exception_chain_preserves_runtime_classification() -> None:
+    classification = _user_classification()
+    classified = TracecatRuntimeError(classification)
 
     try:
         raise RuntimeError("Outer wrapper") from classified
     except RuntimeError as error:
-        assert extract_error_envelope(error) == envelope
+        assert extract_error_classification(error) == classification
 
 
 def test_error_owners_remain_attribution_only() -> None:

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -511,6 +511,35 @@ def test_wrapper_map_extracts_every_classified_envelope() -> None:
     assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
 
 
+def test_envelope_extraction_can_ignore_only_implicit_context() -> None:
+    """Boundary extraction skips incidental context but keeps deliberate causes."""
+    envelope = _user_envelope()
+    classified_error = _capture_application_error(envelope)
+
+    try:
+        raise classified_error
+    except ApplicationError:
+        try:
+            raise RuntimeError("Handler failed")
+        except RuntimeError as implicit_error:
+            assert implicit_error.__context__ is classified_error
+            assert extract_error_envelopes(implicit_error) == (envelope,)
+            assert (
+                extract_error_envelopes(
+                    implicit_error,
+                    include_implicit_context=False,
+                )
+                == ()
+            )
+
+    explicit_error = RuntimeError("Explicit wrapper")
+    explicit_error.__cause__ = classified_error
+    assert extract_error_envelopes(
+        explicit_error,
+        include_implicit_context=False,
+    ) == (envelope,)
+
+
 def test_arbitrary_nested_envelope_does_not_collide_with_action_error_map() -> None:
     envelope = _user_envelope()
     error = ApplicationError(

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from datetime import timedelta
 from inspect import signature
+from typing import Literal
 
 import pytest
-from pydantic import TypeAdapter, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
@@ -12,6 +13,10 @@ from temporalio.exceptions import ApplicationError
 from tests.shared import capture_application_error as _capture_application_error
 from tracecat.dsl._converter import get_data_converter
 from tracecat.dsl.action import FinalizeGatherActivityResult
+from tracecat.dsl.error_transport import (
+    ActionErrorTransportDetail,
+    parse_classified_action_error_payload,
+)
 from tracecat.dsl.types import ActionErrorInfo
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.runtime.errors import (
@@ -67,6 +72,13 @@ def _capture_wrapped_application_error(
     return exc_info.value
 
 
+class SyntheticAgentDiagnostic(BaseModel):
+    """Agent-shaped diagnostic proving the transport is workflow-agnostic."""
+
+    phase: Literal["model_call"]
+    message: str
+
+
 @pytest.mark.anyio
 async def test_legacy_action_error_payload_is_unchanged_without_classification() -> (
     None
@@ -104,14 +116,38 @@ async def test_transport_detail_carries_classification_and_preserves_payload() -
     assert error.type == RuntimeErrorKind.ACTION_EXECUTION_FAILED.value
     assert error.details[0]["schema"] == ERROR_TRANSPORT_DETAIL_SCHEMA
     assert error.details[0]["classification"]["schema"] == "tracecat.error.v1"
-    assert error.details[0]["action_error"] == error_info.model_dump(mode="json")
+    assert error.details[0]["diagnostic"] == error_info.model_dump(mode="json")
     assert extract_error_classification(error) == classification
     assert extract_error_classification(decoded) == classification
     assert isinstance(decoded, ApplicationError)
-    parsed = parse_classified_error_payload(decoded.details[0])
+    parsed = parse_classified_action_error_payload(decoded.details[0])
+    assert isinstance(parsed, ActionErrorTransportDetail)
+    assert parsed.classification == classification
+    assert parsed.diagnostic == error_info
+
+
+def test_transport_detail_supports_non_action_diagnostics() -> None:
+    classification = _platform_classification()
+    diagnostic = SyntheticAgentDiagnostic(
+        phase="model_call",
+        message="The model call failed",
+    )
+    serialized = build_error_transport_detail(
+        classification,
+        diagnostic,
+    ).model_dump(mode="json")
+
+    assert serialized["diagnostic"] == diagnostic.model_dump(mode="json")
+    assert "action_error" not in serialized
+
+    parsed = parse_classified_error_payload(serialized)
     assert isinstance(parsed, ErrorTransportDetail)
     assert parsed.classification == classification
-    assert parsed.action_error == error_info
+    assert parsed.diagnostic == diagnostic.model_dump(mode="json")
+    assert (
+        extract_error_classification(ApplicationError("Agent failed", serialized))
+        == classification
+    )
 
 
 def test_aggregate_action_error_attribution_lives_on_transport_detail() -> None:
@@ -150,11 +186,11 @@ def test_aggregate_action_error_attribution_lives_on_transport_detail() -> None:
             ).model_dump(mode="json")
         },
     )
-    parsed = parse_classified_error_payload(error.details[0])
+    parsed = parse_classified_action_error_payload(error.details[0])
 
     assert extract_error_classifications(error) == (classification,)
     assert isinstance(parsed, dict)
-    assert parsed["gather"].action_error == aggregate
+    assert parsed["gather"].diagnostic == aggregate
 
 
 @pytest.mark.parametrize("mapped", [False, True])
@@ -242,13 +278,13 @@ def test_error_handler_input_carries_unwrapped_action_errors() -> None:
         message=classification.message,
         type="RuntimeError",
     )
-    transport_detail = parse_classified_error_payload(
+    transport_detail = parse_classified_action_error_payload(
         build_error_transport_detail(classification, error_info).model_dump(mode="json")
     )
-    assert isinstance(transport_detail, ErrorTransportDetail)
-    assert isinstance(transport_detail.action_error, ActionErrorInfo)
+    assert isinstance(transport_detail, ActionErrorTransportDetail)
+    assert isinstance(transport_detail.diagnostic, ActionErrorInfo)
     assert transport_detail.classification == classification
-    assert transport_detail.action_error == error_info
+    assert transport_detail.diagnostic == error_info
 
     handler_wf_id = WorkflowUUID.new_uuid4()
     orig_wf_id = WorkflowUUID.new_uuid4()
@@ -259,7 +295,7 @@ def test_error_handler_input_carries_unwrapped_action_errors() -> None:
         orig_wf_exec_id=generate_exec_id(orig_wf_id),
         orig_wf_title="Synthetic workflow",
         trigger_type=TriggerType.MANUAL,
-        errors=[transport_detail.action_error],
+        errors=[transport_detail.diagnostic],
     )
 
     serialized = TypeAdapter(ErrorHandlerWorkflowInput).dump_python(
@@ -287,7 +323,7 @@ def test_legacy_action_error_is_transported_beside_classification_detail() -> No
     assert error.details[1] == build_error_transport_detail(classification).model_dump(
         mode="json"
     )
-    assert error.details[1]["action_error"] is None
+    assert error.details[1]["diagnostic"] is None
     assert extract_error_classification(error) == classification
 
 
@@ -463,7 +499,7 @@ def test_action_error_detail_requires_nested_schema_discriminator() -> None:
                 "retry_disposition": "non_retryable",
                 "cause_type": None,
             },
-            "action_error": {
+            "diagnostic": {
                 "ref": "action",
                 "message": "Missing discriminator",
                 "type": "ValueError",
@@ -496,7 +532,7 @@ def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
             "retry_disposition": "non_retryable",
             "cause_type": None,
         },
-        "action_error": aggregate,
+        "diagnostic": aggregate,
     }
 
     assert (

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from inspect import signature
 
 import pytest
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
@@ -23,10 +23,14 @@ from tracecat.runtime.errors import (
 )
 from tracecat.storage.object import InlineObject
 from tracecat.temporal.errors import (
+    TEMPORAL_ERROR_DETAILS_SCHEMA,
+    ClassifiedErrorDetail,
     extract_error_envelope,
     extract_error_envelopes,
+    parse_classified_detail,
     raise_application_error_from_envelope,
     raise_wrapped_application_error,
+    wrap_error,
 )
 from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.executions.types import ErrorHandlerWorkflowInput
@@ -76,36 +80,40 @@ async def test_legacy_action_error_payload_is_unchanged_without_envelope() -> No
 
 
 @pytest.mark.anyio
-async def test_action_error_payload_carries_discriminated_envelope() -> None:
+async def test_classified_wrapper_carries_envelope_and_preserves_payload() -> None:
+    """The wrapper carries the envelope; its payload survives unwrapping intact."""
     envelope = _user_envelope()
     error_info = ActionErrorInfo(
         ref="action",
         message="The action failed",
         type="ValueError",
-        envelope=envelope,
     )
-    error = _capture_application_error(envelope, error_info)
+    error = _capture_application_error(envelope, wrap_error(envelope, error_info))
     failure = Failure()
     await DataConverter.default.encode_failure(error, failure)
     decoded = await DataConverter.default.decode_failure(failure)
 
     assert len(error.details) == 1
     assert error.type == RuntimeErrorKind.ACTION_EXECUTION_FAILED.value
+    assert error.details[0]["schema"] == TEMPORAL_ERROR_DETAILS_SCHEMA
     assert error.details[0]["envelope"]["schema"] == "tracecat.error.v1"
+    assert error.details[0]["error"] == error_info.model_dump(mode="json")
     assert extract_error_envelope(error) == envelope
     assert extract_error_envelope(decoded) == envelope
     assert isinstance(decoded, ApplicationError)
-    parsed = ActionErrorInfo.model_validate(decoded.details[0])
+    parsed = parse_classified_detail(decoded.details[0])
+    assert isinstance(parsed, ClassifiedErrorDetail)
     assert parsed.envelope == envelope
+    assert parsed.error == error_info
 
 
-def test_aggregate_action_errors_preserve_classified_children() -> None:
+def test_aggregate_action_error_attribution_lives_on_the_wrapper() -> None:
+    """Gather payloads stay envelope-free; the wrapper alone carries attribution."""
     envelope = _platform_envelope()
     child = ActionErrorInfo(
         ref="scatter[0]",
         message=envelope.message,
         type="RuntimeError",
-        envelope=envelope,
     )
     finalized = FinalizeGatherActivityResult(
         result=InlineObject(data=[]),
@@ -114,10 +122,8 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
 
     serialized_finalized = finalized.model_dump(mode="json")
     parsed_finalized = FinalizeGatherActivityResult.model_validate(serialized_finalized)
-    assert serialized_finalized["errors"][0]["envelope"] == envelope.model_dump(
-        mode="json"
-    )
-    assert parsed_finalized.errors[0].envelope == envelope
+    assert "envelope" not in serialized_finalized["errors"][0]
+    assert parsed_finalized.errors == [child]
 
     aggregate = ActionErrorInfo(
         ref="gather",
@@ -126,50 +132,64 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
         children=parsed_finalized.errors,
     )
     serialized_aggregate = aggregate.model_dump(mode="json")
-    parsed_aggregate = ActionErrorInfo.model_validate(serialized_aggregate)
+    assert "envelope" not in serialized_aggregate
+    assert "envelope" not in serialized_aggregate["children"][0]
 
-    assert serialized_aggregate["children"][0]["envelope"] == envelope.model_dump(
-        mode="json"
+    error = ApplicationError(
+        "Gather failed",
+        {"gather": wrap_error(envelope, aggregate).model_dump(mode="json")},
     )
-    assert parsed_aggregate.children is not None
-    assert parsed_aggregate.children[0].envelope == envelope
+    parsed = parse_classified_detail(error.details[0])
 
-    error = ApplicationError("Gather failed", {"gather": serialized_aggregate})
     assert extract_error_envelopes(error) == (envelope,)
+    assert isinstance(parsed, dict)
+    assert parsed["gather"].error == aggregate
 
 
-@pytest.mark.parametrize("serialized", [False, True])
-def test_aggregate_action_error_rejects_partially_classified_children(
-    serialized: bool,
-) -> None:
+@pytest.mark.parametrize("mapped", [False, True])
+def test_embedded_payload_envelopes_never_classify(mapped: bool) -> None:
+    """Envelope keys inside a payload fail validation, so the detail is unclassified."""
     envelope = _user_envelope()
-    aggregate = ActionErrorInfo(
-        ref="gather",
-        message="Gather failed",
-        type="ApplicationError",
-        envelope=envelope,
-        children=[
-            ActionErrorInfo(
-                ref="scatter[0]",
-                message=envelope.message,
-                type="ValueError",
-                envelope=envelope,
-            ),
-            ActionErrorInfo(
-                ref="scatter[1]",
-                message="Legacy failure",
-                type="RuntimeError",
-            ),
+    serialized_envelope = envelope.model_dump(mode="json")
+    with pytest.raises(ValidationError):
+        ActionErrorInfo.model_validate(
+            {
+                "ref": "scatter[0]",
+                "message": envelope.message,
+                "type": "ValueError",
+                "envelope": serialized_envelope,
+            }
+        )
+
+    aggregate = {
+        "ref": "gather",
+        "message": "Gather failed",
+        "type": "ApplicationError",
+        "envelope": serialized_envelope,
+        "children": [
+            {
+                "ref": "scatter[0]",
+                "message": envelope.message,
+                "type": "ValueError",
+                "envelope": serialized_envelope,
+            },
+            {
+                "ref": "scatter[1]",
+                "message": "Legacy failure",
+                "type": "RuntimeError",
+            },
         ],
-    )
-    detail = aggregate.model_dump(mode="json") if serialized else aggregate
+    }
+    detail = {"gather": aggregate} if mapped else aggregate
 
     assert extract_error_envelopes(ApplicationError("Gather failed", detail)) == ()
 
 
 @pytest.mark.anyio
-async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -> None:
-    user_envelope = _user_envelope()
+async def test_unclassified_aggregate_keeps_fallback_envelope_after_serialization() -> (
+    None
+):
+    """An unclassified aggregate detail leaves the appended fallback authoritative."""
     fallback = _platform_envelope()
     aggregate = ActionErrorInfo(
         ref="gather",
@@ -178,9 +198,8 @@ async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -
         children=[
             ActionErrorInfo(
                 ref="scatter[0]",
-                message=user_envelope.message,
+                message="The action failed",
                 type="ValueError",
-                envelope=user_envelope,
             ),
             ActionErrorInfo(
                 ref="scatter[1]",
@@ -188,7 +207,7 @@ async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -
                 type="RuntimeError",
             ),
         ],
-    )
+    ).model_dump(mode="json")
 
     error = _capture_application_error(fallback, aggregate)
     failure = Failure()
@@ -197,18 +216,27 @@ async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -
 
     assert error.type == fallback.kind.value
     assert error.non_retryable is False
+    assert error.details[0] == aggregate
     assert extract_error_envelopes(error) == (fallback,)
     assert extract_error_envelopes(decoded) == (fallback,)
 
 
-def test_error_handler_input_preserves_action_error_envelope() -> None:
+def test_error_handler_input_carries_unwrapped_action_errors() -> None:
+    """Handler input carries envelope-free payloads identical to the unwrapped ones."""
     envelope = _platform_envelope()
     error_info = ActionErrorInfo(
         ref="action",
         message=envelope.message,
         type="RuntimeError",
-        envelope=envelope,
     )
+    wrapped = parse_classified_detail(
+        wrap_error(envelope, error_info).model_dump(mode="json")
+    )
+    assert isinstance(wrapped, ClassifiedErrorDetail)
+    assert isinstance(wrapped.error, ActionErrorInfo)
+    assert wrapped.envelope == envelope
+    assert wrapped.error == error_info
+
     handler_wf_id = WorkflowUUID.new_uuid4()
     orig_wf_id = WorkflowUUID.new_uuid4()
     handler_input = ErrorHandlerWorkflowInput(
@@ -218,7 +246,7 @@ def test_error_handler_input_preserves_action_error_envelope() -> None:
         orig_wf_exec_id=generate_exec_id(orig_wf_id),
         orig_wf_title="Synthetic workflow",
         trigger_type=TriggerType.MANUAL,
-        errors=[error_info],
+        errors=[wrapped.error],
     )
 
     serialized = TypeAdapter(ErrorHandlerWorkflowInput).dump_python(
@@ -226,23 +254,26 @@ def test_error_handler_input_preserves_action_error_envelope() -> None:
         mode="json",
     )
 
-    assert serialized["errors"][0]["envelope"] == envelope.model_dump(mode="json")
+    assert serialized["errors"][0] == error_info.model_dump(mode="json")
+    assert "envelope" not in serialized["errors"][0]
 
 
-def test_legacy_action_error_is_extended_without_changing_existing_fields() -> None:
+def test_legacy_action_error_is_transported_verbatim_beside_the_wrapper() -> None:
+    """A legacy payload travels unchanged; classification rides an appended wrapper."""
     envelope = _user_envelope()
-    error_info = ActionErrorInfo(
+    legacy = ActionErrorInfo(
         ref="action",
         message="The action failed",
         type="ValueError",
-    )
-    legacy = error_info.model_dump(mode="json")
+    ).model_dump(mode="json")
 
-    error = _capture_application_error(envelope, error_info)
+    error = _capture_application_error(envelope, legacy)
 
-    detail = error.details[0]
-    assert {key: detail[key] for key in legacy} == legacy
-    assert detail["envelope"] == envelope.model_dump(mode="json")
+    assert len(error.details) == 2
+    assert error.details[0] == legacy
+    assert error.details[1] == wrap_error(envelope).model_dump(mode="json")
+    assert error.details[1]["error"] is None
+    assert extract_error_envelope(error) == envelope
 
 
 @pytest.mark.parametrize(
@@ -453,21 +484,26 @@ def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
     )
 
 
-def test_action_error_map_extracts_every_classified_envelope() -> None:
+def test_wrapper_map_extracts_every_classified_envelope() -> None:
+    """A terminal ``{ref: wrapper}`` map yields each wrapper's envelope in order."""
     user_envelope = _user_envelope()
     platform_envelope = _platform_envelope()
     details = {
-        "user_action": ActionErrorInfo(
-            ref="user_action",
-            message=user_envelope.message,
-            type="ValueError",
-            envelope=user_envelope,
+        "user_action": wrap_error(
+            user_envelope,
+            ActionErrorInfo(
+                ref="user_action",
+                message=user_envelope.message,
+                type="ValueError",
+            ),
         ).model_dump(mode="json"),
-        "platform_action": ActionErrorInfo(
-            ref="platform_action",
-            message=platform_envelope.message,
-            type="RuntimeError",
-            envelope=platform_envelope,
+        "platform_action": wrap_error(
+            platform_envelope,
+            ActionErrorInfo(
+                ref="platform_action",
+                message=platform_envelope.message,
+                type="RuntimeError",
+            ),
         ).model_dump(mode="json"),
     }
     error = ApplicationError("Workflow failed", details)
@@ -490,18 +526,32 @@ def test_arbitrary_nested_envelope_does_not_collide_with_action_error_map() -> N
     assert extract_error_envelopes(error) == ()
 
 
-def test_action_error_map_rejects_partial_shape_match() -> None:
+@pytest.mark.parametrize("companion", ["arbitrary", "legacy"])
+def test_map_with_any_unwrapped_value_is_unclassified(companion: str) -> None:
+    """Classification is all-or-nothing on the map: one unwrapped value voids it."""
     envelope = _user_envelope()
+    legacy_payload = ActionErrorInfo(
+        ref="legacy_action",
+        message="Legacy failure",
+        type="RuntimeError",
+    ).model_dump(mode="json")
+    companion_payload = (
+        legacy_payload
+        if companion == "legacy"
+        else {"payload": "not a classified detail"}
+    )
     error = ApplicationError(
         "Mixed payload",
         {
-            "action": ActionErrorInfo(
-                ref="action",
-                message=envelope.message,
-                type="ValueError",
-                envelope=envelope,
+            "action": wrap_error(
+                envelope,
+                ActionErrorInfo(
+                    ref="action",
+                    message=envelope.message,
+                    type="ValueError",
+                ),
             ).model_dump(mode="json"),
-            "arbitrary": {"payload": "not an action error"},
+            "companion": companion_payload,
         },
     )
 

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -151,6 +151,35 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
     assert extract_error_envelopes(error) == (envelope,)
 
 
+@pytest.mark.parametrize("serialized", [False, True])
+def test_aggregate_action_error_rejects_partially_classified_children(
+    serialized: bool,
+) -> None:
+    envelope = _user_envelope()
+    aggregate = ActionErrorInfo(
+        ref="gather",
+        message="Gather failed",
+        type="ApplicationError",
+        envelope=envelope,
+        children=[
+            ActionErrorInfo(
+                ref="scatter[0]",
+                message=envelope.message,
+                type="ValueError",
+                envelope=envelope,
+            ),
+            ActionErrorInfo(
+                ref="scatter[1]",
+                message="Legacy failure",
+                type="RuntimeError",
+            ),
+        ],
+    )
+    detail = aggregate.model_dump(mode="json") if serialized else aggregate
+
+    assert extract_error_envelopes(ApplicationError("Gather failed", detail)) == ()
+
+
 def test_error_handler_input_preserves_action_error_envelope() -> None:
     envelope = _platform_envelope()
     error_info = ActionErrorInfo(

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -23,6 +23,7 @@ from tracecat.runtime.errors import (
 from tracecat.storage.object import InlineObject
 from tracecat.temporal.errors import (
     extract_error_envelope,
+    extract_error_envelopes,
     raise_application_error_from_envelope,
     raise_wrapped_application_error,
 )
@@ -98,9 +99,8 @@ async def test_action_error_payload_carries_discriminated_envelope() -> None:
     )
     error = _capture_application_error(envelope, error_info)
     failure = Failure()
-    data_converter = get_data_converter()
-    await data_converter.encode_failure(error, failure)
-    decoded = await data_converter.decode_failure(failure)
+    await DataConverter.default.encode_failure(error, failure)
+    decoded = await DataConverter.default.decode_failure(failure)
 
     assert len(error.details) == 1
     assert error.type == RuntimeErrorKind.ACTION_EXECUTION_FAILED.value
@@ -146,16 +146,9 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
     )
     assert parsed_aggregate.children is not None
     assert parsed_aggregate.children[0].envelope == envelope
-    assert (
-        extract_error_envelope(ApplicationError("Gather failed", serialized_aggregate))
-        == envelope
-    )
-    assert (
-        extract_error_envelope(
-            ApplicationError("Gather failed", {"gather": serialized_aggregate})
-        )
-        == envelope
-    )
+
+    error = ApplicationError("Gather failed", {"gather": serialized_aggregate})
+    assert extract_error_envelopes(error) == (envelope,)
 
 
 def test_error_handler_input_preserves_action_error_envelope() -> None:
@@ -363,51 +356,59 @@ def test_payload_key_does_not_collide_without_valid_discriminator() -> None:
     assert extract_error_envelope(error) is None
 
 
-def test_action_error_detail_requires_nested_schema_discriminator() -> None:
+def test_action_error_map_extracts_every_classified_envelope() -> None:
+    user_envelope = _user_envelope()
+    platform_envelope = _platform_envelope()
+    details = {
+        "user_action": ActionErrorInfo(
+            ref="user_action",
+            message=user_envelope.message,
+            type="ValueError",
+            envelope=user_envelope,
+        ).model_dump(mode="json"),
+        "platform_action": ActionErrorInfo(
+            ref="platform_action",
+            message=platform_envelope.message,
+            type="RuntimeError",
+            envelope=platform_envelope,
+        ).model_dump(mode="json"),
+    }
+    error = ApplicationError("Workflow failed", details)
+
+    assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
+
+
+def test_arbitrary_nested_envelope_does_not_collide_with_action_error_map() -> None:
+    envelope = _user_envelope()
     error = ApplicationError(
-        "Legacy error",
+        "User payload",
         {
-            "ref": "action",
-            "message": "Missing discriminator",
-            "type": "ValueError",
-            "envelope": {
-                "owner": "user",
-                "kind": "action.execution.failed",
-                "message": "Missing discriminator",
-                "retry_disposition": "non_retryable",
-                "cause_type": None,
-            },
+            "arbitrary": {
+                "payload": "not an action error",
+                "envelope": envelope.model_dump(mode="json"),
+            }
         },
     )
 
-    assert extract_error_envelope(error) is None
+    assert extract_error_envelopes(error) == ()
 
 
-def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
-    child = {
-        "ref": "scatter[0]",
-        "message": "Missing discriminator",
-        "type": "ValueError",
-        "envelope": {
-            "owner": "user",
-            "kind": "action.execution.failed",
-            "message": "Missing discriminator",
-            "retry_disposition": "non_retryable",
-            "cause_type": None,
+def test_action_error_map_rejects_partial_shape_match() -> None:
+    envelope = _user_envelope()
+    error = ApplicationError(
+        "Mixed payload",
+        {
+            "action": ActionErrorInfo(
+                ref="action",
+                message=envelope.message,
+                type="ValueError",
+                envelope=envelope,
+            ).model_dump(mode="json"),
+            "arbitrary": {"payload": "not an action error"},
         },
-    }
-    aggregate = {
-        "ref": "gather",
-        "message": "Gather failed",
-        "type": "ApplicationError",
-        "children": [child],
-    }
-
-    assert extract_error_envelope(ApplicationError("Gather failed", aggregate)) is None
-    assert (
-        extract_error_envelope(ApplicationError("Gather failed", {"gather": aggregate}))
-        is None
     )
+
+    assert extract_error_envelopes(error) == ()
 
 
 def test_wrapping_preserves_existing_classification() -> None:
@@ -424,77 +425,6 @@ def test_wrapping_preserves_existing_classification() -> None:
     assert wrapped.details == original.details
     assert extract_error_envelope(wrapped) == original_envelope
     assert extract_error_envelope(wrapped) != fallback
-
-
-@pytest.mark.anyio
-async def test_wrapping_drops_outer_details_for_cause_classification() -> None:
-    original_envelope = _user_envelope()
-    fallback = _platform_envelope()
-    classified = _capture_application_error(original_envelope)
-    try:
-        raise ApplicationError(
-            "Outer platform failure",
-            {"diagnostic": "postgresql://user:secret@example.invalid/database"},
-        ) from classified
-    except ApplicationError as outer:
-        wrapped = _capture_wrapped_application_error(outer, fallback=fallback)
-    failure = Failure()
-
-    await DataConverter.default.encode_failure(wrapped, failure)
-
-    assert len(wrapped.details) == 1
-    assert wrapped.details[0]["schema"] == "tracecat.temporal_error.v1"
-    assert wrapped.type == original_envelope.kind.value
-    assert extract_error_envelope(wrapped) == original_envelope
-    assert "secret" not in str(failure)
-    assert "example.invalid" not in str(failure)
-
-
-def test_wrapping_unclassified_application_error_drops_original_details() -> None:
-    fallback = _platform_envelope()
-    original = ApplicationError(
-        "Raw platform failure",
-        {"diagnostic": "postgresql://user:secret@example.invalid/database"},
-    )
-
-    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
-
-    assert len(wrapped.details) == 1
-    assert wrapped.details[0]["schema"] == "tracecat.temporal_error.v1"
-    assert "secret" not in str(wrapped.details)
-    assert "example.invalid" not in str(wrapped.details)
-    assert extract_error_envelope(wrapped) == fallback
-
-
-@pytest.mark.parametrize(
-    ("retry_disposition", "expected_delay"),
-    [
-        (RetryDisposition.RETRYABLE, timedelta(seconds=5)),
-        (RetryDisposition.NON_RETRYABLE, None),
-    ],
-)
-def test_wrapping_applies_retry_delay_only_to_retryable_envelope(
-    retry_disposition: RetryDisposition,
-    expected_delay: timedelta | None,
-) -> None:
-    original_delay = timedelta(seconds=5)
-    fallback = ErrorEnvelope.platform(
-        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
-        message="Tracecat could not execute the workflow",
-        retry_disposition=retry_disposition,
-    )
-    original = ApplicationError(
-        "Unclassified platform failure",
-        next_retry_delay=original_delay,
-    )
-
-    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
-
-    assert wrapped.next_retry_delay == expected_delay
-    assert wrapped.non_retryable is (
-        retry_disposition is RetryDisposition.NON_RETRYABLE
-    )
-    assert extract_error_envelope(wrapped) == fallback
 
 
 def test_ambiguous_nested_envelope_does_not_override_fallback() -> None:

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -9,6 +9,7 @@ from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
 
+from tests.shared import capture_application_error as _capture_application_error
 from tracecat.dsl._converter import get_data_converter
 from tracecat.dsl.action import FinalizeGatherActivityResult
 from tracecat.dsl.types import ActionErrorInfo
@@ -47,20 +48,6 @@ def _platform_envelope() -> ErrorEnvelope:
         message="Tracecat could not execute the workflow",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-
-
-def _capture_application_error(
-    envelope: ErrorEnvelope,
-    *details: object,
-    next_retry_delay: timedelta | None = None,
-) -> ApplicationError:
-    with pytest.raises(ApplicationError) as exc_info:
-        raise_application_error_from_envelope(
-            envelope,
-            *details,
-            next_retry_delay=next_retry_delay,
-        )
-    return exc_info.value
 
 
 def _capture_wrapped_application_error(

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -356,6 +356,53 @@ def test_payload_key_does_not_collide_without_valid_discriminator() -> None:
     assert extract_error_envelope(error) is None
 
 
+def test_action_error_detail_requires_nested_schema_discriminator() -> None:
+    error = ApplicationError(
+        "Legacy error",
+        {
+            "ref": "action",
+            "message": "Missing discriminator",
+            "type": "ValueError",
+            "envelope": {
+                "owner": "user",
+                "kind": "action.execution.failed",
+                "message": "Missing discriminator",
+                "retry_disposition": "non_retryable",
+                "cause_type": None,
+            },
+        },
+    )
+
+    assert extract_error_envelope(error) is None
+
+
+def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
+    child = {
+        "ref": "scatter[0]",
+        "message": "Missing discriminator",
+        "type": "ValueError",
+        "envelope": {
+            "owner": "user",
+            "kind": "action.execution.failed",
+            "message": "Missing discriminator",
+            "retry_disposition": "non_retryable",
+            "cause_type": None,
+        },
+    }
+    aggregate = {
+        "ref": "gather",
+        "message": "Gather failed",
+        "type": "ApplicationError",
+        "children": [child],
+    }
+
+    assert extract_error_envelope(ApplicationError("Gather failed", aggregate)) is None
+    assert (
+        extract_error_envelope(ApplicationError("Gather failed", {"gather": aggregate}))
+        is None
+    )
+
+
 def test_action_error_map_extracts_every_classified_envelope() -> None:
     user_envelope = _user_envelope()
     platform_envelope = _platform_envelope()

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -474,6 +474,46 @@ def test_wrapping_preserves_existing_classification() -> None:
     assert extract_error_envelope(wrapped) != fallback
 
 
+@pytest.mark.anyio
+async def test_wrapping_drops_outer_details_for_cause_classification() -> None:
+    original_envelope = _user_envelope()
+    fallback = _platform_envelope()
+    classified = _capture_application_error(original_envelope)
+    try:
+        raise ApplicationError(
+            "Outer platform failure",
+            {"diagnostic": "postgresql://user:secret@example.invalid/database"},
+        ) from classified
+    except ApplicationError as outer:
+        wrapped = _capture_wrapped_application_error(outer, fallback=fallback)
+    failure = Failure()
+
+    await DataConverter.default.encode_failure(wrapped, failure)
+
+    assert len(wrapped.details) == 1
+    assert wrapped.details[0]["schema"] == "tracecat.temporal_error.v1"
+    assert wrapped.type == original_envelope.kind.value
+    assert extract_error_envelope(wrapped) == original_envelope
+    assert "secret" not in str(failure)
+    assert "example.invalid" not in str(failure)
+
+
+def test_wrapping_unclassified_application_error_drops_original_details() -> None:
+    fallback = _platform_envelope()
+    original = ApplicationError(
+        "Raw platform failure",
+        {"diagnostic": "postgresql://user:secret@example.invalid/database"},
+    )
+
+    wrapped = _capture_wrapped_application_error(original, fallback=fallback)
+
+    assert len(wrapped.details) == 1
+    assert wrapped.details[0]["schema"] == "tracecat.temporal_error.v1"
+    assert "secret" not in str(wrapped.details)
+    assert "example.invalid" not in str(wrapped.details)
+    assert extract_error_envelope(wrapped) == fallback
+
+
 def test_ambiguous_nested_envelope_does_not_override_fallback() -> None:
     nested_envelope = _user_envelope()
     fallback = _platform_envelope()

--- a/tests/unit/test_temporal_search_attribute_registration.py
+++ b/tests/unit/test_temporal_search_attribute_registration.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
+from tenacity import stop_after_attempt, wait_none
 
 from tracecat.api import common
+from tracecat.api.app import lifespan
 from tracecat.workflow.executions.enums import TemporalSearchAttr
 
 
@@ -24,6 +28,33 @@ async def test_add_temporal_search_attributes_registers_correlation_id(
     ].search_attributes
     assert TemporalSearchAttr.CORRELATION_ID.value in search_attributes
     assert TemporalSearchAttr.ERROR_OWNER.value in search_attributes
+
+
+@pytest.mark.anyio
+async def test_add_temporal_search_attributes_propagates_registration_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operator_service = SimpleNamespace(
+        add_search_attributes=AsyncMock(
+            side_effect=RuntimeError("Temporal unavailable")
+        )
+    )
+    client = SimpleNamespace(operator_service=operator_service)
+    monkeypatch.setattr(common, "get_temporal_client", AsyncMock(return_value=client))
+    single_attempt_add = cast(Any, common.add_temporal_search_attributes).retry_with(
+        stop=stop_after_attempt(1),
+        wait=wait_none(),
+    )
+
+    with pytest.raises(RuntimeError, match="Temporal unavailable"):
+        await single_attempt_add()
+
+
+def test_api_lifespan_waits_for_temporal_search_attributes() -> None:
+    source = inspect.getsource(lifespan)
+
+    assert "await add_temporal_search_attributes()" in source
+    assert "create_task(add_temporal_search_attributes())" not in source
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_temporal_search_attribute_registration.py
+++ b/tests/unit/test_temporal_search_attribute_registration.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
+from temporalio.api.enums.v1 import IndexedValueType
+from temporalio.api.operatorservice.v1 import ListSearchAttributesResponse
 from tenacity import stop_after_attempt, wait_none
 
 from tracecat.api import common
@@ -17,7 +19,10 @@ from tracecat.workflow.executions.enums import TemporalSearchAttr
 async def test_add_temporal_search_attributes_registers_correlation_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    operator_service = SimpleNamespace(add_search_attributes=AsyncMock())
+    operator_service = SimpleNamespace(
+        list_search_attributes=AsyncMock(return_value=ListSearchAttributesResponse()),
+        add_search_attributes=AsyncMock(),
+    )
     client = SimpleNamespace(operator_service=operator_service)
     monkeypatch.setattr(common, "get_temporal_client", AsyncMock(return_value=client))
 
@@ -31,13 +36,97 @@ async def test_add_temporal_search_attributes_registers_correlation_id(
 
 
 @pytest.mark.anyio
+async def test_add_temporal_search_attributes_registers_only_missing_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_attributes = {
+        attr.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
+        for attr in TemporalSearchAttr
+        if attr is not TemporalSearchAttr.ERROR_OWNER
+    }
+    operator_service = SimpleNamespace(
+        list_search_attributes=AsyncMock(
+            return_value=ListSearchAttributesResponse(
+                custom_attributes=existing_attributes
+            )
+        ),
+        add_search_attributes=AsyncMock(),
+    )
+    client = SimpleNamespace(operator_service=operator_service)
+    monkeypatch.setattr(common, "get_temporal_client", AsyncMock(return_value=client))
+
+    await common.add_temporal_search_attributes()
+
+    request = operator_service.add_search_attributes.await_args.args[0]
+    assert dict(request.search_attributes) == {
+        TemporalSearchAttr.ERROR_OWNER.value: (
+            IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
+        )
+    }
+
+
+@pytest.mark.anyio
+async def test_add_temporal_search_attributes_skips_registered_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_attributes = {
+        attr.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
+        for attr in TemporalSearchAttr
+    }
+    operator_service = SimpleNamespace(
+        list_search_attributes=AsyncMock(
+            return_value=ListSearchAttributesResponse(
+                custom_attributes=existing_attributes
+            )
+        ),
+        add_search_attributes=AsyncMock(),
+    )
+    client = SimpleNamespace(operator_service=operator_service)
+    monkeypatch.setattr(common, "get_temporal_client", AsyncMock(return_value=client))
+
+    await common.add_temporal_search_attributes()
+
+    operator_service.add_search_attributes.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_add_temporal_search_attributes_rejects_wrong_registered_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operator_service = SimpleNamespace(
+        list_search_attributes=AsyncMock(
+            return_value=ListSearchAttributesResponse(
+                custom_attributes={
+                    TemporalSearchAttr.ERROR_OWNER.value: (
+                        IndexedValueType.INDEXED_VALUE_TYPE_TEXT
+                    )
+                }
+            )
+        ),
+        add_search_attributes=AsyncMock(),
+    )
+    client = SimpleNamespace(operator_service=operator_service)
+    monkeypatch.setattr(common, "get_temporal_client", AsyncMock(return_value=client))
+    single_attempt_add = cast(Any, common.add_temporal_search_attributes).retry_with(
+        stop=stop_after_attempt(1),
+        wait=wait_none(),
+    )
+
+    with pytest.raises(RuntimeError, match="TracecatErrorOwner"):
+        await single_attempt_add()
+
+    operator_service.add_search_attributes.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_add_temporal_search_attributes_propagates_registration_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     operator_service = SimpleNamespace(
+        list_search_attributes=AsyncMock(return_value=ListSearchAttributesResponse()),
         add_search_attributes=AsyncMock(
             side_effect=RuntimeError("Temporal unavailable")
-        )
+        ),
     )
     client = SimpleNamespace(operator_service=operator_service)
     monkeypatch.setattr(common, "get_temporal_client", AsyncMock(return_value=client))

--- a/tests/unit/test_temporal_search_attribute_registration.py
+++ b/tests/unit/test_temporal_search_attribute_registration.py
@@ -23,6 +23,7 @@ async def test_add_temporal_search_attributes_registers_correlation_id(
         0
     ].search_attributes
     assert TemporalSearchAttr.CORRELATION_ID.value in search_attributes
+    assert TemporalSearchAttr.ERROR_OWNER.value in search_attributes
 
 
 @pytest.mark.anyio
@@ -39,3 +40,4 @@ async def test_remove_temporal_search_attributes_removes_correlation_id(
         0
     ].search_attributes
     assert TemporalSearchAttr.CORRELATION_ID.value in search_attributes
+    assert TemporalSearchAttr.ERROR_OWNER.value in search_attributes

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -185,9 +185,10 @@ async def lifespan(app: FastAPI):
     assert_soft_delete_listener_registered()
 
     # Temporal
-    # Run in background to avoid blocking startup
-    asyncio.create_task(add_temporal_search_attributes())
-    logger.debug("Spawned lifespan task to add temporal search attributes")
+    # Workflows may upsert these attributes as soon as the API accepts requests.
+    # Gate startup so a failed registration is retried and remains visible.
+    await add_temporal_search_attributes()
+    logger.debug("Temporal search attributes are ready")
 
     # Storage
     await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS)

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -186,6 +186,7 @@ async def add_temporal_search_attributes():
         TemporalSearchAttr.ALIAS.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
         TemporalSearchAttr.CORRELATION_ID.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
         TemporalSearchAttr.EXECUTION_TYPE.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+        TemporalSearchAttr.ERROR_OWNER.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
     }
     try:
         await client.operator_service.add_search_attributes(
@@ -231,6 +232,7 @@ async def remove_temporal_search_attributes():
                     TemporalSearchAttr.ALIAS.value,
                     TemporalSearchAttr.CORRELATION_ID.value,
                     TemporalSearchAttr.EXECUTION_TYPE.value,
+                    TemporalSearchAttr.ERROR_OWNER.value,
                 ],
                 namespace=namespace,
             )
@@ -252,5 +254,6 @@ async def remove_temporal_search_attributes():
                 TemporalSearchAttr.ALIAS.value,
                 TemporalSearchAttr.CORRELATION_ID.value,
                 TemporalSearchAttr.EXECUTION_TYPE.value,
+                TemporalSearchAttr.ERROR_OWNER.value,
             ],
         )

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -201,12 +201,12 @@ async def add_temporal_search_attributes():
             exc=e,
             namespace=namespace,
         )
-    else:
-        logger.info(
-            "Temporal search attributes added",
-            namespace=namespace,
-            search_attributes=list(attrs.keys()),
-        )
+        raise
+    logger.info(
+        "Temporal search attributes added",
+        namespace=namespace,
+        search_attributes=list(attrs.keys()),
+    )
 
 
 @retry(

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -27,6 +27,12 @@ from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 from tracecat.workflow.executions.enums import TemporalSearchAttr
 
+# All Tracecat search attributes are Keyword-typed.
+_SEARCH_ATTRIBUTE_TYPES: dict[str, IndexedValueType.ValueType] = {
+    attr.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
+    for attr in TemporalSearchAttr
+}
+
 
 async def generic_exception_handler(request: Request, exc: Exception) -> Response:
     logger.exception(
@@ -180,15 +186,7 @@ async def add_temporal_search_attributes():
     """
     client = await get_temporal_client()
     namespace = TEMPORAL__CLUSTER_NAMESPACE
-    attrs = {
-        TemporalSearchAttr.TRIGGER_TYPE.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-        TemporalSearchAttr.TRIGGERED_BY_USER_ID.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-        TemporalSearchAttr.WORKSPACE_ID.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-        TemporalSearchAttr.ALIAS.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-        TemporalSearchAttr.CORRELATION_ID.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-        TemporalSearchAttr.EXECUTION_TYPE.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-        TemporalSearchAttr.ERROR_OWNER.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-    }
+    attrs = _SEARCH_ATTRIBUTE_TYPES
     try:
         registered = await client.operator_service.list_search_attributes(
             ListSearchAttributesRequest(namespace=namespace)
@@ -208,7 +206,7 @@ async def add_temporal_search_attributes():
             logger.info(
                 "Temporal search attributes already registered",
                 namespace=namespace,
-                search_attributes=list(attrs.keys()),
+                search_attributes=list(_SEARCH_ATTRIBUTE_TYPES),
             )
             return
 
@@ -248,15 +246,7 @@ async def remove_temporal_search_attributes():
     try:
         await client.operator_service.remove_search_attributes(
             RemoveSearchAttributesRequest(
-                search_attributes=[
-                    TemporalSearchAttr.TRIGGER_TYPE.value,
-                    TemporalSearchAttr.TRIGGERED_BY_USER_ID.value,
-                    TemporalSearchAttr.WORKSPACE_ID.value,
-                    TemporalSearchAttr.ALIAS.value,
-                    TemporalSearchAttr.CORRELATION_ID.value,
-                    TemporalSearchAttr.EXECUTION_TYPE.value,
-                    TemporalSearchAttr.ERROR_OWNER.value,
-                ],
+                search_attributes=list(_SEARCH_ATTRIBUTE_TYPES),
                 namespace=namespace,
             )
         )
@@ -265,18 +255,11 @@ async def remove_temporal_search_attributes():
             "Error removing temporal search attributes",
             exc=e,
             namespace=namespace,
+            search_attributes=list(_SEARCH_ATTRIBUTE_TYPES),
         )
     else:
         logger.info(
             "Temporal search attributes removed",
             namespace=namespace,
-            search_attributes=[
-                TemporalSearchAttr.TRIGGER_TYPE.value,
-                TemporalSearchAttr.TRIGGERED_BY_USER_ID.value,
-                TemporalSearchAttr.WORKSPACE_ID.value,
-                TemporalSearchAttr.ALIAS.value,
-                TemporalSearchAttr.CORRELATION_ID.value,
-                TemporalSearchAttr.EXECUTION_TYPE.value,
-                TemporalSearchAttr.ERROR_OWNER.value,
-            ],
+            search_attributes=list(_SEARCH_ATTRIBUTE_TYPES),
         )

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.api.enums.v1 import IndexedValueType
 from temporalio.api.operatorservice.v1 import (
     AddSearchAttributesRequest,
+    ListSearchAttributesRequest,
     RemoveSearchAttributesRequest,
 )
 from tenacity import (
@@ -189,9 +190,31 @@ async def add_temporal_search_attributes():
         TemporalSearchAttr.ERROR_OWNER.value: IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
     }
     try:
+        registered = await client.operator_service.list_search_attributes(
+            ListSearchAttributesRequest(namespace=namespace)
+        )
+        missing_attrs: dict[str, IndexedValueType.ValueType] = {}
+        for name, expected_type in attrs.items():
+            registered_type = registered.custom_attributes.get(name)
+            if registered_type is None:
+                missing_attrs[name] = expected_type
+            elif registered_type != expected_type:
+                raise RuntimeError(
+                    "Temporal search attribute has an unexpected type: "
+                    f"{name} (expected {expected_type}, got {registered_type})"
+                )
+
+        if not missing_attrs:
+            logger.info(
+                "Temporal search attributes already registered",
+                namespace=namespace,
+                search_attributes=list(attrs.keys()),
+            )
+            return
+
         await client.operator_service.add_search_attributes(
             AddSearchAttributesRequest(
-                search_attributes=attrs,
+                search_attributes=missing_attrs,
                 namespace=namespace,
             )
         )
@@ -205,7 +228,7 @@ async def add_temporal_search_attributes():
     logger.info(
         "Temporal search attributes added",
         namespace=namespace,
-        search_attributes=list(attrs.keys()),
+        search_attributes=list(missing_attrs.keys()),
     )
 
 

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -219,12 +219,8 @@ class BuildAgentArgsActivityInput(BaseModel):
     default_environment: str
 
 
-class BuildPresetAgentArgsActivityInput(BaseModel):
-    args: dict[str, Any]
-    operand: ExecutionContext
-    role: Role
-    task_environment: str | None
-    default_environment: str
+class BuildPresetAgentArgsActivityInput(BuildAgentArgsActivityInput):
+    """Input for building preset agent arguments with the shared wire shape."""
 
 
 class EvaluateTemplatedObjectActivityInput(BaseModel):
@@ -302,6 +298,17 @@ async def _store_collection_as_refs(prefix: str, items: list[Any]) -> Collection
         stored = await storage.store(collection_item_key(prefix, i), item)
         refs.append(stored.model_dump())
     return await store_collection(prefix, refs, element_kind="stored_object")
+
+
+async def _store_list_result(key: str, items: list[Any]) -> StoredObject:
+    """Store a list as a CollectionObject when result externalization is enabled.
+
+    Falls back to an inline list for non-externalized deployments, which cannot
+    use chunked storage.
+    """
+    if config.TRACECAT__RESULT_EXTERNALIZATION_ENABLED:
+        return await _store_collection_as_refs(key, items)
+    return InlineObject(data=items, typename="list")
 
 
 async def _materialize_task_result(task_result: TaskResult) -> MaterializedTaskResult:
@@ -638,10 +645,7 @@ class DSLActivities:
                 element_kind="stored_object",
             )
         else:
-            values: list[Any] = []
-            for obj in input.collection:
-                value = await storage.retrieve(obj)
-                values.append(value)
+            values = [await storage.retrieve(obj) for obj in input.collection]
             return InlineObject(data=values, typename="list")
 
     @staticmethod
@@ -658,38 +662,31 @@ class DSLActivities:
         Returns the CollectionObject handle and any partitioned errors.
         """
         storage = get_object_storage()
-        values: list[Any] = []
-        for obj in input.collection:
-            value = await storage.retrieve(obj)
-            values.append(value)
+        values = [await storage.retrieve(obj) for obj in input.collection]
 
         if input.drop_nulls:
             values = [v for v in values if v is not None]
 
-        results: list[Any] = []
-        errors: list[ActionErrorInfo] = []
         match input.error_strategy:
-            case StreamErrorHandlingStrategy.PARTITION:
-                results, errors = _partition_errors(values)
-            case StreamErrorHandlingStrategy.DROP:
-                results = [v for v in values if not _is_error_info(v)]
-            case StreamErrorHandlingStrategy.INCLUDE:
-                results = list(values)
-            case StreamErrorHandlingStrategy.RAISE:
+            case (
+                StreamErrorHandlingStrategy.PARTITION
+                | StreamErrorHandlingStrategy.RAISE
+            ):
                 # Caller is responsible for raising if errors are present.
                 results, errors = _partition_errors(values)
+            case StreamErrorHandlingStrategy.DROP:
+                results, _ = _partition_errors(values)
+                errors = []
+            case StreamErrorHandlingStrategy.INCLUDE:
+                results = list(values)
+                errors = []
             case _:
                 raise ApplicationError(
                     f"Invalid error handling strategy: {input.error_strategy}",
                     non_retryable=True,
                 )
 
-        # Guard CollectionObject: only use chunked storage when externalization
-        # is enabled. Fall back to inline list for non-externalized deployments.
-        if config.TRACECAT__RESULT_EXTERNALIZATION_ENABLED:
-            stored = await _store_collection_as_refs(input.key, results)
-        else:
-            stored = InlineObject(data=results, typename="list")
+        stored = await _store_list_result(input.key, results)
         return FinalizeGatherActivityResult(result=stored, errors=errors)
 
     @staticmethod
@@ -697,37 +694,9 @@ class DSLActivities:
     async def build_agent_args_activity(
         input: BuildAgentArgsActivityInput,
     ) -> AgentActionArgs:
-        """Build an AgentActionArgs from a dictionary of arguments.
-
-        Resolves the effective environment, fetches workspace VARS,
-        materializes any StoredObjects in operand, then evaluates templated
-        args. CPU-bound work is offloaded via asyncio.to_thread to avoid
-        blocking the Temporal event loop.
-        """
-        operand = input.operand
-        materialized = await materialize_context(operand)
-        environment = await asyncio.to_thread(
-            _resolve_environment,
-            input.task_environment,
-            input.default_environment,
-            materialized,
-        )
-        collected = await asyncio.to_thread(collect_expressions, input.args)
-        if collected.variables:
-            workspace_variables = await get_workspace_variables(
-                variable_exprs=collected.variables,
-                environment=environment,
-                role=input.role,
-            )
-            if workspace_variables:
-                operand["VARS"] = workspace_variables
-                materialized = await materialize_context(operand)
-        args = _strip_string_values(input.args)
-        evaled_args = await asyncio.to_thread(
-            eval_templated_object, args, operand=materialized
-        )
-        mcp_integration_ids = evaled_args.pop("mcp_integrations", None)
-        if mcp_integration_ids:
+        """Build AgentActionArgs via the shared _evaluate_agent_args helper."""
+        evaled_args = await _evaluate_agent_args(input)
+        if mcp_integration_ids := evaled_args.pop("mcp_integrations", None):
             evaled_args["mcp_servers"] = await _resolve_mcp_integrations(
                 mcp_integration_ids, role=input.role
             )
@@ -738,35 +707,8 @@ class DSLActivities:
     async def build_preset_agent_args_activity(
         input: BuildPresetAgentArgsActivityInput,
     ) -> PresetAgentActionArgs:
-        """Build a PresetAgentActionArgs from a dictionary of arguments.
-
-        Resolves the effective environment, fetches workspace VARS,
-        materializes any StoredObjects in operand, then evaluates templated
-        args. CPU-bound work is offloaded via asyncio.to_thread to avoid
-        blocking the Temporal event loop.
-        """
-        operand = input.operand
-        materialized = await materialize_context(operand)
-        environment = await asyncio.to_thread(
-            _resolve_environment,
-            input.task_environment,
-            input.default_environment,
-            materialized,
-        )
-        collected = await asyncio.to_thread(collect_expressions, input.args)
-        if collected.variables:
-            workspace_variables = await get_workspace_variables(
-                variable_exprs=collected.variables,
-                environment=environment,
-                role=input.role,
-            )
-            if workspace_variables:
-                operand["VARS"] = workspace_variables
-                materialized = await materialize_context(operand)
-        args = _strip_string_values(input.args)
-        evaled_args = await asyncio.to_thread(
-            eval_templated_object, args, operand=materialized
-        )
+        """Build PresetAgentActionArgs via the shared _evaluate_agent_args helper."""
+        evaled_args = await _evaluate_agent_args(input)
         return PresetAgentActionArgs(**evaled_args)
 
     @staticmethod
@@ -852,6 +794,30 @@ class DSLActivities:
             )
 
 
+async def _evaluate_agent_args(input: BuildAgentArgsActivityInput) -> dict[str, Any]:
+    """Resolve environment and VARS, materialize the operand, and evaluate templated args."""
+    operand = input.operand
+    materialized = await materialize_context(operand)
+    environment = await asyncio.to_thread(
+        _resolve_environment,
+        input.task_environment,
+        input.default_environment,
+        materialized,
+    )
+    collected = await asyncio.to_thread(collect_expressions, input.args)
+    if collected.variables:
+        workspace_variables = await get_workspace_variables(
+            variable_exprs=collected.variables,
+            environment=environment,
+            role=input.role,
+        )
+        if workspace_variables:
+            operand["VARS"] = workspace_variables
+            materialized = await materialize_context(operand)
+    args = _strip_string_values(input.args)
+    return await asyncio.to_thread(eval_templated_object, args, operand=materialized)
+
+
 def _subflow_error_envelope(error: Exception) -> ErrorEnvelope:
     """Classify a subflow error without overriding established semantics."""
     if envelope := extract_error_envelope(error):
@@ -862,26 +828,28 @@ def _subflow_error_envelope(error: Exception) -> ErrorEnvelope:
         if isinstance(error, ApplicationError) and error.non_retryable
         else RetryDisposition.RETRYABLE
     )
-    if isinstance(error, SubflowDefinitionNotFoundError):
-        return ErrorEnvelope.user(
-            kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
-            message=error.message or "The child workflow could not be prepared",
-            retry_disposition=retry_disposition,
-            cause=error,
-        )
-    if isinstance(error, ApplicationError) and UserError.matches(error):
-        return ErrorEnvelope.user(
-            kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID,
-            message=error.message or "The child workflow inputs are invalid",
-            retry_disposition=retry_disposition,
-            cause=error,
-        )
-    return ErrorEnvelope.platform(
-        kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED,
-        message="Tracecat could not prepare the child workflow",
-        retry_disposition=retry_disposition,
-        cause=error,
-    )
+    match error:
+        case SubflowDefinitionNotFoundError():
+            return ErrorEnvelope.user(
+                kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
+                message=error.message or "The child workflow could not be prepared",
+                retry_disposition=retry_disposition,
+                cause=error,
+            )
+        case ApplicationError() if UserError.matches(error):
+            return ErrorEnvelope.user(
+                kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID,
+                message=error.message or "The child workflow inputs are invalid",
+                retry_disposition=retry_disposition,
+                cause=error,
+            )
+        case _:
+            return ErrorEnvelope.platform(
+                kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED,
+                message="Tracecat could not prepare the child workflow",
+                retry_disposition=retry_disposition,
+                cause=error,
+            )
 
 
 def _raise_classified_subflow_application_error(
@@ -941,12 +909,7 @@ def _evaluate_scatter_input(input: ScatterActionInput) -> StoredObject:
         )
 
     items = list(result)
-    # Guard CollectionObject: only use chunked storage when externalization
-    # is enabled. Fall back to inline list for non-externalized deployments.
-    if config.TRACECAT__RESULT_EXTERNALIZATION_ENABLED:
-        return run_sync(_store_collection_as_refs(input.key, items))
-    else:
-        return InlineObject(data=items, typename="list")
+    return run_sync(_store_list_result(input.key, items))
 
 
 def _patch_object(
@@ -971,18 +934,6 @@ def _partition_errors(
         else:
             results.append(item)
     return results, errors
-
-
-def _is_error_info(detail: Any) -> bool:
-    if isinstance(detail, ActionErrorInfo):
-        return True
-    if not isinstance(detail, Mapping):
-        return False
-    try:
-        ActionErrorInfo.model_validate(detail)
-        return True
-    except Exception:
-        return False
 
 
 def _as_error_info(detail: Any) -> ActionErrorInfo | None:
@@ -1249,15 +1200,9 @@ async def _prepare_subflow(input: PrepareSubflowActivityInput) -> PreparedSubflo
         dsl_config=dsl.config,
     )
 
-    # Guard CollectionObject: only use chunked storage when externalization
-    # is enabled. Fall back to inline list for non-externalized deployments.
-    trigger_inputs_stored: StoredObject
-    if config.TRACECAT__RESULT_EXTERNALIZATION_ENABLED:
-        trigger_inputs_stored = await _store_collection_as_refs(
-            f"{input.key}/trigger_inputs", trigger_inputs_list
-        )
-    else:
-        trigger_inputs_stored = InlineObject(data=trigger_inputs_list, typename="list")
+    trigger_inputs_stored = await _store_list_result(
+        f"{input.key}/trigger_inputs", trigger_inputs_list
+    )
 
     return PreparedSubflowResult(
         wf_id=wf_id,

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -26,6 +26,7 @@ from tracecat.dsl.common import (
     ResolvedSubflowConfig,
 )
 from tracecat.dsl.enums import StreamErrorHandlingStrategy
+from tracecat.dsl.error_transport import is_classified_action_error_payload
 from tracecat.dsl.schemas import (
     ActionStatement,
     DSLConfig,
@@ -77,7 +78,6 @@ from tracecat.storage.utils import is_retryable_storage_transport_error
 from tracecat.temporal.errors import (
     build_error_transport_detail,
     extract_error_classification,
-    is_classified_error_payload,
     raise_wrapped_application_error,
 )
 from tracecat.temporal.exceptions import UserError
@@ -859,7 +859,9 @@ def _raise_classified_subflow_application_error(
     if isinstance(error, ApplicationError):
         error_type = error.type or type(error).__name__
         legacy_details = tuple(
-            detail for detail in error.details if is_classified_error_payload(detail)
+            detail
+            for detail in error.details
+            if is_classified_action_error_payload(detail)
         )
     else:
         error_type = type(error).__name__

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -4,7 +4,7 @@ import asyncio
 import threading
 import weakref
 from collections.abc import Callable, Coroutine, Mapping
-from typing import Any, cast
+from typing import Any, Never, cast
 
 import dateparser
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -53,6 +53,12 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.integrations.mcp_validation import MCPValidationError
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import (
+    ErrorEnvelope,
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
 from tracecat.storage.collection import (
     materialize_collection_values,
     store_collection,
@@ -68,6 +74,10 @@ from tracecat.storage.object import (
     retrieve_stored_object,
 )
 from tracecat.storage.utils import is_retryable_storage_transport_error
+from tracecat.temporal.errors import (
+    extract_error_envelope,
+    raise_application_error_from_envelope,
+)
 from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
 
@@ -818,7 +828,76 @@ class DSLActivities:
 
         Returns PreparedSubflowResult containing all shared data needed to spawn child workflows.
         """
-        return await _prepare_subflow(input)
+        try:
+            return await _prepare_subflow(input)
+        except Exception as error:
+            envelope = _subflow_error_envelope(error)
+            if envelope.owner is RuntimeErrorOwner.PLATFORM:
+                logger.error(
+                    "Platform error preparing child workflow",
+                    error=error,
+                    ref=input.task.ref,
+                )
+            _raise_classified_subflow_application_error(
+                input=input,
+                error=error,
+                envelope=envelope,
+            )
+
+
+def _subflow_error_envelope(error: Exception) -> ErrorEnvelope:
+    """Classify a subflow error without overriding established semantics."""
+    if envelope := extract_error_envelope(error):
+        return envelope
+
+    retry_disposition = (
+        RetryDisposition.NON_RETRYABLE
+        if isinstance(error, ApplicationError) and error.non_retryable
+        else RetryDisposition.RETRYABLE
+    )
+    if isinstance(error, ApplicationError) and UserError.matches(error):
+        return ErrorEnvelope.user(
+            kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
+            message=error.message or "The child workflow could not be prepared",
+            retry_disposition=retry_disposition,
+            cause=error,
+        )
+    return ErrorEnvelope.platform(
+        kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED,
+        message="Tracecat could not prepare the child workflow",
+        retry_disposition=retry_disposition,
+        cause=error,
+    )
+
+
+def _raise_classified_subflow_application_error(
+    *,
+    input: PrepareSubflowActivityInput,
+    error: BaseException,
+    envelope: ErrorEnvelope,
+) -> Never:
+    """Raise a history-safe classified failure for subflow preparation."""
+    if isinstance(error, ApplicationError):
+        error_type = error.type or type(error).__name__
+        legacy_details = tuple(error.details)
+        next_retry_delay = error.next_retry_delay
+    else:
+        error_type = type(error).__name__
+        legacy_details = ()
+        next_retry_delay = None
+
+    detail = ActionErrorInfo(
+        ref=input.task.ref,
+        message=envelope.message,
+        type=error_type,
+        envelope=envelope,
+    )
+    raise_application_error_from_envelope(
+        envelope,
+        detail,
+        *legacy_details,
+        next_retry_delay=next_retry_delay,
+    )
 
 
 def _evaluate_scatter_input(input: ScatterActionInput) -> StoredObject:

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -78,6 +78,7 @@ from tracecat.temporal.errors import (
     extract_error_envelope,
     is_classified_detail,
     raise_wrapped_application_error,
+    wrap_error,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
@@ -864,11 +865,13 @@ def _raise_classified_subflow_application_error(
         error_type = type(error).__name__
         legacy_details = ()
 
-    detail = ActionErrorInfo(
-        ref=input.task.ref,
-        message=envelope.message,
-        type=error_type,
-        envelope=envelope,
+    detail = wrap_error(
+        envelope,
+        ActionErrorInfo(
+            ref=input.task.ref,
+            message=envelope.message,
+            type=error_type,
+        ),
     )
     raise_wrapped_application_error(
         error,

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -54,8 +54,8 @@ from tracecat.integrations.mcp_validation import MCPValidationError
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.runtime.errors import (
-    ErrorEnvelope,
     RetryDisposition,
+    RuntimeErrorClassification,
     RuntimeErrorKind,
     RuntimeErrorOwner,
 )
@@ -75,10 +75,10 @@ from tracecat.storage.object import (
 )
 from tracecat.storage.utils import is_retryable_storage_transport_error
 from tracecat.temporal.errors import (
-    extract_error_envelope,
-    is_classified_detail,
+    build_error_transport_detail,
+    extract_error_classification,
+    is_classified_error_payload,
     raise_wrapped_application_error,
-    wrap_error,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
@@ -775,19 +775,19 @@ class DSLActivities:
         try:
             return await _prepare_subflow(input)
         except Exception as error:
-            envelope = _subflow_error_envelope(error)
-            if envelope.owner is RuntimeErrorOwner.PLATFORM:
+            classification = _subflow_error_classification(error)
+            if classification.owner is RuntimeErrorOwner.PLATFORM:
                 logger.error(
                     "Platform error preparing child workflow",
                     error_type=type(error).__name__,
-                    error_kind=envelope.kind.value,
-                    retry_disposition=envelope.retry_disposition.value,
+                    error_kind=classification.kind.value,
+                    retry_disposition=classification.retry_disposition.value,
                     ref=input.task.ref,
                 )
             _raise_classified_subflow_application_error(
                 input=input,
                 error=error,
-                envelope=envelope,
+                classification=classification,
             )
 
 
@@ -815,10 +815,10 @@ async def _evaluate_agent_args(input: BuildAgentArgsActivityInput) -> dict[str, 
     return await asyncio.to_thread(eval_templated_object, args, operand=materialized)
 
 
-def _subflow_error_envelope(error: Exception) -> ErrorEnvelope:
+def _subflow_error_classification(error: Exception) -> RuntimeErrorClassification:
     """Classify a subflow error without overriding established semantics."""
-    if envelope := extract_error_envelope(error):
-        return envelope
+    if classification := extract_error_classification(error):
+        return classification
 
     retry_disposition = (
         RetryDisposition.NON_RETRYABLE
@@ -827,21 +827,21 @@ def _subflow_error_envelope(error: Exception) -> ErrorEnvelope:
     )
     match error:
         case SubflowDefinitionNotFoundError():
-            return ErrorEnvelope.user(
+            return RuntimeErrorClassification.user(
                 kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
                 message=error.message or "The child workflow could not be prepared",
                 retry_disposition=retry_disposition,
                 cause=error,
             )
         case ApplicationError() if UserError.matches(error):
-            return ErrorEnvelope.user(
+            return RuntimeErrorClassification.user(
                 kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID,
                 message=error.message or "The child workflow inputs are invalid",
                 retry_disposition=retry_disposition,
                 cause=error,
             )
         case _:
-            return ErrorEnvelope.platform(
+            return RuntimeErrorClassification.platform(
                 kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_PREPARATION_FAILED,
                 message="Tracecat could not prepare the child workflow",
                 retry_disposition=retry_disposition,
@@ -853,29 +853,29 @@ def _raise_classified_subflow_application_error(
     *,
     input: PrepareSubflowActivityInput,
     error: BaseException,
-    envelope: ErrorEnvelope,
+    classification: RuntimeErrorClassification,
 ) -> Never:
     """Raise a history-safe classified failure for subflow preparation."""
     if isinstance(error, ApplicationError):
         error_type = error.type or type(error).__name__
         legacy_details = tuple(
-            detail for detail in error.details if is_classified_detail(detail)
+            detail for detail in error.details if is_classified_error_payload(detail)
         )
     else:
         error_type = type(error).__name__
         legacy_details = ()
 
-    detail = wrap_error(
-        envelope,
+    detail = build_error_transport_detail(
+        classification,
         ActionErrorInfo(
             ref=input.task.ref,
-            message=envelope.message,
+            message=classification.message,
             type=error_type,
         ),
     )
     raise_wrapped_application_error(
         error,
-        fallback=envelope,
+        fallback_classification=classification,
         details=(detail, *legacy_details),
     )
 

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -76,12 +76,17 @@ from tracecat.storage.object import (
 from tracecat.storage.utils import is_retryable_storage_transport_error
 from tracecat.temporal.errors import (
     extract_error_envelope,
+    extract_error_envelopes_from_details,
     raise_application_error_from_envelope,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
 
 _thread_local = threading.local()
+
+
+class SubflowDefinitionNotFoundError(UserError):
+    """A requested child workflow definition could not be resolved."""
 
 
 def _close_asyncio_runner(runner: asyncio.Runner) -> None:
@@ -835,7 +840,9 @@ class DSLActivities:
             if envelope.owner is RuntimeErrorOwner.PLATFORM:
                 logger.error(
                     "Platform error preparing child workflow",
-                    error=error,
+                    error_type=type(error).__name__,
+                    error_kind=envelope.kind.value,
+                    retry_disposition=envelope.retry_disposition.value,
                     ref=input.task.ref,
                 )
             _raise_classified_subflow_application_error(
@@ -855,10 +862,17 @@ def _subflow_error_envelope(error: Exception) -> ErrorEnvelope:
         if isinstance(error, ApplicationError) and error.non_retryable
         else RetryDisposition.RETRYABLE
     )
-    if isinstance(error, ApplicationError) and UserError.matches(error):
+    if isinstance(error, SubflowDefinitionNotFoundError):
         return ErrorEnvelope.user(
             kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
             message=error.message or "The child workflow could not be prepared",
+            retry_disposition=retry_disposition,
+            cause=error,
+        )
+    if isinstance(error, ApplicationError) and UserError.matches(error):
+        return ErrorEnvelope.user(
+            kind=RuntimeErrorKind.WORKFLOW_SUBFLOW_INPUT_INVALID,
+            message=error.message or "The child workflow inputs are invalid",
             retry_disposition=retry_disposition,
             cause=error,
         )
@@ -879,8 +893,16 @@ def _raise_classified_subflow_application_error(
     """Raise a history-safe classified failure for subflow preparation."""
     if isinstance(error, ApplicationError):
         error_type = error.type or type(error).__name__
-        legacy_details = tuple(error.details)
-        next_retry_delay = error.next_retry_delay
+        legacy_details = (
+            tuple(error.details)
+            if extract_error_envelopes_from_details(error.details)
+            else ()
+        )
+        next_retry_delay = (
+            error.next_retry_delay
+            if envelope.retry_disposition is RetryDisposition.RETRYABLE
+            else None
+        )
     else:
         error_type = type(error).__name__
         legacy_details = ()
@@ -1176,7 +1198,9 @@ async def _prepare_subflow(input: PrepareSubflowActivityInput) -> PreparedSubflo
                 use_committed=input.use_committed,
             )
             if resolved_id is None:
-                raise UserError(f"Workflow alias '{workflow_alias}' not found")
+                raise SubflowDefinitionNotFoundError(
+                    f"Workflow alias '{workflow_alias}' not found"
+                )
             wf_id = WorkflowUUID.new(resolved_id)
     elif workflow_id := val_args.workflow_id:
         wf_id = WorkflowUUID.new(workflow_id)
@@ -1189,7 +1213,9 @@ async def _prepare_subflow(input: PrepareSubflowActivityInput) -> PreparedSubflo
             wf_id, version=evaluated_args.get("version")
         )
         if not defn:
-            raise UserError(f"Workflow definition not found for {wf_id.short()}")
+            raise SubflowDefinitionNotFoundError(
+                f"Workflow definition not found for {wf_id.short()}"
+            )
     dsl = DSLInput(**defn.content)
     registry_lock = (
         RegistryLock.model_validate(defn.registry_lock) if defn.registry_lock else None

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -893,10 +893,10 @@ def _raise_classified_subflow_application_error(
     """Raise a history-safe classified failure for subflow preparation."""
     if isinstance(error, ApplicationError):
         error_type = error.type or type(error).__name__
-        legacy_details = (
-            tuple(error.details)
-            if extract_error_envelopes_from_details(error.details)
-            else ()
+        legacy_details = tuple(
+            detail
+            for detail in error.details
+            if extract_error_envelopes_from_details((detail,))
         )
         next_retry_delay = (
             error.next_retry_delay

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -76,8 +76,8 @@ from tracecat.storage.object import (
 from tracecat.storage.utils import is_retryable_storage_transport_error
 from tracecat.temporal.errors import (
     extract_error_envelope,
-    extract_error_envelopes_from_details,
-    raise_application_error_from_envelope,
+    is_classified_detail,
+    raise_wrapped_application_error,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
@@ -217,10 +217,6 @@ class BuildAgentArgsActivityInput(BaseModel):
     role: Role
     task_environment: str | None
     default_environment: str
-
-
-class BuildPresetAgentArgsActivityInput(BuildAgentArgsActivityInput):
-    """Input for building preset agent arguments with the shared wire shape."""
 
 
 class EvaluateTemplatedObjectActivityInput(BaseModel):
@@ -705,7 +701,7 @@ class DSLActivities:
     @staticmethod
     @activity.defn
     async def build_preset_agent_args_activity(
-        input: BuildPresetAgentArgsActivityInput,
+        input: BuildAgentArgsActivityInput,
     ) -> PresetAgentActionArgs:
         """Build PresetAgentActionArgs via the shared _evaluate_agent_args helper."""
         evaled_args = await _evaluate_agent_args(input)
@@ -862,19 +858,11 @@ def _raise_classified_subflow_application_error(
     if isinstance(error, ApplicationError):
         error_type = error.type or type(error).__name__
         legacy_details = tuple(
-            detail
-            for detail in error.details
-            if extract_error_envelopes_from_details((detail,))
-        )
-        next_retry_delay = (
-            error.next_retry_delay
-            if envelope.retry_disposition is RetryDisposition.RETRYABLE
-            else None
+            detail for detail in error.details if is_classified_detail(detail)
         )
     else:
         error_type = type(error).__name__
         legacy_details = ()
-        next_retry_delay = None
 
     detail = ActionErrorInfo(
         ref=input.task.ref,
@@ -882,11 +870,10 @@ def _raise_classified_subflow_application_error(
         type=error_type,
         envelope=envelope,
     )
-    raise_application_error_from_envelope(
-        envelope,
-        detail,
-        *legacy_details,
-        next_retry_delay=next_retry_delay,
+    raise_wrapped_application_error(
+        error,
+        fallback=envelope,
+        details=(detail, *legacy_details),
     )
 
 

--- a/tracecat/dsl/error_policy.py
+++ b/tracecat/dsl/error_policy.py
@@ -1,0 +1,88 @@
+"""Terminal error adaptation policy for DSL workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from temporalio.exceptions import ApplicationError
+
+from tracecat.dsl.types import ActionErrorInfo, TaskExceptionInfo
+from tracecat.runtime.errors import ErrorEnvelope, select_error_envelope
+from tracecat.temporal.errors import (
+    application_error_from_envelope,
+    extract_error_envelopes,
+    parse_classified_detail,
+    wrap_error,
+)
+
+
+def build_terminal_application_error(
+    task_exceptions: Mapping[str, TaskExceptionInfo],
+) -> ApplicationError:
+    """Build the terminal workflow error without changing legacy payloads."""
+    n_exceptions = len(task_exceptions)
+    task_envelopes: dict[str, ErrorEnvelope] = {}
+    for ref, info in task_exceptions.items():
+        envelopes = extract_error_envelopes(info.exception)
+        if not envelopes:
+            break
+        task_envelopes[ref] = select_error_envelope(envelopes)
+    else:
+        if task_envelopes:
+            terminal_envelope = select_error_envelope(task_envelopes.values())
+            error_details = {
+                ref: wrap_error(task_envelopes[ref], info.details).model_dump(
+                    mode="json"
+                )
+                for ref, info in task_exceptions.items()
+            }
+            return application_error_from_envelope(
+                terminal_envelope,
+                error_details,
+            )
+
+    formatted_exceptions = "\n".join(
+        f"{'=' * 10} ({i + 1}/{n_exceptions}) {details.expr_context}.{ref} {'=' * 10}\n\n{info.exception!s}"
+        for i, (ref, info) in enumerate(task_exceptions.items())
+        if (details := info.details)
+    )
+    return ApplicationError(
+        f"Workflow failed with {n_exceptions} error(s)\n\n{formatted_exceptions}",
+        {ref: info.details for ref, info in task_exceptions.items()},
+        non_retryable=True,
+        type=ApplicationError.__name__,
+    )
+
+
+def adapt_error_handler_details(
+    details: Sequence[Any],
+) -> list[ActionErrorInfo] | None:
+    """Adapt terminal application error details for an error handler."""
+    if not details:
+        return None
+
+    err_info_map = details[0]
+    if not isinstance(err_info_map, dict):
+        return [
+            ActionErrorInfo(
+                ref="N/A",
+                message=(
+                    "Unexpected error info object of type "
+                    f"{type(err_info_map).__name__}: {err_info_map}"
+                ),
+                type=type(err_info_map).__name__,
+            )
+        ]
+    if isinstance(parsed := parse_classified_detail(err_info_map), dict):
+        return [
+            wrapped.error
+            if wrapped.error is not None
+            else ActionErrorInfo(
+                ref=child_ref,
+                message=wrapped.envelope.message,
+                type=wrapped.envelope.kind.value,
+            )
+            for child_ref, wrapped in parsed.items()
+        ]
+    return [ActionErrorInfo.model_validate(data) for data in err_info_map.values()]

--- a/tracecat/dsl/error_policy.py
+++ b/tracecat/dsl/error_policy.py
@@ -8,12 +8,15 @@ from typing import Any
 from temporalio.exceptions import ApplicationError
 
 from tracecat.dsl.types import ActionErrorInfo, TaskExceptionInfo
-from tracecat.runtime.errors import ErrorEnvelope, select_error_envelope
+from tracecat.runtime.errors import (
+    RuntimeErrorClassification,
+    select_error_classification,
+)
 from tracecat.temporal.errors import (
-    application_error_from_envelope,
-    extract_error_envelopes,
-    parse_classified_detail,
-    wrap_error,
+    application_error_from_classification,
+    build_error_transport_detail,
+    extract_error_classifications,
+    parse_classified_error_payload,
 )
 
 
@@ -22,23 +25,26 @@ def build_terminal_application_error(
 ) -> ApplicationError:
     """Build the terminal workflow error without changing legacy payloads."""
     n_exceptions = len(task_exceptions)
-    task_envelopes: dict[str, ErrorEnvelope] = {}
+    task_classifications: dict[str, RuntimeErrorClassification] = {}
     for ref, info in task_exceptions.items():
-        envelopes = extract_error_envelopes(info.exception)
-        if not envelopes:
+        classifications = extract_error_classifications(info.exception)
+        if not classifications:
             break
-        task_envelopes[ref] = select_error_envelope(envelopes)
+        task_classifications[ref] = select_error_classification(classifications)
     else:
-        if task_envelopes:
-            terminal_envelope = select_error_envelope(task_envelopes.values())
+        if task_classifications:
+            terminal_classification = select_error_classification(
+                task_classifications.values()
+            )
             error_details = {
-                ref: wrap_error(task_envelopes[ref], info.details).model_dump(
-                    mode="json"
-                )
+                ref: build_error_transport_detail(
+                    task_classifications[ref],
+                    info.details,
+                ).model_dump(mode="json")
                 for ref, info in task_exceptions.items()
             }
-            return application_error_from_envelope(
-                terminal_envelope,
+            return application_error_from_classification(
+                terminal_classification,
                 error_details,
             )
 
@@ -74,15 +80,15 @@ def adapt_error_handler_details(
                 type=type(err_info_map).__name__,
             )
         ]
-    if isinstance(parsed := parse_classified_detail(err_info_map), dict):
+    if isinstance(parsed := parse_classified_error_payload(err_info_map), dict):
         return [
-            wrapped.error
-            if wrapped.error is not None
+            transport_detail.action_error
+            if transport_detail.action_error is not None
             else ActionErrorInfo(
                 ref=child_ref,
-                message=wrapped.envelope.message,
-                type=wrapped.envelope.kind.value,
+                message=transport_detail.classification.message,
+                type=transport_detail.classification.kind.value,
             )
-            for child_ref, wrapped in parsed.items()
+            for child_ref, transport_detail in parsed.items()
         ]
     return [ActionErrorInfo.model_validate(data) for data in err_info_map.values()]

--- a/tracecat/dsl/error_policy.py
+++ b/tracecat/dsl/error_policy.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from temporalio.exceptions import ApplicationError
 
+from tracecat.dsl.error_transport import parse_classified_action_error_payload
 from tracecat.dsl.types import ActionErrorInfo, TaskExceptionInfo
 from tracecat.runtime.errors import (
     RuntimeErrorClassification,
@@ -16,7 +17,6 @@ from tracecat.temporal.errors import (
     application_error_from_classification,
     build_error_transport_detail,
     extract_error_classifications,
-    parse_classified_error_payload,
 )
 
 
@@ -80,10 +80,10 @@ def adapt_error_handler_details(
                 type=type(err_info_map).__name__,
             )
         ]
-    if isinstance(parsed := parse_classified_error_payload(err_info_map), dict):
+    if isinstance(parsed := parse_classified_action_error_payload(err_info_map), dict):
         return [
-            transport_detail.action_error
-            if transport_detail.action_error is not None
+            transport_detail.diagnostic
+            if transport_detail.diagnostic is not None
             else ActionErrorInfo(
                 ref=child_ref,
                 message=transport_detail.classification.message,

--- a/tracecat/dsl/error_transport.py
+++ b/tracecat/dsl/error_transport.py
@@ -1,0 +1,36 @@
+"""DSL-specific adaptation for classified error transport payloads."""
+
+from __future__ import annotations
+
+from pydantic import TypeAdapter, ValidationError
+
+from tracecat.dsl.types import ActionErrorInfo
+from tracecat.temporal.errors import ErrorTransportDetail
+
+
+class ActionErrorTransportDetail(ErrorTransportDetail[ActionErrorInfo]):
+    """Classified transport specialized for DSL action diagnostics."""
+
+
+type ClassifiedActionErrorPayload = (
+    ActionErrorTransportDetail | dict[str, ActionErrorTransportDetail]
+)
+
+_CLASSIFIED_ACTION_ERROR_PAYLOAD_ADAPTER: TypeAdapter[ClassifiedActionErrorPayload] = (
+    TypeAdapter(ClassifiedActionErrorPayload)
+)
+
+
+def parse_classified_action_error_payload(
+    payload: object,
+) -> ClassifiedActionErrorPayload | None:
+    """Parse a classified payload carrying DSL action diagnostics."""
+    try:
+        return _CLASSIFIED_ACTION_ERROR_PAYLOAD_ADAPTER.validate_python(payload)
+    except ValidationError:
+        return None
+
+
+def is_classified_action_error_payload(payload: object) -> bool:
+    """Return whether a payload has valid classification and action diagnostics."""
+    return parse_classified_action_error_payload(payload) is not None

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -72,7 +72,10 @@ with workflow.unsafe.imports_passed_through():
         action_collection_prefix,
         action_key,
     )
-    from tracecat.temporal.errors import extract_error_envelope
+    from tracecat.temporal.errors import (
+        extract_error_envelope,
+        extract_error_envelopes_from_details,
+    )
 
 
 def _get_collection_size(stored: StoredObject) -> int:
@@ -104,6 +107,8 @@ def _classified_action_error_info(
         return None
 
     for detail in error.details:
+        if not extract_error_envelopes_from_details((detail,)):
+            continue
         try:
             parsed = ActionErrorInfo.model_validate(detail)
         except ValidationError:
@@ -147,7 +152,7 @@ def _validated_action_error_map(
         except ValidationError:
             return None
 
-    if not parsed or not any(_action_error_contains_envelope(item) for item in parsed):
+    if not parsed or not all(_action_error_contains_envelope(item) for item in parsed):
         return None
     return tuple(parsed)
 

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -64,11 +64,11 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.expressions.common import ExprContext
     from tracecat.expressions.core import extract_expressions
     from tracecat.runtime.errors import (
-        ErrorEnvelope,
         RetryDisposition,
+        RuntimeErrorClassification,
         RuntimeErrorKind,
         RuntimeErrorOwner,
-        select_error_envelope,
+        select_error_classification,
     )
     from tracecat.storage.object import (
         CollectionObject,
@@ -79,11 +79,11 @@ with workflow.unsafe.imports_passed_through():
         action_key,
     )
     from tracecat.temporal.errors import (
-        ClassifiedErrorDetail,
-        application_error_from_envelope,
-        extract_error_envelope,
-        parse_classified_detail,
-        wrap_error,
+        ErrorTransportDetail,
+        application_error_from_classification,
+        build_error_transport_detail,
+        extract_error_classification,
+        parse_classified_error_payload,
     )
 
 
@@ -109,39 +109,40 @@ def _classified_action_error_info(
     *,
     ref: str,
     stream_id: StreamID,
-) -> tuple[ActionErrorInfo, ErrorEnvelope] | None:
+) -> tuple[ActionErrorInfo, RuntimeErrorClassification] | None:
     """Adapt a classified activity failure into the scheduler error shape."""
-    envelope = extract_error_envelope(error)
-    if envelope is None:
+    classification = extract_error_classification(error)
+    if classification is None:
         return None
 
     for detail in error.details:
-        match parse_classified_detail(detail):
-            case ClassifiedErrorDetail(error=ActionErrorInfo() as info):
+        match parse_classified_error_payload(detail):
+            case ErrorTransportDetail(action_error=ActionErrorInfo() as info):
                 return (
                     info.model_copy(update={"ref": ref, "stream_id": stream_id}),
-                    envelope,
+                    classification,
                 )
-            case dict() as wrapped_map if wrapped_map:
+            case dict() as transport_map if transport_map:
                 # A child workflow's terminal ``{ref: detail}`` map. Ownership
                 # aggregates platform-wins across entries so a platform-owned
                 # child failure is never hidden behind an earlier user entry.
-                map_envelope = select_error_envelope(
-                    wrapped.envelope for wrapped in wrapped_map.values()
+                map_classification = select_error_classification(
+                    transport_detail.classification
+                    for transport_detail in transport_map.values()
                 )
                 children = [
-                    _unwrapped_action_error(child_ref, wrapped)
-                    for child_ref, wrapped in wrapped_map.items()
+                    _action_error_from_transport_detail(child_ref, transport_detail)
+                    for child_ref, transport_detail in transport_map.items()
                 ]
                 return (
                     ActionErrorInfo(
                         ref=ref,
-                        message=map_envelope.message,
+                        message=map_classification.message,
                         type=error.type or error.__class__.__name__,
                         stream_id=stream_id,
                         children=children,
                     ),
-                    map_envelope,
+                    map_classification,
                 )
             case _:
                 continue
@@ -149,24 +150,25 @@ def _classified_action_error_info(
     return (
         ActionErrorInfo(
             ref=ref,
-            message=envelope.message,
+            message=classification.message,
             type=error.type or error.__class__.__name__,
             stream_id=stream_id,
         ),
-        envelope,
+        classification,
     )
 
 
-def _unwrapped_action_error(
-    ref: str, wrapped: ClassifiedErrorDetail
+def _action_error_from_transport_detail(
+    ref: str,
+    transport_detail: ErrorTransportDetail,
 ) -> ActionErrorInfo:
-    """Unwrap a classified detail's payload, synthesizing one for bare envelopes."""
-    if wrapped.error is not None:
-        return wrapped.error
+    """Unwrap action diagnostics, synthesizing them when absent."""
+    if transport_detail.action_error is not None:
+        return transport_detail.action_error
     return ActionErrorInfo(
         ref=ref,
-        message=wrapped.envelope.message,
-        type=wrapped.envelope.kind.value,
+        message=transport_detail.classification.message,
+        type=transport_detail.classification.kind.value,
     )
 
 
@@ -246,7 +248,9 @@ class DSLScheduler:
         # Mut
         self.task_exceptions: dict[str, TaskExceptionInfo] = {}
         self.stream_exceptions: dict[StreamID, TaskExceptionInfo] = {}
-        self.stream_error_envelopes: dict[StreamID, ErrorEnvelope] = {}
+        self.stream_error_classifications: dict[
+            StreamID, RuntimeErrorClassification
+        ] = {}
 
         # Build adjacency list with sets for efficient construction
         adj_temp: dict[str, set[AdjDst]] = defaultdict(set)
@@ -530,11 +534,11 @@ class DSLScheduler:
                     stream_id=task.stream_id,
                 )
             ):
-                details, envelope = classified
+                details, classification = classified
                 # Recorded so a later gather failure can aggregate ownership
                 # across its classified children; never pruned (bounded by
                 # failed tasks) so it survives stream cleanup.
-                self.stream_error_envelopes[task.stream_id] = envelope
+                self.stream_error_classifications[task.stream_id] = classification
             elif isinstance(exc, ApplicationError) and exc.details:
                 self.logger.info(
                     "Task failed with application error",
@@ -1659,31 +1663,36 @@ class DSLScheduler:
                 children=finalized.errors,
                 stream_id=parent_stream_id,
             )
-            child_envelopes = [
-                self.stream_error_envelopes.get(child.stream_id)
+            child_classifications = [
+                self.stream_error_classifications.get(child.stream_id)
                 for child in finalized.errors
             ]
-            if all(envelope is not None for envelope in child_envelopes):
+            if all(
+                classification is not None for classification in child_classifications
+            ):
                 # Every child failure was classified: attribute the gather using
                 # the canonical platform-wins selection policy.
-                selected_child_envelope = select_error_envelope(
-                    envelope for envelope in child_envelopes if envelope is not None
+                selected_child_classification = select_error_classification(
+                    classification
+                    for classification in child_classifications
+                    if classification is not None
                 )
                 build = (
-                    ErrorEnvelope.platform
-                    if selected_child_envelope.owner is RuntimeErrorOwner.PLATFORM
-                    else ErrorEnvelope.user
+                    RuntimeErrorClassification.platform
+                    if selected_child_classification.owner is RuntimeErrorOwner.PLATFORM
+                    else RuntimeErrorClassification.user
                 )
-                gather_envelope = build(
+                gather_classification = build(
                     kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
                     message=message,
                     retry_disposition=RetryDisposition.NON_RETRYABLE,
                 )
-                app_error = application_error_from_envelope(
-                    gather_envelope,
+                app_error = application_error_from_classification(
+                    gather_classification,
                     {
-                        gather_ref: wrap_error(
-                            gather_envelope, gather_error
+                        gather_ref: build_error_transport_detail(
+                            gather_classification,
+                            gather_error,
                         ).model_dump(mode="json")
                     },
                 )

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any
@@ -17,7 +17,6 @@ _SCHEDULER_TASK_SPAWN_YIELD_EVERY = 16
 """Yield while spawning ready task coroutines to avoid long workflow activations."""
 
 with workflow.unsafe.imports_passed_through():
-    from pydantic import ValidationError
     from pydantic_core import to_json
     from temporalio.exceptions import ApplicationError
 
@@ -64,6 +63,12 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.exceptions import TaskUnreachable
     from tracecat.expressions.common import ExprContext
     from tracecat.expressions.core import extract_expressions
+    from tracecat.runtime.errors import (
+        ErrorEnvelope,
+        RetryDisposition,
+        RuntimeErrorKind,
+        RuntimeErrorOwner,
+    )
     from tracecat.storage.object import (
         CollectionObject,
         InlineObject,
@@ -73,8 +78,11 @@ with workflow.unsafe.imports_passed_through():
         action_key,
     )
     from tracecat.temporal.errors import (
+        ClassifiedErrorDetail,
+        application_error_from_envelope,
         extract_error_envelope,
-        is_classified_detail,
+        parse_classified_detail,
+        wrap_error,
     )
 
 
@@ -100,58 +108,60 @@ def _classified_action_error_info(
     *,
     ref: str,
     stream_id: StreamID,
-) -> ActionErrorInfo | None:
+) -> tuple[ActionErrorInfo, ErrorEnvelope] | None:
     """Adapt a classified activity failure into the scheduler error shape."""
     envelope = extract_error_envelope(error)
     if envelope is None:
         return None
 
     for detail in error.details:
-        if not is_classified_detail(detail):
-            continue
-        try:
-            parsed = ActionErrorInfo.model_validate(detail)
-        except ValidationError:
-            pass
-        else:
-            return parsed.model_copy(update={"ref": ref, "stream_id": stream_id})
+        match parse_classified_detail(detail):
+            case ClassifiedErrorDetail(error=ActionErrorInfo() as info):
+                return (
+                    info.model_copy(update={"ref": ref, "stream_id": stream_id}),
+                    envelope,
+                )
+            case dict() as wrapped_map if wrapped_map:
+                # A child workflow's terminal ``{ref: detail}`` map.
+                children = [
+                    _unwrapped_action_error(child_ref, wrapped)
+                    for child_ref, wrapped in wrapped_map.items()
+                ]
+                return (
+                    ActionErrorInfo(
+                        ref=ref,
+                        message=envelope.message,
+                        type=error.type or error.__class__.__name__,
+                        stream_id=stream_id,
+                        children=children,
+                    ),
+                    envelope,
+                )
+            case _:
+                continue
 
-        if children := _validated_action_error_map(detail):
-            return ActionErrorInfo(
-                ref=ref,
-                message=envelope.message,
-                type=error.type or error.__class__.__name__,
-                stream_id=stream_id,
-                children=list(children),
-                envelope=envelope,
-            )
-
-    return ActionErrorInfo(
-        ref=ref,
-        message=envelope.message,
-        type=error.type or error.__class__.__name__,
-        stream_id=stream_id,
-        envelope=envelope,
+    return (
+        ActionErrorInfo(
+            ref=ref,
+            message=envelope.message,
+            type=error.type or error.__class__.__name__,
+            stream_id=stream_id,
+        ),
+        envelope,
     )
 
 
-def _validated_action_error_map(
-    detail: object,
-) -> tuple[ActionErrorInfo, ...] | None:
-    """Validate a classified workflow ``{ref: ActionErrorInfo}`` detail."""
-    if not isinstance(detail, Mapping):
-        return None
-
-    parsed: list[ActionErrorInfo] = []
-    for ref, value in detail.items():
-        if not isinstance(ref, str):
-            return None
-        try:
-            parsed.append(ActionErrorInfo.model_validate(value))
-        except ValidationError:
-            return None
-
-    return tuple(parsed)
+def _unwrapped_action_error(
+    ref: str, wrapped: ClassifiedErrorDetail
+) -> ActionErrorInfo:
+    """Unwrap a classified detail's payload, synthesizing one for bare envelopes."""
+    if wrapped.error is not None:
+        return wrapped.error
+    return ActionErrorInfo(
+        ref=ref,
+        message=wrapped.envelope.message,
+        type=wrapped.envelope.kind.value,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,6 +240,7 @@ class DSLScheduler:
         # Mut
         self.task_exceptions: dict[str, TaskExceptionInfo] = {}
         self.stream_exceptions: dict[StreamID, TaskExceptionInfo] = {}
+        self.stream_error_envelopes: dict[StreamID, ErrorEnvelope] = {}
 
         # Build adjacency list with sets for efficient construction
         adj_temp: dict[str, set[AdjDst]] = defaultdict(set)
@@ -507,13 +518,17 @@ class DSLScheduler:
             # XXX: This can sometimes return null because the exception isn't an ApplicationError
             # But rather a ChildWorkflowError or CancelledError
             if isinstance(exc, ApplicationError) and (
-                classified_details := _classified_action_error_info(
+                classified := _classified_action_error_info(
                     exc,
                     ref=ref,
                     stream_id=task.stream_id,
                 )
             ):
-                details = classified_details
+                details, envelope = classified
+                # Recorded so a later gather failure can aggregate ownership
+                # across its classified children; never pruned (bounded by
+                # failed tasks) so it survives stream cleanup.
+                self.stream_error_envelopes[task.stream_id] = envelope
             elif isinstance(exc, ApplicationError) and exc.details:
                 self.logger.info(
                     "Task failed with application error",
@@ -1638,11 +1653,38 @@ class DSLScheduler:
                 children=finalized.errors,
                 stream_id=parent_stream_id,
             )
-            app_error = ApplicationError(
-                message,
-                {gather_ref: gather_error.model_dump()},
-                non_retryable=True,
-            )
+            child_envelopes = [
+                self.stream_error_envelopes.get(child.stream_id)
+                for child in finalized.errors
+            ]
+            if all(envelope is not None for envelope in child_envelopes):
+                # Every child failure was classified: attribute the gather to
+                # platform if any child was platform-owned, else to the user.
+                platform_owned = any(
+                    envelope is not None
+                    and envelope.owner is RuntimeErrorOwner.PLATFORM
+                    for envelope in child_envelopes
+                )
+                build = ErrorEnvelope.platform if platform_owned else ErrorEnvelope.user
+                gather_envelope = build(
+                    kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+                    message=message,
+                    retry_disposition=RetryDisposition.NON_RETRYABLE,
+                )
+                app_error = application_error_from_envelope(
+                    gather_envelope,
+                    {
+                        gather_ref: wrap_error(
+                            gather_envelope, gather_error
+                        ).model_dump(mode="json")
+                    },
+                )
+            else:
+                app_error = ApplicationError(
+                    message,
+                    {gather_ref: gather_error.model_dump()},
+                    non_retryable=True,
+                )
             self.logger.warning(
                 "Raising gather error", errors=finalized.errors, app_error=app_error
             )

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -122,7 +122,17 @@ def _classified_action_error_info(
                     envelope,
                 )
             case dict() as wrapped_map if wrapped_map:
-                # A child workflow's terminal ``{ref: detail}`` map.
+                # A child workflow's terminal ``{ref: detail}`` map. Ownership
+                # aggregates platform-wins across entries so a platform-owned
+                # child failure is never hidden behind an earlier user entry.
+                map_envelope = next(
+                    (
+                        wrapped.envelope
+                        for wrapped in wrapped_map.values()
+                        if wrapped.envelope.owner is RuntimeErrorOwner.PLATFORM
+                    ),
+                    envelope,
+                )
                 children = [
                     _unwrapped_action_error(child_ref, wrapped)
                     for child_ref, wrapped in wrapped_map.items()
@@ -130,12 +140,12 @@ def _classified_action_error_info(
                 return (
                     ActionErrorInfo(
                         ref=ref,
-                        message=envelope.message,
+                        message=map_envelope.message,
                         type=error.type or error.__class__.__name__,
                         stream_id=stream_id,
                         children=children,
                     ),
-                    envelope,
+                    map_envelope,
                 )
             case _:
                 continue

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any
@@ -17,6 +17,7 @@ _SCHEDULER_TASK_SPAWN_YIELD_EVERY = 16
 """Yield while spawning ready task coroutines to avoid long workflow activations."""
 
 with workflow.unsafe.imports_passed_through():
+    from pydantic import ValidationError
     from pydantic_core import to_json
     from temporalio.exceptions import ApplicationError
 
@@ -105,10 +106,21 @@ def _classified_action_error_info(
     for detail in error.details:
         try:
             parsed = ActionErrorInfo.model_validate(detail)
-        except Exception:
-            continue
-        if parsed.envelope is not None:
-            return parsed
+        except ValidationError:
+            pass
+        else:
+            if _action_error_contains_envelope(parsed):
+                return parsed
+
+        if children := _validated_action_error_map(detail):
+            return ActionErrorInfo(
+                ref=ref,
+                message=envelope.message,
+                type=error.type or error.__class__.__name__,
+                stream_id=stream_id,
+                children=list(children),
+                envelope=envelope,
+            )
 
     return ActionErrorInfo(
         ref=ref,
@@ -116,6 +128,36 @@ def _classified_action_error_info(
         type=error.type or error.__class__.__name__,
         stream_id=stream_id,
         envelope=envelope,
+    )
+
+
+def _validated_action_error_map(
+    detail: object,
+) -> tuple[ActionErrorInfo, ...] | None:
+    """Validate the established workflow ``{ref: ActionErrorInfo}`` shape."""
+    if not isinstance(detail, Mapping):
+        return None
+
+    parsed: list[ActionErrorInfo] = []
+    for ref, value in detail.items():
+        if not isinstance(ref, str):
+            return None
+        try:
+            parsed.append(ActionErrorInfo.model_validate(value))
+        except ValidationError:
+            return None
+
+    if not parsed or not any(_action_error_contains_envelope(item) for item in parsed):
+        return None
+    return tuple(parsed)
+
+
+def _action_error_contains_envelope(detail: ActionErrorInfo) -> bool:
+    """Return whether an action error directly or transitively is classified."""
+    if detail.envelope is not None:
+        return True
+    return any(
+        _action_error_contains_envelope(child) for child in detail.children or ()
     )
 
 

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -115,7 +115,7 @@ def _classified_action_error_info(
             pass
         else:
             if _action_error_contains_envelope(parsed):
-                return parsed
+                return parsed.model_copy(update={"ref": ref, "stream_id": stream_id})
 
         if children := _validated_action_error_map(detail):
             return ActionErrorInfo(

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -68,6 +68,7 @@ with workflow.unsafe.imports_passed_through():
         RetryDisposition,
         RuntimeErrorKind,
         RuntimeErrorOwner,
+        select_error_envelope,
     )
     from tracecat.storage.object import (
         CollectionObject,
@@ -125,13 +126,8 @@ def _classified_action_error_info(
                 # A child workflow's terminal ``{ref: detail}`` map. Ownership
                 # aggregates platform-wins across entries so a platform-owned
                 # child failure is never hidden behind an earlier user entry.
-                map_envelope = next(
-                    (
-                        wrapped.envelope
-                        for wrapped in wrapped_map.values()
-                        if wrapped.envelope.owner is RuntimeErrorOwner.PLATFORM
-                    ),
-                    envelope,
+                map_envelope = select_error_envelope(
+                    wrapped.envelope for wrapped in wrapped_map.values()
                 )
                 children = [
                     _unwrapped_action_error(child_ref, wrapped)
@@ -1668,14 +1664,16 @@ class DSLScheduler:
                 for child in finalized.errors
             ]
             if all(envelope is not None for envelope in child_envelopes):
-                # Every child failure was classified: attribute the gather to
-                # platform if any child was platform-owned, else to the user.
-                platform_owned = any(
-                    envelope is not None
-                    and envelope.owner is RuntimeErrorOwner.PLATFORM
-                    for envelope in child_envelopes
+                # Every child failure was classified: attribute the gather using
+                # the canonical platform-wins selection policy.
+                selected_child_envelope = select_error_envelope(
+                    envelope for envelope in child_envelopes if envelope is not None
                 )
-                build = ErrorEnvelope.platform if platform_owned else ErrorEnvelope.user
+                build = (
+                    ErrorEnvelope.platform
+                    if selected_child_envelope.owner is RuntimeErrorOwner.PLATFORM
+                    else ErrorEnvelope.user
+                )
                 gather_envelope = build(
                     kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
                     message=message,

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -74,7 +74,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.temporal.errors import (
         extract_error_envelope,
-        extract_error_envelopes_from_details,
+        is_classified_detail,
     )
 
 
@@ -107,15 +107,14 @@ def _classified_action_error_info(
         return None
 
     for detail in error.details:
-        if not extract_error_envelopes_from_details((detail,)):
+        if not is_classified_detail(detail):
             continue
         try:
             parsed = ActionErrorInfo.model_validate(detail)
         except ValidationError:
             pass
         else:
-            if _action_error_contains_envelope(parsed):
-                return parsed.model_copy(update={"ref": ref, "stream_id": stream_id})
+            return parsed.model_copy(update={"ref": ref, "stream_id": stream_id})
 
         if children := _validated_action_error_map(detail):
             return ActionErrorInfo(
@@ -139,7 +138,7 @@ def _classified_action_error_info(
 def _validated_action_error_map(
     detail: object,
 ) -> tuple[ActionErrorInfo, ...] | None:
-    """Validate the established workflow ``{ref: ActionErrorInfo}`` shape."""
+    """Validate a classified workflow ``{ref: ActionErrorInfo}`` detail."""
     if not isinstance(detail, Mapping):
         return None
 
@@ -152,18 +151,7 @@ def _validated_action_error_map(
         except ValidationError:
             return None
 
-    if not parsed or not all(_action_error_contains_envelope(item) for item in parsed):
-        return None
     return tuple(parsed)
-
-
-def _action_error_contains_envelope(detail: ActionErrorInfo) -> bool:
-    """Return whether an action error directly or transitively is classified."""
-    if detail.envelope is not None:
-        return True
-    return any(
-        _action_error_contains_envelope(child) for child in detail.children or ()
-    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -43,6 +43,10 @@ with workflow.unsafe.imports_passed_through():
         SkipStrategy,
         StreamErrorHandlingStrategy,
     )
+    from tracecat.dsl.error_transport import (
+        ActionErrorTransportDetail,
+        parse_classified_action_error_payload,
+    )
     from tracecat.dsl.schemas import (
         ROOT_STREAM,
         ActionStatement,
@@ -79,11 +83,9 @@ with workflow.unsafe.imports_passed_through():
         action_key,
     )
     from tracecat.temporal.errors import (
-        ErrorTransportDetail,
         application_error_from_classification,
         build_error_transport_detail,
         extract_error_classification,
-        parse_classified_error_payload,
     )
 
 
@@ -116,8 +118,8 @@ def _classified_action_error_info(
         return None
 
     for detail in error.details:
-        match parse_classified_error_payload(detail):
-            case ErrorTransportDetail(action_error=ActionErrorInfo() as info):
+        match parse_classified_action_error_payload(detail):
+            case ActionErrorTransportDetail(diagnostic=ActionErrorInfo() as info):
                 return (
                     info.model_copy(update={"ref": ref, "stream_id": stream_id}),
                     classification,
@@ -160,11 +162,11 @@ def _classified_action_error_info(
 
 def _action_error_from_transport_detail(
     ref: str,
-    transport_detail: ErrorTransportDetail,
+    transport_detail: ActionErrorTransportDetail,
 ) -> ActionErrorInfo:
     """Unwrap action diagnostics, synthesizing them when absent."""
-    if transport_detail.action_error is not None:
-        return transport_detail.action_error
+    if transport_detail.diagnostic is not None:
+        return transport_detail.diagnostic
     return ActionErrorInfo(
         ref=ref,
         message=transport_detail.classification.message,

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any
@@ -17,7 +17,6 @@ _SCHEDULER_TASK_SPAWN_YIELD_EVERY = 16
 """Yield while spawning ready task coroutines to avoid long workflow activations."""
 
 with workflow.unsafe.imports_passed_through():
-    from pydantic import ValidationError
     from pydantic_core import to_json
     from temporalio.exceptions import ApplicationError
 
@@ -64,7 +63,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.exceptions import TaskUnreachable
     from tracecat.expressions.common import ExprContext
     from tracecat.expressions.core import extract_expressions
-    from tracecat.runtime.errors import ErrorEnvelope
     from tracecat.storage.object import (
         CollectionObject,
         InlineObject,
@@ -105,9 +103,12 @@ def _classified_action_error_info(
         return None
 
     for detail in error.details:
-        for parsed in _validated_action_error_infos(detail):
-            if _action_error_contains_envelope(parsed, envelope):
-                return parsed
+        try:
+            parsed = ActionErrorInfo.model_validate(detail)
+        except Exception:
+            continue
+        if parsed.envelope is not None:
+            return parsed
 
     return ActionErrorInfo(
         ref=ref,
@@ -115,40 +116,6 @@ def _classified_action_error_info(
         type=error.type or error.__class__.__name__,
         stream_id=stream_id,
         envelope=envelope,
-    )
-
-
-def _validated_action_error_infos(detail: object) -> tuple[ActionErrorInfo, ...]:
-    """Validate a direct action error or the established child-error map shape."""
-    try:
-        return (ActionErrorInfo.model_validate(detail),)
-    except ValidationError:
-        pass
-
-    if not isinstance(detail, Mapping):
-        return ()
-
-    parsed: list[ActionErrorInfo] = []
-    for ref, value in detail.items():
-        if not isinstance(ref, str):
-            return ()
-        try:
-            parsed.append(ActionErrorInfo.model_validate(value))
-        except ValidationError:
-            return ()
-    return tuple(parsed)
-
-
-def _action_error_contains_envelope(
-    detail: ActionErrorInfo,
-    envelope: ErrorEnvelope,
-) -> bool:
-    """Return whether an action error directly or transitively carries an envelope."""
-    if detail.envelope == envelope:
-        return True
-    return any(
-        _action_error_contains_envelope(child, envelope)
-        for child in detail.children or ()
     )
 
 

--- a/tracecat/dsl/types.py
+++ b/tracecat/dsl/types.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 from pydantic import BaseModel, ConfigDict, Field
 
 from tracecat.expressions.common import ExprContext
-from tracecat.runtime.errors import ErrorEnvelope
 
 
 class ActionEdge(TypedDict):
@@ -64,13 +63,9 @@ class ActionErrorInfo(BaseModel):
     attempt: int = 1
     stream_id: StreamID = Field(default_factory=_root_stream_factory)
     children: list[ActionErrorInfo] | None = None
-    envelope: ErrorEnvelope | None = Field(
-        default=None,
-        exclude_if=lambda value: value is None,
-    )
 
     def model_post_init(self, context: Any, /) -> None:
-        """Preserve the pre-envelope Temporal wire shape for defaulted fields."""
+        """Preserve the established Temporal wire shape for defaulted fields."""
         del context
         self.__pydantic_fields_set__.update(
             {"expr_context", "attempt", "stream_id", "children"}

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -274,6 +274,7 @@ class DSLWorkflow:
     # Tier limit tracking
     _tier_limits: EffectiveLimits | None = None
     workflow_concurrency_limits_enabled: bool
+    error_owner_control_flow_enabled: bool
     _workflow_permit_acquired: bool = False
     _workflow_permit_heartbeat_task: asyncio.Task[None] | None = None
     _action_execution_count: int = 0
@@ -362,6 +363,11 @@ class DSLWorkflow:
 
     @workflow.run
     async def run(self, args: DSLRunArgs) -> StoredObject:
+        # Record command-producing compatibility decisions from the workflow's
+        # top-level task, before the scheduler starts child asyncio tasks.
+        self.error_owner_control_flow_enabled = workflow.patched(
+            ERROR_OWNER_CONTROL_FLOW_PATCH
+        )
         self.organization_id = await self._resolve_organization_id()
 
         # Set DSL and registry_lock
@@ -880,13 +886,12 @@ class DSLWorkflow:
             [TemporalSearchAttr.ERROR_OWNER.key.value_set(owner.value)]
         )
 
-    @staticmethod
-    def _has_user_error_cause(error: BaseException) -> bool:
+    def _has_user_error_cause(self, error: BaseException) -> bool:
         envelopes = extract_error_envelopes(error)
         if envelopes and all(
             envelope.owner is RuntimeErrorOwner.USER for envelope in envelopes
         ):
-            return workflow.patched(ERROR_OWNER_CONTROL_FLOW_PATCH)
+            return self.error_owner_control_flow_enabled
 
         current = error
         seen: set[int] = set()

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import re
 import uuid
-from collections.abc import Awaitable, Coroutine, Mapping, Sequence
+from collections.abc import Awaitable, Coroutine, Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any, Never
 
@@ -78,6 +78,10 @@ with workflow.unsafe.imports_passed_through():
         PlatformAction,
         WaitStrategy,
     )
+    from tracecat.dsl.error_policy import (
+        adapt_error_handler_details,
+        build_terminal_application_error,
+    )
     from tracecat.dsl.init_activities import (
         ResolveTimeAnchorActivityInputs,
         resolve_time_anchor_activity,
@@ -116,7 +120,7 @@ with workflow.unsafe.imports_passed_through():
         exec_id_to_parts,
     )
     from tracecat.registry.lock.types import RegistryLock
-    from tracecat.runtime.errors import ErrorEnvelope, RuntimeErrorOwner
+    from tracecat.runtime.errors import RuntimeErrorOwner, select_error_envelope
     from tracecat.storage.object import (
         CollectionObject,
         ExternalObject,
@@ -128,12 +132,7 @@ with workflow.unsafe.imports_passed_through():
         return_key,
         trigger_key,
     )
-    from tracecat.temporal.errors import (
-        extract_error_envelopes,
-        parse_classified_detail,
-        raise_application_error_from_envelope,
-        wrap_error,
-    )
+    from tracecat.temporal.errors import extract_error_envelopes
     from tracecat.temporal.exceptions import UserError
     from tracecat.tiers.activities import (
         AcquireActionPermitInput,
@@ -182,56 +181,11 @@ ERROR_OWNER_CONTROL_FLOW_PATCH = "dsl-error-owner-control-flow-v1"
 ERROR_OWNER_AFTER_HANDLER_PATCH = "dsl-error-owner-after-handler-v1"
 
 
-def _platform_wins_envelope(envelopes: Sequence[ErrorEnvelope]) -> ErrorEnvelope:
-    """Select the first platform-owned envelope, else the first envelope."""
-    return next(
-        (
-            envelope
-            for envelope in envelopes
-            if envelope.owner is RuntimeErrorOwner.PLATFORM
-        ),
-        envelopes[0],
-    )
-
-
 def _raise_workflow_application_error(
     task_exceptions: Mapping[str, TaskExceptionInfo],
 ) -> Never:
     """Raise the terminal workflow error without changing legacy payloads."""
-    n_exceptions = len(task_exceptions)
-    task_envelopes: dict[str, ErrorEnvelope] = {}
-    for ref, info in task_exceptions.items():
-        envelopes = extract_error_envelopes(info.exception)
-        if not envelopes:
-            break
-        # Mirror the scheduler's platform-wins selection: a platform-owned
-        # envelope anywhere in the task's transport (e.g. a later child
-        # terminal map entry) must survive terminal re-extraction.
-        task_envelopes[ref] = _platform_wins_envelope(envelopes)
-    else:
-        if task_envelopes:
-            error_details = {
-                ref: wrap_error(task_envelopes[ref], info.details).model_dump(
-                    mode="json"
-                )
-                for ref, info in task_exceptions.items()
-            }
-            raise_application_error_from_envelope(
-                _platform_wins_envelope(tuple(task_envelopes.values())),
-                error_details,
-            )
-
-    formatted_exceptions = "\n".join(
-        f"{'=' * 10} ({i + 1}/{n_exceptions}) {details.expr_context}.{ref} {'=' * 10}\n\n{info.exception!s}"
-        for i, (ref, info) in enumerate(task_exceptions.items())
-        if (details := info.details)
-    )
-    raise ApplicationError(
-        f"Workflow failed with {n_exceptions} error(s)\n\n{formatted_exceptions}",
-        {ref: info.details for ref, info in task_exceptions.items()},
-        non_retryable=True,
-        type=ApplicationError.__name__,
-    ) from None
+    raise build_terminal_application_error(task_exceptions) from None
 
 
 def _inherit_search_attributes_with_alias(
@@ -841,13 +795,7 @@ class DSLWorkflow:
         if not workflow.patched(ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH):
             return
 
-        owner = (
-            RuntimeErrorOwner.PLATFORM
-            if any(
-                envelope.owner is RuntimeErrorOwner.PLATFORM for envelope in envelopes
-            )
-            else RuntimeErrorOwner.USER
-        )
+        owner = select_error_envelope(envelopes).owner
         workflow.upsert_search_attributes(
             [TemporalSearchAttr.ERROR_OWNER.key.value_set(owner.value)]
         )
@@ -855,8 +803,9 @@ class DSLWorkflow:
     @staticmethod
     def _has_user_error_cause(error: BaseException) -> bool:
         envelopes = extract_error_envelopes(error)
-        if envelopes and all(
-            envelope.owner is RuntimeErrorOwner.USER for envelope in envelopes
+        if (
+            envelopes
+            and select_error_envelope(envelopes).owner is RuntimeErrorOwner.USER
         ):
             return workflow.patched(ERROR_OWNER_CONTROL_FLOW_PATCH)
 
@@ -1965,41 +1914,6 @@ class DSLWorkflow:
             ),
         )
 
-    @staticmethod
-    def _adapt_handler_errors(
-        details: Sequence[Any],
-    ) -> list[ActionErrorInfo] | None:
-        """Adapt legacy application error details for an error handler."""
-        if not details:
-            return None
-
-        err_info_map = details[0]
-        if not isinstance(err_info_map, dict):
-            return [
-                ActionErrorInfo(
-                    ref="N/A",
-                    message=(
-                        "Unexpected error info object of type "
-                        f"{type(err_info_map).__name__}: {err_info_map}"
-                    ),
-                    type=type(err_info_map).__name__,
-                )
-            ]
-        if isinstance(parsed := parse_classified_detail(err_info_map), dict):
-            # Classified terminal map: hand the handler the unwrapped payloads
-            # so its established input shape is unchanged.
-            return [
-                wrapped.error
-                if wrapped.error is not None
-                else ActionErrorInfo(
-                    ref=child_ref,
-                    message=wrapped.envelope.message,
-                    type=wrapped.envelope.kind.value,
-                )
-                for child_ref, wrapped in parsed.items()
-            ]
-        return [ActionErrorInfo.model_validate(data) for data in err_info_map.values()]
-
     async def _handle_application_error(
         self,
         args: DSLRunArgs,
@@ -2026,7 +1940,7 @@ class DSLWorkflow:
                             err_info_map=err_info_map,
                             type=type(err_info_map).__name__,
                         )
-                    errors = self._adapt_handler_errors(error.details)
+                    errors = adapt_error_handler_details(error.details)
                 else:
                     errors = None
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -116,7 +116,7 @@ with workflow.unsafe.imports_passed_through():
         exec_id_to_parts,
     )
     from tracecat.registry.lock.types import RegistryLock
-    from tracecat.runtime.errors import RuntimeErrorOwner
+    from tracecat.runtime.errors import ErrorEnvelope, RuntimeErrorOwner
     from tracecat.storage.object import (
         CollectionObject,
         ExternalObject,
@@ -131,7 +131,9 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.temporal.errors import (
         extract_error_envelope,
         extract_error_envelopes,
+        parse_classified_detail,
         raise_application_error_from_envelope,
+        wrap_error,
     )
     from tracecat.temporal.exceptions import UserError
     from tracecat.tiers.activities import (
@@ -186,21 +188,24 @@ def _raise_workflow_application_error(
 ) -> Never:
     """Raise the terminal workflow error without changing legacy payloads."""
     n_exceptions = len(task_exceptions)
-    envelope_iter = (
-        extract_error_envelope(info.exception) for info in task_exceptions.values()
-    )
-    primary_envelope = next(envelope_iter, None)
-    if primary_envelope is not None and all(
-        envelope is not None for envelope in envelope_iter
-    ):
-        error_details = {
-            ref: info.details.model_dump(mode="json")
-            for ref, info in task_exceptions.items()
-        }
-        raise_application_error_from_envelope(
-            primary_envelope,
-            error_details,
-        )
+    task_envelopes: dict[str, ErrorEnvelope] = {}
+    for ref, info in task_exceptions.items():
+        envelope = extract_error_envelope(info.exception)
+        if envelope is None:
+            break
+        task_envelopes[ref] = envelope
+    else:
+        if task_envelopes:
+            error_details = {
+                ref: wrap_error(task_envelopes[ref], info.details).model_dump(
+                    mode="json"
+                )
+                for ref, info in task_exceptions.items()
+            }
+            raise_application_error_from_envelope(
+                next(iter(task_envelopes.values())),
+                error_details,
+            )
 
     formatted_exceptions = "\n".join(
         f"{'=' * 10} ({i + 1}/{n_exceptions}) {details.expr_context}.{ref} {'=' * 10}\n\n{info.exception!s}"
@@ -1961,6 +1966,19 @@ class DSLWorkflow:
                     ),
                     type=type(err_info_map).__name__,
                 )
+            ]
+        if isinstance(parsed := parse_classified_detail(err_info_map), dict):
+            # Classified terminal map: hand the handler the unwrapped payloads
+            # so its established input shape is unchanged.
+            return [
+                wrapped.error
+                if wrapped.error is not None
+                else ActionErrorInfo(
+                    ref=child_ref,
+                    message=wrapped.envelope.message,
+                    type=wrapped.envelope.kind.value,
+                )
+                for child_ref, wrapped in parsed.items()
             ]
         return [ActionErrorInfo.model_validate(data) for data in err_info_map.values()]
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -831,7 +831,11 @@ class DSLWorkflow:
     @staticmethod
     def _upsert_terminal_error_owner(error: BaseException) -> None:
         """Stamp attribution only when a classified error reaches this boundary."""
-        envelopes = extract_error_envelopes(error)
+        # The escaping error owns terminal attribution. An error handler runs
+        # while the original workflow error remains the active exception, so
+        # following implicit ``__context__`` here can misclassify an
+        # unclassified handler failure as the original error's owner.
+        envelopes = extract_error_envelopes(error, include_implicit_context=False)
         if not envelopes:
             return
         if not workflow.patched(ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH):

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import re
 import uuid
-from collections.abc import Awaitable, Coroutine, Mapping
+from collections.abc import Awaitable, Coroutine, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any, Never
 
@@ -56,7 +56,6 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.dsl.action import (
         BuildAgentArgsActivityInput,
-        BuildPresetAgentArgsActivityInput,
         DSLActivities,
         EvaluateTemplatedObjectActivityInput,
         NormalizeTriggerInputsActivityInputs,
@@ -187,12 +186,13 @@ def _raise_workflow_application_error(
 ) -> Never:
     """Raise the terminal workflow error without changing legacy payloads."""
     n_exceptions = len(task_exceptions)
-    envelopes = tuple(
+    envelope_iter = (
         extract_error_envelope(info.exception) for info in task_exceptions.values()
     )
-    if envelopes and all(envelope is not None for envelope in envelopes):
-        primary_envelope = envelopes[0]
-        assert primary_envelope is not None
+    primary_envelope = next(envelope_iter, None)
+    if primary_envelope is not None and all(
+        envelope is not None for envelope in envelope_iter
+    ):
         error_details = {
             ref: info.details.model_dump(mode="json")
             for ref, info in task_exceptions.items()
@@ -1105,7 +1105,7 @@ class DSLWorkflow:
                     self._set_logical_time_context()
                     preset_action_args = await workflow.execute_activity(
                         DSLActivities.build_preset_agent_args_activity,
-                        arg=BuildPresetAgentArgsActivityInput(
+                        arg=BuildAgentArgsActivityInput(
                             args=dict(task.args),
                             operand=agent_operand,
                             role=self.role,
@@ -1942,6 +1942,28 @@ class DSLWorkflow:
             ),
         )
 
+    @staticmethod
+    def _adapt_handler_errors(
+        details: Sequence[Any],
+    ) -> list[ActionErrorInfo] | None:
+        """Adapt legacy application error details for an error handler."""
+        if not details:
+            return None
+
+        err_info_map = details[0]
+        if not isinstance(err_info_map, dict):
+            return [
+                ActionErrorInfo(
+                    ref="N/A",
+                    message=(
+                        "Unexpected error info object of type "
+                        f"{type(err_info_map).__name__}: {err_info_map}"
+                    ),
+                    type=type(err_info_map).__name__,
+                )
+            ]
+        return [ActionErrorInfo.model_validate(data) for data in err_info_map.values()]
+
     async def _handle_application_error(
         self,
         args: DSLRunArgs,
@@ -1968,21 +1990,7 @@ class DSLWorkflow:
                             err_info_map=err_info_map,
                             type=type(err_info_map).__name__,
                         )
-                        errors = [
-                            ActionErrorInfo(
-                                ref="N/A",
-                                message=(
-                                    "Unexpected error info object of type "
-                                    f"{type(err_info_map).__name__}: {err_info_map}"
-                                ),
-                                type=type(err_info_map).__name__,
-                            )
-                        ]
-                    else:
-                        errors = [
-                            ActionErrorInfo.model_validate(data)
-                            for data in err_info_map.values()
-                        ]
+                    errors = self._adapt_handler_errors(error.details)
                 else:
                     errors = None
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -186,15 +186,12 @@ def _raise_workflow_application_error(
 ) -> Never:
     """Raise the terminal workflow error without changing legacy payloads."""
     n_exceptions = len(task_exceptions)
-    primary_envelope = next(
-        (
-            envelope
-            for info in task_exceptions.values()
-            if (envelope := extract_error_envelope(info.exception)) is not None
-        ),
-        None,
+    envelopes = tuple(
+        extract_error_envelope(info.exception) for info in task_exceptions.values()
     )
-    if primary_envelope is not None:
+    if envelopes and all(envelope is not None for envelope in envelopes):
+        primary_envelope = envelopes[0]
+        assert primary_envelope is not None
         error_details = {
             ref: info.details.model_dump(mode="json")
             for ref, info in task_exceptions.items()

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -178,6 +178,7 @@ with workflow.unsafe.imports_passed_through():
 _CHILD_RUN_ARG_PREP_YIELD_EVERY = 8
 ACTION_HEARTBEAT_TIMEOUT_RETRY_PATCH = "dsl-action-heartbeat-timeout-retry-v1"
 ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH = "dsl-error-owner-search-attribute-v1"
+ERROR_OWNER_CONTROL_FLOW_PATCH = "dsl-error-owner-control-flow-v1"
 
 
 def _raise_workflow_application_error(
@@ -881,6 +882,12 @@ class DSLWorkflow:
 
     @staticmethod
     def _has_user_error_cause(error: BaseException) -> bool:
+        envelopes = extract_error_envelopes(error)
+        if envelopes and all(
+            envelope.owner is RuntimeErrorOwner.USER for envelope in envelopes
+        ):
+            return workflow.patched(ERROR_OWNER_CONTROL_FLOW_PATCH)
+
         current = error
         seen: set[int] = set()
         while True:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -129,7 +129,6 @@ with workflow.unsafe.imports_passed_through():
         trigger_key,
     )
     from tracecat.temporal.errors import (
-        extract_error_envelope,
         extract_error_envelopes,
         parse_classified_detail,
         raise_application_error_from_envelope,
@@ -183,6 +182,18 @@ ERROR_OWNER_CONTROL_FLOW_PATCH = "dsl-error-owner-control-flow-v1"
 ERROR_OWNER_AFTER_HANDLER_PATCH = "dsl-error-owner-after-handler-v1"
 
 
+def _platform_wins_envelope(envelopes: Sequence[ErrorEnvelope]) -> ErrorEnvelope:
+    """Select the first platform-owned envelope, else the first envelope."""
+    return next(
+        (
+            envelope
+            for envelope in envelopes
+            if envelope.owner is RuntimeErrorOwner.PLATFORM
+        ),
+        envelopes[0],
+    )
+
+
 def _raise_workflow_application_error(
     task_exceptions: Mapping[str, TaskExceptionInfo],
 ) -> Never:
@@ -190,10 +201,13 @@ def _raise_workflow_application_error(
     n_exceptions = len(task_exceptions)
     task_envelopes: dict[str, ErrorEnvelope] = {}
     for ref, info in task_exceptions.items():
-        envelope = extract_error_envelope(info.exception)
-        if envelope is None:
+        envelopes = extract_error_envelopes(info.exception)
+        if not envelopes:
             break
-        task_envelopes[ref] = envelope
+        # Mirror the scheduler's platform-wins selection: a platform-owned
+        # envelope anywhere in the task's transport (e.g. a later child
+        # terminal map entry) must survive terminal re-extraction.
+        task_envelopes[ref] = _platform_wins_envelope(envelopes)
     else:
         if task_envelopes:
             error_details = {
@@ -203,7 +217,7 @@ def _raise_workflow_application_error(
                 for ref, info in task_exceptions.items()
             }
             raise_application_error_from_envelope(
-                next(iter(task_envelopes.values())),
+                _platform_wins_envelope(tuple(task_envelopes.values())),
                 error_details,
             )
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 import re
 import uuid
-from collections.abc import Awaitable, Coroutine
+from collections.abc import Awaitable, Coroutine, Mapping
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Never
 
 from temporalio import workflow
 from temporalio.common import (
@@ -96,7 +96,10 @@ with workflow.unsafe.imports_passed_through():
         StreamID,
         TaskResult,
     )
-    from tracecat.dsl.types import ActionErrorInfo
+    from tracecat.dsl.types import (
+        ActionErrorInfo,
+        TaskExceptionInfo,
+    )
     from tracecat.dsl.validation import format_input_schema_validation_error
     from tracecat.dsl.workflow_logging import get_workflow_logger
     from tracecat.ee.interactions.decorators import maybe_interactive
@@ -114,6 +117,7 @@ with workflow.unsafe.imports_passed_through():
         exec_id_to_parts,
     )
     from tracecat.registry.lock.types import RegistryLock
+    from tracecat.runtime.errors import RuntimeErrorOwner
     from tracecat.storage.object import (
         CollectionObject,
         ExternalObject,
@@ -124,6 +128,11 @@ with workflow.unsafe.imports_passed_through():
         action_key,
         return_key,
         trigger_key,
+    )
+    from tracecat.temporal.errors import (
+        extract_error_envelope,
+        extract_error_envelopes,
+        raise_application_error_from_envelope,
     )
     from tracecat.temporal.exceptions import UserError
     from tracecat.tiers.activities import (
@@ -168,6 +177,43 @@ with workflow.unsafe.imports_passed_through():
 
 _CHILD_RUN_ARG_PREP_YIELD_EVERY = 8
 ACTION_HEARTBEAT_TIMEOUT_RETRY_PATCH = "dsl-action-heartbeat-timeout-retry-v1"
+ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH = "dsl-error-owner-search-attribute-v1"
+
+
+def _raise_workflow_application_error(
+    task_exceptions: Mapping[str, TaskExceptionInfo],
+) -> Never:
+    """Raise the terminal workflow error without changing legacy payloads."""
+    n_exceptions = len(task_exceptions)
+    primary_envelope = next(
+        (
+            envelope
+            for info in task_exceptions.values()
+            if (envelope := extract_error_envelope(info.exception)) is not None
+        ),
+        None,
+    )
+    if primary_envelope is not None:
+        error_details = {
+            ref: info.details.model_dump(mode="json")
+            for ref, info in task_exceptions.items()
+        }
+        raise_application_error_from_envelope(
+            primary_envelope,
+            error_details,
+        )
+
+    formatted_exceptions = "\n".join(
+        f"{'=' * 10} ({i + 1}/{n_exceptions}) {details.expr_context}.{ref} {'=' * 10}\n\n{info.exception!s}"
+        for i, (ref, info) in enumerate(task_exceptions.items())
+        if (details := info.details)
+    )
+    raise ApplicationError(
+        f"Workflow failed with {n_exceptions} error(s)\n\n{formatted_exceptions}",
+        {ref: info.details for ref, info in task_exceptions.items()},
+        non_retryable=True,
+        type=ApplicationError.__name__,
+    ) from None
 
 
 def _inherit_search_attributes_with_alias(
@@ -415,6 +461,7 @@ class DSLWorkflow:
         try:
             return await self._run_workflow(args)
         except ApplicationError as e:
+            self._upsert_terminal_error_owner(e)
             # Application error
             self.logger.warning(
                 "Error running workflow, running error handler",
@@ -669,21 +716,8 @@ class DSLWorkflow:
             ) from e
 
         if task_exceptions:
-            n_exc = len(task_exceptions)
-            formatted_exc = "\n".join(
-                f"{'=' * 10} ({i + 1}/{n_exc}) {details.expr_context}.{ref} {'=' * 10}\n\n{info.exception!s}"
-                for i, (ref, info) in enumerate(task_exceptions.items())
-                if (details := info.details)
-            )
             # NOTE: This error is shown in the final activity in the workflow history
-            raise ApplicationError(
-                f"Workflow failed with {n_exc} error(s)\n\n{formatted_exc}",
-                # We should add the details of the exceptions to the error message because this will get captured
-                # in the error handler workflow
-                {ref: info.details for ref, info in task_exceptions.items()},
-                non_retryable=True,
-                type=ApplicationError.__name__,
-            )
+            _raise_workflow_application_error(task_exceptions)
 
         try:
             self.logger.info("DSL workflow completed")
@@ -824,6 +858,26 @@ class DSLWorkflow:
         if outer_message:
             return current, outer_message
         return current, current.__class__.__name__
+
+    @staticmethod
+    def _upsert_terminal_error_owner(error: ApplicationError) -> None:
+        """Stamp attribution only when a classified error reaches this boundary."""
+        envelopes = extract_error_envelopes(error)
+        if not envelopes:
+            return
+        if not workflow.patched(ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH):
+            return
+
+        owner = (
+            RuntimeErrorOwner.PLATFORM
+            if any(
+                envelope.owner is RuntimeErrorOwner.PLATFORM for envelope in envelopes
+            )
+            else RuntimeErrorOwner.USER
+        )
+        workflow.upsert_search_attributes(
+            [TemporalSearchAttr.ERROR_OWNER.key.value_set(owner.value)]
+        )
 
     @staticmethod
     def _has_user_error_cause(error: BaseException) -> bool:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -179,6 +179,7 @@ _CHILD_RUN_ARG_PREP_YIELD_EVERY = 8
 ACTION_HEARTBEAT_TIMEOUT_RETRY_PATCH = "dsl-action-heartbeat-timeout-retry-v1"
 ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH = "dsl-error-owner-search-attribute-v1"
 ERROR_OWNER_CONTROL_FLOW_PATCH = "dsl-error-owner-control-flow-v1"
+ERROR_OWNER_AFTER_HANDLER_PATCH = "dsl-error-owner-after-handler-v1"
 
 
 def _raise_workflow_application_error(
@@ -459,7 +460,16 @@ class DSLWorkflow:
         try:
             return await self._run_workflow(args)
         except ApplicationError as e:
-            await self._handle_application_error(args, e)
+            stamp_owner_after_handler = workflow.patched(
+                ERROR_OWNER_AFTER_HANDLER_PATCH
+            )
+            if not stamp_owner_after_handler:
+                self._upsert_terminal_error_owner(e)
+            await self._handle_application_error(
+                args,
+                e,
+                stamp_terminal_owner=stamp_owner_after_handler,
+            )
         except Exception as e:
             # Platform error
             if is_cancelled_exception(e):
@@ -1936,6 +1946,8 @@ class DSLWorkflow:
         self,
         args: DSLRunArgs,
         error: ApplicationError,
+        *,
+        stamp_terminal_owner: bool,
     ) -> Never:
         """Run an error handler before stamping the error that remains terminal."""
         self.logger.warning(
@@ -1945,7 +1957,8 @@ class DSLWorkflow:
         handler_wf_id = await self._get_error_handler_workflow_id(args)
         if handler_wf_id is None:
             self.logger.warning("No error handler workflow ID found, raising error")
-            self._upsert_terminal_error_owner(error)
+            if stamp_terminal_owner:
+                self._upsert_terminal_error_owner(error)
             raise error
 
         if error.details:
@@ -1988,14 +2001,16 @@ class DSLWorkflow:
             )
             await self._run_error_handler_workflow(err_run_args)
         except Exception as handler_error:
-            self._upsert_terminal_error_owner(handler_error)
+            if stamp_terminal_owner:
+                self._upsert_terminal_error_owner(handler_error)
             self.logger.error(
                 "Failed to run error handler workflow",
                 error_type=type(handler_error).__name__,
             )
             raise handler_error from error
 
-        self._upsert_terminal_error_owner(error)
+        if stamp_terminal_owner:
+            self._upsert_terminal_error_owner(error)
         raise error
 
     async def _get_error_handler_workflow_id(

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -120,7 +120,7 @@ with workflow.unsafe.imports_passed_through():
         exec_id_to_parts,
     )
     from tracecat.registry.lock.types import RegistryLock
-    from tracecat.runtime.errors import RuntimeErrorOwner, select_error_envelope
+    from tracecat.runtime.errors import RuntimeErrorOwner, select_error_classification
     from tracecat.storage.object import (
         CollectionObject,
         ExternalObject,
@@ -132,7 +132,7 @@ with workflow.unsafe.imports_passed_through():
         return_key,
         trigger_key,
     )
-    from tracecat.temporal.errors import extract_error_envelopes
+    from tracecat.temporal.errors import extract_error_classifications
     from tracecat.temporal.exceptions import UserError
     from tracecat.tiers.activities import (
         AcquireActionPermitInput,
@@ -789,23 +789,27 @@ class DSLWorkflow:
         # while the original workflow error remains the active exception, so
         # following implicit ``__context__`` here can misclassify an
         # unclassified handler failure as the original error's owner.
-        envelopes = extract_error_envelopes(error, include_implicit_context=False)
-        if not envelopes:
+        classifications = extract_error_classifications(
+            error,
+            include_implicit_context=False,
+        )
+        if not classifications:
             return
         if not workflow.patched(ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH):
             return
 
-        owner = select_error_envelope(envelopes).owner
+        owner = select_error_classification(classifications).owner
         workflow.upsert_search_attributes(
             [TemporalSearchAttr.ERROR_OWNER.key.value_set(owner.value)]
         )
 
     @staticmethod
     def _has_user_error_cause(error: BaseException) -> bool:
-        envelopes = extract_error_envelopes(error)
+        classifications = extract_error_classifications(error)
         if (
-            envelopes
-            and select_error_envelope(envelopes).owner is RuntimeErrorOwner.USER
+            classifications
+            and select_error_classification(classifications).owner
+            is RuntimeErrorOwner.USER
         ):
             return workflow.patched(ERROR_OWNER_CONTROL_FLOW_PATCH)
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -274,7 +274,6 @@ class DSLWorkflow:
     # Tier limit tracking
     _tier_limits: EffectiveLimits | None = None
     workflow_concurrency_limits_enabled: bool
-    error_owner_control_flow_enabled: bool
     _workflow_permit_acquired: bool = False
     _workflow_permit_heartbeat_task: asyncio.Task[None] | None = None
     _action_execution_count: int = 0
@@ -363,11 +362,6 @@ class DSLWorkflow:
 
     @workflow.run
     async def run(self, args: DSLRunArgs) -> StoredObject:
-        # Record command-producing compatibility decisions from the workflow's
-        # top-level task, before the scheduler starts child asyncio tasks.
-        self.error_owner_control_flow_enabled = workflow.patched(
-            ERROR_OWNER_CONTROL_FLOW_PATCH
-        )
         self.organization_id = await self._resolve_organization_id()
 
         # Set DSL and registry_lock
@@ -886,12 +880,13 @@ class DSLWorkflow:
             [TemporalSearchAttr.ERROR_OWNER.key.value_set(owner.value)]
         )
 
-    def _has_user_error_cause(self, error: BaseException) -> bool:
+    @staticmethod
+    def _has_user_error_cause(error: BaseException) -> bool:
         envelopes = extract_error_envelopes(error)
         if envelopes and all(
             envelope.owner is RuntimeErrorOwner.USER for envelope in envelopes
         ):
-            return self.error_owner_control_flow_enabled
+            return workflow.patched(ERROR_OWNER_CONTROL_FLOW_PATCH)
 
         current = error
         seen: set[int] = set()

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -459,65 +459,7 @@ class DSLWorkflow:
         try:
             return await self._run_workflow(args)
         except ApplicationError as e:
-            self._upsert_terminal_error_owner(e)
-            # Application error
-            self.logger.warning(
-                "Error running workflow, running error handler",
-                type=e.__class__.__name__,
-            )
-            # 1. Get the error handler workflow ID
-            handler_wf_id = await self._get_error_handler_workflow_id(args)
-            if handler_wf_id is None:
-                self.logger.warning("No error handler workflow ID found, raising error")
-                raise e
-
-            if e.details:
-                err_info_map = e.details[0]
-                self.logger.info("Raising error info", err_info_data=err_info_map)
-                if not isinstance(err_info_map, dict):
-                    self.logger.error(
-                        "Unexpected error info object",
-                        err_info_map=err_info_map,
-                        type=type(err_info_map).__name__,
-                    )
-                    # TODO: There's likely a nicer way to gracefully handle this
-                    # instead of a sentinel error value
-                    errors = [
-                        ActionErrorInfo(
-                            ref="N/A",
-                            message=f"Unexpected error info object of type {type(err_info_map).__name__}: {err_info_map}",
-                            type=type(err_info_map).__name__,
-                        )
-                    ]
-                else:
-                    errors = [
-                        ActionErrorInfo.model_validate(data)
-                        for data in err_info_map.values()
-                    ]
-            else:
-                errors = None
-
-            trigger_type = get_trigger_type(workflow.info())
-            try:
-                err_run_args = await self._prepare_error_handler_workflow(
-                    message=e.message,
-                    handler_wf_id=handler_wf_id,
-                    orig_wf_id=args.wf_id,
-                    orig_wf_exec_id=self.wf_exec_id,
-                    orig_dsl=self.dsl,
-                    trigger_type=TriggerType(trigger_type),
-                    errors=errors,
-                )
-                await self._run_error_handler_workflow(err_run_args)
-            except Exception as err_handler_exc:
-                self.logger.error(
-                    "Failed to run error handler workflow",
-                    error=err_handler_exc,
-                )
-                raise err_handler_exc from e
-
-            # Finally, raise the original error
-            raise e
+            await self._handle_application_error(args, e)
         except Exception as e:
             # Platform error
             if is_cancelled_exception(e):
@@ -858,7 +800,7 @@ class DSLWorkflow:
         return current, current.__class__.__name__
 
     @staticmethod
-    def _upsert_terminal_error_owner(error: ApplicationError) -> None:
+    def _upsert_terminal_error_owner(error: BaseException) -> None:
         """Stamp attribution only when a classified error reaches this boundary."""
         envelopes = extract_error_envelopes(error)
         if not envelopes:
@@ -1989,6 +1931,72 @@ class DSLWorkflow:
                 else workflow.ParentClosePolicy.TERMINATE  # Default is TERMINATE
             ),
         )
+
+    async def _handle_application_error(
+        self,
+        args: DSLRunArgs,
+        error: ApplicationError,
+    ) -> Never:
+        """Run an error handler before stamping the error that remains terminal."""
+        self.logger.warning(
+            "Error running workflow, running error handler",
+            type=error.__class__.__name__,
+        )
+        handler_wf_id = await self._get_error_handler_workflow_id(args)
+        if handler_wf_id is None:
+            self.logger.warning("No error handler workflow ID found, raising error")
+            self._upsert_terminal_error_owner(error)
+            raise error
+
+        if error.details:
+            err_info_map = error.details[0]
+            self.logger.info("Raising error info", err_info_data=err_info_map)
+            if not isinstance(err_info_map, dict):
+                self.logger.error(
+                    "Unexpected error info object",
+                    err_info_map=err_info_map,
+                    type=type(err_info_map).__name__,
+                )
+                errors = [
+                    ActionErrorInfo(
+                        ref="N/A",
+                        message=(
+                            "Unexpected error info object of type "
+                            f"{type(err_info_map).__name__}: {err_info_map}"
+                        ),
+                        type=type(err_info_map).__name__,
+                    )
+                ]
+            else:
+                errors = [
+                    ActionErrorInfo.model_validate(data)
+                    for data in err_info_map.values()
+                ]
+        else:
+            errors = None
+
+        trigger_type = get_trigger_type(workflow.info())
+        try:
+            err_run_args = await self._prepare_error_handler_workflow(
+                message=error.message,
+                handler_wf_id=handler_wf_id,
+                orig_wf_id=args.wf_id,
+                orig_wf_exec_id=self.wf_exec_id,
+                orig_dsl=self.dsl,
+                trigger_type=TriggerType(trigger_type),
+                errors=errors,
+            )
+            await self._run_error_handler_workflow(err_run_args)
+        except Exception as handler_error:
+            self._upsert_terminal_error_owner(handler_error)
+            self.logger.error(
+                "Failed to run error handler workflow",
+                error_type=type(handler_error).__name__,
+            )
+            raise handler_error from error
+
+        self._upsert_terminal_error_owner(error)
+        raise error
 
     async def _get_error_handler_workflow_id(
         self, args: DSLRunArgs

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -1954,52 +1954,49 @@ class DSLWorkflow:
             "Error running workflow, running error handler",
             type=error.__class__.__name__,
         )
-        handler_wf_id = await self._get_error_handler_workflow_id(args)
-        if handler_wf_id is None:
-            self.logger.warning("No error handler workflow ID found, raising error")
-            if stamp_terminal_owner:
-                self._upsert_terminal_error_owner(error)
-            raise error
-
-        if error.details:
-            err_info_map = error.details[0]
-            self.logger.info("Raising error info", err_info_data=err_info_map)
-            if not isinstance(err_info_map, dict):
-                self.logger.error(
-                    "Unexpected error info object",
-                    err_info_map=err_info_map,
-                    type=type(err_info_map).__name__,
-                )
-                errors = [
-                    ActionErrorInfo(
-                        ref="N/A",
-                        message=(
-                            "Unexpected error info object of type "
-                            f"{type(err_info_map).__name__}: {err_info_map}"
-                        ),
-                        type=type(err_info_map).__name__,
-                    )
-                ]
-            else:
-                errors = [
-                    ActionErrorInfo.model_validate(data)
-                    for data in err_info_map.values()
-                ]
-        else:
-            errors = None
-
-        trigger_type = get_trigger_type(workflow.info())
         try:
-            err_run_args = await self._prepare_error_handler_workflow(
-                message=error.message,
-                handler_wf_id=handler_wf_id,
-                orig_wf_id=args.wf_id,
-                orig_wf_exec_id=self.wf_exec_id,
-                orig_dsl=self.dsl,
-                trigger_type=TriggerType(trigger_type),
-                errors=errors,
-            )
-            await self._run_error_handler_workflow(err_run_args)
+            handler_wf_id = await self._get_error_handler_workflow_id(args)
+            if handler_wf_id is None:
+                self.logger.warning("No error handler workflow ID found, raising error")
+            else:
+                if error.details:
+                    err_info_map = error.details[0]
+                    self.logger.info("Raising error info", err_info_data=err_info_map)
+                    if not isinstance(err_info_map, dict):
+                        self.logger.error(
+                            "Unexpected error info object",
+                            err_info_map=err_info_map,
+                            type=type(err_info_map).__name__,
+                        )
+                        errors = [
+                            ActionErrorInfo(
+                                ref="N/A",
+                                message=(
+                                    "Unexpected error info object of type "
+                                    f"{type(err_info_map).__name__}: {err_info_map}"
+                                ),
+                                type=type(err_info_map).__name__,
+                            )
+                        ]
+                    else:
+                        errors = [
+                            ActionErrorInfo.model_validate(data)
+                            for data in err_info_map.values()
+                        ]
+                else:
+                    errors = None
+
+                trigger_type = get_trigger_type(workflow.info())
+                err_run_args = await self._prepare_error_handler_workflow(
+                    message=error.message,
+                    handler_wf_id=handler_wf_id,
+                    orig_wf_id=args.wf_id,
+                    orig_wf_exec_id=self.wf_exec_id,
+                    orig_dsl=self.dsl,
+                    trigger_type=TriggerType(trigger_type),
+                    errors=errors,
+                )
+                await self._run_error_handler_workflow(err_run_args)
         except Exception as handler_error:
             if stamp_terminal_owner:
                 self._upsert_terminal_error_owner(handler_error)

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -20,7 +20,7 @@ alertable even when its parent handles that failure and completes. Diagnostic
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from enum import StrEnum
 from typing import Literal
 
@@ -169,6 +169,21 @@ class TracecatRuntimeError(Exception):
     def __init__(self, envelope: ErrorEnvelope) -> None:
         super().__init__(envelope.message)
         self.envelope = envelope
+
+
+def select_error_envelope(envelopes: Iterable[ErrorEnvelope]) -> ErrorEnvelope:
+    """Select the first platform-owned envelope, otherwise the first envelope."""
+    candidates = tuple(envelopes)
+    if not candidates:
+        raise ValueError("Cannot select from an empty error envelope collection")
+    return next(
+        (
+            envelope
+            for envelope in candidates
+            if envelope.owner is RuntimeErrorOwner.PLATFORM
+        ),
+        candidates[0],
+    )
 
 
 def parse_error_envelope(value: object) -> ErrorEnvelope | None:

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -7,10 +7,10 @@ Runtime errors have independent product dimensions:
 * ``retry_disposition`` describes whether another attempt is allowed.
 * Workflow control flow remains owned by the workflow definition and engine.
 
-The contract intentionally excludes transport details, execution identifiers,
-raw platform diagnostics, and routing instructions. Future envelope versions
-must use a new ``schema`` literal and a discriminated union rather than adding a
-second version field.
+The classification intentionally excludes transport details, execution
+identifiers, raw platform diagnostics, and routing instructions. Future
+classification versions must use a new ``schema`` literal and a discriminated
+union rather than adding a second version field.
 
 Attribution is scoped to each Temporal Workflow Execution. A terminal
 platform-attributed child failure remains independently attributable and
@@ -26,7 +26,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-ERROR_ENVELOPE_SCHEMA = "tracecat.error.v1"
+RUNTIME_ERROR_CLASSIFICATION_SCHEMA = "tracecat.error.v1"
 
 
 class RuntimeErrorOwner(StrEnum):
@@ -69,7 +69,7 @@ class RuntimeErrorKind(StrEnum):
     WORKFLOW_SUBFLOW_PREPARATION_FAILED = "workflow.subflow.preparation_failed"
 
 
-class ErrorEnvelope(BaseModel):
+class RuntimeErrorClassification(BaseModel):
     """Versioned error attribution and retry metadata.
 
     User messages must be masked before construction. Platform messages must be
@@ -99,7 +99,7 @@ class ErrorEnvelope(BaseModel):
         message: str,
         retry_disposition: RetryDisposition,
         cause: BaseException | None = None,
-    ) -> ErrorEnvelope:
+    ) -> RuntimeErrorClassification:
         """Construct a user-attributed error from an explicit enum kind."""
         return cls._build(
             RuntimeErrorOwner.USER,
@@ -117,7 +117,7 @@ class ErrorEnvelope(BaseModel):
         message: str,
         retry_disposition: RetryDisposition,
         cause: BaseException | None = None,
-    ) -> ErrorEnvelope:
+    ) -> RuntimeErrorClassification:
         """Construct a platform-attributed error from an explicit enum kind."""
         return cls._build(
             RuntimeErrorOwner.PLATFORM,
@@ -136,12 +136,12 @@ class ErrorEnvelope(BaseModel):
         message: str,
         retry_disposition: RetryDisposition,
         cause: BaseException | None,
-    ) -> ErrorEnvelope:
+    ) -> RuntimeErrorClassification:
         cls._require_kind(kind)
         cls._require_retry_disposition(retry_disposition)
         return cls.model_validate(
             {
-                "schema": ERROR_ENVELOPE_SCHEMA,
+                "schema": RUNTIME_ERROR_CLASSIFICATION_SCHEMA,
                 "owner": owner,
                 "kind": kind,
                 "message": message,
@@ -164,39 +164,41 @@ class ErrorEnvelope(BaseModel):
 
 
 class TracecatRuntimeError(Exception):
-    """Exception carrying an already-classified runtime error envelope."""
+    """Exception carrying an already-classified runtime error."""
 
-    def __init__(self, envelope: ErrorEnvelope) -> None:
-        super().__init__(envelope.message)
-        self.envelope = envelope
+    def __init__(self, classification: RuntimeErrorClassification) -> None:
+        super().__init__(classification.message)
+        self.classification = classification
 
 
-def select_error_envelope(envelopes: Iterable[ErrorEnvelope]) -> ErrorEnvelope:
-    """Select the first platform-owned envelope, otherwise the first envelope."""
-    candidates = tuple(envelopes)
+def select_error_classification(
+    classifications: Iterable[RuntimeErrorClassification],
+) -> RuntimeErrorClassification:
+    """Select the first platform-owned classification, otherwise the first."""
+    candidates = tuple(classifications)
     if not candidates:
-        raise ValueError("Cannot select from an empty error envelope collection")
+        raise ValueError("Cannot select from an empty error classification collection")
     return next(
         (
-            envelope
-            for envelope in candidates
-            if envelope.owner is RuntimeErrorOwner.PLATFORM
+            classification
+            for classification in candidates
+            if classification.owner is RuntimeErrorOwner.PLATFORM
         ),
         candidates[0],
     )
 
 
-def parse_error_envelope(value: object) -> ErrorEnvelope | None:
-    """Parse only payloads carrying the explicit envelope discriminator.
+def parse_error_classification(value: object) -> RuntimeErrorClassification | None:
+    """Parse only payloads carrying the explicit classification discriminator.
 
     The required ``schema`` field makes validation the discriminator check:
     payloads without it fail to parse.
     """
-    if isinstance(value, ErrorEnvelope):
+    if isinstance(value, RuntimeErrorClassification):
         return value
     if not isinstance(value, Mapping):
         return None
     try:
-        return ErrorEnvelope.model_validate(value)
+        return RuntimeErrorClassification.model_validate(value)
     except ValidationError:
         return None

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -89,11 +89,6 @@ class ErrorEnvelope(BaseModel):
     message: str
     retry_disposition: RetryDisposition
     cause_type: str | None = None
-
-    def model_post_init(self, context: Any, /) -> None:
-        """Keep the wire discriminator during exclude-unset serialization."""
-        del context
-        self.__pydantic_fields_set__.add("schema_")
 
     @classmethod
     def user(

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -65,6 +65,7 @@ class RuntimeErrorKind(StrEnum):
     EXECUTOR_SANDBOX_INFRASTRUCTURE_FAILED = "executor.sandbox.infrastructure_failed"
     WORKFLOW_DEFINITION_NOT_FOUND = "workflow.definition.not_found"
     WORKFLOW_DEFINITION_LOOKUP_UNAVAILABLE = "workflow.definition.lookup_unavailable"
+    WORKFLOW_SUBFLOW_INPUT_INVALID = "workflow.subflow.input_invalid"
     WORKFLOW_SUBFLOW_PREPARATION_FAILED = "workflow.subflow.preparation_failed"
 
 

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -81,10 +81,10 @@ class ErrorEnvelope(BaseModel):
 
     # The alias is the public contract. The suffix avoids overriding Pydantic's
     # deprecated ``BaseModel.schema()`` method while keeping the wire key exact.
-    schema_: Literal["tracecat.error.v1"] = Field(
-        default=ERROR_ENVELOPE_SCHEMA,
-        alias="schema",
-    )
+    # The field is deliberately required: validation itself then rejects
+    # undiscriminated payloads, and a required field always survives
+    # ``exclude_unset`` serialization onto the Temporal wire.
+    schema_: Literal["tracecat.error.v1"] = Field(alias="schema")
     owner: RuntimeErrorOwner
     kind: RuntimeErrorKind
     message: str
@@ -101,17 +101,12 @@ class ErrorEnvelope(BaseModel):
         cause: BaseException | None = None,
     ) -> ErrorEnvelope:
         """Construct a user-attributed error from an explicit enum kind."""
-        cls._require_kind(kind)
-        cls._require_retry_disposition(retry_disposition)
-        return cls.model_validate(
-            {
-                "schema": ERROR_ENVELOPE_SCHEMA,
-                "owner": RuntimeErrorOwner.USER,
-                "kind": kind,
-                "message": message,
-                "retry_disposition": retry_disposition,
-                "cause_type": type(cause).__name__ if cause is not None else None,
-            }
+        return cls._build(
+            RuntimeErrorOwner.USER,
+            kind=kind,
+            message=message,
+            retry_disposition=retry_disposition,
+            cause=cause,
         )
 
     @classmethod
@@ -124,12 +119,30 @@ class ErrorEnvelope(BaseModel):
         cause: BaseException | None = None,
     ) -> ErrorEnvelope:
         """Construct a platform-attributed error from an explicit enum kind."""
+        return cls._build(
+            RuntimeErrorOwner.PLATFORM,
+            kind=kind,
+            message=message,
+            retry_disposition=retry_disposition,
+            cause=cause,
+        )
+
+    @classmethod
+    def _build(
+        cls,
+        owner: RuntimeErrorOwner,
+        *,
+        kind: RuntimeErrorKind,
+        message: str,
+        retry_disposition: RetryDisposition,
+        cause: BaseException | None,
+    ) -> ErrorEnvelope:
         cls._require_kind(kind)
         cls._require_retry_disposition(retry_disposition)
         return cls.model_validate(
             {
                 "schema": ERROR_ENVELOPE_SCHEMA,
-                "owner": RuntimeErrorOwner.PLATFORM,
+                "owner": owner,
                 "kind": kind,
                 "message": message,
                 "retry_disposition": retry_disposition,
@@ -159,12 +172,14 @@ class TracecatRuntimeError(Exception):
 
 
 def parse_error_envelope(value: object) -> ErrorEnvelope | None:
-    """Parse only payloads carrying the explicit envelope discriminator."""
+    """Parse only payloads carrying the explicit envelope discriminator.
+
+    The required ``schema`` field makes validation the discriminator check:
+    payloads without it fail to parse.
+    """
     if isinstance(value, ErrorEnvelope):
         return value
     if not isinstance(value, Mapping):
-        return None
-    if value.get("schema") != ERROR_ENVELOPE_SCHEMA:
         return None
     try:
         return ErrorEnvelope.model_validate(value)

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -102,12 +102,15 @@ class ErrorEnvelope(BaseModel):
         """Construct a user-attributed error from an explicit enum kind."""
         cls._require_kind(kind)
         cls._require_retry_disposition(retry_disposition)
-        return cls(
-            owner=RuntimeErrorOwner.USER,
-            kind=kind,
-            message=message,
-            retry_disposition=retry_disposition,
-            cause_type=type(cause).__name__ if cause is not None else None,
+        return cls.model_validate(
+            {
+                "schema": ERROR_ENVELOPE_SCHEMA,
+                "owner": RuntimeErrorOwner.USER,
+                "kind": kind,
+                "message": message,
+                "retry_disposition": retry_disposition,
+                "cause_type": type(cause).__name__ if cause is not None else None,
+            }
         )
 
     @classmethod
@@ -122,12 +125,15 @@ class ErrorEnvelope(BaseModel):
         """Construct a platform-attributed error from an explicit enum kind."""
         cls._require_kind(kind)
         cls._require_retry_disposition(retry_disposition)
-        return cls(
-            owner=RuntimeErrorOwner.PLATFORM,
-            kind=kind,
-            message=message,
-            retry_disposition=retry_disposition,
-            cause_type=type(cause).__name__ if cause is not None else None,
+        return cls.model_validate(
+            {
+                "schema": ERROR_ENVELOPE_SCHEMA,
+                "owner": RuntimeErrorOwner.PLATFORM,
+                "kind": kind,
+                "message": message,
+                "retry_disposition": retry_disposition,
+                "cause_type": type(cause).__name__ if cause is not None else None,
+            }
         )
 
     @staticmethod

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -1,4 +1,14 @@
-"""Temporal transport for the versioned Tracecat runtime error contract."""
+"""Temporal transport for the versioned Tracecat runtime error contract.
+
+Classified failures travel as ``ClassifiedErrorDetail`` transport details: a
+required-discriminator wrapper carrying the ``ErrorEnvelope`` attribution
+stamp plus an optional ``ActionErrorInfo`` payload. Terminal workflow errors
+use the established ``{ref: ClassifiedErrorDetail}`` map. Classification is
+structural — a payload either parses as one of those shapes or it is
+unclassified; there is no partially classified state. Bare legacy payloads
+(pre-envelope histories) therefore fall through as unclassified by
+construction.
+"""
 
 from __future__ import annotations
 
@@ -19,8 +29,8 @@ from tracecat.runtime.errors import (
 TEMPORAL_ERROR_DETAILS_SCHEMA = "tracecat.temporal_error.v1"
 
 
-class TemporalErrorDetails(BaseModel):
-    """Strict adapter for envelopes without an ``ActionErrorInfo`` payload."""
+class ClassifiedErrorDetail(BaseModel):
+    """A classified transport detail: envelope stamp plus optional payload."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, serialize_by_alias=True)
 
@@ -28,36 +38,64 @@ class TemporalErrorDetails(BaseModel):
     # discriminator always survives ``exclude_unset`` serialization.
     schema_: Literal["tracecat.temporal_error.v1"] = Field(alias="schema")
     envelope: ErrorEnvelope
+    error: ActionErrorInfo | None = None
 
 
-def _application_error_from_envelope(
+# The two classified transport shapes: a single wrapped detail, or the
+# established terminal workflow ``{ref: detail}`` map. Anything else —
+# including bare legacy ``ActionErrorInfo`` payloads — is unclassified.
+_CLASSIFIED_DETAIL_ADAPTER: TypeAdapter[
+    ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail]
+] = TypeAdapter(ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail])
+
+
+def wrap_error(
+    envelope: ErrorEnvelope, error: ActionErrorInfo | None = None
+) -> ClassifiedErrorDetail:
+    """Build a classified transport detail from an envelope and payload."""
+    return ClassifiedErrorDetail.model_validate(
+        {
+            "schema": TEMPORAL_ERROR_DETAILS_SCHEMA,
+            "envelope": envelope,
+            "error": error,
+        }
+    )
+
+
+def parse_classified_detail(
+    detail: Any,
+) -> ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail] | None:
+    """Parse a transport detail into its classified shape, or None."""
+    try:
+        return _CLASSIFIED_DETAIL_ADAPTER.validate_python(detail)
+    except ValidationError:
+        return None
+
+
+def is_classified_detail(detail: Any) -> bool:
+    """Return whether a single transport detail is explicitly classified."""
+    return bool(_envelopes_from_detail(detail))
+
+
+def application_error_from_envelope(
     envelope: ErrorEnvelope,
     *details: Any,
     next_retry_delay: timedelta | None = None,
 ) -> ApplicationError:
     """Build an ``ApplicationError`` with transport fields derived from its envelope.
 
-    Existing details remain in their original order. If they already contain a
-    fully validated envelope, they are left unchanged; otherwise a strict
-    non-action detail is appended. Temporal's error type mirrors the stable
-    product kind and is never supplied as a second classification input.
+    Existing details remain in their original order. If none of them is a
+    classified detail, a bare wrapper is appended. Temporal's error type
+    mirrors the stable product kind and is never supplied as a second
+    classification input.
     """
     existing_envelope = _envelope_from_details(details)
     resolved_envelope = existing_envelope or envelope
-    transported_details = _serialized_error_details(
-        details,
-        envelope=None if existing_envelope is not None else envelope,
-    )
-    if (
-        existing_envelope is None
-        and _envelope_from_details(transported_details) is None
-    ):
-        adapter = TemporalErrorDetails.model_validate(
-            {"schema": TEMPORAL_ERROR_DETAILS_SCHEMA, "envelope": resolved_envelope}
-        )
+    transported_details = tuple(_serialized_detail(detail) for detail in details)
+    if existing_envelope is None:
         transported_details = (
             *transported_details,
-            adapter.model_dump(mode="json"),
+            wrap_error(resolved_envelope).model_dump(mode="json"),
         )
 
     non_retryable = (
@@ -86,7 +124,7 @@ def raise_application_error_from_envelope(
     here ensures callers cannot accidentally attach a sensitive caught exception
     through implicit chaining.
     """
-    raise _application_error_from_envelope(
+    raise application_error_from_envelope(
         envelope,
         *details,
         next_retry_delay=next_retry_delay,
@@ -173,85 +211,20 @@ def _envelope_from_details(details: Sequence[Any]) -> ErrorEnvelope | None:
     return None
 
 
-def is_classified_detail(detail: Any) -> bool:
-    """Return whether a single transport detail is explicitly classified."""
-    return bool(_envelopes_from_detail(detail))
-
-
-def _serialized_error_details(
-    details: Sequence[Any], envelope: ErrorEnvelope | None
-) -> tuple[Any, ...]:
-    serialized: list[Any] = []
-    for detail in details:
-        if isinstance(detail, TemporalErrorDetails):
-            serialized.append(detail.model_dump(mode="json"))
-        elif isinstance(detail, ActionErrorInfo) and (
-            detail.envelope is not None or envelope is not None
-        ):
-            classified = ActionErrorInfo(
-                ref=detail.ref,
-                message=detail.message,
-                type=detail.type,
-                expr_context=detail.expr_context,
-                attempt=detail.attempt,
-                stream_id=detail.stream_id,
-                children=detail.children,
-                envelope=detail.envelope or envelope,
-            )
-            serialized.append(classified.model_dump(mode="json"))
-        else:
-            serialized.append(detail)
-    return tuple(serialized)
-
-
-# The three classified transport shapes: a per-action error (optionally
-# nesting children), a bare envelope adapter, and the established workflow
-# ``{ref: info}`` details map. Anything else is unclassified. Validation is the
-# classification gate: both model shapes require the explicit ``schema``
-# discriminator, so an undiscriminated payload fails to parse.
-_CLASSIFIED_DETAIL_ADAPTER: TypeAdapter[
-    ActionErrorInfo | TemporalErrorDetails | dict[str, ActionErrorInfo]
-] = TypeAdapter(ActionErrorInfo | TemporalErrorDetails | dict[str, ActionErrorInfo])
-
-
 def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
-    try:
-        parsed = _CLASSIFIED_DETAIL_ADAPTER.validate_python(detail)
-    except ValidationError:
-        return ()
-    match parsed:
-        case ActionErrorInfo():
-            return _envelopes_from_action_error(parsed)
-        case TemporalErrorDetails():
-            return (parsed.envelope,)
-        case _:
-            # Every map value must be a complete, classified ActionErrorInfo;
-            # accepting a partial match would let arbitrary user payloads
-            # override classification.
-            envelopes: list[ErrorEnvelope] = []
-            seen: set[ErrorEnvelope] = set()
-            for value in parsed.values():
-                value_envelopes = _envelopes_from_action_error(value)
-                if not value_envelopes:
-                    return ()
-                for envelope in value_envelopes:
-                    _append_unique_envelope(envelopes, seen, envelope)
-            return tuple(envelopes)
-
-
-def _envelopes_from_action_error(parsed: ActionErrorInfo) -> tuple[ErrorEnvelope, ...]:
-    """Collect envelopes from an action error tree, all-or-nothing."""
-    envelopes: list[ErrorEnvelope] = []
-    seen: set[ErrorEnvelope] = set()
-    if parsed.envelope is not None:
-        _append_unique_envelope(envelopes, seen, parsed.envelope)
-    for child in parsed.children or ():
-        child_envelopes = _envelopes_from_action_error(child)
-        if not child_envelopes:
+    match parse_classified_detail(detail):
+        case None:
             return ()
-        for child_envelope in child_envelopes:
-            _append_unique_envelope(envelopes, seen, child_envelope)
-    return tuple(envelopes)
+        case ClassifiedErrorDetail() as parsed:
+            return (parsed.envelope,)
+        case parsed:
+            return tuple(wrapped.envelope for wrapped in parsed.values())
+
+
+def _serialized_detail(detail: Any) -> Any:
+    if isinstance(detail, ClassifiedErrorDetail):
+        return detail.model_dump(mode="json")
+    return detail
 
 
 def _append_unique_envelope(

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -2,11 +2,13 @@
 
 Classified failures travel as ``ErrorTransportDetail`` values: a required
 discriminator, a ``RuntimeErrorClassification``, and an optional
-``ActionErrorInfo`` payload. Terminal workflow errors use the established
-``{ref: ErrorTransportDetail}`` map. Classification is structural — a payload
-either parses as one of those shapes or it is unclassified; there is no
-partially classified state. Bare legacy payloads (pre-classification histories)
-therefore fall through as unclassified by construction.
+workflow-specific diagnostic. Terminal workflow errors use the established
+``{ref: ErrorTransportDetail}`` map. The transport stays diagnostic-agnostic;
+workflow layers specialize and validate their own diagnostic models.
+Classification is structural — a payload either parses as one of those shapes
+or it is unclassified; there is no partially classified state. Bare legacy
+payloads (pre-classification histories) therefore fall through as unclassified
+by construction.
 """
 
 from __future__ import annotations
@@ -18,7 +20,6 @@ from typing import Any, Literal, Never
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 from temporalio.exceptions import ApplicationError, FailureError
 
-from tracecat.dsl.types import ActionErrorInfo
 from tracecat.runtime.errors import (
     RetryDisposition,
     RuntimeErrorClassification,
@@ -28,8 +29,8 @@ from tracecat.runtime.errors import (
 ERROR_TRANSPORT_DETAIL_SCHEMA = "tracecat.temporal_error.v1"
 
 
-class ErrorTransportDetail(BaseModel):
-    """A classified transport detail with optional action diagnostics."""
+class ErrorTransportDetail[DiagnosticT](BaseModel):
+    """A classified transport detail with an optional typed diagnostic."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, serialize_by_alias=True)
 
@@ -37,29 +38,34 @@ class ErrorTransportDetail(BaseModel):
     # discriminator always survives ``exclude_unset`` serialization.
     schema_: Literal["tracecat.temporal_error.v1"] = Field(alias="schema")
     classification: RuntimeErrorClassification
-    action_error: ActionErrorInfo | None = None
+    diagnostic: DiagnosticT | None = None
 
 
 # The two classified transport shapes: a single detail, or the established
 # terminal workflow ``{ref: detail}`` map. Anything else —
-# including bare legacy ``ActionErrorInfo`` payloads — is unclassified.
-type ClassifiedErrorPayload = ErrorTransportDetail | dict[str, ErrorTransportDetail]
+# including bare legacy diagnostic payloads — is unclassified. The transport
+# parser deliberately treats the diagnostic as opaque; workflow-specific
+# adapters validate it before consumption or preservation.
+type OpaqueErrorTransportDetail = ErrorTransportDetail[object]
+type ClassifiedErrorPayload = (
+    OpaqueErrorTransportDetail | dict[str, OpaqueErrorTransportDetail]
+)
 
 _CLASSIFIED_ERROR_PAYLOAD_ADAPTER: TypeAdapter[ClassifiedErrorPayload] = TypeAdapter(
     ClassifiedErrorPayload
 )
 
 
-def build_error_transport_detail(
+def build_error_transport_detail[DiagnosticT](
     classification: RuntimeErrorClassification,
-    action_error: ActionErrorInfo | None = None,
-) -> ErrorTransportDetail:
-    """Build a transport detail from a classification and action diagnostics."""
-    return ErrorTransportDetail.model_validate(
+    diagnostic: DiagnosticT | None = None,
+) -> ErrorTransportDetail[DiagnosticT]:
+    """Build a transport detail from a classification and typed diagnostic."""
+    return ErrorTransportDetail[DiagnosticT].model_validate(
         {
             "schema": ERROR_TRANSPORT_DETAIL_SCHEMA,
             "classification": classification,
-            "action_error": action_error,
+            "diagnostic": diagnostic,
         }
     )
 
@@ -68,6 +74,8 @@ def parse_classified_error_payload(
     payload: Any,
 ) -> ClassifiedErrorPayload | None:
     """Parse a transport payload into its classified shape, or None."""
+    if isinstance(payload, ErrorTransportDetail):
+        payload = payload.model_dump(mode="json")
     try:
         return _CLASSIFIED_ERROR_PAYLOAD_ADAPTER.validate_python(payload)
     except ValidationError:

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -53,9 +53,12 @@ def _application_error_from_envelope(
     transported_details = (
         serialized_details if serialized_details is not None else tuple(details)
     )
-    if existing_envelope is None and serialized_details is None:
-        adapter = TemporalErrorDetails(envelope=envelope)
-        transported_details = (*details, adapter.model_dump(mode="json"))
+    if _envelope_from_details(transported_details) is None:
+        adapter = TemporalErrorDetails(envelope=resolved_envelope)
+        transported_details = (
+            *transported_details,
+            adapter.model_dump(mode="json"),
+        )
 
     non_retryable = (
         resolved_envelope.retry_disposition is RetryDisposition.NON_RETRYABLE

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -109,7 +109,11 @@ def raise_wrapped_application_error(
             if details_envelope is not None and not details
             else tuple(details)
         )
-        next_retry_delay = error.next_retry_delay
+        next_retry_delay = (
+            error.next_retry_delay
+            if envelope.retry_disposition is RetryDisposition.RETRYABLE
+            else None
+        )
     else:
         wrapped_details = tuple(details)
         next_retry_delay = None

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator, Sequence
 from datetime import timedelta
 from typing import Any, Literal, Never
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 from temporalio.exceptions import ApplicationError, FailureError
 
 from tracecat.dsl.types import ActionErrorInfo
@@ -14,7 +14,6 @@ from tracecat.runtime.errors import (
     ErrorEnvelope,
     RetryDisposition,
     TracecatRuntimeError,
-    parse_error_envelope,
 )
 
 TEMPORAL_ERROR_DETAILS_SCHEMA = "tracecat.temporal_error.v1"
@@ -25,10 +24,9 @@ class TemporalErrorDetails(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True, serialize_by_alias=True)
 
-    schema_: Literal["tracecat.temporal_error.v1"] = Field(
-        default=TEMPORAL_ERROR_DETAILS_SCHEMA,
-        alias="schema",
-    )
+    # Required so validation itself rejects undiscriminated payloads and the
+    # discriminator always survives ``exclude_unset`` serialization.
+    schema_: Literal["tracecat.temporal_error.v1"] = Field(alias="schema")
     envelope: ErrorEnvelope
 
 
@@ -46,15 +44,17 @@ def _application_error_from_envelope(
     """
     existing_envelope = _envelope_from_details(details)
     resolved_envelope = existing_envelope or envelope
-    serialized_details = _serialized_error_details(
+    transported_details = _serialized_error_details(
         details,
         envelope=None if existing_envelope is not None else envelope,
     )
-    transported_details = (
-        serialized_details if serialized_details is not None else tuple(details)
-    )
-    if _envelope_from_details(transported_details) is None:
-        adapter = TemporalErrorDetails(envelope=resolved_envelope)
+    if (
+        existing_envelope is None
+        and _envelope_from_details(transported_details) is None
+    ):
+        adapter = TemporalErrorDetails.model_validate(
+            {"schema": TEMPORAL_ERROR_DETAILS_SCHEMA, "envelope": resolved_envelope}
+        )
         transported_details = (
             *transported_details,
             adapter.model_dump(mode="json"),
@@ -130,19 +130,27 @@ def raise_wrapped_application_error(
 
 def extract_error_envelope(error: BaseException) -> ErrorEnvelope | None:
     """Extract the first valid envelope from an exception chain."""
-    envelopes = extract_error_envelopes(error)
-    return envelopes[0] if envelopes else None
+    for current in _error_chain(error):
+        if isinstance(current, TracecatRuntimeError):
+            return current.envelope
+        if (
+            isinstance(current, ApplicationError)
+            and (envelope := _envelope_from_details(current.details)) is not None
+        ):
+            return envelope
+    return None
 
 
 def extract_error_envelopes(error: BaseException) -> tuple[ErrorEnvelope, ...]:
     """Extract every valid envelope from an exception chain in transport order."""
     envelopes: list[ErrorEnvelope] = []
+    seen: set[ErrorEnvelope] = set()
     for current in _error_chain(error):
         if isinstance(current, TracecatRuntimeError):
-            _append_unique_envelope(envelopes, current.envelope)
+            _append_unique_envelope(envelopes, seen, current.envelope)
         if isinstance(current, ApplicationError):
-            for envelope in _envelopes_from_details(current.details):
-                _append_unique_envelope(envelopes, envelope)
+            for envelope in extract_error_envelopes_from_details(current.details):
+                _append_unique_envelope(envelopes, seen, envelope)
     return tuple(envelopes)
 
 
@@ -150,31 +158,33 @@ def extract_error_envelopes_from_details(
     details: Sequence[Any],
 ) -> tuple[ErrorEnvelope, ...]:
     """Extract envelopes only from explicitly classified transport details."""
-    return _envelopes_from_details(details)
+    envelopes: list[ErrorEnvelope] = []
+    seen: set[ErrorEnvelope] = set()
+    for detail in details:
+        for envelope in _envelopes_from_detail(detail):
+            _append_unique_envelope(envelopes, seen, envelope)
+    return tuple(envelopes)
 
 
 def _envelope_from_details(details: Sequence[Any]) -> ErrorEnvelope | None:
-    envelopes = _envelopes_from_details(details)
-    return envelopes[0] if envelopes else None
-
-
-def _envelopes_from_details(details: Sequence[Any]) -> tuple[ErrorEnvelope, ...]:
-    envelopes: list[ErrorEnvelope] = []
     for detail in details:
-        for envelope in _envelopes_from_detail(detail):
-            _append_unique_envelope(envelopes, envelope)
-    return tuple(envelopes)
+        if envelopes := _envelopes_from_detail(detail):
+            return envelopes[0]
+    return None
+
+
+def is_classified_detail(detail: Any) -> bool:
+    """Return whether a single transport detail is explicitly classified."""
+    return bool(_envelopes_from_detail(detail))
 
 
 def _serialized_error_details(
     details: Sequence[Any], envelope: ErrorEnvelope | None
-) -> tuple[Any, ...] | None:
+) -> tuple[Any, ...]:
     serialized: list[Any] = []
-    changed = False
     for detail in details:
         if isinstance(detail, TemporalErrorDetails):
             serialized.append(detail.model_dump(mode="json"))
-            changed = True
         elif isinstance(detail, ActionErrorInfo) and (
             detail.envelope is not None or envelope is not None
         ):
@@ -189,80 +199,68 @@ def _serialized_error_details(
                 envelope=detail.envelope or envelope,
             )
             serialized.append(classified.model_dump(mode="json"))
-            changed = True
         else:
             serialized.append(detail)
-    return tuple(serialized) if changed else None
+    return tuple(serialized)
+
+
+# The three classified transport shapes: a per-action error (optionally
+# nesting children), a bare envelope adapter, and the established workflow
+# ``{ref: info}`` details map. Anything else is unclassified. Validation is the
+# classification gate: both model shapes require the explicit ``schema``
+# discriminator, so an undiscriminated payload fails to parse.
+_CLASSIFIED_DETAIL_ADAPTER: TypeAdapter[
+    ActionErrorInfo | TemporalErrorDetails | dict[str, ActionErrorInfo]
+] = TypeAdapter(ActionErrorInfo | TemporalErrorDetails | dict[str, ActionErrorInfo])
 
 
 def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
-    if isinstance(detail, ActionErrorInfo):
-        nested_envelopes: list[ErrorEnvelope] = []
-        if detail.envelope is not None:
-            _append_unique_envelope(nested_envelopes, detail.envelope)
-        for child in detail.children or ():
-            child_envelopes = _envelopes_from_detail(child)
-            if not child_envelopes:
-                return ()
-            for envelope in child_envelopes:
-                _append_unique_envelope(nested_envelopes, envelope)
-        return tuple(nested_envelopes)
-    if isinstance(detail, TemporalErrorDetails):
-        return (detail.envelope,)
-    if not isinstance(detail, Mapping):
-        return ()
-
-    if detail.get("schema") == TEMPORAL_ERROR_DETAILS_SCHEMA:
-        if parse_error_envelope(detail.get("envelope")) is None:
-            return ()
-        try:
-            return (TemporalErrorDetails.model_validate(detail).envelope,)
-        except ValidationError:
-            return ()
-
     try:
-        parsed = ActionErrorInfo.model_validate(detail)
+        parsed = _CLASSIFIED_DETAIL_ADAPTER.validate_python(detail)
     except ValidationError:
-        pass
-    else:
-        raw_envelopes: list[ErrorEnvelope] = []
-        if parsed.envelope is not None:
-            if envelope := parse_error_envelope(detail.get("envelope")):
-                _append_unique_envelope(raw_envelopes, envelope)
-
-        if parsed.children is not None:
-            children = detail.get("children")
-            if not isinstance(children, Sequence):
-                return ()
-            for child in children:
-                child_envelopes = _envelopes_from_detail(child)
-                if not child_envelopes:
+        return ()
+    match parsed:
+        case ActionErrorInfo():
+            return _envelopes_from_action_error(parsed)
+        case TemporalErrorDetails():
+            return (parsed.envelope,)
+        case _:
+            # Every map value must be a complete, classified ActionErrorInfo;
+            # accepting a partial match would let arbitrary user payloads
+            # override classification.
+            envelopes: list[ErrorEnvelope] = []
+            seen: set[ErrorEnvelope] = set()
+            for value in parsed.values():
+                value_envelopes = _envelopes_from_action_error(value)
+                if not value_envelopes:
                     return ()
-                for envelope in child_envelopes:
-                    _append_unique_envelope(raw_envelopes, envelope)
-        return tuple(raw_envelopes)
+                for envelope in value_envelopes:
+                    _append_unique_envelope(envelopes, seen, envelope)
+            return tuple(envelopes)
 
-    # Workflow-level action failures retain the established ``{ref: info}``
-    # details shape. Every value must be a complete ActionErrorInfo; accepting a
-    # partial match would let arbitrary user payloads override classification.
+
+def _envelopes_from_action_error(parsed: ActionErrorInfo) -> tuple[ErrorEnvelope, ...]:
+    """Collect envelopes from an action error tree, all-or-nothing."""
     envelopes: list[ErrorEnvelope] = []
-    for value in detail.values():
-        try:
-            ActionErrorInfo.model_validate(value)
-        except ValidationError:
+    seen: set[ErrorEnvelope] = set()
+    if parsed.envelope is not None:
+        _append_unique_envelope(envelopes, seen, parsed.envelope)
+    for child in parsed.children or ():
+        child_envelopes = _envelopes_from_action_error(child)
+        if not child_envelopes:
             return ()
-        value_envelopes = _envelopes_from_detail(value)
-        if not value_envelopes:
-            return ()
-        for envelope in value_envelopes:
-            _append_unique_envelope(envelopes, envelope)
+        for child_envelope in child_envelopes:
+            _append_unique_envelope(envelopes, seen, child_envelope)
     return tuple(envelopes)
 
 
 def _append_unique_envelope(
-    envelopes: list[ErrorEnvelope], envelope: ErrorEnvelope
+    envelopes: list[ErrorEnvelope],
+    seen: set[ErrorEnvelope],
+    envelope: ErrorEnvelope,
 ) -> None:
-    if envelope not in envelopes:
+    if envelope not in seen:
+        seen.add(envelope)
         envelopes.append(envelope)
 
 

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -179,11 +179,24 @@ def extract_error_envelope(error: BaseException) -> ErrorEnvelope | None:
     return None
 
 
-def extract_error_envelopes(error: BaseException) -> tuple[ErrorEnvelope, ...]:
-    """Extract every valid envelope from an exception chain in transport order."""
+def extract_error_envelopes(
+    error: BaseException,
+    *,
+    include_implicit_context: bool = True,
+) -> tuple[ErrorEnvelope, ...]:
+    """Extract every valid envelope from an exception chain in transport order.
+
+    Args:
+        error: The exception whose classification should be extracted.
+        include_implicit_context: Whether to traverse Python's incidental
+            ``__context__`` chain in addition to Temporal and explicit causes.
+    """
     envelopes: list[ErrorEnvelope] = []
     seen: set[ErrorEnvelope] = set()
-    for current in _error_chain(error):
+    for current in _error_chain(
+        error,
+        include_implicit_context=include_implicit_context,
+    ):
         if isinstance(current, TracecatRuntimeError):
             _append_unique_envelope(envelopes, seen, current.envelope)
         if isinstance(current, ApplicationError):
@@ -237,7 +250,11 @@ def _append_unique_envelope(
         envelopes.append(envelope)
 
 
-def _error_chain(error: BaseException) -> Iterator[BaseException]:
+def _error_chain(
+    error: BaseException,
+    *,
+    include_implicit_context: bool = True,
+) -> Iterator[BaseException]:
     current: BaseException | None = error
     seen: set[int] = set()
     while current is not None:
@@ -253,8 +270,10 @@ def _error_chain(error: BaseException) -> Iterator[BaseException]:
             current = current.cause
         elif isinstance(current.__cause__, BaseException):
             current = current.__cause__
-        elif not current.__suppress_context__ and isinstance(
-            current.__context__, BaseException
+        elif (
+            include_implicit_context
+            and not current.__suppress_context__
+            and isinstance(current.__context__, BaseException)
         ):
             current = current.__context__
         else:

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -97,9 +97,18 @@ def raise_wrapped_application_error(
     details: Sequence[Any] = (),
 ) -> Never:
     """Raise a history-safe wrapper while preserving existing classification."""
-    envelope = extract_error_envelope(error) or fallback
+    details_envelope = (
+        _envelope_from_details(error.details)
+        if isinstance(error, ApplicationError)
+        else None
+    )
+    envelope = details_envelope or extract_error_envelope(error) or fallback
     if isinstance(error, ApplicationError):
-        wrapped_details = tuple(error.details) if not details else tuple(details)
+        wrapped_details = (
+            tuple(error.details)
+            if details_envelope is not None and not details
+            else tuple(details)
+        )
         next_retry_delay = error.next_retry_delay
     else:
         wrapped_details = tuple(details)

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -143,6 +143,13 @@ def extract_error_envelopes(error: BaseException) -> tuple[ErrorEnvelope, ...]:
     return tuple(envelopes)
 
 
+def extract_error_envelopes_from_details(
+    details: Sequence[Any],
+) -> tuple[ErrorEnvelope, ...]:
+    """Extract envelopes only from explicitly classified transport details."""
+    return _envelopes_from_details(details)
+
+
 def _envelope_from_details(details: Sequence[Any]) -> ErrorEnvelope | None:
     envelopes = _envelopes_from_details(details)
     return envelopes[0] if envelopes else None
@@ -235,7 +242,10 @@ def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
             ActionErrorInfo.model_validate(value)
         except ValidationError:
             return ()
-        for envelope in _envelopes_from_detail(value):
+        value_envelopes = _envelopes_from_detail(value)
+        if not value_envelopes:
+            return ()
+        for envelope in value_envelopes:
             _append_unique_envelope(envelopes, envelope)
     return tuple(envelopes)
 

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -1,13 +1,12 @@
 """Temporal transport for the versioned Tracecat runtime error contract.
 
-Classified failures travel as ``ClassifiedErrorDetail`` transport details: a
-required-discriminator wrapper carrying the ``ErrorEnvelope`` attribution
-stamp plus an optional ``ActionErrorInfo`` payload. Terminal workflow errors
-use the established ``{ref: ClassifiedErrorDetail}`` map. Classification is
-structural — a payload either parses as one of those shapes or it is
-unclassified; there is no partially classified state. Bare legacy payloads
-(pre-envelope histories) therefore fall through as unclassified by
-construction.
+Classified failures travel as ``ErrorTransportDetail`` values: a required
+discriminator, a ``RuntimeErrorClassification``, and an optional
+``ActionErrorInfo`` payload. Terminal workflow errors use the established
+``{ref: ErrorTransportDetail}`` map. Classification is structural — a payload
+either parses as one of those shapes or it is unclassified; there is no
+partially classified state. Bare legacy payloads (pre-classification histories)
+therefore fall through as unclassified by construction.
 """
 
 from __future__ import annotations
@@ -21,100 +20,99 @@ from temporalio.exceptions import ApplicationError, FailureError
 
 from tracecat.dsl.types import ActionErrorInfo
 from tracecat.runtime.errors import (
-    ErrorEnvelope,
     RetryDisposition,
+    RuntimeErrorClassification,
     TracecatRuntimeError,
 )
 
-TEMPORAL_ERROR_DETAILS_SCHEMA = "tracecat.temporal_error.v1"
+ERROR_TRANSPORT_DETAIL_SCHEMA = "tracecat.temporal_error.v1"
 
 
-class ClassifiedErrorDetail(BaseModel):
-    """A classified transport detail: envelope stamp plus optional payload."""
+class ErrorTransportDetail(BaseModel):
+    """A classified transport detail with optional action diagnostics."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, serialize_by_alias=True)
 
     # Required so validation itself rejects undiscriminated payloads and the
     # discriminator always survives ``exclude_unset`` serialization.
     schema_: Literal["tracecat.temporal_error.v1"] = Field(alias="schema")
-    envelope: ErrorEnvelope
-    error: ActionErrorInfo | None = None
+    classification: RuntimeErrorClassification
+    action_error: ActionErrorInfo | None = None
 
 
-# The two classified transport shapes: a single wrapped detail, or the
-# established terminal workflow ``{ref: detail}`` map. Anything else —
+# The two classified transport shapes: a single detail, or the established
+# terminal workflow ``{ref: detail}`` map. Anything else —
 # including bare legacy ``ActionErrorInfo`` payloads — is unclassified.
-type ClassifiedDetail = ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail]
+type ClassifiedErrorPayload = ErrorTransportDetail | dict[str, ErrorTransportDetail]
 
-_CLASSIFIED_DETAIL_ADAPTER: TypeAdapter[ClassifiedDetail] = TypeAdapter(
-    ClassifiedDetail
+_CLASSIFIED_ERROR_PAYLOAD_ADAPTER: TypeAdapter[ClassifiedErrorPayload] = TypeAdapter(
+    ClassifiedErrorPayload
 )
 
 
-def wrap_error(
-    envelope: ErrorEnvelope, error: ActionErrorInfo | None = None
-) -> ClassifiedErrorDetail:
-    """Build a classified transport detail from an envelope and payload."""
-    return ClassifiedErrorDetail.model_validate(
+def build_error_transport_detail(
+    classification: RuntimeErrorClassification,
+    action_error: ActionErrorInfo | None = None,
+) -> ErrorTransportDetail:
+    """Build a transport detail from a classification and action diagnostics."""
+    return ErrorTransportDetail.model_validate(
         {
-            "schema": TEMPORAL_ERROR_DETAILS_SCHEMA,
-            "envelope": envelope,
-            "error": error,
+            "schema": ERROR_TRANSPORT_DETAIL_SCHEMA,
+            "classification": classification,
+            "action_error": action_error,
         }
     )
 
 
-def parse_classified_detail(
-    detail: Any,
-) -> ClassifiedDetail | None:
-    """Parse a transport detail into its classified shape, or None."""
+def parse_classified_error_payload(
+    payload: Any,
+) -> ClassifiedErrorPayload | None:
+    """Parse a transport payload into its classified shape, or None."""
     try:
-        return _CLASSIFIED_DETAIL_ADAPTER.validate_python(detail)
+        return _CLASSIFIED_ERROR_PAYLOAD_ADAPTER.validate_python(payload)
     except ValidationError:
         return None
 
 
-def is_classified_detail(detail: Any) -> bool:
-    """Return whether a single transport detail is explicitly classified."""
-    return bool(_envelopes_from_detail(detail))
+def is_classified_error_payload(payload: Any) -> bool:
+    """Return whether a transport payload is explicitly classified."""
+    return bool(_classifications_from_payload(payload))
 
 
-def application_error_from_envelope(
-    envelope: ErrorEnvelope,
+def application_error_from_classification(
+    classification: RuntimeErrorClassification,
     *details: Any,
     next_retry_delay: timedelta | None = None,
 ) -> ApplicationError:
-    """Build an ``ApplicationError`` with transport fields derived from its envelope.
+    """Build an ``ApplicationError`` from a runtime error classification.
 
-    The passed envelope is authoritative for the transport fields (message,
-    type, retryability) — detail order never overrides the caller's selection.
-    Existing details remain in their original order; if none of them is a
-    classified detail, a bare wrapper is appended. Temporal's error type
-    mirrors the stable product kind and is never supplied as a second
-    classification input.
+    The passed classification is authoritative for message, type, and
+    retryability; detail order never overrides the caller's selection. Existing
+    details remain in their original order. If none is classified, a transport
+    detail without action diagnostics is appended.
     """
     transported_details = tuple(_serialized_detail(detail) for detail in details)
-    if _envelope_from_details(details) is None:
+    if _classification_from_details(details) is None:
         transported_details = (
             *transported_details,
-            wrap_error(envelope).model_dump(mode="json"),
+            build_error_transport_detail(classification).model_dump(mode="json"),
         )
 
-    non_retryable = envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
+    non_retryable = classification.retry_disposition is RetryDisposition.NON_RETRYABLE
     if non_retryable and next_retry_delay is not None:
         raise ValueError("A non-retryable error cannot set next_retry_delay")
 
     return ApplicationError(
-        envelope.message,
+        classification.message,
         *transported_details,
-        type=envelope.kind.value,
+        type=classification.kind.value,
         non_retryable=non_retryable,
         next_retry_delay=next_retry_delay,
     )
 
 
-def raise_application_error_from_envelope(
-    envelope: ErrorEnvelope,
+def raise_application_error_from_classification(
+    classification: RuntimeErrorClassification,
     *details: Any,
     next_retry_delay: timedelta | None = None,
 ) -> Never:
@@ -124,8 +122,8 @@ def raise_application_error_from_envelope(
     here ensures callers cannot accidentally attach a sensitive caught exception
     through implicit chaining.
     """
-    raise application_error_from_envelope(
-        envelope,
+    raise application_error_from_classification(
+        classification,
         *details,
         next_retry_delay=next_retry_delay,
     ) from None
@@ -134,120 +132,139 @@ def raise_application_error_from_envelope(
 def raise_wrapped_application_error(
     error: BaseException,
     *,
-    fallback: ErrorEnvelope,
+    fallback_classification: RuntimeErrorClassification,
     details: Sequence[Any] = (),
 ) -> Never:
-    """Raise a history-safe wrapper while preserving existing classification."""
-    details_envelope = (
-        _envelope_from_details(error.details)
+    """Raise a history-safe application error preserving classification."""
+    details_classification = (
+        _classification_from_details(error.details)
         if isinstance(error, ApplicationError)
         else None
     )
-    envelope = details_envelope or extract_error_envelope(error) or fallback
+    classification = (
+        details_classification
+        or extract_error_classification(error)
+        or fallback_classification
+    )
     if isinstance(error, ApplicationError):
         wrapped_details = (
             tuple(error.details)
-            if details_envelope is not None and not details
+            if details_classification is not None and not details
             else tuple(details)
         )
         next_retry_delay = (
             error.next_retry_delay
-            if envelope.retry_disposition is RetryDisposition.RETRYABLE
+            if classification.retry_disposition is RetryDisposition.RETRYABLE
             else None
         )
     else:
         wrapped_details = tuple(details)
         next_retry_delay = None
 
-    raise_application_error_from_envelope(
-        envelope,
+    raise_application_error_from_classification(
+        classification,
         *wrapped_details,
         next_retry_delay=next_retry_delay,
     )
 
 
-def extract_error_envelope(error: BaseException) -> ErrorEnvelope | None:
-    """Extract the first valid envelope from an exception chain."""
+def extract_error_classification(
+    error: BaseException,
+) -> RuntimeErrorClassification | None:
+    """Extract the first valid classification from an exception chain."""
     for current in _error_chain(error):
         if isinstance(current, TracecatRuntimeError):
-            return current.envelope
+            return current.classification
         if (
             isinstance(current, ApplicationError)
-            and (envelope := _envelope_from_details(current.details)) is not None
+            and (classification := _classification_from_details(current.details))
+            is not None
         ):
-            return envelope
+            return classification
     return None
 
 
-def extract_error_envelopes(
+def extract_error_classifications(
     error: BaseException,
     *,
     include_implicit_context: bool = True,
-) -> tuple[ErrorEnvelope, ...]:
-    """Extract every valid envelope from an exception chain in transport order.
+) -> tuple[RuntimeErrorClassification, ...]:
+    """Extract every valid classification in exception-chain transport order.
 
     Args:
         error: The exception whose classification should be extracted.
         include_implicit_context: Whether to traverse Python's incidental
             ``__context__`` chain in addition to Temporal and explicit causes.
     """
-    envelopes: list[ErrorEnvelope] = []
-    seen: set[ErrorEnvelope] = set()
+    classifications: list[RuntimeErrorClassification] = []
+    seen: set[RuntimeErrorClassification] = set()
     for current in _error_chain(
         error,
         include_implicit_context=include_implicit_context,
     ):
         if isinstance(current, TracecatRuntimeError):
-            _append_unique_envelope(envelopes, seen, current.envelope)
+            _append_unique_classification(
+                classifications,
+                seen,
+                current.classification,
+            )
         if isinstance(current, ApplicationError):
-            for envelope in extract_error_envelopes_from_details(current.details):
-                _append_unique_envelope(envelopes, seen, envelope)
-    return tuple(envelopes)
+            for classification in extract_error_classifications_from_details(
+                current.details
+            ):
+                _append_unique_classification(classifications, seen, classification)
+    return tuple(classifications)
 
 
-def extract_error_envelopes_from_details(
+def extract_error_classifications_from_details(
     details: Sequence[Any],
-) -> tuple[ErrorEnvelope, ...]:
-    """Extract envelopes only from explicitly classified transport details."""
-    envelopes: list[ErrorEnvelope] = []
-    seen: set[ErrorEnvelope] = set()
+) -> tuple[RuntimeErrorClassification, ...]:
+    """Extract classifications only from explicitly classified details."""
+    classifications: list[RuntimeErrorClassification] = []
+    seen: set[RuntimeErrorClassification] = set()
     for detail in details:
-        for envelope in _envelopes_from_detail(detail):
-            _append_unique_envelope(envelopes, seen, envelope)
-    return tuple(envelopes)
+        for classification in _classifications_from_payload(detail):
+            _append_unique_classification(classifications, seen, classification)
+    return tuple(classifications)
 
 
-def _envelope_from_details(details: Sequence[Any]) -> ErrorEnvelope | None:
+def _classification_from_details(
+    details: Sequence[Any],
+) -> RuntimeErrorClassification | None:
     for detail in details:
-        if envelopes := _envelopes_from_detail(detail):
-            return envelopes[0]
+        if classifications := _classifications_from_payload(detail):
+            return classifications[0]
     return None
 
 
-def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
-    match parse_classified_detail(detail):
+def _classifications_from_payload(
+    payload: Any,
+) -> tuple[RuntimeErrorClassification, ...]:
+    match parse_classified_error_payload(payload):
         case None:
             return ()
-        case ClassifiedErrorDetail() as parsed:
-            return (parsed.envelope,)
+        case ErrorTransportDetail() as parsed:
+            return (parsed.classification,)
         case parsed:
-            return tuple(wrapped.envelope for wrapped in parsed.values())
+            return tuple(
+                transport_detail.classification for transport_detail in parsed.values()
+            )
 
 
 def _serialized_detail(detail: Any) -> Any:
-    if isinstance(detail, ClassifiedErrorDetail):
+    if isinstance(detail, ErrorTransportDetail):
         return detail.model_dump(mode="json")
     return detail
 
 
-def _append_unique_envelope(
-    envelopes: list[ErrorEnvelope],
-    seen: set[ErrorEnvelope],
-    envelope: ErrorEnvelope,
+def _append_unique_classification(
+    classifications: list[RuntimeErrorClassification],
+    seen: set[RuntimeErrorClassification],
+    classification: RuntimeErrorClassification,
 ) -> None:
-    if envelope not in seen:
-        seen.add(envelope)
-        envelopes.append(envelope)
+    if classification not in seen:
+        seen.add(classification)
+        classifications.append(classification)
 
 
 def _error_chain(

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -199,7 +199,19 @@ def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
     except ValidationError:
         pass
     else:
-        return _envelopes_from_detail(parsed)
+        raw_envelopes: list[ErrorEnvelope] = []
+        if parsed.envelope is not None:
+            if envelope := parse_error_envelope(detail.get("envelope")):
+                _append_unique_envelope(raw_envelopes, envelope)
+
+        if parsed.children is not None:
+            children = detail.get("children")
+            if not isinstance(children, Sequence):
+                return ()
+            for child in children:
+                for envelope in _envelopes_from_detail(child):
+                    _append_unique_envelope(raw_envelopes, envelope)
+        return tuple(raw_envelopes)
 
     # Workflow-level action failures retain the established ``{ref: info}``
     # details shape. Every value must be a complete ActionErrorInfo; accepting a
@@ -207,10 +219,10 @@ def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
     envelopes: list[ErrorEnvelope] = []
     for value in detail.values():
         try:
-            parsed = ActionErrorInfo.model_validate(value)
+            ActionErrorInfo.model_validate(value)
         except ValidationError:
             return ()
-        for envelope in _envelopes_from_detail(parsed):
+        for envelope in _envelopes_from_detail(value):
             _append_unique_envelope(envelopes, envelope)
     return tuple(envelopes)
 

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -198,7 +198,10 @@ def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
         if detail.envelope is not None:
             _append_unique_envelope(nested_envelopes, detail.envelope)
         for child in detail.children or ():
-            for envelope in _envelopes_from_detail(child):
+            child_envelopes = _envelopes_from_detail(child)
+            if not child_envelopes:
+                return ()
+            for envelope in child_envelopes:
                 _append_unique_envelope(nested_envelopes, envelope)
         return tuple(nested_envelopes)
     if isinstance(detail, TemporalErrorDetails):
@@ -229,7 +232,10 @@ def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
             if not isinstance(children, Sequence):
                 return ()
             for child in children:
-                for envelope in _envelopes_from_detail(child):
+                child_envelopes = _envelopes_from_detail(child)
+                if not child_envelopes:
+                    return ()
+                for envelope in child_envelopes:
                     _append_unique_envelope(raw_envelopes, envelope)
         return tuple(raw_envelopes)
 

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -86,30 +86,28 @@ def application_error_from_envelope(
 ) -> ApplicationError:
     """Build an ``ApplicationError`` with transport fields derived from its envelope.
 
-    Existing details remain in their original order. If none of them is a
+    The passed envelope is authoritative for the transport fields (message,
+    type, retryability) — detail order never overrides the caller's selection.
+    Existing details remain in their original order; if none of them is a
     classified detail, a bare wrapper is appended. Temporal's error type
     mirrors the stable product kind and is never supplied as a second
     classification input.
     """
-    existing_envelope = _envelope_from_details(details)
-    resolved_envelope = existing_envelope or envelope
     transported_details = tuple(_serialized_detail(detail) for detail in details)
-    if existing_envelope is None:
+    if _envelope_from_details(details) is None:
         transported_details = (
             *transported_details,
-            wrap_error(resolved_envelope).model_dump(mode="json"),
+            wrap_error(envelope).model_dump(mode="json"),
         )
 
-    non_retryable = (
-        resolved_envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
-    )
+    non_retryable = envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
     if non_retryable and next_retry_delay is not None:
         raise ValueError("A non-retryable error cannot set next_retry_delay")
 
     return ApplicationError(
-        resolved_envelope.message,
+        envelope.message,
         *transported_details,
-        type=resolved_envelope.kind.value,
+        type=envelope.kind.value,
         non_retryable=non_retryable,
         next_retry_delay=next_retry_delay,
     )

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -44,9 +44,11 @@ class ClassifiedErrorDetail(BaseModel):
 # The two classified transport shapes: a single wrapped detail, or the
 # established terminal workflow ``{ref: detail}`` map. Anything else —
 # including bare legacy ``ActionErrorInfo`` payloads — is unclassified.
-_CLASSIFIED_DETAIL_ADAPTER: TypeAdapter[
-    ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail]
-] = TypeAdapter(ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail])
+type ClassifiedDetail = ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail]
+
+_CLASSIFIED_DETAIL_ADAPTER: TypeAdapter[ClassifiedDetail] = TypeAdapter(
+    ClassifiedDetail
+)
 
 
 def wrap_error(
@@ -64,7 +66,7 @@ def wrap_error(
 
 def parse_classified_detail(
     detail: Any,
-) -> ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail] | None:
+) -> ClassifiedDetail | None:
     """Parse a transport detail into its classified shape, or None."""
     try:
         return _CLASSIFIED_DETAIL_ADAPTER.validate_python(detail)

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from datetime import timedelta
 from typing import Any, Literal, Never
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from temporalio.exceptions import ApplicationError, FailureError
 
 from tracecat.dsl.types import ActionErrorInfo
@@ -18,7 +18,6 @@ from tracecat.runtime.errors import (
 )
 
 TEMPORAL_ERROR_DETAILS_SCHEMA = "tracecat.temporal_error.v1"
-_ACTION_ERROR_MAP_ADAPTER = TypeAdapter(dict[str, ActionErrorInfo])
 
 
 class TemporalErrorDetails(BaseModel):
@@ -47,13 +46,16 @@ def _application_error_from_envelope(
     """
     existing_envelope = _envelope_from_details(details)
     resolved_envelope = existing_envelope or envelope
-    transported_details, embedded = _serialized_error_details(
+    serialized_details = _serialized_error_details(
         details,
         envelope=None if existing_envelope is not None else envelope,
     )
-    if existing_envelope is None and not embedded:
+    transported_details = (
+        serialized_details if serialized_details is not None else tuple(details)
+    )
+    if existing_envelope is None and serialized_details is None:
         adapter = TemporalErrorDetails(envelope=envelope)
-        transported_details = (*transported_details, adapter.model_dump(mode="json"))
+        transported_details = (*details, adapter.model_dump(mode="json"))
 
     non_retryable = (
         resolved_envelope.retry_disposition is RetryDisposition.NON_RETRYABLE
@@ -95,24 +97,10 @@ def raise_wrapped_application_error(
     details: Sequence[Any] = (),
 ) -> Never:
     """Raise a history-safe wrapper while preserving existing classification."""
-    details_envelope = (
-        _envelope_from_details(error.details)
-        if isinstance(error, ApplicationError)
-        else None
-    )
-    existing_envelope = details_envelope or extract_error_envelope(error)
-    envelope = existing_envelope or fallback
+    envelope = extract_error_envelope(error) or fallback
     if isinstance(error, ApplicationError):
-        wrapped_details = (
-            tuple(error.details)
-            if details_envelope is not None and not details
-            else tuple(details)
-        )
-        next_retry_delay = (
-            error.next_retry_delay
-            if envelope.retry_disposition is RetryDisposition.RETRYABLE
-            else None
-        )
+        wrapped_details = tuple(error.details) if not details else tuple(details)
+        next_retry_delay = error.next_retry_delay
     else:
         wrapped_details = tuple(details)
         next_retry_delay = None
@@ -126,32 +114,44 @@ def raise_wrapped_application_error(
 
 def extract_error_envelope(error: BaseException) -> ErrorEnvelope | None:
     """Extract the first valid envelope from an exception chain."""
+    envelopes = extract_error_envelopes(error)
+    return envelopes[0] if envelopes else None
+
+
+def extract_error_envelopes(error: BaseException) -> tuple[ErrorEnvelope, ...]:
+    """Extract every valid envelope from an exception chain in transport order."""
+    envelopes: list[ErrorEnvelope] = []
     for current in _error_chain(error):
         if isinstance(current, TracecatRuntimeError):
-            return current.envelope
+            _append_unique_envelope(envelopes, current.envelope)
         if isinstance(current, ApplicationError):
-            if envelope := _envelope_from_details(current.details):
-                return envelope
-    return None
+            for envelope in _envelopes_from_details(current.details):
+                _append_unique_envelope(envelopes, envelope)
+    return tuple(envelopes)
 
 
 def _envelope_from_details(details: Sequence[Any]) -> ErrorEnvelope | None:
+    envelopes = _envelopes_from_details(details)
+    return envelopes[0] if envelopes else None
+
+
+def _envelopes_from_details(details: Sequence[Any]) -> tuple[ErrorEnvelope, ...]:
+    envelopes: list[ErrorEnvelope] = []
     for detail in details:
-        if envelope := _envelope_from_detail(detail):
-            return envelope
-    return None
+        for envelope in _envelopes_from_detail(detail):
+            _append_unique_envelope(envelopes, envelope)
+    return tuple(envelopes)
 
 
 def _serialized_error_details(
     details: Sequence[Any], envelope: ErrorEnvelope | None
-) -> tuple[tuple[Any, ...], bool]:
-    """Serialize details for transport, reporting whether an envelope is embedded."""
+) -> tuple[Any, ...] | None:
     serialized: list[Any] = []
-    embedded = False
+    changed = False
     for detail in details:
         if isinstance(detail, TemporalErrorDetails):
             serialized.append(detail.model_dump(mode="json"))
-            embedded = True
+            changed = True
         elif isinstance(detail, ActionErrorInfo) and (
             detail.envelope is not None or envelope is not None
         ):
@@ -166,49 +166,60 @@ def _serialized_error_details(
                 envelope=detail.envelope or envelope,
             )
             serialized.append(classified.model_dump(mode="json"))
-            embedded = True
+            changed = True
         else:
             serialized.append(detail)
-    return tuple(serialized), embedded
+    return tuple(serialized) if changed else None
 
 
-def _envelope_from_detail(detail: Any) -> ErrorEnvelope | None:
+def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
     if isinstance(detail, ActionErrorInfo):
-        return detail.envelope or _envelope_from_details(detail.children or ())
+        nested_envelopes: list[ErrorEnvelope] = []
+        if detail.envelope is not None:
+            _append_unique_envelope(nested_envelopes, detail.envelope)
+        for child in detail.children or ():
+            for envelope in _envelopes_from_detail(child):
+                _append_unique_envelope(nested_envelopes, envelope)
+        return tuple(nested_envelopes)
     if isinstance(detail, TemporalErrorDetails):
-        return detail.envelope
+        return (detail.envelope,)
     if not isinstance(detail, Mapping):
-        return None
+        return ()
 
     if detail.get("schema") == TEMPORAL_ERROR_DETAILS_SCHEMA:
         if parse_error_envelope(detail.get("envelope")) is None:
-            return None
+            return ()
         try:
-            return TemporalErrorDetails.model_validate(detail).envelope
+            return (TemporalErrorDetails.model_validate(detail).envelope,)
         except ValidationError:
-            return None
+            return ()
 
     try:
         parsed = ActionErrorInfo.model_validate(detail)
     except ValidationError:
+        pass
+    else:
+        return _envelopes_from_detail(parsed)
+
+    # Workflow-level action failures retain the established ``{ref: info}``
+    # details shape. Every value must be a complete ActionErrorInfo; accepting a
+    # partial match would let arbitrary user payloads override classification.
+    envelopes: list[ErrorEnvelope] = []
+    for value in detail.values():
         try:
-            _ACTION_ERROR_MAP_ADAPTER.validate_python(detail)
+            parsed = ActionErrorInfo.model_validate(value)
         except ValidationError:
-            return None
-        for action_error in detail.values():
-            if envelope := _envelope_from_detail(action_error):
-                return envelope
-        return None
+            return ()
+        for envelope in _envelopes_from_detail(parsed):
+            _append_unique_envelope(envelopes, envelope)
+    return tuple(envelopes)
 
-    if parsed.envelope is not None:
-        return parse_error_envelope(detail.get("envelope"))
-    if parsed.children is None:
-        return None
 
-    children = detail.get("children")
-    if not isinstance(children, Sequence):
-        return None
-    return _envelope_from_details(children)
+def _append_unique_envelope(
+    envelopes: list[ErrorEnvelope], envelope: ErrorEnvelope
+) -> None:
+    if envelope not in envelopes:
+        envelopes.append(envelope)
 
 
 def _error_chain(error: BaseException) -> Iterator[BaseException]:

--- a/tracecat/workflow/executions/enums.py
+++ b/tracecat/workflow/executions/enums.py
@@ -165,6 +165,9 @@ class TemporalSearchAttr(StrEnum):
     EXECUTION_TYPE = "TracecatExecutionType"
     """The `Keyword` Search Attribute for the execution type (draft or published)."""
 
+    ERROR_OWNER = "TracecatErrorOwner"
+    """The `Keyword` Search Attribute for terminal runtime error ownership."""
+
     @cached_property
     def key(self) -> SearchAttributeKey[str]:
         return SearchAttributeKey.for_keyword(self.value)


### PR DESCRIPTION
## Summary

- classify failures at the subflow-preparation activity boundary and keep existing typed classification and retry semantics authoritative
- carry namespaced error kinds through Temporal, scheduler handling, and terminal workflow aggregation without leaking raw platform diagnostics into workflow history
- make classification structural: classified failures travel as a `ClassifiedErrorDetail` wrapper (required `schema` discriminator) carrying the `ErrorEnvelope` stamp plus an optional `ActionErrorInfo` payload — a detail either parses as a wrapped shape or is unclassified, and bare legacy payloads stay unclassified by construction
- drop the embedded envelope from `ActionErrorInfo`; the scheduler records per-stream envelopes at fail time and gather failures aggregate ownership at raise time, platform-wins on mixed owners
- aggregate child workflow terminal `{ref: detail}` maps platform-wins as well, so a platform-owned entry is never hidden behind an earlier user-owned one
- stamp the replay-gated `TracecatErrorOwner` Search Attribute only when a classified failure reaches the terminal DSL workflow boundary

## Why

The contract in #3267 needs one real end-to-end execution path before classification is expanded broadly. Subflow preparation exercises activity retries, handled user errors, platform failures, scheduler aggregation, workflow termination, and Temporal Search Attributes in a bounded steel thread.

This layer also proves the revised contract: `kind` is the stable taxonomy identity, Temporal `ApplicationError.type` mirrors it, and `cause_type` remains diagnostic only. Error handlers receive unwrapped payloads, so their input contract is unchanged.

## Impact

Handled errors, successful retries, cancellation, termination, timeout, legacy payloads, and previously established retry budgets retain their native semantics. This layer does not add Sentry capture or change alert-routing and completion policy.

## Stack

- builds on the error contract from #3267 (merged); base branch is `main`

## Validation

- focused unit coverage for classification, history safety, retry preservation, cancellation, aggregation, replay gating, Search Attribute registration, and scheduler compatibility
- `uv run ruff check` and `uv run ruff format --check`
- targeted `uv run basedpyright` with 0 errors and 0 warnings
- repository commit hooks

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 669 | 404 |
| Tests | 1631 | 477 |
| Infra/config | 1 | 0 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads classified runtime error diagnostics through DSL workflows and subflow preparation so terminal failures carry user/platform ownership without changing error handler input.

- Classified failures travel in a generic `ErrorTransportDetail` wrapper with a required `schema` discriminator; a detail either parses as a wrapped shape or is unclassified by construction, and DSL actions specialize it as `ActionErrorTransportDetail`.
- The wrapper carries a `RuntimeErrorClassification` stamp and an optional workflow-specific diagnostic; terminal workflow errors use a `{ref: detail}` map.
- `ActionErrorInfo` no longer embeds a stamp; gathers aggregate ownership at raise time, platform-wins on mixed owners, and error handlers still receive unwrapped payloads.
- Subflow preparation adds an invalid-subflow-input kind, filters and redacts unclassified details, and keeps user errors non-retryable while platform errors stay retryable.
- Terminal aggregation picks platform ownership across each task's enveloped details, and the selected detail's fields are stamped onto the transport so detail order cannot override ownership.
- `TracecatErrorOwner` stamping is replay-gated and snapshots the terminal error policy at workflow start; it runs after error handlers and treats handler and handler-setup failures as terminal.
- Search attribute registration is awaited and retried at API startup, listing existing attributes before adding from a centralized dictionary.

<sup>Written for commit e7ff2b13667538cb57c904b10548c3da1a2a7b89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

