### PR TITLE
fix(auth): leave org enrollment to provisioning and invitations

### DIFF
--- a/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
+++ b/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
@@ -145,6 +145,7 @@ async def create_superuser(
                 session=session,
                 user_id=user.id,
                 is_superuser=True,
+                allow_new_members=True,
             )
             await session.commit()
 
@@ -169,6 +170,7 @@ async def create_superuser(
                 session=session,
                 user_id=user.id,
                 is_superuser=True,
+                allow_new_members=True,
             )
             await session.commit()
             await session.refresh(user)
@@ -464,6 +466,7 @@ async def create_dev_user(
             user_id=superuser.id,
             is_superuser=True,
             organization_id=organization_id,
+            allow_new_members=True,
         )
         user, created = await _get_or_create_local_user(
             session=session,

--- a/packages/tracecat-ee/tracecat_ee/admin/users/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/users/service.py
@@ -52,6 +52,7 @@ class AdminUserService(BasePlatformService):
                 session=self.session,
                 user_id=user.id,
                 is_superuser=user.is_superuser,
+                allow_new_members=True,
             )
             await self.session.commit()
         except IntegrityError as e:
@@ -94,6 +95,7 @@ class AdminUserService(BasePlatformService):
             session=self.session,
             user_id=user.id,
             is_superuser=user.is_superuser,
+            allow_new_members=True,
         )
         await self.session.commit()
         await self.session.refresh(user)

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -294,6 +294,49 @@ async def test_authenticate_user_only_invalidates_scope_cache_when_defaults_chan
 
 
 @pytest.mark.anyio
+async def test_authenticate_user_does_not_enroll() -> None:
+    """The auth path leaves enrollment to provisioning or invitation."""
+    request = MagicMock(spec=Request)
+    request.state = MagicMock()
+    request.state.auth_cache = None
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.is_superuser = False
+    session = AsyncMock()
+
+    defaults = AsyncMock(
+        return_value=SingleTenantUserDefaultsResult(
+            organization_id=None,
+            changed=False,
+        )
+    )
+    with (
+        patch(
+            "tracecat.auth.credentials.ensure_single_tenant_user_defaults_for_session",
+            new=defaults,
+        ),
+        patch(
+            "tracecat.auth.credentials._resolve_org_for_regular_user",
+            new=AsyncMock(return_value=uuid.uuid4()),
+        ),
+        patch(
+            "tracecat.auth.credentials.compute_effective_scopes",
+            new=AsyncMock(return_value=frozenset()),
+        ),
+        patch("tracecat.auth.credentials.set_rls_context", new=AsyncMock()),
+    ):
+        await _authenticate_user(
+            request=request,
+            session=session,
+            user=user,
+            workspace_id=None,
+        )
+
+    assert defaults.await_args is not None
+    assert defaults.await_args.kwargs.get("allow_new_members", False) is False
+
+
+@pytest.mark.anyio
 async def test_role_dependency_resolves_superuser_workspace_membership_without_platform_scopes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_org_enrollment_policy.py
