### PR TITLE
feat(registry)!: name real vendor parameters on recently shipped providers

### DIFF
--- a/docs/tools/elastic_security.mdx
+++ b/docs/tools/elastic_security.mdx
@@ -93,23 +93,21 @@ Required secrets:
 
 ### Input fields
 
-<ParamField path="payload" type="object" required>
+<ParamField path="assignees" type="object" required>
 
-API-native JSON request body.
+Details about the assignees to assign and unassign. Requires `add` and `remove`, each a list of user profile `uid`s to assign or unassign. Users need to activate their user profile by logging into Kibana at least once.
+
+</ParamField>
+
+<ParamField path="ids" type="array[string]" required>
+
+A list of alerts `id`s.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -161,9 +159,9 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="dry_run" type="boolean | null">
 
-Optional native Kibana query parameters.
+Enables dry run mode for the request call. Enable dry run mode to verify that bulk actions can be applied to specified rules. Certain rules, such as prebuilt Elastic rules on a Basic subscription, can't be edited and will return errors in the request response. Rules specified in the request will be temporarily updated. These updates won't be written to Elasticsearch. Dry run mode is not supported for the `export` bulk action.
 
 Default: `null`.
 
@@ -203,21 +201,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -264,14 +254,6 @@ API-native JSON request body.
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -343,14 +325,6 @@ Default: `"application/octet-stream"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="space_id" type="string | null">
 
 Optional Kibana space ID. Omit for the default space.
@@ -392,14 +366,6 @@ API-native JSON request body.
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters, including API identifiers where required.
 
 Default: `null`.
 
@@ -451,14 +417,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters, including API identifiers where required.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="space_id" type="string | null">
 
 Optional Kibana space ID. Omit for the default space.
@@ -499,9 +457,25 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="id" type="string | null">
 
-Optional native Kibana query parameters, including API identifiers where required.
+Exception item's identifier. Either `id` or `item_id` must be specified.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="item_id" type="string | null">
+
+Human readable exception item string identifier, e.g. `trusted-linux-processes`. Either `id` or `item_id` must be specified.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="namespace_type" type="string | null">
+
+`single` deletes the item in the current Kibana space; `agnostic` deletes an item in a space-agnostic list. Must match the list that owns the item. Defaults to single.
 
 Default: `null`.
 
@@ -559,14 +533,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="space_id" type="string | null">
 
 Optional Kibana space ID. Omit for the default space.
@@ -613,9 +579,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="exclude_export_details" type="boolean | null">
 
-Optional native Kibana query parameters.
+Determines whether a summary of the exported rules is returned. Defaults to `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="file_name" type="string | null">
+
+File name for saving the exported rules. Defaults to `export.ndjson`.
 
 Default: `null`.
 
@@ -655,21 +629,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -721,14 +687,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="space_id" type="string | null">
 
 Optional Kibana space ID. Omit for the default space.
