### PR TITLE
feat(ui): make version history shell host-configurable

### DIFF
--- a/frontend/src/components/version-history/types.ts
+++ b/frontend/src/components/version-history/types.ts
@@ -24,7 +24,12 @@ export interface VersionHistoryEntry {
   description?: string
   /** ISO 8601 creation timestamp of the version. */
   createdAt: string
-  /** True when this version is the one the document currently points at. */
+  /**
+   * True when this entry is current within its host-defined version stream.
+   * When provided, this takes precedence over the document descriptor's
+   * `currentVersionId` fallback, allowing hosts to mark multiple current
+   * entries (for example, one per independently versioned field).
+   */
   isCurrent?: boolean
 }
 
@@ -78,7 +83,11 @@ export interface VersionedDocumentDescriptor {
   entityLabel: string
   /** Display name of this particular document. */
   name: string
-  /** Version the document currently points at. Null when never published. */
+  /**
+   * Current version fallback for entries without an explicit `isCurrent`.
+   * Null when there is no single current version, including hosts with
+   * multiple independently versioned streams.
+   */
   currentVersionId: string | null
 }
 

--- a/frontend/src/components/version-history/version-history-menu.tsx
+++ b/frontend/src/components/version-history/version-history-menu.tsx
@@ -46,7 +46,11 @@ export type VersionHistoryMenuProps = {
   renderVersionDiff: (versionId: string) => ReactNode
   /** Human-readable kind of document used in copy, e.g. `agent` or `skill`. */
   entityLabel: string
-  /** Optional host-owned controls rendered above the version list. */
+  /**
+   * Optional host-owned menu controls rendered above the version list.
+   * Interactive controls must use menu-aware primitives such as
+   * `DropdownMenuItem` so they participate in the menu's keyboard focus model.
+   */
   listControls?: ReactNode
   /**
    * Renders comparison copy for the selected entry. Defaults to comparing the
@@ -248,7 +252,7 @@ export function VersionHistoryMenu({
             <DropdownMenuSeparator className="mx-0 my-0" />
             {listControls !== undefined && listControls !== null ? (
               <>
-                <div className="px-3 py-2">{listControls}</div>
+                {listControls}
                 <DropdownMenuSeparator className="mx-0 my-0" />
               </>
             ) : null}

--- a/frontend/src/components/version-history/version-history-menu.tsx
+++ b/frontend/src/components/version-history/version-history-menu.tsx
@@ -46,6 +46,20 @@ export type VersionHistoryMenuProps = {
   renderVersionDiff: (versionId: string) => ReactNode
   /** Human-readable kind of document used in copy, e.g. `agent` or `skill`. */
   entityLabel: string
+  /** Optional host-owned controls rendered above the version list. */
+  listControls?: ReactNode
+  /**
+   * Renders comparison copy for the selected entry. Defaults to comparing the
+   * entry with the document's current draft.
+   */
+  renderComparisonDescription?: (version: VersionHistoryEntry) => ReactNode
+  /**
+   * Renders restore-confirmation copy for the selected entry. Defaults to the
+   * existing warning that unsaved changes will be replaced.
+   */
+  renderRestoreConfirmationDescription?: (
+    version: VersionHistoryEntry
+  ) => ReactNode
   /** Versions to list in the dropdown, newest first. */
   versions: VersionHistoryEntry[]
   /** True while the version list is being fetched. */
@@ -69,6 +83,8 @@ export type VersionHistoryMenuProps = {
    * stays open and dismissible.
    */
   restoreDisabled?: boolean
+  /** Disables restore when the selected entry matches a host-owned condition. */
+  isRestoreDisabled?: (version: VersionHistoryEntry) => boolean
   /** Horizontal alignment of the dropdown relative to the trigger. */
   align?: "start" | "end"
 }
@@ -84,12 +100,16 @@ export function VersionHistoryMenu({
   document: documentDescriptor,
   renderVersionDiff,
   entityLabel,
+  listControls,
+  renderComparisonDescription,
+  renderRestoreConfirmationDescription,
   versions,
   isLoading,
   loadError,
   onRestore,
   disabled,
   restoreDisabled,
+  isRestoreDisabled,
   align = "end",
 }: VersionHistoryMenuProps) {
   const [selectedVersion, setSelectedVersion] =
@@ -175,6 +195,29 @@ export function VersionHistoryMenu({
     setSelectedVersion(null)
   }
 
+  function renderDialogDescription(): ReactNode {
+    if (!selectedVersion) {
+      return "Restoring replaces unsaved changes."
+    }
+
+    const comparison = renderComparisonDescription
+      ? renderComparisonDescription(selectedVersion)
+      : `Compare ${selectedVersion.label} with the current draft of ${documentDescriptor.name}.`
+    const confirmation = renderRestoreConfirmationDescription
+      ? renderRestoreConfirmationDescription(selectedVersion)
+      : "Restoring replaces unsaved changes."
+
+    return (
+      <>
+        {comparison} {confirmation}
+      </>
+    )
+  }
+
+  const selectedRestoreDisabled = selectedVersion
+    ? Boolean(isRestoreDisabled?.(selectedVersion))
+    : false
+
   return (
     <>
       <DropdownMenu>
@@ -203,6 +246,12 @@ export function VersionHistoryMenu({
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator className="mx-0 my-0" />
+            {listControls !== undefined && listControls !== null ? (
+              <>
+                <div className="px-3 py-2">{listControls}</div>
+                <DropdownMenuSeparator className="mx-0 my-0" />
+              </>
+            ) : null}
             {renderVersionList()}
           </div>
         </DropdownMenuContent>
@@ -220,9 +269,7 @@ export function VersionHistoryMenu({
           <AlertDialogHeader>
             <AlertDialogTitle>Restore version</AlertDialogTitle>
             <AlertDialogDescription>
-              {selectedVersion
-                ? `Compare ${selectedVersion.label} with the current draft of ${documentDescriptor.name}. Restoring replaces unsaved changes.`
-                : "Restoring replaces unsaved changes."}
+              {renderDialogDescription()}
             </AlertDialogDescription>
           </AlertDialogHeader>
           {selectedVersion ? (
@@ -239,7 +286,9 @@ export function VersionHistoryMenu({
                 event.preventDefault()
                 void handleConfirmRestore()
               }}
-              disabled={restorePending || restoreDisabled}
+              disabled={
+                restorePending || restoreDisabled || selectedRestoreDisabled
+              }
             >
               {restorePending ? (
                 <>

--- a/frontend/tests/version-history-menu.test.tsx
+++ b/frontend/tests/version-history-menu.test.tsx
@@ -117,9 +117,12 @@ describe("VersionHistoryMenu", () => {
     expect(screen.queryByText("No versions yet.")).not.toBeInTheDocument()
   })
 
-  it("lists versions and marks the current one", async () => {
+  it("lists versions, marks the current one, and disables its restore", async () => {
     const user = userEvent.setup()
-    renderMenu()
+    const isRestoreDisabled = jest.fn(
+      (version: VersionHistoryEntry) => version.isCurrent === true
+    )
+    renderMenu({ isRestoreDisabled })
 
     await openDropdown(user)
 
@@ -127,21 +130,45 @@ describe("VersionHistoryMenu", () => {
     expect(screen.getByText("v1")).toBeInTheDocument()
     expect(screen.getByText("2 files")).toBeInTheDocument()
     expect(screen.getByText("Current")).toBeInTheDocument()
+
+    await user.click(screen.getByText("v2"))
+
+    expect(isRestoreDisabled).toHaveBeenCalledWith(VERSIONS[0])
+    expect(
+      screen.getByRole("button", { name: "Restore version" })
+    ).toBeDisabled()
   })
 
   it("invokes renderVersionDiff with the selected version id", async () => {
     const user = userEvent.setup()
-    const props = renderMenu()
+    const renderComparisonDescription = jest.fn(
+      (version: VersionHistoryEntry) =>
+        `Compare ${version.label} with its predecessor.`
+    )
+    const renderRestoreConfirmationDescription = jest.fn(
+      (version: VersionHistoryEntry) =>
+        `Restoring ${version.label} replaces the current value.`
+    )
+    const props = renderMenu({
+      listControls: <div>Field filters</div>,
+      renderComparisonDescription,
+      renderRestoreConfirmationDescription,
+    })
 
     await openDropdown(user)
+    expect(screen.getByText("Field filters")).toBeInTheDocument()
     await user.click(screen.getByText("v1"))
 
     expect(screen.getByRole("alertdialog")).toBeInTheDocument()
     expect(props.renderVersionDiff).toHaveBeenCalledWith("ver-1")
     expect(screen.getByTestId("diff-body")).toHaveTextContent("ver-1")
+    expect(renderComparisonDescription).toHaveBeenCalledWith(VERSIONS[1])
+    expect(renderRestoreConfirmationDescription).toHaveBeenCalledWith(
+      VERSIONS[1]
+    )
     expect(
       screen.getByText(
-        "Compare v1 with the current draft of Triage agent. Restoring replaces unsaved changes."
+        "Compare v1 with its predecessor. Restoring v1 replaces the current value."
       )
     ).toBeInTheDocument()
   })
@@ -229,6 +256,11 @@ describe("VersionHistoryMenu", () => {
     await openDropdown(user)
     await user.click(screen.getByText("v1"))
 
+    expect(
+      screen.getByText(
+        "Compare v1 with the current draft of Triage agent. Restoring replaces unsaved changes."
+      )
+    ).toBeInTheDocument()
     expect(screen.getByText("Current draft → v1")).toBeInTheDocument()
     expect(screen.getByTestId("inline-diff-view")).toHaveTextContent(
       "instructions.md"

--- a/frontend/tests/version-history-menu.test.tsx
+++ b/frontend/tests/version-history-menu.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import type {
   VersionFileEntry,
@@ -150,13 +151,17 @@ describe("VersionHistoryMenu", () => {
         `Restoring ${version.label} replaces the current value.`
     )
     const props = renderMenu({
-      listControls: <div>Field filters</div>,
+      listControls: <DropdownMenuItem>Field filters</DropdownMenuItem>,
       renderComparisonDescription,
       renderRestoreConfirmationDescription,
     })
 
     await openDropdown(user)
-    expect(screen.getByText("Field filters")).toBeInTheDocument()
+    const listControls = screen.getByRole("menuitem", {
+      name: "Field filters",
+    })
+    await user.keyboard("{ArrowDown}")
+    expect(listControls).toHaveFocus()
     await user.click(screen.getByText("v1"))
 
     expect(screen.getByRole("alertdialog")).toBeInTheDocument()


### PR DESCRIPTION
## Summary

- add an optional host-owned controls slot above the shared version list
- let hosts customize selected-version comparison and restore-confirmation copy
- support selected-entry restore disabling while keeping entries reviewable
- preserve existing agent-preset defaults and clarify multi-stream current markers

## Testing

- `./node_modules/.bin/jest --runInBand tests/version-history-menu.test.tsx tests/agent-preset-version-history.test.tsx` (16 tests passed)
- `./node_modules/.bin/tsc --noEmit --incremental`
- frontend Biome and typecheck pre-commit hooks

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | +64 | -6 |
| Tests | +36 | -4 |

## Tracking

- [ENG-1675](https://linear.app/tracecat/issue/ENG-1675/featui-make-version-history-shell-host-configurable)