+++ b/tests/unit/test_org_enrollment_policy.py
@@ -1,0 +1,221 @@
+"""Organization enrollment policy for single-tenant deployments.
+
+Membership is granted by provisioning or invitation acceptance. Self-service
+paths repair existing members without admitting new ones.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.schemas import UserRole
+from tracecat.auth.users import UserManager
+from tracecat.authz.seeding import seed_system_roles_for_org
+from tracecat.db.models import (
+    Organization,
+    OrganizationMembership,
+    User,
+    UserRoleAssignment,
+)
+from tracecat.organization.management import (
+    ensure_single_tenant_user_defaults_for_session,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+async def _create_org_with_roles(session: AsyncSession) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Enrollment Policy Test Org",
+        slug=f"enrollment-policy-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(org)
+    await session.flush()
+    await seed_system_roles_for_org(session, org.id)
+    return org
+
+
+async def _create_user(session: AsyncSession, *, is_superuser: bool = False) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"user-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.ADMIN if is_superuser else UserRole.BASIC,
+        is_active=True,
+        is_superuser=is_superuser,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _org_role_assignment_count(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> int:
+    result = await session.execute(
+        select(UserRoleAssignment).where(
+            UserRoleAssignment.user_id == user_id,
+            UserRoleAssignment.organization_id == organization_id,
+            UserRoleAssignment.workspace_id.is_(None),
+        )
+    )
+    return len(result.all())
+
+
+async def _assert_not_enrolled(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> None:
+    membership = await session.get(
+        OrganizationMembership,
+        {"user_id": user_id, "organization_id": organization_id},
+    )
+    assert membership is None, "account was enrolled into the organization"
+    assert (
+        await _org_role_assignment_count(
+            session, user_id=user_id, organization_id=organization_id
+        )
+        == 0
+    ), "account received an org-wide role assignment"
+
+
+@pytest.mark.anyio
+async def test_registration_does_not_enroll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``on_after_register`` leaves enrollment to provisioning or invitation."""
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.email = "user@example.com"
+    user.is_superuser = False
+
+    defaults = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "tracecat.auth.users.ensure_single_tenant_user_defaults", defaults
+    )
+    monkeypatch.setattr(
+        "tracecat.auth.users.config.TRACECAT__AUTH_SUPERADMIN_EMAIL", None
+    )
+
+    manager = UserManager.__new__(UserManager)
+    manager.logger = MagicMock()
+    manager._pending_invitation_token = None
+    monkeypatch.setattr(manager, "_emit_user_create_audit", AsyncMock())
+
+    await manager.on_after_register(user)
+
+    assert defaults.await_args is not None
+    assert defaults.await_args.kwargs.get("allow_new_members", False) is False
+
+
+@pytest.mark.anyio
+async def test_self_service_path_does_not_enroll(
+    session: AsyncSession,
+) -> None:
+    """``allow_new_members=False`` blocks admission rather than only advising it."""
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session)
+
+    result = await ensure_single_tenant_user_defaults_for_session(
+        session=session,
+        user_id=user.id,
+        is_superuser=False,
+        organization_id=org.id,
+        allow_new_members=False,
+    )
+    await session.flush()
+
+    assert result.organization_id is None
+    assert not result.changed
+    await _assert_not_enrolled(session, user_id=user.id, organization_id=org.id)
+
+
+@pytest.mark.anyio
+async def test_admission_is_denied_by_default(
+    session: AsyncSession,
+) -> None:
+    """Omitting ``allow_new_members`` does not admit the account.
+
+    Callers that inherit the default never pass the argument, so the default
+    itself needs direct coverage.
+    """
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session)
+
+    result = await ensure_single_tenant_user_defaults_for_session(
+        session=session,
+        user_id=user.id,
+        is_superuser=False,
+        organization_id=org.id,
+    )
+    await session.flush()
+
+    assert result.organization_id is None
+    await _assert_not_enrolled(session, user_id=user.id, organization_id=org.id)
+
+
+@pytest.mark.anyio
+async def test_existing_member_is_still_repaired(
+    session: AsyncSession,
+) -> None:
+    """An account with a membership row keeps its role repaired."""
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session)
+
+    session.add(OrganizationMembership(user_id=user.id, organization_id=org.id))
+    await session.flush()
+
+    result = await ensure_single_tenant_user_defaults_for_session(
+        session=session,
+        user_id=user.id,
+        is_superuser=False,
+        organization_id=org.id,
+        allow_new_members=False,
+    )
+    await session.flush()
+
+    assert result.organization_id == org.id
+    assert (
+        await _org_role_assignment_count(
+            session, user_id=user.id, organization_id=org.id
+        )
+        == 1
+    )
+
+
+@pytest.mark.anyio
+async def test_superuser_bootstrap_still_enrolls(
+    session: AsyncSession,
+) -> None:
+    """Superuser bootstrap provisions membership regardless of the flag."""
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session, is_superuser=True)
+
+    result = await ensure_single_tenant_user_defaults_for_session(
+        session=session,
+        user_id=user.id,
+        is_superuser=True,
+        organization_id=org.id,
+        allow_new_members=False,
+    )
+    await session.flush()
+
+    assert result.organization_id == org.id
+    membership = await session.get(
+        OrganizationMembership,
+        {"user_id": user.id, "organization_id": org.id},
+    )
+    assert membership is not None

