### PR TITLE
feat(cases): add case version history and restore APIs

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9521,6 +9521,170 @@ export const $CaseUpdate = {
   title: "CaseUpdate",
 } as const
 
+export const $CaseVersionActorRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    email: {
+      type: "string",
+      title: "Email",
+    },
+    first_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "First Name",
+    },
+    last_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Name",
+    },
+  },
+  type: "object",
+  required: ["id", "email"],
+  title: "CaseVersionActorRead",
+  description: "Minimal user metadata for a case-version author.",
+} as const
+
+export const $CaseVersionCompareRead = {
+  properties: {
+    selected: {
+      $ref: "#/components/schemas/CaseVersionContentRead",
+    },
+    predecessor: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseVersionContentRead",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  type: "object",
+  required: ["selected"],
+  title: "CaseVersionCompareRead",
+  description:
+    "A selected case version and its immediate same-field predecessor.",
+} as const
+
+export const $CaseVersionContentRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    field: {
+      $ref: "#/components/schemas/CaseVersionField",
+    },
+    version: {
+      type: "integer",
+      title: "Version",
+    },
+    content: {
+      type: "string",
+      title: "Content",
+    },
+  },
+  type: "object",
+  required: ["id", "field", "version", "content"],
+  title: "CaseVersionContentRead",
+  description: "Content for one immutable case field version.",
+} as const
+
+export const $CaseVersionField = {
+  type: "string",
+  enum: ["summary", "description"],
+  title: "CaseVersionField",
+  description: "Case text fields that have immutable version history.",
+} as const
+
+export const $CaseVersionReadMinimal = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    field: {
+      $ref: "#/components/schemas/CaseVersionField",
+    },
+    version: {
+      type: "integer",
+      title: "Version",
+    },
+    actor: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseVersionActorRead",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    is_latest: {
+      type: "boolean",
+      title: "Is Latest",
+      description: "Whether this is the latest immutable version for its field",
+    },
+  },
+  type: "object",
+  required: ["id", "field", "version", "created_at", "is_latest"],
+  title: "CaseVersionReadMinimal",
+  description: "Version metadata returned by the case history endpoint.",
+} as const
+
+export const $CaseVersionRestoreRead = {
+  properties: {
+    restored: {
+      type: "boolean",
+      title: "Restored",
+      default: true,
+    },
+    case_id: {
+      type: "string",
+      format: "uuid",
+      title: "Case Id",
+    },
+    restored_from_version_id: {
+      type: "string",
+      format: "uuid",
+      title: "Restored From Version Id",
+    },
+    field: {
+      $ref: "#/components/schemas/CaseVersionField",
+    },
+  },
+  type: "object",
+  required: ["case_id", "restored_from_version_id", "field"],
+  title: "CaseVersionRestoreRead",
+  description:
+    "Confirmation that a historical case field version was restored.",
+} as const
+
 export const $CaseViewedEventRead = {
   properties: {
     wf_exec_id: {
@@ -11303,6 +11467,69 @@ export const $CursorPaginatedResponse_CaseTableRowRead_ = {
   type: "object",
   required: ["items"],
   title: "CursorPaginatedResponse[CaseTableRowRead]",
+} as const
+
+export const $CursorPaginatedResponse_CaseVersionReadMinimal_ = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/CaseVersionReadMinimal",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CursorPaginatedResponse[CaseVersionReadMinimal]",
 } as const
 
 export const $CursorPaginatedResponse_InboxItemRead_ = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -314,6 +314,8 @@ import type {
   CasesBatchDeleteCasesResponse,
   CasesBatchUpdateCasesData,
   CasesBatchUpdateCasesResponse,
+  CasesCompareCaseVersionData,
+  CasesCompareCaseVersionResponse,
   CasesCreateCaseData,
   CasesCreateCaseResponse,
   CasesCreateCommentData,
@@ -342,6 +344,8 @@ import type {
   CasesListCaseRowsResponse,
   CasesListCasesData,
   CasesListCasesResponse,
+  CasesListCaseVersionsData,
+  CasesListCaseVersionsResponse,
   CasesListCommentsData,
   CasesListCommentsResponse,
   CasesListCommentThreadsData,
@@ -356,6 +360,8 @@ import type {
   CasesListTasksResponse,
   CasesRemoveTagData,
   CasesRemoveTagResponse,
+  CasesRestoreCaseVersionData,
+  CasesRestoreCaseVersionResponse,
   CasesSearchCaseAggregatesData,
   CasesSearchCaseAggregatesResponse,
   CasesSearchCasesData,
@@ -9809,6 +9815,93 @@ export const casesBatchDeleteCases = (
     },
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Case Versions
+ * List immutable case field versions newest-first.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.workspaceId
+ * @param data.limit Maximum items per page
+ * @param data.cursor Cursor for pagination
+ * @param data.field Optionally include only summary or description versions
+ * @returns CursorPaginatedResponse_CaseVersionReadMinimal_ Successful Response
+ * @throws ApiError
+ */
+export const casesListCaseVersions = (
+  data: CasesListCaseVersionsData
+): CancelablePromise<CasesListCaseVersionsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions",
+    path: {
+      case_id: data.caseId,
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      limit: data.limit,
+      cursor: data.cursor,
+      field: data.field,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Compare Case Version
+ * Compare a case field version with its immediate predecessor.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.versionId
+ * @param data.workspaceId
+ * @returns CaseVersionCompareRead Successful Response
+ * @throws ApiError
+ */
+export const casesCompareCaseVersion = (
+  data: CasesCompareCaseVersionData
+): CancelablePromise<CasesCompareCaseVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/compare",
+    path: {
+      case_id: data.caseId,
+      version_id: data.versionId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Restore Case Version
+ * Restore one historical case field version atomically.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.versionId
+ * @param data.workspaceId
+ * @returns CaseVersionRestoreRead Successful Response
+ * @throws ApiError
+ */
+export const casesRestoreCaseVersion = (
+  data: CasesRestoreCaseVersionData
+): CancelablePromise<CasesRestoreCaseVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/restore",
+    path: {
+      case_id: data.caseId,
+      version_id: data.versionId,
+      workspace_id: data.workspaceId,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2526,6 +2526,64 @@ export type CaseUpdate = {
 }
 
 /**
+ * Minimal user metadata for a case-version author.
+ */
+export type CaseVersionActorRead = {
+  id: string
+  email: string
+  first_name?: string | null
+  last_name?: string | null
+}
+
+/**
+ * A selected case version and its immediate same-field predecessor.
+ */
+export type CaseVersionCompareRead = {
+  selected: CaseVersionContentRead
+  predecessor?: CaseVersionContentRead | null
+}
+
+/**
+ * Content for one immutable case field version.
+ */
+export type CaseVersionContentRead = {
+  id: string
+  field: CaseVersionField
+  version: number
+  content: string
+}
+
+/**
+ * Case text fields that have immutable version history.
+ */
+export type CaseVersionField = "summary" | "description"
+
+/**
+ * Version metadata returned by the case history endpoint.
+ */
+export type CaseVersionReadMinimal = {
+  id: string
+  field: CaseVersionField
+  version: number
+  actor?: CaseVersionActorRead | null
+  created_at: string
+  /**
+   * Whether this is the latest immutable version for its field
+   */
+  is_latest: boolean
+}
+
+/**
+ * Confirmation that a historical case field version was restored.
+ */
+export type CaseVersionRestoreRead = {
+  restored?: boolean
+  case_id: string
+  restored_from_version_id: string
+  field: CaseVersionField
+}
+
+/**
  * Event for when a case is viewed.
  */
 export type CaseViewedEventRead = {
@@ -3188,6 +3246,30 @@ export type CursorPaginatedResponse_CaseReadMinimal_ = {
 
 export type CursorPaginatedResponse_CaseTableRowRead_ = {
   items: Array<CaseTableRowRead>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+}
+
+export type CursorPaginatedResponse_CaseVersionReadMinimal_ = {
+  items: Array<CaseVersionReadMinimal>
   /**
    * Cursor for next page
    */
@@ -13003,6 +13085,42 @@ export type CasesBatchDeleteCasesData = {
 
 export type CasesBatchDeleteCasesResponse = CaseBatchResponse
 
+export type CasesListCaseVersionsData = {
+  caseId: string
+  /**
+   * Cursor for pagination
+   */
+  cursor?: string | null
+  /**
+   * Optionally include only summary or description versions
+   */
+  field?: CaseVersionField | null
+  /**
+   * Maximum items per page
+   */
+  limit?: number
+  workspaceId: string
+}
+
+export type CasesListCaseVersionsResponse =
+  CursorPaginatedResponse_CaseVersionReadMinimal_
+
+export type CasesCompareCaseVersionData = {
+  caseId: string
+  versionId: string
+  workspaceId: string
+}
+
+export type CasesCompareCaseVersionResponse = CaseVersionCompareRead
+
+export type CasesRestoreCaseVersionData = {
+  caseId: string
+  versionId: string
+  workspaceId: string
+}
+
+export type CasesRestoreCaseVersionResponse = CaseVersionRestoreRead
+
 export type CasesGetCaseData = {
   caseId: string
   /**
@@ -18850,6 +18968,51 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: CaseBatchResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions": {
+    get: {
+      req: CasesListCaseVersionsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CursorPaginatedResponse_CaseVersionReadMinimal_
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/compare": {
+    get: {
+      req: CasesCompareCaseVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseVersionCompareRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/restore": {
+    post: {
+      req: CasesRestoreCaseVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseVersionRestoreRead
         /**
          * Validation Error
          */

--- a/tests/integration/test_case_versions.py
+++ b/tests/integration/test_case_versions.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
@@ -26,7 +27,9 @@ from tracecat.cases.enums import (
 from tracecat.cases.schemas import CaseCreate, CaseUpdate
 from tracecat.cases.service import CasesService
 from tracecat.cases.versions.service import CaseVersionsService
-from tracecat.db.models import Case, CaseVersion, User, Workspace
+from tracecat.db.models import Case, CaseEvent, CaseVersion, User, Workspace
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.pagination import PageParams
 
 pytestmark = [
     pytest.mark.anyio,
@@ -203,3 +206,337 @@ async def test_concurrent_case_version_allocation(svc_role: Role) -> None:
             assert versions.all() == [1, 2, 3]
     finally:
         await engine.dispose()
+
+
+async def test_case_version_history_pagination_filter_and_compare(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """History stays stable across tied timestamps and exposes predecessor content."""
+    assert svc_role.user_id is not None
+    actor_email = f"case-history-{svc_role.user_id}@example.com"
+    session.add(
+        User(
+            id=svc_role.user_id,
+            email=actor_email,
+            hashed_password="hashed",
+        )
+    )
+    await session.flush()
+
+    service = CasesService(session=session, role=svc_role)
+    case = await service.create_case(
+        CaseCreate(
+            summary="Summary v1",
+            description="Description v1",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+    await service.update_case(case, CaseUpdate(summary="Summary v2"))
+    await service.update_case(case, CaseUpdate(description="Description v2"))
+
+    tied_timestamp = datetime(2026, 1, 1, tzinfo=UTC)
+    await session.execute(
+        update(CaseVersion)
+        .where(CaseVersion.case_id == case.id)
+        .values(created_at=tied_timestamp)
+    )
+    await session.commit()
+
+    expected_ids = list(
+        (
+            await session.execute(
+                select(CaseVersion.id)
+                .where(CaseVersion.case_id == case.id)
+                .order_by(
+                    CaseVersion.created_at.desc(),
+                    CaseVersion.surrogate_id.desc(),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    history_ids: list[uuid.UUID] = []
+    history = []
+    cursor: str | None = None
+    while True:
+        page = await service.versions.list_versions(
+            case_id=case.id,
+            page=PageParams(limit=1, cursor=cursor),
+        )
+        history.extend(page.items)
+        history_ids.extend(item.id for item in page.items)
+        cursor = page.next_cursor
+        if cursor is None:
+            break
+
+    assert history_ids == expected_ids
+    assert len(history_ids) == len(set(history_ids)) == 4
+    assert {item.field for item in history if item.is_latest} == {
+        CaseVersionField.SUMMARY,
+        CaseVersionField.DESCRIPTION,
+    }
+    assert {item.actor.email for item in history if item.actor is not None} == {
+        actor_email
+    }
+    assert all("content" not in item.model_dump() for item in history)
+
+    summary_history = await service.versions.list_versions(
+        case_id=case.id,
+        page=PageParams(limit=10),
+        field=CaseVersionField.SUMMARY,
+    )
+    assert [item.version for item in summary_history.items] == [2, 1]
+    assert [item.is_latest for item in summary_history.items] == [True, False]
+
+    summary_versions = (
+        (
+            await session.execute(
+                select(CaseVersion)
+                .where(
+                    CaseVersion.case_id == case.id,
+                    CaseVersion.field == CaseVersionField.SUMMARY,
+                )
+                .order_by(CaseVersion.version)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    baseline = await service.versions.compare_with_predecessor(
+        case_id=case.id,
+        version_id=summary_versions[0].id,
+    )
+    assert baseline is not None
+    assert baseline.selected.content == "Summary v1"
+    assert baseline.predecessor is None
+
+    comparison = await service.versions.compare_with_predecessor(
+        case_id=case.id,
+        version_id=summary_versions[1].id,
+    )
+    assert comparison is not None
+    assert comparison.selected.content == "Summary v2"
+    assert comparison.predecessor is not None
+    assert comparison.predecessor.content == "Summary v1"
+
+    other_case = await service.create_case(
+        CaseCreate(
+            summary="Other summary",
+            description="Other description",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+    assert (
+        await service.versions.compare_with_predecessor(
+            case_id=other_case.id,
+            version_id=summary_versions[1].id,
+        )
+        is None
+    )
+
+
+async def test_restore_case_version_is_scoped_append_only_and_atomic(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Restore updates one field, appends history, and rolls back with activity."""
+    assert svc_role.user_id is not None
+    session.add(
+        User(
+            id=svc_role.user_id,
+            email=f"case-restore-{svc_role.user_id}@example.com",
+            hashed_password="hashed",
+        )
+    )
+    await session.flush()
+
+    service = CasesService(session=session, role=svc_role)
+    case = await service.create_case(
+        CaseCreate(
+            summary="Summary v1",
+            description="Description v1",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+    await service.update_case(
+        case,
+        CaseUpdate(summary="Summary v2", description="Description v2"),
+    )
+    summary_v1 = await session.scalar(
+        select(CaseVersion).where(
+            CaseVersion.case_id == case.id,
+            CaseVersion.field == CaseVersionField.SUMMARY,
+            CaseVersion.version == 1,
+        )
+    )
+    assert summary_v1 is not None
+    event_count_before = await session.scalar(
+        select(func.count()).select_from(CaseEvent).where(CaseEvent.case_id == case.id)
+    )
+    assert event_count_before is not None
+
+    restored = await service.restore_version(
+        case_id=case.id,
+        version_id=summary_v1.id,
+    )
+    assert restored.restored is True
+    assert restored.field == CaseVersionField.SUMMARY
+
+    await session.refresh(case)
+    assert case.summary == "Summary v1"
+    assert case.description == "Description v2"
+    summary_history = (
+        (
+            await session.execute(
+                select(CaseVersion)
+                .where(
+                    CaseVersion.case_id == case.id,
+                    CaseVersion.field == CaseVersionField.SUMMARY,
+                )
+                .order_by(CaseVersion.version)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [(item.version, item.content) for item in summary_history] == [
+        (1, "Summary v1"),
+        (2, "Summary v2"),
+        (3, "Summary v1"),
+    ]
+    assert summary_history[-1].user_id == svc_role.user_id
+    assert summary_history[0].content == "Summary v1"
+    restored_case_id = case.id
+    summary_v2_id = summary_history[1].id
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(CaseEvent)
+            .where(CaseEvent.case_id == case.id)
+        )
+        == event_count_before + 1
+    )
+    await service.restore_version(
+        case_id=restored_case_id,
+        version_id=summary_v1.id,
+    )
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(CaseVersion)
+            .where(
+                CaseVersion.case_id == restored_case_id,
+                CaseVersion.field == CaseVersionField.SUMMARY,
+            )
+        )
+        == 4
+    )
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(CaseEvent)
+            .where(CaseEvent.case_id == restored_case_id)
+        )
+        == event_count_before + 2
+    )
+
+    other_case = await service.create_case(
+        CaseCreate(
+            summary="Other summary",
+            description="Other description",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+    other_version_id = await session.scalar(
+        select(CaseVersion.id).where(
+            CaseVersion.case_id == other_case.id,
+            CaseVersion.field == CaseVersionField.SUMMARY,
+        )
+    )
+    assert other_version_id is not None
+    with pytest.raises(TracecatNotFoundError):
+        await service.restore_version(
+            case_id=restored_case_id,
+            version_id=other_version_id,
+        )
+
+    foreign_workspace_id = uuid.uuid4()
+    foreign_case_id = uuid.uuid4()
+    foreign_version_id = uuid.uuid4()
+    assert svc_role.organization_id is not None
+    session.add_all(
+        [
+            Workspace(
+                id=foreign_workspace_id,
+                name="foreign-case-version-workspace",
+                organization_id=svc_role.organization_id,
+            ),
+            Case(
+                id=foreign_case_id,
+                workspace_id=foreign_workspace_id,
+                case_number=1,
+                summary="Foreign summary",
+                description="Foreign description",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            ),
+            CaseVersion(
+                id=foreign_version_id,
+                workspace_id=foreign_workspace_id,
+                case_id=foreign_case_id,
+                field=CaseVersionField.SUMMARY,
+                version=1,
+                content="Foreign summary",
+            ),
+        ]
+    )
+    await session.commit()
+    with pytest.raises(TracecatNotFoundError):
+        await service.restore_version(
+            case_id=restored_case_id,
+            version_id=foreign_version_id,
+        )
+
+    failing_service = CasesService(session=session, role=svc_role)
+    with (
+        patch.object(
+            failing_service.events,
+            "create_event",
+            new=AsyncMock(side_effect=RuntimeError("activity write failed")),
+        ),
+        pytest.raises(RuntimeError, match="activity write failed"),
+    ):
+        await failing_service.restore_version(
+            case_id=restored_case_id,
+            version_id=summary_v2_id,
+        )
+
+    await session.refresh(case)
+    assert case.summary == "Summary v1"
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(CaseVersion)
+            .where(
+                CaseVersion.case_id == restored_case_id,
+                CaseVersion.field == CaseVersionField.SUMMARY,
+            )
+        )
+        == 4
+    )
+    test_workspace = await session.scalar(
+        select(Workspace).where(Workspace.id == svc_role.workspace_id)
+    )
+    assert test_workspace is not None
+    await session.refresh(test_workspace)

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -19,6 +19,7 @@ from tracecat.cases.enums import (
     CasePriority,
     CaseSeverity,
     CaseStatus,
+    CaseVersionField,
 )
 from tracecat.cases.schemas import (
     CaseBatchItemResult,
@@ -29,11 +30,18 @@ from tracecat.cases.schemas import (
     CaseSearchAggregateRead,
     CaseStatusGroupCounts,
 )
+from tracecat.cases.versions.schemas import (
+    CaseVersionCompareRead,
+    CaseVersionContentRead,
+    CaseVersionReadMinimal,
+    CaseVersionRestoreRead,
+)
 from tracecat.contexts import ctx_role
 from tracecat.db.models import Case, CaseTag, Workspace
 from tracecat.exceptions import (
     EntitlementRequired,
     TracecatConflictError,
+    TracecatNotFoundError,
     TracecatValidationError,
 )
 from tracecat.pagination import CursorPaginatedResponse
@@ -755,6 +763,162 @@ async def test_update_case_success(
 
         # Verify service was called
         mock_svc.update_case.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_list_case_versions_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """GET case versions forwards pagination and field filters."""
+    version_id = uuid.uuid4()
+    version = CaseVersionReadMinimal(
+        id=version_id,
+        field=CaseVersionField.SUMMARY,
+        version=2,
+        created_at=datetime(2024, 1, 2, tzinfo=UTC),
+        is_latest=True,
+    )
+    response_page = CursorPaginatedResponse(
+        items=[version],
+        has_more=False,
+        has_previous=False,
+    )
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_case.return_value = mock_case
+        mock_service.versions.list_versions.return_value = response_page
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            f"/cases/{mock_case.id}/versions",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "limit": 25,
+                "field": "summary",
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["items"][0] == {
+        "id": str(version_id),
+        "field": "summary",
+        "version": 2,
+        "actor": None,
+        "created_at": "2024-01-02T00:00:00Z",
+        "is_latest": True,
+    }
+    call = mock_service.versions.list_versions.await_args
+    assert call.kwargs["case_id"] == mock_case.id
+    assert call.kwargs["field"] == CaseVersionField.SUMMARY
+    assert call.kwargs["page"].limit == 25
+
+
+@pytest.mark.anyio
+async def test_list_case_versions_missing_case_returns_404(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Version history does not treat a missing case as empty history."""
+    case_id = uuid.uuid4()
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_case.return_value = None
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            f"/cases/{case_id}/versions",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    mock_service.versions.list_versions.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_compare_case_version_success_and_mismatch_404(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Compare serializes predecessor content and hides mismatched versions."""
+    selected_id = uuid.uuid4()
+    predecessor_id = uuid.uuid4()
+    comparison = CaseVersionCompareRead(
+        selected=CaseVersionContentRead(
+            id=selected_id,
+            field=CaseVersionField.DESCRIPTION,
+            version=2,
+            content="New body",
+        ),
+        predecessor=CaseVersionContentRead(
+            id=predecessor_id,
+            field=CaseVersionField.DESCRIPTION,
+            version=1,
+            content="Old body",
+        ),
+    )
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.versions.compare_with_predecessor.side_effect = [
+            comparison,
+            None,
+        ]
+        mock_service_cls.return_value = mock_service
+
+        success = client.get(
+            f"/cases/{mock_case.id}/versions/{selected_id}/compare",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+        missing = client.get(
+            f"/cases/{mock_case.id}/versions/{uuid.uuid4()}/compare",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert success.status_code == status.HTTP_200_OK
+    assert success.json()["predecessor"]["content"] == "Old body"
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_restore_case_version_success_and_mismatch_404(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Restore returns a typed confirmation and maps scoped misses to 404."""
+    version_id = uuid.uuid4()
+    restored = CaseVersionRestoreRead(
+        case_id=mock_case.id,
+        restored_from_version_id=version_id,
+        field=CaseVersionField.SUMMARY,
+    )
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.restore_version.side_effect = [
+            restored,
+            TracecatNotFoundError("Case version not found"),
+        ]
+        mock_service_cls.return_value = mock_service
+
+        success = client.post(
+            f"/cases/{mock_case.id}/versions/{version_id}/restore",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+        missing = client.post(
+            f"/cases/{mock_case.id}/versions/{uuid.uuid4()}/restore",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert success.status_code == status.HTTP_200_OK
+    assert success.json() == {
+        "restored": True,
+        "case_id": str(mock_case.id),
+        "restored_from_version_id": str(version_id),
+        "field": "summary",
+    }
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_case_versions_service.py
+++ b/tests/unit/test_case_versions_service.py
@@ -1,0 +1,66 @@
+"""Authorization tests for case version services."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.cases.service import CasesService
+from tracecat.cases.versions.service import CaseVersionsService
+from tracecat.exceptions import ScopeDeniedError
+from tracecat.pagination import PageParams
+
+
+def _role_with_scopes(*scopes: str) -> Role:
+    return Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        scopes=frozenset(scopes),
+    )
+
+
+@pytest.mark.anyio
+async def test_case_version_reads_require_case_read() -> None:
+    """List, selected-version, and compare reads enforce case:read."""
+    session = AsyncSession()
+    service = CaseVersionsService(session, _role_with_scopes())
+    case_id = uuid.uuid4()
+    version_id = uuid.uuid4()
+    try:
+        with pytest.raises(ScopeDeniedError):
+            await service.list_versions(
+                case_id=case_id,
+                page=PageParams(limit=1),
+            )
+        with pytest.raises(ScopeDeniedError):
+            await service.get_version(
+                case_id=case_id,
+                version_id=version_id,
+            )
+        with pytest.raises(ScopeDeniedError):
+            await service.compare_with_predecessor(
+                case_id=case_id,
+                version_id=version_id,
+            )
+    finally:
+        await session.close()
+
+
+@pytest.mark.anyio
+async def test_case_version_restore_requires_case_update() -> None:
+    """Restoring a version rejects a read-only role at the service boundary."""
+    session = AsyncSession()
+    service = CasesService(session, _role_with_scopes("case:read"))
+    try:
+        with pytest.raises(ScopeDeniedError):
+            await service.restore_version(
+                case_id=uuid.uuid4(),
+                version_id=uuid.uuid4(),
+            )
+    finally:
+        await session.close()

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -12,6 +12,7 @@ from tracecat.agent.folders import router as agent_folder_router
 from tracecat.agent.preset import router as agent_preset_router
 from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
 from tracecat.auth.types import Role
+from tracecat.cases import router as cases_router
 from tracecat.cases.dropdowns import router as case_dropdowns_router
 from tracecat.cases.durations import router as case_durations_router
 from tracecat.cases.rows import router as case_rows_router
@@ -361,6 +362,21 @@ async def test_workspace_collection_scope_guards(endpoint: AsyncEndpoint) -> Non
     ],
 )
 async def test_case_duration_scope_guards(
+    endpoint: AsyncEndpoint, required_scope: str
+) -> None:
+    await _assert_endpoint_requires_scope(endpoint, required_scope)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("endpoint", "required_scope"),
+    [
+        (cases_router.list_case_versions, "case:read"),
+        (cases_router.compare_case_version, "case:read"),
+        (cases_router.restore_case_version, "case:update"),
+    ],
+)
+async def test_case_version_scope_guards(
     endpoint: AsyncEndpoint, required_scope: str
 ) -> None:
     await _assert_endpoint_requires_scope(endpoint, required_scope)

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -23,7 +23,12 @@ from tracecat.auth.schemas import UserRead
 from tracecat.auth.users import search_users
 from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
-from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.enums import (
+    CasePriority,
+    CaseSeverity,
+    CaseStatus,
+    CaseVersionField,
+)
 from tracecat.cases.filters import parse_assignee_filter
 from tracecat.cases.rows.service import CaseTableRowsService
 from tracecat.cases.schemas import (
@@ -59,6 +64,11 @@ from tracecat.cases.service import (
 )
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
+from tracecat.cases.versions.schemas import (
+    CaseVersionCompareRead,
+    CaseVersionReadMinimal,
+    CaseVersionRestoreRead,
+)
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import (
     TracecatAuthorizationError,
@@ -71,6 +81,7 @@ from tracecat.logger import logger
 from tracecat.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
+    PageParams,
 )
 from tracecat.tiers.enums import Entitlement
 
@@ -543,6 +554,99 @@ async def batch_delete_cases(
         raise HTTPException(
             status_code=HTTP_409_CONFLICT,
             detail=exc.detail or str(exc),
+        ) from exc
+
+
+@cases_router.get(
+    "/{case_id}/versions",
+    response_model=CursorPaginatedResponse[CaseVersionReadMinimal],
+)
+@require_scope("case:read")
+async def list_case_versions(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    limit: int = Query(
+        config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+        description="Maximum items per page",
+    ),
+    cursor: str | None = Query(None, description="Cursor for pagination"),
+    field: CaseVersionField | None = Query(
+        None,
+        description="Optionally include only summary or description versions",
+    ),
+) -> CursorPaginatedResponse[CaseVersionReadMinimal]:
+    """List immutable case field versions newest-first."""
+    service = CasesService(session, role)
+    if await service.get_case(case_id) is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Case with ID {case_id} not found",
+        )
+    try:
+        return await service.versions.list_versions(
+            case_id=case_id,
+            page=PageParams(limit=limit, cursor=cursor),
+            field=field,
+        )
+    except TracecatValidationError as exc:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=exc.detail or str(exc),
+        ) from exc
+
+
+@cases_router.get(
+    "/{case_id}/versions/{version_id}/compare",
+    response_model=CaseVersionCompareRead,
+)
+@require_scope("case:read")
+async def compare_case_version(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    version_id: uuid.UUID,
+) -> CaseVersionCompareRead:
+    """Compare a case field version with its immediate predecessor."""
+    service = CasesService(session, role)
+    comparison = await service.versions.compare_with_predecessor(
+        case_id=case_id,
+        version_id=version_id,
+    )
+    if comparison is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Case version '{version_id}' not found",
+        )
+    return comparison
+
+
+@cases_router.post(
+    "/{case_id}/versions/{version_id}/restore",
+    response_model=CaseVersionRestoreRead,
+)
+@require_scope("case:update")
+async def restore_case_version(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    version_id: uuid.UUID,
+) -> CaseVersionRestoreRead:
+    """Restore one historical case field version atomically."""
+    try:
+        return await CasesService(session, role).restore_version(
+            case_id=case_id,
+            version_id=version_id,
+        )
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=str(exc),
         ) from exc
 
 

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -97,6 +97,7 @@ from tracecat.cases.schemas import (
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
 from tracecat.cases.triggers.publisher import publish_case_event_payload
+from tracecat.cases.versions.schemas import CaseVersionRestoreRead
 from tracecat.cases.versions.service import CaseVersionsService
 from tracecat.contexts import ctx_run
 from tracecat.custom_fields import CustomFieldsService
@@ -925,13 +926,20 @@ class CasesService(BaseWorkspaceService):
 
     @require_scope("case:update")
     @audit_log(resource_type="case", action="update")
-    async def update_case(self, case: Case, params: CaseUpdate) -> Case:
+    async def update_case(
+        self,
+        case: Case,
+        params: CaseUpdate,
+        *,
+        force_version_fields: frozenset[CaseVersionField] = frozenset(),
+    ) -> Case:
         """Update a case and optionally its custom fields.
 
         Args:
             case: The case object to update
             params: Optional case update parameters
-            fields_data: Optional new field values
+            force_version_fields: Versioned fields that must append even when the
+                restored content equals the mutable head.
 
         Returns:
             Updated case with fields
@@ -947,7 +955,11 @@ class CasesService(BaseWorkspaceService):
                     case,
                     attribute_names=["summary", "description"],
                 )
-            await self._apply_case_update(case, params)
+            await self._apply_case_update(
+                case,
+                params,
+                force_version_fields=force_version_fields,
+            )
             # Commit once to persist all updates and emitted events atomically
             await self.session.commit()
             await self.session.refresh(case)
@@ -956,7 +968,46 @@ class CasesService(BaseWorkspaceService):
             await self.session.rollback()
             raise
 
-    async def _apply_case_update(self, case: Case, params: CaseUpdate) -> None:
+    @require_scope("case:update")
+    async def restore_version(
+        self,
+        *,
+        case_id: uuid.UUID,
+        version_id: uuid.UUID,
+    ) -> CaseVersionRestoreRead:
+        """Restore one scoped field version through the normal update transaction."""
+        case = await self.get_case(case_id, for_update=True)
+        if case is None:
+            raise TracecatNotFoundError(f"Case '{case_id}' not found")
+
+        version = await self.versions.get_version(
+            case_id=case_id,
+            version_id=version_id,
+        )
+        if version is None:
+            raise TracecatNotFoundError(
+                f"Case version '{version_id}' not found for case '{case_id}'"
+            )
+
+        params = CaseUpdate.model_validate({version.field.value: version.content})
+        await self.update_case(
+            case,
+            params,
+            force_version_fields=frozenset({version.field}),
+        )
+        return CaseVersionRestoreRead(
+            case_id=case_id,
+            restored_from_version_id=version.id,
+            field=version.field,
+        )
+
+    async def _apply_case_update(
+        self,
+        case: Case,
+        params: CaseUpdate,
+        *,
+        force_version_fields: frozenset[CaseVersionField] = frozenset(),
+    ) -> None:
         """Apply a case update without committing the active transaction."""
         run_ctx = ctx_run.get()
         wf_exec_id = run_ctx.wf_exec_id if run_ctx else None
@@ -1063,10 +1114,14 @@ class CasesService(BaseWorkspaceService):
         for key, value in set_fields.items():
             old = getattr(case, key, None)
             setattr(case, key, value)
-            if key in {"summary", "description"} and old != value:
+            version_field = (
+                CaseVersionField(key) if key in {"summary", "description"} else None
+            )
+            version_forced = version_field in force_version_fields
+            if version_field is not None and (old != value or version_forced):
                 await self.versions.append_version(
                     case_id=case.id,
-                    field=CaseVersionField(key),
+                    field=version_field,
                     content=value,
                 )
 
@@ -1077,7 +1132,7 @@ class CasesService(BaseWorkspaceService):
                         AssigneeChangedEvent(old=old, new=value, wf_exec_id=wf_exec_id)
                     )
             elif key == "summary":
-                if old != value:
+                if old != value or version_forced:
                     events.append(
                         UpdatedEvent(
                             field="summary",

--- a/tracecat/cases/versions/schemas.py
+++ b/tracecat/cases/versions/schemas.py
@@ -1,0 +1,58 @@
+"""API schemas for immutable case text-field versions."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import Field
+
+from tracecat.cases.enums import CaseVersionField
+from tracecat.core.schemas import Schema
+
+
+class CaseVersionActorRead(Schema):
+    """Minimal user metadata for a case-version author."""
+
+    id: uuid.UUID
+    email: str
+    first_name: str | None = Field(default=None)
+    last_name: str | None = Field(default=None)
+
+
+class CaseVersionReadMinimal(Schema):
+    """Version metadata returned by the case history endpoint."""
+
+    id: uuid.UUID
+    field: CaseVersionField
+    version: int
+    actor: CaseVersionActorRead | None = Field(default=None)
+    created_at: datetime
+    is_latest: bool = Field(
+        description="Whether this is the latest immutable version for its field"
+    )
+
+
+class CaseVersionContentRead(Schema):
+    """Content for one immutable case field version."""
+
+    id: uuid.UUID
+    field: CaseVersionField
+    version: int
+    content: str
+
+
+class CaseVersionCompareRead(Schema):
+    """A selected case version and its immediate same-field predecessor."""
+
+    selected: CaseVersionContentRead
+    predecessor: CaseVersionContentRead | None = Field(default=None)
+
+
+class CaseVersionRestoreRead(Schema):
+    """Confirmation that a historical case field version was restored."""
+
+    restored: bool = Field(default=True)
+    case_id: uuid.UUID
+    restored_from_version_id: uuid.UUID
+    field: CaseVersionField

--- a/tracecat/cases/versions/service.py
+++ b/tracecat/cases/versions/service.py
@@ -3,19 +3,34 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
+from typing import cast
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from tracecat.auth.types import Role
+from tracecat.authz.controls import require_scope
 from tracecat.cases.enums import CaseVersionField
+from tracecat.cases.versions.schemas import (
+    CaseVersionActorRead,
+    CaseVersionCompareRead,
+    CaseVersionContentRead,
+    CaseVersionReadMinimal,
+)
 from tracecat.db.models import Case, CaseVersion, User
 from tracecat.exceptions import TracecatNotFoundError
+from tracecat.pagination import (
+    CursorPaginatedResponse,
+    PageParams,
+    paginate,
+)
 from tracecat.service import BaseWorkspaceService
 
 
 class CaseVersionsService(BaseWorkspaceService):
-    """Create immutable versions for case titles and descriptions."""
+    """Manage immutable versions for case titles and descriptions."""
 
     service_name = "case_versions"
 
@@ -78,3 +93,140 @@ class CaseVersionsService(BaseWorkspaceService):
         self.session.add(version)
         await self.session.flush()
         return version
+
+    @require_scope("case:read")
+    async def list_versions(
+        self,
+        *,
+        case_id: uuid.UUID,
+        page: PageParams,
+        field: CaseVersionField | None = None,
+    ) -> CursorPaginatedResponse[CaseVersionReadMinimal]:
+        """List case version metadata newest-first without loading content."""
+        latest = CaseVersion.__table__.alias("latest_case_version")
+        latest_version = (
+            select(func.max(latest.c.version))
+            .where(
+                latest.c.workspace_id == self.workspace_id,
+                latest.c.case_id == case_id,
+                latest.c.field == CaseVersion.field,
+            )
+            .correlate(CaseVersion)
+            .scalar_subquery()
+        )
+        user = User.__table__
+        statement = (
+            select(
+                CaseVersion.id,
+                CaseVersion.field,
+                CaseVersion.version,
+                CaseVersion.created_at,
+                CaseVersion.version == latest_version,
+                user.c.id,
+                user.c.email,
+                user.c.first_name,
+                user.c.last_name,
+            )
+            .outerjoin(user, user.c.id == CaseVersion.user_id)
+            .where(
+                CaseVersion.workspace_id == self.workspace_id,
+                CaseVersion.case_id == case_id,
+            )
+        )
+        if field is not None:
+            statement = statement.where(CaseVersion.field == field)
+
+        result = await paginate(
+            self.session,
+            statement,
+            page=page,
+            order_by=(
+                CaseVersion.created_at.desc(),
+                CaseVersion.surrogate_id.desc(),
+            ),
+            row_factory=self._version_metadata_from_row,
+        )
+        return CursorPaginatedResponse(
+            items=result.items,
+            next_cursor=result.next_cursor,
+            prev_cursor=result.prev_cursor,
+            has_more=result.has_more,
+            has_previous=result.has_previous,
+        )
+
+    @staticmethod
+    def _version_metadata_from_row(
+        values: tuple[object, ...],
+    ) -> CaseVersionReadMinimal:
+        """Build list metadata from the projected version and actor columns."""
+        actor_id = cast(uuid.UUID | None, values[5])
+        actor = None
+        if actor_id is not None:
+            actor = CaseVersionActorRead(
+                id=actor_id,
+                email=cast(str, values[6]),
+                first_name=cast(str | None, values[7]),
+                last_name=cast(str | None, values[8]),
+            )
+        return CaseVersionReadMinimal(
+            id=cast(uuid.UUID, values[0]),
+            field=cast(CaseVersionField, values[1]),
+            version=cast(int, values[2]),
+            created_at=cast(datetime, values[3]),
+            is_latest=cast(bool, values[4]),
+            actor=actor,
+        )
+
+    @require_scope("case:read")
+    async def get_version(
+        self,
+        *,
+        case_id: uuid.UUID,
+        version_id: uuid.UUID,
+    ) -> CaseVersion | None:
+        """Load a version only when its workspace and parent case match."""
+        statement = select(CaseVersion).where(
+            CaseVersion.workspace_id == self.workspace_id,
+            CaseVersion.case_id == case_id,
+            CaseVersion.id == version_id,
+        )
+        return (await self.session.execute(statement)).scalar_one_or_none()
+
+    @require_scope("case:read")
+    async def compare_with_predecessor(
+        self,
+        *,
+        case_id: uuid.UUID,
+        version_id: uuid.UUID,
+    ) -> CaseVersionCompareRead | None:
+        """Return one scoped version and its immediate same-field predecessor."""
+        selected = aliased(CaseVersion, name="selected_case_version")
+        predecessor = aliased(CaseVersion, name="predecessor_case_version")
+        statement = (
+            select(selected, predecessor)
+            .outerjoin(
+                predecessor,
+                (predecessor.workspace_id == selected.workspace_id)
+                & (predecessor.case_id == selected.case_id)
+                & (predecessor.field == selected.field)
+                & (predecessor.version == selected.version - 1),
+            )
+            .where(
+                selected.workspace_id == self.workspace_id,
+                selected.case_id == case_id,
+                selected.id == version_id,
+            )
+        )
+        row = (await self.session.execute(statement)).one_or_none()
+        if row is None:
+            return None
+        selected_version = cast(CaseVersion, row[0])
+        predecessor_version = cast(CaseVersion | None, row[1])
+        return CaseVersionCompareRead(
+            selected=CaseVersionContentRead.model_validate(selected_version),
+            predecessor=(
+                CaseVersionContentRead.model_validate(predecessor_version)
+                if predecessor_version is not None
+                else None
+            ),
+        )


### PR DESCRIPTION
## Summary

- Add cursor-paginated history for case `summary` and `description` versions, with actor and latest-version metadata.
- Add compare and restore endpoints for a selected version and its immediate same-field predecessor.
- Keep restore append-only and atomic by routing it through the existing locked case-update transaction, with workspace/case-scoped `404` behavior.

Depends on #3272. Implements [ENG-1676](https://linear.app/tracecat/issue/ENG-1676/featcases-add-case-version-history-and-restore-apis).

## Review guide

1. **API contract:** `tracecat/cases/versions/schemas.py` and the three routes in `tracecat/cases/router.py`.
2. **History reads:** `CaseVersionsService` projects metadata only for lists, uses stable `(created_at, surrogate_id)` cursors, and fetches the immediate predecessor for comparison.
3. **Restore semantics:** `CasesService.restore_version` validates scope, locks the case, and forces a new immutable version even when restored content matches the current head.
4. **Coverage/client:** focused unit and integration tests cover pagination, auth, mismatches, compare, restore, rollback, and concurrency; the generated TypeScript client exposes the new APIs.

| Method | Endpoint | Purpose |
| --- | --- | --- |
| `GET` | `/cases/{case_id}/versions` | List version metadata, optionally filtered by field |
| `GET` | `/cases/{case_id}/versions/{version_id}/compare` | Return the selected version and immediate predecessor |
| `POST` | `/cases/{case_id}/versions/{version_id}/restore` | Restore through the normal case-update transaction |

## Verification

- `uv run pytest tests/unit/test_case_versions_service.py tests/unit/test_cases_service.py tests/unit/api/test_api_cases.py tests/unit/test_route_scope_guards.py tests/integration/test_case_versions.py -x` — 223 passed
- `uv run ruff check .` and `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- `pnpm -C frontend check` and `pnpm -C frontend run typecheck`
- Signed commit hooks, including secret scanning and generated-client validation

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 379 | 10 |
| Tests | 585 | 2 |
| Generated | 483 | 0 |
