### PR TITLE
fix(registry): resolve bracketed template inputs

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_projects.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_projects.yml
@@ -31,6 +31,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.terraform.TERRAFORM_API_TOKEN }}
           Content-Type: application/vnd.api+json
         params:
-          page[size]: ${{ inputs.page[size] }}
-          page[number]: ${{ inputs.page[number] }}
+          page[size]: ${{ inputs.'page[size]' }}
+          page[number]: ${{ inputs.'page[number]' }}
   returns: ${{ steps.list_projects.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_runs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_runs.yml
@@ -31,6 +31,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.terraform.TERRAFORM_API_TOKEN }}
           Content-Type: application/vnd.api+json
         params:
-          page[size]: ${{ inputs.page[size] }}
-          page[number]: ${{ inputs.page[number] }}
+          page[size]: ${{ inputs.'page[size]' }}
+          page[number]: ${{ inputs.'page[number]' }}
   returns: ${{ steps.list_runs.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_workspaces.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_workspaces.yml
@@ -47,6 +47,6 @@ definition:
           Authorization: Bearer ${{ SECRETS.terraform.TERRAFORM_API_TOKEN }}
           Content-Type: application/vnd.api+json
         params:
-          page[size]: ${{ inputs.page[size] }}
-          page[number]: ${{ inputs.page[number] }}
+          page[size]: ${{ inputs.'page[size]' }}
+          page[number]: ${{ inputs.'page[number]' }}
   returns: ${{ steps.list_workspaces.result.data }}

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -487,6 +487,8 @@ def test_eval_templated_object_inline_fails_if_not_str():
         ("   ACTIONS.action_test", {"bar": 1, "baz": 2}),
         ("VARS.api_config.base_url", "https://example.com"),
         ("VARS.api_config.timeout", 30),
+        # Template action input expressions
+        ("inputs.'page[size]'", 50),
         # Secret expressions
         ("SECRETS.secret_test.KEY", "SECRET"),
         ("   SECRETS.secret_test.KEY    ", "SECRET"),
@@ -822,6 +824,9 @@ def test_expression_parser(expr, expected):
         ExprContext.LOCAL_VARS: {
             "x": 5,
             "y": "100",
+        },
+        ExprContext.TEMPLATE_ACTION_INPUTS: {
+            "page[size]": 50,
         },
     }
     # visitor = ExprEvaluatorVisitor(context=context)
@@ -1288,6 +1293,20 @@ def test_parse_trigger_json(context, expr, expected):
             "${{ inputs.my_input.nested }}",
             [{"type": ExprType.TEMPLATE_ACTION_INPUT, "status": "success"}],
         ),
+        (
+            "${{ inputs.'page[size]' }}",
+            [{"type": ExprType.TEMPLATE_ACTION_INPUT, "status": "success"}],
+        ),
+        (
+            "${{ inputs.page[size] }}",
+            [
+                {
+                    "type": ExprType.TEMPLATE_ACTION_INPUT,
+                    "status": "error",
+                    "contains_msg": "Invalid input reference 'page'",
+                }
+            ],
+        ),
         # Test invalid template action input references
         (
             "${{ inputs.invalid_input }}",
@@ -1295,7 +1314,7 @@ def test_parse_trigger_json(context, expr, expected):
                 {
                     "type": ExprType.TEMPLATE_ACTION_INPUT,
                     "status": "error",
-                    "contains_msg": "Invalid input reference 'invalid_input'. Valid inputs are: ['my_input', 'other_input']",
+                    "contains_msg": "Invalid input reference 'invalid_input'. Valid inputs are: ['my_input', 'other_input', 'page[size]']",
                 }
             ],
         ),
@@ -1346,6 +1365,7 @@ async def test_template_action_validator(expr, expected):
         expects={
             "my_input": ExpectedField(type="str"),
             "other_input": ExpectedField(type="int"),
+            "page[size]": ExpectedField(type="int"),
         },
         step_refs={"step1", "step2"},
     )