--- a/tests/unit/test_single_tenant_user_defaults.py
+++ b/tests/unit/test_single_tenant_user_defaults.py
@@ -86,6 +86,7 @@ async def test_single_tenant_defaults_noop_in_multi_tenant(
     organization_id = await ensure_single_tenant_user_defaults(
         user_id=uuid.uuid4(),
         is_superuser=False,
+        allow_new_members=True,
     )
 
     assert organization_id is None
@@ -102,6 +103,7 @@ async def test_single_tenant_defaults_for_session_noop_in_multi_tenant(
         session=session,
         user_id=uuid.uuid4(),
         is_superuser=False,
+        allow_new_members=True,
     )
 
     assert result.organization_id is None
@@ -120,6 +122,7 @@ async def test_single_tenant_defaults_for_session_resolves_default_org(
         session=session,
         user_id=user.id,
         is_superuser=False,
+        allow_new_members=True,
     )
     await session.flush()
 
@@ -144,6 +147,7 @@ async def test_single_tenant_defaults_assign_member_role(
         user_id=user.id,
         organization_id=org.id,
         is_superuser=False,
+        allow_new_members=True,
     )
     await session.flush()
 
@@ -172,6 +176,7 @@ async def test_single_tenant_defaults_assign_owner_for_superuser(
         user_id=user.id,
         organization_id=org.id,
         is_superuser=True,
+        allow_new_members=True,
     )
     await session.flush()
 
@@ -196,6 +201,7 @@ async def test_single_tenant_defaults_are_idempotent(
             user_id=user.id,
             organization_id=org.id,
             is_superuser=False,
+            allow_new_members=True,
         )
     await session.flush()
 
@@ -253,6 +259,7 @@ async def test_single_tenant_defaults_handle_concurrent_repairs() -> None:
                 user_id=user_id,
                 organization_id=org_id,
                 is_superuser=False,
+                allow_new_members=True,
             )
             await repair_session.commit()
 
@@ -331,6 +338,7 @@ async def test_single_tenant_defaults_keep_existing_role_after_repair(
         user_id=user.id,
         organization_id=org.id,
         is_superuser=False,
+        allow_new_members=True,
     )
     await session.flush()
 
@@ -372,6 +380,7 @@ async def test_single_tenant_defaults_normalize_existing_role_during_repair(
         user_id=user.id,
         organization_id=org.id,
         is_superuser=False,
+        allow_new_members=True,
     )
     await session.flush()
 
@@ -418,6 +427,7 @@ async def test_single_tenant_defaults_upgrade_superuser_to_owner(
         user_id=user.id,
         organization_id=org.id,
         is_superuser=True,
+        allow_new_members=True,
     )
     await session.flush()
 

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -353,13 +353,18 @@ async def ensure_single_tenant_user_defaults(
     *,
     user_id: uuid.UUID,
     is_superuser: bool,
+    allow_new_members: bool = False,
 ) -> OrganizationID | None:
     """Ensure single-tenant users are real members of the default organization.
 
     In multi-tenant deployments this is a no-op. In single-tenant deployments,
-    every user receives default organization membership. Superusers receive the
-    organization-owner role; regular users receive organization-member unless
-    they already have an org-wide assignment.
+    superusers receive the organization-owner role and existing members are
+    repaired to organization-member unless they already have an org-wide
+    assignment.
+
+    Admission is opt-in: pass ``allow_new_members=True`` from provisioning
+    paths. Self-service callers keep the default, so registration leaves
+    membership to provisioning or invitation acceptance.
     """
     if config.TRACECAT__EE_MULTI_TENANT:
         return None
@@ -371,6 +376,7 @@ async def ensure_single_tenant_user_defaults(
             user_id=user_id,
             organization_id=organization_id,
             is_superuser=is_superuser,
+            allow_new_members=allow_new_members,
         )
         await session.commit()
     return result.organization_id
@@ -382,11 +388,16 @@ async def ensure_single_tenant_user_defaults_for_session(
     user_id: uuid.UUID,
     is_superuser: bool,
     organization_id: OrganizationID | None = None,
+    allow_new_members: bool = False,
 ) -> SingleTenantUserDefaultsResult:
     """Ensure single-tenant user defaults in a caller-owned session.
 
     This checks tenant mode, resolves or creates the default organization, and
     applies membership/RBAC without committing the caller's session.
+
+    Admission is opt-in: pass ``allow_new_members=True`` from provisioning
+    paths. Under the default, existing members are repaired without granting
+    new memberships.
     """
     if config.TRACECAT__EE_MULTI_TENANT:
         return SingleTenantUserDefaultsResult(organization_id=None, changed=False)
