### PR TITLE
fix(registry): repair bracketed pagination inputs and numeric ID filters

### DIFF
--- a/docs/tools/github.mdx
+++ b/docs/tools/github.mdx
@@ -3272,7 +3272,7 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="milestone" type="string | null">
+<ParamField path="milestone" type="integer | string | null">
 
 If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.
 

--- a/docs/tools/gitlab.mdx
+++ b/docs/tools/gitlab.mdx
@@ -360,13 +360,13 @@ GitLab API path value for project_id.
 
 </ParamField>
 
-<ParamField path="target_issue_iid" type="string" required>
+<ParamField path="target_issue_iid" type="integer | string" required>
 
 The internal ID of a target project's issue.
 
 </ParamField>
 
-<ParamField path="target_project_id" type="string" required>
+<ParamField path="target_project_id" type="integer | string" required>
 
 The ID or URL-encoded path of the project of a target project.
 

--- a/docs/tools/terraform.mdx
+++ b/docs/tools/terraform.mdx
@@ -178,7 +178,7 @@ The name of the Terraform Cloud organization.
 
 </ParamField>
 
-<ParamField path="page[number]" type="integer">
+<ParamField path="page_number" type="integer">
 
 The page number to return.
 
@@ -186,7 +186,7 @@ Default: `1`.
 
 </ParamField>
 
-<ParamField path="page[size]" type="integer">
+<ParamField path="page_size" type="integer">
 
 The number of projects to return per page.
 
@@ -216,7 +216,7 @@ The ID of the workspace to list runs for.
 
 </ParamField>
 
-<ParamField path="page[number]" type="integer">
+<ParamField path="page_number" type="integer">
 
 The page number to return.
 
@@ -224,7 +224,7 @@ Default: `1`.
 
 </ParamField>
 
-<ParamField path="page[size]" type="integer">
+<ParamField path="page_size" type="integer">
 
 The number of runs to return per page.
 
@@ -276,7 +276,7 @@ The name of the Terraform Cloud organization.
 
 </ParamField>
 
-<ParamField path="page[number]" type="integer">
+<ParamField path="page_number" type="integer">
 
 The page number to return.
 
@@ -284,7 +284,7 @@ Default: `1`.
 
 </ParamField>
 
-<ParamField path="page[size]" type="integer">
+<ParamField path="page_size" type="integer">
 
 The number of workspaces to return per page.
 

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/list_repository_issues.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/github/issues/list_repository_issues.yml
@@ -18,7 +18,7 @@ definition:
       type: str
       description: GitHub API path value for repo.
     milestone:
-      type: str | None
+      type: int | str | None
       description: If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.
       default: null
     state:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/create_issue_link.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gitlab/issues/create_issue_link.yml
@@ -19,10 +19,10 @@ definition:
       type: int
       description: GitLab API path value for issue_iid.
     target_project_id:
-      type: str
+      type: int | str
       description: The ID or URL-encoded path of the project of a target project.
     target_issue_iid:
-      type: str
+      type: int | str
       description: The internal ID of a target project's issue.
     link_type:
       type: str | None

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_projects.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_projects.yml
@@ -13,11 +13,11 @@ definition:
     organization:
       type: str
       description: The name of the Terraform Cloud organization.
-    page[size]:
+    page_size:
       type: int
       description: The number of projects to return per page.
       default: 20
-    page[number]:
+    page_number:
       type: int
       description: The page number to return.
       default: 1
@@ -31,6 +31,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.terraform.TERRAFORM_API_TOKEN }}
           Content-Type: application/vnd.api+json
         params:
-          page[size]: ${{ inputs.page[size] }}
-          page[number]: ${{ inputs.page[number] }}
+          "page[size]": ${{ inputs.page_size }}
+          "page[number]": ${{ inputs.page_number }}
   returns: ${{ steps.list_projects.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_runs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_runs.yml
@@ -13,11 +13,11 @@ definition:
     workspace_id:
       type: str
       description: The ID of the workspace to list runs for.
-    page[size]:
+    page_size:
       type: int
       description: The number of runs to return per page.
       default: 20
-    page[number]:
+    page_number:
       type: int
       description: The page number to return.
       default: 1
@@ -31,6 +31,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.terraform.TERRAFORM_API_TOKEN }}
           Content-Type: application/vnd.api+json
         params:
