### PR TITLE
fix(docker): use dynamic ports for service healthchecks

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -98,7 +98,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${PORT:-8000}/health || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 30
@@ -374,7 +374,7 @@ services:
       migrations:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4000/health/readiness"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${TRACECAT__LITELLM_PORT:-4000}/health/readiness || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -103,7 +103,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${PORT:-8000}/health || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 30
@@ -386,7 +386,7 @@ services:
       migrations:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4000/health/readiness"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${TRACECAT__LITELLM_PORT:-4000}/health/readiness || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${PORT:-8000}/health || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 30
@@ -380,7 +380,7 @@ services:
       migrations:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4000/health/readiness"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$${TRACECAT__LITELLM_PORT:-4000}/health/readiness || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
## Problem
When running Tracecat locally, if a user exports a custom `PORT` (e.g. `export PORT=8001`) to avoid conflicts, the healthchecks in the `docker-compose` files fail because they are hardcoded to query `http://localhost:8000/health`.

## Solution
Modified the `api` and `litellm` healthchecks across all docker-compose files (`dev`, `local`, `prod`) to use `CMD-SHELL` instead of `CMD`. This allows the healthcheck to dynamically evaluate the container's internal environment variables (`$PORT` and `$TRACECAT__LITELLM_PORT`) when curling the endpoints. 

If the port is overridden by the user, the healthcheck will now correctly query the overridden port instead of failing.

Fixes #3237