### PR TITLE
feat(cases): add case version history and restore APIs

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9732,6 +9732,170 @@ export const $CaseUpdate = {
   title: "CaseUpdate",
 } as const
 
+export const $CaseVersionActorRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    email: {
+      type: "string",
+      title: "Email",
+    },
+    first_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "First Name",
+    },
+    last_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Name",
+    },
+  },
+  type: "object",
+  required: ["id", "email"],
+  title: "CaseVersionActorRead",
+  description: "Minimal user metadata for a case-version author.",
+} as const
+
+export const $CaseVersionCompareRead = {
+  properties: {
+    selected: {
+      $ref: "#/components/schemas/CaseVersionContentRead",
+    },
+    predecessor: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseVersionContentRead",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  type: "object",
+  required: ["selected"],
+  title: "CaseVersionCompareRead",
+  description:
+    "A selected case version and its immediate same-field predecessor.",
+} as const
+
+export const $CaseVersionContentRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    field: {
+      $ref: "#/components/schemas/CaseVersionField",
+    },
+    version: {
+      type: "integer",
+      title: "Version",
+    },
+    content: {
+      type: "string",
+      title: "Content",
+    },
+  },
+  type: "object",
+  required: ["id", "field", "version", "content"],
+  title: "CaseVersionContentRead",
+  description: "Content for one immutable case field version.",
+} as const
+
+export const $CaseVersionField = {
+  type: "string",
+  enum: ["summary", "description"],
+  title: "CaseVersionField",
+  description: "Case text fields that have immutable version history.",
+} as const
+
+export const $CaseVersionReadMinimal = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    field: {
+      $ref: "#/components/schemas/CaseVersionField",
+    },
+    version: {
+      type: "integer",
+      title: "Version",
+    },
+    actor: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseVersionActorRead",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    is_latest: {
+      type: "boolean",
+      title: "Is Latest",
+      description: "Whether this is the latest immutable version for its field",
+    },
+  },
+  type: "object",
+  required: ["id", "field", "version", "created_at", "is_latest"],
+  title: "CaseVersionReadMinimal",
+  description: "Version metadata returned by the case history endpoint.",
+} as const
+
+export const $CaseVersionRestoreRead = {
+  properties: {
+    restored: {
+      type: "boolean",
+      title: "Restored",
+      default: true,
+    },
+    case_id: {
+      type: "string",
+      format: "uuid",
+      title: "Case Id",
+    },
+    restored_from_version_id: {
+      type: "string",
+      format: "uuid",
+      title: "Restored From Version Id",
+    },
+    field: {
+      $ref: "#/components/schemas/CaseVersionField",
+    },
+  },
+  type: "object",
+  required: ["case_id", "restored_from_version_id", "field"],
+  title: "CaseVersionRestoreRead",
+  description:
+    "Confirmation that a historical case field version was restored.",
+} as const
+
 export const $CaseViewedEventRead = {
   properties: {
     wf_exec_id: {
@@ -11514,6 +11678,69 @@ export const $CursorPaginatedResponse_CaseTableRowRead_ = {
   type: "object",
   required: ["items"],
   title: "CursorPaginatedResponse[CaseTableRowRead]",
+} as const
+
+export const $CursorPaginatedResponse_CaseVersionReadMinimal_ = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/CaseVersionReadMinimal",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CursorPaginatedResponse[CaseVersionReadMinimal]",
 } as const
 
 export const $CursorPaginatedResponse_InboxItemRead_ = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9787,12 +9787,22 @@ export const $CaseVersionCompareRead = {
         },
       ],
     },
+    diff: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseVersionDiffRead",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
   },
   type: "object",
   required: ["selected"],
   title: "CaseVersionCompareRead",
   description:
