### PR TITLE
feat(registry): add GitHub search and gist actions

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/gists/get_gist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/gists/get_gist.yml
@@ -1,0 +1,36 @@
+type: action
+definition:
+  title: Get gist
+  description: 'Get gist. Calls GET /gists/{gist_id} directly. Accepted OAuth scopes: gist (required only for secret or authenticated-user gists; omit for public gists).'
+  display_group: GitHub
+  doc_url: https://docs.github.com/en/rest
+  namespace: tools.github
+  name: get_gist
+  secrets:
+  - type: oauth
+    provider_id: github
+    grant_type: authorization_code
+  expects:
+    gist_id:
+      type: str
+      description: GitHub API path value for gist_id.
+    params:
+      type: dict[str, Any] | None
+      description: API-native query parameters, including pagination and filters.
+      default: null
+    base_url:
+      type: str
+      description: GitHub.com REST API base URL.
+      default: https://api.github.com
+  steps:
+  - ref: request
+    action: core.http_request
+    args:
+      url: ${{ inputs.base_url }}/gists/${{ FN.url_encode(inputs.gist_id) }}
+      method: GET
+      headers:
+        Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
+        Accept: application/vnd.github+json
+        X-GitHub-Api-Version: '2022-11-28'
+      params: ${{ inputs.params }}
+  returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/gists/list_gist_commits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/gists/list_gist_commits.yml
@@ -1,0 +1,36 @@
+type: action
+definition:
+  title: List gist commits
+  description: 'List gist commits. Calls GET /gists/{gist_id}/commits directly. Accepted OAuth scopes: gist (required only for secret or authenticated-user gists; omit for public gists).'
+  display_group: GitHub
+  doc_url: https://docs.github.com/en/rest
+  namespace: tools.github
+  name: list_gist_commits
+  secrets:
+  - type: oauth
+    provider_id: github
+    grant_type: authorization_code
+  expects:
+    gist_id:
+      type: str
+      description: GitHub API path value for gist_id.
+    params:
+      type: dict[str, Any] | None
+      description: API-native query parameters, including pagination and filters.
+      default: null
+    base_url:
+      type: str
+      description: GitHub.com REST API base URL.
+      default: https://api.github.com
+  steps:
+  - ref: request
+    action: core.http_request
+    args:
+      url: ${{ inputs.base_url }}/gists/${{ FN.url_encode(inputs.gist_id) }}/commits
+      method: GET
+      headers:
+        Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
+        Accept: application/vnd.github+json
+        X-GitHub-Api-Version: '2022-11-28'
+      params: ${{ inputs.params }}
+  returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_commits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_commits.yml
@@ -1,0 +1,33 @@
+type: action
+definition:
+  title: Search commits
+  description: 'Search commits. Calls GET /search/commits directly. Accepted OAuth scopes: repo (default; omit only for public repository data).'
+  display_group: GitHub
+  doc_url: https://docs.github.com/en/rest
+  namespace: tools.github
+  name: search_commits
+  secrets:
+  - type: oauth
+    provider_id: github
+    grant_type: authorization_code
+  expects:
+    params:
+      type: dict[str, Any] | None
+      description: API-native query parameters, including pagination and filters.
+      default: null
+    base_url:
+      type: str
+      description: GitHub.com REST API base URL.
+      default: https://api.github.com
+  steps:
+  - ref: request
+    action: core.http_request
+    args:
+      url: ${{ inputs.base_url }}/search/commits
+      method: GET
+      headers:
+        Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
+        Accept: application/vnd.github+json
+        X-GitHub-Api-Version: '2022-11-28'
+      params: ${{ inputs.params }}
+  returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_issues.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_issues.yml
@@ -1,0 +1,33 @@
+type: action
+definition:
+  title: Search issues
+  description: 'Search issues. Calls GET /search/issues directly. Accepted OAuth scopes: repo (default; omit only for public repository data). Pass advanced_search in params when GitHub requires it.'
+  display_group: GitHub
+  doc_url: https://docs.github.com/en/rest
+  namespace: tools.github
+  name: search_issues
+  secrets:
+  - type: oauth
+    provider_id: github
+    grant_type: authorization_code
+  expects:
+    params:
+      type: dict[str, Any] | None
+      description: API-native query parameters, including pagination and filters.
+      default: null
+    base_url:
+      type: str
+      description: GitHub.com REST API base URL.
+      default: https://api.github.com
+  steps:
+  - ref: request
+    action: core.http_request
+    args:
+      url: ${{ inputs.base_url }}/search/issues
+      method: GET
+      headers:
+        Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
+        Accept: application/vnd.github+json
+        X-GitHub-Api-Version: '2022-11-28'
+      params: ${{ inputs.params }}
+  returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_repositories.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_repositories.yml
@@ -1,0 +1,33 @@
+type: action
+definition:
+  title: Search repositories
+  description: 'Search repositories. Calls GET /search/repositories directly. Accepted OAuth scopes: repo (default; omit only for public repository data).'
+  display_group: GitHub
+  doc_url: https://docs.github.com/en/rest
+  namespace: tools.github
+  name: search_repositories
+  secrets:
+  - type: oauth
+    provider_id: github
+    grant_type: authorization_code
+  expects:
+    params:
+      type: dict[str, Any] | None
+      description: API-native query parameters, including pagination and filters.
+      default: null
+    base_url:
+      type: str
+      description: GitHub.com REST API base URL.
+      default: https://api.github.com
+  steps:
+  - ref: request
+    action: core.http_request
+    args:
+      url: ${{ inputs.base_url }}/search/repositories
+      method: GET
+      headers:
+        Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
+        Accept: application/vnd.github+json
+        X-GitHub-Api-Version: '2022-11-28'
+      params: ${{ inputs.params }}
+  returns: ${{ steps.request.result }}


