### PR TITLE
feat(logging): trace API workflows through Temporal

### DIFF
--- a/tests/temporal/test_platform_tracing.py
+++ b/tests/temporal/test_platform_tracing.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import timedelta
+
+import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from tracecat import config
+from tracecat.observability.otel import (
+    initialize_platform_tracing,
+    set_current_span_attributes,
+    shutdown_platform_tracing,
+    temporal_tracing_interceptor,
+)
+
+pytestmark = [pytest.mark.temporal]
+
+
+@activity.defn
+async def traced_executor_activity() -> str:
+    info = activity.info()
+    set_current_span_attributes(
+        {
+            "tracecat.workflow.execution.id": info.workflow_id,
+            "tracecat.action.name": "core.test.trace",
+            "temporal.activity.attempt": info.attempt,
+            "temporal.task_queue": info.task_queue,
+        }
+    )
+    return "ok"
+
+
+@workflow.defn(sandboxed=False)
+class TracedWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return await workflow.execute_activity(
+            traced_executor_activity,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+
+
+@pytest.fixture
+async def traced_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncGenerator[tuple[WorkflowEnvironment, InMemorySpanExporter], None]:
+    shutdown_platform_tracing()
+    monkeypatch.setattr(config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
+    exporter = InMemorySpanExporter()
+    initialize_platform_tracing("tracecat-api", exporter=exporter)
+    interceptor = temporal_tracing_interceptor()
+    assert interceptor is not None
+
+    async with await WorkflowEnvironment.start_time_skipping(
+        interceptors=[interceptor]
+    ) as env:
+        yield env, exporter
+
+    shutdown_platform_tracing()
+
+
+@pytest.mark.anyio
+async def test_async_api_dispatch_keeps_one_temporal_activity_trace(
+    traced_env: tuple[WorkflowEnvironment, InMemorySpanExporter],
+) -> None:
+    env, exporter = traced_env
+    workflow_id = "synthetic-platform-trace"
+
+    async with Worker(
+        env.client,
+        task_queue="platform-tracing-test",
+        workflows=[TracedWorkflow],
+        activities=[traced_executor_activity],
+        max_cached_workflows=0,
+    ):
+        runtime = initialize_platform_tracing(
+            "tracecat-api",
+            exporter=exporter,
+        )
+        assert runtime is not None
+        with runtime.tracer("test.api").start_as_current_span(
+            "POST /workflow-executions"
+        ):
+            dispatch = asyncio.create_task(
+                env.client.execute_workflow(
+                    TracedWorkflow.run,
+                    id=workflow_id,
+                    task_queue="platform-tracing-test",
+                )
+            )
+
+        assert await dispatch == "ok"
+
+    spans = exporter.get_finished_spans()
+    assert all(span.context is not None for span in spans)
+    trace_ids = {span.context.trace_id for span in spans if span.context is not None}
+    assert len(trace_ids) == 1
+    span_names = {span.name for span in spans}
+    assert "POST /workflow-executions" in span_names
+    assert any("StartWorkflow" in name for name in span_names)
+    assert any("RunWorkflow" in name for name in span_names)
+    assert any("RunActivity" in name for name in span_names)
+
+    activity_spans = [span for span in spans if "RunActivity" in span.name]
+    assert len(activity_spans) == 1
+    activity_span = activity_spans[0]
+    assert activity_span.attributes is not None
+    assert activity_span.attributes["tracecat.workflow.execution.id"] == workflow_id
+    assert activity_span.attributes["tracecat.action.name"] == "core.test.trace"
+
+    workflow_spans = [span for span in spans if "RunWorkflow" in span.name]
+    assert len(workflow_spans) == 1

--- a/tests/temporal/test_platform_tracing.py
+++ b/tests/temporal/test_platform_tracing.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator
 from datetime import timedelta
 
 import pytest
+from opentelemetry import baggage, context
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -45,6 +46,26 @@ class TracedWorkflow:
             traced_executor_activity,
             start_to_close_timeout=timedelta(seconds=10),
         )
+
+
+_SYNTHETIC_BAGGAGE_KEY = "synthetic-platform-baggage"
+
+
+@activity.defn
+async def baggage_probe_activity() -> bool:
+    return baggage.get_baggage(_SYNTHETIC_BAGGAGE_KEY) is not None
+
+
+@workflow.defn(sandboxed=False)
+class BaggageProbeWorkflow:
+    @workflow.run
+    async def run(self) -> list[bool]:
+        workflow_has_baggage = baggage.get_baggage(_SYNTHETIC_BAGGAGE_KEY) is not None
+        activity_has_baggage = await workflow.execute_activity(
+            baggage_probe_activity,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+        return [workflow_has_baggage, activity_has_baggage]
 
 
 @pytest.fixture
@@ -117,3 +138,33 @@ async def test_async_api_dispatch_keeps_one_temporal_activity_trace(
 
     workflow_spans = [span for span in spans if "RunWorkflow" in span.name]
     assert len(workflow_spans) == 1
+
+
+@pytest.mark.anyio
+async def test_temporal_tracing_does_not_propagate_baggage(
+    traced_env: tuple[WorkflowEnvironment, InMemorySpanExporter],
+) -> None:
+    env, _ = traced_env
+
+    async with Worker(
+        env.client,
+        task_queue="platform-tracing-baggage-test",
+        workflows=[BaggageProbeWorkflow],
+        activities=[baggage_probe_activity],
+        max_cached_workflows=0,
+    ):
+        baggage_context = baggage.set_baggage(
+            _SYNTHETIC_BAGGAGE_KEY,
+            "synthetic-do-not-propagate",
+        )
+        token = context.attach(baggage_context)
+        try:
+            baggage_visibility = await env.client.execute_workflow(
+                BaggageProbeWorkflow.run,
+                id="synthetic-platform-baggage-test",
+                task_queue="platform-tracing-baggage-test",
+            )
+        finally:
+            context.detach(token)
+
+    assert baggage_visibility == [False, False]

--- a/tests/temporal/test_platform_tracing.py
+++ b/tests/temporal/test_platform_tracing.py
@@ -9,7 +9,10 @@ from opentelemetry import baggage, context
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
+from opentelemetry.trace import StatusCode
 from temporalio import activity, workflow
+from temporalio.client import WorkflowFailureError
+from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
@@ -66,6 +69,24 @@ class BaggageProbeWorkflow:
             start_to_close_timeout=timedelta(seconds=10),
         )
         return [workflow_has_baggage, activity_has_baggage]
+
+
+_SYNTHETIC_FAILURE_DETAIL = "synthetic-customer-secret-must-not-export"
+
+
+@activity.defn
+async def failing_traced_activity() -> None:
+    raise ApplicationError(_SYNTHETIC_FAILURE_DETAIL, non_retryable=True)
+
+
+@workflow.defn(sandboxed=False)
+class FailingTracedWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.execute_activity(
+            failing_traced_activity,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
 
 
 @pytest.fixture
@@ -168,3 +189,38 @@ async def test_temporal_tracing_does_not_propagate_baggage(
             context.detach(token)
 
     assert baggage_visibility == [False, False]
+
+
+@pytest.mark.anyio
+async def test_temporal_tracing_does_not_export_failure_details(
+    traced_env: tuple[WorkflowEnvironment, InMemorySpanExporter],
+) -> None:
+    env, exporter = traced_env
+
+    async with Worker(
+        env.client,
+        task_queue="platform-tracing-failure-test",
+        workflows=[FailingTracedWorkflow],
+        activities=[failing_traced_activity],
+        max_cached_workflows=0,
+    ):
+        with pytest.raises(WorkflowFailureError):
+            await env.client.execute_workflow(
+                FailingTracedWorkflow.run,
+                id="synthetic-platform-failure-test",
+                task_queue="platform-tracing-failure-test",
+            )
+
+    failed_spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if "RunActivity" in span.name or "CompleteWorkflow" in span.name
+    ]
+    assert len(failed_spans) == 2
+    for span in failed_spans:
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.status.description is None
+        assert span.attributes is not None
+        assert span.attributes["error.type"] == "temporal.failure"
+        assert span.events == ()
+        assert _SYNTHETIC_FAILURE_DETAIL not in str(span)

--- a/tests/unit/test_platform_otel.py
+++ b/tests/unit/test_platform_otel.py
@@ -146,6 +146,7 @@ def test_fastapi_span_uses_route_template_instead_of_path_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
+    monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
     exporter = InMemorySpanExporter()
     initialize_platform_tracing("tracecat-api", exporter=exporter)
     app = FastAPI()
@@ -169,6 +170,7 @@ def test_fastapi_span_uses_route_template_instead_of_path_credentials(
     assert span_attributes["http.target"] == "/webhooks/{workflow_id}/{secret}"
     assert span_attributes["http.url"] == "/webhooks/{workflow_id}/{secret}"
     assert span_attributes["url.full"] == "/webhooks/{workflow_id}/{secret}"
+    assert span_attributes["url.path"] == "/webhooks/{workflow_id}/{secret}"
     assert "synthetic-workflow-id" not in str(span_attributes)
     assert "synthetic-webhook-secret" not in str(span_attributes)
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -129,6 +129,12 @@ from tracecat.middleware import (
     RequestLoggingMiddleware,
 )
 from tracecat.middleware.security import SecurityHeadersMiddleware
+from tracecat.observability.otel import (
+    TRACE_ID_HEADER,
+    TRACE_SAMPLED_HEADER,
+    instrument_fastapi_app,
+    shutdown_platform_tracing,
+)
 from tracecat.organization.management import (
     ensure_default_organization,
     get_default_organization_id,
@@ -258,6 +264,7 @@ async def lifespan(app: FastAPI):
 
     await supervisor.drain()
     await close_storage_client_cache()
+    shutdown_platform_tracing()
 
 
 async def setup_org_settings(session: AsyncSession, admin_role: Role):
@@ -652,7 +659,9 @@ def create_app(**kwargs) -> FastAPI:
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
+        expose_headers=[TRACE_ID_HEADER, TRACE_SAMPLED_HEADER],
     )
+    instrument_fastapi_app(app, service_name="tracecat-api")
 
     logger.info(
         "App started",

--- a/tracecat/dsl/client.py
+++ b/tracecat/dsl/client.py
@@ -23,6 +23,7 @@ from tracecat.config import (
 )
 from tracecat.dsl._converter import get_data_converter
 from tracecat.logger import logger
+from tracecat.observability.otel import temporal_tracing_interceptor
 
 _client: Client | None = None
 
@@ -68,6 +69,10 @@ async def connect_to_temporal(plugins: list[Plugin] | None = None) -> Client:
             runtime = init_runtime_with_prometheus(port=int(TEMPORAL__METRICS_PORT))
         except Exception as e:
             logger.warning("Failed to initialize Prometheus runtime", error=e)
+    interceptors = []
+    if tracing_interceptor := temporal_tracing_interceptor():
+        interceptors.append(tracing_interceptor)
+
     client = await Client.connect(
         target_host=TEMPORAL__CLUSTER_URL,
         namespace=TEMPORAL__CLUSTER_NAMESPACE,
@@ -79,6 +84,7 @@ async def connect_to_temporal(plugins: list[Plugin] | None = None) -> Client:
         ),
         runtime=runtime,
         plugins=plugins or [],
+        interceptors=interceptors,
     )
     return client
 

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -38,6 +38,10 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.workflow import DSLWorkflow
     from tracecat.ee.interactions.service import InteractionService
     from tracecat.logger import logger
+    from tracecat.observability.otel import (
+        initialize_platform_tracing,
+        shutdown_platform_tracing,
+    )
     from tracecat.observability.sentry import initialize_sentry_from_environment
     from tracecat.storage.blob import close_storage_client_cache
     from tracecat.storage.collection import CollectionActivities
@@ -119,6 +123,8 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
 
     _logger._is_worker_process = True
 
+    initialize_platform_tracing("tracecat-worker")
+
     client = await get_temporal_client()
 
     initialize_sentry_from_environment()
@@ -182,6 +188,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
             logger.info("Temporal Worker context exited")
     finally:
         await close_storage_client_cache()
+        shutdown_platform_tracing()
 
 
 if __name__ == "__main__":

--- a/tracecat/executor/activities.py
+++ b/tracecat/executor/activities.py
@@ -35,6 +35,7 @@ from tracecat.executor.error_policy import (
 )
 from tracecat.executor.service import dispatch_action
 from tracecat.logger import logger
+from tracecat.observability.otel import set_current_span_attributes
 from tracecat.runtime.errors import RetryDisposition, RuntimeErrorOwner
 from tracecat.storage.object import StoredObject, action_key, get_object_storage
 from tracecat.temporal.errors import (
@@ -115,6 +116,18 @@ class ExecutorActivities:
 
         act_info = activity.info()
         act_attempt = act_info.attempt
+        set_current_span_attributes(
+            {
+                "tracecat.workspace.id": (
+                    str(role.workspace_id) if role.workspace_id else None
+                ),
+                "tracecat.workflow.id": str(input.run_context.wf_id),
+                "tracecat.workflow.execution.id": str(input.run_context.wf_exec_id),
+                "tracecat.action.name": action_name,
+                "temporal.activity.attempt": act_attempt,
+                "temporal.task_queue": act_info.task_queue,
+            }
+        )
         log.debug(
             "Execute action activity details",
             task=task,

--- a/tracecat/executor/worker.py
+++ b/tracecat/executor/worker.py
@@ -62,6 +62,10 @@ with workflow.unsafe.imports_passed_through():
         shutdown_executor_backend,
     )
     from tracecat.logger import logger
+    from tracecat.observability.otel import (
+        initialize_platform_tracing,
+        shutdown_platform_tracing,
+    )
     from tracecat.observability.sentry import initialize_sentry_from_environment
     from tracecat.registry.sync.workflow import (
         RegistryArtifactsBackfillWorkflow,
@@ -126,6 +130,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
         threadpool_max_workers=threadpool_max_workers,
         executor_backend=config.TRACECAT__EXECUTOR_BACKEND,
     )
+    initialize_platform_tracing("tracecat-executor")
     action_gateway = ActionGateway()
 
     try:
@@ -203,6 +208,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
         await shutdown_executor_backend()
         await close_storage_client_cache()
         await action_gateway.stop()
+        shutdown_platform_tracing()
 
 
 if __name__ == "__main__":

--- a/tracecat/observability/otel.py
+++ b/tracecat/observability/otel.py
@@ -26,7 +26,11 @@ from opentelemetry.trace import Span, TraceFlags
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from starlette.datastructures import MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
-from temporalio.contrib.opentelemetry import TracingInterceptor
+from temporalio.contrib.opentelemetry import (
+    TracingInterceptor,
+    TracingWorkflowInboundInterceptor,
+)
+from temporalio.worker import WorkflowInboundInterceptor, WorkflowInterceptorClassInput
 
 from tracecat import __version__, config
 
@@ -55,6 +59,7 @@ _EXCLUDED_FASTAPI_URLS: Final = ",".join(
 _NEVER_CAPTURE_HTTP_HEADER: Final = r"(?!)"
 _REDACTED_HTTP_PATH: Final = "/[REDACTED]"
 _REDACTED_ATTRIBUTE_VALUE: Final = "[REDACTED]"
+_TRACE_CONTEXT_PROPAGATOR: Final = TraceContextTextMapPropagator()
 
 
 @dataclass(frozen=True)
@@ -121,7 +126,7 @@ def initialize_platform_tracing(
             # Baggage is deliberately excluded from the platform propagation
             # contract so arbitrary caller-provided values do not cross service
             # and Temporal boundaries.
-            set_global_textmap(TraceContextTextMapPropagator())
+            set_global_textmap(_TRACE_CONTEXT_PROPAGATOR)
             _runtime = PlatformTracing(
                 service_name=service_name,
                 tracer_provider=provider,
@@ -168,10 +173,40 @@ def temporal_tracing_interceptor() -> TracingInterceptor | None:
     runtime = get_platform_tracing()
     if runtime is None:
         return None
-    return TracingInterceptor(
+    return _TraceContextOnlyTracingInterceptor(
         tracer=runtime.tracer("tracecat.temporal"),
         always_create_workflow_spans=False,
     )
+
+
+class _TraceContextOnlyWorkflowTracingInterceptor(TracingWorkflowInboundInterceptor):
+    """Extract and inject trace context without persisting OTel baggage."""
+
+    def __init__(self, next_interceptor: WorkflowInboundInterceptor) -> None:
+        super().__init__(next_interceptor)
+        self.text_map_propagator = _TRACE_CONTEXT_PROPAGATOR
+
+
+class _TraceContextOnlyTracingInterceptor(TracingInterceptor):
+    """Temporal tracing interceptor with a trace-context-only carrier."""
+
+    def __init__(
+        self,
+        *,
+        tracer: trace.Tracer,
+        always_create_workflow_spans: bool,
+    ) -> None:
+        super().__init__(
+            tracer=tracer,
+            always_create_workflow_spans=always_create_workflow_spans,
+        )
+        self.text_map_propagator = _TRACE_CONTEXT_PROPAGATOR
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> type[TracingWorkflowInboundInterceptor]:
+        super().workflow_interceptor_class(input)
+        return _TraceContextOnlyWorkflowTracingInterceptor
 
 
 def set_current_span_attributes(attributes: dict[str, str | int | bool | None]) -> None:

--- a/tracecat/observability/otel.py
+++ b/tracecat/observability/otel.py
@@ -7,10 +7,13 @@ settings. Platform services export to the operator-controlled OTLP endpoint.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from threading import Lock
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, Protocol
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -22,14 +25,17 @@ from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
     SpanExporter,
 )
-from opentelemetry.trace import Span, TraceFlags
+from opentelemetry.trace import Link, Span, SpanKind, Status, StatusCode, TraceFlags
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.util.types import Attributes
 from starlette.datastructures import MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from temporalio.api.common.v1 import Payload
 from temporalio.contrib.opentelemetry import (
     TracingInterceptor,
     TracingWorkflowInboundInterceptor,
 )
+from temporalio.exceptions import ApplicationError, ApplicationErrorCategory
 from temporalio.worker import WorkflowInboundInterceptor, WorkflowInterceptorClassInput
 
 from tracecat import __version__, config
@@ -60,6 +66,39 @@ _NEVER_CAPTURE_HTTP_HEADER: Final = r"(?!)"
 _REDACTED_HTTP_PATH: Final = "/[REDACTED]"
 _REDACTED_ATTRIBUTE_VALUE: Final = "[REDACTED]"
 _TRACE_CONTEXT_PROPAGATOR: Final = TraceContextTextMapPropagator()
+_TEMPORAL_FAILURE_TYPE: Final = "temporal.failure"
+
+type _TraceCarrier = dict[str, list[str] | str]
+
+
+class _TemporalInputWithHeaders(Protocol):
+    headers: Mapping[str, Payload]
+
+
+class _CompletedWorkflowSpanInput(Protocol):
+    @property
+    def context(self) -> Mapping[str, list[str] | str]: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def attributes(self) -> Attributes: ...
+
+    @property
+    def time_ns(self) -> int: ...
+
+    @property
+    def link_context(self) -> Mapping[str, list[str] | str] | None: ...
+
+    @property
+    def exception(self) -> Exception | None: ...
+
+    @property
+    def kind(self) -> SpanKind: ...
+
+    @property
+    def parent_missing(self) -> bool: ...
 
 
 @dataclass(frozen=True)
@@ -188,7 +227,7 @@ class _TraceContextOnlyWorkflowTracingInterceptor(TracingWorkflowInboundIntercep
 
 
 class _TraceContextOnlyTracingInterceptor(TracingInterceptor):
-    """Temporal tracing interceptor with a trace-context-only carrier."""
+    """Temporal tracing with a trace-only carrier and sanitized failures."""
 
     def __init__(
         self,
@@ -201,6 +240,77 @@ class _TraceContextOnlyTracingInterceptor(TracingInterceptor):
             always_create_workflow_spans=always_create_workflow_spans,
         )
         self.text_map_propagator = _TRACE_CONTEXT_PROPAGATOR
+
+    @contextmanager
+    def _start_as_current_span(
+        self,
+        name: str,
+        *,
+        attributes: Attributes,
+        input: _TemporalInputWithHeaders | None = None,
+        kind: SpanKind,
+        context: otel_context.Context | None = None,
+    ) -> Iterator[None]:
+        """Create a Temporal span without exporting exception content."""
+        token = otel_context.attach(context) if context else None
+        try:
+            with self.tracer.start_as_current_span(
+                name,
+                attributes=attributes,
+                kind=kind,
+                context=context,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                if input:
+                    input.headers = self._context_to_headers(input.headers)
+                try:
+                    yield None
+                except Exception as exc:
+                    if (
+                        not isinstance(exc, ApplicationError)
+                        or exc.category != ApplicationErrorCategory.BENIGN
+                    ):
+                        span.set_status(Status(status_code=StatusCode.ERROR))
+                        span.set_attribute("error.type", _TEMPORAL_FAILURE_TYPE)
+                    raise
+        finally:
+            if token and context is otel_context.get_current():
+                otel_context.detach(token)
+
+    def _completed_workflow_span(
+        self, params: _CompletedWorkflowSpanInput
+    ) -> _TraceCarrier | None:
+        """Export workflow failures without messages or stack traces."""
+        if params.parent_missing and not self._always_create_workflow_spans:
+            return None
+
+        span_context = self.text_map_propagator.extract(params.context)
+        links: Sequence[Link] = []
+        if params.link_context:
+            link_span = trace.get_current_span(
+                self.text_map_propagator.extract(params.link_context)
+            )
+            if link_span is not trace.INVALID_SPAN:
+                links = [Link(link_span.get_span_context())]
+
+        span = self.tracer.start_span(
+            params.name,
+            span_context,
+            attributes=params.attributes,
+            links=links,
+            start_time=params.time_ns,
+            kind=params.kind,
+        )
+        span_context = trace.set_span_in_context(span, span_context)
+        if params.exception:
+            span.set_status(Status(status_code=StatusCode.ERROR))
+            span.set_attribute("error.type", _TEMPORAL_FAILURE_TYPE)
+        span.end(end_time=params.time_ns)
+
+        carrier: _TraceCarrier = {}
+        self.text_map_propagator.inject(carrier, span_context)
+        return carrier
 
     def workflow_interceptor_class(
         self, input: WorkflowInterceptorClassInput

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -39,6 +39,7 @@ from tracecat.identifiers.workflow import (
     exec_id_to_parts,
 )
 from tracecat.logger import logger
+from tracecat.observability.otel import set_current_span_attributes
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.settings.service import get_setting
@@ -1027,6 +1028,18 @@ async def create_workflow_execution(
                 if defn.registry_lock
                 else None
             ),
+        )
+        set_current_span_attributes(
+            {
+                "tracecat.organization.id": (
+                    str(role.organization_id) if role.organization_id else None
+                ),
+                "tracecat.workspace.id": (
+                    str(role.workspace_id) if role.workspace_id else None
+                ),
+                "tracecat.workflow.id": str(response["wf_id"]),
+                "tracecat.workflow.execution.id": str(response["wf_exec_id"]),
+            }
         )
         return response
     except TracecatValidationError as e:


### PR DESCRIPTION
## Summary

- Initialize platform tracing in the API, Temporal worker, and executor processes.
- Carry W3C trace context across Temporal workflow and activity boundaries.
- Restrict propagated metadata to trace context and sanitize Temporal failure details.
- Add hierarchy, baggage-safety, failure-safety, and unparented-workflow regression coverage.

## Stack

This is the second Tracecat tracing layer.

1. #3273 — platform tracing runtime
2. **#3274 — Temporal propagation**
3. #3275 — webhook-to-agent correlation

## Testing

- `uv run pytest -q --confcutdir=tests/unit tests/unit/test_platform_otel.py` — 13 passed
- `uv run pytest -q --confcutdir=tests/temporal tests/temporal/test_platform_tracing.py` — 3 passed at this layer
- Ruff check and format — passed
- BasedPyright on changed Python files — 0 errors

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 204 | 5 |
| Tests | 228 | 0 |
| **Total** | **432** | **5** |

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