@@ -397,15 +408,18 @@ async def ensure_single_tenant_user_defaults_for_session(
         except NoResultFound:
             organization_id = await ensure_default_organization()
 
-    changed = await ensure_single_tenant_user_defaults_in_session(
+    enrolled = await ensure_single_tenant_user_defaults_in_session(
         session=session,
         user_id=user_id,
         organization_id=organization_id,
         is_superuser=is_superuser,
+        allow_new_members=allow_new_members,
     )
+    if enrolled is None:
+        return SingleTenantUserDefaultsResult(organization_id=None, changed=False)
     return SingleTenantUserDefaultsResult(
         organization_id=organization_id,
-        changed=changed,
+        changed=enrolled,
     )
 
 
@@ -415,8 +429,13 @@ async def ensure_single_tenant_user_defaults_in_session(
     user_id: uuid.UUID,
     organization_id: OrganizationID,
     is_superuser: bool,
-) -> bool:
-    """Ensure single-tenant org membership and org-wide RBAC in a session."""
+    allow_new_members: bool = False,
+) -> bool | None:
+    """Ensure single-tenant org membership and org-wide RBAC in a session.
+
+    Returns whether anything changed, or ``None`` when ``allow_new_members`` is
+    False and the user holds no membership to repair.
+    """
     # Fast path: if the user already has default-org membership and an
     # acceptable org-wide role, there is nothing to repair.
     membership_result = await session.execute(
@@ -426,6 +445,10 @@ async def ensure_single_tenant_user_defaults_in_session(
         )
     )
     membership = membership_result.scalar_one_or_none()
+
+    # Self-service paths repair existing members but never admit new ones.
+    if membership is None and not allow_new_members and not is_superuser:
+        return None
 
     assignment_result = await session.execute(
         select(UserRoleAssignment, DBRole.slug)


### PR DESCRIPTION
Registration no longer grants organization membership. Membership now comes from provisioning or invitation acceptance.

## Before

In single-tenant deployments, `ensure_single_tenant_user_defaults` ran unconditionally from two self-service paths:

| Path | When |
|---|---|
| `on_after_register` | every registration |
| `_authenticate_user` | every authenticated request |

So an account created through `POST /api/auth/register` became an active `organization-member` of the existing organization, without an invitation. The auth dependency re-applied this on every request, so gating registration alone would have had no effect.

## After

`allow_new_members` on the single-tenant defaults helpers, defaulting to denied. It gates the `membership is None` branch that already existed:

```python
if membership is None and not allow_new_members and not is_superuser:
    return None
```

| Callers | Policy |
|---|---|
| 3× `tracecat-admin` CLI, `POST /admin/users`, EE superuser promotion | `allow_new_members=True` |
| `on_after_register`, `_authenticate_user` | inherit the default |

Accounts without membership land on the existing `NoOrganizationAccess` screen, which fetches pending invitations by email and offers an accept link for each. No frontend changes.

## What still works

- **Invited users** — accept from the no-organization screen.
- **First-user bootstrap** — superadmin promotion runs before enrollment, so the first user still receives `organization-owner`.
- **CLI and admin provisioning** — unchanged; those callers opt in explicitly.
- **Existing members** — a member missing a role assignment is still repaired on the auth path.

## Verification

91 unit tests pass. `ruff` clean, `basedpyright` 0 errors.

Mutation-checked, since the behaviour rests on one default value:

| Change | Result |
|---|---|
| default flipped to `True` | test fails |
| guard polarity inverted | 7 tests fail |

`test_admission_is_denied_by_default` covers the default directly — the self-service callers inherit it rather than passing it, so nothing else exercises it.

## Follow-ups

1. **Config knob** — `TRACECAT__AUTH_ALLOW_SELF_REGISTRATION` to disable the registration endpoint entirely. This PR makes accounts inert without membership; it does not stop account creation.
2. **Ordering** — `ensure_default_organization()` runs before the membership check, so a denied caller can still trigger default-org provisioning. Idempotent on any deployed instance, but the wrong order.
3. **Return type** — the inner helper returns `bool | None`, conflating "nothing changed" with "not admitted".

## LOC

| Category | + | − |
|---|---|---|
| Tests | 274 | 0 |
| Logic | 35 | 7 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-enrolling users into the default org on registration and auth; enrollment now only comes from provisioning or invitation acceptance. Previously, single-tenant self-service paths granted organization-member by default; now they deny admission by default, still repairing roles for existing members.

- Adds an `allow_new_members` flag (default False) to single-tenant defaults helpers; self-service paths inherit the default while provisioning explicitly opts in.
- Updates provisioning callers to enroll: `tracecat-admin` bootstrap flows and `tracecat-ee` admin create/promote set `allow_new_members=True`.
- Keeps behavior: existing members are repaired; first superuser bootstrap still enrolls as owner; new self-registered accounts land on NoOrganizationAccess and can accept invitations.
- API note: `ensure_single_tenant_user_defaults_in_session` can return None when admission is denied; update any external callers that assumed a bool.
- Known side effect: default-org provisioning still runs before the admission check (idempotent but order to be fixed later).

<sup>Written for commit 4f94bed404b0dedcb5ae2f08c7d43322b939f1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