### PR DESCRIPTION
## Why

#3193 added the `tools.github` REST catalog — 68 templates across workflows, code, issues, pull requests, posture, security, and security reports. Five endpoints that come up repeatedly in public-exposure work were left out: three of the four `/search/*` endpoints, and gists entirely.

These were built and exercised in a private registry; this upstreams them so they stop being duplicated downstream.

## What's added

| Action | Endpoint |
|---|---|
| `tools.github.search_repositories` | `GET /search/repositories` |
| `tools.github.search_commits` | `GET /search/commits` |
| `tools.github.search_issues` | `GET /search/issues` |
| `tools.github.get_gist` | `GET /gists/{gist_id}` |
| `tools.github.list_gist_commits` | `GET /gists/{gist_id}/commits` |

`search/` already held `search_code.yml`; `gists/` is new.

Typical use: find public repos, commits, and issues mentioning a company, domain, or leaked identifier, then pull gist metadata and commit history for a candidate surfaced by search.

## Conventions

Each template mirrors the existing 68 — API-native `params: dict[str, Any] | None` pass-through, `FN.url_encode` on the `gist_id` path segment, `returns: ${{ steps.request.result }}`, `X-GitHub-Api-Version: '2022-11-28'`, and the `github` OAuth authorization-code secret. No `run_python` steps.

Three notes for review:

- **`base_url` is `str` with a literal default**, matching all 68 siblings. `packages/tracecat-registry/AGENTS.md` prescribes `str | None` with `inputs.base_url || VARS.<tool>.base_url || <url>`, which no `tools.github` template currently follows. I kept namespace consistency rather than making these five the odd ones out — happy to switch if you'd rather start that migration here.
- **`search_issues`** — GitHub gates `/search/issues` behind `advanced_search`. The `params` pass-through means a caller sets it without a template change; the action description says so.
- **Gist scopes** — the two gist actions document the `gist` scope (needed only for secret or authenticated-user gists), not the `repo` blurb the other templates carry.

No new tests: `tests/registry/test_templates.py` discovers templates via `rglob("*.yml")` and validates parsing, secret-expression policy, and registration, so these are covered automatically.

## Not done in this PR

- `docs/tools/github.mdx` is **not** regenerated here — run `just gen-tool-docs` before or after merge to pick up the five new entries.
- Not smoke-tested against live GitHub. Worth one run per action against a connected OAuth grant before relying on them.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five GitHub REST actions to the `tools.github` registry: `search_repositories`, `search_commits`, `search_issues`, `get_gist`, and `list_gist_commits`, covering the remaining `/search/*` and gist endpoints. This enables public repo/commit/issue discovery and gist metadata/history retrieval without duplicating downstream templates.

**Review notes**
- Matches existing `tools.github` templates: API-native `params` pass-through, `FN.url_encode` for `gist_id`, returns full `core.http_request` result, and `X-GitHub-Api-Version: '2022-11-28'`.
- `base_url` remains type `str` with default `https://api.github.com` to stay consistent with current namespace (broader migration to `str | None` deferred).
- `/search/issues` may require `advanced_search`; callers must pass it via `params`.
- Auth scopes: search defaults to `repo` (omit only for public data); gists may require `gist` for secret or authenticated-user gists.
- Regenerate docs by running `just gen-tool-docs`.

<sup>Written for commit 258e41bdb335fa0dd2f98d2ec0cfbffc9417f813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

