### PR TITLE
fix(registry): default GitHub secret scanning to hide_secret

### DIFF
--- a/docs/tools/github.mdx
+++ b/docs/tools/github.mdx
@@ -1670,7 +1670,7 @@ Default: `"https://api.github.com"`.
 
 <ParamField path="params" type="object | null">
 
-API-native query parameters, including pagination and filters.
+API-native query parameters, including pagination and filters. hide_secret defaults to true so plaintext secret values are not returned; pass hide_secret false to override.
 
 Default: `null`.
 
@@ -2118,7 +2118,7 @@ Default: `"https://api.github.com"`.
 
 <ParamField path="params" type="object | null">
 
-API-native query parameters, including pagination and filters.
+API-native query parameters, including pagination and filters. hide_secret defaults to true so plaintext secret values are not returned; pass hide_secret false to override.
 
 Default: `null`.
 
@@ -2476,7 +2476,7 @@ Default: `"https://api.github.com"`.
 
 <ParamField path="params" type="object | null">
 
-API-native query parameters, including pagination and filters.
+API-native query parameters, including pagination and filters. hide_secret defaults to true so plaintext secret values are not returned; pass hide_secret false to override.
 
 Default: `null`.
 

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_secret_scanning_alert.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_secret_scanning_alert.yml
@@ -22,7 +22,7 @@ definition:
       description: GitHub API path value for alert_number.
     params:
       type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+      description: API-native query parameters, including pagination and filters. hide_secret defaults to true so plaintext secret values are not returned; pass hide_secret false to override.
       default: null
     base_url:
       type: str
@@ -38,5 +38,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params: '${{ FN.merge([{"hide_secret": True}, inputs.params || {"hide_secret": True}]) }}'
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_org_secret_scanning_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_org_secret_scanning_alerts.yml
@@ -16,7 +16,7 @@ definition:
       description: GitHub API path value for org.
     params:
       type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+      description: API-native query parameters, including pagination and filters. hide_secret defaults to true so plaintext secret values are not returned; pass hide_secret false to override.
       default: null
     base_url:
       type: str
@@ -32,5 +32,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params: '${{ FN.merge([{"hide_secret": True}, inputs.params || {"hide_secret": True}]) }}'
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_repo_secret_scanning_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_repo_secret_scanning_alerts.yml
@@ -19,7 +19,7 @@ definition:
       description: GitHub API path value for repo.
     params:
       type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+      description: API-native query parameters, including pagination and filters. hide_secret defaults to true so plaintext secret values are not returned; pass hide_secret false to override.
       default: null
     base_url:
       type: str
@@ -35,5 +35,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params: '${{ FN.merge([{"hide_secret": True}, inputs.params || {"hide_secret": True}]) }}'
   returns: ${{ steps.request.result }}


### PR DESCRIPTION
## The problem

GitHub's secret-scanning endpoints accept a `hide_secret` query parameter that defaults to **`false`**. With it unset, the response body includes the `secret` field — the raw plaintext credential that was detected.

Our templates pass `params` straight through with no default, so they inherit that. Calling `tools.github.list_repo_secret_scanning_alerts` with no `params` writes every detected plaintext secret into the action result store, the execution logs, and any downstream agent context that reads the result. Nothing in the action surface hints that this is happening.

The credential was already leaked once — this makes Tracecat a second copy of it.

## The fix

Default `hide_secret` to `true` on the three endpoints that can return secret values:

- `list_org_secret_scanning_alerts`
- `list_repo_secret_scanning_alerts`
- `get_secret_scanning_alert`

```yaml
params: '${{ FN.merge([{"hide_secret": True}, inputs.params || {"hide_secret": True}]) }}'
```

The caller's `params` merges last, so `params: {hide_secret: false}` still wins for anyone who genuinely needs the value. `list_secret_scanning_alert_locations` is untouched — it returns locations, not secret values, and has no `hide_secret` parameter.

## Reviewer notes

**This is a deliberate output change**, which is why it's split out from #PENDING rather than bundled with it. Anyone currently relying on the default response containing `secret` will need to opt back in explicitly. That seems clearly right for a fail-open security default, but it is a behaviour change and worth a conscious ack.

**The expression looks redundant on purpose.** Two grammar constraints forced it:

- `BOOL_LITERAL` is defined as `"True" | "False"` — lowercase `true` is a parse error.
- The empty-dict literal `{}` evaluates to `None` and raises `TypeError: cannot convert dictionary update sequence element #0 to a sequence` inside `FN.merge`, so the fallback cannot be `|| {}` and has to repeat the default.

The single quotes around the whole expression are required too: a bare YAML plain scalar can't contain `: `. Same convention as `tools/sentinel_one/list_inventory.yml`.

Both are arguably worth fixing in the expression layer separately — an empty-dict literal that evaluates to `None` is a trap.

## Verification

```
uv run pytest "tests/registry/test_templates.py::test_template_action_validation" -q -k "secret_scanning"
5 passed, 676 deselected
```

Evaluated against the expression engine, loading the committed YAML:

| `inputs.params` | resolved query params |
|---|---|
| unset (`None`) | `{'hide_secret': True}` |
| `{'state': 'open'}` | `{'hide_secret': True, 'state': 'open'}` |
| `{'hide_secret': False}` | `{'hide_secret': False}` |

`docs/tools/github.mdx` regenerated via `scripts/generate_tool_docs.py` — three description strings, no other churn.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default GitHub secret-scanning templates to hide_secret=true to prevent plaintext secrets from appearing in action results, logs, and downstream contexts. Previously, the GitHub default (false) included a secret field; now the templates set it to true unless explicitly overridden.

- Affects `list_org_secret_scanning_alerts`, `list_repo_secret_scanning_alerts`, and `get_secret_scanning_alert`; `list_secret_scanning_alert_locations` is unchanged.
- Caller can still request plaintext by passing `params: { hide_secret: false }`; caller params override the default via `FN.merge`.
- Updates `docs/tools/github.mdx` to document the new default.
- Migration: workflows that rely on the `secret` value must set `hide_secret: false` in `params`.

<sup>Written for commit 4435388945cd35391e1d20eac98e4142c98201b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

