### PR TITLE
fix(registry): correct Socket query parameter serialization

### DIFF
--- a/docs/tools/socket.mdx
+++ b/docs/tools/socket.mdx
@@ -70,7 +70,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="committers" type="string | null">
+<ParamField path="committers" type="array[string] | null">
 
 The committers to associate with the full-scan. Set query more than once to set multiple.
 
@@ -208,7 +208,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="committers" type="string | null">
+<ParamField path="committers" type="array[string] | null">
 
 The committers to associate with the full-scan. Set query more than once to set multiple.
 
@@ -316,7 +316,7 @@ Default: `"application/x-ndjson"`.
 
 </ParamField>
 
-<ParamField path="actions" type="array[string] | null">
+<ParamField path="actions" type="string | null">
 
 Include only alerts with comma separated actions defined by security policy. Supported values are error, monitor, warn and ignore.
 

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/socket/packages/fetch_packages_by_purl.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/socket/packages/fetch_packages_by_purl.yml
@@ -32,7 +32,7 @@ definition:
       description: Include alert metadata.
       default: null
     actions:
-      type: list[str] | None
+      type: str | None
       description: >-
         Include only alerts with comma separated actions defined by security policy. Supported
         values are error, monitor, warn and ignore.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/socket/scans/create_full_scan.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/socket/scans/create_full_scan.yml
@@ -45,7 +45,7 @@ definition:
       description: The pull request number to associate the full-scan with.
       default: null
     committers:
-      type: str | None
+      type: list[str] | None
       description: >-
         The committers to associate with the full-scan. Set query more than once to set multiple.
       default: null

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/socket/scans/create_full_scan_from_archive.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/socket/scans/create_full_scan_from_archive.yml
@@ -46,7 +46,7 @@ definition:
       description: The pull request number to associate the full-scan with.
       default: null
     committers:
-      type: str | None
+      type: list[str] | None
       description: >-
         The committers to associate with the full-scan. Set query more than once to set multiple.
       default: null


### PR DESCRIPTION
Two Socket query parameters were typed against the wrong serialization. Both are confirmed from
Socket's own OpenAPI at `https://api.socket.dev/v0/openapi`, and they fail in opposite directions.

**`actions`** on `POST /v0/orgs/{org_slug}/purl` is declared `type: array` — but with
`style: form, explode: false`, which is OpenAPI for one comma-separated value, and the vendor
description says *"Include only alerts with comma separated actions defined by security policy."*
httpx serialises a Python list as repeated pairs (`actions=error&actions=warn`), which is
`explode: true`. Now `str | None`, so the caller supplies the documented comma-separated form.

**`committers`** on `POST /v0/orgs/{org_slug}/full-scans` is the opposite: Socket types it `string`,
but its description says *"Set query more than once to set multiple."* — repeated pairs, which is
exactly what httpx produces from a list. Now `list[str] | None`, here and on the archive variant.

Both were reported by the Codex reviewer on #3288 and #3289; the templates landed in #3288.

Verified against the spec rather than the description alone, because the two parameters contradict
each other and only the `style`/`explode` annotations distinguish them.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects Socket query parameter serialization to match the vendor OpenAPI. Previously, `actions` was sent as repeated pairs and `committers` as a single string; now `actions` is a comma-separated string and `committers` is sent as repeated query parameters, preventing mis-encoded requests.

- POST /v0/orgs/{org_slug}/purl: pass `actions` as a single comma-separated string (e.g., "error,warn"). Do not pass a list.
- POST /v0/orgs/{org_slug}/full-scans and the archive variant: pass `committers` as `list[str]` to emit repeated query params; use a one-item list for a single committer.
- Docs updated in `docs/tools/socket.mdx` and templates updated under `packages/tracecat-registry` to enforce these types.

<sup>Written for commit c04088afc8d7cd30f8f68d904e66847b2036c542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