-          page[size]: ${{ inputs.page[size] }}
-          page[number]: ${{ inputs.page[number] }}
+          "page[size]": ${{ inputs.page_size }}
+          "page[number]": ${{ inputs.page_number }}
   returns: ${{ steps.list_runs.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_workspaces.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_workspaces.yml
@@ -17,11 +17,11 @@ definition:
       type: str | None
       description: Optional project ID to filter workspaces by project.
       default: null
-    page[size]:
+    page_size:
       type: int
       description: The number of workspaces to return per page.
       default: 20
-    page[number]:
+    page_number:
       type: int
       description: The page number to return.
       default: 1
@@ -47,6 +47,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.terraform.TERRAFORM_API_TOKEN }}
           Content-Type: application/vnd.api+json
         params:
-          page[size]: ${{ inputs.page[size] }}
-          page[number]: ${{ inputs.page[number] }}
+          "page[size]": ${{ inputs.page_size }}
+          "page[number]": ${{ inputs.page_number }}
   returns: ${{ steps.list_workspaces.result.data }}


### PR DESCRIPTION
Two unrelated defects, both surfaced while reviewing #3289. Neither was part of that PR's scope, so
they are fixed here separately.

## Terraform Cloud pagination has never worked

`list_runs`, `list_projects` and `list_workspaces` declare inputs literally named `page[size]` and
`page[number]`, and reference them as `${{ inputs.page[size] }}`. The expression parser reads
`[size]` as an index, so both resolve to `None`:

```python
eval_templated_object("${{ inputs.page[size] }}", {"inputs": {"page[size]": 20}})
# -> None
```

The parameters are then dropped, so all three actions have always returned Terraform Cloud's default
page with no way to change it.

Fixed by renaming the inputs `page_size` / `page_number` and keeping the vendor's bracketed strings as
the wire keys — the same safe-name-plus-exact-wire-key form used for `tweet.fields`, `epss-gt` and
`iids[]`, and the only form that transmits. Verified they now resolve to their values.

The renamed inputs are technically an input-contract change on shipped actions, but the old names
could not have worked, so nothing that functioned is broken.

## Three ID filters rejected the vendor's documented integer form

| Field | Was | Now | Vendor |
|---|---|---|---|
| `github` `list_repository_issues.milestone` | `str \| None` | `int \| str \| None` | schema says `string`, description says *"if an `integer` is passed, it should refer to a milestone by its `number` field"* |
| `gitlab` `create_issue_link.target_issue_iid` | `str` | `int \| str` | *"integer or string"* |
| `gitlab` `create_issue_link.target_project_id` | `str` | `int \| str` | *"integer or string"* |

GitHub is the interesting one: its OpenAPI coarsely types `milestone` as `string`, but its own
description documents the integer form, and the union preserves the `*` and `none` tokens. GitLab's
`target_issue_iid` also now matches its sibling `issue_iid`, which was already `int`.

Swept the registry for the same class. The remaining `str`-typed inputs whose descriptions mention
integers are correct as they stand: `hackernews` `numericFilters` is a filter expression
(`points>10`), `gitlab` `view` is an enum string, and `confluence` `page_id` is a path segment.

Both reported by the Codex reviewer on #3289.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two registry defects: Terraform Cloud list actions now paginate correctly, and GitHub/GitLab ID filters accept integers per vendor docs.

- Old behavior: Terraform inputs named page[size]/page[number] evaluated to None, so `list_runs`, `list_projects`, and `list_workspaces` always returned the vendor’s default page. GitHub/GitLab filters rejected documented integer IDs.
- New behavior: Inputs are `page_size` and `page_number` and are sent as the vendor’s bracketed keys; pagination works. `github` `list_repository_issues.milestone` is now `int | str | None`, and `gitlab` `create_issue_link.target_issue_iid` and `target_project_id` are `int | str`.

**Migration**
- Update callers to pass `page_size` and/or `page_number` for Terraform Cloud actions. The old input names never worked, so no functional regressions.

<sup>Written for commit 495a18e9ff691b54c236fd8e5da6eb0ba27cc855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

