### PR TITLE
fix(sync): preserve nested workflow catalog IDs

### DIFF
--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -5002,7 +5002,7 @@ async def test_agent_preset_sync_requires_an_ambiguous_catalog_choice_per_pull(
 
 
 @pytest.mark.anyio
-async def test_workspace_sync_catalog_mapping_rewrites_preset_and_workflow_together(
+async def test_workspace_sync_catalog_mapping_rewrites_preset_and_nested_workflow(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
@@ -5033,10 +5033,6 @@ async def test_workspace_sync_catalog_mapping_rewrites_preset_and_workflow_toget
             action_ref="run_shared_agent",
             action_args={
                 "user_prompt": "Investigate the event.",
-                "model_provider": model_provider,
-                "model_name": model_name,
-                "catalog_id": str(source_catalog_id),
-                "base_url": "https://source-flat.models.example.com/v1",
                 "model": {
                     "model_provider": model_provider,
                     "model_name": model_name,
@@ -5080,8 +5076,8 @@ async def test_workspace_sync_catalog_mapping_rewrites_preset_and_workflow_toget
     prepared_action_args = (
         prepared.snapshot.spec.workflows[workflow_source_id].definition.actions[0].args
     )
-    assert prepared_action_args["catalog_id"] == str(chosen_catalog.id)
-    assert prepared_action_args["base_url"] is None
+    assert "catalog_id" not in prepared_action_args
+    assert "base_url" not in prepared_action_args
     prepared_nested_model = prepared_action_args["model"]
     assert isinstance(prepared_nested_model, dict)
     assert prepared_nested_model["catalog_id"] == str(chosen_catalog.id)
@@ -5120,8 +5116,8 @@ async def test_workspace_sync_catalog_mapping_rewrites_preset_and_workflow_toget
         workflow_alias=workflow_alias,
         action_type="ai.agent",
     )
-    assert imported_args["catalog_id"] == str(chosen_catalog.id)
-    assert imported_args["base_url"] is None
+    assert "catalog_id" not in imported_args
+    assert "base_url" not in imported_args
     imported_nested_model = imported_args["model"]
     assert isinstance(imported_nested_model, dict)
     assert imported_nested_model["catalog_id"] == str(chosen_catalog.id)

--- a/tests/unit/test_workspace_sync_agent_catalog_shape.py
+++ b/tests/unit/test_workspace_sync_agent_catalog_shape.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import yaml
+
+from tracecat.agent.catalog.service import AgentCatalogService
+from tracecat.agent.catalog.types import ModelKey
+from tracecat.exceptions import RegistryValidationError
+from tracecat.registry.repository import Repository
+from tracecat.sync import CatalogMappingCandidate
+from tracecat.workspace_sync.adapters import AGENT_PRESET_RESOURCE_ADAPTER
+from tracecat.workspace_sync.adapters.base import SyncMappingService
+from tracecat.workspace_sync.schemas import WorkflowResourceSpec
+from tracecat.workspace_sync.workflow import serialize_workflow_spec
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture(scope="module")
+def registry_repository() -> Repository:
+    repository = Repository()
+    repository.init(include_base=True, include_templates=False)
+    return repository
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("action_type", ["ai.agent", "ai.action"])
+async def test_catalog_remap_keeps_nested_model_catalog_id_nested(
+    action_type: str,
+    registry_repository: Repository,
+) -> None:
+    source_catalog_id = uuid.uuid4()
+    target_catalog_id = uuid.uuid4()
+    model_key = ModelKey("openai", "test-model")
+    workflow = WorkflowResourceSpec.model_validate(
+        {
+            "id": "nested-model-workflow",
+            "definition": {
+                "title": "Nested model workflow",
+                "description": "",
+                "entrypoint": {"ref": "run_agent", "expects": {}},
+                "actions": [
+                    {
+                        "ref": "run_agent",
+                        "action": action_type,
+                        "args": {
+                            "user_prompt": "Investigate the event.",
+                            "model": {
+                                "model_provider": model_key.model_provider,
+                                "model_name": model_key.model_name,
+                                "catalog_id": str(source_catalog_id),
+                            },
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    workspace_service = cast(
+        SyncMappingService,
+        SimpleNamespace(
+            session=object(),
+            organization_id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+        ),
+    )
+    candidate = CatalogMappingCandidate(
+        catalog_id=target_catalog_id,
+        model_provider=model_key.model_provider,
+        model_name=model_key.model_name,
+        provider_name="OpenAI",
+        model_display_name=None,
+        endpoint_hostname=None,
+        origin="platform",
+    )
+
+    with (
+        patch.object(
+            AgentCatalogService,
+            "enabled_catalog_models",
+            AsyncMock(return_value={}),
+        ),
+        patch.object(
+            AgentCatalogService,
+            "catalog_candidates_by_models",
+            AsyncMock(return_value={model_key: [candidate]}),
+        ),
+    ):
+        correlated = await AGENT_PRESET_RESOURCE_ADAPTER.correlate_catalog_ids(
+            workspace_service,
+            presets={},
+            workflows={"nested-model-workflow": workflow},
+        )
+
+    correlated_workflow = correlated.workflows["nested-model-workflow"]
+    action_args = correlated_workflow.definition.actions[0].args
+    nested_model = action_args["model"]
+    assert isinstance(nested_model, dict)
+    assert "catalog_id" not in action_args
+    assert nested_model["catalog_id"] == str(target_catalog_id)
+
+    serialized = yaml.safe_load(serialize_workflow_spec(correlated_workflow))
+    serialized_args = serialized["definition"]["actions"][0]["args"]
+    assert "catalog_id" not in serialized_args
+    assert serialized_args["model"]["catalog_id"] == str(target_catalog_id)
+
+    bound_action = registry_repository.get(action_type)
+    validated_args = bound_action.validate_args(serialized_args)
+    assert validated_args["model"]["catalog_id"] == str(target_catalog_id)
+
+    with pytest.raises(RegistryValidationError):
+        bound_action.validate_args(
+            {**serialized_args, "catalog_id": str(target_catalog_id)}
+        )

--- a/tracecat/workspace_sync/adapters/agent_preset.py
+++ b/tracecat/workspace_sync/adapters/agent_preset.py
@@ -797,7 +797,8 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
                 new_catalog_id = str(local_catalog_id)
                 new_args = dict(action.args)
-                new_args["catalog_id"] = new_catalog_id
+                if "catalog_id" in new_args:
+                    new_args["catalog_id"] = new_catalog_id
                 if "base_url" in new_args:
                     new_args["base_url"] = None
                 if nested_model is not None:


### PR DESCRIPTION
## Problem

When syncing a workspace, `AgentPresetAdapter` remaps source catalog IDs to target-workspace catalog IDs. For workflow actions it unconditionally wrote a top-level `catalog_id` key:

```python
new_args["catalog_id"] = new_catalog_id
```

`ai.agent` / `ai.action` no longer accept a top-level `catalog_id` — the catalog ID lives nested under `model`. So the rewrite injected a key the action schema rejects, and a synced workflow that used a nested `model` block failed arg validation on import.

## Fix

Only rewrite `catalog_id` when the action args already carry it; the nested `model.catalog_id` rewrite is unchanged. Actions that use the nested shape now round-trip through sync without gaining a stray top-level key.

## Tests

- New `tests/unit/test_workspace_sync_agent_catalog_shape.py`: drives `correlate_catalog_ids` for both `ai.agent` and `ai.action`, asserts the remapped ID stays nested, survives YAML serialization, and passes real registry `validate_args` — plus asserts that adding a top-level `catalog_id` back raises `RegistryValidationError`, pinning the schema contract that motivated the fix.
- Updated the acceptance-contract test to use the nested-only shape and assert `catalog_id` / `base_url` are absent from the top level end-to-end (prepare + import).

## LOC breakdown

| Category | + | - |
| --- | --- | --- |
| Logic | 2 | 1 |
| Tests | 127 | 9 |