--- a/tracecat/expressions/validator/validator.py
+++ b/tracecat/expressions/validator/validator.py
@@ -3,12 +3,18 @@ from collections.abc import Iterator, Mapping
 from types import TracebackType
 from typing import Any, Literal, Self, TypeVar, override
 
+import jsonpath_ng.jsonpath as jsonpath_nodes
 from lark import Token, Tree
 from pydantic import BaseModel, Field
 
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.dsl.schemas import TaskResult
-from tracecat.expressions.common import MAX_VARS_PATH_DEPTH, ExprContext, ExprType
+from tracecat.expressions.common import (
+    MAX_VARS_PATH_DEPTH,
+    ExprContext,
+    ExprType,
+    parse_jsonpath,
+)
 from tracecat.expressions.expectations import ExpectedField
 from tracecat.expressions.validator.base import BaseExprValidator
 from tracecat.integrations.enums import OAuthGrantType
@@ -25,6 +31,19 @@ from tracecat.variables.schemas import VariableSearch
 from tracecat.variables.service import VariablesService
 
 T = TypeVar("T")
+
+
+def _first_jsonpath_field(selector: str) -> str | None:
+    """Return the first field selected from a partial JSONPath."""
+    path = parse_jsonpath("$" + selector)
+    while isinstance(path, jsonpath_nodes.Child):
+        if isinstance(path.left, jsonpath_nodes.Root):
+            path = path.right
+            break
+        path = path.left
+    if isinstance(path, jsonpath_nodes.Fields) and len(path.fields) == 1:
+        return path.fields[0]
+    return None
 
 
 class ExprValidationContext(BaseModel):
@@ -444,8 +463,7 @@ class TemplateActionExprValidator(
         if not isinstance(token, Token):
             raise ValueError("Expected a string token")
 
-        jsonpath = token.lstrip(".")
-        input_field = jsonpath.split(".")[0]  # Get first segment
+        input_field = _first_jsonpath_field(str(token))
 
         if input_field not in self._context.expects:
             self.add(


### PR DESCRIPTION
## Summary

- quote Terraform Cloud's provider-native bracketed pagination inputs so they resolve as literal fields
- validate template action input references using the parsed JSONPath, rejecting unsafe forms such as `inputs.created_at[gte]`
- cover quoted bracketed input evaluation and validation with regression tests

## Testing

- `TRACECAT__DB_ENCRYPTION_KEY=<test-key> uv run pytest tests/unit/test_expressions.py -q` (239 passed)
- `uv run pytest tests/registry/test_templates.py::test_base_registry_validate_template_actions -q`
- `uv run ruff check tracecat/expressions/validator/validator.py tests/unit/test_expressions.py`
- `uv run ruff format --check tracecat/expressions/validator/validator.py tests/unit/test_expressions.py`
- `uv run basedpyright --warnings tracecat/expressions/validator/validator.py`
- pre-commit hooks, including generated client verification and Python type checking

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | +27 | -9 |
| Tests | +21 | -1 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resolution of bracketed template inputs and tightens validation for template action input references. Previously expressions like inputs.page[size] were parsed as nested paths; now inputs.'page[size]' resolves the literal field, and unsafe/unquoted bracketed forms are rejected.

- Updated Terraform Cloud templates in `tracecat_registry` to quote pagination params: use inputs.'page[size]' and inputs.'page[number]'.
- Validator now parses JSONPath to extract the first field and rejects unsafe forms (e.g., inputs.created_at[gte]); error messages list valid inputs.
- Added regression tests for quoted bracketed evaluation and validation.

**Migration**
- If a template references bracketed input names, quote them:
  - Replace inputs.page[size] with inputs.'page[size]'.
  - Replace inputs.page[number] with inputs.'page[number]'.
- Fix any validation errors by quoting other bracketed keys (e.g., inputs.'created_at[gte]').

<sup>Written for commit a1da230a1afbd9fd1d999d024ab16fdf6dd56644. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