@@ -763,21 +721,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), path (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -817,21 +767,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -878,14 +820,6 @@ Response action ID.
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -943,14 +877,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="space_id" type="string | null">
 
 Optional Kibana space ID. Omit for the default space.
@@ -989,6 +915,14 @@ Base64-encoded NDJSON rules file.
 
 </ParamField>
 
+<ParamField path="as_new_list" type="boolean | null">
+
+Generates a new list ID for each imported exception list. Defaults to `false`.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
@@ -1005,9 +939,25 @@ Default: `"rules.ndjson"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="overwrite" type="boolean | null">
 
-Optional native import query parameters such as overwrite.
+Determines whether existing rules with the same `rule_id` are overwritten. Defaults to `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="overwrite_action_connectors" type="boolean | null">
+
+Determines whether existing actions with the same `kibana.alert.rule.actions.id` are overwritten. Defaults to `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="overwrite_exceptions" type="boolean | null">
+
+Determines whether existing exception lists with the same `list_id` are overwritten. Both the exception list container and its items are overwritten. Defaults to `false`.
 
 Default: `null`.
 
@@ -1047,21 +997,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -1107,9 +1049,81 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="fields" type="array[string] | null">
 
-Optional native Kibana query parameters.
+List of `alert.attributes` field names to return for each rule (for example `name`, `enabled`). If omitted, the default field set is returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+Search query. Filters the returned results according to the value of the specified field, using the `alert.attributes.&lt;field name>:&lt;field value>` syntax, where `&lt;field name>` can be: name, enabled, tags, createdBy, interval, updatedBy. Even though the JSON rule object uses `created_by` and `updated_by` fields, you must use `createdBy` and `updatedBy` fields in the filter.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="gap_auto_fill_scheduler_id" type="string | null">
+
+Gap auto fill scheduler ID used to determine gap fill status for rules.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="gap_fill_statuses" type="array[string] | null">
+
+Gap fill statuses. Possible values: unfilled, in_progress, filled, error.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="gaps_range_end" type="string | null">
+
+Gaps range end.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="gaps_range_start" type="string | null">
+
+Gaps range start.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number. Defaults to 1.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Rules per page. Defaults to 20.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_field" type="string | null">
+
+Field to sort by. Possible values: created_at, createdAt, enabled, execution_summary.last_execution.date, execution_summary.last_execution.metrics.execution_gap_duration_s, execution_summary.last_execution.metrics.total_indexing_duration_ms, execution_summary.last_execution.metrics.total_search_duration_ms, execution_summary.last_execution.status, name, risk_score, riskScore, severity, updated_at, updatedAt.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_order" type="string | null">
+
+Sort order. Possible values: asc, desc.
 
 Default: `null`.
 
@@ -1155,9 +1169,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="kuery" type="string | null">
 
-Optional native Kibana query parameters.
+A KQL query string to filter the list of scripts. Nearly all fields in the script object are searchable.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number of the results to return. Defaults to 1.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="pageSize" type="integer | null">
+
+Number of results to return per page. Defaults to 10. Max value is 1000.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sortDirection" type="string | null">
+
+The direction to sort the results by. Defaults to asc (ascending). Allowed values are `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sortField" type="string | null">
+
+The field to sort the results by. Defaults to name. Allowed values are `name`, `createdAt`, `createdBy`, `updatedAt`, `updatedBy`, `fileSize`.
 
 Default: `null`.
 
@@ -1195,6 +1241,12 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="hostStatuses" type="array[string]" required>
+
+A set of host statuses to filter the results by (for example, `healthy`, `updating`). Allowed values are `healthy`, `offline`, `updating`, `inactive`, `unenrolled`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
@@ -1203,9 +1255,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="kuery" type="string | null">
 
-Optional native Kibana query parameters.
+A KQL string to filter the endpoint metadata results.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number to return.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="pageSize" type="integer | null">
+
+The number of endpoints to return per page.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sortDirection" type="string | null">
+
+The sort order, either `asc` or `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sortField" type="string | null">
+
+The field used to sort the results. Allowed values are `enrolled_at`, `metadata.host.hostname`, `host_status`, `metadata.Endpoint.policy.applied.name`, `metadata.Endpoint.policy.applied.status`, `metadata.host.os.name`, `metadata.host.ip`, `metadata.agent.version`, `last_checkin`.
 
 Default: `null`.
 
@@ -1243,6 +1327,12 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="list_id" type="array[string]" required>
+
+The `list_id`s of the items to fetch.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
@@ -1251,9 +1341,57 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="filter" type="array[string] | null">
 
-Optional native Kibana query parameters, including API identifiers where required.
+Filters the returned results according to the value of the specified field, using the `&lt;field name>:&lt;field value>` syntax.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="namespace_type" type="array[string] | null">
+
+Determines whether the returned containers are Kibana associated with a Kibana space or available in all spaces. Possible values: agnostic, single.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number to return.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of exception list items to return per page.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search" type="string | null">
+
+Free-text search term applied to exception list item fields (for example a hostname or file path fragment).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_field" type="string | null">
+
+Determines which field is used to sort the results.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_order" type="string | null">
+
+Determines the sort order, which can be `desc` or `asc`.
 
 Default: `null`.
 
@@ -1299,9 +1437,49 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="filter" type="string | null">
 
-Optional native Kibana query parameters, including API identifiers where required.
+Filters the returned results according to the value of the specified field. Uses the `so type.field name:field` value syntax, where `so type` can be: exception-list (specify a space-aware exception list) or exception-list-agnostic (specify an exception list that is shared across spaces).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="namespace_type" type="array[string] | null">
+
+Determines whether the returned containers are Kibana associated with a Kibana space or available in all spaces. Possible values: agnostic, single.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number to return.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of exception lists to return per page.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_field" type="string | null">
+
+Determines which field is used to sort the results.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_order" type="string | null">
+
+Determines the sort order, which can be `desc` or `asc`.
 
 Default: `null`.
 
@@ -1339,6 +1517,22 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="agentIds" type="array[string] | null">
+
+A list of Elastic Agent IDs to filter the response actions by.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="agentTypes" type="string | null">
+
+The agent type to filter response actions by. Defaults to `endpoint`. Allowed values are `endpoint`, `sentinel_one`, `crowdstrike`, `microsoft_defender_endpoint`.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
@@ -1347,9 +1541,33 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="commands" type="array[string] | null">
 
-Optional native Kibana query parameters.
+A list of response action command names to filter by. Allowed values are `isolate`, `unisolate`, `kill-process`, `suspend-process`, `running-processes`, `get-file`, `execute`, `upload`, `scan`, `runscript`, `cancel`, `memory-dump`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="endDate" type="string | null">
+
+An end date in ISO 8601 format or Date Math format (for example, `now`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number to return.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="pageSize" type="integer | null">
+
+The number of response actions to return per page.
 
 Default: `null`.
 
@@ -1363,11 +1581,43 @@ Default: `null`.
 
 </ParamField>
 
+<ParamField path="startDate" type="string | null">
+
+A start date in ISO 8601 format or Date Math format (for example, `now-24h`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="types" type="array[string] | null">
+
+A list of response action types to filter by (`automated`, `manual`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="userIds" type="array[string] | null">
+
+A list of user IDs that submitted the response actions.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="verify_ssl" type="boolean">
 
 Whether to verify SSL certificates.
 
 Default: `true`.
+
+</ParamField>
+
+<ParamField path="withOutputs" type="array[string] | null">
+
+A list of response action IDs whose outputs should be included in the response.
+
+Default: `null`.
 
 </ParamField>
 
@@ -1396,14 +1646,6 @@ API-native JSON request body.
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -1455,9 +1697,9 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="enable_logged_requests" type="boolean | null">
 
-Optional native Kibana query parameters.
+Enables logging and returning in response ES queries, performed during rule execution.
 
 Default: `null`.
 
@@ -1497,21 +1739,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -1551,21 +1785,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: command (required), endpoint_ids (required), agent_type, alert_ids, case_ids, comment, timeout.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -1605,21 +1831,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -1671,14 +1889,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="space_id" type="string | null">
 
 Optional Kibana space ID. Omit for the default space.
@@ -1713,21 +1923,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), path (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -1765,6 +1967,14 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="alert_ids" type="array[string] | null">
+
+Filter results to Attack discoveries that include any of the provided alert IDs.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
@@ -1773,9 +1983,105 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="connector_names" type="array[string] | null">
 
-Optional native search, filter, pagination, and sorting parameters.
+Filter results to Attack discoveries created by any of the provided human readable connector names. Note that values must match the human readable `connector_name` property of an Attack discovery, which are distinct from `connector_id` values used to generate Attack discoveries.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="enable_field_rendering" type="boolean | null">
+
+Enables a markdown syntax used to render pivot fields. This is primarily used for Attack Discovery views within Kibana. Defaults to `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="end" type="string | null">
+
+End of the time range for the search. Accepts absolute timestamps (ISO 8601) or relative date math (e.g. "now", "now-24h").
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ids" type="array[string] | null">
+
+Filter results to the Attack discoveries with the specified IDs.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="include_all_authors" type="boolean | null">
+
+If `true`, the response will include all attack discoveries matching other criteria regardless of who created them. Mutually exclusive with `shared`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="include_unique_alert_ids" type="boolean | null">
+
+If `true`, the response will include `unique_alert_ids` and `unique_alert_ids_count` aggregated across the matched Attack discoveries.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number to return (used for pagination). Defaults to 1.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of Attack discoveries to return per page (used for pagination). Defaults to 10.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="scheduled" type="boolean | null">
+
+Whether to filter by scheduled or ad-hoc attack discoveries. If omitted, both types of attack discoveries are returned. Use `true` to return only scheduled discoveries or `false` to return only ad-hoc discoveries.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search" type="string | null">
+
+Free-text search query applied to relevant text fields of Attack discoveries (title, description, tags, etc.).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="shared" type="boolean | null">
+
+Whether to filter by shared visibility. If omitted, both shared and privately visible Attack discoveries are returned. Use `true` to return only shared discoveries, `false` to return only those visible to the current user. Mutually exclusive with `include_all_authors`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_field" type="string | null">
+
+Field used to sort results. Possible values: @timestamp. Defaults to @timestamp.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_order" type="string | null">
+
+Sort order direction, `asc` for ascending or `desc` for descending. Possible values: asc, desc. Defaults to desc.
 
 Default: `null`.
 
@@ -1789,11 +2095,35 @@ Default: `null`.
 
 </ParamField>
 
+<ParamField path="start" type="string | null">
+
+Start of the time range for the search. Accepts absolute timestamps (ISO 8601) or relative date math (e.g. "now-7d").
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="status" type="array[string] | null">
+
+Filter by alert workflow status. Provide one or more of the allowed workflow states. Possible values: acknowledged, closed, open.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="verify_ssl" type="boolean">
 
 Whether to verify SSL certificates.
 
 Default: `true`.
+
+</ParamField>
+
+<ParamField path="with_replacements" type="boolean | null">
+
+When true, return the created Attack discoveries with text replacements applied to the detailsMarkdown, entitySummaryMarkdown, summaryMarkdown, and title fields. Defaults to `true`.
+
+Default: `null`.
 
 </ParamField>
 
@@ -1822,14 +2152,6 @@ API-native JSON request body.
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -1875,9 +2197,89 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="entity_types" type="array[string] | null">
 
-Optional native entity filters, fields, sorting, and pagination parameters.
+Entity types to include in the results. Possible values: user, host, service, generic.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="fields" type="array[string] | null">
+
+Fields to include in the response.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+A Kibana Query Language (KQL) filter for the search-after mode.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filterQuery" type="string | null">
+
+An Elasticsearch query string to filter entities in page mode.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number to return (1-indexed) in page mode.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of entities per page in page mode.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="searchAfter" type="string | null">
+
+JSON-encoded search_after value for cursor-based pagination.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="size" type="integer | null">
+
+Number of entities to return in search-after mode.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_field" type="string | null">
+
+Field to sort results by in page mode.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort_order" type="string | null">
+
+Sort order in page mode. Possible values: asc, desc.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="source" type="array[string] | null">
+
+Fields to include in the response source.
 
 Default: `null`.
 
@@ -1929,14 +2331,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="space_id" type="string | null">
 
 Optional Kibana space ID. Omit for the default space.
@@ -1971,21 +2365,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -2025,21 +2411,13 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -2077,23 +2455,21 @@ Required secrets:
 
 ### Input fields
 
-<ParamField path="payload" type="object" required>
+<ParamField path="ids" type="array[string]" required>
 
-API-native JSON request body.
+A list of alerts `id`s.
+
+</ParamField>
+
+<ParamField path="tags" type="object" required>
+
+Object with list of tags to add and remove. Requires `tags_to_add` and `tags_to_remove`, each a list of keywords to organize related alerts into categories that you can filter and group.
 
 </ParamField>
 
 <ParamField path="base_url" type="string | null">
 
 Kibana base URL (e.g. https://localhost:5601).
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
 
 Default: `null`.
 
@@ -2162,14 +2538,6 @@ Default: `null`.
 MIME type of the uploaded file.
 
 Default: `"application/octet-stream"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-Optional native Kibana query parameters.
-
-Default: `null`.
 
 </ParamField>
 

--- a/docs/tools/emailrep.mdx
+++ b/docs/tools/emailrep.mdx
@@ -52,6 +52,6 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native report body containing email, tags, and optional context.
+API-native request body. Documented fields: email (required), tags (required), description, expires, timestamp.
 
 </ParamField>

--- a/docs/tools/github.mdx
+++ b/docs/tools/github.mdx
@@ -46,22 +46,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
-
-</ParamField>
-
 ## Compare commits
 
 Action ID: `tools.github.compare_commits`
@@ -104,9 +88,17 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
 
 Default: `null`.
 
@@ -148,17 +140,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for POST /repos/&#123;owner&#125;/&#123;repo&#125;/issues: title (required), body, assignee, milestone, labels, assignees, issue_field_values, type.
 
 Default: `null`.
 
@@ -179,6 +163,12 @@ Required secrets:
 - `github_oauth`: OAuth token `GITHUB_USER_TOKEN`.
 
 ### Input fields
+
+<ParamField path="body" type="string" required>
+
+The contents of the comment.
+
+</ParamField>
 
 <ParamField path="issue_number" type="integer" required>
 
@@ -203,22 +193,6 @@ GitHub API path value for repo.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
 
 </ParamField>
 
@@ -264,17 +238,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: content (required), message (required), author, branch, committer, sha.
 
 Default: `null`.
 
@@ -316,17 +282,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for POST /repos/&#123;owner&#125;/&#123;repo&#125;/pulls: title, head (required), head_repo, base (required), body, maintainer_can_modify, draft, issue.
 
 Default: `null`.
 
@@ -374,17 +332,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for POST /repos/&#123;owner&#125;/&#123;repo&#125;/pulls/&#123;pull_number&#125;/reviews: commit_id, body, event, comments.
 
 Default: `null`.
 
@@ -432,17 +382,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for POST /repos/&#123;owner&#125;/&#123;repo&#125;/pulls/&#123;pull_number&#125;/comments: body (required), commit_id (required), path (required), position, side, line, start_line, start_side, in_reply_to, subject_type.
 
 Default: `null`.
 
@@ -484,17 +426,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: description (required), summary (required), vulnerabilities (required), credits, cve_id, cvss_vector_string, cwe_ids, severity, start_private_fork.
 
 Default: `null`.
 
@@ -542,22 +476,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
-
-</ParamField>
-
 ## Disable private vulnerability reporting
 
 Action ID: `tools.github.disable_private_vulnerability_reporting`
@@ -594,22 +512,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
-
-</ParamField>
-
 ## Disable vulnerability alerts
 
 Action ID: `tools.github.disable_vulnerability_alerts`
@@ -643,22 +545,6 @@ GitHub API path value for repo.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
 
 </ParamField>
 
@@ -704,17 +590,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for POST /repos/&#123;owner&#125;/&#123;repo&#125;/actions/workflows/&#123;workflow_id&#125;/dispatches: ref (required), inputs, return_run_details.
 
 Default: `null`.
 
@@ -762,14 +640,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Enable private vulnerability reporting
 
 Action ID: `tools.github.enable_private_vulnerability_reporting`
@@ -806,22 +676,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
-
-</ParamField>
-
 ## Enable vulnerability alerts
 
 Action ID: `tools.github.enable_vulnerability_alerts`
@@ -855,22 +709,6 @@ GitHub API path value for repo.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
 
 </ParamField>
 
@@ -916,14 +754,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get code scanning alert
 
 Action ID: `tools.github.get_code_scanning_alert`
@@ -966,14 +796,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get code scanning default setup
 
 Action ID: `tools.github.get_code_scanning_default_setup`
@@ -1007,14 +829,6 @@ GitHub API path value for repo.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
 
 </ParamField>
 
@@ -1060,9 +874,17 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
 
 Default: `null`.
 
@@ -1110,14 +932,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get gist
 
 Action ID: `tools.github.get_gist`
@@ -1148,14 +962,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get global security advisory
 
 Action ID: `tools.github.get_global_security_advisory`
@@ -1183,14 +989,6 @@ GitHub API path value for ghsa_id.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
 
 </ParamField>
 
@@ -1236,14 +1034,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get organization audit log
 
 Action ID: `tools.github.get_organization_audit_log`
@@ -1266,6 +1056,14 @@ GitHub API path value for org.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for events after this cursor.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -1274,9 +1072,41 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for events before this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="include" type="string | null">
+
+The event types to include: web - returns web (non-Git) events. git - returns Git events. all - returns both web and Git events. The default is web.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order" type="string | null">
+
+The order of audit log events. To list newest events first, specify desc. To list oldest events first, specify asc. The default is desc.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="phrase" type="string | null">
+
+A search phrase.
 
 Default: `null`.
 
@@ -1315,14 +1145,6 @@ GitHub API path value for repo.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
 
 </ParamField>
 
@@ -1368,14 +1190,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get pull request merge state
 
 Action ID: `tools.github.get_pull_request_merge_state`
@@ -1418,14 +1232,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get repository
 
 Action ID: `tools.github.get_repository`
@@ -1459,14 +1265,6 @@ GitHub API path value for repo.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
 
 </ParamField>
 
@@ -1512,14 +1310,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get repository content
 
 Action ID: `tools.github.get_repository_content`
@@ -1562,9 +1352,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="ref" type="string | null">
 
-API-native query parameters, including pagination and filters.
+The name of the commit/branch/tag. Default: the repository’s default branch.
 
 Default: `null`.
 
@@ -1603,14 +1393,6 @@ GitHub API path value for repo.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
 
 </ParamField>
 
@@ -1656,14 +1438,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get secret scanning alert
 
 Action ID: `tools.github.get_secret_scanning_alert`
@@ -1706,9 +1480,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="hide_secret" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+A boolean value representing whether or not to hide literal secrets in the results. Default: `false`.
 
 Default: `null`.
 
@@ -1747,14 +1521,6 @@ GitHub API path value for repo.
 GitHub.com REST API base URL.
 
 Default: `"https://api.github.com"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
 
 </ParamField>
 
@@ -1800,9 +1566,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="exclude_pull_requests" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+If `true` pull requests are omitted from the response (empty array).
 
 Default: `null`.
 
@@ -1914,9 +1680,33 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page number of the results to fetch. Default: `1`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="pr" type="integer | null">
+
+The number of the pull request for the results you want to list.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ref" type="string | null">
+
+The Git reference for the results you want to list. The `ref` for a branch can be formatted either as `refs/heads/&lt;branch name>` or simply `&lt;branch name>`. To reference a pull request use `refs/pull/&lt;number>/merge`.
 
 Default: `null`.
 
@@ -1950,6 +1740,14 @@ GitHub API path value for repo.
 
 </ParamField>
 
+<ParamField path="author" type="string | null">
+
+GitHub username or email address to use to filter by commit author.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -1958,9 +1756,57 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="committer" type="string | null">
 
-API-native query parameters, including pagination and filters.
+GitHub username or email address to use to filter by commit committer.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="path" type="string | null">
+
+Only commits containing this file path will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sha" type="string | null">
+
+SHA or branch to start listing commits from. Default: the repository’s default branch (usually main).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="since" type="string | null">
+
+Only show results that were last updated after the given time. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Due to limitations of Git, timestamps must be between 1970-01-01 and 2099-12-31 (inclusive) or unexpected results may be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="until" type="string | null">
+
+Only commits before this date will be returned. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Due to limitations of Git, timestamps must be between 1970-01-01 and 2099-12-31 (inclusive) or unexpected results may be returned.
 
 Default: `null`.
 
@@ -1996,9 +1842,17 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
 
 Default: `null`.
 
@@ -2020,6 +1874,22 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="affects" type="string | null">
+
+If specified, only return advisories that affect any of `package` or `package@version`. A maximum of 1000 packages can be specified. If the query parameter causes the URL to exceed the maximum URL length supported by your client, you must specify fewer packages. Example: `affects=package1,package2@1.0.0,package3@2.0.0` or `affects[]=package1&amp;affects[]=package2@1.0.0`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2028,9 +1898,129 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="cve_id" type="string | null">
+
+If specified, only advisories with this CVE (Common Vulnerabilities and Exposures) identifier will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="cwes" type="string | null">
+
+If specified, only advisories with these Common Weakness Enumerations (CWEs) will be returned. Example: `cwes=79,284,22` or `cwes[]=79&amp;cwes[]=284&amp;cwes[]=22`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ecosystem" type="string | null">
+
+If specified, only advisories for these ecosystems will be returned. Can be one of: `rubygems`, `npm`, `pip`, `maven`, `nuget`, `composer`, `go`, `rust`, `erlang`, `actions`, `pub`, `other`, `swift`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="epss_percentage" type="string | null">
+
+If specified, only return advisories that have an EPSS percentage score that matches the provided value. The EPSS percentage represents the likelihood of a CVE being exploited.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="epss_percentile" type="string | null">
+
+If specified, only return advisories that have an EPSS percentile score that matches the provided value. The EPSS percentile represents the relative rank of the CVE's likelihood of being exploited compared to other CVEs.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ghsa_id" type="string | null">
+
+If specified, only advisories with this GHSA (GitHub Security Advisory) identifier will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="is_withdrawn" type="boolean | null">
+
+Whether to only return advisories that have been withdrawn.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="modified" type="string | null">
+
+If specified, only show advisories that were updated or published on a date or date range.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="published" type="string | null">
+
+If specified, only return advisories that were published on a date or date range.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="severity" type="string | null">
+
+If specified, only advisories with these severities will be returned. Can be one of: `unknown`, `low`, `medium`, `high`, `critical`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property to sort the results by. Default: `published`. Can be one of: `updated`, `published`, `epss_percentage`, `epss_percentile`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="type" type="string | null">
+
+If specified, only advisories of this type will be returned. By default, a request with no other parameters defined will only return reviewed advisories that are not malware. Default: `reviewed`. Can be one of: `reviewed`, `malware`, `unreviewed`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="updated" type="string | null">
+
+If specified, only return advisories that were updated on a date or date range.
 
 Default: `null`.
 
@@ -2078,9 +2068,25 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="since" type="string | null">
+
+Only show results that were last updated after the given time. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
 
 Default: `null`.
 
@@ -2108,6 +2114,22 @@ GitHub API path value for org.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignees" type="string | null">
+
+Filter alerts by assignees. Provide a comma-separated list of user handles (e.g., `octocat` or `octocat,hubot`). Use `*` to list alerts with at least one assignee or `none` to list alerts with no assignees.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2116,9 +2138,73 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch. Default: `1`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="severity" type="string | null">
+
+If specified, only code scanning alerts with this severity will be returned. Can be one of: `critical`, `high`, `medium`, `low`, `warning`, `note`, `error`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property by which to sort the results. Default: `created`. Can be one of: `created`, `updated`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+If specified, only code scanning alerts with this state will be returned. Can be one of: `open`, `closed`, `dismissed`, `fixed`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="tool_guid" type="string | null">
+
+The GUID of a code scanning tool. Only results by this tool will be listed. Note that some code scanning tools may not include a GUID in their analysis data. You can specify the tool by using either `tool_guid` or `tool_name`, but not both.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="tool_name" type="string | null">
+
+The name of a code scanning tool. Only results by this tool will be listed. You can specify the tool by using either `tool_name` or `tool_guid`, but not both.
 
 Default: `null`.
 
@@ -2146,6 +2232,38 @@ GitHub API path value for org.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="artifact_registry" type="string | null">
+
+A comma-separated list of Artifact Registry name strings. If specified, only alerts for repositories with storage records matching these registries will be returned. Can be: `jfrog-artifactory`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="artifact_registry_url" type="string | null">
+
+A comma-separated list of artifact registry URLs. If specified, only alerts for repositories with storage records matching these URLs will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignee" type="string | null">
+
+Filter alerts by assignees. Provide a comma-separated list of user handles (e.g., `octocat` or `octocat,hubot`) to return alerts assigned to any of the specified users. Use `*` to list alerts with at least one assignee or `none` to list alerts with no assignees.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2154,9 +2272,113 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="classification" type="string | null">
+
+A comma-separated list of vulnerability classifications. If specified, only alerts for vulnerabilities with these classifications will be returned. Can be: `malware`, `general`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ecosystem" type="string | null">
+
+A comma-separated list of ecosystems. If specified, only alerts for these ecosystems will be returned. Can be: `composer`, `go`, `maven`, `npm`, `nuget`, `pip`, `pub`, `rubygems`, `rust`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="epss_percentage" type="string | null">
+
+CVE Exploit Prediction Scoring System (EPSS) percentage. Can be specified as: - An exact number (`n`) - Comparators such as `>n`, `&lt;n`, `>=n`, `&lt;=n` - A range like `n..n`, where `n` is a number from 0.0 to 1.0 Filters the list of alerts based on EPSS percentages. If specified, only alerts with the provided EPSS percentages will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="has" type="array[string] | null">
+
+Filters the list of alerts based on whether the alert has the given value. If specified, only alerts meeting this criterion will be returned. Multiple `has` filters can be passed to filter for alerts that have all of the values.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="package" type="string | null">
+
+A comma-separated list of package names. If specified, only alerts for these packages will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="relationship" type="string | null">
+
+A comma-separated list of relationships of the vulnerable dependency to your project. If specified, only alerts with these relationships will be returned. We are rolling out support for dependency relationship across ecosystems. This value will be "unknown" for all dependencies in unsupported ecosystems.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="runtime_risk" type="string | null">
+
+A comma-separated list of runtime risk strings. If specified, only alerts for repositories with deployment records matching these risks will be returned. Can be: `critical-resource`, `internet-exposed`, `sensitive-data`, `lateral-movement`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="scope" type="string | null">
+
+The scope of the vulnerable dependency. If specified, only alerts with this scope will be returned. Can be one of: `development`, `runtime`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="severity" type="string | null">
+
+A comma-separated list of severities. If specified, only alerts with these severities will be returned. Can be: `low`, `medium`, `high`, `critical`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property by which to sort the results. `created` means when the alert was created. `updated` means when the alert's state last changed. `epss_percentage` sorts alerts by the Exploit Prediction Scoring System (EPSS) percentage. Default: `created`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+A comma-separated list of states. If specified, only alerts with these states will be returned. Can be: `auto_dismissed`, `dismissed`, `fixed`, `open`
 
 Default: `null`.
 
@@ -2184,6 +2406,22 @@ GitHub API path value for org.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for events after this cursor. To receive an initial cursor on your first request, include an empty "after" query string.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignee" type="string | null">
+
+Filters alerts by assignee. Use `*` to get all assigned alerts, `none` to get all unassigned alerts, or a GitHub username to get alerts assigned to a specific user.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2192,9 +2430,145 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for events before this cursor. To receive an initial cursor on your first request, include an empty "before" query string.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="exclude_providers" type="string | null">
+
+A comma-separated list of provider slugs to exclude from the results. Provider slugs use lowercase with underscores (e.g., `github_secret_scanning`, `clojars`). You can find the provider slug in the `provider_slug` field of each alert. Cannot be combined with the `providers` parameter.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="exclude_secret_types" type="string | null">
+
+A comma-separated list of secret types to exclude from the results. All default secret patterns are returned except those matching the specified types. Cannot be combined with the `secret_type` parameter. See "Supported secret scanning patterns" for a complete list of secret types.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="hide_secret" type="boolean | null">
+
+A boolean value representing whether or not to hide literal secrets in the results. Default: `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="included_metadata" type="string | null">
+
+A comma-separated list of metadata fields to filter alerts by. Only alerts that have all of the specified metadata fields attached will be returned. Possible values are: `owner-email`, `owner-id`, `owner-name`, `secret-id`, `secret-name`, `secret-issued-date`, `secret-expiration-date`, `organization-name`, `organization-id`, `last-used-date`, and `has-organization-access`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="is_bypassed" type="boolean | null">
+
+A boolean value (`true` or `false`) indicating whether to filter alerts by their push protection bypass status. When set to `true`, only alerts that were created because a push protection rule was bypassed will be returned. When set to `false`, only alerts that were not caused by a push protection bypass will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="is_multi_repo" type="boolean | null">
+
+A boolean value representing whether or not to filter alerts by the multi-repo tag being present. Default: `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="is_publicly_leaked" type="boolean | null">
+
+A boolean value representing whether or not to filter alerts by the publicly-leaked tag being present. Default: `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="owner_email_hash" type="string | null">
+
+Filters alerts to only those whose attached `owner_email` metadata field matches the provided value. The value must be the lowercase hex-encoded SHA-256 hash of the email address to match (for example, the SHA-256 of `user@example.com`). Only alerts that have an `owner_email` metadata value whose SHA-256 hash equals this parameter are returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch. Default: `1`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="providers" type="string | null">
+
+A comma-separated list of provider slugs to filter by. Provider slugs use lowercase with underscores (e.g., `github_secret_scanning`, `clojars`). You can find the provider slug in the `provider_slug` field of each alert. Cannot be combined with the `exclude_providers` parameter.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="resolution" type="string | null">
+
+A comma-separated list of resolutions. Only secret scanning alerts with one of these resolutions are listed. Valid resolutions are `false_positive`, `wont_fix`, `revoked`, `pattern_edited`, `pattern_deleted` or `used_in_tests`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="secret_type" type="string | null">
+
+A comma-separated list of secret types to return. All default secret patterns are returned. To return generic patterns, pass the token name(s) in the parameter. See "Supported secret scanning patterns" for a complete list of secret types.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property to sort the results by. `created` means when the alert was created. `updated` means when the alert was updated or resolved. Default: `created`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Set to `open` or `resolved` to only list secret scanning alerts in a specific state.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="validity" type="string | null">
+
+A comma-separated list of validities that, when present, will return alerts that match the validities in this list. Valid options are `active`, `inactive`, and `unknown`.
 
 Default: `null`.
 
@@ -2222,6 +2596,14 @@ GitHub API path value for org.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2230,9 +2612,41 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of advisories to return per page. Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property to sort the results by. Default: `created`. Can be one of: `created`, `updated`, `published`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Filter by the state of the repository advisories. Only advisories of this state will be returned. Can be one of: `triage`, `draft`, `published`, `closed`.
 
 Default: `null`.
 
@@ -2280,9 +2694,17 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
 
 Default: `null`.
 
@@ -2330,9 +2752,41 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="direction" type="string | null">
 
-API-native query parameters, including pagination and filters.
+The direction to sort results. Ignored without `sort` parameter. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="since" type="string | null">
+
+Only show results that were last updated after the given time. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property to sort the results by. Can be one of: `created`, `updated`.
 
 Default: `null`.
 
@@ -2366,6 +2820,14 @@ GitHub API path value for repo.
 
 </ParamField>
 
+<ParamField path="base" type="string | null">
+
+Filter pulls by base branch name. Example: `gh-pages`.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2374,9 +2836,49 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="direction" type="string | null">
 
-API-native query parameters, including pagination and filters.
+The direction of the sort. Default: `desc` when sort is `created` or sort is not specified, otherwise `asc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="head" type="string | null">
+
+Filter pulls by head user or head organization and branch name in the format of `user:ref-name` or `organization:ref-name`. For example: `github:new-script-format` or `octocat:test-branch`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+What to sort results by. `popularity` will sort by the number of comments. `long-running` will sort by date created and will limit the results to pull requests that have been open for more than a month and have had activity within the past month. Can be one of: `created`, `updated`, `popularity`, `long-running`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Either `open`, `closed`, or `all` to filter by state. Can be one of: `open`, `closed`, `all`.
 
 Default: `null`.
 
@@ -2410,6 +2912,22 @@ GitHub API path value for repo.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignees" type="string | null">
+
+Filter alerts by assignees. Provide a comma-separated list of user handles (e.g., `octocat` or `octocat,hubot`). Use `*` to list alerts with at least one assignee or `none` to list alerts with no assignees.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2418,9 +2936,89 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch. Default: `1`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="pr" type="integer | null">
+
+The number of the pull request for the results you want to list.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ref" type="string | null">
+
+The Git reference for the results you want to list. The `ref` for a branch can be formatted either as `refs/heads/&lt;branch name>` or simply `&lt;branch name>`. To reference a pull request use `refs/pull/&lt;number>/merge`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="severity" type="string | null">
+
+If specified, only code scanning alerts with this severity will be returned. Can be one of: `critical`, `high`, `medium`, `low`, `warning`, `note`, `error`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property by which to sort the results. Default: `created`. Can be one of: `created`, `updated`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+If specified, only code scanning alerts with this state will be returned. Can be one of: `open`, `closed`, `dismissed`, `fixed`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="tool_guid" type="string | null">
+
+The GUID of a code scanning tool. Only results by this tool will be listed. Note that some code scanning tools may not include a GUID in their analysis data. You can specify the tool by using either `tool_guid` or `tool_name`, but not both.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="tool_name" type="string | null">
+
+The name of a code scanning tool. Only results by this tool will be listed. You can specify the tool by using either `tool_name` or `tool_guid`, but not both.
 
 Default: `null`.
 
@@ -2454,6 +3052,22 @@ GitHub API path value for repo.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignee" type="string | null">
+
+Filter alerts by assignees. Provide a comma-separated list of user handles (e.g., `octocat` or `octocat,hubot`) to return alerts assigned to any of the specified users. Use `*` to list alerts with at least one assignee or `none` to list alerts with no assignees.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2462,9 +3076,113 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="classification" type="string | null">
+
+A comma-separated list of vulnerability classifications. If specified, only alerts for vulnerabilities with these classifications will be returned. Can be: `malware`, `general`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ecosystem" type="string | null">
+
+A comma-separated list of ecosystems. If specified, only alerts for these ecosystems will be returned. Can be: `composer`, `go`, `maven`, `npm`, `nuget`, `pip`, `pub`, `rubygems`, `rust`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="epss_percentage" type="string | null">
+
+CVE Exploit Prediction Scoring System (EPSS) percentage. Can be specified as: - An exact number (`n`) - Comparators such as `>n`, `&lt;n`, `>=n`, `&lt;=n` - A range like `n..n`, where `n` is a number from 0.0 to 1.0 Filters the list of alerts based on EPSS percentages. If specified, only alerts with the provided EPSS percentages will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="has" type="array[string] | null">
+
+Filters the list of alerts based on whether the alert has the given value. If specified, only alerts meeting this criterion will be returned. Multiple `has` filters can be passed to filter for alerts that have all of the values. Currently, only `patch` is supported.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="manifest" type="string | null">
+
+A comma-separated list of full manifest paths. If specified, only alerts for these manifests will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="package" type="string | null">
+
+A comma-separated list of package names. If specified, only alerts for these packages will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="relationship" type="string | null">
+
+A comma-separated list of relationships of the vulnerable dependency to your project. If specified, only alerts with these relationships will be returned. We are rolling out support for dependency relationship across ecosystems. This value will be "unknown" for all dependencies in unsupported ecosystems.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="scope" type="string | null">
+
+The scope of the vulnerable dependency. If specified, only alerts with this scope will be returned. Can be one of: `development`, `runtime`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="severity" type="string | null">
+
+A comma-separated list of severities. If specified, only alerts with these severities will be returned. Can be: `low`, `medium`, `high`, `critical`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property by which to sort the results. `created` means when the alert was created. `updated` means when the alert's state last changed. `epss_percentage` sorts alerts by the Exploit Prediction Scoring System (EPSS) percentage. Default: `created`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+A comma-separated list of states. If specified, only alerts with these states will be returned. Can be: `auto_dismissed`, `dismissed`, `fixed`, `open`
 
 Default: `null`.
 
@@ -2498,6 +3216,14 @@ GitHub API path value for repo.
 
 </ParamField>
 
+<ParamField path="assignee" type="string | null">
+
+Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues assigned to any user.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2506,9 +3232,97 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="creator" type="string | null">
 
-API-native query parameters, including pagination and filters.
+The user that created the issue.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="issue_field_values" type="string | null">
+
+A comma-separated list of issue field filters in `field_slug:value` format. Only issues matching all specified field values are returned. Requires issue fields to be enabled for the repository. Issue fields are not available for user-owned repositories, and field availability for organization-owned public repositories depends on the organization's visibility settings. For example, `priority:Urgent,severity:High` filters issues where the `priority` field is `Urgent` AND the `severity` field is `High`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="labels" type="string | null">
+
+A list of comma separated label names. Example: `bug,ui,@high`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="mentioned" type="string | null">
+
+A user that's mentioned in the issue.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="milestone" type="string | null">
+
+If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="since" type="string | null">
+
+Only show results that were last updated after the given time. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+What to sort results by. Can be one of: `created`, `updated`, `comments`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Indicates the state of the issues to return. Can be one of: `open`, `closed`, `all`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="type" type="string | null">
+
+Can be the name of an issue type. If the string `*` is passed, issues with any type are accepted. If the string `none` is passed, issues without type are returned.
 
 Default: `null`.
 
@@ -2542,6 +3356,22 @@ GitHub API path value for repo.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for events after this cursor. To receive an initial cursor on your first request, include an empty "after" query string.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignee" type="string | null">
+
+Filters alerts by assignee. Use `*` to get all assigned alerts, `none` to get all unassigned alerts, or a GitHub username to get alerts assigned to a specific user.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2550,9 +3380,145 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for events before this cursor. To receive an initial cursor on your first request, include an empty "before" query string.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="exclude_providers" type="string | null">
+
+A comma-separated list of provider slugs to exclude from the results. Provider slugs use lowercase with underscores (e.g., `github_secret_scanning`, `clojars`). You can find the provider slug in the `provider_slug` field of each alert. Cannot be combined with the `providers` parameter.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="exclude_secret_types" type="string | null">
+
+A comma-separated list of secret types to exclude from the results. All default secret patterns are returned except those matching the specified types. Cannot be combined with the `secret_type` parameter. See "Supported secret scanning patterns" for a complete list of secret types.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="hide_secret" type="boolean | null">
+
+A boolean value representing whether or not to hide literal secrets in the results. Default: `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="included_metadata" type="string | null">
+
+A comma-separated list of metadata fields to filter alerts by. Only alerts that have all of the specified metadata fields attached will be returned. Possible values are: `owner-email`, `owner-id`, `owner-name`, `secret-id`, `secret-name`, `secret-issued-date`, `secret-expiration-date`, `organization-name`, `organization-id`, `last-used-date`, and `has-organization-access`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="is_bypassed" type="boolean | null">
+
+A boolean value (`true` or `false`) indicating whether to filter alerts by their push protection bypass status. When set to `true`, only alerts that were created because a push protection rule was bypassed will be returned. When set to `false`, only alerts that were not caused by a push protection bypass will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="is_multi_repo" type="boolean | null">
+
+A boolean value representing whether or not to filter alerts by the multi-repo tag being present. Default: `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="is_publicly_leaked" type="boolean | null">
+
+A boolean value representing whether or not to filter alerts by the publicly-leaked tag being present. Default: `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="owner_email_hash" type="string | null">
+
+Filters alerts to only those whose attached `owner_email` metadata field matches the provided value. The value must be the lowercase hex-encoded SHA-256 hash of the email address to match (for example, the SHA-256 of `user@example.com`). Only alerts that have an `owner_email` metadata value whose SHA-256 hash equals this parameter are returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch. Default: `1`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="providers" type="string | null">
+
+A comma-separated list of provider slugs to filter by. Provider slugs use lowercase with underscores (e.g., `github_secret_scanning`, `clojars`). You can find the provider slug in the `provider_slug` field of each alert. Cannot be combined with the `exclude_providers` parameter.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="resolution" type="string | null">
+
+A comma-separated list of resolutions. Only secret scanning alerts with one of these resolutions are listed. Valid resolutions are `false_positive`, `wont_fix`, `revoked`, `pattern_edited`, `pattern_deleted` or `used_in_tests`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="secret_type" type="string | null">
+
+A comma-separated list of secret types to return. All default secret patterns are returned. To return generic patterns, pass the token name(s) in the parameter. See "Supported secret scanning patterns" for a complete list of secret types.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property to sort the results by. `created` means when the alert was created. `updated` means when the alert was updated or resolved. Default: `created`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Set to `open` or `resolved` to only list secret scanning alerts in a specific state.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="validity" type="string | null">
+
+A comma-separated list of validities that, when present, will return alerts that match the validities in this list. Valid options are `active`, `inactive`, and `unknown`.
 
 Default: `null`.
 
@@ -2586,6 +3552,14 @@ GitHub API path value for repo.
 
 </ParamField>
 
+<ParamField path="after" type="string | null">
+
+A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2594,9 +3568,41 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="before" type="string | null">
 
-API-native query parameters, including pagination and filters.
+A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="direction" type="string | null">
+
+The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of advisories to return per page. Default: `30`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The property to sort the results by. Default: `created`. Can be one of: `created`, `updated`, `published`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Filter by state of the repository advisories. Only advisories of this state will be returned. Can be one of: `triage`, `draft`, `published`, `closed`.
 
 Default: `null`.
 
@@ -2630,6 +3636,14 @@ GitHub API path value for repo.
 
 </ParamField>
 
+<ParamField path="actor" type="string | null">
+
+Returns someone's workflow runs. Use the login for the user who created the `push` associated with the check suite or workflow run.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2638,9 +3652,73 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="branch" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Returns workflow runs associated with a branch. Use the name of the branch of the `push`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="check_suite_id" type="integer | null">
+
+Returns workflow runs with the `check_suite_id` that you specify.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created" type="string | null">
+
+Returns workflow runs created within the given date-time range. For more information on the syntax, see "[Understanding the search syntax](https://docs.github.com/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates)."
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="event" type="string | null">
+
+Returns workflow run triggered by the event you specify. For example, `push`, `pull_request` or `issue`. For more information, see "[Events that trigger workflows](https://docs.github.com/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows)."
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="exclude_pull_requests" type="boolean | null">
+
+If `true` pull requests are omitted from the response (empty array).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="head_sha" type="string | null">
+
+Only returns workflow runs that are associated with the specified `head_sha`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="status" type="string | null">
+
+Returns workflow runs with the check run `status` or `conclusion` that you specify. For example, a conclusion can be `success` or a status can be `in_progress`. Only GitHub Actions can set a status of `waiting`, `pending`, or `requested`. Can be one of: `completed`, `action_required`, `cancelled`, `failure`, `neutral`, `skipped`, `stale`, `success`, `timed_out`, `in_progress`, `queued`, `requested`, `waiting`, `pending`.
 
 Default: `null`.
 
@@ -2682,9 +3760,17 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
 
 Default: `null`.
 
@@ -2732,9 +3818,17 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page number of the results to fetch. Default: `1`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100). Default: `30`.
 
 Default: `null`.
 
@@ -2782,9 +3876,25 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="filter" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Filters jobs by their `completed_at` timestamp. `latest` returns jobs from the most recent execution of the workflow run. `all` returns all jobs for a workflow run, including from old executions of the workflow run. Can be one of: `latest`, `all`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
 
 Default: `null`.
 
@@ -2832,17 +3942,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for PUT /repos/&#123;owner&#125;/&#123;repo&#125;/pulls/&#123;pull_number&#125;/merge: commit_title, commit_message, sha, merge_method.
 
 Default: `null`.
 
@@ -2890,22 +3992,6 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
-
-</ParamField>
-
 ## Rerun failed workflow jobs
 
 Action ID: `tools.github.rerun_failed_workflow_jobs`
@@ -2948,17 +4034,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for POST /repos/&#123;owner&#125;/&#123;repo&#125;/actions/runs/&#123;run_id&#125;/rerun-failed-jobs: enable_debug_logging.
 
 Default: `null`.
 
@@ -2980,6 +4058,12 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="q" type="string" required>
+
+The query contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. The REST API supports the same qualifiers as the web interface for GitHub. See Searching code for a detailed list of qualifiers.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -2988,9 +4072,33 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="order" type="string | null">
 
-API-native query parameters, including pagination and filters.
+This field is closing down. Determines whether the first search result returned is the highest number of matches (desc) or lowest number of matches (asc). This parameter is ignored unless you provide sort.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+This field is closing down. Sorts the results of your query. Can only be indexed, which indicates how recently a file has been indexed by the GitHub search infrastructure. Default: best match
 
 Default: `null`.
 
@@ -3012,6 +4120,12 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="q" type="string" required>
+
+The query contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. The REST API supports the same qualifiers as the web interface for GitHub. See Searching commits for a detailed list of qualifiers.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -3020,9 +4134,33 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="order" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Determines whether the first search result returned is the highest number of matches (desc) or lowest number of matches (asc). This parameter is ignored unless you provide sort.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+Sorts the results of your query by author-date or committer-date. Default: best match
 
 Default: `null`.
 
@@ -3044,6 +4182,20 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="q" type="string" required>
+
+The query contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. The REST API supports the same qualifiers as the web interface for GitHub. See Searching issues and pull requests for a detailed list of qualifiers.
+
+</ParamField>
+
+<ParamField path="advanced_search" type="string | null">
+
+Set to true to use advanced search.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -3052,9 +4204,41 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="order" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Determines whether the first search result returned is the highest number of matches (desc) or lowest number of matches (asc). This parameter is ignored unless you provide sort.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search_type" type="string | null">
+
+The type of search to perform on issues. When not specified, the default is lexical search. semantic performs a pure semantic (vector) search using embedding-based understanding. hybrid combines semantic search with lexical search for best results. Semantic and hybrid search require authentication and are rate limited to 10 requests per minute. Only applies to issue searches (/search/issues).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+Sorts the results of your query by the number of comments, reactions, reactions-+1, reactions--1, reactions-smile, reactions-thinking_face, reactions-heart, reactions-tada, or interactions. You can also sort results by how recently the items were created or updated, Default: best match
 
 Default: `null`.
 
@@ -3076,6 +4260,12 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="q" type="string" required>
+
+The query contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. The REST API supports the same qualifiers as the web interface for GitHub. See Searching for repositories for a detailed list of qualifiers.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitHub.com REST API base URL.
@@ -3084,9 +4274,33 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="order" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Determines whether the first search result returned is the highest number of matches (desc) or lowest number of matches (asc). This parameter is ignored unless you provide sort.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+The page number of the results to fetch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page (max 100).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+Sorts the results of your query by number of stars, forks, or help-wanted-issues or how recently the items were updated. Default: best match
 
 Default: `null`.
 
@@ -3128,17 +4342,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: description (required), summary (required), cvss_vector_string, cwe_ids, severity, start_private_fork, vulnerabilities.
 
 Default: `null`.
 
@@ -3186,17 +4392,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: allow_deletions, allow_force_pushes, allow_fork_syncing, block_creations, enforce_admins, lock_branch, required_conversation_resolution, required_linear_history, required_pull_request_reviews, required_status_checks, restrictions.
 
 Default: `null`.
 
@@ -3244,17 +4442,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: assignees, create_request, dismissed_comment, dismissed_reason, state.
 
 Default: `null`.
 
@@ -3296,17 +4486,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: languages, query_suite, runner_label, runner_type, state, threat_model.
 
 Default: `null`.
 
@@ -3354,17 +4536,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: agent_assignment, assignees, dismissed_comment, dismissed_reason, state.
 
 Default: `null`.
 
@@ -3412,17 +4586,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for PATCH /repos/&#123;owner&#125;/&#123;repo&#125;/issues/&#123;issue_number&#125;: title, body, assignee, state, state_reason, duplicate_issue_id, milestone, labels, assignees, issue_field_values, type.
 
 Default: `null`.
 
@@ -3470,17 +4636,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body passed through without validation. Body fields documented for PATCH /repos/&#123;owner&#125;/&#123;repo&#125;/pulls/&#123;pull_number&#125;: title, body, state, base, maintainer_can_modify.
 
 Default: `null`.
 
@@ -3528,17 +4686,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: collaborating_teams, collaborating_users, credits, cve_id, cvss_vector_string, cwe_ids, description, severity, state, summary, vulnerabilities.
 
 Default: `null`.
 
@@ -3586,17 +4736,9 @@ Default: `"https://api.github.com"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: assignee, resolution, resolution_comment, state, validity.
 
 Default: `null`.
 

--- a/docs/tools/gitlab.mdx
+++ b/docs/tools/gitlab.mdx
@@ -1596,9 +1596,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="iids" type="array[string] | null">
+<ParamField path="iids" type="array[integer] | null">
 
 Returns merge requests matching the provided IIDs.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="in" type="string | null">
+
+Change the scope of the `search` attribute. `title`, `description`, or a string joining them with comma. Default is `title,description`.
 
 Default: `null`.
 
@@ -1711,14 +1719,6 @@ Default: `null`.
 <ParamField path="search" type="string | null">
 
 Search merge requests against their `title` and `description`. Combine with `in` attribute.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="search_in" type="string | null">
-
-Change the scope of the `search` attribute. `title`, `description`, or a string joining them with comma. Default is `title,description`.
 
 Default: `null`.
 

--- a/docs/tools/gitlab.mdx
+++ b/docs/tools/gitlab.mdx
@@ -40,22 +40,6 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
-
-</ParamField>
-
 ## Create commit
 
 Action ID: `tools.gitlab.create_commit`
@@ -72,9 +56,53 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="branch" type="string" required>
+
+Name of the branch to commit into. To create a new branch, also provide either `start_branch` or `start_sha`, and optionally `start_project`.
+
+</ParamField>
+
+<ParamField path="commit_message" type="string" required>
+
+Commit message.
+
+</ParamField>
+
 <ParamField path="project_id" type="string" required>
 
 GitLab API path value for project_id.
+
+</ParamField>
+
+<ParamField path="actions" type="array[object] | null">
+
+An array of action hashes to commit as a batch. Each action hash takes `action` (one of `create`, `delete`, `move`, `update`, or `chmod`), `file_path`, and optionally `content`, `encoding`, `execute_filemode`, `last_commit_id`, and `previous_path`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="allow_empty" type="boolean | null">
+
+When `true`, creates an empty commit. Default is `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="author_email" type="string | null">
+
+Specify the commit author's email address.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="author_name" type="string | null">
+
+Specify the commit author's name.
+
+Default: `null`.
 
 </ParamField>
 
@@ -86,17 +114,41 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="force" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+If `true`, overwrites `branch` with a new commit based on `start_branch` or `start_sha`, replacing the branch's existing commit history. Default is `false`.
 
 Default: `null`.
 
 </ParamField>
 
-<ParamField path="payload" type="object | null">
+<ParamField path="start_branch" type="string | null">
 
-API-native request body passed through without validation.
+Name of the branch to use as the parent for the new commit. If not provided and `start_sha` is also not provided, defaults to the value of `branch`. Mutually exclusive with `start_sha`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="start_project" type="string | null">
+
+The project ID or URL-encoded path of the project to use as the source for `start_branch` or `start_sha`. Defaults to the value of `id`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="start_sha" type="string | null">
+
+SHA of the commit to use as the parent for the new commit. Must be a full 40-character SHA. Mutually exclusive with `start_branch`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="stats" type="boolean | null">
+
+Include commit stats. Default is `true`.
 
 Default: `null`.
 
@@ -124,6 +176,28 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="title" type="string" required>
+
+The title of an issue.
+
+</ParamField>
+
+<ParamField path="assignee_id" type="integer | null">
+
+The ID of the user to assign the issue to. Only appears on GitLab Free.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignee_ids" type="string | null">
+
+The IDs of the users to assign the issue to, as a comma-separated list. Premium and Ultimate only.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -132,9 +206,97 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="confidential" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+Set an issue to be confidential. Default is `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created_at" type="string | null">
+
+When the issue was created. Date time string, ISO 8601 formatted, for example `2016-03-11T03:45:40Z`. Requires administrator or project/group owner rights.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="description" type="string | null">
+
+The description of an issue. Limited to 1,048,576 characters.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="discussion_to_resolve" type="string | null">
+
+The ID of a discussion to resolve. This fills out the issue with a default description and marks the discussion as resolved. Use in combination with `merge_request_to_resolve_discussions_of`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="due_date" type="string | null">
+
+The due date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="epic_id" type="integer | null">
+
+ID of the epic to add the issue to. Valid values are greater than or equal to 0. Premium and Ultimate only.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="iid" type="integer | null">
+
+The internal ID of the project's issue (requires administrator or project owner rights).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="issue_type" type="string | null">
+
+The type of issue. One of `issue`, `incident`, `test_case` or `task`. Default is `issue`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="labels" type="string | null">
+
+Comma-separated label names to assign to the new issue. If a label does not already exist, this creates a new project label and assigns it to the issue.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="merge_request_to_resolve_discussions_of" type="integer | null">
+
+The IID of a merge request in which to resolve all issues. This fills out the issue with a default description and marks all discussions as resolved. When passing a description or title, these values take precedence over the default values.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="milestone" type="string | null">
+
+The title of a project or ancestor-group milestone to assign the issue to. Matched exactly (case-sensitive). Mutually exclusive with `milestone_id`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="milestone_id" type="integer | null">
+
+The global ID of a milestone to assign issue. Mutually exclusive with `milestone`.
 
 Default: `null`.
 
@@ -143,6 +305,30 @@ Default: `null`.
 <ParamField path="payload" type="object | null">
 
 API-native request body passed through without validation.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="severity" type="string | null">
+
+The severity of the issue. Applies only to incidents. One of `unknown`, `low`, `medium`, `high`, or `critical`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="start_date" type="string | null">
+
+The start date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="weight" type="integer | null">
+
+The weight of the issue. Valid values are greater than or equal to 0. Premium and Ultimate only.
 
 Default: `null`.
 
@@ -176,6 +362,18 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="target_issue_iid" type="string" required>
+
+The internal ID of a target project's issue.
+
+</ParamField>
+
+<ParamField path="target_project_id" type="string" required>
+
+The ID or URL-encoded path of the project of a target project.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -184,9 +382,9 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="link_type" type="string | null">
 
-API-native query parameters, including pagination and filters.
+The type of the relation (`relates_to`, `blocks`, `is_blocked_by`), defaults to `relates_to`.
 
 Default: `null`.
 
@@ -216,6 +414,12 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="body" type="string" required>
+
+The content of a note. Limited to 1,000,000 characters.
+
+</ParamField>
+
 <ParamField path="issue_iid" type="integer" required>
 
 GitLab API path value for issue_iid.
@@ -236,9 +440,25 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="confidential" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+Deprecated: Renamed to `internal`. The confidential flag of a note. Default is false.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created_at" type="string | null">
+
+Date time string, ISO 8601 formatted. It must be after 1970-01-01. Example: `2016-03-11T03:45:40Z` (requires administrator or project/group owner rights).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="internal" type="boolean | null">
+
+The internal flag of a note. Overrides `confidential` when both parameters are submitted. Default is false.
 
 Default: `null`.
 
@@ -282,17 +502,9 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: source_branch (required), target_branch (required), title (required), allow_collaboration, allow_maintainer_to_push, approvals_before_merge, assignee_id, assignee_ids, description, labels, merge_after, milestone, milestone_id, remove_source_branch, reviewer_ids, squash, target_project_id.
 
 Default: `null`.
 
@@ -334,17 +546,9 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: body (required), created_at, internal, merge_request_diff_head_sha.
 
 Default: `null`.
 
@@ -372,6 +576,12 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="ref" type="string" required>
+
+The branch or tag to run the pipeline on. For merge request pipelines use the merge requests endpoint.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -380,17 +590,17 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="inputs" type="object | null">
 
-API-native query parameters, including pagination and filters.
+A hash containing the inputs, as key-value pairs, to use when creating the pipeline.
 
 Default: `null`.
 
 </ParamField>
 
-<ParamField path="payload" type="object | null">
+<ParamField path="variables" type="array[object] | null">
 
-API-native request body passed through without validation.
+An array of hashes containing the variables available in the pipeline, matching the structure `[&#123; 'key': 'UPLOAD_TO_S3', 'variable_type': 'file', 'value': 'true' &#125;, &#123;'key': 'TEST', 'value': 'test variable'&#125;]`. If `variable_type` is excluded, it defaults to `env_var`.
 
 Default: `null`.
 
@@ -426,17 +636,9 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native vulnerability export request body.
+API-native request body. Documented fields: export_format, report_data, send_email.
 
 Default: `null`.
 
@@ -486,22 +688,6 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
-
-</ParamField>
-
 ## Download vulnerability export
 
 Action ID: `tools.gitlab.download_vulnerability_export`
@@ -529,14 +715,6 @@ GitLab API path value for export_id.
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
 
 Default: `"https://gitlab.com/api/v4"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
 
 </ParamField>
 
@@ -576,14 +754,6 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get job trace
 
 Action ID: `tools.gitlab.get_job_trace`
@@ -620,9 +790,17 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="byte_limit" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+Maximum number of bytes to return.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="byte_offset" type="integer | null">
+
+Byte offset to start reading from.
 
 Default: `null`.
 
@@ -664,9 +842,25 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="include_diverged_commits_count" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+If `true`, response includes the commits behind the target branch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="include_rebase_in_progress" type="boolean | null">
+
+If `true`, response includes whether a rebase operation is in progress.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="render_html" type="boolean | null">
+
+If `true`, response includes rendered HTML for title and description.
 
 Default: `null`.
 
@@ -702,9 +896,25 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="license" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+Include project license data.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="statistics" type="boolean | null">
+
+Include project statistics. Available only to users with the Reporter, Developer, Maintainer, or Owner role.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="with_custom_attributes" type="boolean | null">
+
+Include custom attributes in response. Administrator access.
 
 Default: `null`.
 
@@ -740,14 +950,6 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get repository file
 
 Action ID: `tools.gitlab.get_repository_file`
@@ -776,19 +978,17 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="ref" type="string" required>
+
+Name of branch, tag, or commit. Use `HEAD` to automatically use the default branch.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
 
 Default: `"https://gitlab.com/api/v4"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
 
 </ParamField>
 
@@ -822,14 +1022,6 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 ## List commits
 
 Action ID: `tools.gitlab.list_commits`
@@ -852,6 +1044,22 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="all" type="boolean | null">
+
+Retrieve every commit from the repository. If `true`, the `ref_name` parameter is ignored.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="author" type="string | null">
+
+Search commits by commit author.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -860,9 +1068,89 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="first_parent" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+If `true`, follows only the first parent commit upon seeing a merge commit.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="follow" type="boolean | null">
+
+If `true`, follows file renames when filtering commits by `path`, and returns commits for the file even if it was renamed. If `false`, returns only commits where the file existed at its current path. Used only when `path` specifies a single file. Defaults to `true`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order" type="string | null">
+
+List commits in order. Possible values: `default`, `topo`. Defaults to `default`, the commits are shown in reverse chronological order.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="path" type="string | null">
+
+The file path.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ref_name" type="string | null">
+
+The name of a repository branch, tag, or revision range, or if not given the default branch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="since" type="string | null">
+
+Only commits after or on this date are returned in ISO 8601 format `YYYY-MM-DDTHH:MM:SSZ`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="trailers" type="boolean | null">
+
+If `true`, parses and includes Git trailers for every commit.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="until" type="string | null">
+
+Only commits before or on this date are returned in ISO 8601 format `YYYY-MM-DDTHH:MM:SSZ`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="with_stats" type="boolean | null">
+
+If `true`, retrieve stats about each commit.
 
 Default: `null`.
 
@@ -896,6 +1184,14 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="activity_filter" type="string | null">
+
+Filter notes by activity type. Valid values: `all_notes`, `only_comments`, `only_activity`. Default is `all_notes`.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -904,9 +1200,33 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="order_by" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Return issue notes ordered by `created_at` or `updated_at` fields. Default is `created_at`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+Return issue notes sorted in `asc` or `desc` order. Default is `desc`.
 
 Default: `null`.
 
@@ -948,9 +1268,17 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
 
 Default: `null`.
 
@@ -992,9 +1320,25 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+The page of results to return. Defaults to 1.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+The number of results per page. Defaults to 20.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="unidiff" type="boolean | null">
+
+Present diffs in the unified diff format. Default is false.
 
 Default: `null`.
 
@@ -1036,9 +1380,33 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="order_by" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Return merge request notes ordered by `created_at` or `updated_at` fields. Default is `created_at`
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+Return merge request notes sorted in `asc` or `desc` order. Default is `desc`
 
 Default: `null`.
 
@@ -1080,9 +1448,17 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
 
 Default: `null`.
 
@@ -1110,6 +1486,62 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="approved_by_ids" type="array[string] | null">
+
+Returns merge requests approved by all the users with the given `id`, up to 5 users. `None` returns merge requests with no approvals. `Any` returns merge requests with an approval.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="approved_by_usernames" type="array[string] | null">
+
+Returns merge requests approved by all the users with the given `username`, up to 5 users. `None` returns merge requests with no approvals. `Any` returns merge requests with an approval.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="approver_ids" type="array[string] | null">
+
+Returns merge requests which have all users with the specified `id` as eligible approvers according to the approval rules. `None` returns merge requests with no eligible approvers. `Any` returns merge requests with at least one eligible approver. Premium and Ultimate only.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignee_id" type="string | null">
+
+Returns merge requests assigned to the given user `id`. `None` returns unassigned merge requests. `Any` returns merge requests with an assignee. Mutually exclusive with `assignee_username`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignee_username" type="array[string] | null">
+
+Returns merge requests assigned to the given usernames. Mutually exclusive with `assignee_id`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="author_id" type="integer | null">
+
+Returns merge requests created by the given user `id`. Mutually exclusive with `author_username`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="author_username" type="string | null">
+
+Returns merge requests created by the given `username`. Mutually exclusive with `author_id`.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -1118,9 +1550,257 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="created_after" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Returns merge requests created on or after the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created_before" type="string | null">
+
+Returns merge requests created on or before the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="deployed_after" type="string | null">
+
+Returns merge requests deployed after the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="deployed_before" type="string | null">
+
+Returns merge requests deployed before the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="draft" type="boolean | null">
+
+Filter merge requests by their `draft` status. `true` returns only draft merge requests, `false` returns non-draft merge requests. Mutually exclusive with `wip`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="environment" type="string | null">
+
+Returns merge requests deployed to the given environment.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="iids" type="array[string] | null">
+
+Returns merge requests matching the provided IIDs.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="labels" type="string | null">
+
+Returns merge requests matching a comma-separated list of labels. `None` lists all merge requests with no labels. `Any` lists all merge requests with at least one label. Predefined names are case-insensitive.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="merge_user_id" type="integer | null">
+
+Returns merge requests merged by the user with the given user `id`. Mutually exclusive with `merge_user_username`. Introduced in GitLab 17.0.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="merge_user_username" type="string | null">
+
+Returns merge requests merged by the user with the given `username`. Mutually exclusive with `merge_user_id`. Introduced in GitLab 17.0.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="merged_after" type="string | null">
+
+Returns merge requests merged on or after the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="merged_before" type="string | null">
+
+Returns merge requests merged on or before the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="milestone" type="string | null">
+
+Returns merge requests for a specific milestone. `None` returns merge requests with no milestone. `Any` returns merge requests that have an assigned milestone.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="my_reaction_emoji" type="string | null">
+
+Returns merge requests reacted by the authenticated user by the given `emoji`. `None` returns issues not given a reaction. `Any` returns issues given at least one reaction.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+Returns merge requests ordered by `created_at`, `updated_at`, `merged_at` (introduced in GitLab 17.2), `label_priority`, `priority`, `milestone_due`, `popularity`, or `title` fields. Default is `created_at`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="reviewer_id" type="string | null">
+
+Returns merge requests which have the user as a reviewer with the given user `id`. `None` returns merge requests with no reviewers. `Any` returns merge requests with any reviewer. Mutually exclusive with `reviewer_username`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="reviewer_username" type="string | null">
+
+Returns merge requests which have the user as a reviewer with the given `username`. `None` returns merge requests with no reviewers. `Any` returns merge requests with any reviewer. Mutually exclusive with `reviewer_id`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="scope" type="string | null">
+
+Returns merge requests for the given scope: `created_by_me`, `assigned_to_me`, `reviews_for_me`, or `all`. `reviews_for_me` returns merge requests where the current user is assigned as a reviewer. Defaults to `all`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search" type="string | null">
+
+Search merge requests against their `title` and `description`. Combine with `in` attribute.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search_in" type="string | null">
+
+Change the scope of the `search` attribute. `title`, `description`, or a string joining them with comma. Default is `title,description`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+Returns merge requests sorted in `asc` or `desc` order. Default is `desc`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="source_branch" type="string | null">
+
+Returns merge requests with the given source branch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Returns all merge requests (`all`) or just those that are `opened`, `closed`, `locked`, or `merged`. Defaults to `all`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="target_branch" type="string | null">
+
+Returns merge requests with the given target branch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="updated_after" type="string | null">
+
+Returns merge requests updated on or after the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="updated_before" type="string | null">
+
+Returns merge requests updated on or before the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="view" type="string | null">
+
+If `simple`, returns the `iid`, URL, title, description, and basic state of merge request.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="wip" type="string | null">
+
+Deprecated in GitLab 19.0. Use `draft` instead. Filter merge requests by their `wip` status. `yes` returns only draft merge requests, `no` returns non-draft merge requests.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="with_labels_details" type="boolean | null">
+
+If `true`, response returns more details for each label in labels field: `:name`, `:color`, `:description`, `:description_html`, `:text_color`. Default is `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="with_merge_status_recheck" type="boolean | null">
+
+If `true`, this projection requests (but does not guarantee) an asynchronous recalculation of the `merge_status` field. Enable the `restrict_merge_status_recheck` feature flag to ignore this attribute when requested by users without the Developer, Maintainer, or Owner role.
 
 Default: `null`.
 
@@ -1162,9 +1842,33 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="include_retried" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+Include retried jobs in the response. Defaults to `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="scope" type="string | null">
+
+Scope of jobs to show, as one of the job status values: `created`, `waiting_for_resource`, `preparing`, `waiting_for_callback`, `pending`, `running`, `success`, `failed`, `canceling`, `canceled`, `skipped`, `manual`, or `scheduled`. All jobs are returned if `scope` is not provided.
 
 Default: `null`.
 
@@ -1200,9 +1904,129 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="created_after" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Return pipelines created after the specified date. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created_before" type="string | null">
+
+Return pipelines created before the specified date. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="name" type="string | null">
+
+Return pipelines with the specified name.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The field to order pipelines by: `id`, `status`, `ref`, `updated_at`, or `user_id` (default: `id`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ref" type="string | null">
+
+Return pipelines for the specified branch or tag.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="scope" type="string | null">
+
+Return pipelines in the specified scope: `running`, `pending`, `finished`, `branches`, or `tags`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sha" type="string | null">
+
+Return pipelines for the specified commit SHA.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+The sort order: `asc` or `desc` (default: `desc`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="source" type="string | null">
+
+Return pipelines with the specified source.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="status" type="string | null">
+
+Return pipelines with the specified status: `created`, `waiting_for_resource`, `preparing`, `waiting_for_callback`, `pending`, `running`, `success`, `failed`, `canceling`, `canceled`, `skipped`, `manual`, or `scheduled`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="updated_after" type="string | null">
+
+Return pipelines updated after the specified date. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="updated_before" type="string | null">
+
+Return pipelines updated before the specified date. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="username" type="string | null">
+
+Return pipelines triggered by the specified username.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="yaml_errors" type="boolean | null">
+
+Return pipelines with invalid configurations.
 
 Default: `null`.
 
@@ -1238,9 +2062,17 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
 
 Default: `null`.
 
@@ -1276,9 +2108,33 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="created_after" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Return project audit events created on or after the given time. Format: ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`)
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created_before" type="string | null">
+
+Return project audit events created on or before the given time. Format: ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`)
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
 
 Default: `null`.
 
@@ -1314,9 +2170,25 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="package_manager" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Returns dependencies belonging to specified package manager. Valid values: `bundler`, `composer`, `conan`, `go`, `gradle`, `maven`, `npm`, `nuget`, `pip`, `pipenv`, `pnpm`, `yarn`, `sbt`, or `setuptools`. Accepts a comma-separated list.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
 
 Default: `null`.
 
@@ -1344,6 +2216,14 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="archived" type="boolean | null">
+
+If `true`, returns only archived labels. If unset, returns all labels.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -1352,9 +2232,41 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="include_ancestor_groups" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+Include ancestor groups. Defaults to `true`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search" type="string | null">
+
+Keyword to filter labels by.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="with_counts" type="boolean | null">
+
+Whether or not to include issue and merge request counts. Defaults to `false`.
 
 Default: `null`.
 
@@ -1390,9 +2302,49 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="query" type="string | null">
+
+Filters results based on a given name, email, or username. Use partial values to widen the scope of the query.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="show_seat_info" type="boolean | null">
+
+Show seat information for users.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Filter results by member state, one of `awaiting` or `active`. Premium and Ultimate only.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="user_ids" type="string | null">
+
+Filter the results on the given user IDs, as a comma-separated list.
 
 Default: `null`.
 
@@ -1428,9 +2380,49 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="pipeline_id" type="string | null">
+
+Returns vulnerability findings belonging to specified pipeline.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="report_type" type="string | null">
+
+Returns vulnerability findings belonging to specified report type. Valid values: `sast`, `dast`, `dependency_scanning`, or `container_scanning`. Defaults to all. Accepts a comma-separated list.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="scope" type="string | null">
+
+Returns vulnerability findings for the given scope: `all` or `dismissed`. Defaults to `dismissed`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="severity" type="string | null">
+
+Returns vulnerability findings belonging to specified severity level: `info`, `unknown`, `low`, `medium`, `high`, or `critical`. Defaults to all. Accepts a comma-separated list.
 
 Default: `null`.
 
@@ -1466,9 +2458,9 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="with_content" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+Include pages' content.
 
 Default: `null`.
 
@@ -1504,9 +2496,25 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search" type="string | null">
+
+Name or part of the name of protected branches to search for.
 
 Default: `null`.
 
@@ -1542,9 +2550,65 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="page" type="integer | null">
 
-API-native query parameters, including pagination and filters.
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page_token" type="string | null">
+
+Tree record ID at which to fetch the next page. Used only with keyset pagination.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="pagination" type="string | null">
+
+If `keyset`, use the keyset-based pagination method.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="path" type="string | null">
+
+Path inside the repository. Used to get content of subdirectories.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of results to show per page. If not specified, defaults to `20`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="recursive" type="boolean | null">
+
+If `true`, get a recursive tree. Default is `false`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ref" type="string | null">
+
+Name of a repository branch or tag. If not specified, uses the default branch.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="with_last_commit" type="boolean | null">
+
+If `true`, include the last commit for each tree entry. Cannot be combined with `recursive`. Default is `false`.
 
 Default: `null`.
 
@@ -1586,17 +2650,9 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: auto_merge, merge_commit_message, merge_when_pipeline_succeeds, sha, should_remove_source_branch, squash, squash_commit_message.
 
 Default: `null`.
 
@@ -1638,22 +2694,6 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
-
-</ParamField>
-
 ## Search project
 
 Action ID: `tools.gitlab.search_project`
@@ -1676,6 +2716,18 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="scope" type="string" required>
+
+The scope to search in. Values include `issues`, `work_items`, `merge_requests`, `milestones`, and `users`. Additional scopes are `wiki_blobs`, `commits`, `blobs`, and `notes`.
+
+</ParamField>
+
+<ParamField path="search" type="string" required>
+
+The search term.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -1684,9 +2736,97 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="confidential" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+Filter by confidentiality. Supports `issues` and `work_items` scopes; other scopes are ignored.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="fields" type="string | null">
+
+Array of fields you wish to search, allowed values are `title` only. Supports only `issues` and `merge_requests` scopes. Premium and Ultimate only.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="num_context_lines" type="integer | null">
+
+Number of context lines to include around each match in the results. Available for advanced and exact code search only.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+Allowed values are `created_at` only. If not set, results are sorted by `created_at` in descending order for basic search, or by the most relevant documents for advanced search.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="page" type="integer | null">
+
+Page number (default: `1`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="per_page" type="integer | null">
+
+Number of items to list per page (default: `20`, max: `100`).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="ref" type="string | null">
+
+The name of a repository branch or tag to search on. The project's default branch is used by default. Applicable only for scopes `blobs`, `commits`, and `wiki_blobs`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="regex" type="boolean | null">
+
+Uses regular expressions to search for code. Available for exact code search. If not set, regular expressions are used.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search_type" type="string | null">
+
+The search type to use. Values include `basic`, `advanced`, and `zoekt`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sort" type="string | null">
+
+Allowed values are `asc` or `desc` only. If not set, results are sorted by `created_at` in descending order for basic search, or by the most relevant documents for advanced search.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state" type="string | null">
+
+Filter by state. Supports `issues`, `work_items`, and `merge_requests` scopes; other scopes are ignored.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="type" type="string | null">
+
+Filter work items by type. Only applies to `work_items` scope. Available types: `issue`, `task`, `epic`, `incident`, `test_case`, `requirement`, `objective`, `key_result`, `ticket`.
 
 Default: `null`.
 
@@ -1714,6 +2854,12 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="q" type="string" required>
+
+Natural language search query.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -1722,9 +2868,25 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="directory_path" type="string | null">
 
-API-native query parameters, including pagination and filters.
+Directory path to scope the search to.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="knn" type="integer | null">
+
+Number of nearest neighbors to consider during the vector search (1-100). Default is `64`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+Maximum number of results to return (1-100). Default is `20`.
 
 Default: `null`.
 
@@ -1758,6 +2920,22 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="add_labels" type="string | null">
+
+Comma-separated label names to add to an issue. If a label does not already exist, this creates a new project label and assigns it to the issue.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="assignee_ids" type="string | null">
+
+The ID of the users to assign the issue to, as a comma-separated list. Set to `0` to unassign all assignees.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -1766,9 +2944,73 @@ Default: `"https://gitlab.com/api/v4"`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="confidential" type="boolean | null">
 
-API-native query parameters, including pagination and filters.
+Updates an issue to be confidential.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="description" type="string | null">
+
+The description of an issue. Limited to 1,048,576 characters.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="discussion_locked" type="boolean | null">
+
+Flag indicating if the issue's discussion is locked. If the discussion is locked only project members can add or edit comments.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="due_date" type="string | null">
+
+The due date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="epic_id" type="integer | null">
+
+ID of the epic to add the issue to. Valid values are greater than or equal to 0. Premium and Ultimate only.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="issue_type" type="string | null">
+
+Updates the type of issue. One of `issue`, `incident`, or `test_case`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="labels" type="string | null">
+
+Comma-separated label names for an issue. If a label does not already exist, this creates a new project label and assigns it to the issue.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="milestone" type="string | null">
+
+The title of a project or ancestor-group milestone to assign the issue to. Matched exactly (case-sensitive). Mutually exclusive with `milestone_id`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="milestone_id" type="integer | null">
+
+The global ID of a milestone to assign the issue to. Set to `0` to unassign a milestone. Mutually exclusive with `milestone`.
 
 Default: `null`.
 
@@ -1777,6 +3019,54 @@ Default: `null`.
 <ParamField path="payload" type="object | null">
 
 API-native request body passed through without validation.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="remove_labels" type="string | null">
+
+Comma-separated label names to remove from an issue.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="severity" type="string | null">
+
+The severity of the issue. Only applies to incidents. One of `unknown`, `low`, `medium`, `high`, or `critical`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="start_date" type="string | null">
+
+The start date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="state_event" type="string | null">
+
+The state event of an issue. To close the issue, use `close`, and to reopen it, use `reopen`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="title" type="string | null">
+
+The title of an issue.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="updated_at" type="string | null">
+
+When the issue was updated. Date time string, ISO 8601 formatted, for example `2016-03-11T03:45:40Z` (requires administrator or project owner rights).
 
 Default: `null`.
 
@@ -1804,26 +3094,16 @@ GitLab API path value for project_id.
 
 </ParamField>
 
+<ParamField path="secret_push_protection_enabled" type="boolean" required>
+
+Enables secret push protection for the project.
+
+</ParamField>
+
 <ParamField path="base_url" type="string">
 
 GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
 
 Default: `"https://gitlab.com/api/v4"`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including pagination and filters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
-
-Default: `null`.
 
 </ParamField>

--- a/docs/tools/gitlab.mdx
+++ b/docs/tools/gitlab.mdx
@@ -56,6 +56,12 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="actions" type="array[object]" required>
+
+An array of action hashes to commit as a batch. Each action hash takes `action` (one of `create`, `delete`, `move`, `update`, or `chmod`), `file_path`, and optionally `content`, `encoding`, `execute_filemode`, `last_commit_id`, and `previous_path`. Pass an empty array with allow_empty to create an empty commit.
+
+</ParamField>
+
 <ParamField path="branch" type="string" required>
 
 Name of the branch to commit into. To create a new branch, also provide either `start_branch` or `start_sha`, and optionally `start_project`.
@@ -71,14 +77,6 @@ Commit message.
 <ParamField path="project_id" type="string" required>
 
 GitLab API path value for project_id.
-
-</ParamField>
-
-<ParamField path="actions" type="array[object] | null">
-
-An array of action hashes to commit as a batch. Each action hash takes `action` (one of `create`, `delete`, `move`, `update`, or `chmod`), `file_path`, and optionally `content`, `encoding`, `execute_filemode`, `last_commit_id`, and `previous_path`.
-
-Default: `null`.
 
 </ParamField>
 
@@ -1866,7 +1864,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="scope" type="string | null">
+<ParamField path="scope" type="array[string] | null">
 
 Scope of jobs to show, as one of the job status values: `created`, `waiting_for_resource`, `preparing`, `waiting_for_callback`, `pending`, `running`, `success`, `failed`, `canceling`, `canceled`, `skipped`, `manual`, or `scheduled`. All jobs are returned if `scope` is not provided.
 

--- a/docs/tools/gitlab.mdx
+++ b/docs/tools/gitlab.mdx
@@ -1484,7 +1484,7 @@ GitLab API path value for project_id.
 
 </ParamField>
 
-<ParamField path="approved_by_ids" type="array[string] | null">
+<ParamField path="approved_by_ids" type="array[integer | string] | null">
 
 Returns merge requests approved by all the users with the given `id`, up to 5 users. `None` returns merge requests with no approvals. `Any` returns merge requests with an approval.
 
@@ -1500,7 +1500,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="approver_ids" type="array[string] | null">
+<ParamField path="approver_ids" type="array[integer | string] | null">
 
 Returns merge requests which have all users with the specified `id` as eligible approvers according to the approval rules. `None` returns merge requests with no eligible approvers. `Any` returns merge requests with at least one eligible approver. Premium and Ultimate only.
 
@@ -1508,7 +1508,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="assignee_id" type="string | null">
+<ParamField path="assignee_id" type="integer | string | null">
 
 Returns merge requests assigned to the given user `id`. `None` returns unassigned merge requests. `Any` returns merge requests with an assignee. Mutually exclusive with `assignee_username`.
 
@@ -1692,7 +1692,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="reviewer_id" type="string | null">
+<ParamField path="reviewer_id" type="integer | string | null">
 
 Returns merge requests which have the user as a reviewer with the given user `id`. `None` returns merge requests with no reviewers. `Any` returns merge requests with any reviewer. Mutually exclusive with `reviewer_username`.
 

--- a/docs/tools/rippling.mdx
+++ b/docs/tools/rippling.mdx
@@ -1056,15 +1056,15 @@ Required secrets:
 
 ### Input fields
 
-<ParamField path="group_id" type="string" required>
+<ParamField path="Operations" type="array[object]" required>
 
-Rippling API path value for group_id.
+The list of operations to apply. Each operation takes `op` (add or remove) and `value`, the members to add or remove, each carrying an `id` (a member id).
 
 </ParamField>
 
-<ParamField path="operations" type="array[object]" required>
+<ParamField path="group_id" type="string" required>
 
-The list of operations to apply. Each operation takes `op` (add or remove) and `value`, the members to add or remove, each carrying an `id` (a member id).
+Rippling API path value for group_id.
 
 </ParamField>
 
@@ -1092,15 +1092,15 @@ Required secrets:
 
 ### Input fields
 
-<ParamField path="group_id" type="string" required>
+<ParamField path="Operations" type="array[object]" required>
 
-Rippling API path value for group_id.
+The list of operations to apply. Each operation takes `op` (add or remove) and `value`, the members to add or remove, each carrying an `id` (a member id).
 
 </ParamField>
 
-<ParamField path="operations" type="array[object]" required>
+<ParamField path="group_id" type="string" required>
 
-The list of operations to apply. Each operation takes `op` (add or remove) and `value`, the members to add or remove, each carrying an `id` (a member id).
+Rippling API path value for group_id.
 
 </ParamField>
 

--- a/docs/tools/rippling.mdx
+++ b/docs/tools/rippling.mdx
@@ -20,25 +20,15 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="draft_hires" type="array[object]" required>
+
+List of draft hires. Each draft hire requires `personal_info`, `employment_info`, and `work_location_info`, and optionally accepts `custom_fields`, `headcount_info`, and `documents`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Rippling REST API.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
 
 Default: `null`.
 
@@ -68,17 +58,9 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: software_id (required), active_group_type, group_id, ma_device_group_id.
 
 Default: `null`.
 
@@ -114,14 +96,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get report run
 
 Action ID: `tools.rippling.get_report_run`
@@ -152,14 +126,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 ## Get SSO me
 
 Action ID: `tools.rippling.get_sso_me`
@@ -184,9 +150,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `company`.
 
 Default: `null`.
 
@@ -222,9 +196,9 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="expand" type="string | null">
 
-API-native query parameters.
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `user`, `manager`, `legal_entity`, `employment_type`, `compensation`, `department`, `teams`, `level`, `job_function`, `custom_fields`, `business_partners`.
 
 Default: `null`.
 
@@ -254,9 +228,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `worker`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+The `filter` query parameter is used to filter the data returned from the API - similar to a `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or, in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `spoke_user_identifier`, `app_handle`, `created_at`, `updated_at`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -286,9 +292,33 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `parent`, `department_hierarchy`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -318,9 +348,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `worker`, `pending_actions`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+The `filter` query parameter is used to filter the data returned from the API - similar to a `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or, in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `serial_number`, `lifecycle_state`, `enrollment_status`. Allowed values for `lifecycle_state`: INIT, ACTIVE, ACTIVATING, LOCKED, LOCKING, INACTIVE, PENDING_MDM, CLEANING, READY, DECOMMISSIONING, DECOMMISSIONED, FULL_WIPING, FULL_WIPED, E_CYCLED, MDM_LOCKED, LOST, LOST_PLAYING_SOUND. Allowed values for `enrollment_status`: ENROLLED, WAITING_FOR_CONNECTION, ERROR, UNENROLLED.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -350,14 +412,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
-
-Default: `null`.
-
-</ParamField>
-
 ## List leave balances
 
 Action ID: `tools.rippling.list_leave_balances`
@@ -382,9 +436,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `worker`, `leave_type`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+The `filter` query parameter is used to filter the data returned from the API - similar to a `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or, in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `leave_type_id`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -414,9 +500,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `worker`, `requester`, `leave_type`, `reviewer`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+The `filter` query parameter is used to filter the data returned from the API - similar to a `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or, in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `requester_id`, `reviewer_id`, `status`, `leave_policy_id`, `leave_type_id`, `start_date`, `end_date`. Allowed values for `status`: PENDING, APPROVED, REJECTED, CANCELED.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -446,9 +564,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `software`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+The `filter` query parameter is used to filter the data returned from the API - similar to a `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or, in. Example: status eq 'ACTIVE'. Filterable fields: `software_id`, `active_group_type`. Allowed values for `active_group_type`: Role, Device.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -484,9 +634,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="expand" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `worker`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -516,9 +674,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="filter" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+The `filter` query parameter is used to filter the data returned from the API - similar to a `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or, in. Example: status eq 'ACTIVE'. Filterable fields: `app_owner_id`, `group_type`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -548,9 +714,33 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `parent`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -580,9 +770,25 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -612,9 +818,25 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -644,9 +866,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `worker`, `changed_by`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+The `filter` query parameter is used to filter the data returned from the API - similar to a `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or, in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `applied_on`, `effective_on`, `changed_by_id`, `reason_code`, `field_key`, `event_type`. Allowed values for `event_type`: HIRE, CHANGE, SCHEDULED_CHANGE, OFFBOARD, SCHEDULED_OFFBOARD, IMPORT, UNDO, EFFECTIVE_DATE_AMENDMENT.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`, `applied_on`, `effective_on`.
 
 Default: `null`.
 
@@ -676,9 +930,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters, including cursor for pagination. Support for filter, expand, and order_by varies by endpoint; see the linked Rippling documentation.
+`cursor` is used to fetch the next page of results. Start with a request without cursor, read the `next_link` value from the response, and continue until `next_link` is `null`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="expand" type="string | null">
+
+Fields in a response can represent objects themselves. Instead of making an additional API call, you can expand field(s) in a response using the `expand` query parameter. Use commas to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API supports two levels of expansion and up to ten expanded fields per request. Expandable fields: `user`, `manager`, `legal_entity`, `employment_type`, `compensation`, `department`, `teams`, `level`, `job_function`, `custom_fields`, `business_partners`.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="filter" type="string | null">
+
+The `filter` query parameter is used to filter the data returned from the API - similar to a `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or, in. Example: status eq 'ACTIVE'. Filterable fields: `status`, `work_email`, `user_id`, `created_at`, `updated_at`. Allowed values for `status`: INIT, HIRED, ACCEPTED, ACTIVE, TERMINATED.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+`limit` controls how many results are returned in a single page. Default page size is 50. Most endpoints allow a maximum of 100.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="order_by" type="string | null">
+
+The `order_by` parameter is used to select field(s) to sort by and to define whether results are sorted in ascending or descending order. Supported sort directions are `asc` for ascending order and `desc` for descending order. Unless indicated, the default sort direction is ascending order. Use commas to specify multiple fields to sort. Sortable fields: `id`, `created_at`, `updated_at`.
 
 Default: `null`.
 
@@ -708,17 +994,9 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: report_id (required), filters, format_currency_fields, format_date_fields, include_object_ids, include_total_rows, output_type, view_as.
 
 Default: `null`.
 
@@ -754,17 +1032,9 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
 <ParamField path="payload" type="object | null">
 
-API-native request body passed through without validation.
+API-native request body. Documented fields: end_date (required), start_date (required), status (required), worker_id (required), comments, end_date_custom_hours, end_time, leave_event_id, leave_policy_id, leave_type_id, reason_for_leave, requester_id, reviewed_at, reviewer_id, start_date_custom_hours, start_time.
 
 Default: `null`.
 
@@ -792,25 +1062,15 @@ Rippling API path value for group_id.
 
 </ParamField>
 
+<ParamField path="operations" type="array[object]" required>
+
+The list of operations to apply. Each operation takes `op` (add or remove) and `value`, the members to add or remove, each carrying an `id` (a member id).
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Rippling REST API.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
 
 Default: `null`.
 
@@ -838,25 +1098,15 @@ Rippling API path value for group_id.
 
 </ParamField>
 
+<ParamField path="operations" type="array[object]" required>
+
+The list of operations to apply. Each operation takes `op` (add or remove) and `value`, the members to add or remove, each carrying an `id` (a member id).
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Rippling REST API.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="params" type="object | null">
-
-API-native query parameters.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="payload" type="object | null">
-
-API-native request body passed through without validation.
 
 Default: `null`.
 

--- a/docs/tools/socket.mdx
+++ b/docs/tools/socket.mdx
@@ -364,7 +364,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="labels" type="array[string] | null">
+<ParamField path="labels" type="string | null">
 
 Repository label slugs to apply policies. Only one label is supported currently; the parameter is an array to allow future support for multiple labels.
 

--- a/docs/tools/socket.mdx
+++ b/docs/tools/socket.mdx
@@ -70,7 +70,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="committers" type="string | null">
+<ParamField path="committers" type="array[string] | null">
 
 The committers to associate with the full-scan. Set query more than once to set multiple.
 
@@ -208,7 +208,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="committers" type="string | null">
+<ParamField path="committers" type="array[string] | null">
 
 The committers to associate with the full-scan. Set query more than once to set multiple.
 
@@ -316,7 +316,7 @@ Default: `"application/x-ndjson"`.
 
 </ParamField>
 
-<ParamField path="actions" type="array[string] | null">
+<ParamField path="actions" type="string | null">
 
 Include only alerts with comma separated actions defined by security policy. Supported values are error, monitor, warn and ignore.
 

--- a/docs/tools/sublime.mdx
+++ b/docs/tools/sublime.mdx
@@ -56,9 +56,9 @@ List ID.
 
 </ParamField>
 
-<ParamField path="payload" type="object" required>
+<ParamField path="string" type="string" required>
 
-API-native JSON request body.
+String list entry
 
 </ParamField>
 
@@ -112,7 +112,7 @@ Reference: [https://docs.sublime.security/reference/analysis-api-introduction](h
 
 <ParamField path="payload" type="object" required>
 
-API-native analyze request containing raw_message and optional rules or queries.
+API-native request body. Documented fields: raw_message (required), queries, rules, run_active_detection_rules, run_all_detection_rules, run_all_insights.
 
 </ParamField>
 
@@ -148,7 +148,7 @@ Sublime message ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: queries, rules, run_active_detection_rules, run_all_detection_rules, run_all_insights.
 
 </ParamField>
 
@@ -302,9 +302,21 @@ Required secrets:
 
 ### Input fields
 
-<ParamField path="payload" type="object" required>
+<ParamField path="end_time" type="string" required>
 
-API-native JSON request body.
+End of the email bomb time range (must not be in the future)
+
+</ParamField>
+
+<ParamField path="mailbox_id" type="string" required>
+
+ID of the mailbox to declare the email bomb for
+
+</ParamField>
+
+<ParamField path="start_time" type="string" required>
+
+Start of the email bomb time range
 
 </ParamField>
 
@@ -332,9 +344,15 @@ Required secrets:
 
 ### Input fields
 
-<ParamField path="payload" type="object" required>
+<ParamField path="description" type="string" required>
 
-API-native JSON request body.
+Description of list
+
+</ParamField>
+
+<ParamField path="name" type="string" required>
+
+Unique name used to reference the list in MQL
 
 </ParamField>
 
@@ -364,7 +382,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: raw_message (required), canonical_id, external_created_at, external_message_id, external_thread_id, folder, labels, mailbox_email_address, message_type, route_type.
 
 </ParamField>
 
@@ -394,7 +412,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: name (required), source (required), action_ids, active, attack_types, authors, auto_review_auto_share, auto_review_classification, description, detection_methods, false_positives, internal_type, label, maturity, references, run_triage_on_excluded_messages, severity, tactics_and_techniques, tags, triage_abuse_reports, triage_classification_changes, triage_dlp_rule_matched, triage_flagged_messages, type, user_provided_tags.
 
 </ParamField>
 
@@ -488,17 +506,15 @@ List ID.
 
 </ParamField>
 
-<ParamField path="base_url" type="string | null">
+<ParamField path="string" type="string" required>
 
-Base URL of the Sublime API.
-
-Default: `null`.
+String list entry
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="base_url" type="string | null">
 
-API-native query parameters.
+Base URL of the Sublime API.
 
 Default: `null`.
 
@@ -558,7 +574,7 @@ Email bomb ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: review_comment.
 
 </ParamField>
 
@@ -594,7 +610,7 @@ Message group canonical ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: classification, report_label, review_comment.
 
 </ParamField>
 
@@ -624,7 +640,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
 
 </ParamField>
 
@@ -756,9 +772,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="limit" type="integer | null">
 
-API-native query parameters.
+The maximum number of results to return.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="offset" type="integer | null">
+
+The (zero-based) offset of the first hunt job results to return.
 
 Default: `null`.
 
@@ -846,17 +870,15 @@ List ID.
 
 </ParamField>
 
-<ParamField path="base_url" type="string | null">
+<ParamField path="string" type="string" required>
 
-Base URL of the Sublime API.
-
-Default: `null`.
+String list entry
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="base_url" type="string | null">
 
-API-native query parameters.
+Base URL of the Sublime API.
 
 Default: `null`.
 
@@ -878,6 +900,12 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="entry_type" type="string" required>
+
+List type to filter by. One of 'string', 'user_group', 'provider_org_unit'.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Sublime API.
@@ -886,9 +914,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="id" type="string | null">
 
-API-native query parameters.
+Optional ID (exact match) to filter by
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="name" type="string | null">
+
+Optional name (exact match) to filter by
 
 Default: `null`.
 
@@ -924,9 +960,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="recompute_mdm_from_raw" type="boolean | null">
 
-API-native query parameters.
+When true, recompute the MDM from the raw EML. For internal use only!
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="remove_large_text_fields" type="boolean | null">
+
+When true, any text field over 1MB will be cleared before returning
 
 Default: `null`.
 
@@ -998,9 +1042,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="recompute_mdm_from_raw" type="boolean | null">
 
-API-native query parameters.
+When true, recompute the MDM from the raw EML. For internal use only!
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="remove_large_text_fields" type="boolean | null">
+
+When true, any text field over 1MB will be cleared before returning
 
 Default: `null`.
 
@@ -1066,9 +1118,9 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="sort_previews_message_id__is" type="array[string] | null">
 
-API-native query parameters.
+Sort previews with these message IDs at the top
 
 Default: `null`.
 
@@ -1104,9 +1156,25 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="created_at__gte" type="string | null">
 
-API-native query parameters.
+Only return action states created after this time
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+The maximum number of action states to return. If the value exceeds the maximum, then the maximum value will be used.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="offset" type="integer | null">
+
+The (zero-based) offset of the action states to return
 
 Default: `null`.
 
@@ -1136,9 +1204,41 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="cursor" type="string | null">
 
-API-native query parameters.
+Opaque pagination cursor returned in the previous response's cursor field.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+The maximum number of message groups to return.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="timestamp__gte" type="string | null">
+
+Inclusive lower bound on the sort timestamp (newest_created_at for type=flagged, first_reported_as_phish_at for type=reported).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="timestamp__lt" type="string | null">
+
+Exclusive upper bound on the sort timestamp (newest_created_at for type=flagged, first_reported_as_phish_at for type=reported).
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="type" type="string | null">
+
+Which timestamp the endpoint sorts/filters on: 'flagged' uses newest_created_at, 'reported' uses first_reported_as_phish_at. Possible values: flagged, reported.
 
 Default: `null`.
 
@@ -1174,9 +1274,17 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="recompute_mdm_from_raw" type="boolean | null">
 
-API-native query parameters.
+When true, recompute the MDM from the raw EML. For internal use only!
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="remove_large_text_fields" type="boolean | null">
+
+When true, any text field over 1MB will be cleared before returning
 
 Default: `null`.
 
@@ -1212,9 +1320,33 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="link_duration_seconds" type="integer | null">
 
-API-native query parameters.
+Period link should be valid for. Default is 15 minutes, max 7 days.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="platform_link" type="boolean | null">
+
+When true, link will always be presigned against Sublime. When false, the link may be to S3 directly.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="recompute_mdm_from_raw" type="boolean | null">
+
+When true, recompute the MDM from the raw EML. For internal use only!
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="remove_large_text_fields" type="boolean | null">
+
+When true, any text field over 1MB will be cleared before returning
 
 Default: `null`.
 
@@ -1280,9 +1412,25 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="classification_created_at_gte" type="string | null">
 
-API-native query parameters.
+Filter by classifications made after this datetime. Results are limited to the most recent 180 days.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="classification_created_at_lte" type="string | null">
+
+Filter by classifications made before this datetime. Results are limited to the most recent 180 days.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="use_rule_last_updated_as_created_at" type="boolean | null">
+
+Filter by classifications made since the rule has been updated. Results are limited to the most recent 180 days.
 
 Default: `null`.
 
@@ -1336,7 +1484,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
 
 </ParamField>
 
@@ -1364,6 +1512,14 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="active" type="boolean | null">
+
+Filter by active status. true = only active, false = only inactive, null = all
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Sublime API.
@@ -1372,9 +1528,25 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="dismissed" type="boolean | null">
 
-API-native query parameters.
+Filter by dismissed status. true = only dismissed, false = only not dismissed, null = all
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+The maximum number of email bombs to return
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="offset" type="integer | null">
+
+The (zero-based) offset of the email bombs to return
 
 Default: `null`.
 
@@ -1396,6 +1568,14 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="active" type="boolean | null">
+
+Filter for effectively active mailboxes (marked active with a live subscription)
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Sublime API.
@@ -1404,9 +1584,65 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="email_addresses" type="string | null">
 
-API-native query parameters.
+Email addresses of the mailboxes to return (comma-delimited)
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+The maximum number of entries to return. If the value exceeds the maximum, then the maximum value will be used
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="mailbox_types" type="string | null">
+
+Comma-delimited list of mailbox types to filter by
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="marked_active" type="boolean | null">
+
+Filter for mailboxes marked active
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="message_source_id" type="string | null">
+
+ID of the message source the mailboxes belong to
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="offset" type="integer | null">
+
+The (zero-based) offset of the first mailbox to return
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search" type="string | null">
+
+Search across mailbox names and email addresses
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sub_error_types" type="string | null">
+
+Comma-delimited list of subscription error types to filter by
 
 Default: `null`.
 
@@ -1428,6 +1664,38 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="attachment_name__is" type="array[string] | null">
+
+Filters result to only message groups with the provided attachment name
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="attachment_sha256__is" type="array[string] | null">
+
+Filters result to only message groups with the provided attachment SHA256
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="attack_score_verdict__is" type="array[string] | null">
+
+Filters result to only message groups with the provided attack score verdict. Possible values: unknown, likely_benign, suspicious, malicious, graymail, spam.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="attack_surface_reduction__filter" type="boolean | null">
+
+Filters result to only message groups that have flagged (ONLY) rules with the 'Attack surface reduction' tag
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Sublime API.
@@ -1436,9 +1704,193 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="canonical_id__is" type="array[string] | null">
 
-API-native query parameters.
+Filters result to only message groups with the provided canonical ID
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created_at__gte" type="string | null">
+
+Inclusive start datetime filter, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only message groups that contain a message processed at or after this time will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created_at__lt" type="string | null">
+
+Exclusive end datetime filter, in UTC using the ISO 8601 format (e.g., '2021-05-04T15:09:26Z'). Only message groups that contain a message processed before this time will be returned. Paired with created_at__gte this selects groups that were active at any point in the window, including groups that are still receiving messages after it. Note that this bounds a group's oldest message while created_at__gte bounds its newest, so the two cannot be served by a single index and the request may time out on high volume organizations or wide date ranges. If you only need groups whose newest message falls inside the window, prefer last_created_at__lt, which bounds the same field as created_at__gte.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="first_message_reported_at__gte" type="string | null">
+
+Filters result to only message groups with a message first reported at or after the provided time. Datetime must be in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z').
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="flagged" type="boolean | null">
+
+Filters result to only message groups with at least one flagged message
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="flagged_rule_id__is" type="array[string] | null">
+
+Filters result to only message groups with the provided flagged rule ID
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="flagged_rule_severity__is" type="array[string] | null">
+
+Filters result to only message groups with the provided flagged rule severity. Possible values: informational, low, medium, high, critical.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="historically_flagged_rule_id__is" type="array[string] | null">
+
+Filters result to only message groups with the provided historically flagged rule ID
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="historically_flagged_rule_severity__is" type="array[string] | null">
+
+Filters result to only message groups with the provided historically flagged rule severity. Possible values: informational, low, medium, high, critical.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="last_created_at__gte" type="string | null">
+
+Inclusive start datetime filter, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only message groups whose newest message was processed at or after this time will be returned. Equivalent to created_at__gte.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="last_created_at__lt" type="string | null">
+
+Exclusive end datetime filter, in UTC using the ISO 8601 format (e.g., '2021-05-04T15:09:26Z'). Only message groups whose newest message was processed before this time will be returned. Unlike created_at__lt, groups that are still receiving messages after this time are excluded. Prefer this over created_at__lt for historical lookbacks, since it bounds the same field as created_at__gte and both can then be served by a single index. High volume organizations may still need to request narrow time windows to avoid a timeout.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+The maximum number of message groups to return. If the value exceeds the maximum, then the maximum value will be used.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="mailbox_email__is" type="array[string] | null">
+
+Filters result to only message groups with the provided mailbox email
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="offset" type="integer | null">
+
+The (zero-based) offset of the message groups to return
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="recipient_email__is" type="array[string] | null">
+
+Filters result to only message groups with the provided recipient email
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="reported_as_phish_by__is" type="array[string] | null">
+
+Filters result to only message groups with the provided reporter
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="reviewed" type="boolean | null">
+
+Filters result to only message groups which have or have not been reviewed
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sender_display_name__is" type="array[string] | null">
+
+Filters result to only message groups with the provided sender display name
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sender_domain__is" type="array[string] | null">
+
+Filters result to only message groups with the provided sender domain
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sender_email__is" type="array[string] | null">
+
+Filters result to only message groups with the provided sender email
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="spam__is" type="array[string] | null">
+
+Filters result to only message groups with the provided spam status. Possible values: spam, not_spam, mixed.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="subject__is" type="array[string] | null">
+
+Filters result to only message groups with the provided subject
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="user_reported" type="boolean | null">
+
+Filters result to only message groups with at least one reported message
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="vendor_id__is" type="array[string] | null">
+
+Filters result to only message groups with the provided vendor
 
 Default: `null`.
 
@@ -1460,6 +1912,26 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="classification_created_at_gte" type="string" required>
+
+Filter by classifications made after this datetime. Results are limited to the most recent 180 days.
+
+</ParamField>
+
+<ParamField path="classification_created_at_lte" type="string" required>
+
+Filter by classifications made before this datetime. Results are limited to the most recent 180 days.
+
+</ParamField>
+
+<ParamField path="active" type="boolean | null">
+
+Restrict to rules that are active
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Sublime API.
@@ -1468,9 +1940,33 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="count" type="integer | null">
 
-API-native query parameters.
+Number of results to return
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="in_feed" type="boolean | null">
+
+Restrict to rules that are in a feed
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="offset" type="integer | null">
+
+Offset from the first result
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="type" type="array[string] | null">
+
+Restrict to rules that have one of the given types. One of 'detection', 'triage', 'dlp'.
 
 Default: `null`.
 
@@ -1500,9 +1996,33 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="in_feed" type="boolean | null">
 
-API-native query parameters.
+Restrict to rules that are explicitly in or not in a feed
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+The maximum number of entries to return. Maximum value is 500.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="offset" type="integer | null">
+
+The (zero-based) offset of the first rule to return
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="search" type="string | null">
+
+Search for matching case-insensitive substring across rule name, description, and MQL source
 
 Default: `null`.
 
@@ -1532,9 +2052,25 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="limit" type="integer | null">
 
-API-native query parameters.
+The maximum number of message groups to return. If the value exceeds the maximum, then the maximum value will be used.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="reported_at_gte" type="string | null">
+
+Inclusive start datetime filter for time of report, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only reports at or after this time will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="reported_at_lt" type="string | null">
+
+Exclusive end datetime filter for time of report, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only reports before this time will be returned.
 
 Default: `null`.
 
@@ -1556,15 +2092,15 @@ Required secrets:
 
 ### Input fields
 
-<ParamField path="id" type="string" required>
+<ParamField path="description" type="string" required>
 
-List ID.
+Description of list
 
 </ParamField>
 
-<ParamField path="payload" type="object" required>
+<ParamField path="id" type="string" required>
 
-API-native JSON request body.
+List ID.
 
 </ParamField>
 
@@ -1600,7 +2136,7 @@ Sublime message ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: action, custom_action_ids, share_with_sublime.
 
 </ParamField>
 
@@ -1636,7 +2172,7 @@ Message group canonical ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: classification, report_label, review_comment.
 
 </ParamField>
 
@@ -1666,7 +2202,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
 
 </ParamField>
 
@@ -1696,7 +2232,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: raw (required), file_type.
 
 </ParamField>
 
@@ -1762,7 +2298,7 @@ Message group canonical ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: classification, report_label, review_comment.
 
 </ParamField>
 
@@ -1792,7 +2328,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
 
 </ParamField>
 
@@ -1882,7 +2418,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: classification (required), message_group_ids (required), action, custom_action_ids, generate_asa_lesson, review_comment, share_with_sublime.
 
 </ParamField>
 
@@ -1946,6 +2482,38 @@ Required secrets:
 
 ### Input fields
 
+<ParamField path="any" type="string | null">
+
+Searches every field (performs a case insensitive, OR search in all fields). Not compatible with other search fields.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="attachment_md5" type="string | null">
+
+Search for messages containing an attachment MD5 match
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="attachment_sha1" type="string | null">
+
+Search for messages containing an attachment SHA1 match
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="attachment_sha256" type="string | null">
+
+Search for messages containing an attachment SHA256 match
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="base_url" type="string | null">
 
 Base URL of the Sublime API.
@@ -1954,9 +2522,113 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="params" type="object | null">
+<ParamField path="created_at_gte" type="string | null">
 
-API-native query parameters.
+Inclusive start datetime filter for search, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only message groups with a message processed at or after this time will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="created_at_lt" type="string | null">
+
+Exclusive end datetime filter for search, in UTC using the ISO 8601 format (e.g., '2021-05-04T15:09:26Z'). Only message groups with a message processed before this time will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="file_name" type="string | null">
+
+Search in attachment filenames (case insensitive wildcard match)
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="first_reported_as_phish_at_gte" type="string | null">
+
+Inclusive start datetime filter for search, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only message groups reported at or after this time will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="first_reported_as_phish_at_lt" type="string | null">
+
+Exclusive end datetime filter for search, in UTC using the ISO 8601 format (e.g., '2021-05-04T15:09:26Z'). Only message groups reported before this time will be returned.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="limit" type="integer | null">
+
+The maximum number of message groups to return. If the value exceeds the maximum, then the maximum value will be used.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="mailbox" type="string | null">
+
+Search for a mailbox by email address (case insensitive, wildcard match)
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="message_id" type="string | null">
+
+Search in the Message-ID header (case insensitive exact match; wildcards are not supported)
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="offset" type="integer | null">
+
+The (zero-based) offset of the message groups to return
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="sender" type="string | null">
+
+Search in the From field (case insensitive wildcard match)
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="states" type="array[string] | null">
+
+Search for messages in any of the given states
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="subject" type="string | null">
+
+Search in the message subject (case insensitive wildcard match)
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="to" type="string | null">
+
+Search in the To, CC, and Bcc fields (case insensitive wildcard match). If possible, use 'mailbox' and 'type' instead for better performance
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="type" type="array[string] | null">
+
+Search for messages by type. Multiple values are OR'd together.
 
 Default: `null`.
 
@@ -1978,15 +2650,15 @@ Required secrets:
 
 ### Input fields
 
-<ParamField path="id" type="string" required>
+<ParamField path="entries" type="array[string]" required>
 
-List ID.
+List entries
 
 </ParamField>
 
-<ParamField path="payload" type="object" required>
+<ParamField path="id" type="string" required>
 
-API-native JSON request body.
+List ID.
 
 </ParamField>
 
@@ -2022,7 +2694,7 @@ Sublime message ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: justification.
 
 </ParamField>
 
@@ -2058,7 +2730,7 @@ Message group canonical ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: destination, report_label, review_comment.
 
 </ParamField>
 
@@ -2088,7 +2760,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: range_end_time (required), range_start_time (required), source (required), name, private, triage_email_bomb, triage_flagged, triage_reported.
 
 </ParamField>
 
@@ -2154,7 +2826,7 @@ Message group canonical ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: classification, report_label, review_comment.
 
 </ParamField>
 
@@ -2184,7 +2856,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
 
 </ParamField>
 
@@ -2220,7 +2892,7 @@ Sublime rule ID.
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: name (required), source (required), action_ids, attack_types, authors, auto_review_auto_share, auto_review_classification, description, detection_methods, false_positives, internal_type, label, maturity, references, run_triage_on_excluded_messages, severity, tactics_and_techniques, tags, triage_abuse_reports, triage_classification_changes, triage_dlp_rule_matched, triage_flagged_messages, user_provided_tags.
 
 </ParamField>
 
@@ -2250,7 +2922,7 @@ Required secrets:
 
 <ParamField path="payload" type="object" required>
 
-API-native JSON request body.
+API-native request body. Documented fields: name (required), source (required), action_ids, active, attack_types, authors, auto_review_auto_share, auto_review_classification, description, detection_methods, false_positives, internal_type, label, maturity, references, run_triage_on_excluded_messages, severity, tactics_and_techniques, tags, triage_abuse_reports, triage_classification_changes, triage_dlp_rule_matched, triage_flagged_messages, type, user_provided_tags.
 
 </ParamField>
 

--- a/packages/tracecat-registry/AGENTS.md
+++ b/packages/tracecat-registry/AGENTS.md
@@ -48,9 +48,21 @@ do not break their public inputs or outputs without an explicitly planned migrat
 
 ### Thin-wrapper contract
 
+These rules govern **new and materially expanded** integrations, and the registry
+predates them. Where a rule governs a **published contract** — an action's `returns`,
+its declared inputs, or how it takes credentials — existing templates keep theirs:
+521 of 880 return `.result.data`, 238 declare `base_url` differently, and `jira`,
+`confluence` and `opensearch` authenticate over Basic. Conform new work; migrate
+existing work only on explicit request, never as a drive-by. Every other rule here
+is unconditional — those describe internal implementation, not contracts, so fixing
+a violation breaks nothing and no exemption should be inferred.
+
+#### Naming the parameters
+
 - Keep one action close to one provider endpoint or SDK method. Declare that endpoint's
   documented parameters as named action inputs, using the vendor's exact parameter names
   and the vendor's own wording for each description.
+  Example: `tools/hunter/search/domain_search.yml`.
 - Never expose a single generic `params`, `payload`, `body`, or `query_params` dictionary
   as a stand-in for an endpoint's parameters. An action's `expects` schema is handed
   directly to agents as their tool schema and rendered as the docs page, so an opaque
@@ -64,28 +76,34 @@ do not break their public inputs or outputs without an explicitly planned migrat
   sorting, time ranges, output modifiers. You need not enumerate every documented
   parameter, but every parameter you do declare must be verbatim from the vendor's
   documentation.
-- A free-form `dict[str, Any]` input is correct only where the vendor itself documents a
-  free-form object: a JSON document body, a custom-fields map, a provider query DSL. It is
-  never a substitute for named parameters. Most request bodies are not free-form — check
-  the vendor's schema before assuming, because a flat documented field set is the common
-  case and an opaque dict hides it.
-- When you do keep a free-form `dict[str, Any]`, justify it with an inline YAML comment on
-  the input saying which vendor construct makes it free-form. Without that note the next
-  author cannot tell a deliberate exception from an unfinished one, and will copy it.
-- **A request body whose optional fields cannot be sent as `null` is the one non-free-form
-  case where a generic `payload` is still correct.** `core.http_request` prunes null
-  `params` and `headers`, but not `payload`, because a JSON `null` in a body is often
-  meaningful — GitHub documents `null` as "disable this protection" on branch protection.
-  A literal `payload:` map therefore has no way to omit an unset optional: it emits
-  `"comment": null`. Vendors that validate strictly reject that outright — GitHub answers
-  `422 ... nil is not a boolean`, and Kibana's endpoint actions use zod `.optional()`,
-  which fails on an explicit null.
-- So before enumerating a body, check what the vendor does with a null optional. If it
-  rejects them, keep `payload: dict[str, Any]` and **put the vendor's documented field list
-  in the `description`** so the surface is still discoverable, plus an inline comment naming
-  the reason. Enumerate a body only when every field is required, or the vendor accepts
-  nulls on the optional ones — and say which, so the next author does not have to re-derive
-  it.
+- Optional inputs are `<type> | None` with `default: null`, referenced directly from the
+  literal `params:` or `headers:` map. See "Unset optional parameters" for what the
+  platform does with them.
+- Do not use `FN.merge` to assemble `params`, `payload`, or `headers`. Write one literal
+  map. Merging makes precedence depend on argument order, and where a secret sits inside a
+  merged map it lets a caller-supplied dict replace a declared credential.
+
+#### Choosing the input shape
+
+Named inputs are the default. A generic dictionary is correct only in these cases, and
+each one must carry an inline YAML comment saying which applies — without it the next
+author cannot tell a deliberate exception from an unfinished one, and will copy it.
+
+| Situation | Shape | Why | Example |
+|---|---|---|---|
+| The endpoint documents a parameter set | named inputs | the default | `tools/hunter/search/domain_search.yml` |
+| The vendor documents a free-form object | `dict[str, Any]` | query DSL, custom-field map, user-supplied document | `tools/gitlab/security/create_project_vulnerability_export_and_wait.yml` (`report_data`) |
+| The vendor rejects `null` on optional body fields | `payload: dict[str, Any]` | a literal map cannot omit a field | `tools/elastic_security/endpoint_response/isolate_endpoint.yml` |
+| The vendor's body is a discriminated union | `payload: dict[str, Any]` | there is no single field set to name | `tools/elastic_security/detections/create_detection_rule.yml` |
+| `base_url` resolves to a customer-run cluster | `params: dict[str, Any]` | the API version is unknowable | `tools/opensearch/search_events.yml` |
+| A generic SDK dispatch UDF | `params: dict[str, Any]` | the method is a runtime value | `integrations/slack_sdk.py` |
+
+Most request bodies are **not** free-form — check the vendor's schema first, because a flat
+documented field set is the common case. Before enumerating a body, check what the vendor does with a
+null optional: `payload` is not null-pruned (see "Unset optional parameters"), so a literal map emits
+`"comment": null`, which strict validators reject — GitHub answers `422 ... nil is not a boolean`,
+Kibana's endpoint actions use zod `.optional()`. Where that is so, keep the dict and put the vendor's
+documented field list in the `description` so the surface stays discoverable.
 
 ```yaml
     payload:
@@ -97,44 +115,102 @@ do not break their public inputs or outputs without an explicitly planned migrat
         endpoint_ids (required), alert_ids, case_ids, comment, agent_type.
 ```
 
-```yaml
-    payload:
-      # Free-form: OpenSearch query DSL. The body is the query language itself,
-      # and its shape varies with the cluster's version.
-      type: dict[str, Any]
-      description: API-native OpenSearch search request body.
-```
-- Optional inputs are `<type> | None` with `default: null`, referenced directly from the
-  literal `params:` or `headers:` map. `core.http_request` prunes null params and null
-  headers, so an unset optional is omitted rather than sent as an empty value or rejected.
-  Do not add a `core.script.run_python` step to strip nulls; the platform does it.
-- Do not use `FN.merge` to assemble `params`, `payload`, or `headers`. Write one literal
-  map. Merging makes precedence depend on argument order, and where a secret sits inside a
-  merged map it lets a caller-supplied dict replace a declared credential.
-- Put credentials where the vendor documents them, preferring a header when the vendor
-  offers one. Put an API key in the query string only when that is the sole documented
-  mechanism, and then place it directly in the literal `params:` map — not in the URL,
-  because httpx replaces an existing query string when `params` is also passed.
-- `core.http_request` types `headers` as `dict[str, str | None]`. String-valued
-  expressions and nulls are allowed; a `bool` or `int` input fails validation before the
-  request is made. Serialize booleans to the vendor's documented string values.
-- Do not add provider enums, duplicated argument validation, defensive state
-  machines, or exception translation. Let HTTP status codes or native SDK exceptions
-  remain authoritative.
+The self-hosted case is about version control, not parameter count — several of those endpoints
+document only five query parameters, while enumerated providers here declare 27 and 28 on a single
+action. The test is whether the template pins the API version: `elastic_security` targets Kibana at a
+pinned `/v8/`, so its parameters are named — do not group it with `elasticsearch` on the strength of
+the name. A cluster's *body* is separate: a search body is a query DSL and stays `dict[str, Any]`
+regardless. Templates over an SDK dispatch wrapper follow the normal rules — see
+`tools/slack/conversations/archive_channel.yml`, which declares `channel` and passes
+`params: {channel: ${{ inputs.channel }}}`. A generic dict at the *template* layer is still wrong,
+SDK-backed or not.
+
+#### Input names, wire keys, and types
+
+- Where the vendor's parameter name is not a valid Python identifier, the input takes a safe name
+  and the wire key keeps the vendor's exact string: `tweet_fields` → `"tweet.fields"`
+  (`tools/x/posts/get_tweet.yml`), `epss_gt` → `epss-gt`
+  (`tools/first_epss/scores/search_scores.yml`), `iids` → `"iids[]"`
+  (`tools/gitlab/merge_requests/list_merge_requests.yml`).
+- **Do not rename when the vendor's name already works.** Python keywords are fine as input names —
+  `inputs.in`, `inputs.from` and `inputs.not` all parse and resolve — and so is unusual casing, as
+  with Rippling's `Operations`. An alias you did not need is an invented parameter.
+- Array query parameters depend on the vendor's serialization, and getting it wrong is silent.
+  httpx emits a list as repeated pairs (`a=1&a=2`), which is OpenAPI `explode: true` and the right
+  form for most backends. Two exceptions: `explode: false` means one comma-separated value, so type
+  the input `str` (`tools/socket/packages/fetch_packages_by_purl.yml`, `actions` and `labels`); and
+  Rack-backed GitLab collapses repeated bare keys to the last value, so it uses `[]` suffixes and
+  comma-separated coercers. Check the spec's `style`/`explode`, not just the documented type.
+- The type grammar supports more than the primitives: `list[int]`, `list[str]`,
+  `list[dict[str, Any]]`, `dict[str, Any]`, `datetime`, and unions with `None`. Reach for the
+  precise type rather than widening to `str` or dropping a field as inexpressible.
+- Do not add provider enums. Put the vendor's allowed values in the `description` instead; enums
+  change upstream and the API stays authoritative.
+- State the provider's documented maximum in the `description` of the relevant
+  input when one exists, since callers cannot discover it from the schema and
+  exceeding it is usually an error rather than a clamp.
+
+#### Credentials
+
+- Put credentials where the vendor documents them. **When a vendor offers several mechanisms,
+  implement exactly one: the header token.** Do not also wire up the query parameter or Basic.
+  Hunter documents an `api_key` query parameter, an `X-API-KEY` header and a Bearer header —
+  the template sends `X-API-KEY` only. Socket documents Bearer and Basic — the template sends
+  Bearer only.
+- Put an API key in the query string only when that is the sole documented mechanism, and then
+  place it directly in the literal `params:` map — not in the URL, because httpx replaces an
+  existing query string when `params` is also passed. Example: `tools/shodan/hosts/lookup_host.yml`.
+- Use Basic when Basic *is* the vendor's mechanism — Atlassian's API tokens are email + token over
+  Basic, so `jira` and `confluence` are correct. `core.http_request`'s `auth:` argument and an
+  explicit `Authorization: Basic ${{ FN.to_base64(...) }}` header are equally fine.
+  **Shipped providers that authenticate over Basic keep it**: `jira`, `confluence` and `opensearch`
+  do, the vendors still accept it, and a workspace's stored secret is a published contract. Add a
+  header-token path alongside if one exists, but never replace. Existing templates only — this does
+  not license Basic in new work.
+- Where a vendor supports both OAuth and an API key, support both. `jamf/computers/*` and
+  `google_scc/*` declare an `oauth` secret and a key secret together.
+- Declare credentials through `RegistrySecret` or OAuth rather than ordinary action
+  inputs. Document required scopes, API versions, and product-tier constraints.
+- `core.http_request` types `headers` as `dict[str, str | None]`. String-valued expressions and
+  nulls are allowed; a `bool` or `int` input fails validation before the request is made. Serialize
+  booleans to the vendor's documented string values.
+
+#### Inputs, outputs, and transforms
+
+- **New actions return the untouched full `core.http_request` result**, including `status_code`,
+  `headers`, and `data`. The envelope is not decoration: pagination cursors and `Link` headers live
+  in `headers`, and an action returning only `.data` cannot be paged by the workflow author. Do not
+  select, rename, filter, or reshape provider output. SDK wrappers may only adapt values enough to
+  make the native result serializable. Example: `tools/shodan/hosts/lookup_host.yml`.
+  **Do not change a shipped action's `returns`** — 521 of 880 templates return `.result.data`, and
+  that is a published output contract.
+- **New actions declare REST `base_url` as `str | None` with a `null` default**, resolved
+  `inputs.base_url || VARS.<tool_name>.base_url || <official public URL>`. Omit only the final
+  fallback when the provider has no universal public endpoint. Existing templates that declare it
+  differently keep their contract.
+- Most actions need no transform at all — 75% of templates pass the request straight through, and
+  that is the target. Do not reshape provider input or output to make an action feel tidier.
+- When a transform is genuinely required, use a `core.script.run_python` step. Prefer it over a
+  chain of inline `FN.*` expressions and `core.transform.reshape`: a named function with real
+  control flow is easier to read and review than an expression pipeline, and it keeps the logic in
+  one place. Example: `tools/elastic_security/endpoint_response/isolate_endpoint.yml` builds the
+  Kibana space prefix in a `build_path` step.
+- Choosing Python is about *how* to write a necessary transform, not permission to add unnecessary
+  ones. Keep narrow actions narrow: a status-transition action should only transition. Do not add
+  duplicated argument validation, defensive state machines, or exception translation — send the
+  request and let the provider return the authoritative error.
 - Narrow boundary handling is allowed for credential isolation and security,
   blocking private SDK dispatch, URL and path encoding, JSON serialization,
   binary or streaming values, protocol-required checks, and bounded pagination.
   Small input parsing or normalization is allowed only when it makes the outbound
   API call more robust; it must not become a semantic data transform.
-- Declare credentials through `RegistrySecret` or OAuth rather than ordinary action
-  inputs. Document required scopes, API versions, and product-tier constraints.
-- Encode every dynamic URL path segment with `FN.url_encode`.
-- Declare REST `base_url` as `str | None` with a `null` default. Resolve it in this
-  order: `inputs.base_url || VARS.<tool_name>.base_url || <official public URL>`.
-  Omit only the final fallback when the provider has no universal public endpoint.
-- Return the untouched full `core.http_request` result, including `status_code`,
-  `headers`, and `data`. Do not select, rename, filter, or reshape provider output.
-  SDK wrappers may only adapt values enough to make the native result serializable.
+- If JSON-string parsing is intentionally supported for a field, keep it local and minimal. Do not
+  add broad recursive parsing or magic conversions across generic payload maps.
+- For field-map inputs, support rich objects by allowing them as values inside the existing field
+  maps rather than changing the outer input shape.
+
+#### Pagination and polling
+
 - Do not paginate inside an HTTP template. One action is one request. Expose the
   provider's own paging inputs — `page`, `page-size`, `limit`, `offset`, `cursor`,
   or whatever it calls them — return the single page the provider returned, and
@@ -143,9 +219,6 @@ do not break their public inputs or outputs without an explicitly planned migrat
   template, and do not hide a fetch-all behind a `max_pages` argument.
   Auto-pagination hides cost and rate-limit pressure from the person running the
   workflow, and it hard-codes a stop condition that belongs to them.
-- State the provider's documented maximum in the `description` of the relevant
-  input when one exists, since callers cannot discover it from the schema and
-  exceeding it is usually an error rather than a clamp.
 - The SDK wrappers are the exception, not the precedent. Where a maintained SDK
   paginates natively — the Slack and boto3 wrappers — preserve provider order,
   document whether the result is a page list or a flattened item list, and
@@ -155,42 +228,6 @@ do not break their public inputs or outputs without an explicitly planned migrat
   success values. Return the raw terminal response, including provider-declared
   failure states.
 
-#### Generic SDK dispatch wrappers
-
-- The rules above govern action templates — the layer users and agents call. They do not
-  govern a generic SDK dispatch UDF such as `tools.slack_sdk.call_method`, or the
-  equivalent boto3, Google API, Cloudflare, Kubernetes and Okta wrappers. Those take an
-  SDK method name plus a `params: dict[str, Any] | None` of that method's arguments, and
-  being generic is their contract: the method is a runtime value, so there is no fixed
-  parameter set to name.
-- YAML templates layered over an SDK wrapper still follow the normal rules: declare the
-  method's real named arguments as inputs and pass a literal `params:` map. See
-  `templates/tools/slack/conversations/archive_channel.yml`, which declares `channel` and
-  passes `sdk_method: conversations_archive` with `params: {channel: ${{ inputs.channel }}}`.
-  A generic dict at the template layer is still wrong, SDK-backed or not.
-- Null-pruning is a `core.http_request` behaviour and does not reach SDK-backed templates.
-  SDK wrappers follow the SDK's own semantics — `slack_sdk.call_method` forwards `params`
-  as kwargs untouched, while `okta_sdk` prunes explicitly via its own `_drop_none`. When
-  adding an SDK wrapper, state which it does.
-
-#### Self-hosted APIs on a customer-controlled version
-
-- A generic `params: dict[str, Any] | None` is the correct shape when `base_url` resolves to
-  infrastructure the customer runs and whose version we cannot know. Elasticsearch and OpenSearch are
-  the cases in this registry: neither pins an API version, clusters in the field span Elasticsearch
-  7/8/9, and OpenSearch has been a hard fork with diverging parameters since 2021. A named parameter
-  set baked into the template would be wrong for some fraction of clusters with no way to detect it.
-- This is about version control, not parameter count. Endpoint size is not the test: several of those
-  endpoints document only five query parameters, while enumerated providers elsewhere in this registry
-  declare 27 and 28 on a single action.
-- The test is whether the template pins the API version. `elastic_security` targets Kibana at a
-  pinned `/v8/` with `kbn-xsrf`, so its surface is fixed and its parameters are named — do not group
-  it with `elasticsearch` on the strength of the name. `github` (`X-GitHub-Api-Version`), `gitlab`
-  (`/api/v4`) and `sublime` (`/v0/`) are likewise versioned and enumerated.
-- The request body is a separate question. An Elasticsearch or OpenSearch search body is a query DSL
-  and stays `dict[str, Any]` under the free-form rule above, regardless of how the query parameters
-  are modelled.
-
 #### Unset optional parameters
 
 - `core.http_request`, `core.http_poll` and `core.http_paginate` drop `None` values from
@@ -199,12 +236,16 @@ do not break their public inputs or outputs without an explicitly planned migrat
 - This was not always true. Unset optional query parameters were previously serialized as
   `key=` (httpx maps `None` to `""`), and unset optional headers were rejected outright by
   argument validation. Templates worked around it with `core.script.run_python` params
-  builders or `FN.merge`. Neither is needed any more; do not reintroduce them.
+  builders or `FN.merge`. Neither is needed any more; do not reintroduce them for this purpose.
 - Pruning applies to `params` and `headers` only. `payload` and `form_data` are **not**
   pruned, because a JSON `null` is a meaningful value in a request body and the vendor —
   not Tracecat — decides what it means. When an endpoint's optional body fields cannot be
-  sent as `null`, say so in the action description and let the caller omit them; do not add
-  a step to strip them.
+  sent as `null`, keep a generic `payload` and say so in the description; do not add a step
+  to strip them.
+- Null-pruning is a `core.http_request` behaviour and does not reach SDK-backed templates. SDK
+  wrappers follow the SDK's own semantics — `slack_sdk.call_method` forwards `params` as kwargs
+  untouched, while `okta_sdk` prunes explicitly via its own `_drop_none`. When adding an SDK
+  wrapper, state which it does.
 
 ### Tests
 
@@ -219,18 +260,6 @@ do not break their public inputs or outputs without an explicitly planned migrat
   ambient credential discovery, network-target restrictions, and shared protocol
   machinery. Provider-local dispatch, validation, pagination, or serialization is
   not a platform-boundary exception merely because Tracecat implements it.
-
-## Template design
-
-- Treat templates as thin API wrappers. Prefer passing through API-native shapes over reimplementing API validation or business logic in YAML/Python steps.
-- Preserve existing input contracts. Add support additively; do not replace established shapes such as `list[dict[str, Any]]` with a different object contract unless explicitly requested.
-- Avoid hard-coding provider enums or state machines when they can change upstream. Let the provider API validate mutable values such as statuses, transition IDs, priorities, field IDs, project-specific options, or vendor-specific enum strings.
-- Avoid Python transform steps beyond small, mechanical payload assembly, such as collecting a list of field maps into one dict or preserving existing plaintext compatibility wrappers.
-- Do not add defensive validation layers that catch provider errors and raise template-specific errors. Prefer sending the request and letting the provider API return the authoritative error.
-- For object inputs, use simple API-native pass-through. Do not guess, recursively normalize, or validate arbitrary dictionaries unless the template contract explicitly defines that shape.
-- If JSON-string parsing is intentionally supported for a field, keep it local and minimal. Do not add broad recursive parsing or magic conversions across generic payload maps.
-- Keep narrow actions narrow. For example, a status-transition action should only transition; users should compose it with field-update or comment actions for extra writes.
-- For field-map inputs, support rich objects by allowing them as values inside the existing field maps rather than changing the outer input shape.
 
 ## Jira ADF pattern
 

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/attack_discovery/search_attack_discoveries.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/attack_discovery/search_attack_discoveries.yml
@@ -10,9 +10,73 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native search, filter, pagination, and sorting parameters.
+    alert_ids:
+      type: list[str] | None
+      description: Filter results to Attack discoveries that include any of the provided alert IDs.
+      default: null
+    connector_names:
+      type: list[str] | None
+      description: Filter results to Attack discoveries created by any of the provided human readable connector names. Note that values must match the human readable `connector_name` property of an Attack discovery, which are distinct from `connector_id` values used to generate Attack discoveries.
+      default: null
+    enable_field_rendering:
+      type: bool | None
+      description: Enables a markdown syntax used to render pivot fields. This is primarily used for Attack Discovery views within Kibana. Defaults to `false`.
+      default: null
+    end:
+      type: str | None
+      description: 'End of the time range for the search. Accepts absolute timestamps (ISO 8601) or relative date math (e.g. "now", "now-24h").'
+      default: null
+    ids:
+      type: list[str] | None
+      description: Filter results to the Attack discoveries with the specified IDs.
+      default: null
+    include_unique_alert_ids:
+      type: bool | None
+      description: If `true`, the response will include `unique_alert_ids` and `unique_alert_ids_count` aggregated across the matched Attack discoveries.
+      default: null
+    page:
+      type: int | None
+      description: Page number to return (used for pagination). Defaults to 1.
+      default: null
+    per_page:
+      type: int | None
+      description: Number of Attack discoveries to return per page (used for pagination). Defaults to 10.
+      default: null
+    search:
+      type: str | None
+      description: Free-text search query applied to relevant text fields of Attack discoveries (title, description, tags, etc.).
+      default: null
+    shared:
+      type: bool | None
+      description: Whether to filter by shared visibility. If omitted, both shared and privately visible Attack discoveries are returned. Use `true` to return only shared discoveries, `false` to return only those visible to the current user. Mutually exclusive with `include_all_authors`.
+      default: null
+    include_all_authors:
+      type: bool | None
+      description: If `true`, the response will include all attack discoveries matching other criteria regardless of who created them. Mutually exclusive with `shared`.
+      default: null
+    scheduled:
+      type: bool | None
+      description: Whether to filter by scheduled or ad-hoc attack discoveries. If omitted, both types of attack discoveries are returned. Use `true` to return only scheduled discoveries or `false` to return only ad-hoc discoveries.
+      default: null
+    sort_field:
+      type: str | None
+      description: "Field used to sort results. Possible values: @timestamp. Defaults to @timestamp."
+      default: null
+    sort_order:
+      type: str | None
+      description: "Sort order direction, `asc` for ascending or `desc` for descending. Possible values: asc, desc. Defaults to desc."
+      default: null
+    start:
+      type: str | None
+      description: 'Start of the time range for the search. Accepts absolute timestamps (ISO 8601) or relative date math (e.g. "now-7d").'
+      default: null
+    status:
+      type: list[str] | None
+      description: "Filter by alert workflow status. Provide one or more of the allowed workflow states. Possible values: acknowledged, closed, open."
+      default: null
+    with_replacements:
+      type: bool | None
+      description: When true, return the created Attack discoveries with text replacements applied to the detailsMarkdown, entitySummaryMarkdown, summaryMarkdown, and title fields. Defaults to `true`.
       default: null
     base_url:
       type: str | None
@@ -45,7 +109,24 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          alert_ids: ${{ inputs.alert_ids }}
+          connector_names: ${{ inputs.connector_names }}
+          enable_field_rendering: ${{ inputs.enable_field_rendering }}
+          end: ${{ inputs.end }}
+          ids: ${{ inputs.ids }}
+          include_unique_alert_ids: ${{ inputs.include_unique_alert_ids }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
+          search: ${{ inputs.search }}
+          shared: ${{ inputs.shared }}
+          include_all_authors: ${{ inputs.include_all_authors }}
+          scheduled: ${{ inputs.scheduled }}
+          sort_field: ${{ inputs.sort_field }}
+          sort_order: ${{ inputs.sort_order }}
+          start: ${{ inputs.start }}
+          status: ${{ inputs.status }}
+          with_replacements: ${{ inputs.with_replacements }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/assign_detection_alert_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/assign_detection_alert_users.yml
@@ -10,13 +10,14 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    payload:
+    assignees:
+      # Documented object shape; the `expects` grammar has no nested-object type,
+      # so the vendor's sub-keys are named in the description instead.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: Details about the assignees to assign and unassign. Requires `add` and `remove`, each a list of user profile `uid`s to assign or unassign. Users need to activate their user profile by logging into Kibana at least once.
+    ids:
+      type: list[str]
+      description: A list of alerts `id`s.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,11 +49,12 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}
           kbn-xsrf: tracecat
           Content-Type: application/json
-        payload: ${{ inputs.payload }}
+        payload:
+          assignees: ${{ inputs.assignees }}
+          ids: ${{ inputs.ids }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/bulk_action_detection_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/bulk_action_detection_rules.yml
@@ -11,11 +11,13 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Free-form: the vendor documents this body as an 8-way oneOf discriminated on `action`, so there is
+      # no single field set to enumerate.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
+    dry_run:
+      type: bool | None
+      description: Enables dry run mode for the request call. Enable dry run mode to verify that bulk actions can be applied to specified rules. Certain rules, such as prebuilt Elastic rules on a Basic subscription, can't be edited and will return errors in the request response. Rules specified in the request will be temporarily updated. These updates won't be written to Elasticsearch. Dry run mode is not supported for the `export` bulk action.
       default: null
     base_url:
       type: str | None
@@ -48,7 +50,8 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
+        params:
+          dry_run: ${{ inputs.dry_run }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/create_detection_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/create_detection_rule.yml
@@ -11,12 +11,10 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Free-form: the vendor documents this body as a discriminated union on `type` across 8 rule kinds, so there is
+      # no single field set to enumerate.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +46,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/export_detection_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/export_detection_rules.yml
@@ -11,11 +11,17 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
+    exclude_export_details:
+      type: bool | None
+      description: Determines whether a summary of the exported rules is returned. Defaults to `false`.
+      default: null
+    file_name:
+      type: str | None
+      description: File name for saving the exported rules. Defaults to `export.ndjson`.
       default: null
     base_url:
       type: str | None
@@ -48,7 +54,9 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
+        params:
+          exclude_export_details: ${{ inputs.exclude_export_details }}
+          file_name: ${{ inputs.file_name }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/import_detection_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/import_detection_rules.yml
@@ -17,9 +17,21 @@ definition:
       type: str
       description: Filename sent to Elastic.
       default: rules.ndjson
-    params:
-      type: dict[str, Any] | None
-      description: Optional native import query parameters such as overwrite.
+    overwrite:
+      type: bool | None
+      description: Determines whether existing rules with the same `rule_id` are overwritten. Defaults to `false`.
+      default: null
+    overwrite_exceptions:
+      type: bool | None
+      description: Determines whether existing exception lists with the same `list_id` are overwritten. Both the exception list container and its items are overwritten. Defaults to `false`.
+      default: null
+    overwrite_action_connectors:
+      type: bool | None
+      description: Determines whether existing actions with the same `kibana.alert.rule.actions.id` are overwritten. Defaults to `false`.
+      default: null
+    as_new_list:
+      type: bool | None
+      description: Generates a new list ID for each imported exception list. Defaults to `false`.
       default: null
     base_url:
       type: str | None
@@ -52,7 +64,11 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
+        params:
+          overwrite: ${{ inputs.overwrite }}
+          overwrite_exceptions: ${{ inputs.overwrite_exceptions }}
+          overwrite_action_connectors: ${{ inputs.overwrite_action_connectors }}
+          as_new_list: ${{ inputs.as_new_list }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/list_detection_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/list_detection_rules.yml
@@ -10,9 +10,45 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
+    fields:
+      type: list[str] | None
+      description: List of `alert.attributes` field names to return for each rule (for example `name`, `enabled`). If omitted, the default field set is returned.
+      default: null
+    filter:
+      type: str | None
+      description: "Search query. Filters the returned results according to the value of the specified field, using the `alert.attributes.<field name>:<field value>` syntax, where `<field name>` can be: name, enabled, tags, createdBy, interval, updatedBy. Even though the JSON rule object uses `created_by` and `updated_by` fields, you must use `createdBy` and `updatedBy` fields in the filter."
+      default: null
+    sort_field:
+      type: str | None
+      description: "Field to sort by. Possible values: created_at, createdAt, enabled, execution_summary.last_execution.date, execution_summary.last_execution.metrics.execution_gap_duration_s, execution_summary.last_execution.metrics.total_indexing_duration_ms, execution_summary.last_execution.metrics.total_search_duration_ms, execution_summary.last_execution.status, name, risk_score, riskScore, severity, updated_at, updatedAt."
+      default: null
+    sort_order:
+      type: str | None
+      description: "Sort order. Possible values: asc, desc."
+      default: null
+    page:
+      type: int | None
+      description: Page number. Defaults to 1.
+      default: null
+    per_page:
+      type: int | None
+      description: Rules per page. Defaults to 20.
+      default: null
+    gaps_range_start:
+      type: str | None
+      description: Gaps range start.
+      default: null
+    gaps_range_end:
+      type: str | None
+      description: Gaps range end.
+      default: null
+    gap_fill_statuses:
+      type: list[str] | None
+      description: "Gap fill statuses. Possible values: unfilled, in_progress, filled, error."
+      default: null
+    gap_auto_fill_scheduler_id:
+      type: str | None
+      description: Gap auto fill scheduler ID used to determine gap fill status for rules.
       default: null
     base_url:
       type: str | None
@@ -45,7 +81,17 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          fields: ${{ inputs.fields }}
+          filter: ${{ inputs.filter }}
+          sort_field: ${{ inputs.sort_field }}
+          sort_order: ${{ inputs.sort_order }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
+          gaps_range_start: ${{ inputs.gaps_range_start }}
+          gaps_range_end: ${{ inputs.gaps_range_end }}
+          gap_fill_statuses: ${{ inputs.gap_fill_statuses }}
+          gap_auto_fill_scheduler_id: ${{ inputs.gap_auto_fill_scheduler_id }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/patch_detection_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/patch_detection_rule.yml
@@ -11,12 +11,10 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Free-form: the vendor documents this body as a discriminated union on `type` across 8 rule kinds, so there is
+      # no single field set to enumerate.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +46,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: PATCH
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/preview_detection_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/preview_detection_rule.yml
@@ -11,11 +11,13 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Free-form: the vendor documents this body as a discriminated union on `type` across 8 rule kinds, so there is
+      # no single field set to enumerate.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
+    enable_logged_requests:
+      type: bool | None
+      description: Enables logging and returning in response ES queries, performed during rule execution.
       default: null
     base_url:
       type: str | None
@@ -48,7 +50,8 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
+        params:
+          enable_logged_requests: ${{ inputs.enable_logged_requests }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/search_detection_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/search_detection_alerts.yml
@@ -11,12 +11,10 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Free-form: the vendor documents this body as a raw Elasticsearch query DSL document, so there is
+      # no single field set to enumerate.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +46,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/set_detection_alert_status.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/set_detection_alert_status.yml
@@ -11,12 +11,10 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Free-form: the vendor documents this body as a oneOf of by-ids and by-query forms, so there is
+      # no single field set to enumerate.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +46,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/update_detection_alert_tags.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/detections/update_detection_alert_tags.yml
@@ -10,13 +10,14 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    payload:
+    ids:
+      type: list[str]
+      description: A list of alerts `id`s.
+    tags:
+      # Documented object shape; the `expects` grammar has no nested-object type,
+      # so the vendor's sub-keys are named in the description instead.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: Object with list of tags to add and remove. Requires `tags_to_add` and `tags_to_remove`, each a list of keywords to organize related alerts into categories that you can filter and group.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,11 +49,12 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}
           kbn-xsrf: tracecat
           Content-Type: application/json
-        payload: ${{ inputs.payload }}
+        payload:
+          ids: ${{ inputs.ids }}
+          tags: ${{ inputs.tags }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/cancel_response_action.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/cancel_response_action.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/create_endpoint_script.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/create_endpoint_script.yml
@@ -11,6 +11,8 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: assembled into multipart form data by the build_form_data step below,
+      # which owns this body's field handling.
       type: dict[str, Any]
       description: API-native multipart script metadata fields.
     base64_content:
@@ -23,10 +25,6 @@ definition:
       type: str
       description: MIME type of the script file.
       default: application/octet-stream
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -76,7 +74,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         form_data: ${{ steps.build_form_data.result }}
         files:
           file:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/download_response_file.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/download_response_file.yml
@@ -16,10 +16,6 @@ definition:
     file_id:
       type: str
       description: Response file ID.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -51,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         base64_encode_data: true
         headers:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/generate_endpoint_memory_dump.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/generate_endpoint_memory_dump.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_endpoint.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_endpoint.yml
@@ -13,10 +13,6 @@ definition:
     endpoint_id:
       type: str
       description: Endpoint ID.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +44,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_endpoint_file.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_endpoint_file.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), path (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_endpoint_processes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_endpoint_processes.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_response_action.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_response_action.yml
@@ -13,10 +13,6 @@ definition:
     action_id:
       type: str
       description: Response action ID.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +44,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_response_file_info.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/get_response_file_info.yml
@@ -16,10 +16,6 @@ definition:
     file_id:
       type: str
       description: Response file ID.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -51,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/isolate_endpoint.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/isolate_endpoint.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/list_endpoint_scripts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/list_endpoint_scripts.yml
@@ -10,9 +10,25 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
+    page:
+      type: int | None
+      description: Page number of the results to return. Defaults to 1.
+      default: null
+    pageSize:
+      type: int | None
+      description: Number of results to return per page. Defaults to 10. Max value is 1000.
+      default: null
+    sortField:
+      type: str | None
+      description: The field to sort the results by. Defaults to name. Allowed values are `name`, `createdAt`, `createdBy`, `updatedAt`, `updatedBy`, `fileSize`.
+      default: null
+    sortDirection:
+      type: str | None
+      description: The direction to sort the results by. Defaults to asc (ascending). Allowed values are `asc`, `desc`.
+      default: null
+    kuery:
+      type: str | None
+      description: A KQL query string to filter the list of scripts. Nearly all fields in the script object are searchable.
       default: null
     base_url:
       type: str | None
@@ -45,7 +61,12 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          page: ${{ inputs.page }}
+          pageSize: ${{ inputs.pageSize }}
+          sortField: ${{ inputs.sortField }}
+          sortDirection: ${{ inputs.sortDirection }}
+          kuery: ${{ inputs.kuery }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/list_endpoints.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/list_endpoints.yml
@@ -10,9 +10,28 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
+    hostStatuses:
+      type: list[str]
+      description: A set of host statuses to filter the results by (for example, `healthy`, `updating`). Allowed values are `healthy`, `offline`, `updating`, `inactive`, `unenrolled`.
+    page:
+      type: int | None
+      description: The page number to return.
+      default: null
+    pageSize:
+      type: int | None
+      description: The number of endpoints to return per page.
+      default: null
+    kuery:
+      type: str | None
+      description: A KQL string to filter the endpoint metadata results.
+      default: null
+    sortField:
+      type: str | None
+      description: The field used to sort the results. Allowed values are `enrolled_at`, `metadata.host.hostname`, `host_status`, `metadata.Endpoint.policy.applied.name`, `metadata.Endpoint.policy.applied.status`, `metadata.host.os.name`, `metadata.host.ip`, `metadata.agent.version`, `last_checkin`.
+      default: null
+    sortDirection:
+      type: str | None
+      description: The sort order, either `asc` or `desc`.
       default: null
     base_url:
       type: str | None
@@ -45,7 +64,13 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          hostStatuses: ${{ inputs.hostStatuses }}
+          page: ${{ inputs.page }}
+          pageSize: ${{ inputs.pageSize }}
+          kuery: ${{ inputs.kuery }}
+          sortField: ${{ inputs.sortField }}
+          sortDirection: ${{ inputs.sortDirection }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/list_response_actions.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/list_response_actions.yml
@@ -10,9 +10,45 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
+    page:
+      type: int | None
+      description: The page number to return.
+      default: null
+    pageSize:
+      type: int | None
+      description: The number of response actions to return per page.
+      default: null
+    commands:
+      type: list[str] | None
+      description: A list of response action command names to filter by. Allowed values are `isolate`, `unisolate`, `kill-process`, `suspend-process`, `running-processes`, `get-file`, `execute`, `upload`, `scan`, `runscript`, `cancel`, `memory-dump`.
+      default: null
+    agentIds:
+      type: list[str] | None
+      description: A list of Elastic Agent IDs to filter the response actions by.
+      default: null
+    userIds:
+      type: list[str] | None
+      description: A list of user IDs that submitted the response actions.
+      default: null
+    startDate:
+      type: str | None
+      description: A start date in ISO 8601 format or Date Math format (for example, `now-24h`).
+      default: null
+    endDate:
+      type: str | None
+      description: An end date in ISO 8601 format or Date Math format (for example, `now`).
+      default: null
+    agentTypes:
+      type: str | None
+      description: The agent type to filter response actions by. Defaults to `endpoint`. Allowed values are `endpoint`, `sentinel_one`, `crowdstrike`, `microsoft_defender_endpoint`.
+      default: null
+    withOutputs:
+      type: list[str] | None
+      description: A list of response action IDs whose outputs should be included in the response.
+      default: null
+    types:
+      type: list[str] | None
+      description: A list of response action types to filter by (`automated`, `manual`).
       default: null
     base_url:
       type: str | None
@@ -45,7 +81,17 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          page: ${{ inputs.page }}
+          pageSize: ${{ inputs.pageSize }}
+          commands: ${{ inputs.commands }}
+          agentIds: ${{ inputs.agentIds }}
+          userIds: ${{ inputs.userIds }}
+          startDate: ${{ inputs.startDate }}
+          endDate: ${{ inputs.endDate }}
+          agentTypes: ${{ inputs.agentTypes }}
+          withOutputs: ${{ inputs.withOutputs }}
+          types: ${{ inputs.types }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/release_endpoint.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/release_endpoint.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/run_endpoint_command.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/run_endpoint_command.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: command (required), endpoint_ids (required), agent_type, alert_ids, case_ids, comment, timeout.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/run_endpoint_script.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/run_endpoint_script.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/scan_endpoint_path.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/scan_endpoint_path.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), path (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/suspend_endpoint_process.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/suspend_endpoint_process.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/terminate_endpoint_process.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/terminate_endpoint_process.yml
@@ -11,12 +11,11 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
+      description: >-
+        API-native request body. Documented fields: endpoint_ids (required), parameters (required), agent_type, alert_ids, case_ids, comment.
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +47,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/upload_endpoint_file.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/endpoint_response/upload_endpoint_file.yml
@@ -11,6 +11,8 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: assembled into multipart form data by the build_form_data step below,
+      # which owns this body's field handling.
       type: dict[str, Any]
       description: API-native multipart fields, such as endpoint_ids and parameters.
     base64_content:
@@ -23,10 +25,6 @@ definition:
       type: str
       description: MIME type of the uploaded file.
       default: application/octet-stream
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -76,7 +74,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         form_data: ${{ steps.build_form_data.result }}
         files:
           file:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/entity_analytics/search_entities.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/entity_analytics/search_entities.yml
@@ -10,9 +10,49 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native entity filters, fields, sorting, and pagination parameters.
+    filter:
+      type: str | None
+      description: A Kibana Query Language (KQL) filter for the search-after mode.
+      default: null
+    size:
+      type: int | None
+      description: Number of entities to return in search-after mode.
+      default: null
+    searchAfter:
+      type: str | None
+      description: JSON-encoded search_after value for cursor-based pagination.
+      default: null
+    source:
+      type: list[str] | None
+      description: Fields to include in the response source.
+      default: null
+    fields:
+      type: list[str] | None
+      description: Fields to include in the response.
+      default: null
+    sort_field:
+      type: str | None
+      description: Field to sort results by in page mode.
+      default: null
+    sort_order:
+      type: str | None
+      description: "Sort order in page mode. Possible values: asc, desc."
+      default: null
+    page:
+      type: int | None
+      description: Page number to return (1-indexed) in page mode.
+      default: null
+    per_page:
+      type: int | None
+      description: Number of entities per page in page mode.
+      default: null
+    filterQuery:
+      type: str | None
+      description: An Elasticsearch query string to filter entities in page mode.
+      default: null
+    entity_types:
+      type: list[str] | None
+      description: "Entity types to include in the results. Possible values: user, host, service, generic."
       default: null
     base_url:
       type: str | None
@@ -45,7 +85,18 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          size: ${{ inputs.size }}
+          searchAfter: ${{ inputs.searchAfter }}
+          source: ${{ inputs.source }}
+          fields: ${{ inputs.fields }}
+          sort_field: ${{ inputs.sort_field }}
+          sort_order: ${{ inputs.sort_order }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
+          filterQuery: ${{ inputs.filterQuery }}
+          entity_types: ${{ inputs.entity_types }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/create_exception_list.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/create_exception_list.yml
@@ -11,12 +11,10 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters, including API identifiers where required.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +46,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/create_exception_list_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/create_exception_list_item.yml
@@ -11,12 +11,10 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Free-form: the vendor documents this body as a 13-way oneOf over entry types, so there is
+      # no single field set to enumerate.
       type: dict[str, Any]
       description: API-native JSON request body.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters, including API identifiers where required.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +46,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/delete_exception_list_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/delete_exception_list_item.yml
@@ -10,9 +10,17 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters, including API identifiers where required.
+    id:
+      type: str | None
+      description: Exception item's identifier. Either `id` or `item_id` must be specified.
+      default: null
+    item_id:
+      type: str | None
+      description: Human readable exception item string identifier, e.g. `trusted-linux-processes`. Either `id` or `item_id` must be specified.
+      default: null
+    namespace_type:
+      type: str | None
+      description: "`single` deletes the item in the current Kibana space; `agnostic` deletes an item in a space-agnostic list. Must match the list that owns the item. Defaults to single."
       default: null
     base_url:
       type: str | None
@@ -45,7 +53,10 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: DELETE
-        params: ${{ inputs.params }}
+        params:
+          id: ${{ inputs.id }}
+          item_id: ${{ inputs.item_id }}
+          namespace_type: ${{ inputs.namespace_type }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/list_exception_list_items.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/list_exception_list_items.yml
@@ -10,9 +10,36 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters, including API identifiers where required.
+    list_id:
+      type: list[str]
+      description: The `list_id`s of the items to fetch.
+    filter:
+      type: list[str] | None
+      description: Filters the returned results according to the value of the specified field, using the `<field name>:<field value>` syntax.
+      default: null
+    namespace_type:
+      type: list[str] | None
+      description: "Determines whether the returned containers are Kibana associated with a Kibana space or available in all spaces. Possible values: agnostic, single."
+      default: null
+    search:
+      type: str | None
+      description: Free-text search term applied to exception list item fields (for example a hostname or file path fragment).
+      default: null
+    page:
+      type: int | None
+      description: The page number to return.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of exception list items to return per page.
+      default: null
+    sort_field:
+      type: str | None
+      description: Determines which field is used to sort the results.
+      default: null
+    sort_order:
+      type: str | None
+      description: Determines the sort order, which can be `desc` or `asc`.
       default: null
     base_url:
       type: str | None
@@ -45,7 +72,15 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          list_id: ${{ inputs.list_id }}
+          filter: ${{ inputs.filter }}
+          namespace_type: ${{ inputs.namespace_type }}
+          search: ${{ inputs.search }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
+          sort_field: ${{ inputs.sort_field }}
+          sort_order: ${{ inputs.sort_order }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/list_exception_lists.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/exceptions/list_exception_lists.yml
@@ -10,9 +10,29 @@ definition:
     - name: elastic_security
       keys: ["ELASTIC_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters, including API identifiers where required.
+    filter:
+      type: str | None
+      description: "Filters the returned results according to the value of the specified field. Uses the `so type.field name:field` value syntax, where `so type` can be: exception-list (specify a space-aware exception list) or exception-list-agnostic (specify an exception list that is shared across spaces)."
+      default: null
+    namespace_type:
+      type: list[str] | None
+      description: "Determines whether the returned containers are Kibana associated with a Kibana space or available in all spaces. Possible values: agnostic, single."
+      default: null
+    page:
+      type: int | None
+      description: The page number to return.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of exception lists to return per page.
+      default: null
+    sort_field:
+      type: str | None
+      description: Determines which field is used to sort the results.
+      default: null
+    sort_order:
+      type: str | None
+      description: Determines the sort order, which can be `desc` or `asc`.
       default: null
     base_url:
       type: str | None
@@ -45,7 +65,13 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          namespace_type: ${{ inputs.namespace_type }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
+          sort_field: ${{ inputs.sort_field }}
+          sort_order: ${{ inputs.sort_order }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/osquery/run_osquery_live_query.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/osquery/run_osquery_live_query.yml
@@ -11,12 +11,10 @@ definition:
       keys: ["ELASTIC_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any]
       description: API-native live query JSON request body, including targets and query or pack details.
-    params:
-      type: dict[str, Any] | None
-      description: Optional native Kibana query parameters.
-      default: null
     base_url:
       type: str | None
       description: Kibana base URL (e.g. https://localhost:5601).
@@ -48,7 +46,6 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.elastic_security.base_url }}${{ steps.build_path.result }}
         method: POST
-        params: ${{ inputs.params }}
         verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/emailrep/report_email_address.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/emailrep/report_email_address.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["EMAILREP_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native report body containing email, tags, and optional context.
+      description: >-
+        API-native request body. Documented fields: email (required), tags (required), description, expires, timestamp.
   steps:
     - ref: request
       action: core.http_request

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/cancel_workflow_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/cancel_workflow_run.yml
@@ -20,14 +20,6 @@ definition:
     run_id:
       type: int
       description: GitHub API path value for run_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -42,6 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
-      payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/dispatch_workflow.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/dispatch_workflow.yml
@@ -20,13 +20,11 @@ definition:
     workflow_id:
       type: str | int
       description: GitHub API path value for workflow_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Free-form: the vendor documents this body as carrying an `inputs` map with `additionalProperties: true`, i.e. keys defined per workflow, so there is
+      # no single field set to enumerate.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches: ref (required), inputs, return_run_details.'
       default: null
     base_url:
       type: str
@@ -42,6 +40,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/download_workflow_job_logs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/download_workflow_job_logs.yml
@@ -20,10 +20,6 @@ definition:
     job_id:
       type: int
       description: GitHub API path value for job_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,7 +34,6 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       follow_redirects: true
       base64_encode_data: true
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/get_workflow_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/get_workflow_run.yml
@@ -20,9 +20,9 @@ definition:
     run_id:
       type: int
       description: GitHub API path value for run_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    exclude_pull_requests:
+      type: bool | None
+      description: If `true` pull requests are omitted from the response (empty array).
       default: null
     base_url:
       type: str
@@ -38,5 +38,6 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        exclude_pull_requests: ${{ inputs.exclude_pull_requests }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/list_repository_workflow_runs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/list_repository_workflow_runs.yml
@@ -17,9 +17,45 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    actor:
+      type: str | None
+      description: Returns someone's workflow runs. Use the login for the user who created the `push` associated with the check suite or workflow run.
+      default: null
+    branch:
+      type: str | None
+      description: Returns workflow runs associated with a branch. Use the name of the branch of the `push`.
+      default: null
+    event:
+      type: str | None
+      description: Returns workflow run triggered by the event you specify. For example, `push`, `pull_request` or `issue`. For more information, see "[Events that trigger workflows](https://docs.github.com/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows)."
+      default: null
+    status:
+      type: str | None
+      description: 'Returns workflow runs with the check run `status` or `conclusion` that you specify. For example, a conclusion can be `success` or a status can be `in_progress`. Only GitHub Actions can set a status of `waiting`, `pending`, or `requested`. Can be one of: `completed`, `action_required`, `cancelled`, `failure`, `neutral`, `skipped`, `stale`, `success`, `timed_out`, `in_progress`, `queued`, `requested`, `waiting`, `pending`.'
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
+      default: null
+    created:
+      type: str | None
+      description: Returns workflow runs created within the given date-time range. For more information on the syntax, see "[Understanding the search syntax](https://docs.github.com/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#query-for-dates)."
+      default: null
+    exclude_pull_requests:
+      type: bool | None
+      description: If `true` pull requests are omitted from the response (empty array).
+      default: null
+    check_suite_id:
+      type: int | None
+      description: Returns workflow runs with the `check_suite_id` that you specify.
+      default: null
+    head_sha:
+      type: str | None
+      description: Only returns workflow runs that are associated with the specified `head_sha`.
       default: null
     base_url:
       type: str
@@ -35,5 +71,15 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        actor: ${{ inputs.actor }}
+        branch: ${{ inputs.branch }}
+        event: ${{ inputs.event }}
+        status: ${{ inputs.status }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
+        created: ${{ inputs.created }}
+        exclude_pull_requests: ${{ inputs.exclude_pull_requests }}
+        check_suite_id: ${{ inputs.check_suite_id }}
+        head_sha: ${{ inputs.head_sha }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/list_repository_workflows.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/list_repository_workflows.yml
@@ -17,9 +17,13 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -35,5 +39,7 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/list_workflow_run_jobs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/list_workflow_run_jobs.yml
@@ -20,9 +20,17 @@ definition:
     run_id:
       type: int
       description: GitHub API path value for run_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    filter:
+      type: str | None
+      description: 'Filters jobs by their `completed_at` timestamp. `latest` returns jobs from the most recent execution of the workflow run. `all` returns all jobs for a workflow run, including from old executions of the workflow run. Can be one of: `latest`, `all`.'
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -38,5 +46,8 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        filter: ${{ inputs.filter }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/rerun_failed_workflow_jobs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/actions/rerun_failed_workflow_jobs.yml
@@ -20,13 +20,11 @@ definition:
     run_id:
       type: int
       description: GitHub API path value for run_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs: enable_debug_logging.'
       default: null
     base_url:
       type: str
@@ -42,6 +40,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/compare_commits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/compare_commits.yml
@@ -20,9 +20,13 @@ definition:
     basehead:
       type: str
       description: GitHub API path value for basehead.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
       default: null
     base_url:
       type: str
@@ -38,5 +42,7 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        page: ${{ inputs.page }}
+        per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/create_or_update_repository_content.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/create_or_update_repository_content.yml
@@ -20,13 +20,12 @@ definition:
     path:
       type: str
       description: Nested repository content path.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: content (required), message (required), author, branch, committer, sha.
       default: null
     base_url:
       type: str
@@ -42,6 +41,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/get_commit.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/get_commit.yml
@@ -20,9 +20,13 @@ definition:
     ref:
       type: str
       description: GitHub API path value for ref.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
       default: null
     base_url:
       type: str
@@ -38,5 +42,7 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        page: ${{ inputs.page }}
+        per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/get_repository.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/get_repository.yml
@@ -17,10 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -35,5 +31,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/get_repository_content.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/get_repository_content.yml
@@ -20,9 +20,9 @@ definition:
     path:
       type: str
       description: Nested repository content path.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    ref:
+      type: str | None
+      description: "The name of the commit/branch/tag. Default: the repository’s default branch."
       default: null
     base_url:
       type: str
@@ -38,5 +38,6 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        ref: ${{ inputs.ref }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/list_commits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/code/list_commits.yml
@@ -17,9 +17,37 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    sha:
+      type: str | None
+      description: "SHA or branch to start listing commits from. Default: the repository’s default branch (usually main)."
+      default: null
+    path:
+      type: str | None
+      description: Only commits containing this file path will be returned.
+      default: null
+    author:
+      type: str | None
+      description: GitHub username or email address to use to filter by commit author.
+      default: null
+    committer:
+      type: str | None
+      description: GitHub username or email address to use to filter by commit committer.
+      default: null
+    since:
+      type: str | None
+      description: "Only show results that were last updated after the given time. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Due to limitations of Git, timestamps must be between 1970-01-01 and 2099-12-31 (inclusive) or unexpected results may be returned."
+      default: null
+    until:
+      type: str | None
+      description: "Only commits before this date will be returned. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Due to limitations of Git, timestamps must be between 1970-01-01 and 2099-12-31 (inclusive) or unexpected results may be returned."
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -35,5 +63,13 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        sha: ${{ inputs.sha }}
+        path: ${{ inputs.path }}
+        author: ${{ inputs.author }}
+        committer: ${{ inputs.committer }}
+        since: ${{ inputs.since }}
+        until: ${{ inputs.until }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/gists/get_gist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/gists/get_gist.yml
@@ -14,10 +14,6 @@ definition:
     gist_id:
       type: str
       description: GitHub API path value for gist_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -32,5 +28,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/gists/list_gist_commits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/gists/list_gist_commits.yml
@@ -14,9 +14,13 @@ definition:
     gist_id:
       type: str
       description: GitHub API path value for gist_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -32,5 +36,7 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/create_issue.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/create_issue.yml
@@ -17,13 +17,11 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for POST /repos/{owner}/{repo}/issues: title (required), body, assignee, milestone, labels, assignees, issue_field_values, type.'
       default: null
     base_url:
       type: str
@@ -39,6 +37,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/create_issue_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/create_issue_comment.yml
@@ -20,14 +20,9 @@ definition:
     issue_number:
       type: int
       description: GitHub API path value for issue_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
+    body:
+      type: str
+      description: The contents of the comment.
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -42,6 +37,6 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
-      payload: ${{ inputs.payload }}
+      payload:
+        body: ${{ inputs.body }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/get_issue.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/get_issue.yml
@@ -20,10 +20,6 @@ definition:
     issue_number:
       type: int
       description: GitHub API path value for issue_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,5 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/list_issue_comments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/list_issue_comments.yml
@@ -20,9 +20,17 @@ definition:
     issue_number:
       type: int
       description: GitHub API path value for issue_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    since:
+      type: str | None
+      description: 'Only show results that were last updated after the given time. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.'
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -38,5 +46,8 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        since: ${{ inputs.since }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/list_repository_issues.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/list_repository_issues.yml
@@ -17,9 +17,57 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    milestone:
+      type: str | None
+      description: If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.
+      default: null
+    state:
+      type: str | None
+      description: 'Indicates the state of the issues to return. Can be one of: `open`, `closed`, `all`.'
+      default: null
+    assignee:
+      type: str | None
+      description: Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues assigned to any user.
+      default: null
+    type:
+      type: str | None
+      description: Can be the name of an issue type. If the string `*` is passed, issues with any type are accepted. If the string `none` is passed, issues without type are returned.
+      default: null
+    creator:
+      type: str | None
+      description: The user that created the issue.
+      default: null
+    mentioned:
+      type: str | None
+      description: A user that's mentioned in the issue.
+      default: null
+    issue_field_values:
+      type: str | None
+      description: A comma-separated list of issue field filters in `field_slug:value` format. Only issues matching all specified field values are returned. Requires issue fields to be enabled for the repository. Issue fields are not available for user-owned repositories, and field availability for organization-owned public repositories depends on the organization's visibility settings. For example, `priority:Urgent,severity:High` filters issues where the `priority` field is `Urgent` AND the `severity` field is `High`.
+      default: null
+    labels:
+      type: str | None
+      description: 'A list of comma separated label names. Example: `bug,ui,@high`'
+      default: null
+    sort:
+      type: str | None
+      description: 'What to sort results by. Can be one of: `created`, `updated`, `comments`.'
+      default: null
+    direction:
+      type: str | None
+      description: 'The direction to sort the results by. Can be one of: `asc`, `desc`.'
+      default: null
+    since:
+      type: str | None
+      description: 'Only show results that were last updated after the given time. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.'
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -35,5 +83,18 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        milestone: ${{ inputs.milestone }}
+        state: ${{ inputs.state }}
+        assignee: ${{ inputs.assignee }}
+        type: ${{ inputs.type }}
+        creator: ${{ inputs.creator }}
+        mentioned: ${{ inputs.mentioned }}
+        issue_field_values: ${{ inputs.issue_field_values }}
+        labels: ${{ inputs.labels }}
+        sort: ${{ inputs.sort }}
+        direction: ${{ inputs.direction }}
+        since: ${{ inputs.since }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/update_issue.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/update_issue.yml
@@ -20,13 +20,11 @@ definition:
     issue_number:
       type: int
       description: GitHub API path value for issue_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for PATCH /repos/{owner}/{repo}/issues/{issue_number}: title, body, assignee, state, state_reason, duplicate_issue_id, milestone, labels, assignees, issue_field_values, type.'
       default: null
     base_url:
       type: str
@@ -42,6 +40,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/organization/get_organization_audit_log.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/organization/get_organization_audit_log.yml
@@ -14,9 +14,29 @@ definition:
     org:
       type: str
       description: GitHub API path value for org.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    phrase:
+      type: str | None
+      description: A search phrase.
+      default: null
+    include:
+      type: str | None
+      description: "The event types to include: web - returns web (non-Git) events. git - returns Git events. all - returns both web and Git events. The default is web."
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for events after this cursor.
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for events before this cursor.
+      default: null
+    order:
+      type: str | None
+      description: The order of audit log events. To list newest events first, specify desc. To list oldest events first, specify asc. The default is desc.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
       default: null
     base_url:
       type: str
@@ -32,5 +52,11 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        phrase: ${{ inputs.phrase }}
+        include: ${{ inputs.include }}
+        after: ${{ inputs.after }}
+        before: ${{ inputs.before }}
+        order: ${{ inputs.order }}
+        per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/posture/get_branch_protection.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/posture/get_branch_protection.yml
@@ -20,10 +20,6 @@ definition:
     branch:
       type: str
       description: GitHub API path value for branch.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,5 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/posture/get_repository_collaborator_permission.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/posture/get_repository_collaborator_permission.yml
@@ -20,10 +20,6 @@ definition:
     username:
       type: str
       description: GitHub API path value for username.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,5 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/posture/update_branch_protection.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/posture/update_branch_protection.yml
@@ -20,13 +20,12 @@ definition:
     branch:
       type: str
       description: GitHub API path value for branch.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: allow_deletions, allow_force_pushes, allow_fork_syncing, block_creations, enforce_admins, lock_branch, required_conversation_resolution, required_linear_history, required_pull_request_reviews, required_status_checks, restrictions.
       default: null
     base_url:
       type: str
@@ -42,6 +41,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/create_pull_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/create_pull_request.yml
@@ -17,13 +17,11 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for POST /repos/{owner}/{repo}/pulls: title, head (required), head_repo, base (required), body, maintainer_can_modify, draft, issue.'
       default: null
     base_url:
       type: str
@@ -39,6 +37,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/create_pull_request_review.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/create_pull_request_review.yml
@@ -20,13 +20,11 @@ definition:
     pull_number:
       type: int
       description: GitHub API path value for pull_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews: commit_id, body, event, comments.'
       default: null
     base_url:
       type: str
@@ -42,6 +40,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/create_pull_request_review_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/create_pull_request_review_comment.yml
@@ -20,13 +20,11 @@ definition:
     pull_number:
       type: int
       description: GitHub API path value for pull_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for POST /repos/{owner}/{repo}/pulls/{pull_number}/comments: body (required), commit_id (required), path (required), position, side, line, start_line, start_side, in_reply_to, subject_type.'
       default: null
     base_url:
       type: str
@@ -42,6 +40,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/get_pull_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/get_pull_request.yml
@@ -20,10 +20,6 @@ definition:
     pull_number:
       type: int
       description: GitHub API path value for pull_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,5 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/get_pull_request_merge_state.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/get_pull_request_merge_state.yml
@@ -20,10 +20,6 @@ definition:
     pull_number:
       type: int
       description: GitHub API path value for pull_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,7 +34,6 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       ignore_status_codes:
       - 404
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/list_pull_request_files.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/list_pull_request_files.yml
@@ -20,9 +20,13 @@ definition:
     pull_number:
       type: int
       description: GitHub API path value for pull_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -38,5 +42,7 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/list_pull_request_review_comments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/list_pull_request_review_comments.yml
@@ -20,9 +20,25 @@ definition:
     pull_number:
       type: int
       description: GitHub API path value for pull_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    sort:
+      type: str | None
+      description: 'The property to sort the results by. Can be one of: `created`, `updated`.'
+      default: null
+    direction:
+      type: str | None
+      description: 'The direction to sort results. Ignored without `sort` parameter. Can be one of: `asc`, `desc`.'
+      default: null
+    since:
+      type: str | None
+      description: 'Only show results that were last updated after the given time. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`.'
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -38,5 +54,10 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        sort: ${{ inputs.sort }}
+        direction: ${{ inputs.direction }}
+        since: ${{ inputs.since }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/list_pull_requests.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/list_pull_requests.yml
@@ -17,9 +17,33 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    state:
+      type: str | None
+      description: 'Either `open`, `closed`, or `all` to filter by state. Can be one of: `open`, `closed`, `all`.'
+      default: null
+    head:
+      type: str | None
+      description: 'Filter pulls by head user or head organization and branch name in the format of `user:ref-name` or `organization:ref-name`. For example: `github:new-script-format` or `octocat:test-branch`.'
+      default: null
+    base:
+      type: str | None
+      description: 'Filter pulls by base branch name. Example: `gh-pages`.'
+      default: null
+    sort:
+      type: str | None
+      description: 'What to sort results by. `popularity` will sort by the number of comments. `long-running` will sort by date created and will limit the results to pull requests that have been open for more than a month and have had activity within the past month. Can be one of: `created`, `updated`, `popularity`, `long-running`.'
+      default: null
+    direction:
+      type: str | None
+      description: 'The direction of the sort. Default: `desc` when sort is `created` or sort is not specified, otherwise `asc`. Can be one of: `asc`, `desc`.'
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -35,5 +59,12 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        state: ${{ inputs.state }}
+        head: ${{ inputs.head }}
+        base: ${{ inputs.base }}
+        sort: ${{ inputs.sort }}
+        direction: ${{ inputs.direction }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/merge_pull_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/merge_pull_request.yml
@@ -20,13 +20,11 @@ definition:
     pull_number:
       type: int
       description: GitHub API path value for pull_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge: commit_title, commit_message, sha, merge_method.'
       default: null
     base_url:
       type: str
@@ -42,6 +40,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/update_pull_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/pull_requests/update_pull_request.yml
@@ -20,13 +20,11 @@ definition:
     pull_number:
       type: int
       description: GitHub API path value for pull_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields, and a
+      # literal payload map cannot omit an unset optional. Fields are in the description.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: 'API-native request body passed through without validation. Body fields documented for PATCH /repos/{owner}/{repo}/pulls/{pull_number}: title, body, state, base, maintainer_can_modify.'
       default: null
     base_url:
       type: str
@@ -42,6 +40,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_code.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_code.yml
@@ -11,9 +11,24 @@ definition:
     provider_id: github
     grant_type: authorization_code
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    q:
+      type: str
+      description: The query contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. The REST API supports the same qualifiers as the web interface for GitHub. See Searching code for a detailed list of qualifiers.
+    sort:
+      type: str | None
+      description: "This field is closing down. Sorts the results of your query. Can only be indexed, which indicates how recently a file has been indexed by the GitHub search infrastructure. Default: best match"
+      default: null
+    order:
+      type: str | None
+      description: This field is closing down. Determines whether the first search result returned is the highest number of matches (desc) or lowest number of matches (asc). This parameter is ignored unless you provide sort.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -29,5 +44,10 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        q: ${{ inputs.q }}
+        sort: ${{ inputs.sort }}
+        order: ${{ inputs.order }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_commits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_commits.yml
@@ -11,9 +11,24 @@ definition:
     provider_id: github
     grant_type: authorization_code
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    q:
+      type: str
+      description: The query contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. The REST API supports the same qualifiers as the web interface for GitHub. See Searching commits for a detailed list of qualifiers.
+    sort:
+      type: str | None
+      description: "Sorts the results of your query by author-date or committer-date. Default: best match"
+      default: null
+    order:
+      type: str | None
+      description: Determines whether the first search result returned is the highest number of matches (desc) or lowest number of matches (asc). This parameter is ignored unless you provide sort.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -29,5 +44,10 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        q: ${{ inputs.q }}
+        sort: ${{ inputs.sort }}
+        order: ${{ inputs.order }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_issues.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_issues.yml
@@ -11,9 +11,32 @@ definition:
     provider_id: github
     grant_type: authorization_code
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    q:
+      type: str
+      description: The query contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. The REST API supports the same qualifiers as the web interface for GitHub. See Searching issues and pull requests for a detailed list of qualifiers.
+    sort:
+      type: str | None
+      description: "Sorts the results of your query by the number of comments, reactions, reactions-+1, reactions--1, reactions-smile, reactions-thinking_face, reactions-heart, reactions-tada, or interactions. You can also sort results by how recently the items were created or updated, Default: best match"
+      default: null
+    order:
+      type: str | None
+      description: Determines whether the first search result returned is the highest number of matches (desc) or lowest number of matches (asc). This parameter is ignored unless you provide sort.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
+      default: null
+    advanced_search:
+      type: str | None
+      description: Set to true to use advanced search.
+      default: null
+    search_type:
+      type: str | None
+      description: The type of search to perform on issues. When not specified, the default is lexical search. semantic performs a pure semantic (vector) search using embedding-based understanding. hybrid combines semantic search with lexical search for best results. Semantic and hybrid search require authentication and are rate limited to 10 requests per minute. Only applies to issue searches (/search/issues).
       default: null
     base_url:
       type: str
@@ -29,5 +52,12 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        q: ${{ inputs.q }}
+        sort: ${{ inputs.sort }}
+        order: ${{ inputs.order }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
+        advanced_search: ${{ inputs.advanced_search }}
+        search_type: ${{ inputs.search_type }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_repositories.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/search/search_repositories.yml
@@ -11,9 +11,24 @@ definition:
     provider_id: github
     grant_type: authorization_code
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    q:
+      type: str
+      description: The query contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. The REST API supports the same qualifiers as the web interface for GitHub. See Searching for repositories for a detailed list of qualifiers.
+    sort:
+      type: str | None
+      description: "Sorts the results of your query by number of stars, forks, or help-wanted-issues or how recently the items were updated. Default: best match"
+      default: null
+    order:
+      type: str | None
+      description: Determines whether the first search result returned is the highest number of matches (desc) or lowest number of matches (asc). This parameter is ignored unless you provide sort.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page (max 100).
+      default: null
+    page:
+      type: int | None
+      description: The page number of the results to fetch.
       default: null
     base_url:
       type: str
@@ -29,5 +44,10 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        q: ${{ inputs.q }}
+        sort: ${{ inputs.sort }}
+        order: ${{ inputs.order }}
+        per_page: ${{ inputs.per_page }}
+        page: ${{ inputs.page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/disable_vulnerability_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/disable_vulnerability_alerts.yml
@@ -17,14 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -39,6 +31,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
-      payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/enable_vulnerability_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/enable_vulnerability_alerts.yml
@@ -17,14 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -39,6 +31,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
-      payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_code_scanning_alert.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_code_scanning_alert.yml
@@ -20,10 +20,6 @@ definition:
     alert_number:
       type: int
       description: GitHub API path value for alert_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,5 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_code_scanning_default_setup.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_code_scanning_default_setup.yml
@@ -17,10 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -35,5 +31,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_dependabot_alert.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_dependabot_alert.yml
@@ -20,10 +20,6 @@ definition:
     alert_number:
       type: int
       description: GitHub API path value for alert_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,5 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_repository_sbom.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_repository_sbom.yml
@@ -17,10 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -35,5 +31,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_secret_scanning_alert.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_secret_scanning_alert.yml
@@ -20,9 +20,9 @@ definition:
     alert_number:
       type: int
       description: GitHub API path value for alert_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    hide_secret:
+      type: bool | None
+      description: "A boolean value representing whether or not to hide literal secrets in the results. Default: `false`."
       default: null
     base_url:
       type: str
@@ -38,5 +38,6 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        hide_secret: ${{ inputs.hide_secret }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_vulnerability_alert_status.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/get_vulnerability_alert_status.yml
@@ -17,10 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -35,7 +31,6 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       ignore_status_codes:
       - 404
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_code_scanning_alert_instances.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_code_scanning_alert_instances.yml
@@ -20,9 +20,21 @@ definition:
     alert_number:
       type: int
       description: GitHub API path value for alert_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: "The page number of the results to fetch. Default: `1`."
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
+      default: null
+    ref:
+      type: str | None
+      description: The Git reference for the results you want to list. The `ref` for a branch can be formatted either as `refs/heads/<branch name>` or simply `<branch name>`. To reference a pull request use `refs/pull/<number>/merge`.
+      default: null
+    pr:
+      type: int | None
+      description: The number of the pull request for the results you want to list.
       default: null
     base_url:
       type: str
@@ -38,5 +50,9 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        page: ${{ inputs.page }}
+        per_page: ${{ inputs.per_page }}
+        ref: ${{ inputs.ref }}
+        pr: ${{ inputs.pr }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_org_code_scanning_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_org_code_scanning_alerts.yml
@@ -14,9 +14,49 @@ definition:
     org:
       type: str
       description: GitHub API path value for org.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    tool_name:
+      type: str | None
+      description: The name of a code scanning tool. Only results by this tool will be listed. You can specify the tool by using either `tool_name` or `tool_guid`, but not both.
+      default: null
+    tool_guid:
+      type: str | None
+      description: The GUID of a code scanning tool. Only results by this tool will be listed. Note that some code scanning tools may not include a GUID in their analysis data. You can specify the tool by using either `tool_guid` or `tool_name`, but not both.
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+      default: null
+    page:
+      type: int | None
+      description: "The page number of the results to fetch. Default: `1`."
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
+      default: null
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    state:
+      type: str | None
+      description: "If specified, only code scanning alerts with this state will be returned. Can be one of: `open`, `closed`, `dismissed`, `fixed`."
+      default: null
+    sort:
+      type: str | None
+      description: "The property by which to sort the results. Default: `created`. Can be one of: `created`, `updated`."
+      default: null
+    severity:
+      type: str | None
+      description: "If specified, only code scanning alerts with this severity will be returned. Can be one of: `critical`, `high`, `medium`, `low`, `warning`, `note`, `error`."
+      default: null
+    assignees:
+      type: str | None
+      description: Filter alerts by assignees. Provide a comma-separated list of user handles (e.g., `octocat` or `octocat,hubot`). Use `*` to list alerts with at least one assignee or `none` to list alerts with no assignees.
       default: null
     base_url:
       type: str
@@ -32,5 +72,16 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        tool_name: ${{ inputs.tool_name }}
+        tool_guid: ${{ inputs.tool_guid }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        page: ${{ inputs.page }}
+        per_page: ${{ inputs.per_page }}
+        direction: ${{ inputs.direction }}
+        state: ${{ inputs.state }}
+        sort: ${{ inputs.sort }}
+        severity: ${{ inputs.severity }}
+        assignees: ${{ inputs.assignees }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_org_dependabot_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_org_dependabot_alerts.yml
@@ -14,9 +14,77 @@ definition:
     org:
       type: str
       description: GitHub API path value for org.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    classification:
+      type: str | None
+      description: "A comma-separated list of vulnerability classifications. If specified, only alerts for vulnerabilities with these classifications will be returned. Can be: `malware`, `general`"
+      default: null
+    state:
+      type: str | None
+      description: "A comma-separated list of states. If specified, only alerts with these states will be returned. Can be: `auto_dismissed`, `dismissed`, `fixed`, `open`"
+      default: null
+    severity:
+      type: str | None
+      description: "A comma-separated list of severities. If specified, only alerts with these severities will be returned. Can be: `low`, `medium`, `high`, `critical`"
+      default: null
+    ecosystem:
+      type: str | None
+      description: "A comma-separated list of ecosystems. If specified, only alerts for these ecosystems will be returned. Can be: `composer`, `go`, `maven`, `npm`, `nuget`, `pip`, `pub`, `rubygems`, `rust`"
+      default: null
+    package:
+      type: str | None
+      description: A comma-separated list of package names. If specified, only alerts for these packages will be returned.
+      default: null
+    epss_percentage:
+      type: str | None
+      description: "CVE Exploit Prediction Scoring System (EPSS) percentage. Can be specified as: - An exact number (`n`) - Comparators such as `>n`, `<n`, `>=n`, `<=n` - A range like `n..n`, where `n` is a number from 0.0 to 1.0 Filters the list of alerts based on EPSS percentages. If specified, only alerts with the provided EPSS percentages will be returned."
+      default: null
+    artifact_registry_url:
+      type: str | None
+      description: A comma-separated list of artifact registry URLs. If specified, only alerts for repositories with storage records matching these URLs will be returned.
+      default: null
+    artifact_registry:
+      type: str | None
+      description: "A comma-separated list of Artifact Registry name strings. If specified, only alerts for repositories with storage records matching these registries will be returned. Can be: `jfrog-artifactory`"
+      default: null
+    has:
+      type: list[str] | None
+      description: Filters the list of alerts based on whether the alert has the given value. If specified, only alerts meeting this criterion will be returned. Multiple `has` filters can be passed to filter for alerts that have all of the values.
+      default: null
+    assignee:
+      type: str | None
+      description: Filter alerts by assignees. Provide a comma-separated list of user handles (e.g., `octocat` or `octocat,hubot`) to return alerts assigned to any of the specified users. Use `*` to list alerts with at least one assignee or `none` to list alerts with no assignees.
+      default: null
+    runtime_risk:
+      type: str | None
+      description: "A comma-separated list of runtime risk strings. If specified, only alerts for repositories with deployment records matching these risks will be returned. Can be: `critical-resource`, `internet-exposed`, `sensitive-data`, `lateral-movement`"
+      default: null
+    scope:
+      type: str | None
+      description: "The scope of the vulnerable dependency. If specified, only alerts with this scope will be returned. Can be one of: `development`, `runtime`."
+      default: null
+    relationship:
+      type: str | None
+      description: A comma-separated list of relationships of the vulnerable dependency to your project. If specified, only alerts with these relationships will be returned. We are rolling out support for dependency relationship across ecosystems. This value will be "unknown" for all dependencies in unsupported ecosystems.
+      default: null
+    sort:
+      type: str | None
+      description: "The property by which to sort the results. `created` means when the alert was created. `updated` means when the alert's state last changed. `epss_percentage` sorts alerts by the Exploit Prediction Scoring System (EPSS) percentage. Default: `created`."
+      default: null
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
       default: null
     base_url:
       type: str
@@ -32,5 +100,23 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        classification: ${{ inputs.classification }}
+        state: ${{ inputs.state }}
+        severity: ${{ inputs.severity }}
+        ecosystem: ${{ inputs.ecosystem }}
+        package: ${{ inputs.package }}
+        epss_percentage: ${{ inputs.epss_percentage }}
+        artifact_registry_url: ${{ inputs.artifact_registry_url }}
+        artifact_registry: ${{ inputs.artifact_registry }}
+        has: ${{ inputs.has }}
+        assignee: ${{ inputs.assignee }}
+        runtime_risk: ${{ inputs.runtime_risk }}
+        scope: ${{ inputs.scope }}
+        relationship: ${{ inputs.relationship }}
+        sort: ${{ inputs.sort }}
+        direction: ${{ inputs.direction }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_org_secret_scanning_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_org_secret_scanning_alerts.yml
@@ -14,9 +14,85 @@ definition:
     org:
       type: str
       description: GitHub API path value for org.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    state:
+      type: str | None
+      description: Set to `open` or `resolved` to only list secret scanning alerts in a specific state.
+      default: null
+    secret_type:
+      type: str | None
+      description: A comma-separated list of secret types to return. All default secret patterns are returned. To return generic patterns, pass the token name(s) in the parameter. See "Supported secret scanning patterns" for a complete list of secret types.
+      default: null
+    exclude_secret_types:
+      type: str | None
+      description: A comma-separated list of secret types to exclude from the results. All default secret patterns are returned except those matching the specified types. Cannot be combined with the `secret_type` parameter. See "Supported secret scanning patterns" for a complete list of secret types.
+      default: null
+    exclude_providers:
+      type: str | None
+      description: A comma-separated list of provider slugs to exclude from the results. Provider slugs use lowercase with underscores (e.g., `github_secret_scanning`, `clojars`). You can find the provider slug in the `provider_slug` field of each alert. Cannot be combined with the `providers` parameter.
+      default: null
+    providers:
+      type: str | None
+      description: A comma-separated list of provider slugs to filter by. Provider slugs use lowercase with underscores (e.g., `github_secret_scanning`, `clojars`). You can find the provider slug in the `provider_slug` field of each alert. Cannot be combined with the `exclude_providers` parameter.
+      default: null
+    resolution:
+      type: str | None
+      description: A comma-separated list of resolutions. Only secret scanning alerts with one of these resolutions are listed. Valid resolutions are `false_positive`, `wont_fix`, `revoked`, `pattern_edited`, `pattern_deleted` or `used_in_tests`.
+      default: null
+    assignee:
+      type: str | None
+      description: Filters alerts by assignee. Use `*` to get all assigned alerts, `none` to get all unassigned alerts, or a GitHub username to get alerts assigned to a specific user.
+      default: null
+    sort:
+      type: str | None
+      description: "The property to sort the results by. `created` means when the alert was created. `updated` means when the alert was updated or resolved. Default: `created`."
+      default: null
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    page:
+      type: int | None
+      description: "The page number of the results to fetch. Default: `1`."
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for events before this cursor. To receive an initial cursor on your first request, include an empty "before" query string.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for events after this cursor. To receive an initial cursor on your first request, include an empty "after" query string.
+      default: null
+    validity:
+      type: str | None
+      description: A comma-separated list of validities that, when present, will return alerts that match the validities in this list. Valid options are `active`, `inactive`, and `unknown`.
+      default: null
+    is_publicly_leaked:
+      type: bool | None
+      description: "A boolean value representing whether or not to filter alerts by the publicly-leaked tag being present. Default: `false`."
+      default: null
+    is_multi_repo:
+      type: bool | None
+      description: "A boolean value representing whether or not to filter alerts by the multi-repo tag being present. Default: `false`."
+      default: null
+    hide_secret:
+      type: bool | None
+      description: "A boolean value representing whether or not to hide literal secrets in the results. Default: `false`."
+      default: null
+    is_bypassed:
+      type: bool | None
+      description: A boolean value (`true` or `false`) indicating whether to filter alerts by their push protection bypass status. When set to `true`, only alerts that were created because a push protection rule was bypassed will be returned. When set to `false`, only alerts that were not caused by a push protection bypass will be returned.
+      default: null
+    included_metadata:
+      type: str | None
+      description: "A comma-separated list of metadata fields to filter alerts by. Only alerts that have all of the specified metadata fields attached will be returned. Possible values are: `owner-email`, `owner-id`, `owner-name`, `secret-id`, `secret-name`, `secret-issued-date`, `secret-expiration-date`, `organization-name`, `organization-id`, `last-used-date`, and `has-organization-access`."
+      default: null
+    owner_email_hash:
+      type: str | None
+      description: Filters alerts to only those whose attached `owner_email` metadata field matches the provided value. The value must be the lowercase hex-encoded SHA-256 hash of the email address to match (for example, the SHA-256 of `user@example.com`). Only alerts that have an `owner_email` metadata value whose SHA-256 hash equals this parameter are returned.
       default: null
     base_url:
       type: str
@@ -32,5 +108,25 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        state: ${{ inputs.state }}
+        secret_type: ${{ inputs.secret_type }}
+        exclude_secret_types: ${{ inputs.exclude_secret_types }}
+        exclude_providers: ${{ inputs.exclude_providers }}
+        providers: ${{ inputs.providers }}
+        resolution: ${{ inputs.resolution }}
+        assignee: ${{ inputs.assignee }}
+        sort: ${{ inputs.sort }}
+        direction: ${{ inputs.direction }}
+        page: ${{ inputs.page }}
+        per_page: ${{ inputs.per_page }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        validity: ${{ inputs.validity }}
+        is_publicly_leaked: ${{ inputs.is_publicly_leaked }}
+        is_multi_repo: ${{ inputs.is_multi_repo }}
+        hide_secret: ${{ inputs.hide_secret }}
+        is_bypassed: ${{ inputs.is_bypassed }}
+        included_metadata: ${{ inputs.included_metadata }}
+        owner_email_hash: ${{ inputs.owner_email_hash }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_repo_code_scanning_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_repo_code_scanning_alerts.yml
@@ -17,9 +17,57 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    tool_name:
+      type: str | None
+      description: The name of a code scanning tool. Only results by this tool will be listed. You can specify the tool by using either `tool_name` or `tool_guid`, but not both.
+      default: null
+    tool_guid:
+      type: str | None
+      description: The GUID of a code scanning tool. Only results by this tool will be listed. Note that some code scanning tools may not include a GUID in their analysis data. You can specify the tool by using either `tool_guid` or `tool_name`, but not both.
+      default: null
+    page:
+      type: int | None
+      description: "The page number of the results to fetch. Default: `1`."
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
+      default: null
+    ref:
+      type: str | None
+      description: The Git reference for the results you want to list. The `ref` for a branch can be formatted either as `refs/heads/<branch name>` or simply `<branch name>`. To reference a pull request use `refs/pull/<number>/merge`.
+      default: null
+    pr:
+      type: int | None
+      description: The number of the pull request for the results you want to list.
+      default: null
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+      default: null
+    sort:
+      type: str | None
+      description: "The property by which to sort the results. Default: `created`. Can be one of: `created`, `updated`."
+      default: null
+    state:
+      type: str | None
+      description: "If specified, only code scanning alerts with this state will be returned. Can be one of: `open`, `closed`, `dismissed`, `fixed`."
+      default: null
+    severity:
+      type: str | None
+      description: "If specified, only code scanning alerts with this severity will be returned. Can be one of: `critical`, `high`, `medium`, `low`, `warning`, `note`, `error`."
+      default: null
+    assignees:
+      type: str | None
+      description: Filter alerts by assignees. Provide a comma-separated list of user handles (e.g., `octocat` or `octocat,hubot`). Use `*` to list alerts with at least one assignee or `none` to list alerts with no assignees.
       default: null
     base_url:
       type: str
@@ -35,5 +83,18 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        tool_name: ${{ inputs.tool_name }}
+        tool_guid: ${{ inputs.tool_guid }}
+        page: ${{ inputs.page }}
+        per_page: ${{ inputs.per_page }}
+        ref: ${{ inputs.ref }}
+        pr: ${{ inputs.pr }}
+        direction: ${{ inputs.direction }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        sort: ${{ inputs.sort }}
+        state: ${{ inputs.state }}
+        severity: ${{ inputs.severity }}
+        assignees: ${{ inputs.assignees }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_repo_dependabot_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_repo_dependabot_alerts.yml
@@ -17,9 +17,69 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    classification:
+      type: str | None
+      description: "A comma-separated list of vulnerability classifications. If specified, only alerts for vulnerabilities with these classifications will be returned. Can be: `malware`, `general`"
+      default: null
+    state:
+      type: str | None
+      description: "A comma-separated list of states. If specified, only alerts with these states will be returned. Can be: `auto_dismissed`, `dismissed`, `fixed`, `open`"
+      default: null
+    severity:
+      type: str | None
+      description: "A comma-separated list of severities. If specified, only alerts with these severities will be returned. Can be: `low`, `medium`, `high`, `critical`"
+      default: null
+    ecosystem:
+      type: str | None
+      description: "A comma-separated list of ecosystems. If specified, only alerts for these ecosystems will be returned. Can be: `composer`, `go`, `maven`, `npm`, `nuget`, `pip`, `pub`, `rubygems`, `rust`"
+      default: null
+    package:
+      type: str | None
+      description: A comma-separated list of package names. If specified, only alerts for these packages will be returned.
+      default: null
+    manifest:
+      type: str | None
+      description: A comma-separated list of full manifest paths. If specified, only alerts for these manifests will be returned.
+      default: null
+    epss_percentage:
+      type: str | None
+      description: "CVE Exploit Prediction Scoring System (EPSS) percentage. Can be specified as: - An exact number (`n`) - Comparators such as `>n`, `<n`, `>=n`, `<=n` - A range like `n..n`, where `n` is a number from 0.0 to 1.0 Filters the list of alerts based on EPSS percentages. If specified, only alerts with the provided EPSS percentages will be returned."
+      default: null
+    has:
+      type: list[str] | None
+      description: Filters the list of alerts based on whether the alert has the given value. If specified, only alerts meeting this criterion will be returned. Multiple `has` filters can be passed to filter for alerts that have all of the values. Currently, only `patch` is supported.
+      default: null
+    assignee:
+      type: str | None
+      description: Filter alerts by assignees. Provide a comma-separated list of user handles (e.g., `octocat` or `octocat,hubot`) to return alerts assigned to any of the specified users. Use `*` to list alerts with at least one assignee or `none` to list alerts with no assignees.
+      default: null
+    scope:
+      type: str | None
+      description: "The scope of the vulnerable dependency. If specified, only alerts with this scope will be returned. Can be one of: `development`, `runtime`."
+      default: null
+    relationship:
+      type: str | None
+      description: A comma-separated list of relationships of the vulnerable dependency to your project. If specified, only alerts with these relationships will be returned. We are rolling out support for dependency relationship across ecosystems. This value will be "unknown" for all dependencies in unsupported ecosystems.
+      default: null
+    sort:
+      type: str | None
+      description: "The property by which to sort the results. `created` means when the alert was created. `updated` means when the alert's state last changed. `epss_percentage` sorts alerts by the Exploit Prediction Scoring System (EPSS) percentage. Default: `created`."
+      default: null
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
       default: null
     base_url:
       type: str
@@ -35,5 +95,21 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        classification: ${{ inputs.classification }}
+        state: ${{ inputs.state }}
+        severity: ${{ inputs.severity }}
+        ecosystem: ${{ inputs.ecosystem }}
+        package: ${{ inputs.package }}
+        manifest: ${{ inputs.manifest }}
+        epss_percentage: ${{ inputs.epss_percentage }}
+        has: ${{ inputs.has }}
+        assignee: ${{ inputs.assignee }}
+        scope: ${{ inputs.scope }}
+        relationship: ${{ inputs.relationship }}
+        sort: ${{ inputs.sort }}
+        direction: ${{ inputs.direction }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_repo_secret_scanning_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_repo_secret_scanning_alerts.yml
@@ -17,9 +17,85 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    state:
+      type: str | None
+      description: Set to `open` or `resolved` to only list secret scanning alerts in a specific state.
+      default: null
+    secret_type:
+      type: str | None
+      description: A comma-separated list of secret types to return. All default secret patterns are returned. To return generic patterns, pass the token name(s) in the parameter. See "Supported secret scanning patterns" for a complete list of secret types.
+      default: null
+    exclude_secret_types:
+      type: str | None
+      description: A comma-separated list of secret types to exclude from the results. All default secret patterns are returned except those matching the specified types. Cannot be combined with the `secret_type` parameter. See "Supported secret scanning patterns" for a complete list of secret types.
+      default: null
+    exclude_providers:
+      type: str | None
+      description: A comma-separated list of provider slugs to exclude from the results. Provider slugs use lowercase with underscores (e.g., `github_secret_scanning`, `clojars`). You can find the provider slug in the `provider_slug` field of each alert. Cannot be combined with the `providers` parameter.
+      default: null
+    providers:
+      type: str | None
+      description: A comma-separated list of provider slugs to filter by. Provider slugs use lowercase with underscores (e.g., `github_secret_scanning`, `clojars`). You can find the provider slug in the `provider_slug` field of each alert. Cannot be combined with the `exclude_providers` parameter.
+      default: null
+    resolution:
+      type: str | None
+      description: A comma-separated list of resolutions. Only secret scanning alerts with one of these resolutions are listed. Valid resolutions are `false_positive`, `wont_fix`, `revoked`, `pattern_edited`, `pattern_deleted` or `used_in_tests`.
+      default: null
+    assignee:
+      type: str | None
+      description: Filters alerts by assignee. Use `*` to get all assigned alerts, `none` to get all unassigned alerts, or a GitHub username to get alerts assigned to a specific user.
+      default: null
+    sort:
+      type: str | None
+      description: "The property to sort the results by. `created` means when the alert was created. `updated` means when the alert was updated or resolved. Default: `created`."
+      default: null
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    page:
+      type: int | None
+      description: "The page number of the results to fetch. Default: `1`."
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for events before this cursor. To receive an initial cursor on your first request, include an empty "before" query string.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for events after this cursor. To receive an initial cursor on your first request, include an empty "after" query string.
+      default: null
+    validity:
+      type: str | None
+      description: A comma-separated list of validities that, when present, will return alerts that match the validities in this list. Valid options are `active`, `inactive`, and `unknown`.
+      default: null
+    is_publicly_leaked:
+      type: bool | None
+      description: "A boolean value representing whether or not to filter alerts by the publicly-leaked tag being present. Default: `false`."
+      default: null
+    is_multi_repo:
+      type: bool | None
+      description: "A boolean value representing whether or not to filter alerts by the multi-repo tag being present. Default: `false`."
+      default: null
+    hide_secret:
+      type: bool | None
+      description: "A boolean value representing whether or not to hide literal secrets in the results. Default: `false`."
+      default: null
+    is_bypassed:
+      type: bool | None
+      description: A boolean value (`true` or `false`) indicating whether to filter alerts by their push protection bypass status. When set to `true`, only alerts that were created because a push protection rule was bypassed will be returned. When set to `false`, only alerts that were not caused by a push protection bypass will be returned.
+      default: null
+    included_metadata:
+      type: str | None
+      description: "A comma-separated list of metadata fields to filter alerts by. Only alerts that have all of the specified metadata fields attached will be returned. Possible values are: `owner-email`, `owner-id`, `owner-name`, `secret-id`, `secret-name`, `secret-issued-date`, `secret-expiration-date`, `organization-name`, `organization-id`, `last-used-date`, and `has-organization-access`."
+      default: null
+    owner_email_hash:
+      type: str | None
+      description: Filters alerts to only those whose attached `owner_email` metadata field matches the provided value. The value must be the lowercase hex-encoded SHA-256 hash of the email address to match (for example, the SHA-256 of `user@example.com`). Only alerts that have an `owner_email` metadata value whose SHA-256 hash equals this parameter are returned.
       default: null
     base_url:
       type: str
@@ -35,5 +111,25 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        state: ${{ inputs.state }}
+        secret_type: ${{ inputs.secret_type }}
+        exclude_secret_types: ${{ inputs.exclude_secret_types }}
+        exclude_providers: ${{ inputs.exclude_providers }}
+        providers: ${{ inputs.providers }}
+        resolution: ${{ inputs.resolution }}
+        assignee: ${{ inputs.assignee }}
+        sort: ${{ inputs.sort }}
+        direction: ${{ inputs.direction }}
+        page: ${{ inputs.page }}
+        per_page: ${{ inputs.per_page }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        validity: ${{ inputs.validity }}
+        is_publicly_leaked: ${{ inputs.is_publicly_leaked }}
+        is_multi_repo: ${{ inputs.is_multi_repo }}
+        hide_secret: ${{ inputs.hide_secret }}
+        is_bypassed: ${{ inputs.is_bypassed }}
+        included_metadata: ${{ inputs.included_metadata }}
+        owner_email_hash: ${{ inputs.owner_email_hash }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_secret_scanning_alert_locations.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/list_secret_scanning_alert_locations.yml
@@ -20,9 +20,13 @@ definition:
     alert_number:
       type: int
       description: GitHub API path value for alert_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: "The page number of the results to fetch. Default: `1`."
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
       default: null
     base_url:
       type: str
@@ -38,5 +42,7 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        page: ${{ inputs.page }}
+        per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/update_code_scanning_alert.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/update_code_scanning_alert.yml
@@ -20,13 +20,12 @@ definition:
     alert_number:
       type: int
       description: GitHub API path value for alert_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: assignees, create_request, dismissed_comment, dismissed_reason, state.
       default: null
     base_url:
       type: str
@@ -42,6 +41,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/update_code_scanning_default_setup.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/update_code_scanning_default_setup.yml
@@ -17,13 +17,12 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: languages, query_suite, runner_label, runner_type, state, threat_model.
       default: null
     base_url:
       type: str
@@ -39,6 +38,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/update_dependabot_alert.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/update_dependabot_alert.yml
@@ -20,13 +20,12 @@ definition:
     alert_number:
       type: int
       description: GitHub API path value for alert_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: agent_assignment, assignees, dismissed_comment, dismissed_reason, state.
       default: null
     base_url:
       type: str
@@ -42,6 +41,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/update_secret_scanning_alert.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security/update_secret_scanning_alert.yml
@@ -20,13 +20,12 @@ definition:
     alert_number:
       type: int
       description: GitHub API path value for alert_number.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: assignee, resolution, resolution_comment, state, validity.
       default: null
     base_url:
       type: str
@@ -42,6 +41,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/create_repository_security_advisory.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/create_repository_security_advisory.yml
@@ -17,13 +17,12 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: description (required), summary (required), vulnerabilities (required), credits, cve_id, cvss_vector_string, cwe_ids, severity, start_private_fork.
       default: null
     base_url:
       type: str
@@ -39,6 +38,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/create_security_advisory_fork.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/create_security_advisory_fork.yml
@@ -20,14 +20,6 @@ definition:
     ghsa_id:
       type: str
       description: GitHub API path value for ghsa_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -42,6 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
-      payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/disable_private_vulnerability_reporting.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/disable_private_vulnerability_reporting.yml
@@ -17,14 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -39,6 +31,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
-      payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/enable_private_vulnerability_reporting.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/enable_private_vulnerability_reporting.yml
@@ -17,14 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -39,6 +31,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
-      payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/get_global_security_advisory.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/get_global_security_advisory.yml
@@ -14,10 +14,6 @@ definition:
     ghsa_id:
       type: str
       description: GitHub API path value for ghsa_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -32,5 +28,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/get_private_vulnerability_reporting.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/get_private_vulnerability_reporting.yml
@@ -17,10 +17,6 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -35,5 +31,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/get_repo_security_advisory.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/get_repo_security_advisory.yml
@@ -20,10 +20,6 @@ definition:
     ghsa_id:
       type: str
       description: GitHub API path value for ghsa_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -38,5 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/list_global_security_advisories.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/list_global_security_advisories.yml
@@ -11,9 +11,77 @@ definition:
     provider_id: github
     grant_type: authorization_code
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    ghsa_id:
+      type: str | None
+      description: If specified, only advisories with this GHSA (GitHub Security Advisory) identifier will be returned.
+      default: null
+    type:
+      type: str | None
+      description: "If specified, only advisories of this type will be returned. By default, a request with no other parameters defined will only return reviewed advisories that are not malware. Default: `reviewed`. Can be one of: `reviewed`, `malware`, `unreviewed`."
+      default: null
+    cve_id:
+      type: str | None
+      description: If specified, only advisories with this CVE (Common Vulnerabilities and Exposures) identifier will be returned.
+      default: null
+    ecosystem:
+      type: str | None
+      description: "If specified, only advisories for these ecosystems will be returned. Can be one of: `rubygems`, `npm`, `pip`, `maven`, `nuget`, `composer`, `go`, `rust`, `erlang`, `actions`, `pub`, `other`, `swift`."
+      default: null
+    severity:
+      type: str | None
+      description: "If specified, only advisories with these severities will be returned. Can be one of: `unknown`, `low`, `medium`, `high`, `critical`."
+      default: null
+    cwes:
+      type: str | None
+      description: "If specified, only advisories with these Common Weakness Enumerations (CWEs) will be returned. Example: `cwes=79,284,22` or `cwes[]=79&cwes[]=284&cwes[]=22`"
+      default: null
+    is_withdrawn:
+      type: bool | None
+      description: Whether to only return advisories that have been withdrawn.
+      default: null
+    affects:
+      type: str | None
+      description: "If specified, only return advisories that affect any of `package` or `package@version`. A maximum of 1000 packages can be specified. If the query parameter causes the URL to exceed the maximum URL length supported by your client, you must specify fewer packages. Example: `affects=package1,package2@1.0.0,package3@2.0.0` or `affects[]=package1&affects[]=package2@1.0.0`"
+      default: null
+    published:
+      type: str | None
+      description: If specified, only return advisories that were published on a date or date range.
+      default: null
+    updated:
+      type: str | None
+      description: If specified, only return advisories that were updated on a date or date range.
+      default: null
+    modified:
+      type: str | None
+      description: If specified, only show advisories that were updated or published on a date or date range.
+      default: null
+    epss_percentage:
+      type: str | None
+      description: If specified, only return advisories that have an EPSS percentage score that matches the provided value. The EPSS percentage represents the likelihood of a CVE being exploited.
+      default: null
+    epss_percentile:
+      type: str | None
+      description: If specified, only return advisories that have an EPSS percentile score that matches the provided value. The EPSS percentile represents the relative rank of the CVE's likelihood of being exploited compared to other CVEs.
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+      default: null
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of results per page (max 100). Default: `30`."
+      default: null
+    sort:
+      type: str | None
+      description: "The property to sort the results by. Default: `published`. Can be one of: `updated`, `published`, `epss_percentage`, `epss_percentile`."
       default: null
     base_url:
       type: str
@@ -29,5 +97,23 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        ghsa_id: ${{ inputs.ghsa_id }}
+        type: ${{ inputs.type }}
+        cve_id: ${{ inputs.cve_id }}
+        ecosystem: ${{ inputs.ecosystem }}
+        severity: ${{ inputs.severity }}
+        cwes: ${{ inputs.cwes }}
+        is_withdrawn: ${{ inputs.is_withdrawn }}
+        affects: ${{ inputs.affects }}
+        published: ${{ inputs.published }}
+        updated: ${{ inputs.updated }}
+        modified: ${{ inputs.modified }}
+        epss_percentage: ${{ inputs.epss_percentage }}
+        epss_percentile: ${{ inputs.epss_percentile }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        direction: ${{ inputs.direction }}
+        per_page: ${{ inputs.per_page }}
+        sort: ${{ inputs.sort }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/list_organization_security_advisories.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/list_organization_security_advisories.yml
@@ -14,9 +14,29 @@ definition:
     org:
       type: str
       description: GitHub API path value for org.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    sort:
+      type: str | None
+      description: "The property to sort the results by. Default: `created`. Can be one of: `created`, `updated`, `published`."
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of advisories to return per page. Default: `30`."
+      default: null
+    state:
+      type: str | None
+      description: "Filter by the state of the repository advisories. Only advisories of this state will be returned. Can be one of: `triage`, `draft`, `published`, `closed`."
       default: null
     base_url:
       type: str
@@ -32,5 +52,11 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        direction: ${{ inputs.direction }}
+        sort: ${{ inputs.sort }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        per_page: ${{ inputs.per_page }}
+        state: ${{ inputs.state }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/list_repo_security_advisories.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/list_repo_security_advisories.yml
@@ -17,9 +17,29 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    direction:
+      type: str | None
+      description: "The direction to sort the results by. Default: `desc`. Can be one of: `asc`, `desc`."
+      default: null
+    sort:
+      type: str | None
+      description: "The property to sort the results by. Default: `created`. Can be one of: `created`, `updated`, `published`."
+      default: null
+    before:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results before this cursor.
+      default: null
+    after:
+      type: str | None
+      description: A cursor, as given in the Link header. If specified, the query only searches for results after this cursor.
+      default: null
+    per_page:
+      type: int | None
+      description: "The number of advisories to return per page. Default: `30`."
+      default: null
+    state:
+      type: str | None
+      description: "Filter by state of the repository advisories. Only advisories of this state will be returned. Can be one of: `triage`, `draft`, `published`, `closed`."
       default: null
     base_url:
       type: str
@@ -35,5 +55,11 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
+      params:
+        direction: ${{ inputs.direction }}
+        sort: ${{ inputs.sort }}
+        before: ${{ inputs.before }}
+        after: ${{ inputs.after }}
+        per_page: ${{ inputs.per_page }}
+        state: ${{ inputs.state }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/request_security_advisory_cve.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/request_security_advisory_cve.yml
@@ -20,14 +20,6 @@ definition:
     ghsa_id:
       type: str
       description: GitHub API path value for ghsa_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitHub.com REST API base URL.
@@ -42,6 +34,4 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
-      payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/submit_private_vulnerability_report.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/submit_private_vulnerability_report.yml
@@ -17,13 +17,12 @@ definition:
     repo:
       type: str
       description: GitHub API path value for repo.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: description (required), summary (required), cvss_vector_string, cwe_ids, severity, start_private_fork, vulnerabilities.
       default: null
     base_url:
       type: str
@@ -39,6 +38,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/update_repo_security_advisory.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/security_reports/update_repo_security_advisory.yml
@@ -20,13 +20,12 @@ definition:
     ghsa_id:
       type: str
       description: GitHub API path value for ghsa_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: collaborating_teams, collaborating_users, credits, cve_id, cvss_vector_string, cwe_ids, description, severity, state, summary, vulnerabilities.
       default: null
     base_url:
       type: str
@@ -42,6 +41,5 @@ definition:
         Authorization: Bearer ${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}
         Accept: application/vnd.github+json
         X-GitHub-Api-Version: '2022-11-28'
-      params: ${{ inputs.params }}
       payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/cancel_pipeline.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/cancel_pipeline.yml
@@ -18,14 +18,6 @@ definition:
     pipeline_id:
       type: int
       description: GitLab API path value for pipeline_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -39,6 +31,4 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/create_pipeline.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/create_pipeline.yml
@@ -15,13 +15,16 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    ref:
+      type: str
+      description: The branch or tag to run the pipeline on. For merge request pipelines use the merge requests endpoint.
+    variables:
+      type: list[dict[str, Any]] | None
+      description: "An array of hashes containing the variables available in the pipeline, matching the structure `[{ 'key': 'UPLOAD_TO_S3', 'variable_type': 'file', 'value': 'true' }, {'key': 'TEST', 'value': 'test variable'}]`. If `variable_type` is excluded, it defaults to `env_var`."
       default: null
-    payload:
+    inputs:
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: A hash containing the inputs, as key-value pairs, to use when creating the pipeline.
       default: null
     base_url:
       type: str
@@ -36,6 +39,8 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
+        payload:
+          ref: ${{ inputs.ref }}
+          variables: ${{ inputs.variables }}
+          inputs: ${{ inputs.inputs }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/delete_pipeline.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/delete_pipeline.yml
@@ -18,14 +18,6 @@ definition:
     pipeline_id:
       type: int
       description: GitLab API path value for pipeline_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -39,6 +31,4 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/get_job_trace.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/get_job_trace.yml
@@ -18,9 +18,13 @@ definition:
     job_id:
       type: int
       description: GitLab API path value for job_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    byte_offset:
+      type: int | None
+      description: Byte offset to start reading from.
+      default: null
+    byte_limit:
+      type: int | None
+      description: Maximum number of bytes to return.
       default: null
     base_url:
       type: str
@@ -35,6 +39,8 @@ definition:
         headers:
           Authorization: Bearer ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: text/plain
-        params: ${{ inputs.params }}
+        params:
+          byte_offset: ${{ inputs.byte_offset }}
+          byte_limit: ${{ inputs.byte_limit }}
         follow_redirects: true
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/list_pipeline_jobs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/list_pipeline_jobs.yml
@@ -23,7 +23,7 @@ definition:
       description: Include retried jobs in the response. Defaults to `false`.
       default: null
     scope:
-      type: str | None
+      type: list[str] | None
       description: "Scope of jobs to show, as one of the job status values: `created`, `waiting_for_resource`, `preparing`, `waiting_for_callback`, `pending`, `running`, `success`, `failed`, `canceling`, `canceled`, `skipped`, `manual`, or `scheduled`. All jobs are returned if `scope` is not provided."
       default: null
     page:
@@ -49,7 +49,7 @@ definition:
           Accept: application/json
         params:
           include_retried: ${{ inputs.include_retried }}
-          scope: ${{ inputs.scope }}
+          scope[]: ${{ inputs.scope }}
           page: ${{ inputs.page }}
           per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/list_pipeline_jobs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/list_pipeline_jobs.yml
@@ -18,9 +18,21 @@ definition:
     pipeline_id:
       type: int
       description: GitLab API path value for pipeline_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    include_retried:
+      type: bool | None
+      description: Include retried jobs in the response. Defaults to `false`.
+      default: null
+    scope:
+      type: str | None
+      description: "Scope of jobs to show, as one of the job status values: `created`, `waiting_for_resource`, `preparing`, `waiting_for_callback`, `pending`, `running`, `success`, `failed`, `canceling`, `canceled`, `skipped`, `manual`, or `scheduled`. All jobs are returned if `scope` is not provided."
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -35,5 +47,9 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          include_retried: ${{ inputs.include_retried }}
+          scope: ${{ inputs.scope }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/list_pipelines.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/list_pipelines.yml
@@ -15,9 +15,69 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    name:
+      type: str | None
+      description: Return pipelines with the specified name.
+      default: null
+    order_by:
+      type: str | None
+      description: "The field to order pipelines by: `id`, `status`, `ref`, `updated_at`, or `user_id` (default: `id`)."
+      default: null
+    ref:
+      type: str | None
+      description: Return pipelines for the specified branch or tag.
+      default: null
+    scope:
+      type: str | None
+      description: "Return pipelines in the specified scope: `running`, `pending`, `finished`, `branches`, or `tags`."
+      default: null
+    sha:
+      type: str | None
+      description: Return pipelines for the specified commit SHA.
+      default: null
+    sort:
+      type: str | None
+      description: "The sort order: `asc` or `desc` (default: `desc`)."
+      default: null
+    source:
+      type: str | None
+      description: Return pipelines with the specified source.
+      default: null
+    status:
+      type: str | None
+      description: "Return pipelines with the specified status: `created`, `waiting_for_resource`, `preparing`, `waiting_for_callback`, `pending`, `running`, `success`, `failed`, `canceling`, `canceled`, `skipped`, `manual`, or `scheduled`."
+      default: null
+    updated_after:
+      type: str | None
+      description: Return pipelines updated after the specified date. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    updated_before:
+      type: str | None
+      description: Return pipelines updated before the specified date. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    created_after:
+      type: str | None
+      description: Return pipelines created after the specified date. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    created_before:
+      type: str | None
+      description: Return pipelines created before the specified date. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    username:
+      type: str | None
+      description: Return pipelines triggered by the specified username.
+      default: null
+    yaml_errors:
+      type: bool | None
+      description: Return pipelines with invalid configurations.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +92,21 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          name: ${{ inputs.name }}
+          order_by: ${{ inputs.order_by }}
+          ref: ${{ inputs.ref }}
+          scope: ${{ inputs.scope }}
+          sha: ${{ inputs.sha }}
+          sort: ${{ inputs.sort }}
+          source: ${{ inputs.source }}
+          status: ${{ inputs.status }}
+          updated_after: ${{ inputs.updated_after }}
+          updated_before: ${{ inputs.updated_before }}
+          created_after: ${{ inputs.created_after }}
+          created_before: ${{ inputs.created_before }}
+          username: ${{ inputs.username }}
+          yaml_errors: ${{ inputs.yaml_errors }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/retry_pipeline.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/cicd/retry_pipeline.yml
@@ -18,14 +18,6 @@ definition:
     pipeline_id:
       type: int
       description: GitLab API path value for pipeline_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -39,6 +31,4 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/create_commit.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/create_commit.yml
@@ -22,9 +22,10 @@ definition:
       type: str
       description: Commit message.
     actions:
-      type: list[dict[str, Any]] | None
-      description: An array of action hashes to commit as a batch. Each action hash takes `action` (one of `create`, `delete`, `move`, `update`, or `chmod`), `file_path`, and optionally `content`, `encoding`, `execute_filemode`, `last_commit_id`, and `previous_path`.
-      default: null
+      # Documented object shape; the `expects` grammar has no nested-object type,
+      # so the vendor's sub-keys are named in the description instead.
+      type: list[dict[str, Any]]
+      description: An array of action hashes to commit as a batch. Each action hash takes `action` (one of `create`, `delete`, `move`, `update`, or `chmod`), `file_path`, and optionally `content`, `encoding`, `execute_filemode`, `last_commit_id`, and `previous_path`. Pass an empty array with allow_empty to create an empty commit.
     allow_empty:
       type: bool | None
       description: When `true`, creates an empty commit. Default is `false`.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/create_commit.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/create_commit.yml
@@ -15,13 +15,47 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    branch:
+      type: str
+      description: Name of the branch to commit into. To create a new branch, also provide either `start_branch` or `start_sha`, and optionally `start_project`.
+    commit_message:
+      type: str
+      description: Commit message.
+    actions:
+      type: list[dict[str, Any]] | None
+      description: An array of action hashes to commit as a batch. Each action hash takes `action` (one of `create`, `delete`, `move`, `update`, or `chmod`), `file_path`, and optionally `content`, `encoding`, `execute_filemode`, `last_commit_id`, and `previous_path`.
       default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+    allow_empty:
+      type: bool | None
+      description: When `true`, creates an empty commit. Default is `false`.
+      default: null
+    author_email:
+      type: str | None
+      description: Specify the commit author's email address.
+      default: null
+    author_name:
+      type: str | None
+      description: Specify the commit author's name.
+      default: null
+    force:
+      type: bool | None
+      description: If `true`, overwrites `branch` with a new commit based on `start_branch` or `start_sha`, replacing the branch's existing commit history. Default is `false`.
+      default: null
+    start_branch:
+      type: str | None
+      description: Name of the branch to use as the parent for the new commit. If not provided and `start_sha` is also not provided, defaults to the value of `branch`. Mutually exclusive with `start_sha`.
+      default: null
+    start_project:
+      type: str | None
+      description: The project ID or URL-encoded path of the project to use as the source for `start_branch` or `start_sha`. Defaults to the value of `id`.
+      default: null
+    start_sha:
+      type: str | None
+      description: SHA of the commit to use as the parent for the new commit. Must be a full 40-character SHA. Mutually exclusive with `start_branch`.
+      default: null
+    stats:
+      type: bool | None
+      description: Include commit stats. Default is `true`.
       default: null
     base_url:
       type: str
@@ -36,6 +70,16 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
+        payload:
+          branch: ${{ inputs.branch }}
+          commit_message: ${{ inputs.commit_message }}
+          actions: ${{ inputs.actions }}
+          allow_empty: ${{ inputs.allow_empty }}
+          author_email: ${{ inputs.author_email }}
+          author_name: ${{ inputs.author_name }}
+          force: ${{ inputs.force }}
+          start_branch: ${{ inputs.start_branch }}
+          start_project: ${{ inputs.start_project }}
+          start_sha: ${{ inputs.start_sha }}
+          stats: ${{ inputs.stats }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/get_project.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/get_project.yml
@@ -15,9 +15,17 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    license:
+      type: bool | None
+      description: Include project license data.
+      default: null
+    statistics:
+      type: bool | None
+      description: Include project statistics. Available only to users with the Reporter, Developer, Maintainer, or Owner role.
+      default: null
+    with_custom_attributes:
+      type: bool | None
+      description: Include custom attributes in response. Administrator access.
       default: null
     base_url:
       type: str
@@ -32,5 +40,8 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          license: ${{ inputs.license }}
+          statistics: ${{ inputs.statistics }}
+          with_custom_attributes: ${{ inputs.with_custom_attributes }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/get_repository_file.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/get_repository_file.yml
@@ -18,10 +18,9 @@ definition:
     file_path:
       type: str
       description: GitLab API path value for file_path.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
+    ref:
+      type: str
+      description: Name of branch, tag, or commit. Use `HEAD` to automatically use the default branch.
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -35,5 +34,6 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          ref: ${{ inputs.ref }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/list_commits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/list_commits.yml
@@ -15,9 +15,57 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    all:
+      type: bool | None
+      description: Retrieve every commit from the repository. If `true`, the `ref_name` parameter is ignored.
+      default: null
+    author:
+      type: str | None
+      description: Search commits by commit author.
+      default: null
+    first_parent:
+      type: bool | None
+      description: If `true`, follows only the first parent commit upon seeing a merge commit.
+      default: null
+    follow:
+      type: bool | None
+      description: If `true`, follows file renames when filtering commits by `path`, and returns commits for the file even if it was renamed. If `false`, returns only commits where the file existed at its current path. Used only when `path` specifies a single file. Defaults to `true`.
+      default: null
+    order:
+      type: str | None
+      description: "List commits in order. Possible values: `default`, `topo`. Defaults to `default`, the commits are shown in reverse chronological order."
+      default: null
+    path:
+      type: str | None
+      description: The file path.
+      default: null
+    ref_name:
+      type: str | None
+      description: The name of a repository branch, tag, or revision range, or if not given the default branch.
+      default: null
+    since:
+      type: str | None
+      description: Only commits after or on this date are returned in ISO 8601 format `YYYY-MM-DDTHH:MM:SSZ`.
+      default: null
+    trailers:
+      type: bool | None
+      description: If `true`, parses and includes Git trailers for every commit.
+      default: null
+    until:
+      type: str | None
+      description: Only commits before or on this date are returned in ISO 8601 format `YYYY-MM-DDTHH:MM:SSZ`.
+      default: null
+    with_stats:
+      type: bool | None
+      description: If `true`, retrieve stats about each commit.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +80,18 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          all: ${{ inputs.all }}
+          author: ${{ inputs.author }}
+          first_parent: ${{ inputs.first_parent }}
+          follow: ${{ inputs.follow }}
+          order: ${{ inputs.order }}
+          path: ${{ inputs.path }}
+          ref_name: ${{ inputs.ref_name }}
+          since: ${{ inputs.since }}
+          trailers: ${{ inputs.trailers }}
+          until: ${{ inputs.until }}
+          with_stats: ${{ inputs.with_stats }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/list_project_wiki_pages.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/list_project_wiki_pages.yml
@@ -15,9 +15,9 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    with_content:
+      type: bool | None
+      description: Include pages' content.
       default: null
     base_url:
       type: str
@@ -32,5 +32,6 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          with_content: ${{ inputs.with_content }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/list_repository_tree.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/list_repository_tree.yml
@@ -15,9 +15,37 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    page_token:
+      type: str | None
+      description: Tree record ID at which to fetch the next page. Used only with keyset pagination.
+      default: null
+    pagination:
+      type: str | None
+      description: If `keyset`, use the keyset-based pagination method.
+      default: null
+    path:
+      type: str | None
+      description: Path inside the repository. Used to get content of subdirectories.
+      default: null
+    per_page:
+      type: int | None
+      description: Number of results to show per page. If not specified, defaults to `20`.
+      default: null
+    recursive:
+      type: bool | None
+      description: If `true`, get a recursive tree. Default is `false`.
+      default: null
+    ref:
+      type: str | None
+      description: Name of a repository branch or tag. If not specified, uses the default branch.
+      default: null
+    with_last_commit:
+      type: bool | None
+      description: If `true`, include the last commit for each tree entry. Cannot be combined with `recursive`. Default is `false`.
       default: null
     base_url:
       type: str
@@ -32,5 +60,13 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          page: ${{ inputs.page }}
+          page_token: ${{ inputs.page_token }}
+          pagination: ${{ inputs.pagination }}
+          path: ${{ inputs.path }}
+          per_page: ${{ inputs.per_page }}
+          recursive: ${{ inputs.recursive }}
+          ref: ${{ inputs.ref }}
+          with_last_commit: ${{ inputs.with_last_commit }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/search_project.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/search_project.yml
@@ -15,9 +15,59 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    scope:
+      type: str
+      description: The scope to search in. Values include `issues`, `work_items`, `merge_requests`, `milestones`, and `users`. Additional scopes are `wiki_blobs`, `commits`, `blobs`, and `notes`.
+    search:
+      type: str
+      description: The search term.
+    search_type:
+      type: str | None
+      description: The search type to use. Values include `basic`, `advanced`, and `zoekt`.
+      default: null
+    confidential:
+      type: bool | None
+      description: Filter by confidentiality. Supports `issues` and `work_items` scopes; other scopes are ignored.
+      default: null
+    regex:
+      type: bool | None
+      description: Uses regular expressions to search for code. Available for exact code search. If not set, regular expressions are used.
+      default: null
+    fields:
+      type: str | None
+      description: Array of fields you wish to search, allowed values are `title` only. Supports only `issues` and `merge_requests` scopes. Premium and Ultimate only.
+      default: null
+    num_context_lines:
+      type: int | None
+      description: Number of context lines to include around each match in the results. Available for advanced and exact code search only.
+      default: null
+    ref:
+      type: str | None
+      description: The name of a repository branch or tag to search on. The project's default branch is used by default. Applicable only for scopes `blobs`, `commits`, and `wiki_blobs`.
+      default: null
+    state:
+      type: str | None
+      description: Filter by state. Supports `issues`, `work_items`, and `merge_requests` scopes; other scopes are ignored.
+      default: null
+    type:
+      type: str | None
+      description: "Filter work items by type. Only applies to `work_items` scope. Available types: `issue`, `task`, `epic`, `incident`, `test_case`, `requirement`, `objective`, `key_result`, `ticket`."
+      default: null
+    order_by:
+      type: str | None
+      description: Allowed values are `created_at` only. If not set, results are sorted by `created_at` in descending order for basic search, or by the most relevant documents for advanced search.
+      default: null
+    sort:
+      type: str | None
+      description: Allowed values are `asc` or `desc` only. If not set, results are sorted by `created_at` in descending order for basic search, or by the most relevant documents for advanced search.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +82,19 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          scope: ${{ inputs.scope }}
+          search: ${{ inputs.search }}
+          search_type: ${{ inputs.search_type }}
+          confidential: ${{ inputs.confidential }}
+          regex: ${{ inputs.regex }}
+          fields: ${{ inputs.fields }}
+          num_context_lines: ${{ inputs.num_context_lines }}
+          ref: ${{ inputs.ref }}
+          state: ${{ inputs.state }}
+          type: ${{ inputs.type }}
+          order_by: ${{ inputs.order_by }}
+          sort: ${{ inputs.sort }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/semantic_code_search.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/code/semantic_code_search.yml
@@ -15,9 +15,20 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    q:
+      type: str
+      description: Natural language search query.
+    directory_path:
+      type: str | None
+      description: Directory path to scope the search to.
+      default: null
+    knn:
+      type: int | None
+      description: Number of nearest neighbors to consider during the vector search (1-100). Default is `64`.
+      default: null
+    limit:
+      type: int | None
+      description: Maximum number of results to return (1-100). Default is `20`.
       default: null
     base_url:
       type: str
@@ -32,5 +43,9 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          q: ${{ inputs.q }}
+          directory_path: ${{ inputs.directory_path }}
+          knn: ${{ inputs.knn }}
+          limit: ${{ inputs.limit }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/create_issue.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/create_issue.yml
@@ -15,11 +15,82 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    title:
+      type: str
+      description: The title of an issue.
+    assignee_id:
+      type: int | None
+      description: The ID of the user to assign the issue to. Only appears on GitLab Free.
+      default: null
+    assignee_ids:
+      type: str | None
+      description: The IDs of the users to assign the issue to, as a comma-separated list. Premium and Ultimate only.
+      default: null
+    confidential:
+      type: bool | None
+      description: Set an issue to be confidential. Default is `false`.
+      default: null
+    created_at:
+      type: str | None
+      description: When the issue was created. Date time string, ISO 8601 formatted, for example `2016-03-11T03:45:40Z`. Requires administrator or project/group owner rights.
+      default: null
+    description:
+      type: str | None
+      description: The description of an issue. Limited to 1,048,576 characters.
+      default: null
+    discussion_to_resolve:
+      type: str | None
+      description: The ID of a discussion to resolve. This fills out the issue with a default description and marks the discussion as resolved. Use in combination with `merge_request_to_resolve_discussions_of`.
+      default: null
+    due_date:
+      type: str | None
+      description: The due date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.
+      default: null
+    epic_id:
+      type: int | None
+      description: ID of the epic to add the issue to. Valid values are greater than or equal to 0. Premium and Ultimate only.
+      default: null
+    iid:
+      type: int | None
+      description: The internal ID of the project's issue (requires administrator or project owner rights).
+      default: null
+    issue_type:
+      type: str | None
+      description: The type of issue. One of `issue`, `incident`, `test_case` or `task`. Default is `issue`.
+      default: null
+    labels:
+      type: str | None
+      description: Comma-separated label names to assign to the new issue. If a label does not already exist, this creates a new project label and assigns it to the issue.
+      default: null
+    merge_request_to_resolve_discussions_of:
+      type: int | None
+      description: The IID of a merge request in which to resolve all issues. This fills out the issue with a default description and marks all discussions as resolved. When passing a description or title, these values take precedence over the default values.
+      default: null
+    milestone_id:
+      type: int | None
+      description: The global ID of a milestone to assign issue. Mutually exclusive with `milestone`.
+      default: null
+    milestone:
+      type: str | None
+      description: The title of a project or ancestor-group milestone to assign the issue to. Matched exactly (case-sensitive). Mutually exclusive with `milestone_id`.
+      default: null
+    severity:
+      type: str | None
+      description: The severity of the issue. Applies only to incidents. One of `unknown`, `low`, `medium`, `high`, or `critical`.
+      default: null
+    start_date:
+      type: str | None
+      description: The start date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.
+      default: null
+    weight:
+      type: int | None
+      description: The weight of the issue. Valid values are greater than or equal to 0. Premium and Ultimate only.
       default: null
     payload:
+      # Generic: GitLab accepts these attributes in the query string (its own curl
+      # examples do) or a JSON body, but a null body field violates NOT NULL on
+      # `confidential` and Grape reads a null array as "unassign". Named inputs above
+      # go on the query string; this stays for callers sending a body.
       type: dict[str, Any] | None
       description: API-native request body passed through without validation.
       default: null
@@ -36,6 +107,24 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          title: ${{ inputs.title }}
+          assignee_id: ${{ inputs.assignee_id }}
+          assignee_ids: ${{ inputs.assignee_ids }}
+          confidential: ${{ inputs.confidential }}
+          created_at: ${{ inputs.created_at }}
+          description: ${{ inputs.description }}
+          discussion_to_resolve: ${{ inputs.discussion_to_resolve }}
+          due_date: ${{ inputs.due_date }}
+          epic_id: ${{ inputs.epic_id }}
+          iid: ${{ inputs.iid }}
+          issue_type: ${{ inputs.issue_type }}
+          labels: ${{ inputs.labels }}
+          merge_request_to_resolve_discussions_of: ${{ inputs.merge_request_to_resolve_discussions_of }}
+          milestone_id: ${{ inputs.milestone_id }}
+          milestone: ${{ inputs.milestone }}
+          severity: ${{ inputs.severity }}
+          start_date: ${{ inputs.start_date }}
+          weight: ${{ inputs.weight }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/create_issue_link.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/create_issue_link.yml
@@ -18,11 +18,21 @@ definition:
     issue_iid:
       type: int
       description: GitLab API path value for issue_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    target_project_id:
+      type: str
+      description: The ID or URL-encoded path of the project of a target project.
+    target_issue_iid:
+      type: str
+      description: The internal ID of a target project's issue.
+    link_type:
+      type: str | None
+      description: The type of the relation (`relates_to`, `blocks`, `is_blocked_by`), defaults to `relates_to`.
       default: null
     payload:
+      # Generic: GitLab accepts these attributes in the query string (its own curl
+      # examples do) or a JSON body, but a null body field violates NOT NULL on
+      # `confidential` and Grape reads a null array as "unassign". Named inputs above
+      # go on the query string; this stays for callers sending a body.
       type: dict[str, Any] | None
       description: API-native request body passed through without validation.
       default: null
@@ -39,6 +49,9 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          target_project_id: ${{ inputs.target_project_id }}
+          target_issue_iid: ${{ inputs.target_issue_iid }}
+          link_type: ${{ inputs.link_type }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/create_issue_note.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/create_issue_note.yml
@@ -18,11 +18,26 @@ definition:
     issue_iid:
       type: int
       description: GitLab API path value for issue_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    body:
+      type: str
+      description: The content of a note. Limited to 1,000,000 characters.
+    confidential:
+      type: bool | None
+      description: "Deprecated: Renamed to `internal`. The confidential flag of a note. Default is false."
+      default: null
+    internal:
+      type: bool | None
+      description: The internal flag of a note. Overrides `confidential` when both parameters are submitted. Default is false.
+      default: null
+    created_at:
+      type: str | None
+      description: "Date time string, ISO 8601 formatted. It must be after 1970-01-01. Example: `2016-03-11T03:45:40Z` (requires administrator or project/group owner rights)."
       default: null
     payload:
+      # Generic: GitLab accepts these attributes in the query string (its own curl
+      # examples do) or a JSON body, but a null body field violates NOT NULL on
+      # `confidential` and Grape reads a null array as "unassign". Named inputs above
+      # go on the query string; this stays for callers sending a body.
       type: dict[str, Any] | None
       description: API-native request body passed through without validation.
       default: null
@@ -39,6 +54,10 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          body: ${{ inputs.body }}
+          confidential: ${{ inputs.confidential }}
+          internal: ${{ inputs.internal }}
+          created_at: ${{ inputs.created_at }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/get_issue.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/get_issue.yml
@@ -18,10 +18,6 @@ definition:
     issue_iid:
       type: int
       description: GitLab API path value for issue_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -35,5 +31,4 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/list_issue_notes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/list_issue_notes.yml
@@ -18,9 +18,25 @@ definition:
     issue_iid:
       type: int
       description: GitLab API path value for issue_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    activity_filter:
+      type: str | None
+      description: "Filter notes by activity type. Valid values: `all_notes`, `only_comments`, `only_activity`. Default is `all_notes`."
+      default: null
+    sort:
+      type: str | None
+      description: Return issue notes sorted in `asc` or `desc` order. Default is `desc`.
+      default: null
+    order_by:
+      type: str | None
+      description: Return issue notes ordered by `created_at` or `updated_at` fields. Default is `created_at`.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -35,5 +51,10 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          activity_filter: ${{ inputs.activity_filter }}
+          sort: ${{ inputs.sort }}
+          order_by: ${{ inputs.order_by }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/list_project_labels.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/list_project_labels.yml
@@ -15,9 +15,29 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    with_counts:
+      type: bool | None
+      description: Whether or not to include issue and merge request counts. Defaults to `false`.
+      default: null
+    include_ancestor_groups:
+      type: bool | None
+      description: Include ancestor groups. Defaults to `true`.
+      default: null
+    search:
+      type: str | None
+      description: Keyword to filter labels by.
+      default: null
+    archived:
+      type: bool | None
+      description: If `true`, returns only archived labels. If unset, returns all labels.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +52,11 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          with_counts: ${{ inputs.with_counts }}
+          include_ancestor_groups: ${{ inputs.include_ancestor_groups }}
+          search: ${{ inputs.search }}
+          archived: ${{ inputs.archived }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/update_issue.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/update_issue.yml
@@ -18,11 +18,79 @@ definition:
     issue_iid:
       type: int
       description: GitLab API path value for issue_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    add_labels:
+      type: str | None
+      description: Comma-separated label names to add to an issue. If a label does not already exist, this creates a new project label and assigns it to the issue.
+      default: null
+    assignee_ids:
+      type: str | None
+      description: The ID of the users to assign the issue to, as a comma-separated list. Set to `0` to unassign all assignees.
+      default: null
+    confidential:
+      type: bool | None
+      description: Updates an issue to be confidential.
+      default: null
+    description:
+      type: str | None
+      description: The description of an issue. Limited to 1,048,576 characters.
+      default: null
+    discussion_locked:
+      type: bool | None
+      description: Flag indicating if the issue's discussion is locked. If the discussion is locked only project members can add or edit comments.
+      default: null
+    due_date:
+      type: str | None
+      description: The due date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.
+      default: null
+    epic_id:
+      type: int | None
+      description: ID of the epic to add the issue to. Valid values are greater than or equal to 0. Premium and Ultimate only.
+      default: null
+    issue_type:
+      type: str | None
+      description: Updates the type of issue. One of `issue`, `incident`, or `test_case`.
+      default: null
+    labels:
+      type: str | None
+      description: Comma-separated label names for an issue. If a label does not already exist, this creates a new project label and assigns it to the issue.
+      default: null
+    milestone_id:
+      type: int | None
+      description: The global ID of a milestone to assign the issue to. Set to `0` to unassign a milestone. Mutually exclusive with `milestone`.
+      default: null
+    milestone:
+      type: str | None
+      description: The title of a project or ancestor-group milestone to assign the issue to. Matched exactly (case-sensitive). Mutually exclusive with `milestone_id`.
+      default: null
+    remove_labels:
+      type: str | None
+      description: Comma-separated label names to remove from an issue.
+      default: null
+    severity:
+      type: str | None
+      description: The severity of the issue. Only applies to incidents. One of `unknown`, `low`, `medium`, `high`, or `critical`.
+      default: null
+    start_date:
+      type: str | None
+      description: The start date. Date time string in the format `YYYY-MM-DD`, for example `2016-03-11`.
+      default: null
+    state_event:
+      type: str | None
+      description: The state event of an issue. To close the issue, use `close`, and to reopen it, use `reopen`.
+      default: null
+    title:
+      type: str | None
+      description: The title of an issue.
+      default: null
+    updated_at:
+      type: str | None
+      description: When the issue was updated. Date time string, ISO 8601 formatted, for example `2016-03-11T03:45:40Z` (requires administrator or project owner rights).
       default: null
     payload:
+      # Generic: GitLab accepts these attributes in the query string (its own curl
+      # examples do) or a JSON body, but a null body field violates NOT NULL on
+      # `confidential` and Grape reads a null array as "unassign". Named inputs above
+      # go on the query string; this stays for callers sending a body.
       type: dict[str, Any] | None
       description: API-native request body passed through without validation.
       default: null
@@ -39,6 +107,23 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          add_labels: ${{ inputs.add_labels }}
+          assignee_ids: ${{ inputs.assignee_ids }}
+          confidential: ${{ inputs.confidential }}
+          description: ${{ inputs.description }}
+          discussion_locked: ${{ inputs.discussion_locked }}
+          due_date: ${{ inputs.due_date }}
+          epic_id: ${{ inputs.epic_id }}
+          issue_type: ${{ inputs.issue_type }}
+          labels: ${{ inputs.labels }}
+          milestone_id: ${{ inputs.milestone_id }}
+          milestone: ${{ inputs.milestone }}
+          remove_labels: ${{ inputs.remove_labels }}
+          severity: ${{ inputs.severity }}
+          start_date: ${{ inputs.start_date }}
+          state_event: ${{ inputs.state_event }}
+          title: ${{ inputs.title }}
+          updated_at: ${{ inputs.updated_at }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/create_merge_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/create_merge_request.yml
@@ -15,13 +15,12 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: source_branch (required), target_branch (required), title (required), allow_collaboration, allow_maintainer_to_push, approvals_before_merge, assignee_id, assignee_ids, description, labels, merge_after, milestone, milestone_id, remove_source_branch, reviewer_ids, squash, target_project_id.
       default: null
     base_url:
       type: str
@@ -36,6 +35,5 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/create_merge_request_note.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/create_merge_request_note.yml
@@ -18,13 +18,12 @@ definition:
     merge_request_iid:
       type: int
       description: GitLab API path value for merge_request_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: body (required), created_at, internal, merge_request_diff_head_sha.
       default: null
     base_url:
       type: str
@@ -39,6 +38,5 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/get_merge_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/get_merge_request.yml
@@ -18,9 +18,17 @@ definition:
     merge_request_iid:
       type: int
       description: GitLab API path value for merge_request_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    include_diverged_commits_count:
+      type: bool | None
+      description: If `true`, response includes the commits behind the target branch.
+      default: null
+    include_rebase_in_progress:
+      type: bool | None
+      description: If `true`, response includes whether a rebase operation is in progress.
+      default: null
+    render_html:
+      type: bool | None
+      description: If `true`, response includes rendered HTML for title and description.
       default: null
     base_url:
       type: str
@@ -35,5 +43,8 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          include_diverged_commits_count: ${{ inputs.include_diverged_commits_count }}
+          include_rebase_in_progress: ${{ inputs.include_rebase_in_progress }}
+          render_html: ${{ inputs.render_html }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_request_commits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_request_commits.yml
@@ -18,9 +18,13 @@ definition:
     merge_request_iid:
       type: int
       description: GitLab API path value for merge_request_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -35,5 +39,7 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_request_diffs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_request_diffs.yml
@@ -18,9 +18,17 @@ definition:
     merge_request_iid:
       type: int
       description: GitLab API path value for merge_request_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: The page of results to return. Defaults to 1.
+      default: null
+    per_page:
+      type: int | None
+      description: The number of results per page. Defaults to 20.
+      default: null
+    unidiff:
+      type: bool | None
+      description: Present diffs in the unified diff format. Default is false.
       default: null
     base_url:
       type: str
@@ -35,5 +43,8 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
+          unidiff: ${{ inputs.unidiff }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_request_notes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_request_notes.yml
@@ -18,9 +18,21 @@ definition:
     merge_request_iid:
       type: int
       description: GitLab API path value for merge_request_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    sort:
+      type: str | None
+      description: Return merge request notes sorted in `asc` or `desc` order. Default is `desc`
+      default: null
+    order_by:
+      type: str | None
+      description: Return merge request notes ordered by `created_at` or `updated_at` fields. Default is `created_at`
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -35,5 +47,9 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          sort: ${{ inputs.sort }}
+          order_by: ${{ inputs.order_by }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_request_pipelines.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_request_pipelines.yml
@@ -18,9 +18,13 @@ definition:
     merge_request_iid:
       type: int
       description: GitLab API path value for merge_request_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -35,5 +39,7 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_requests.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_requests.yml
@@ -15,9 +15,161 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    iids:
+      type: list[str] | None
+      description: Returns merge requests matching the provided IIDs.
+      default: null
+    approved_by_ids:
+      type: list[str] | None
+      description: Returns merge requests approved by all the users with the given `id`, up to 5 users. `None` returns merge requests with no approvals. `Any` returns merge requests with an approval.
+      default: null
+    approved_by_usernames:
+      type: list[str] | None
+      description: Returns merge requests approved by all the users with the given `username`, up to 5 users. `None` returns merge requests with no approvals. `Any` returns merge requests with an approval.
+      default: null
+    approver_ids:
+      type: list[str] | None
+      description: Returns merge requests which have all users with the specified `id` as eligible approvers according to the approval rules. `None` returns merge requests with no eligible approvers. `Any` returns merge requests with at least one eligible approver. Premium and Ultimate only.
+      default: null
+    assignee_id:
+      type: str | None
+      description: Returns merge requests assigned to the given user `id`. `None` returns unassigned merge requests. `Any` returns merge requests with an assignee. Mutually exclusive with `assignee_username`.
+      default: null
+    assignee_username:
+      type: list[str] | None
+      description: Returns merge requests assigned to the given usernames. Mutually exclusive with `assignee_id`.
+      default: null
+    author_id:
+      type: int | None
+      description: Returns merge requests created by the given user `id`. Mutually exclusive with `author_username`.
+      default: null
+    author_username:
+      type: str | None
+      description: Returns merge requests created by the given `username`. Mutually exclusive with `author_id`.
+      default: null
+    created_after:
+      type: datetime | None
+      description: Returns merge requests created on or after the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    created_before:
+      type: datetime | None
+      description: Returns merge requests created on or before the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    deployed_after:
+      type: datetime | None
+      description: Returns merge requests deployed after the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    deployed_before:
+      type: datetime | None
+      description: Returns merge requests deployed before the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    merged_after:
+      type: datetime | None
+      description: Returns merge requests merged on or after the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    merged_before:
+      type: datetime | None
+      description: Returns merge requests merged on or before the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    environment:
+      type: str | None
+      description: Returns merge requests deployed to the given environment.
+      default: null
+    search_in:
+      type: str | None
+      description: Change the scope of the `search` attribute. `title`, `description`, or a string joining them with comma. Default is `title,description`.
+      default: null
+    labels:
+      type: str | None
+      description: Returns merge requests matching a comma-separated list of labels. `None` lists all merge requests with no labels. `Any` lists all merge requests with at least one label. Predefined names are case-insensitive.
+      default: null
+    merge_user_id:
+      type: int | None
+      description: Returns merge requests merged by the user with the given user `id`. Mutually exclusive with `merge_user_username`. Introduced in GitLab 17.0.
+      default: null
+    merge_user_username:
+      type: str | None
+      description: Returns merge requests merged by the user with the given `username`. Mutually exclusive with `merge_user_id`. Introduced in GitLab 17.0.
+      default: null
+    milestone:
+      type: str | None
+      description: Returns merge requests for a specific milestone. `None` returns merge requests with no milestone. `Any` returns merge requests that have an assigned milestone.
+      default: null
+    my_reaction_emoji:
+      type: str | None
+      description: Returns merge requests reacted by the authenticated user by the given `emoji`. `None` returns issues not given a reaction. `Any` returns issues given at least one reaction.
+      default: null
+    order_by:
+      type: str | None
+      description: Returns merge requests ordered by `created_at`, `updated_at`, `merged_at` (introduced in GitLab 17.2), `label_priority`, `priority`, `milestone_due`, `popularity`, or `title` fields. Default is `created_at`.
+      default: null
+    reviewer_id:
+      type: str | None
+      description: Returns merge requests which have the user as a reviewer with the given user `id`. `None` returns merge requests with no reviewers. `Any` returns merge requests with any reviewer. Mutually exclusive with `reviewer_username`.
+      default: null
+    reviewer_username:
+      type: str | None
+      description: Returns merge requests which have the user as a reviewer with the given `username`. `None` returns merge requests with no reviewers. `Any` returns merge requests with any reviewer. Mutually exclusive with `reviewer_id`.
+      default: null
+    scope:
+      type: str | None
+      description: "Returns merge requests for the given scope: `created_by_me`, `assigned_to_me`, `reviews_for_me`, or `all`. `reviews_for_me` returns merge requests where the current user is assigned as a reviewer. Defaults to `all`."
+      default: null
+    search:
+      type: str | None
+      description: Search merge requests against their `title` and `description`. Combine with `in` attribute.
+      default: null
+    sort:
+      type: str | None
+      description: Returns merge requests sorted in `asc` or `desc` order. Default is `desc`.
+      default: null
+    source_branch:
+      type: str | None
+      description: Returns merge requests with the given source branch.
+      default: null
+    state:
+      type: str | None
+      description: Returns all merge requests (`all`) or just those that are `opened`, `closed`, `locked`, or `merged`. Defaults to `all`.
+      default: null
+    target_branch:
+      type: str | None
+      description: Returns merge requests with the given target branch.
+      default: null
+    updated_after:
+      type: datetime | None
+      description: Returns merge requests updated on or after the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    updated_before:
+      type: datetime | None
+      description: Returns merge requests updated on or before the given date and time. Expected in ISO 8601 format (`2019-03-15T08:00:00Z`).
+      default: null
+    view:
+      type: str | None
+      description: If `simple`, returns the `iid`, URL, title, description, and basic state of merge request.
+      default: null
+    draft:
+      type: bool | None
+      description: Filter merge requests by their `draft` status. `true` returns only draft merge requests, `false` returns non-draft merge requests. Mutually exclusive with `wip`.
+      default: null
+    wip:
+      type: str | None
+      description: Deprecated in GitLab 19.0. Use `draft` instead. Filter merge requests by their `wip` status. `yes` returns only draft merge requests, `no` returns non-draft merge requests.
+      default: null
+    with_labels_details:
+      type: bool | None
+      description: "If `true`, response returns more details for each label in labels field: `:name`, `:color`, `:description`, `:description_html`, `:text_color`. Default is `false`."
+      default: null
+    with_merge_status_recheck:
+      type: bool | None
+      description: If `true`, this projection requests (but does not guarantee) an asynchronous recalculation of the `merge_status` field. Enable the `restrict_merge_status_recheck` feature flag to ignore this attribute when requested by users without the Developer, Maintainer, or Owner role.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +184,44 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          "iids[]": ${{ inputs.iids }}
+          "approved_by_ids[]": ${{ inputs.approved_by_ids }}
+          "approved_by_usernames[]": ${{ inputs.approved_by_usernames }}
+          "approver_ids[]": ${{ inputs.approver_ids }}
+          assignee_id: ${{ inputs.assignee_id }}
+          "assignee_username[]": ${{ inputs.assignee_username }}
+          author_id: ${{ inputs.author_id }}
+          author_username: ${{ inputs.author_username }}
+          created_after: ${{ inputs.created_after }}
+          created_before: ${{ inputs.created_before }}
+          deployed_after: ${{ inputs.deployed_after }}
+          deployed_before: ${{ inputs.deployed_before }}
+          merged_after: ${{ inputs.merged_after }}
+          merged_before: ${{ inputs.merged_before }}
+          environment: ${{ inputs.environment }}
+          in: ${{ inputs.search_in }}
+          labels: ${{ inputs.labels }}
+          merge_user_id: ${{ inputs.merge_user_id }}
+          merge_user_username: ${{ inputs.merge_user_username }}
+          milestone: ${{ inputs.milestone }}
+          my_reaction_emoji: ${{ inputs.my_reaction_emoji }}
+          order_by: ${{ inputs.order_by }}
+          reviewer_id: ${{ inputs.reviewer_id }}
+          reviewer_username: ${{ inputs.reviewer_username }}
+          scope: ${{ inputs.scope }}
+          search: ${{ inputs.search }}
+          sort: ${{ inputs.sort }}
+          source_branch: ${{ inputs.source_branch }}
+          state: ${{ inputs.state }}
+          target_branch: ${{ inputs.target_branch }}
+          updated_after: ${{ inputs.updated_after }}
+          updated_before: ${{ inputs.updated_before }}
+          view: ${{ inputs.view }}
+          draft: ${{ inputs.draft }}
+          wip: ${{ inputs.wip }}
+          with_labels_details: ${{ inputs.with_labels_details }}
+          with_merge_status_recheck: ${{ inputs.with_merge_status_recheck }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_requests.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_requests.yml
@@ -16,7 +16,7 @@ definition:
       type: str
       description: GitLab API path value for project_id.
     iids:
-      type: list[str] | None
+      type: list[int] | None
       description: Returns merge requests matching the provided IIDs.
       default: null
     approved_by_ids:
@@ -75,7 +75,7 @@ definition:
       type: str | None
       description: Returns merge requests deployed to the given environment.
       default: null
-    search_in:
+    in:
       type: str | None
       description: Change the scope of the `search` attribute. `title`, `description`, or a string joining them with comma. Default is `title,description`.
       default: null
@@ -200,7 +200,7 @@ definition:
           merged_after: ${{ inputs.merged_after }}
           merged_before: ${{ inputs.merged_before }}
           environment: ${{ inputs.environment }}
-          in: ${{ inputs.search_in }}
+          in: ${{ inputs.in }}
           labels: ${{ inputs.labels }}
           merge_user_id: ${{ inputs.merge_user_id }}
           merge_user_username: ${{ inputs.merge_user_username }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_requests.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/list_merge_requests.yml
@@ -20,7 +20,7 @@ definition:
       description: Returns merge requests matching the provided IIDs.
       default: null
     approved_by_ids:
-      type: list[str] | None
+      type: list[int | str] | None
       description: Returns merge requests approved by all the users with the given `id`, up to 5 users. `None` returns merge requests with no approvals. `Any` returns merge requests with an approval.
       default: null
     approved_by_usernames:
@@ -28,11 +28,11 @@ definition:
       description: Returns merge requests approved by all the users with the given `username`, up to 5 users. `None` returns merge requests with no approvals. `Any` returns merge requests with an approval.
       default: null
     approver_ids:
-      type: list[str] | None
+      type: list[int | str] | None
       description: Returns merge requests which have all users with the specified `id` as eligible approvers according to the approval rules. `None` returns merge requests with no eligible approvers. `Any` returns merge requests with at least one eligible approver. Premium and Ultimate only.
       default: null
     assignee_id:
-      type: str | None
+      type: int | str | None
       description: Returns merge requests assigned to the given user `id`. `None` returns unassigned merge requests. `Any` returns merge requests with an assignee. Mutually exclusive with `assignee_username`.
       default: null
     assignee_username:
@@ -104,7 +104,7 @@ definition:
       description: Returns merge requests ordered by `created_at`, `updated_at`, `merged_at` (introduced in GitLab 17.2), `label_priority`, `priority`, `milestone_due`, `popularity`, or `title` fields. Default is `created_at`.
       default: null
     reviewer_id:
-      type: str | None
+      type: int | str | None
       description: Returns merge requests which have the user as a reviewer with the given user `id`. `None` returns merge requests with no reviewers. `Any` returns merge requests with any reviewer. Mutually exclusive with `reviewer_username`.
       default: null
     reviewer_username:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/merge_merge_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/merge_requests/merge_merge_request.yml
@@ -18,13 +18,12 @@ definition:
     merge_request_iid:
       type: int
       description: GitLab API path value for merge_request_iid.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: auto_merge, merge_commit_message, merge_when_pipeline_succeeds, sha, should_remove_source_branch, squash, squash_commit_message.
       default: null
     base_url:
       type: str
@@ -39,6 +38,5 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/posture/list_project_approval_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/posture/list_project_approval_rules.yml
@@ -15,9 +15,13 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +36,7 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/posture/list_project_members_with_inherited_access.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/posture/list_project_members_with_inherited_access.yml
@@ -15,9 +15,29 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    query:
+      type: str | None
+      description: Filters results based on a given name, email, or username. Use partial values to widen the scope of the query.
+      default: null
+    user_ids:
+      type: str | None
+      description: Filter the results on the given user IDs, as a comma-separated list.
+      default: null
+    show_seat_info:
+      type: bool | None
+      description: Show seat information for users.
+      default: null
+    state:
+      type: str | None
+      description: Filter results by member state, one of `awaiting` or `active`. Premium and Ultimate only.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +52,11 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          query: ${{ inputs.query }}
+          user_ids: ${{ inputs.user_ids }}
+          show_seat_info: ${{ inputs.show_seat_info }}
+          state: ${{ inputs.state }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/posture/list_protected_branches.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/posture/list_protected_branches.yml
@@ -15,9 +15,17 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    search:
+      type: str | None
+      description: Name or part of the name of protected branches to search for.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +40,8 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          search: ${{ inputs.search }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/create_project_vulnerability_export_and_wait.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/create_project_vulnerability_export_and_wait.yml
@@ -15,13 +15,12 @@ definition:
     project_id:
       type: str
       description: Numeric project ID or namespaced project path.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native vulnerability export request body.
+      description: >-
+        API-native request body. Documented fields: export_format, report_data, send_email.
       default: null
     poll_interval:
       type: float | None
@@ -40,7 +39,6 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
         payload: ${{ inputs.payload }}
     - ref: poll
       action: core.http_poll

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/download_vulnerability_export.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/download_vulnerability_export.yml
@@ -15,10 +15,6 @@ definition:
     export_id:
       type: int
       description: GitLab API path value for export_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -32,7 +28,6 @@ definition:
         headers:
           Authorization: Bearer ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/octet-stream
-        params: ${{ inputs.params }}
         follow_redirects: true
         base64_encode_data: true
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/get_project_security_settings.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/get_project_security_settings.yml
@@ -15,10 +15,6 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -32,5 +28,4 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/get_vulnerability.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/get_vulnerability.yml
@@ -15,10 +15,6 @@ definition:
     vulnerability_id:
       type: int
       description: GitLab API path value for vulnerability_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -32,5 +28,4 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/list_project_audit_events.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/list_project_audit_events.yml
@@ -15,9 +15,21 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    created_after:
+      type: str | None
+      description: "Return project audit events created on or after the given time. Format: ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`)"
+      default: null
+    created_before:
+      type: str | None
+      description: "Return project audit events created on or before the given time. Format: ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`)"
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +44,9 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          created_after: ${{ inputs.created_after }}
+          created_before: ${{ inputs.created_before }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/list_project_dependencies.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/list_project_dependencies.yml
@@ -15,9 +15,17 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    package_manager:
+      type: str | None
+      description: "Returns dependencies belonging to specified package manager. Valid values: `bundler`, `composer`, `conan`, `go`, `gradle`, `maven`, `npm`, `nuget`, `pip`, `pipenv`, `pnpm`, `yarn`, `sbt`, or `setuptools`. Accepts a comma-separated list."
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +40,8 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          package_manager: ${{ inputs.package_manager }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/list_project_vulnerability_findings.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/list_project_vulnerability_findings.yml
@@ -15,9 +15,29 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
+    report_type:
+      type: str | None
+      description: "Returns vulnerability findings belonging to specified report type. Valid values: `sast`, `dast`, `dependency_scanning`, or `container_scanning`. Defaults to all. Accepts a comma-separated list."
+      default: null
+    scope:
+      type: str | None
+      description: "Returns vulnerability findings for the given scope: `all` or `dismissed`. Defaults to `dismissed`."
+      default: null
+    severity:
+      type: str | None
+      description: "Returns vulnerability findings belonging to specified severity level: `info`, `unknown`, `low`, `medium`, `high`, or `critical`. Defaults to all. Accepts a comma-separated list."
+      default: null
+    pipeline_id:
+      type: str | None
+      description: Returns vulnerability findings belonging to specified pipeline.
+      default: null
+    page:
+      type: int | None
+      description: "Page number (default: `1`)."
+      default: null
+    per_page:
+      type: int | None
+      description: "Number of items to list per page (default: `20`, max: `100`)."
       default: null
     base_url:
       type: str
@@ -32,5 +52,11 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
+        params:
+          report_type: ${{ inputs.report_type }}
+          scope: ${{ inputs.scope }}
+          severity: ${{ inputs.severity }}
+          pipeline_id: ${{ inputs.pipeline_id }}
+          page: ${{ inputs.page }}
+          per_page: ${{ inputs.per_page }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/update_project_security_settings.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/security/update_project_security_settings.yml
@@ -15,14 +15,9 @@ definition:
     project_id:
       type: str
       description: GitLab API path value for project_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters, including pagination and filters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
+    secret_push_protection_enabled:
+      type: bool
+      description: Enables secret push protection for the project.
     base_url:
       type: str
       description: GitLab API v4 base URL. Set this input to a workspace variable for a reusable self-managed host.
@@ -36,6 +31,6 @@ definition:
         headers:
           PRIVATE-TOKEN: ${{ SECRETS.gitlab.GITLAB_API_TOKEN }}
           Accept: application/json
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
+        payload:
+          secret_push_protection_enabled: ${{ inputs.secret_push_protection_enabled }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/create_software_deployment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/create_software_deployment.yml
@@ -12,13 +12,12 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: software_id (required), active_group_type, group_id, ma_device_group_id.
       default: null
     base_url:
       type: str | None
@@ -34,6 +33,5 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/delete_software_deployment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/delete_software_deployment.yml
@@ -16,10 +16,6 @@ definition:
     id:
       type: str
       description: Rippling API path value for id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
     base_url:
       type: str | None
       description: Base URL of the Rippling REST API.
@@ -34,5 +30,4 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/list_app_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/list_app_users.yml
@@ -14,11 +14,43 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    filter:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `filter` query parameter is used to filter the data returned from the API - similar to a
+        `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or,
+        in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `spoke_user_identifier`,
+        `app_handle`, `created_at`, `updated_at`.
+      default: null
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `worker`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -34,5 +66,10 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/list_software_deployments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/list_software_deployments.yml
@@ -12,11 +12,43 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    filter:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `filter` query parameter is used to filter the data returned from the API - similar to a
+        `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or,
+        in. Example: status eq 'ACTIVE'. Filterable fields: `software_id`, `active_group_type`.
+        Allowed values for `active_group_type`: Role, Device.
+      default: null
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `software`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -32,5 +64,10 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/list_supergroup_members.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/list_supergroup_members.yml
@@ -16,11 +16,23 @@ definition:
     group_id:
       type: str
       description: Rippling API path value for group_id.
-    params:
-      type: dict[str, Any] | None
+    expand:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `worker`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
       default: null
     base_url:
       type: str | None
@@ -36,5 +48,7 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/list_supergroups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/list_supergroups.yml
@@ -12,11 +12,21 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    filter:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `filter` query parameter is used to filter the data returned from the API - similar to a
+        `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or,
+        in. Example: status eq 'ACTIVE'. Filterable fields: `app_owner_id`, `group_type`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
       default: null
     base_url:
       type: str | None
@@ -32,5 +42,7 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          order_by: ${{ inputs.order_by }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/update_supergroup_exclusion_members.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/update_supergroup_exclusion_members.yml
@@ -16,7 +16,7 @@ definition:
     group_id:
       type: str
       description: Rippling API path value for group_id.
-    operations:
+    Operations:
       # Documented object shape; the `expects` grammar has no nested-object type,
       # so the vendor's sub-keys are named in the description instead.
       type: list[dict[str, Any]]
@@ -38,5 +38,5 @@ definition:
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
         payload:
-          Operations: ${{ inputs.operations }}
+          Operations: ${{ inputs.Operations }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/update_supergroup_exclusion_members.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/update_supergroup_exclusion_members.yml
@@ -16,14 +16,13 @@ definition:
     group_id:
       type: str
       description: Rippling API path value for group_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
+    operations:
+      # Documented object shape; the `expects` grammar has no nested-object type,
+      # so the vendor's sub-keys are named in the description instead.
+      type: list[dict[str, Any]]
+      description: >-
+        The list of operations to apply. Each operation takes `op` (add or remove) and `value`, the
+        members to add or remove, each carrying an `id` (a member id).
     base_url:
       type: str | None
       description: Base URL of the Rippling REST API.
@@ -38,6 +37,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
+        payload:
+          Operations: ${{ inputs.operations }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/update_supergroup_inclusion_members.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/update_supergroup_inclusion_members.yml
@@ -16,7 +16,7 @@ definition:
     group_id:
       type: str
       description: Rippling API path value for group_id.
-    operations:
+    Operations:
       # Documented object shape; the `expects` grammar has no nested-object type,
       # so the vendor's sub-keys are named in the description instead.
       type: list[dict[str, Any]]
@@ -38,5 +38,5 @@ definition:
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
         payload:
-          Operations: ${{ inputs.operations }}
+          Operations: ${{ inputs.Operations }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/update_supergroup_inclusion_members.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/access/update_supergroup_inclusion_members.yml
@@ -16,14 +16,13 @@ definition:
     group_id:
       type: str
       description: Rippling API path value for group_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
+    operations:
+      # Documented object shape; the `expects` grammar has no nested-object type,
+      # so the vendor's sub-keys are named in the description instead.
+      type: list[dict[str, Any]]
+      description: >-
+        The list of operations to apply. Each operation takes `op` (add or remove) and `value`, the
+        members to add or remove, each carrying an `id` (a member id).
     base_url:
       type: str | None
       description: Base URL of the Rippling REST API.
@@ -38,6 +37,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
+        payload:
+          Operations: ${{ inputs.operations }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/devices/list_devices.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/devices/list_devices.yml
@@ -13,11 +13,46 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    filter:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `filter` query parameter is used to filter the data returned from the API - similar to a
+        `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or,
+        in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `serial_number`,
+        `lifecycle_state`, `enrollment_status`. Allowed values for `lifecycle_state`: INIT, ACTIVE,
+        ACTIVATING, LOCKED, LOCKING, INACTIVE, PENDING_MDM, CLEANING, READY, DECOMMISSIONING,
+        DECOMMISSIONED, FULL_WIPING, FULL_WIPED, E_CYCLED, MDM_LOCKED, LOST, LOST_PLAYING_SOUND.
+        Allowed values for `enrollment_status`: ENROLLED, WAITING_FOR_CONNECTION, ERROR, UNENROLLED.
+      default: null
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `worker`, `pending_actions`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -33,5 +68,10 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/leave/list_leave_balances.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/leave/list_leave_balances.yml
@@ -13,11 +13,42 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    filter:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `filter` query parameter is used to filter the data returned from the API - similar to a
+        `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or,
+        in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `leave_type_id`.
+      default: null
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `worker`, `leave_type`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -33,5 +64,10 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/leave/list_leave_requests.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/leave/list_leave_requests.yml
@@ -13,11 +13,44 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    filter:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `filter` query parameter is used to filter the data returned from the API - similar to a
+        `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or,
+        in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `requester_id`,
+        `reviewer_id`, `status`, `leave_policy_id`, `leave_type_id`, `start_date`, `end_date`.
+        Allowed values for `status`: PENDING, APPROVED, REJECTED, CANCELED.
+      default: null
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `worker`, `requester`, `leave_type`, `reviewer`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -33,5 +66,10 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/leave/update_leave_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/leave/update_leave_request.yml
@@ -15,13 +15,12 @@ definition:
     id:
       type: str
       description: Rippling API path value for id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: end_date (required), start_date (required), status (required), worker_id (required), comments, end_date_custom_hours, end_time, leave_event_id, leave_policy_id, leave_type_id, reason_for_leave, requester_id, reviewed_at, reviewer_id, start_date_custom_hours, start_time.
       default: null
     base_url:
       type: str | None
@@ -37,6 +36,5 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/meta/get_sso_me.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/meta/get_sso_me.yml
@@ -14,9 +14,20 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `company`.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -32,5 +43,7 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          expand: ${{ inputs.expand }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/meta/list_entitlements.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/meta/list_entitlements.yml
@@ -13,12 +13,6 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
-      default: null
     base_url:
       type: str | None
       description: Base URL of the Rippling REST API.
@@ -33,5 +27,4 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/onboarding/create_draft_hires.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/onboarding/create_draft_hires.yml
@@ -12,14 +12,14 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
-    payload:
-      type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
-      default: null
+    draft_hires:
+      # Documented object shape; the `expects` grammar has no nested-object type,
+      # so the vendor's sub-keys are named in the description instead.
+      type: list[dict[str, Any]]
+      description: >-
+        List of draft hires. Each draft hire requires `personal_info`, `employment_info`, and
+        `work_location_info`, and optionally accepts `custom_fields`, `headcount_info`, and
+        `documents`.
     base_url:
       type: str | None
       description: Base URL of the Rippling REST API.
@@ -34,6 +34,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
-        payload: ${{ inputs.payload }}
+        payload:
+          draft_hires: ${{ inputs.draft_hires }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/org/list_departments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/org/list_departments.yml
@@ -12,11 +12,35 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    expand:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `parent`, `department_hierarchy`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -32,5 +56,9 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/org/list_teams.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/org/list_teams.yml
@@ -12,11 +12,35 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    expand:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `parent`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -32,5 +56,9 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/org/list_work_locations.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/org/list_work_locations.yml
@@ -13,11 +13,26 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    order_by:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -33,5 +48,8 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/reports/get_report_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/reports/get_report_run.yml
@@ -16,10 +16,6 @@ definition:
     run_id:
       type: str
       description: Rippling API path value for run_id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
     base_url:
       type: str | None
       description: Base URL of the Rippling REST API.
@@ -34,5 +30,4 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/reports/trigger_report_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/reports/trigger_report_run.yml
@@ -13,13 +13,12 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any] | None
-      description: API-native request body passed through without validation.
+      description: >-
+        API-native request body. Documented fields: report_id (required), filters, format_currency_fields, format_date_fields, include_object_ids, include_total_rows, output_type, view_as.
       default: null
     base_url:
       type: str | None
@@ -35,6 +34,5 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
         payload: ${{ inputs.payload }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/workers/get_worker.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/workers/get_worker.yml
@@ -16,9 +16,15 @@ definition:
     id:
       type: str
       description: Rippling API path value for id.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `user`, `manager`, `legal_entity`, `employment_type`, `compensation`, `department`,
+        `teams`, `level`, `job_function`, `custom_fields`, `business_partners`.
       default: null
     base_url:
       type: str | None
@@ -34,5 +40,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          expand: ${{ inputs.expand }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/workers/list_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/workers/list_users.yml
@@ -12,11 +12,26 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    order_by:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -32,5 +47,8 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/workers/list_worker_changes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/workers/list_worker_changes.yml
@@ -12,11 +12,45 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    filter:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `filter` query parameter is used to filter the data returned from the API - similar to a
+        `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or,
+        in. Example: status eq 'ACTIVE'. Filterable fields: `worker_id`, `applied_on`,
+        `effective_on`, `changed_by_id`, `reason_code`, `field_key`, `event_type`. Allowed values
+        for `event_type`: HIRE, CHANGE, SCHEDULED_CHANGE, OFFBOARD, SCHEDULED_OFFBOARD, IMPORT,
+        UNDO, EFFECTIVE_DATE_AMENDMENT.
+      default: null
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `worker`, `changed_by`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`, `applied_on`, `effective_on`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -32,5 +66,10 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/workers/list_workers.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/rippling/workers/list_workers.yml
@@ -12,11 +12,45 @@ definition:
     - name: rippling
       keys: ["RIPPLING_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
+    filter:
+      type: str | None
       description: >-
-        API-native query parameters, including cursor for pagination. Support for filter,
-        expand, and order_by varies by endpoint; see the linked Rippling documentation.
+        The `filter` query parameter is used to filter the data returned from the API - similar to a
+        `where` clause. The following operators are supported: eq, ne, gt, gte, lt, lte, and, or,
+        in. Example: status eq 'ACTIVE'. Filterable fields: `status`, `work_email`, `user_id`,
+        `created_at`, `updated_at`. Allowed values for `status`: INIT, HIRED, ACCEPTED, ACTIVE,
+        TERMINATED.
+      default: null
+    expand:
+      type: str | None
+      description: >-
+        Fields in a response can represent objects themselves. Instead of making an additional API
+        call, you can expand field(s) in a response using the `expand` query parameter. Use commas
+        to specify multiple fields to expand. Use dot notation (.) to recursively expand. The API
+        supports two levels of expansion and up to ten expanded fields per request. Expandable
+        fields: `user`, `manager`, `legal_entity`, `employment_type`, `compensation`, `department`,
+        `teams`, `level`, `job_function`, `custom_fields`, `business_partners`.
+      default: null
+    order_by:
+      type: str | None
+      description: >-
+        The `order_by` parameter is used to select field(s) to sort by and to define whether results
+        are sorted in ascending or descending order. Supported sort directions are `asc` for
+        ascending order and `desc` for descending order. Unless indicated, the default sort
+        direction is ascending order. Use commas to specify multiple fields to sort. Sortable
+        fields: `id`, `created_at`, `updated_at`.
+      default: null
+    limit:
+      type: int | None
+      description: >-
+        `limit` controls how many results are returned in a single page. Default page size is 50.
+        Most endpoints allow a maximum of 100.
+      default: null
+    cursor:
+      type: str | None
+      description: >-
+        `cursor` is used to fetch the next page of results. Start with a request without cursor,
+        read the `next_link` value from the response, and continue until `next_link` is `null`.
       default: null
     base_url:
       type: str | None
@@ -32,5 +66,10 @@ definition:
           Authorization: Bearer ${{ SECRETS.rippling.RIPPLING_API_KEY }}
           Accept: application/json
           Rippling-Api-Version: '2024-08-01'
-        params: ${{ inputs.params }}
+        params:
+          filter: ${{ inputs.filter }}
+          expand: ${{ inputs.expand }}
+          order_by: ${{ inputs.order_by }}
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
   returns: ${{ steps.request.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/socket/packages/fetch_packages_by_purl.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/socket/packages/fetch_packages_by_purl.yml
@@ -32,7 +32,7 @@ definition:
       description: Include alert metadata.
       default: null
     actions:
-      type: list[str] | None
+      type: str | None
       description: >-
         Include only alerts with comma separated actions defined by security policy. Supported
         values are error, monitor, warn and ignore.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/socket/packages/fetch_packages_by_purl.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/socket/packages/fetch_packages_by_purl.yml
@@ -22,7 +22,7 @@ definition:
       description: Response media type to request.
       default: application/x-ndjson
     labels:
-      type: list[str] | None
+      type: str | None
       description: >-
         Repository label slugs to apply policies. Only one label is supported currently; the
         parameter is an array to allow future support for multiple labels.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/socket/scans/create_full_scan.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/socket/scans/create_full_scan.yml
@@ -45,7 +45,7 @@ definition:
       description: The pull request number to associate the full-scan with.
       default: null
     committers:
-      type: str | None
+      type: list[str] | None
       description: >-
         The committers to associate with the full-scan. Set query more than once to set multiple.
       default: null

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/socket/scans/create_full_scan_from_archive.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/socket/scans/create_full_scan_from_archive.yml
@@ -46,7 +46,7 @@ definition:
       description: The pull request number to associate the full-scan with.
       default: null
     committers:
-      type: str | None
+      type: list[str] | None
       description: >-
         The committers to associate with the full-scan. Set query more than once to set multiple.
       default: null

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/email_bombs/create_email_bomb.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/email_bombs/create_email_bomb.yml
@@ -10,9 +10,15 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    payload:
-      type: dict[str, Any]
-      description: API-native JSON request body.
+    mailbox_id:
+      type: str
+      description: ID of the mailbox to declare the email bomb for
+    start_time:
+      type: datetime
+      description: Start of the email bomb time range
+    end_time:
+      type: datetime
+      description: End of the email bomb time range (must not be in the future)
     base_url:
       type: str | None
       description: Base URL of the Sublime API.
@@ -25,5 +31,8 @@ definition:
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
-        payload: ${{ inputs.payload }}
+        payload:
+          mailbox_id: ${{ inputs.mailbox_id }}
+          start_time: ${{ inputs.start_time }}
+          end_time: ${{ inputs.end_time }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/email_bombs/dismiss_email_bomb.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/email_bombs/dismiss_email_bomb.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Email bomb ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/email_bombs/list_email_bombs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/email_bombs/list_email_bombs.yml
@@ -10,9 +10,21 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    active:
+      type: bool | None
+      description: Filter by active status. true = only active, false = only inactive, null = all
+      default: null
+    dismissed:
+      type: bool | None
+      description: Filter by dismissed status. true = only dismissed, false = only not dismissed, null = all
+      default: null
+    limit:
+      type: int | None
+      description: The maximum number of email bombs to return
+      default: null
+    offset:
+      type: int | None
+      description: The (zero-based) offset of the email bombs to return
       default: null
     base_url:
       type: str | None
@@ -24,7 +36,11 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/messages/bombs
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          active: ${{ inputs.active }}
+          dismissed: ${{ inputs.dismissed }}
+          limit: ${{ inputs.limit }}
+          offset: ${{ inputs.offset }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/eml_analyze.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/eml_analyze.yml
@@ -8,8 +8,11 @@ definition:
   name: eml_analyze
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native analyze request containing raw_message and optional rules or queries.
+      description: >-
+        API-native request body. Documented fields: raw_message (required), queries, rules, run_active_detection_rules, run_all_detection_rules, run_all_insights.
     base_url:
       type: str
       description: Base URL of the Sublime EML Analyzer API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/hunt_jobs/get_hunt_job_results.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/hunt_jobs/get_hunt_job_results.yml
@@ -13,9 +13,13 @@ definition:
     id:
       type: str
       description: Hunt job ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    limit:
+      type: int | None
+      description: The maximum number of results to return.
+      default: null
+    offset:
+      type: int | None
+      description: The (zero-based) offset of the first hunt job results to return.
       default: null
     base_url:
       type: str | None
@@ -27,7 +31,9 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/hunt-jobs/${{ FN.url_encode(inputs.id) }}/results
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          limit: ${{ inputs.limit }}
+          offset: ${{ inputs.offset }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/hunt_jobs/start_hunt_job.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/hunt_jobs/start_hunt_job.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: range_end_time (required), range_start_time (required), source (required), name, private, triage_email_bomb, triage_flagged, triage_reported.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/add_list_entry.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/add_list_entry.yml
@@ -13,9 +13,9 @@ definition:
     id:
       type: str
       description: List ID.
-    payload:
-      type: dict[str, Any]
-      description: API-native JSON request body.
+    string:
+      type: str
+      description: String list entry
     base_url:
       type: str | None
       description: Base URL of the Sublime API.
@@ -28,5 +28,6 @@ definition:
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
-        payload: ${{ inputs.payload }}
+        payload:
+          string: ${{ inputs.string }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/create_list.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/create_list.yml
@@ -10,9 +10,12 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    payload:
-      type: dict[str, Any]
-      description: API-native JSON request body.
+    name:
+      type: str
+      description: Unique name used to reference the list in MQL
+    description:
+      type: str
+      description: Description of list
     base_url:
       type: str | None
       description: Base URL of the Sublime API.
@@ -25,5 +28,7 @@ definition:
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
-        payload: ${{ inputs.payload }}
+        payload:
+          name: ${{ inputs.name }}
+          description: ${{ inputs.description }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/delete_list_entry.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/delete_list_entry.yml
@@ -13,10 +13,9 @@ definition:
     id:
       type: str
       description: List ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
+    string:
+      type: str
+      description: String list entry
     base_url:
       type: str | None
       description: Base URL of the Sublime API.
@@ -27,7 +26,8 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/lists/${{ FN.url_encode(inputs.id) }}/entries/entry
         method: DELETE
-        params: ${{ inputs.params }}
+        params:
+          string: ${{ inputs.string }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/get_list_entry.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/get_list_entry.yml
@@ -13,10 +13,9 @@ definition:
     id:
       type: str
       description: List ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
-      default: null
+    string:
+      type: str
+      description: String list entry
     base_url:
       type: str | None
       description: Base URL of the Sublime API.
@@ -27,7 +26,8 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/lists/${{ FN.url_encode(inputs.id) }}/entries/entry
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          string: ${{ inputs.string }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/get_lists.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/get_lists.yml
@@ -10,9 +10,16 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    entry_type:
+      type: str
+      description: List type to filter by. One of 'string', 'user_group', 'provider_org_unit'.
+    id:
+      type: str | None
+      description: Optional ID (exact match) to filter by
+      default: null
+    name:
+      type: str | None
+      description: Optional name (exact match) to filter by
       default: null
     base_url:
       type: str | None
@@ -24,7 +31,10 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/lists
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          entry_type: ${{ inputs.entry_type }}
+          id: ${{ inputs.id }}
+          name: ${{ inputs.name }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/patch_list.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/patch_list.yml
@@ -13,9 +13,9 @@ definition:
     id:
       type: str
       description: List ID.
-    payload:
-      type: dict[str, Any]
-      description: API-native JSON request body.
+    description:
+      type: str
+      description: Description of list
     base_url:
       type: str | None
       description: Base URL of the Sublime API.
@@ -28,5 +28,6 @@ definition:
         method: PATCH
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
-        payload: ${{ inputs.payload }}
+        payload:
+          description: ${{ inputs.description }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/set_list_entries.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/lists/set_list_entries.yml
@@ -13,9 +13,9 @@ definition:
     id:
       type: str
       description: List ID.
-    payload:
-      type: dict[str, Any]
-      description: API-native JSON request body.
+    entries:
+      type: list[str]
+      description: List entries
     base_url:
       type: str | None
       description: Base URL of the Sublime API.
@@ -28,5 +28,6 @@ definition:
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
-        payload: ${{ inputs.payload }}
+        payload:
+          entries: ${{ inputs.entries }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/mailboxes/list_mailboxes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/mailboxes/list_mailboxes.yml
@@ -10,9 +10,41 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    active:
+      type: bool | None
+      description: Filter for effectively active mailboxes (marked active with a live subscription)
+      default: null
+    email_addresses:
+      type: str | None
+      description: Email addresses of the mailboxes to return (comma-delimited)
+      default: null
+    limit:
+      type: int | None
+      description: The maximum number of entries to return. If the value exceeds the maximum, then the maximum value will be used
+      default: null
+    mailbox_types:
+      type: str | None
+      description: Comma-delimited list of mailbox types to filter by
+      default: null
+    marked_active:
+      type: bool | None
+      description: Filter for mailboxes marked active
+      default: null
+    message_source_id:
+      type: str | None
+      description: ID of the message source the mailboxes belong to
+      default: null
+    offset:
+      type: int | None
+      description: The (zero-based) offset of the first mailbox to return
+      default: null
+    search:
+      type: str | None
+      description: Search across mailbox names and email addresses
+      default: null
+    sub_error_types:
+      type: str | None
+      description: Comma-delimited list of subscription error types to filter by
       default: null
     base_url:
       type: str | None
@@ -24,7 +56,16 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/mailboxes
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          active: ${{ inputs.active }}
+          email_addresses: ${{ inputs.email_addresses }}
+          limit: ${{ inputs.limit }}
+          mailbox_types: ${{ inputs.mailbox_types }}
+          marked_active: ${{ inputs.marked_active }}
+          message_source_id: ${{ inputs.message_source_id }}
+          offset: ${{ inputs.offset }}
+          search: ${{ inputs.search }}
+          sub_error_types: ${{ inputs.sub_error_types }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/dismiss_message_canonical_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/dismiss_message_canonical_group.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Message group canonical ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/dismiss_multiple_message_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/dismiss_multiple_message_groups.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/get_message_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/get_message_group.yml
@@ -13,9 +13,9 @@ definition:
     id:
       type: str
       description: Message group canonical ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    sort_previews_message_id__is:
+      type: list[str] | None
+      description: Sort previews with these message IDs at the top
       default: null
     base_url:
       type: str | None
@@ -27,7 +27,8 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/message-groups/${{ FN.url_encode(inputs.id) }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          sort_previews_message_id__is: ${{ inputs.sort_previews_message_id__is }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/get_message_group_siem_summary.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/get_message_group_siem_summary.yml
@@ -10,9 +10,25 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    cursor:
+      type: str | None
+      description: Opaque pagination cursor returned in the previous response's cursor field.
+      default: null
+    limit:
+      type: int | None
+      description: The maximum number of message groups to return.
+      default: null
+    timestamp__gte:
+      type: str | None
+      description: Inclusive lower bound on the sort timestamp (newest_created_at for type=flagged, first_reported_as_phish_at for type=reported).
+      default: null
+    timestamp__lt:
+      type: str | None
+      description: Exclusive upper bound on the sort timestamp (newest_created_at for type=flagged, first_reported_as_phish_at for type=reported).
+      default: null
+    type:
+      type: str | None
+      description: "Which timestamp the endpoint sorts/filters on: 'flagged' uses newest_created_at, 'reported' uses first_reported_as_phish_at. Possible values: flagged, reported."
       default: null
     base_url:
       type: str | None
@@ -24,7 +40,12 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/message-groups/siem-summary
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          cursor: ${{ inputs.cursor }}
+          limit: ${{ inputs.limit }}
+          timestamp__gte: ${{ inputs.timestamp__gte }}
+          timestamp__lt: ${{ inputs.timestamp__lt }}
+          type: ${{ inputs.type }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/graymail_multiple_message_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/graymail_multiple_message_groups.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/list_message_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/list_message_groups.yml
@@ -10,9 +10,117 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    attachment_name__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided attachment name
+      default: null
+    attachment_sha256__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided attachment SHA256
+      default: null
+    attack_score_verdict__is:
+      type: list[str] | None
+      description: "Filters result to only message groups with the provided attack score verdict. Possible values: unknown, likely_benign, suspicious, malicious, graymail, spam."
+      default: null
+    attack_surface_reduction__filter:
+      type: bool | None
+      description: Filters result to only message groups that have flagged (ONLY) rules with the 'Attack surface reduction' tag
+      default: null
+    canonical_id__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided canonical ID
+      default: null
+    created_at__gte:
+      type: str | None
+      description: Inclusive start datetime filter, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only message groups that contain a message processed at or after this time will be returned.
+      default: null
+    created_at__lt:
+      type: str | None
+      description: Exclusive end datetime filter, in UTC using the ISO 8601 format (e.g., '2021-05-04T15:09:26Z'). Only message groups that contain a message processed before this time will be returned. Paired with created_at__gte this selects groups that were active at any point in the window, including groups that are still receiving messages after it. Note that this bounds a group's oldest message while created_at__gte bounds its newest, so the two cannot be served by a single index and the request may time out on high volume organizations or wide date ranges. If you only need groups whose newest message falls inside the window, prefer last_created_at__lt, which bounds the same field as created_at__gte.
+      default: null
+    first_message_reported_at__gte:
+      type: str | None
+      description: Filters result to only message groups with a message first reported at or after the provided time. Datetime must be in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z').
+      default: null
+    flagged:
+      type: bool | None
+      description: Filters result to only message groups with at least one flagged message
+      default: null
+    flagged_rule_id__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided flagged rule ID
+      default: null
+    flagged_rule_severity__is:
+      type: list[str] | None
+      description: "Filters result to only message groups with the provided flagged rule severity. Possible values: informational, low, medium, high, critical."
+      default: null
+    historically_flagged_rule_id__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided historically flagged rule ID
+      default: null
+    historically_flagged_rule_severity__is:
+      type: list[str] | None
+      description: "Filters result to only message groups with the provided historically flagged rule severity. Possible values: informational, low, medium, high, critical."
+      default: null
+    last_created_at__gte:
+      type: str | None
+      description: Inclusive start datetime filter, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only message groups whose newest message was processed at or after this time will be returned. Equivalent to created_at__gte.
+      default: null
+    last_created_at__lt:
+      type: str | None
+      description: Exclusive end datetime filter, in UTC using the ISO 8601 format (e.g., '2021-05-04T15:09:26Z'). Only message groups whose newest message was processed before this time will be returned. Unlike created_at__lt, groups that are still receiving messages after this time are excluded. Prefer this over created_at__lt for historical lookbacks, since it bounds the same field as created_at__gte and both can then be served by a single index. High volume organizations may still need to request narrow time windows to avoid a timeout.
+      default: null
+    limit:
+      type: int | None
+      description: The maximum number of message groups to return. If the value exceeds the maximum, then the maximum value will be used.
+      default: null
+    mailbox_email__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided mailbox email
+      default: null
+    offset:
+      type: int | None
+      description: The (zero-based) offset of the message groups to return
+      default: null
+    recipient_email__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided recipient email
+      default: null
+    reported_as_phish_by__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided reporter
+      default: null
+    reviewed:
+      type: bool | None
+      description: Filters result to only message groups which have or have not been reviewed
+      default: null
+    sender_display_name__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided sender display name
+      default: null
+    sender_domain__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided sender domain
+      default: null
+    sender_email__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided sender email
+      default: null
+    spam__is:
+      type: list[str] | None
+      description: "Filters result to only message groups with the provided spam status. Possible values: spam, not_spam, mixed."
+      default: null
+    subject__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided subject
+      default: null
+    user_reported:
+      type: bool | None
+      description: Filters result to only message groups with at least one reported message
+      default: null
+    vendor_id__is:
+      type: list[str] | None
+      description: Filters result to only message groups with the provided vendor
       default: null
     base_url:
       type: str | None
@@ -24,7 +132,35 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/message-groups
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          attachment_name__is: ${{ inputs.attachment_name__is }}
+          attachment_sha256__is: ${{ inputs.attachment_sha256__is }}
+          attack_score_verdict__is: ${{ inputs.attack_score_verdict__is }}
+          attack_surface_reduction__filter: ${{ inputs.attack_surface_reduction__filter }}
+          canonical_id__is: ${{ inputs.canonical_id__is }}
+          created_at__gte: ${{ inputs.created_at__gte }}
+          created_at__lt: ${{ inputs.created_at__lt }}
+          first_message_reported_at__gte: ${{ inputs.first_message_reported_at__gte }}
+          flagged: ${{ inputs.flagged }}
+          flagged_rule_id__is: ${{ inputs.flagged_rule_id__is }}
+          flagged_rule_severity__is: ${{ inputs.flagged_rule_severity__is }}
+          historically_flagged_rule_id__is: ${{ inputs.historically_flagged_rule_id__is }}
+          historically_flagged_rule_severity__is: ${{ inputs.historically_flagged_rule_severity__is }}
+          last_created_at__gte: ${{ inputs.last_created_at__gte }}
+          last_created_at__lt: ${{ inputs.last_created_at__lt }}
+          limit: ${{ inputs.limit }}
+          mailbox_email__is: ${{ inputs.mailbox_email__is }}
+          offset: ${{ inputs.offset }}
+          recipient_email__is: ${{ inputs.recipient_email__is }}
+          reported_as_phish_by__is: ${{ inputs.reported_as_phish_by__is }}
+          reviewed: ${{ inputs.reviewed }}
+          sender_display_name__is: ${{ inputs.sender_display_name__is }}
+          sender_domain__is: ${{ inputs.sender_domain__is }}
+          sender_email__is: ${{ inputs.sender_email__is }}
+          spam__is: ${{ inputs.spam__is }}
+          subject__is: ${{ inputs.subject__is }}
+          user_reported: ${{ inputs.user_reported }}
+          vendor_id__is: ${{ inputs.vendor_id__is }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/quarantine_message_canonical_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/quarantine_message_canonical_group.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Message group canonical ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/quarantine_multiple_message_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/quarantine_multiple_message_groups.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/restore_message_canonical_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/restore_message_canonical_group.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Message group canonical ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/restore_multiple_message_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/restore_multiple_message_groups.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/review_message_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/review_message_groups.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: classification (required), message_group_ids (required), action, custom_action_ids, generate_asa_lesson, review_comment, share_with_sublime.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/search_message_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/search_message_groups.yml
@@ -10,9 +10,77 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    any:
+      type: str | None
+      description: Searches every field (performs a case insensitive, OR search in all fields). Not compatible with other search fields.
+      default: null
+    attachment_md5:
+      type: str | None
+      description: Search for messages containing an attachment MD5 match
+      default: null
+    attachment_sha1:
+      type: str | None
+      description: Search for messages containing an attachment SHA1 match
+      default: null
+    attachment_sha256:
+      type: str | None
+      description: Search for messages containing an attachment SHA256 match
+      default: null
+    created_at_gte:
+      type: str | None
+      description: Inclusive start datetime filter for search, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only message groups with a message processed at or after this time will be returned.
+      default: null
+    created_at_lt:
+      type: str | None
+      description: Exclusive end datetime filter for search, in UTC using the ISO 8601 format (e.g., '2021-05-04T15:09:26Z'). Only message groups with a message processed before this time will be returned.
+      default: null
+    file_name:
+      type: str | None
+      description: Search in attachment filenames (case insensitive wildcard match)
+      default: null
+    first_reported_as_phish_at_gte:
+      type: str | None
+      description: Inclusive start datetime filter for search, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only message groups reported at or after this time will be returned.
+      default: null
+    first_reported_as_phish_at_lt:
+      type: str | None
+      description: Exclusive end datetime filter for search, in UTC using the ISO 8601 format (e.g., '2021-05-04T15:09:26Z'). Only message groups reported before this time will be returned.
+      default: null
+    limit:
+      type: int | None
+      description: The maximum number of message groups to return. If the value exceeds the maximum, then the maximum value will be used.
+      default: null
+    mailbox:
+      type: str | None
+      description: Search for a mailbox by email address (case insensitive, wildcard match)
+      default: null
+    message_id:
+      type: str | None
+      description: Search in the Message-ID header (case insensitive exact match; wildcards are not supported)
+      default: null
+    offset:
+      type: int | None
+      description: The (zero-based) offset of the message groups to return
+      default: null
+    sender:
+      type: str | None
+      description: Search in the From field (case insensitive wildcard match)
+      default: null
+    states:
+      type: list[str] | None
+      description: Search for messages in any of the given states
+      default: null
+    subject:
+      type: str | None
+      description: Search in the message subject (case insensitive wildcard match)
+      default: null
+    to:
+      type: str | None
+      description: Search in the To, CC, and Bcc fields (case insensitive wildcard match). If possible, use 'mailbox' and 'type' instead for better performance
+      default: null
+    type:
+      type: list[str] | None
+      description: Search for messages by type. Multiple values are OR'd together.
       default: null
     base_url:
       type: str | None
@@ -24,7 +92,25 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/message-groups/search
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          any: ${{ inputs.any }}
+          attachment_md5: ${{ inputs.attachment_md5 }}
+          attachment_sha1: ${{ inputs.attachment_sha1 }}
+          attachment_sha256: ${{ inputs.attachment_sha256 }}
+          created_at[gte]: ${{ inputs.created_at_gte }}
+          created_at[lt]: ${{ inputs.created_at_lt }}
+          file_name: ${{ inputs.file_name }}
+          first_reported_as_phish_at[gte]: ${{ inputs.first_reported_as_phish_at_gte }}
+          first_reported_as_phish_at[lt]: ${{ inputs.first_reported_as_phish_at_lt }}
+          limit: ${{ inputs.limit }}
+          mailbox: ${{ inputs.mailbox }}
+          message_id: ${{ inputs.message_id }}
+          offset: ${{ inputs.offset }}
+          sender: ${{ inputs.sender }}
+          states: ${{ inputs.states }}
+          subject: ${{ inputs.subject }}
+          to: ${{ inputs.to }}
+          type: ${{ inputs.type }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/share_with_sublime_public.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/share_with_sublime_public.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Message group canonical ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: destination, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/trash_message_canonical_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/trash_message_canonical_group.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Message group canonical ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/trash_multiple_message_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/message_groups/trash_multiple_message_groups.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: message_group_ids (required), classification, report_label, review_comment.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/action_message.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/action_message.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Sublime message ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: action, custom_action_ids, share_with_sublime.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/analyze_message_by_id.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/analyze_message_by_id.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Sublime message ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: queries, rules, run_active_detection_rules, run_all_detection_rules, run_all_insights.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/create_message.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/create_message.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: raw_message (required), canonical_id, external_created_at, external_message_id, external_thread_id, folder, labels, mailbox_email_address, message_type, route_type.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message.yml
@@ -13,9 +13,13 @@ definition:
     id:
       type: str
       description: Sublime message ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    recompute_mdm_from_raw:
+      type: bool | None
+      description: When true, recompute the MDM from the raw EML. For internal use only!
+      default: null
+    remove_large_text_fields:
+      type: bool | None
+      description: When true, any text field over 1MB will be cleared before returning
       default: null
     base_url:
       type: str | None
@@ -27,7 +31,9 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/messages/${{ FN.url_encode(inputs.id) }}
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          recompute_mdm_from_raw: ${{ inputs.recompute_mdm_from_raw }}
+          remove_large_text_fields: ${{ inputs.remove_large_text_fields }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_attachment_image_raw.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_attachment_image_raw.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: raw (required), file_type.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_canonical_group_action_state.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_canonical_group_action_state.yml
@@ -13,9 +13,17 @@ definition:
     id:
       type: str
       description: Message group canonical ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    created_at__gte:
+      type: str | None
+      description: Only return action states created after this time
+      default: null
+    limit:
+      type: int | None
+      description: The maximum number of action states to return. If the value exceeds the maximum, then the maximum value will be used.
+      default: null
+    offset:
+      type: int | None
+      description: The (zero-based) offset of the action states to return
       default: null
     base_url:
       type: str | None
@@ -27,7 +35,10 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/messages/groups/${{ FN.url_encode(inputs.id) }}/action-state
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          created_at__gte: ${{ inputs.created_at__gte }}
+          limit: ${{ inputs.limit }}
+          offset: ${{ inputs.offset }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_data_model.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_data_model.yml
@@ -13,9 +13,13 @@ definition:
     id:
       type: str
       description: Sublime message ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    recompute_mdm_from_raw:
+      type: bool | None
+      description: When true, recompute the MDM from the raw EML. For internal use only!
+      default: null
+    remove_large_text_fields:
+      type: bool | None
+      description: When true, any text field over 1MB will be cleared before returning
       default: null
     base_url:
       type: str | None
@@ -27,7 +31,9 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/messages/${{ FN.url_encode(inputs.id) }}/message_data_model
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          recompute_mdm_from_raw: ${{ inputs.recompute_mdm_from_raw }}
+          remove_large_text_fields: ${{ inputs.remove_large_text_fields }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_image.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_image.yml
@@ -13,9 +13,13 @@ definition:
     id:
       type: str
       description: Sublime message ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    recompute_mdm_from_raw:
+      type: bool | None
+      description: When true, recompute the MDM from the raw EML. For internal use only!
+      default: null
+    remove_large_text_fields:
+      type: bool | None
+      description: When true, any text field over 1MB will be cleared before returning
       default: null
     base_url:
       type: str | None
@@ -27,7 +31,9 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/messages/${{ FN.url_encode(inputs.id) }}/image
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          recompute_mdm_from_raw: ${{ inputs.recompute_mdm_from_raw }}
+          remove_large_text_fields: ${{ inputs.remove_large_text_fields }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_image_link.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/get_message_image_link.yml
@@ -13,9 +13,21 @@ definition:
     id:
       type: str
       description: Sublime message ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    link_duration_seconds:
+      type: int | None
+      description: Period link should be valid for. Default is 15 minutes, max 7 days.
+      default: null
+    platform_link:
+      type: bool | None
+      description: When true, link will always be presigned against Sublime. When false, the link may be to S3 directly.
+      default: null
+    recompute_mdm_from_raw:
+      type: bool | None
+      description: When true, recompute the MDM from the raw EML. For internal use only!
+      default: null
+    remove_large_text_fields:
+      type: bool | None
+      description: When true, any text field over 1MB will be cleared before returning
       default: null
     base_url:
       type: str | None
@@ -27,7 +39,11 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/messages/${{ FN.url_encode(inputs.id) }}/image_link
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          link_duration_seconds: ${{ inputs.link_duration_seconds }}
+          platform_link: ${{ inputs.platform_link }}
+          recompute_mdm_from_raw: ${{ inputs.recompute_mdm_from_raw }}
+          remove_large_text_fields: ${{ inputs.remove_large_text_fields }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/set_message_access_justification.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/messages/set_message_access_justification.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Sublime message ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: justification.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/create_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/create_rule.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: name (required), source (required), action_ids, active, attack_types, authors, auto_review_auto_share, auto_review_classification, description, detection_methods, false_positives, internal_type, label, maturity, references, run_triage_on_excluded_messages, severity, tactics_and_techniques, tags, triage_abuse_reports, triage_classification_changes, triage_dlp_rule_matched, triage_flagged_messages, type, user_provided_tags.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/get_rule_history.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/get_rule_history.yml
@@ -13,9 +13,17 @@ definition:
     id:
       type: str
       description: Sublime rule ID.
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    classification_created_at_gte:
+      type: datetime | None
+      description: Filter by classifications made after this datetime. Results are limited to the most recent 180 days.
+      default: null
+    classification_created_at_lte:
+      type: datetime | None
+      description: Filter by classifications made before this datetime. Results are limited to the most recent 180 days.
+      default: null
+    use_rule_last_updated_as_created_at:
+      type: bool | None
+      description: Filter by classifications made since the rule has been updated. Results are limited to the most recent 180 days.
       default: null
     base_url:
       type: str | None
@@ -27,7 +35,10 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/rules/${{ FN.url_encode(inputs.id) }}/rule-history
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          "classification_created_at[gte]": ${{ inputs.classification_created_at_gte }}
+          "classification_created_at[lte]": ${{ inputs.classification_created_at_lte }}
+          use_rule_last_updated_as_created_at: ${{ inputs.use_rule_last_updated_as_created_at }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/list_rule_history.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/list_rule_history.yml
@@ -10,9 +10,31 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    classification_created_at_gte:
+      type: datetime
+      description: Filter by classifications made after this datetime. Results are limited to the most recent 180 days.
+    classification_created_at_lte:
+      type: datetime
+      description: Filter by classifications made before this datetime. Results are limited to the most recent 180 days.
+    active:
+      type: bool | None
+      description: Restrict to rules that are active
+      default: null
+    count:
+      type: int | None
+      description: Number of results to return
+      default: null
+    in_feed:
+      type: bool | None
+      description: Restrict to rules that are in a feed
+      default: null
+    offset:
+      type: int | None
+      description: Offset from the first result
+      default: null
+    type:
+      type: list[str] | None
+      description: Restrict to rules that have one of the given types. One of 'detection', 'triage', 'dlp'.
       default: null
     base_url:
       type: str | None
@@ -24,7 +46,14 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/rules/rule-history
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          "classification_created_at[gte]": ${{ inputs.classification_created_at_gte }}
+          "classification_created_at[lte]": ${{ inputs.classification_created_at_lte }}
+          active: ${{ inputs.active }}
+          count: ${{ inputs.count }}
+          in_feed: ${{ inputs.in_feed }}
+          offset: ${{ inputs.offset }}
+          type: ${{ inputs.type }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/list_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/list_rules.yml
@@ -10,9 +10,21 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    in_feed:
+      type: bool | None
+      description: Restrict to rules that are explicitly in or not in a feed
+      default: null
+    limit:
+      type: int | None
+      description: The maximum number of entries to return. Maximum value is 500.
+      default: null
+    offset:
+      type: int | None
+      description: The (zero-based) offset of the first rule to return
+      default: null
+    search:
+      type: str | None
+      description: Search for matching case-insensitive substring across rule name, description, and MQL source
       default: null
     base_url:
       type: str | None
@@ -24,7 +36,11 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/rules
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          in_feed: ${{ inputs.in_feed }}
+          limit: ${{ inputs.limit }}
+          offset: ${{ inputs.offset }}
+          search: ${{ inputs.search }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/update_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/update_rule.yml
@@ -14,8 +14,11 @@ definition:
       type: str
       description: Sublime rule ID.
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: name (required), source (required), action_ids, attack_types, authors, auto_review_auto_share, auto_review_classification, description, detection_methods, false_positives, internal_type, label, maturity, references, run_triage_on_excluded_messages, severity, tactics_and_techniques, tags, triage_abuse_reports, triage_classification_changes, triage_dlp_rule_matched, triage_flagged_messages, user_provided_tags.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/validate_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/rules/validate_rule.yml
@@ -11,8 +11,11 @@ definition:
       keys: ["SUBLIME_API_KEY"]
   expects:
     payload:
+      # Generic: this endpoint rejects an explicit null on optional body fields,
+      # and a literal payload map cannot omit an unset optional.
       type: dict[str, Any]
-      description: API-native JSON request body.
+      description: >-
+        API-native request body. Documented fields: name (required), source (required), action_ids, active, attack_types, authors, auto_review_auto_share, auto_review_classification, description, detection_methods, false_positives, internal_type, label, maturity, references, run_triage_on_excluded_messages, severity, tactics_and_techniques, tags, triage_abuse_reports, triage_classification_changes, triage_dlp_rule_matched, triage_flagged_messages, type, user_provided_tags.
     base_url:
       type: str | None
       description: Base URL of the Sublime API.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/user_reports/list_user_reports.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sublime/user_reports/list_user_reports.yml
@@ -10,9 +10,17 @@ definition:
     - name: sublime
       keys: ["SUBLIME_API_KEY"]
   expects:
-    params:
-      type: dict[str, Any] | None
-      description: API-native query parameters.
+    limit:
+      type: int | None
+      description: The maximum number of message groups to return. If the value exceeds the maximum, then the maximum value will be used.
+      default: null
+    reported_at_gte:
+      type: datetime | None
+      description: Inclusive start datetime filter for time of report, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only reports at or after this time will be returned.
+      default: null
+    reported_at_lt:
+      type: datetime | None
+      description: Exclusive end datetime filter for time of report, in UTC using the ISO 8601 format (e.g., '2021-03-14T15:09:26Z'). Only reports before this time will be returned.
       default: null
     base_url:
       type: str | None
@@ -24,7 +32,10 @@ definition:
       args:
         url: ${{ inputs.base_url || VARS.sublime.base_url }}/v0/user-reports
         method: GET
-        params: ${{ inputs.params }}
+        params:
+          limit: ${{ inputs.limit }}
+          "reported_at[gte]": ${{ inputs.reported_at_gte }}
+          "reported_at[lt]": ${{ inputs.reported_at_lt }}
         headers:
           Authorization: Bearer ${{ SECRETS.sublime.SUBLIME_API_KEY }}
   returns: ${{ steps.request.result.data }}


### PR DESCRIPTION
Stacked on #3288, which contains the `core.http_request` null-pruning fix this depends on. **Review
and merge #3288 first.**

## Breaking change

Actions in `github`, `gitlab`, `sublime`, `elastic_security`, `rippling` and `emailrep` no longer
accept a generic `params` input. Template arguments validate with `extra="forbid"`
(`tracecat/expressions/expectations.py`), so a workflow passing `params={...}` to one of these actions
will start **failing validation**, not silently ignoring it.

**Migration:** replace the dict with the named parameters the action now declares.

```yaml
# before
args:
  params:
    state: open
    per_page: 50

# after
args:
  state: open
  per_page: 50
```

Every affected provider shipped within the three weeks before this change, so exposure should be small.

## Why

All six landed from the same authoring convention: a single `params: dict[str, Any]` pass-through
instead of the endpoint's documented parameters. An action's `expects` schema is handed verbatim to
agents as their tool schema (`tracecat/agent/tools.py:179`) and rendered as its docs page, so the
entire parameter surface was invisible to both.

| Provider | Actions | Real parameters exposed before |
|---|---:|---:|
| github | 73 | 0 |
| sublime | 46 | 0 |
| gitlab | 42 | 0 |
| elastic_security | 39 | 0 |
| rippling | 24 | 0 |
| emailrep | 1 | 0 |

Rippling is the clearest case: its own descriptions advertised filters the schema never offered —
*"filter on status to select the active roster, terminated workers, or the pre-start pipeline"* — with
no `status` input to set. That filter now exists.

**705 named parameters** replace those 225 dicts, each taken from the vendor's current OpenAPI
description or endpoint documentation: GitHub's `api.github.com.json`, Kibana's `oas_docs` output,
GitLab's `doc/api` sources, Sublime's platform API spec, and Rippling's per-operation schemas.

## What is deliberately left generic

**Request bodies where the endpoint rejects an explicit null.** `core.http_request` prunes null
`params` and `headers` but not `payload`, because a JSON null in a body is often meaningful — GitHub
documents `null` as "disable this protection" on branch protection. A literal `payload:` map therefore
cannot omit an unset optional, and strict validators reject what it does emit:

- GitHub, from live probes: `422 Invalid request. For 'properties/maintainer_can_modify', nil is not a boolean.`
- Kibana: `BaseActionSchema` validates with zod `.optional()`, which fails on an explicit null.
- GitLab: `{"confidential": null}` hits a `NOT NULL` violation on every `create_issue`, and Grape's
  `CommaSeparatedToArray` coerces `nil → []`, which GitLab defines as "unassign" — an enumerated null
  body on `update_issue` would silently clear labels, assignees and milestone.

Those bodies keep `payload: dict[str, Any]` with the vendor's documented field list in the
`description` and an inline comment naming the reason. Every remaining free-form dict in this PR
carries such a comment.

**`elasticsearch` and `opensearch` are not included.** Their `base_url` resolves to a cluster whose
version we do not control — Elasticsearch 7/8/9, and OpenSearch has been a hard fork with diverging
parameters since 2021 — so a named parameter set would be wrong for some fraction of clusters with no
way to detect it. This is now a documented exception in `AGENTS.md`. It is about version control, not
parameter count: several of those endpoints document only five query parameters.

**`gophish` is not included.** It predates this convention by ten months, and all 9 of its
generic-param actions are `create_*` / `modify_*`.

## Not changed

Machine-verified across all 225 files: no `returns`, authentication header, `auth`, `doc_url`,
`secrets`, step URL, method, or `run_python` script differs from `main`. The diff is confined to
`expects` and the `params`/`payload` step arguments.

## Also includes: Socket query parameter serialization

Two Socket parameters were typed against the wrong serialization, both confirmed from
`https://api.socket.dev/v0/openapi`. They fail in opposite directions, and only the `style`/`explode`
annotations distinguish them.

- **`actions`** on `POST /v0/orgs/{org_slug}/purl` is `type: array` with `style: form, explode: false`
  — OpenAPI for one comma-separated value, matching its description ("comma separated actions").
  httpx serialises a list as repeated pairs, which is `explode: true`. Now `str | None`.
- **`committers`** on `POST /v0/orgs/{org_slug}/full-scans` is typed `string` but documents
  *"Set query more than once to set multiple"* — repeated pairs, which httpx produces from a list.
  Now `list[str] | None`, here and on the archive variant.

Folded in here rather than shipped separately because the Socket actions landed in #3288 and have not
been released yet.