-    "A selected case version and its immediate same-field predecessor.",
+    "A selected case version, its predecessor, and their textual diff.",
 } as const
 
 export const $CaseVersionContentRead = {
@@ -9818,6 +9828,55 @@ export const $CaseVersionContentRead = {
   required: ["id", "field", "version", "content"],
   title: "CaseVersionContentRead",
   description: "Content for one immutable case field version.",
+} as const
+
+export const $CaseVersionDiffOperation = {
+  type: "string",
+  enum: ["equal", "insert", "delete"],
+  title: "CaseVersionDiffOperation",
+  description: "Operations in an ordered case-version text diff.",
+} as const
+
+export const $CaseVersionDiffRead = {
+  properties: {
+    granularity: {
+      type: "string",
+      const: "word",
+      title: "Granularity",
+      default: "word",
+    },
+    changed: {
+      type: "boolean",
+      title: "Changed",
+    },
+    segments: {
+      items: {
+        $ref: "#/components/schemas/CaseVersionDiffSegmentRead",
+      },
+      type: "array",
+      title: "Segments",
+    },
+  },
+  type: "object",
+  required: ["changed", "segments"],
+  title: "CaseVersionDiffRead",
+  description: "A word-level edit script from predecessor to selected content.",
+} as const
+
+export const $CaseVersionDiffSegmentRead = {
+  properties: {
+    operation: {
+      $ref: "#/components/schemas/CaseVersionDiffOperation",
+    },
+    text: {
+      type: "string",
+      title: "Text",
+    },
+  },
+  type: "object",
+  required: ["operation", "text"],
+  title: "CaseVersionDiffSegmentRead",
+  description: "One exact-text segment in an ordered case-version diff.",
 } as const
 
 export const $CaseVersionField = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -314,6 +314,8 @@ import type {
   CasesBatchDeleteCasesResponse,
   CasesBatchUpdateCasesData,
   CasesBatchUpdateCasesResponse,
+  CasesCompareCaseVersionData,
+  CasesCompareCaseVersionResponse,
   CasesCreateCaseData,
   CasesCreateCaseResponse,
   CasesCreateCommentData,
@@ -342,6 +344,8 @@ import type {
   CasesListCaseRowsResponse,
   CasesListCasesData,
   CasesListCasesResponse,
+  CasesListCaseVersionsData,
+  CasesListCaseVersionsResponse,
   CasesListCommentsData,
   CasesListCommentsResponse,
   CasesListCommentThreadsData,
@@ -356,6 +360,8 @@ import type {
   CasesListTasksResponse,
   CasesRemoveTagData,
   CasesRemoveTagResponse,
+  CasesRestoreCaseVersionData,
+  CasesRestoreCaseVersionResponse,
   CasesSearchCaseAggregatesData,
   CasesSearchCaseAggregatesResponse,
   CasesSearchCasesData,
@@ -9846,6 +9852,93 @@ export const casesBatchDeleteCases = (
     },
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Case Versions
+ * List immutable case field versions newest-first.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.workspaceId
+ * @param data.limit Maximum items per page
+ * @param data.cursor Cursor for pagination
+ * @param data.field Optionally include only summary or description versions
+ * @returns CursorPaginatedResponse_CaseVersionReadMinimal_ Successful Response
+ * @throws ApiError
+ */
+export const casesListCaseVersions = (
+  data: CasesListCaseVersionsData
+): CancelablePromise<CasesListCaseVersionsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions",
+    path: {
+      case_id: data.caseId,
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      limit: data.limit,
+      cursor: data.cursor,
+      field: data.field,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Compare Case Version
+ * Compare a case field version with its immediate predecessor.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.versionId
+ * @param data.workspaceId
+ * @returns CaseVersionCompareRead Successful Response
+ * @throws ApiError
+ */
+export const casesCompareCaseVersion = (
+  data: CasesCompareCaseVersionData
+): CancelablePromise<CasesCompareCaseVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/compare",
+    path: {
+      case_id: data.caseId,
+      version_id: data.versionId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Restore Case Version
+ * Restore one historical case field version atomically.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.versionId
+ * @param data.workspaceId
+ * @returns CaseVersionRestoreRead Successful Response
+ * @throws ApiError
+ */
+export const casesRestoreCaseVersion = (
+  data: CasesRestoreCaseVersionData
+): CancelablePromise<CasesRestoreCaseVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/restore",
+    path: {
+      case_id: data.caseId,
+      version_id: data.versionId,
+      workspace_id: data.workspaceId,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -9859,93 +9859,6 @@ export const casesBatchDeleteCases = (
 }
 
 /**
- * List Case Versions
- * List immutable case field versions newest-first.
- * @param data The data for the request.
- * @param data.caseId
- * @param data.workspaceId
- * @param data.limit Maximum items per page
- * @param data.cursor Cursor for pagination
- * @param data.field Optionally include only summary or description versions
- * @returns CursorPaginatedResponse_CaseVersionReadMinimal_ Successful Response
- * @throws ApiError
- */
-export const casesListCaseVersions = (
-  data: CasesListCaseVersionsData
-): CancelablePromise<CasesListCaseVersionsResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/workspaces/{workspace_id}/cases/{case_id}/versions",
-    path: {
-      case_id: data.caseId,
-      workspace_id: data.workspaceId,
-    },
-    query: {
-      limit: data.limit,
-      cursor: data.cursor,
-      field: data.field,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Compare Case Version
- * Compare a case field version with its immediate predecessor.
- * @param data The data for the request.
- * @param data.caseId
- * @param data.versionId
- * @param data.workspaceId
- * @returns CaseVersionCompareRead Successful Response
- * @throws ApiError
- */
-export const casesCompareCaseVersion = (
-  data: CasesCompareCaseVersionData
-): CancelablePromise<CasesCompareCaseVersionResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/compare",
-    path: {
-      case_id: data.caseId,
-      version_id: data.versionId,
-      workspace_id: data.workspaceId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Restore Case Version
- * Restore one historical case field version atomically.
- * @param data The data for the request.
- * @param data.caseId
- * @param data.versionId
- * @param data.workspaceId
- * @returns CaseVersionRestoreRead Successful Response
- * @throws ApiError
- */
-export const casesRestoreCaseVersion = (
-  data: CasesRestoreCaseVersionData
-): CancelablePromise<CasesRestoreCaseVersionResponse> => {
-  return __request(OpenAPI, {
-    method: "POST",
-    url: "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/restore",
-    path: {
-      case_id: data.caseId,
-      version_id: data.versionId,
-      workspace_id: data.workspaceId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
  * Get Case
  * Get a specific case.
  * @param data The data for the request.
@@ -10289,6 +10202,93 @@ export const casesDeleteTask = (
     path: {
       case_id: data.caseId,
       task_id: data.taskId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Case Versions
+ * List immutable case field versions newest-first.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.workspaceId
+ * @param data.limit Maximum items per page
+ * @param data.cursor Cursor for pagination
+ * @param data.field Optionally include only summary or description versions
+ * @returns CursorPaginatedResponse_CaseVersionReadMinimal_ Successful Response
+ * @throws ApiError
+ */
+export const casesListCaseVersions = (
+  data: CasesListCaseVersionsData
+): CancelablePromise<CasesListCaseVersionsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions",
+    path: {
+      case_id: data.caseId,
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      limit: data.limit,
+      cursor: data.cursor,
+      field: data.field,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Compare Case Version
+ * Compare a case field version with its immediate predecessor.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.versionId
+ * @param data.workspaceId
+ * @returns CaseVersionCompareRead Successful Response
+ * @throws ApiError
+ */
+export const casesCompareCaseVersion = (
+  data: CasesCompareCaseVersionData
+): CancelablePromise<CasesCompareCaseVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/compare",
+    path: {
+      case_id: data.caseId,
+      version_id: data.versionId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Restore Case Version
+ * Restore one historical case field version atomically.
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.versionId
+ * @param data.workspaceId
+ * @returns CaseVersionRestoreRead Successful Response
+ * @throws ApiError
+ */
+export const casesRestoreCaseVersion = (
+  data: CasesRestoreCaseVersionData
+): CancelablePromise<CasesRestoreCaseVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/restore",
+    path: {
+      case_id: data.caseId,
+      version_id: data.versionId,
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2624,11 +2624,12 @@ export type CaseVersionActorRead = {
 }
 
 /**
- * A selected case version and its immediate same-field predecessor.
+ * A selected case version, its predecessor, and their textual diff.
  */
 export type CaseVersionCompareRead = {
   selected: CaseVersionContentRead
   predecessor?: CaseVersionContentRead | null
+  diff?: CaseVersionDiffRead | null
 }
 
 /**
@@ -2639,6 +2640,28 @@ export type CaseVersionContentRead = {
   field: CaseVersionField
   version: number
   content: string
+}
+
+/**
+ * Operations in an ordered case-version text diff.
+ */
+export type CaseVersionDiffOperation = "equal" | "insert" | "delete"
+
+/**
+ * A word-level edit script from predecessor to selected content.
+ */
+export type CaseVersionDiffRead = {
+  granularity?: "word"
+  changed: boolean
+  segments: Array<CaseVersionDiffSegmentRead>
+}
+
+/**
+ * One exact-text segment in an ordered case-version diff.
+ */
+export type CaseVersionDiffSegmentRead = {
+  operation: CaseVersionDiffOperation
+  text: string
 }
 
 /**

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -13204,42 +13204,6 @@ export type CasesBatchDeleteCasesData = {
 
 export type CasesBatchDeleteCasesResponse = CaseBatchResponse
 
-export type CasesListCaseVersionsData = {
-  caseId: string
-  /**
-   * Cursor for pagination
-   */
-  cursor?: string | null
-  /**
-   * Optionally include only summary or description versions
-   */
-  field?: CaseVersionField | null
-  /**
-   * Maximum items per page
-   */
-  limit?: number
-  workspaceId: string
-}
-
-export type CasesListCaseVersionsResponse =
-  CursorPaginatedResponse_CaseVersionReadMinimal_
-
-export type CasesCompareCaseVersionData = {
-  caseId: string
-  versionId: string
-  workspaceId: string
-}
-
-export type CasesCompareCaseVersionResponse = CaseVersionCompareRead
-
-export type CasesRestoreCaseVersionData = {
-  caseId: string
-  versionId: string
-  workspaceId: string
-}
-
-export type CasesRestoreCaseVersionResponse = CaseVersionRestoreRead
-
 export type CasesGetCaseData = {
   caseId: string
   /**
@@ -13343,6 +13307,42 @@ export type CasesDeleteTaskData = {
 }
 
 export type CasesDeleteTaskResponse = void
+
+export type CasesListCaseVersionsData = {
+  caseId: string
+  /**
+   * Cursor for pagination
+   */
+  cursor?: string | null
+  /**
+   * Optionally include only summary or description versions
+   */
+  field?: CaseVersionField | null
+  /**
+   * Maximum items per page
+   */
+  limit?: number
+  workspaceId: string
+}
+
+export type CasesListCaseVersionsResponse =
+  CursorPaginatedResponse_CaseVersionReadMinimal_
+
+export type CasesCompareCaseVersionData = {
+  caseId: string
+  versionId: string
+  workspaceId: string
+}
+
+export type CasesCompareCaseVersionResponse = CaseVersionCompareRead
+
+export type CasesRestoreCaseVersionData = {
+  caseId: string
+  versionId: string
+  workspaceId: string
+}
+
+export type CasesRestoreCaseVersionResponse = CaseVersionRestoreRead
 
 export type CasesListCaseRowsData = {
   caseId: string
@@ -19117,51 +19117,6 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workspaces/{workspace_id}/cases/{case_id}/versions": {
-    get: {
-      req: CasesListCaseVersionsData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: CursorPaginatedResponse_CaseVersionReadMinimal_
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/compare": {
-    get: {
-      req: CasesCompareCaseVersionData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: CaseVersionCompareRead
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/restore": {
-    post: {
-      req: CasesRestoreCaseVersionData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: CaseVersionRestoreRead
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
   "/workspaces/{workspace_id}/cases/{case_id}": {
     get: {
       req: CasesGetCaseData
@@ -19338,6 +19293,51 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions": {
+    get: {
+      req: CasesListCaseVersionsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CursorPaginatedResponse_CaseVersionReadMinimal_
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/compare": {
+    get: {
+      req: CasesCompareCaseVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseVersionCompareRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/restore": {
+    post: {
+      req: CasesRestoreCaseVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseVersionRestoreRead
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2614,6 +2614,64 @@ export type CaseUpdate = {
 }
 
 /**
+ * Minimal user metadata for a case-version author.
+ */
+export type CaseVersionActorRead = {
+  id: string
+  email: string
+  first_name?: string | null
+  last_name?: string | null
+}
+
+/**
+ * A selected case version and its immediate same-field predecessor.
+ */
+export type CaseVersionCompareRead = {
+  selected: CaseVersionContentRead
+  predecessor?: CaseVersionContentRead | null
+}
+
+/**
+ * Content for one immutable case field version.
+ */
+export type CaseVersionContentRead = {
+  id: string
+  field: CaseVersionField
+  version: number
+  content: string
+}
+
+/**
+ * Case text fields that have immutable version history.
+ */
+export type CaseVersionField = "summary" | "description"
+
+/**
+ * Version metadata returned by the case history endpoint.
+ */
+export type CaseVersionReadMinimal = {
+  id: string
+  field: CaseVersionField
+  version: number
+  actor?: CaseVersionActorRead | null
+  created_at: string
+  /**
+   * Whether this is the latest immutable version for its field
+   */
+  is_latest: boolean
+}
+
+/**
+ * Confirmation that a historical case field version was restored.
+ */
+export type CaseVersionRestoreRead = {
+  restored?: boolean
+  case_id: string
+  restored_from_version_id: string
+  field: CaseVersionField
+}
+
+/**
  * Event for when a case is viewed.
  */
 export type CaseViewedEventRead = {
@@ -3276,6 +3334,30 @@ export type CursorPaginatedResponse_CaseReadMinimal_ = {
 
 export type CursorPaginatedResponse_CaseTableRowRead_ = {
   items: Array<CaseTableRowRead>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+}
+
+export type CursorPaginatedResponse_CaseVersionReadMinimal_ = {
+  items: Array<CaseVersionReadMinimal>
   /**
    * Cursor for next page
    */
@@ -13099,6 +13181,42 @@ export type CasesBatchDeleteCasesData = {
 
 export type CasesBatchDeleteCasesResponse = CaseBatchResponse
 
+export type CasesListCaseVersionsData = {
+  caseId: string
+  /**
+   * Cursor for pagination
+   */
+  cursor?: string | null
+  /**
+   * Optionally include only summary or description versions
+   */
+  field?: CaseVersionField | null
+  /**
+   * Maximum items per page
+   */
+  limit?: number
+  workspaceId: string
+}
+
+export type CasesListCaseVersionsResponse =
+  CursorPaginatedResponse_CaseVersionReadMinimal_
+
+export type CasesCompareCaseVersionData = {
+  caseId: string
+  versionId: string
+  workspaceId: string
+}
+
+export type CasesCompareCaseVersionResponse = CaseVersionCompareRead
+
+export type CasesRestoreCaseVersionData = {
+  caseId: string
+  versionId: string
+  workspaceId: string
+}
+
+export type CasesRestoreCaseVersionResponse = CaseVersionRestoreRead
+
 export type CasesGetCaseData = {
   caseId: string
   /**
@@ -18969,6 +19087,51 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: CaseBatchResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions": {
+    get: {
+      req: CasesListCaseVersionsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CursorPaginatedResponse_CaseVersionReadMinimal_
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/compare": {
+    get: {
+      req: CasesCompareCaseVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseVersionCompareRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/cases/{case_id}/versions/{version_id}/restore": {
+    post: {
+      req: CasesRestoreCaseVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseVersionRestoreRead
         /**
          * Validation Error
          */

--- a/tests/integration/test_case_versions.py
+++ b/tests/integration/test_case_versions.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
@@ -25,7 +26,9 @@ from tracecat.cases.enums import (
 )
 from tracecat.cases.schemas import CaseCreate, CaseUpdate
 from tracecat.cases.service import CasesService
-from tracecat.db.models import Case, CaseVersion, User, Workspace
+from tracecat.db.models import Case, CaseEvent, CaseVersion, User, Workspace
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.pagination import PageParams
 
 pytestmark = [
     pytest.mark.anyio,
@@ -217,3 +220,337 @@ async def test_concurrent_case_version_allocation(
             }
     finally:
         await engine.dispose()
+
+
+async def test_case_version_history_pagination_filter_and_compare(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """History stays stable across tied timestamps and exposes predecessor content."""
+    assert svc_role.user_id is not None
+    actor_email = f"case-history-{svc_role.user_id}@example.com"
+    session.add(
+        User(
+            id=svc_role.user_id,
+            email=actor_email,
+            hashed_password="hashed",
+        )
+    )
+    await session.flush()
+
+    service = CasesService(session=session, role=svc_role)
+    case = await service.create_case(
+        CaseCreate(
+            summary="Summary v1",
+            description="Description v1",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+    await service.update_case(case, CaseUpdate(summary="Summary v2"))
+    await service.update_case(case, CaseUpdate(description="Description v2"))
+
+    tied_timestamp = datetime(2026, 1, 1, tzinfo=UTC)
+    await session.execute(
+        update(CaseVersion)
+        .where(CaseVersion.case_id == case.id)
+        .values(created_at=tied_timestamp)
+    )
+    await session.commit()
+
+    expected_ids = list(
+        (
+            await session.execute(
+                select(CaseVersion.id)
+                .where(CaseVersion.case_id == case.id)
+                .order_by(
+                    CaseVersion.created_at.desc(),
+                    CaseVersion.surrogate_id.desc(),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    history_ids: list[uuid.UUID] = []
+    history = []
+    cursor: str | None = None
+    while True:
+        page = await service.versions.list_versions(
+            case_id=case.id,
+            page=PageParams(limit=1, cursor=cursor),
+        )
+        history.extend(page.items)
+        history_ids.extend(item.id for item in page.items)
+        cursor = page.next_cursor
+        if cursor is None:
+            break
+
+    assert history_ids == expected_ids
+    assert len(history_ids) == len(set(history_ids)) == 4
+    assert {item.field for item in history if item.is_latest} == {
+        CaseVersionField.SUMMARY,
+        CaseVersionField.DESCRIPTION,
+    }
+    assert {item.actor.email for item in history if item.actor is not None} == {
+        actor_email
+    }
+    assert all("content" not in item.model_dump() for item in history)
+
+    summary_history = await service.versions.list_versions(
+        case_id=case.id,
+        page=PageParams(limit=10),
+        field=CaseVersionField.SUMMARY,
+    )
+    assert [item.version for item in summary_history.items] == [2, 1]
+    assert [item.is_latest for item in summary_history.items] == [True, False]
+
+    summary_versions = (
+        (
+            await session.execute(
+                select(CaseVersion)
+                .where(
+                    CaseVersion.case_id == case.id,
+                    CaseVersion.field == CaseVersionField.SUMMARY,
+                )
+                .order_by(CaseVersion.version)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    baseline = await service.versions.compare_with_predecessor(
+        case_id=case.id,
+        version_id=summary_versions[0].id,
+    )
+    assert baseline is not None
+    assert baseline.selected.content == "Summary v1"
+    assert baseline.predecessor is None
+
+    comparison = await service.versions.compare_with_predecessor(
+        case_id=case.id,
+        version_id=summary_versions[1].id,
+    )
+    assert comparison is not None
+    assert comparison.selected.content == "Summary v2"
+    assert comparison.predecessor is not None
+    assert comparison.predecessor.content == "Summary v1"
+
+    other_case = await service.create_case(
+        CaseCreate(
+            summary="Other summary",
+            description="Other description",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+    assert (
+        await service.versions.compare_with_predecessor(
+            case_id=other_case.id,
+            version_id=summary_versions[1].id,
+        )
+        is None
+    )
+
+
+async def test_restore_case_version_is_scoped_append_only_and_atomic(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Restore updates one field, appends history, and rolls back with activity."""
+    assert svc_role.user_id is not None
+    session.add(
+        User(
+            id=svc_role.user_id,
+            email=f"case-restore-{svc_role.user_id}@example.com",
+            hashed_password="hashed",
+        )
+    )
+    await session.flush()
+
+    service = CasesService(session=session, role=svc_role)
+    case = await service.create_case(
+        CaseCreate(
+            summary="Summary v1",
+            description="Description v1",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+    await service.update_case(
+        case,
+        CaseUpdate(summary="Summary v2", description="Description v2"),
+    )
+    summary_v1 = await session.scalar(
+        select(CaseVersion).where(
+            CaseVersion.case_id == case.id,
+            CaseVersion.field == CaseVersionField.SUMMARY,
+            CaseVersion.version == 1,
+        )
+    )
+    assert summary_v1 is not None
+    event_count_before = await session.scalar(
+        select(func.count()).select_from(CaseEvent).where(CaseEvent.case_id == case.id)
+    )
+    assert event_count_before is not None
+
+    restored = await service.restore_version(
+        case_id=case.id,
+        version_id=summary_v1.id,
+    )
+    assert restored.restored is True
+    assert restored.field == CaseVersionField.SUMMARY
+
+    await session.refresh(case)
+    assert case.summary == "Summary v1"
+    assert case.description == "Description v2"
+    summary_history = (
+        (
+            await session.execute(
+                select(CaseVersion)
+                .where(
+                    CaseVersion.case_id == case.id,
+                    CaseVersion.field == CaseVersionField.SUMMARY,
+                )
+                .order_by(CaseVersion.version)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [(item.version, item.content) for item in summary_history] == [
+        (1, "Summary v1"),
+        (2, "Summary v2"),
+        (3, "Summary v1"),
+    ]
+    assert summary_history[-1].user_id == svc_role.user_id
+    assert summary_history[0].content == "Summary v1"
+    restored_case_id = case.id
+    summary_v2_id = summary_history[1].id
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(CaseEvent)
+            .where(CaseEvent.case_id == case.id)
+        )
+        == event_count_before + 1
+    )
+    await service.restore_version(
+        case_id=restored_case_id,
+        version_id=summary_v1.id,
+    )
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(CaseVersion)
+            .where(
+                CaseVersion.case_id == restored_case_id,
+                CaseVersion.field == CaseVersionField.SUMMARY,
+            )
+        )
+        == 4
+    )
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(CaseEvent)
+            .where(CaseEvent.case_id == restored_case_id)
+        )
+        == event_count_before + 2
+    )
+
+    other_case = await service.create_case(
+        CaseCreate(
+            summary="Other summary",
+            description="Other description",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+    other_version_id = await session.scalar(
+        select(CaseVersion.id).where(
+            CaseVersion.case_id == other_case.id,
+            CaseVersion.field == CaseVersionField.SUMMARY,
+        )
+    )
+    assert other_version_id is not None
+    with pytest.raises(TracecatNotFoundError):
+        await service.restore_version(
+            case_id=restored_case_id,
+            version_id=other_version_id,
+        )
+
+    foreign_workspace_id = uuid.uuid4()
+    foreign_case_id = uuid.uuid4()
+    foreign_version_id = uuid.uuid4()
+    assert svc_role.organization_id is not None
+    session.add_all(
+        [
+            Workspace(
+                id=foreign_workspace_id,
+                name="foreign-case-version-workspace",
+                organization_id=svc_role.organization_id,
+            ),
+            Case(
+                id=foreign_case_id,
+                workspace_id=foreign_workspace_id,
+                case_number=1,
+                summary="Foreign summary",
+                description="Foreign description",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            ),
+            CaseVersion(
+                id=foreign_version_id,
+                workspace_id=foreign_workspace_id,
+                case_id=foreign_case_id,
+                field=CaseVersionField.SUMMARY,
+                version=1,
+                content="Foreign summary",
+            ),
+        ]
+    )
+    await session.commit()
+    with pytest.raises(TracecatNotFoundError):
+        await service.restore_version(
+            case_id=restored_case_id,
+            version_id=foreign_version_id,
+        )
+
+    failing_service = CasesService(session=session, role=svc_role)
+    with (
+        patch.object(
+            failing_service.events,
+            "create_event",
+            new=AsyncMock(side_effect=RuntimeError("activity write failed")),
+        ),
+        pytest.raises(RuntimeError, match="activity write failed"),
+    ):
+        await failing_service.restore_version(
+            case_id=restored_case_id,
+            version_id=summary_v2_id,
+        )
+
+    await session.refresh(case)
+    assert case.summary == "Summary v1"
+    assert (
+        await session.scalar(
+            select(func.count())
+            .select_from(CaseVersion)
+            .where(
+                CaseVersion.case_id == restored_case_id,
+                CaseVersion.field == CaseVersionField.SUMMARY,
+            )
+        )
+        == 4
+    )
+    test_workspace = await session.scalar(
+        select(Workspace).where(Workspace.id == svc_role.workspace_id)
+    )
+    assert test_workspace is not None
+    await session.refresh(test_workspace)

--- a/tests/integration/test_case_versions.py
+++ b/tests/integration/test_case_versions.py
@@ -417,10 +417,12 @@ async def test_restore_case_version_is_scoped_append_only_and_atomic(
     )
     assert event_count_before is not None
 
-    restored = await service.restore_version(
-        case_id=case.id,
-        version_id=summary_v1.id,
-    )
+    with patch.object(service, "get_case", new=AsyncMock()) as mock_get_case:
+        restored = await service.restore_version(
+            case_id=case.id,
+            version_id=summary_v1.id,
+        )
+    mock_get_case.assert_not_awaited()
     assert restored.restored is True
     assert restored.field == CaseVersionField.SUMMARY
 

--- a/tests/integration/test_case_versions.py
+++ b/tests/integration/test_case_versions.py
@@ -26,6 +26,7 @@ from tracecat.cases.enums import (
 )
 from tracecat.cases.schemas import CaseCreate, CaseUpdate
 from tracecat.cases.service import CasesService
+from tracecat.cases.versions.diff import compute_case_version_diff
 from tracecat.db.models import Case, CaseEvent, CaseVersion, User, Workspace
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.pagination import PageParams
@@ -329,9 +330,18 @@ async def test_case_version_history_pagination_filter_and_compare(
     assert baseline.predecessor is None
     assert baseline.diff is None
 
-    comparison = await service.versions.compare_with_predecessor(
-        case_id=case.id,
-        version_id=summary_versions[1].id,
+    with patch(
+        "tracecat.cases.versions.service.asyncio.to_thread",
+        new=AsyncMock(wraps=asyncio.to_thread),
+    ) as mock_to_thread:
+        comparison = await service.versions.compare_with_predecessor(
+            case_id=case.id,
+            version_id=summary_versions[1].id,
+        )
+    mock_to_thread.assert_awaited_once_with(
+        compute_case_version_diff,
+        "Summary v1",
+        "Summary v2",
     )
     assert comparison is not None
     assert comparison.selected.content == "Summary v2"

--- a/tests/integration/test_case_versions.py
+++ b/tests/integration/test_case_versions.py
@@ -327,6 +327,7 @@ async def test_case_version_history_pagination_filter_and_compare(
     assert baseline is not None
     assert baseline.selected.content == "Summary v1"
     assert baseline.predecessor is None
+    assert baseline.diff is None
 
     comparison = await service.versions.compare_with_predecessor(
         case_id=case.id,
@@ -336,6 +337,15 @@ async def test_case_version_history_pagination_filter_and_compare(
     assert comparison.selected.content == "Summary v2"
     assert comparison.predecessor is not None
     assert comparison.predecessor.content == "Summary v1"
+    assert comparison.diff is not None
+    assert comparison.diff.changed is True
+    assert [
+        (segment.operation, segment.text) for segment in comparison.diff.segments
+    ] == [
+        ("equal", "Summary "),
+        ("delete", "v1"),
+        ("insert", "v2"),
+    ]
 
     other_case = await service.create_case(
         CaseCreate(

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -31,6 +31,7 @@ from tracecat.cases.schemas import (
     CaseSearchAggregateRead,
     CaseStatusGroupCounts,
 )
+from tracecat.cases.versions import router as case_versions_router
 from tracecat.cases.versions.schemas import (
     CaseVersionCompareRead,
     CaseVersionContentRead,
@@ -788,9 +789,9 @@ async def test_list_case_versions_success(
         has_more=False,
         has_previous=False,
     )
-    with patch.object(cases_router, "CasesService") as mock_service_cls:
+    with patch.object(case_versions_router, "CasesService") as mock_service_cls:
         mock_service = AsyncMock()
-        mock_service.get_case.return_value = mock_case
+        mock_service.case_exists.return_value = True
         mock_service.versions.list_versions.return_value = response_page
         mock_service_cls.return_value = mock_service
 
@@ -816,6 +817,7 @@ async def test_list_case_versions_success(
     assert call.kwargs["case_id"] == mock_case.id
     assert call.kwargs["field"] == CaseVersionField.SUMMARY
     assert call.kwargs["page"].limit == 25
+    mock_service.get_case.assert_not_called()
 
 
 @pytest.mark.anyio
@@ -824,7 +826,7 @@ async def test_list_case_versions_rejects_oversized_cursor(
     test_admin_role: Role,
 ) -> None:
     """Oversized cursors are rejected before reaching the service."""
-    with patch.object(cases_router, "CasesService") as mock_service_cls:
+    with patch.object(case_versions_router, "CasesService") as mock_service_cls:
         response = client.get(
             f"/cases/{uuid.uuid4()}/versions",
             params={
@@ -844,9 +846,9 @@ async def test_list_case_versions_missing_case_returns_404(
 ) -> None:
     """Version history does not treat a missing case as empty history."""
     case_id = uuid.uuid4()
-    with patch.object(cases_router, "CasesService") as mock_service_cls:
+    with patch.object(case_versions_router, "CasesService") as mock_service_cls:
         mock_service = AsyncMock()
-        mock_service.get_case.return_value = None
+        mock_service.case_exists.return_value = False
         mock_service_cls.return_value = mock_service
 
         response = client.get(
@@ -855,6 +857,7 @@ async def test_list_case_versions_missing_case_returns_404(
         )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
+    mock_service.get_case.assert_not_called()
     mock_service.versions.list_versions.assert_not_awaited()
 
 
@@ -898,7 +901,7 @@ async def test_compare_case_version_success_and_mismatch_404(
             ],
         ),
     )
-    with patch.object(cases_router, "CasesService") as mock_service_cls:
+    with patch.object(case_versions_router, "CasesService") as mock_service_cls:
         mock_service = AsyncMock()
         mock_service.versions.compare_with_predecessor.side_effect = [
             comparison,
@@ -942,7 +945,7 @@ async def test_restore_case_version_success_and_mismatch_404(
         restored_from_version_id=version_id,
         field=CaseVersionField.SUMMARY,
     )
-    with patch.object(cases_router, "CasesService") as mock_service_cls:
+    with patch.object(case_versions_router, "CasesService") as mock_service_cls:
         mock_service = AsyncMock()
         mock_service.restore_version.side_effect = [
             restored,

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -816,6 +816,25 @@ async def test_list_case_versions_success(
 
 
 @pytest.mark.anyio
+async def test_list_case_versions_rejects_oversized_cursor(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Oversized cursors are rejected before reaching the service."""
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        response = client.get(
+            f"/cases/{uuid.uuid4()}/versions",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "cursor": "x" * 8193,
+            },
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    mock_service_cls.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_list_case_versions_missing_case_returns_404(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -19,6 +19,7 @@ from tracecat.cases.enums import (
     CasePriority,
     CaseSeverity,
     CaseStatus,
+    CaseVersionDiffOperation,
     CaseVersionField,
 )
 from tracecat.cases.schemas import (
@@ -33,6 +34,8 @@ from tracecat.cases.schemas import (
 from tracecat.cases.versions.schemas import (
     CaseVersionCompareRead,
     CaseVersionContentRead,
+    CaseVersionDiffRead,
+    CaseVersionDiffSegmentRead,
     CaseVersionReadMinimal,
     CaseVersionRestoreRead,
 )
@@ -877,6 +880,23 @@ async def test_compare_case_version_success_and_mismatch_404(
             version=1,
             content="Old body",
         ),
+        diff=CaseVersionDiffRead(
+            changed=True,
+            segments=[
+                CaseVersionDiffSegmentRead(
+                    operation=CaseVersionDiffOperation.DELETE,
+                    text="Old",
+                ),
+                CaseVersionDiffSegmentRead(
+                    operation=CaseVersionDiffOperation.INSERT,
+                    text="New",
+                ),
+                CaseVersionDiffSegmentRead(
+                    operation=CaseVersionDiffOperation.EQUAL,
+                    text=" body",
+                ),
+            ],
+        ),
     )
     with patch.object(cases_router, "CasesService") as mock_service_cls:
         mock_service = AsyncMock()
@@ -897,6 +917,15 @@ async def test_compare_case_version_success_and_mismatch_404(
 
     assert success.status_code == status.HTTP_200_OK
     assert success.json()["predecessor"]["content"] == "Old body"
+    assert success.json()["diff"] == {
+        "granularity": "word",
+        "changed": True,
+        "segments": [
+            {"operation": "delete", "text": "Old"},
+            {"operation": "insert", "text": "New"},
+            {"operation": "equal", "text": " body"},
+        ],
+    }
     assert missing.status_code == status.HTTP_404_NOT_FOUND
 
 

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -19,6 +19,7 @@ from tracecat.cases.enums import (
     CasePriority,
     CaseSeverity,
     CaseStatus,
+    CaseVersionField,
 )
 from tracecat.cases.schemas import (
     CaseBatchItemResult,
@@ -29,11 +30,18 @@ from tracecat.cases.schemas import (
     CaseSearchAggregateRead,
     CaseStatusGroupCounts,
 )
+from tracecat.cases.versions.schemas import (
+    CaseVersionCompareRead,
+    CaseVersionContentRead,
+    CaseVersionReadMinimal,
+    CaseVersionRestoreRead,
+)
 from tracecat.contexts import ctx_role
 from tracecat.db.models import Case, CaseTag, Workspace
 from tracecat.exceptions import (
     EntitlementRequired,
     TracecatConflictError,
+    TracecatNotFoundError,
     TracecatValidationError,
 )
 from tracecat.pagination import CursorPaginatedResponse
@@ -755,6 +763,162 @@ async def test_update_case_success(
 
         # Verify service was called
         mock_svc.update_case.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_list_case_versions_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """GET case versions forwards pagination and field filters."""
+    version_id = uuid.uuid4()
+    version = CaseVersionReadMinimal(
+        id=version_id,
+        field=CaseVersionField.SUMMARY,
+        version=2,
+        created_at=datetime(2024, 1, 2, tzinfo=UTC),
+        is_latest=True,
+    )
+    response_page = CursorPaginatedResponse(
+        items=[version],
+        has_more=False,
+        has_previous=False,
+    )
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_case.return_value = mock_case
+        mock_service.versions.list_versions.return_value = response_page
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            f"/cases/{mock_case.id}/versions",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "limit": 25,
+                "field": "summary",
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["items"][0] == {
+        "id": str(version_id),
+        "field": "summary",
+        "version": 2,
+        "actor": None,
+        "created_at": "2024-01-02T00:00:00Z",
+        "is_latest": True,
+    }
+    call = mock_service.versions.list_versions.await_args
+    assert call.kwargs["case_id"] == mock_case.id
+    assert call.kwargs["field"] == CaseVersionField.SUMMARY
+    assert call.kwargs["page"].limit == 25
+
+
+@pytest.mark.anyio
+async def test_list_case_versions_missing_case_returns_404(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Version history does not treat a missing case as empty history."""
+    case_id = uuid.uuid4()
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_case.return_value = None
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            f"/cases/{case_id}/versions",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    mock_service.versions.list_versions.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_compare_case_version_success_and_mismatch_404(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Compare serializes predecessor content and hides mismatched versions."""
+    selected_id = uuid.uuid4()
+    predecessor_id = uuid.uuid4()
+    comparison = CaseVersionCompareRead(
+        selected=CaseVersionContentRead(
+            id=selected_id,
+            field=CaseVersionField.DESCRIPTION,
+            version=2,
+            content="New body",
+        ),
+        predecessor=CaseVersionContentRead(
+            id=predecessor_id,
+            field=CaseVersionField.DESCRIPTION,
+            version=1,
+            content="Old body",
+        ),
+    )
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.versions.compare_with_predecessor.side_effect = [
+            comparison,
+            None,
+        ]
+        mock_service_cls.return_value = mock_service
+
+        success = client.get(
+            f"/cases/{mock_case.id}/versions/{selected_id}/compare",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+        missing = client.get(
+            f"/cases/{mock_case.id}/versions/{uuid.uuid4()}/compare",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert success.status_code == status.HTTP_200_OK
+    assert success.json()["predecessor"]["content"] == "Old body"
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_restore_case_version_success_and_mismatch_404(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Restore returns a typed confirmation and maps scoped misses to 404."""
+    version_id = uuid.uuid4()
+    restored = CaseVersionRestoreRead(
+        case_id=mock_case.id,
+        restored_from_version_id=version_id,
+        field=CaseVersionField.SUMMARY,
+    )
+    with patch.object(cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.restore_version.side_effect = [
+            restored,
+            TracecatNotFoundError("Case version not found"),
+        ]
+        mock_service_cls.return_value = mock_service
+
+        success = client.post(
+            f"/cases/{mock_case.id}/versions/{version_id}/restore",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+        missing = client.post(
+            f"/cases/{mock_case.id}/versions/{uuid.uuid4()}/restore",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert success.status_code == status.HTTP_200_OK
+    assert success.json() == {
+        "restored": True,
+        "case_id": str(mock_case.id),
+        "restored_from_version_id": str(version_id),
+        "field": "summary",
+    }
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_case_versions_service.py
+++ b/tests/unit/test_case_versions_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -73,6 +74,21 @@ def test_case_version_diff_returns_renderable_replacement_segments() -> None:
         (CaseVersionDiffOperation.DELETE, "unknown"),
         (CaseVersionDiffOperation.INSERT, "new"),
         (CaseVersionDiffOperation.EQUAL, " host"),
+    ]
+
+
+def test_case_version_diff_falls_back_when_token_budget_is_exceeded() -> None:
+    """Large comparisons use an exact coarse diff without SequenceMatcher."""
+    predecessor = "shared old " * 501
+    selected = "shared new " * 501
+
+    with patch("tracecat.cases.versions.diff.SequenceMatcher") as matcher:
+        diff = compute_case_version_diff(predecessor, selected)
+
+    matcher.assert_not_called()
+    assert [(segment.operation, segment.text) for segment in diff.segments] == [
+        (CaseVersionDiffOperation.DELETE, predecessor),
+        (CaseVersionDiffOperation.INSERT, selected),
     ]
 
 

--- a/tests/unit/test_case_versions_service.py
+++ b/tests/unit/test_case_versions_service.py
@@ -1,0 +1,66 @@
+"""Authorization tests for case version services."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.cases.service import CasesService
+from tracecat.cases.versions.service import CaseVersionsService
+from tracecat.exceptions import ScopeDeniedError
+from tracecat.pagination import PageParams
+
+
+def _role_with_scopes(*scopes: str) -> Role:
+    return Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        scopes=frozenset(scopes),
+    )
+
+
+@pytest.mark.anyio
+async def test_case_version_reads_require_case_read() -> None:
+    """List, selected-version, and compare reads enforce case:read."""
+    session = AsyncSession()
+    service = CaseVersionsService(session, _role_with_scopes())
+    case_id = uuid.uuid4()
+    version_id = uuid.uuid4()
+    try:
+        with pytest.raises(ScopeDeniedError):
+            await service.list_versions(
+                case_id=case_id,
+                page=PageParams(limit=1),
+            )
+        with pytest.raises(ScopeDeniedError):
+            await service.get_version(
+                case_id=case_id,
+                version_id=version_id,
+            )
+        with pytest.raises(ScopeDeniedError):
+            await service.compare_with_predecessor(
+                case_id=case_id,
+                version_id=version_id,
+            )
+    finally:
+        await session.close()
+
+
+@pytest.mark.anyio
+async def test_case_version_restore_requires_case_update() -> None:
+    """Restoring a version rejects a read-only role at the service boundary."""
+    session = AsyncSession()
+    service = CasesService(session, _role_with_scopes("case:read"))
+    try:
+        with pytest.raises(ScopeDeniedError):
+            await service.restore_version(
+                case_id=uuid.uuid4(),
+                version_id=uuid.uuid4(),
+            )
+    finally:
+        await session.close()

--- a/tests/unit/test_case_versions_service.py
+++ b/tests/unit/test_case_versions_service.py
@@ -1,4 +1,4 @@
-"""Authorization tests for case version services."""
+"""Unit tests for case version services."""
 
 from __future__ import annotations
 
@@ -8,7 +8,9 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
+from tracecat.cases.enums import CaseVersionDiffOperation
 from tracecat.cases.service import CasesService
+from tracecat.cases.versions.diff import compute_case_version_diff
 from tracecat.cases.versions.service import CaseVersionsService
 from tracecat.exceptions import ScopeDeniedError
 from tracecat.pagination import PageParams
@@ -22,6 +24,56 @@ def _role_with_scopes(*scopes: str) -> Role:
         service_id="tracecat-api",
         scopes=frozenset(scopes),
     )
+
+
+@pytest.mark.parametrize(
+    ("predecessor", "selected"),
+    [
+        ("Login from unknown host", "Login from new host"),
+        ("First line\nSecond line", "First line\nUpdated second line"),
+        ("", "New content"),
+        ("Old content", ""),
+        ("Same content", "Same content"),
+        ("", ""),
+    ],
+)
+def test_case_version_diff_reconstructs_exact_content(
+    predecessor: str,
+    selected: str,
+) -> None:
+    """Diff segments losslessly reconstruct both source snapshots."""
+    diff = compute_case_version_diff(predecessor, selected)
+
+    reconstructed_predecessor = "".join(
+        segment.text
+        for segment in diff.segments
+        if segment.operation != CaseVersionDiffOperation.INSERT
+    )
+    reconstructed_selected = "".join(
+        segment.text
+        for segment in diff.segments
+        if segment.operation != CaseVersionDiffOperation.DELETE
+    )
+
+    assert diff.granularity == "word"
+    assert diff.changed == (predecessor != selected)
+    assert reconstructed_predecessor == predecessor
+    assert reconstructed_selected == selected
+
+
+def test_case_version_diff_returns_renderable_replacement_segments() -> None:
+    """A word replacement is ordered as equal, delete, insert, equal."""
+    diff = compute_case_version_diff(
+        "Login from unknown host",
+        "Login from new host",
+    )
+
+    assert [(segment.operation, segment.text) for segment in diff.segments] == [
+        (CaseVersionDiffOperation.EQUAL, "Login from "),
+        (CaseVersionDiffOperation.DELETE, "unknown"),
+        (CaseVersionDiffOperation.INSERT, "new"),
+        (CaseVersionDiffOperation.EQUAL, " host"),
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -250,6 +250,17 @@ class TestCasesService:
         assert retrieved_case.priority == case_create_params.priority
         assert retrieved_case.severity == case_create_params.severity
 
+    async def test_case_exists(
+        self,
+        cases_service: CasesService,
+        case_create_params: CaseCreate,
+    ) -> None:
+        """Test the lightweight case existence probe."""
+        created_case = await cases_service.create_case(case_create_params)
+
+        assert await cases_service.case_exists(created_case.id) is True
+        assert await cases_service.case_exists(uuid.uuid4()) is False
+
     async def test_create_and_get_case_with_assignee(
         self,
         cases_service: CasesService,

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -12,6 +12,7 @@ from tracecat.agent.folders import router as agent_folder_router
 from tracecat.agent.preset import router as agent_preset_router
 from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
 from tracecat.auth.types import Role
+from tracecat.cases import router as cases_router
 from tracecat.cases.dropdowns import router as case_dropdowns_router
 from tracecat.cases.durations import router as case_durations_router
 from tracecat.cases.rows import router as case_rows_router
@@ -361,6 +362,21 @@ async def test_workspace_collection_scope_guards(endpoint: AsyncEndpoint) -> Non
     ],
 )
 async def test_case_duration_scope_guards(
+    endpoint: AsyncEndpoint, required_scope: str
+) -> None:
+    await _assert_endpoint_requires_scope(endpoint, required_scope)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("endpoint", "required_scope"),
+    [
+        (cases_router.list_case_versions, "case:read"),
+        (cases_router.compare_case_version, "case:read"),
+        (cases_router.restore_case_version, "case:update"),
+    ],
+)
+async def test_case_version_scope_guards(
     endpoint: AsyncEndpoint, required_scope: str
 ) -> None:
     await _assert_endpoint_requires_scope(endpoint, required_scope)

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -12,13 +12,13 @@ from tracecat.agent.folders import router as agent_folder_router
 from tracecat.agent.preset import router as agent_preset_router
 from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
 from tracecat.auth.types import Role
-from tracecat.cases import router as cases_router
 from tracecat.cases.dropdowns import router as case_dropdowns_router
 from tracecat.cases.durations import router as case_durations_router
 from tracecat.cases.rows import router as case_rows_router
 from tracecat.cases.tag_definitions import router as case_tag_definitions_router
 from tracecat.cases.tags import internal_router as internal_case_tags_router
 from tracecat.cases.tags import router as case_tags_router
+from tracecat.cases.versions import router as case_versions_router
 from tracecat.contexts import ctx_role
 from tracecat.exceptions import ScopeDeniedError
 from tracecat.inbox import router as inbox_router
@@ -371,9 +371,9 @@ async def test_case_duration_scope_guards(
 @pytest.mark.parametrize(
     ("endpoint", "required_scope"),
     [
-        (cases_router.list_case_versions, "case:read"),
-        (cases_router.compare_case_version, "case:read"),
-        (cases_router.restore_case_version, "case:update"),
+        (case_versions_router.list_case_versions, "case:read"),
+        (case_versions_router.compare_case_version, "case:read"),
+        (case_versions_router.restore_case_version, "case:update"),
     ],
 )
 async def test_case_version_scope_guards(

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -91,6 +91,7 @@ from tracecat.cases.tag_definitions.router import (
 )
 from tracecat.cases.tags.router import router as case_tags_router
 from tracecat.cases.triggers.consumer import start_case_trigger_consumer
+from tracecat.cases.versions.router import router as case_versions_router
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import AsyncDBSessionBypass
 from tracecat.db.engine import (
@@ -573,6 +574,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(org_secrets_router)
     _include_workspace_scoped_router(app, tables_router)
     _include_workspace_scoped_router(app, cases_router)
+    _include_workspace_scoped_router(app, case_versions_router)
     _include_workspace_scoped_router(app, case_rows_router)
     _include_workspace_scoped_router(app, case_fields_router)
     _include_workspace_scoped_router(app, case_tags_router)

--- a/tracecat/cases/enums.py
+++ b/tracecat/cases/enums.py
@@ -64,6 +64,14 @@ class CaseVersionField(StrEnum):
     DESCRIPTION = "description"
 
 
+class CaseVersionDiffOperation(StrEnum):
+    """Operations in an ordered case-version text diff."""
+
+    EQUAL = "equal"
+    INSERT = "insert"
+    DELETE = "delete"
+
+
 class CaseEventType(StrEnum):
     """Case activity type values."""
 

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -27,7 +27,6 @@ from tracecat.cases.enums import (
     CasePriority,
     CaseSeverity,
     CaseStatus,
-    CaseVersionField,
 )
 from tracecat.cases.filters import parse_assignee_filter
 from tracecat.cases.rows.service import CaseTableRowsService
@@ -64,11 +63,7 @@ from tracecat.cases.service import (
 )
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.cases.versions.schemas import (
-    CaseVersionCompareRead,
-    CaseVersionReadMinimal,
-    CaseVersionRestoreRead,
-)
+from tracecat.cases.versions.router import router as case_versions_router
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import (
     TracecatAuthorizationError,
@@ -81,7 +76,6 @@ from tracecat.logger import logger
 from tracecat.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
-    PageParams,
 )
 from tracecat.tiers.enums import Entitlement
 
@@ -557,101 +551,7 @@ async def batch_delete_cases(
         ) from exc
 
 
-@cases_router.get(
-    "/{case_id}/versions",
-    response_model=CursorPaginatedResponse[CaseVersionReadMinimal],
-)
-@require_scope("case:read")
-async def list_case_versions(
-    *,
-    role: WorkspaceActorRouteRole,
-    session: AsyncDBSession,
-    case_id: uuid.UUID,
-    limit: int = Query(
-        config.TRACECAT__LIMIT_DEFAULT,
-        ge=config.TRACECAT__LIMIT_MIN,
-        le=config.TRACECAT__LIMIT_CURSOR_MAX,
-        description="Maximum items per page",
-    ),
-    cursor: str | None = Query(
-        None,
-        max_length=8192,
-        description="Cursor for pagination",
-    ),
-    field: CaseVersionField | None = Query(
-        None,
-        description="Optionally include only summary or description versions",
-    ),
-) -> CursorPaginatedResponse[CaseVersionReadMinimal]:
-    """List immutable case field versions newest-first."""
-    service = CasesService(session, role)
-    if await service.get_case(case_id) is None:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND,
-            detail=f"Case with ID {case_id} not found",
-        )
-    try:
-        return await service.versions.list_versions(
-            case_id=case_id,
-            page=PageParams(limit=limit, cursor=cursor),
-            field=field,
-        )
-    except TracecatValidationError as exc:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=exc.detail or str(exc),
-        ) from exc
-
-
-@cases_router.get(
-    "/{case_id}/versions/{version_id}/compare",
-    response_model=CaseVersionCompareRead,
-)
-@require_scope("case:read")
-async def compare_case_version(
-    *,
-    role: WorkspaceActorRouteRole,
-    session: AsyncDBSession,
-    case_id: uuid.UUID,
-    version_id: uuid.UUID,
-) -> CaseVersionCompareRead:
-    """Compare a case field version with its immediate predecessor."""
-    service = CasesService(session, role)
-    comparison = await service.versions.compare_with_predecessor(
-        case_id=case_id,
-        version_id=version_id,
-    )
-    if comparison is None:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND,
-            detail=f"Case version '{version_id}' not found",
-        )
-    return comparison
-
-
-@cases_router.post(
-    "/{case_id}/versions/{version_id}/restore",
-    response_model=CaseVersionRestoreRead,
-)
-@require_scope("case:update")
-async def restore_case_version(
-    *,
-    role: WorkspaceActorRouteRole,
-    session: AsyncDBSession,
-    case_id: uuid.UUID,
-    version_id: uuid.UUID,
-) -> CaseVersionRestoreRead:
-    """Restore one historical case field version atomically."""
-    try:
-        return await CasesService(session, role).restore_version(
-            case_id=case_id,
-            version_id=version_id,
-        )
-    except TracecatNotFoundError as exc:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND,
-            detail=str(exc),
-        ) from exc
+cases_router.include_router(case_versions_router)
 
 
 @cases_router.get("/{case_id}")

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -23,7 +23,12 @@ from tracecat.auth.schemas import UserRead
 from tracecat.auth.users import search_users
 from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
-from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.enums import (
+    CasePriority,
+    CaseSeverity,
+    CaseStatus,
+    CaseVersionField,
+)
 from tracecat.cases.filters import parse_assignee_filter
 from tracecat.cases.rows.service import CaseTableRowsService
 from tracecat.cases.schemas import (
@@ -59,6 +64,11 @@ from tracecat.cases.service import (
 )
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
+from tracecat.cases.versions.schemas import (
+    CaseVersionCompareRead,
+    CaseVersionReadMinimal,
+    CaseVersionRestoreRead,
+)
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import (
     TracecatAuthorizationError,
@@ -71,6 +81,7 @@ from tracecat.logger import logger
 from tracecat.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
+    PageParams,
 )
 from tracecat.tiers.enums import Entitlement
 
@@ -543,6 +554,99 @@ async def batch_delete_cases(
         raise HTTPException(
             status_code=HTTP_409_CONFLICT,
             detail=exc.detail or str(exc),
+        ) from exc
+
+
+@cases_router.get(
+    "/{case_id}/versions",
+    response_model=CursorPaginatedResponse[CaseVersionReadMinimal],
+)
+@require_scope("case:read")
+async def list_case_versions(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    limit: int = Query(
+        config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+        description="Maximum items per page",
+    ),
+    cursor: str | None = Query(None, description="Cursor for pagination"),
+    field: CaseVersionField | None = Query(
+        None,
+        description="Optionally include only summary or description versions",
+    ),
+) -> CursorPaginatedResponse[CaseVersionReadMinimal]:
+    """List immutable case field versions newest-first."""
+    service = CasesService(session, role)
+    if await service.get_case(case_id) is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Case with ID {case_id} not found",
+        )
+    try:
+        return await service.versions.list_versions(
+            case_id=case_id,
+            page=PageParams(limit=limit, cursor=cursor),
+            field=field,
+        )
+    except TracecatValidationError as exc:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=exc.detail or str(exc),
+        ) from exc
+
+
+@cases_router.get(
+    "/{case_id}/versions/{version_id}/compare",
+    response_model=CaseVersionCompareRead,
+)
+@require_scope("case:read")
+async def compare_case_version(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    version_id: uuid.UUID,
+) -> CaseVersionCompareRead:
+    """Compare a case field version with its immediate predecessor."""
+    service = CasesService(session, role)
+    comparison = await service.versions.compare_with_predecessor(
+        case_id=case_id,
+        version_id=version_id,
+    )
+    if comparison is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Case version '{version_id}' not found",
+        )
+    return comparison
+
+
+@cases_router.post(
+    "/{case_id}/versions/{version_id}/restore",
+    response_model=CaseVersionRestoreRead,
+)
+@require_scope("case:update")
+async def restore_case_version(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    version_id: uuid.UUID,
+) -> CaseVersionRestoreRead:
+    """Restore one historical case field version atomically."""
+    try:
+        return await CasesService(session, role).restore_version(
+            case_id=case_id,
+            version_id=version_id,
+        )
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=str(exc),
         ) from exc
 
 

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -573,7 +573,11 @@ async def list_case_versions(
         le=config.TRACECAT__LIMIT_CURSOR_MAX,
         description="Maximum items per page",
     ),
-    cursor: str | None = Query(None, description="Cursor for pagination"),
+    cursor: str | None = Query(
+        None,
+        max_length=8192,
+        description="Cursor for pagination",
+    ),
     field: CaseVersionField | None = Query(
         None,
         description="Optionally include only summary or description versions",

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -63,7 +63,6 @@ from tracecat.cases.service import (
 )
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.cases.versions.router import router as case_versions_router
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import (
     TracecatAuthorizationError,
@@ -549,9 +548,6 @@ async def batch_delete_cases(
             status_code=HTTP_409_CONFLICT,
             detail=exc.detail or str(exc),
         ) from exc
-
-
-cases_router.include_router(case_versions_router)
 
 
 @cases_router.get("/{case_id}")

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -744,6 +744,14 @@ class CasesService(BaseWorkspaceService):
 
         return case
 
+    async def case_exists(self, case_id: uuid.UUID) -> bool:
+        """Return whether a case exists without loading its relationships."""
+        statement = select(Case.id).where(
+            Case.workspace_id == self.workspace_id,
+            Case.id == case_id,
+        )
+        return (await self.session.execute(statement)).scalar_one_or_none() is not None
+
     async def _assign_next_case_number(self, case: Case) -> None:
         """Assign the next gapless number at the end of case creation."""
         next_case_number = await self.session.scalar(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -97,6 +97,7 @@ from tracecat.cases.schemas import (
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
 from tracecat.cases.triggers.publisher import publish_case_event_payload
+from tracecat.cases.versions.schemas import CaseVersionRestoreRead
 from tracecat.cases.versions.service import CaseVersionsService
 from tracecat.contexts import ctx_run
 from tracecat.custom_fields import CustomFieldsService
@@ -920,13 +921,20 @@ class CasesService(BaseWorkspaceService):
 
     @require_scope("case:update")
     @audit_log(resource_type="case", action="update")
-    async def update_case(self, case: Case, params: CaseUpdate) -> Case:
+    async def update_case(
+        self,
+        case: Case,
+        params: CaseUpdate,
+        *,
+        force_version_fields: frozenset[CaseVersionField] = frozenset(),
+    ) -> Case:
         """Update a case and optionally its custom fields.
 
         Args:
             case: The case object to update
             params: Optional case update parameters
-            fields_data: Optional new field values
+            force_version_fields: Versioned fields that must append even when the
+                restored content equals the mutable head.
 
         Returns:
             Updated case with fields
@@ -942,7 +950,11 @@ class CasesService(BaseWorkspaceService):
                     case,
                     attribute_names=["summary", "description"],
                 )
-            await self._apply_case_update(case, params)
+            await self._apply_case_update(
+                case,
+                params,
+                force_version_fields=force_version_fields,
+            )
             # Commit once to persist all updates and emitted events atomically
             await self.session.commit()
             await self.session.refresh(case)
@@ -951,7 +963,46 @@ class CasesService(BaseWorkspaceService):
             await self.session.rollback()
             raise
 
-    async def _apply_case_update(self, case: Case, params: CaseUpdate) -> None:
+    @require_scope("case:update")
+    async def restore_version(
+        self,
+        *,
+        case_id: uuid.UUID,
+        version_id: uuid.UUID,
+    ) -> CaseVersionRestoreRead:
+        """Restore one scoped field version through the normal update transaction."""
+        case = await self.get_case(case_id, for_update=True)
+        if case is None:
+            raise TracecatNotFoundError(f"Case '{case_id}' not found")
+
+        version = await self.versions.get_version(
+            case_id=case_id,
+            version_id=version_id,
+        )
+        if version is None:
+            raise TracecatNotFoundError(
+                f"Case version '{version_id}' not found for case '{case_id}'"
+            )
+
+        params = CaseUpdate.model_validate({version.field.value: version.content})
+        await self.update_case(
+            case,
+            params,
+            force_version_fields=frozenset({version.field}),
+        )
+        return CaseVersionRestoreRead(
+            case_id=case_id,
+            restored_from_version_id=version.id,
+            field=version.field,
+        )
+
+    async def _apply_case_update(
+        self,
+        case: Case,
+        params: CaseUpdate,
+        *,
+        force_version_fields: frozenset[CaseVersionField] = frozenset(),
+    ) -> None:
         """Apply a case update without committing the active transaction."""
         run_ctx = ctx_run.get()
         wf_exec_id = run_ctx.wf_exec_id if run_ctx else None
@@ -1058,10 +1109,14 @@ class CasesService(BaseWorkspaceService):
         for key, value in set_fields.items():
             old = getattr(case, key, None)
             setattr(case, key, value)
-            if key in {"summary", "description"} and old != value:
+            version_field = (
+                CaseVersionField(key) if key in {"summary", "description"} else None
+            )
+            version_forced = version_field in force_version_fields
+            if version_field is not None and (old != value or version_forced):
                 await self.versions.append_version(
                     case_id=case.id,
-                    field=CaseVersionField(key),
+                    field=version_field,
                     content=value,
                 )
 
@@ -1072,7 +1127,7 @@ class CasesService(BaseWorkspaceService):
                         AssigneeChangedEvent(old=old, new=value, wf_exec_id=wf_exec_id)
                     )
             elif key == "summary":
-                if old != value:
+                if old != value or version_forced:
                     events.append(
                         UpdatedEvent(
                             field="summary",

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -979,7 +979,7 @@ class CasesService(BaseWorkspaceService):
         version_id: uuid.UUID,
     ) -> CaseVersionRestoreRead:
         """Restore one scoped field version through the normal update transaction."""
-        case = await self.get_case(case_id, for_update=True)
+        case = (await self._lock_cases([case_id])).get(case_id)
         if case is None:
             raise TracecatNotFoundError(f"Case '{case_id}' not found")
 

--- a/tracecat/cases/versions/diff.py
+++ b/tracecat/cases/versions/diff.py
@@ -12,6 +12,9 @@ from tracecat.cases.versions.schemas import (
 )
 
 _WORD_DIFF_TOKEN_PATTERN = re.compile(r"\s+|\w+|[^\w\s]+")
+# Bound SequenceMatcher's quadratic worst case; larger inputs use an exact
+# whole-content replacement diff.
+_MAX_SEQUENCE_MATCHER_TOKEN_PAIRS = 1_000_000
 
 
 def compute_case_version_diff(
@@ -19,12 +22,6 @@ def compute_case_version_diff(
     selected: str,
 ) -> CaseVersionDiffRead:
     """Build a word-level edit script from predecessor to selected content."""
-    predecessor_tokens = _WORD_DIFF_TOKEN_PATTERN.findall(predecessor)
-    selected_tokens = _WORD_DIFF_TOKEN_PATTERN.findall(selected)
-    matcher = SequenceMatcher(
-        a=predecessor_tokens,
-        b=selected_tokens,
-    )
     segments: list[CaseVersionDiffSegmentRead] = []
 
     def append_segment(operation: CaseVersionDiffOperation, text: str) -> None:
@@ -38,6 +35,25 @@ def compute_case_version_diff(
             )
             return
         segments.append(CaseVersionDiffSegmentRead(operation=operation, text=text))
+
+    if predecessor == selected:
+        append_segment(CaseVersionDiffOperation.EQUAL, selected)
+        return CaseVersionDiffRead(changed=False, segments=segments)
+
+    predecessor_tokens = _WORD_DIFF_TOKEN_PATTERN.findall(predecessor)
+    selected_tokens = _WORD_DIFF_TOKEN_PATTERN.findall(selected)
+    if (
+        len(predecessor_tokens) * len(selected_tokens)
+        > _MAX_SEQUENCE_MATCHER_TOKEN_PAIRS
+    ):
+        append_segment(CaseVersionDiffOperation.DELETE, predecessor)
+        append_segment(CaseVersionDiffOperation.INSERT, selected)
+        return CaseVersionDiffRead(changed=True, segments=segments)
+
+    matcher = SequenceMatcher(
+        a=predecessor_tokens,
+        b=selected_tokens,
+    )
 
     for (
         tag,

--- a/tracecat/cases/versions/diff.py
+++ b/tracecat/cases/versions/diff.py
@@ -24,7 +24,6 @@ def compute_case_version_diff(
     matcher = SequenceMatcher(
         a=predecessor_tokens,
         b=selected_tokens,
-        autojunk=False,
     )
     segments: list[CaseVersionDiffSegmentRead] = []
 

--- a/tracecat/cases/versions/diff.py
+++ b/tracecat/cases/versions/diff.py
@@ -1,0 +1,68 @@
+"""Structured textual diffs for immutable case versions."""
+
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+
+from tracecat.cases.enums import CaseVersionDiffOperation
+from tracecat.cases.versions.schemas import (
+    CaseVersionDiffRead,
+    CaseVersionDiffSegmentRead,
+)
+
+_WORD_DIFF_TOKEN_PATTERN = re.compile(r"\s+|\w+|[^\w\s]+")
+
+
+def compute_case_version_diff(
+    predecessor: str,
+    selected: str,
+) -> CaseVersionDiffRead:
+    """Build a word-level edit script from predecessor to selected content."""
+    predecessor_tokens = _WORD_DIFF_TOKEN_PATTERN.findall(predecessor)
+    selected_tokens = _WORD_DIFF_TOKEN_PATTERN.findall(selected)
+    matcher = SequenceMatcher(
+        a=predecessor_tokens,
+        b=selected_tokens,
+        autojunk=False,
+    )
+    segments: list[CaseVersionDiffSegmentRead] = []
+
+    def append_segment(operation: CaseVersionDiffOperation, text: str) -> None:
+        if not text:
+            return
+        if segments and segments[-1].operation == operation:
+            previous = segments[-1]
+            segments[-1] = CaseVersionDiffSegmentRead(
+                operation=operation,
+                text=previous.text + text,
+            )
+            return
+        segments.append(CaseVersionDiffSegmentRead(operation=operation, text=text))
+
+    for (
+        tag,
+        predecessor_start,
+        predecessor_end,
+        selected_start,
+        selected_end,
+    ) in matcher.get_opcodes():
+        predecessor_text = "".join(
+            predecessor_tokens[predecessor_start:predecessor_end]
+        )
+        selected_text = "".join(selected_tokens[selected_start:selected_end])
+        match tag:
+            case "equal":
+                append_segment(CaseVersionDiffOperation.EQUAL, selected_text)
+            case "delete":
+                append_segment(CaseVersionDiffOperation.DELETE, predecessor_text)
+            case "insert":
+                append_segment(CaseVersionDiffOperation.INSERT, selected_text)
+            case "replace":
+                append_segment(CaseVersionDiffOperation.DELETE, predecessor_text)
+                append_segment(CaseVersionDiffOperation.INSERT, selected_text)
+
+    return CaseVersionDiffRead(
+        changed=predecessor != selected,
+        segments=segments,
+    )

--- a/tracecat/cases/versions/router.py
+++ b/tracecat/cases/versions/router.py
@@ -19,7 +19,7 @@ from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.pagination import CursorPaginatedResponse, PageParams
 
-router = APIRouter(prefix="/{case_id}/versions")
+router = APIRouter(prefix="/cases/{case_id}/versions", tags=["cases"])
 
 
 @router.get(

--- a/tracecat/cases/versions/router.py
+++ b/tracecat/cases/versions/router.py
@@ -1,0 +1,119 @@
+"""Router for case version history endpoints."""
+
+import uuid
+
+from fastapi import APIRouter, HTTPException, Query
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
+
+from tracecat import config
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
+from tracecat.authz.controls import require_scope
+from tracecat.cases.enums import CaseVersionField
+from tracecat.cases.service import CasesService
+from tracecat.cases.versions.schemas import (
+    CaseVersionCompareRead,
+    CaseVersionReadMinimal,
+    CaseVersionRestoreRead,
+)
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.pagination import CursorPaginatedResponse, PageParams
+
+router = APIRouter(prefix="/{case_id}/versions")
+
+
+@router.get(
+    "",
+    response_model=CursorPaginatedResponse[CaseVersionReadMinimal],
+)
+@require_scope("case:read")
+async def list_case_versions(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    limit: int = Query(
+        config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+        description="Maximum items per page",
+    ),
+    cursor: str | None = Query(
+        None,
+        max_length=8192,
+        description="Cursor for pagination",
+    ),
+    field: CaseVersionField | None = Query(
+        None,
+        description="Optionally include only summary or description versions",
+    ),
+) -> CursorPaginatedResponse[CaseVersionReadMinimal]:
+    """List immutable case field versions newest-first."""
+    service = CasesService(session, role)
+    if not await service.case_exists(case_id):
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Case with ID {case_id} not found",
+        )
+    try:
+        return await service.versions.list_versions(
+            case_id=case_id,
+            page=PageParams(limit=limit, cursor=cursor),
+            field=field,
+        )
+    except TracecatValidationError as exc:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=exc.detail or str(exc),
+        ) from exc
+
+
+@router.get(
+    "/{version_id}/compare",
+    response_model=CaseVersionCompareRead,
+)
+@require_scope("case:read")
+async def compare_case_version(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    version_id: uuid.UUID,
+) -> CaseVersionCompareRead:
+    """Compare a case field version with its immediate predecessor."""
+    service = CasesService(session, role)
+    comparison = await service.versions.compare_with_predecessor(
+        case_id=case_id,
+        version_id=version_id,
+    )
+    if comparison is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Case version '{version_id}' not found",
+        )
+    return comparison
+
+
+@router.post(
+    "/{version_id}/restore",
+    response_model=CaseVersionRestoreRead,
+)
+@require_scope("case:update")
+async def restore_case_version(
+    *,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    version_id: uuid.UUID,
+) -> CaseVersionRestoreRead:
+    """Restore one historical case field version atomically."""
+    try:
+        return await CasesService(session, role).restore_version(
+            case_id=case_id,
+            version_id=version_id,
+        )
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc

--- a/tracecat/cases/versions/schemas.py
+++ b/tracecat/cases/versions/schemas.py
@@ -1,0 +1,58 @@
+"""API schemas for immutable case text-field versions."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import Field
+
+from tracecat.cases.enums import CaseVersionField
+from tracecat.core.schemas import Schema
+
+
+class CaseVersionActorRead(Schema):
+    """Minimal user metadata for a case-version author."""
+
+    id: uuid.UUID
+    email: str
+    first_name: str | None = Field(default=None)
+    last_name: str | None = Field(default=None)
+
+
+class CaseVersionReadMinimal(Schema):
+    """Version metadata returned by the case history endpoint."""
+
+    id: uuid.UUID
+    field: CaseVersionField
+    version: int
+    actor: CaseVersionActorRead | None = Field(default=None)
+    created_at: datetime
+    is_latest: bool = Field(
+        description="Whether this is the latest immutable version for its field"
+    )
+
+
+class CaseVersionContentRead(Schema):
+    """Content for one immutable case field version."""
+
+    id: uuid.UUID
+    field: CaseVersionField
+    version: int
+    content: str
+
+
+class CaseVersionCompareRead(Schema):
+    """A selected case version and its immediate same-field predecessor."""
+
+    selected: CaseVersionContentRead
+    predecessor: CaseVersionContentRead | None = Field(default=None)
+
+
+class CaseVersionRestoreRead(Schema):
+    """Confirmation that a historical case field version was restored."""
+
+    restored: bool = Field(default=True)
+    case_id: uuid.UUID
+    restored_from_version_id: uuid.UUID
+    field: CaseVersionField

--- a/tracecat/cases/versions/schemas.py
+++ b/tracecat/cases/versions/schemas.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from typing import Literal
 
 from pydantic import Field
 
-from tracecat.cases.enums import CaseVersionField
+from tracecat.cases.enums import CaseVersionDiffOperation, CaseVersionField
 from tracecat.core.schemas import Schema
 
 
@@ -42,11 +43,27 @@ class CaseVersionContentRead(Schema):
     content: str
 
 
+class CaseVersionDiffSegmentRead(Schema):
+    """One exact-text segment in an ordered case-version diff."""
+
+    operation: CaseVersionDiffOperation
+    text: str
+
+
+class CaseVersionDiffRead(Schema):
+    """A word-level edit script from predecessor to selected content."""
+
+    granularity: Literal["word"] = Field(default="word")
+    changed: bool
+    segments: list[CaseVersionDiffSegmentRead]
+
+
 class CaseVersionCompareRead(Schema):
-    """A selected case version and its immediate same-field predecessor."""
+    """A selected case version, its predecessor, and their textual diff."""
 
     selected: CaseVersionContentRead
     predecessor: CaseVersionContentRead | None = Field(default=None)
+    diff: CaseVersionDiffRead | None = Field(default=None)
 
 
 class CaseVersionRestoreRead(Schema):

--- a/tracecat/cases/versions/service.py
+++ b/tracecat/cases/versions/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import aliased
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.cases.enums import CaseVersionField
+from tracecat.cases.versions.diff import compute_case_version_diff
 from tracecat.cases.versions.schemas import (
     CaseVersionActorRead,
     CaseVersionCompareRead,
@@ -252,11 +253,21 @@ class CaseVersionsService(BaseWorkspaceService):
             return None
         selected_version = cast(CaseVersion, row[0])
         predecessor_version = cast(CaseVersion | None, row[1])
+        selected_read = CaseVersionContentRead.model_validate(selected_version)
+        predecessor_read = (
+            CaseVersionContentRead.model_validate(predecessor_version)
+            if predecessor_version is not None
+            else None
+        )
         return CaseVersionCompareRead(
-            selected=CaseVersionContentRead.model_validate(selected_version),
-            predecessor=(
-                CaseVersionContentRead.model_validate(predecessor_version)
-                if predecessor_version is not None
+            selected=selected_read,
+            predecessor=predecessor_read,
+            diff=(
+                compute_case_version_diff(
+                    predecessor_read.content,
+                    selected_read.content,
+                )
+                if predecessor_read is not None
                 else None
             ),
         )

--- a/tracecat/cases/versions/service.py
+++ b/tracecat/cases/versions/service.py
@@ -3,19 +3,34 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
+from typing import cast
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from tracecat.auth.types import Role
+from tracecat.authz.controls import require_scope
 from tracecat.cases.enums import CaseVersionField
+from tracecat.cases.versions.schemas import (
+    CaseVersionActorRead,
+    CaseVersionCompareRead,
+    CaseVersionContentRead,
+    CaseVersionReadMinimal,
+)
 from tracecat.db.models import Case, CaseVersion, User
 from tracecat.exceptions import TracecatNotFoundError
+from tracecat.pagination import (
+    CursorPaginatedResponse,
+    PageParams,
+    paginate,
+)
 from tracecat.service import BaseWorkspaceService
 
 
 class CaseVersionsService(BaseWorkspaceService):
-    """Create immutable versions for case titles and descriptions."""
+    """Manage immutable versions for case titles and descriptions."""
 
     service_name = "case_versions"
 
@@ -108,3 +123,140 @@ class CaseVersionsService(BaseWorkspaceService):
         self.session.add(version)
         await self.session.flush()
         return version
+
+    @require_scope("case:read")
+    async def list_versions(
+        self,
+        *,
+        case_id: uuid.UUID,
+        page: PageParams,
+        field: CaseVersionField | None = None,
+    ) -> CursorPaginatedResponse[CaseVersionReadMinimal]:
+        """List case version metadata newest-first without loading content."""
+        latest = CaseVersion.__table__.alias("latest_case_version")
+        latest_version = (
+            select(func.max(latest.c.version))
+            .where(
+                latest.c.workspace_id == self.workspace_id,
+                latest.c.case_id == case_id,
+                latest.c.field == CaseVersion.field,
+            )
+            .correlate(CaseVersion)
+            .scalar_subquery()
+        )
+        user = User.__table__
+        statement = (
+            select(
+                CaseVersion.id,
+                CaseVersion.field,
+                CaseVersion.version,
+                CaseVersion.created_at,
+                CaseVersion.version == latest_version,
+                user.c.id,
+                user.c.email,
+                user.c.first_name,
+                user.c.last_name,
+            )
+            .outerjoin(user, user.c.id == CaseVersion.user_id)
+            .where(
+                CaseVersion.workspace_id == self.workspace_id,
+                CaseVersion.case_id == case_id,
+            )
+        )
+        if field is not None:
+            statement = statement.where(CaseVersion.field == field)
+
+        result = await paginate(
+            self.session,
+            statement,
+            page=page,
+            order_by=(
+                CaseVersion.created_at.desc(),
+                CaseVersion.surrogate_id.desc(),
+            ),
+            row_factory=self._version_metadata_from_row,
+        )
+        return CursorPaginatedResponse(
+            items=result.items,
+            next_cursor=result.next_cursor,
+            prev_cursor=result.prev_cursor,
+            has_more=result.has_more,
+            has_previous=result.has_previous,
+        )
+
+    @staticmethod
+    def _version_metadata_from_row(
+        values: tuple[object, ...],
+    ) -> CaseVersionReadMinimal:
+        """Build list metadata from the projected version and actor columns."""
+        actor_id = cast(uuid.UUID | None, values[5])
+        actor = None
+        if actor_id is not None:
+            actor = CaseVersionActorRead(
+                id=actor_id,
+                email=cast(str, values[6]),
+                first_name=cast(str | None, values[7]),
+                last_name=cast(str | None, values[8]),
+            )
+        return CaseVersionReadMinimal(
+            id=cast(uuid.UUID, values[0]),
+            field=cast(CaseVersionField, values[1]),
+            version=cast(int, values[2]),
+            created_at=cast(datetime, values[3]),
+            is_latest=cast(bool, values[4]),
+            actor=actor,
+        )
+
+    @require_scope("case:read")
+    async def get_version(
+        self,
+        *,
+        case_id: uuid.UUID,
+        version_id: uuid.UUID,
+    ) -> CaseVersion | None:
+        """Load a version only when its workspace and parent case match."""
+        statement = select(CaseVersion).where(
+            CaseVersion.workspace_id == self.workspace_id,
+            CaseVersion.case_id == case_id,
+            CaseVersion.id == version_id,
+        )
+        return (await self.session.execute(statement)).scalar_one_or_none()
+
+    @require_scope("case:read")
+    async def compare_with_predecessor(
+        self,
+        *,
+        case_id: uuid.UUID,
+        version_id: uuid.UUID,
+    ) -> CaseVersionCompareRead | None:
+        """Return one scoped version and its immediate same-field predecessor."""
+        selected = aliased(CaseVersion, name="selected_case_version")
+        predecessor = aliased(CaseVersion, name="predecessor_case_version")
+        statement = (
+            select(selected, predecessor)
+            .outerjoin(
+                predecessor,
+                (predecessor.workspace_id == selected.workspace_id)
+                & (predecessor.case_id == selected.case_id)
+                & (predecessor.field == selected.field)
+                & (predecessor.version == selected.version - 1),
+            )
+            .where(
+                selected.workspace_id == self.workspace_id,
+                selected.case_id == case_id,
+                selected.id == version_id,
+            )
+        )
+        row = (await self.session.execute(statement)).one_or_none()
+        if row is None:
+            return None
+        selected_version = cast(CaseVersion, row[0])
+        predecessor_version = cast(CaseVersion | None, row[1])
+        return CaseVersionCompareRead(
+            selected=CaseVersionContentRead.model_validate(selected_version),
+            predecessor=(
+                CaseVersionContentRead.model_validate(predecessor_version)
+                if predecessor_version is not None
+                else None
+            ),
+        )

--- a/tracecat/cases/versions/service.py
+++ b/tracecat/cases/versions/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import datetime
 from typing import cast
@@ -259,15 +260,17 @@ class CaseVersionsService(BaseWorkspaceService):
             if predecessor_version is not None
             else None
         )
+        diff = (
+            await asyncio.to_thread(
+                compute_case_version_diff,
+                predecessor_read.content,
+                selected_read.content,
+            )
+            if predecessor_read is not None
+            else None
+        )
         return CaseVersionCompareRead(
             selected=selected_read,
             predecessor=predecessor_read,
-            diff=(
-                compute_case_version_diff(
-                    predecessor_read.content,
-                    selected_read.content,
-                )
-                if predecessor_read is not None
-                else None
-            ),
+            diff=diff,
         )


### PR DESCRIPTION
## Summary

- Add cursor-paginated history for case `summary` and `description` versions, with actor and latest-version metadata.
- Add comparison APIs that return the selected version, its immediate same-field predecessor, and a render-ready word-level textual diff.
- Add append-only restore APIs routed through the existing locked case-update transaction, with workspace/case-scoped `404` behavior.

Depends on #3272. Implements [ENG-1676](https://linear.app/tracecat/issue/ENG-1676/featcases-add-case-version-history-and-restore-apis).

## Review guide

1. **API contract:** `tracecat/cases/versions/schemas.py` and the three routes in `tracecat/cases/router.py`.
2. **History reads:** `CaseVersionsService` projects metadata only for lists, uses stable `(created_at, surrogate_id)` cursors, and fetches the immediate predecessor for comparison.
3. **Textual diff:** `tracecat/cases/versions/diff.py` produces ordered, exact-text `equal`, `delete`, and `insert` segments. Whitespace and punctuation are preserved, replacements are `delete` + `insert`, `changed` handles identical restores, and `diff` is `null` when no predecessor exists.
4. **Restore semantics:** `CasesService.restore_version` validates scope, locks the case, and forces a new immutable version even when restored content matches the current head.
5. **Coverage/client:** focused unit and integration tests cover pagination, auth, cursor validation, mismatches, diff reconstruction, compare, restore, rollback, and concurrency; the generated TypeScript client exposes the complete contract.

| Method | Endpoint | Purpose |
| --- | --- | --- |
| `GET` | `/cases/{case_id}/versions` | List version metadata, optionally filtered by field |
| `GET` | `/cases/{case_id}/versions/{version_id}/compare` | Return the selected version, predecessor, and structured textual diff |
| `POST` | `/cases/{case_id}/versions/{version_id}/restore` | Restore through the normal case-update transaction |

The frontend can render `diff.segments` in order: show `equal` normally, `delete` as removed content, and `insert` as added content. Ignoring inserts reconstructs the predecessor; ignoring deletes reconstructs the selected version.

## Verification

- `uv run pytest tests/unit/test_case_versions_service.py tests/unit/test_cases_service.py tests/unit/api/test_api_cases.py tests/unit/test_route_scope_guards.py tests/integration/test_case_versions.py -x` — 232 passed
- `uv run ruff check .` and `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- `pnpm -C frontend check` and `pnpm -C frontend run typecheck`
- Signed commit hooks, including secret scanning and generated-client validation

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 487 | 10 |
| Tests | 695 | 2 |
| Generated | 565 | 0 |
