### PR TITLE
fix(workflow): persist action environment on create and edit

### DIFF
--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -1342,3 +1342,38 @@ async def test_run_workflow_invalid_inputs_raise_before_dispatch(
             WorkflowUUID.new_uuid4(), inputs={"count": "not-an-int"}, use_draft=True
         )
     assert fake_exec.calls == []
+
+
+@pytest.mark.anyio
+async def test_create_actions_from_dsl_persists_action_environment() -> None:
+    """Action-level ``environment`` must survive DSL -> Action control_flow."""
+    role = _role()
+    session = SimpleNamespace(add=MagicMock(), flush=AsyncMock())
+    service = WorkflowsManagementService(cast(Any, session), role=role)
+    dsl = DSLInput.model_validate(
+        {
+            "title": "env",
+            "description": "",
+            "entrypoint": {"ref": "a", "expects": {}},
+            "actions": [
+                {
+                    "ref": "a",
+                    "action": "core.transform.reshape",
+                    "args": {"value": 1},
+                    "environment": "prod",
+                },
+                {
+                    "ref": "b",
+                    "action": "core.transform.reshape",
+                    "args": {"value": 2},
+                    "depends_on": ["a"],
+                },
+            ],
+        }
+    )
+
+    actions = await service.create_actions_from_dsl(dsl, workflow_id=uuid.uuid4())
+
+    by_ref = {a.ref: a for a in actions}
+    assert by_ref["a"].control_flow["environment"] == "prod"
+    assert by_ref["b"].control_flow["environment"] is None

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1590,6 +1590,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 start_delay=act_stmt.start_delay,
                 wait_until=act_stmt.wait_until,
                 join_strategy=act_stmt.join_strategy,
+                environment=act_stmt.environment,
                 mask_output=act_stmt.mask_output,
             )
             pos = (action_positions or {}).get(act_stmt.ref)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persist action-level environment from the workflow DSL into each action’s control_flow on create and paths that rebuild actions, so actions run in the configured environment. Previously the DSL environment was dropped and control_flow.environment defaulted to None, causing actions to run in the default environment.

- Set environment in control_flow when building from DSL via create_actions_from_dsl.
- Add a unit test that preserves environment "prod" when provided and leaves it None when omitted.
- No schema or API changes; no migration required.

<sup>Written for commit 6f5a9c39370e61f29615fd5cd57893040821fc2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

