### PR TITLE
fix(agent): grant required session execution scopes

### DIFF
--- a/tests/temporal/test_case_comment_agent_invocation_workflow.py
+++ b/tests/temporal/test_case_comment_agent_invocation_workflow.py
@@ -393,7 +393,13 @@ async def test_comment_mention_runs_agent_and_posts_reply(
     monkeypatch: pytest.MonkeyPatch,
     svc_role: Role,
 ) -> None:
-    role = svc_role.model_copy(update={"type": "service", "user_id": None})
+    role = svc_role.model_copy(
+        update={
+            "type": "service",
+            "user_id": None,
+            "scopes": frozenset({"case:update", "agent:execute"}),
+        }
+    )
     assert role.workspace_id is not None
     invocation_id = uuid.uuid4()
     queue = f"comment-agent-e2e-{invocation_id}"

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -9,7 +9,10 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from tracecat.agent.session.schemas import AgentSessionCreate, AgentSessionUpdate
-from tracecat.agent.session.service import AgentSessionService
+from tracecat.agent.session.service import (
+    AGENT_SESSION_EXECUTION_SCOPES,
+    AgentSessionService,
+)
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.agent.types import AgentConfig
@@ -54,6 +57,23 @@ def _build_service() -> tuple[_TestAgentSessionService, SimpleNamespace, Role]:
     )
     service = _TestAgentSessionService(cast(Any, session), role)
     return service, session, role
+
+
+def test_execution_role_adds_only_agent_bootstrap_scopes() -> None:
+    service, _session, actor_role = _build_service()
+
+    execution_role = service.execution_role
+
+    assert execution_role.scopes == (
+        (actor_role.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
+    )
+    assert actor_role.scopes == frozenset({"agent:execute", "action:*:execute"})
+    assert execution_role.user_id == actor_role.user_id
+    assert execution_role.workspace_id == actor_role.workspace_id
+    assert execution_role.organization_id == actor_role.organization_id
+    assert AGENT_SESSION_EXECUTION_SCOPES == frozenset(
+        {"agent:read", "secret:read", "org:secret:read"}
+    )
 
 
 @pytest.mark.anyio
@@ -685,6 +705,14 @@ async def test_workspace_chat_preset_config_scope_filters_actions() -> None:
             assert resolved.actions == ["core.workflow.get_workflow"]
             # Instructions still combine preset + entity context.
             assert resolved.instructions == "preset instructions\n\nentity instructions"
+
+        execution_role = agent_svc_cls.call_args.args[1]
+        assert execution_role.scopes == (
+            (service.role.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
+        )
+        assert service.role.scopes == frozenset(
+            {"agent:execute", "action:core.workflow.get_workflow:execute"}
+        )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -59,7 +59,7 @@ def _build_service() -> tuple[_TestAgentSessionService, SimpleNamespace, Role]:
     return service, session, role
 
 
-def test_execution_role_adds_only_agent_bootstrap_scopes() -> None:
+def test_execution_role_adds_only_agent_runtime_scopes() -> None:
     service, _session, actor_role = _build_service()
 
     execution_role = service.execution_role
@@ -72,7 +72,13 @@ def test_execution_role_adds_only_agent_bootstrap_scopes() -> None:
     assert execution_role.workspace_id == actor_role.workspace_id
     assert execution_role.organization_id == actor_role.organization_id
     assert AGENT_SESSION_EXECUTION_SCOPES == frozenset(
-        {"agent:read", "secret:read", "org:secret:read"}
+        {
+            "action:*:execute",
+            "agent:read",
+            "org:secret:read",
+            "secret:read",
+            "workflow:execute",
+        }
     )
 
 

--- a/tests/unit/test_agent_session_search_attributes.py
+++ b/tests/unit/test_agent_session_search_attributes.py
@@ -11,7 +11,10 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.common import TypedSearchAttributes
 
-from tracecat.agent.session.service import AgentSessionService
+from tracecat.agent.session.service import (
+    AGENT_SESSION_EXECUTION_SCOPES,
+    AgentSessionService,
+)
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
@@ -119,6 +122,11 @@ async def test_run_turn_stamps_tracecat_search_attributes(
     assert response is not None
     first_prompt_check.assert_not_awaited()
     temporal_client.start_workflow.assert_awaited_once()
+    workflow_args = temporal_client.start_workflow.await_args.args[1]
+    assert workflow_args.role.scopes == (
+        (role_with_user.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
+    )
+    assert role_with_user.scopes == frozenset({"agent:execute", "secret:read"})
     kwargs = temporal_client.start_workflow.await_args.kwargs
     search_attributes = kwargs["search_attributes"]
     assert isinstance(search_attributes, TypedSearchAttributes)

--- a/tests/unit/test_case_comment_agent_invocation_activities.py
+++ b/tests/unit/test_case_comment_agent_invocation_activities.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import contextlib
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tracecat.agent.session.service import AGENT_SESSION_EXECUTION_SCOPES
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.types import AgentConfig
+from tracecat.auth.types import Role
+from tracecat.cases.agent_invocations.activities import (
+    prepare_comment_agent_invocation_activity,
+)
+from tracecat.cases.agent_invocations.schemas import (
+    PrepareCommentAgentInvocationInput,
+)
+from tracecat.cases.agent_invocations.types import PreparedCommentAgentSession
+
+
+@pytest.mark.anyio
+async def test_prepare_comment_invocation_uses_session_execution_role() -> None:
+    invocation_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    actor_role = Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"case:update", "agent:execute"}),
+    )
+    execution_role = actor_role.model_copy(
+        update={
+            "scopes": (actor_role.scopes or frozenset())
+            | AGENT_SESSION_EXECUTION_SCOPES
+        }
+    )
+    prepared_session = PreparedCommentAgentSession(
+        invocation_id=invocation_id,
+        session_id=session_id,
+        prompt="Investigate this thread",
+        display_messages=("@Agent investigate",),
+    )
+    prepared_turn = SimpleNamespace(
+        prompt=prepared_session.prompt,
+        session_id=session_id,
+        run_id=uuid.uuid4(),
+        active_stream_id=uuid.uuid4(),
+        config=AgentConfig(
+            model_name="test-model",
+            model_provider="openai",
+            actions=["core.cases.get_case"],
+        ),
+        title="Case agent",
+        entity_type=AgentSessionEntity.CASE,
+        entity_id=uuid.uuid4(),
+        tools=["core.cases.get_case"],
+        agent_preset_id=uuid.uuid4(),
+        agent_preset_version_id=uuid.uuid4(),
+    )
+    dispatcher = SimpleNamespace(
+        session=object(),
+        create_or_get_agent_session=AsyncMock(return_value=prepared_session),
+    )
+    session_service = SimpleNamespace(
+        execution_role=execution_role,
+        prepare_new_turn=AsyncMock(return_value=prepared_turn),
+    )
+
+    @contextlib.asynccontextmanager
+    async def dispatcher_context():
+        yield dispatcher
+
+    with (
+        patch(
+            "tracecat.cases.agent_invocations.activities."
+            "CaseCommentAgentInvocationDispatcher.with_session",
+            return_value=dispatcher_context(),
+        ),
+        patch(
+            "tracecat.cases.agent_invocations.activities.AgentSessionService",
+            return_value=session_service,
+        ),
+    ):
+        result = await prepare_comment_agent_invocation_activity(
+            PrepareCommentAgentInvocationInput(
+                role=actor_role,
+                invocation_id=invocation_id,
+            )
+        )
+
+    assert result.workflow_args is not None
+    assert result.workflow_args.role == execution_role
+    assert result.workflow_args.role.scopes == (
+        (actor_role.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
+    )
+    assert actor_role.scopes == frozenset({"case:update", "agent:execute"})

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -165,9 +165,11 @@ if TYPE_CHECKING:
 AUTO_TITLE_SERVICE_ID = "tracecat-api"
 AGENT_SESSION_EXECUTION_SCOPES: frozenset[str] = frozenset(
     {
+        "action:*:execute",
         "agent:read",
-        "secret:read",
         "org:secret:read",
+        "secret:read",
+        "workflow:execute",
     }
 )
 APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
@@ -401,12 +403,12 @@ class AgentSessionService(BaseWorkspaceService):
 
     @property
     def execution_role(self) -> Role:
-        """Return the actor role with read-only agent bootstrap scopes.
+        """Return the actor role with trusted agent execution scopes.
 
         Agent admission and user-facing tool filtering must continue to use
         ``self.role``. The derived role is only for trusted orchestration that
-        resolves presets, subagents, skills, and model credentials before the
-        sandbox starts. The sandbox receives scoped tokens, not this role.
+        resolves agent resources and dispatches tools already present in the
+        compiled allowlist. The sandbox receives scoped tokens, not this role.
         """
         scopes = (self.role.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
         return self.role.model_copy(update={"scopes": scopes})

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -163,6 +163,13 @@ if TYPE_CHECKING:
     from tracecat.agent.executor.schemas import ToolExecutionResult
 
 AUTO_TITLE_SERVICE_ID = "tracecat-api"
+AGENT_SESSION_EXECUTION_SCOPES: frozenset[str] = frozenset(
+    {
+        "agent:read",
+        "secret:read",
+        "org:secret:read",
+    }
+)
 APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
 _background_tasks: set[asyncio.Task[None]] = set()
 
@@ -391,6 +398,18 @@ class AgentSessionService(BaseWorkspaceService):
     """Service for managing agent sessions and history."""
 
     service_name = "agent-session"
+
+    @property
+    def execution_role(self) -> Role:
+        """Return the actor role with read-only agent bootstrap scopes.
+
+        Agent admission and user-facing tool filtering must continue to use
+        ``self.role``. The derived role is only for trusted orchestration that
+        resolves presets, subagents, skills, and model credentials before the
+        sandbox starts. The sandbox receives scoped tokens, not this role.
+        """
+        scopes = (self.role.scopes or frozenset()) | AGENT_SESSION_EXECUTION_SCOPES
+        return self.role.model_copy(update={"scopes": scopes})
 
     async def _get_default_tools(self, entity_type: AgentSessionEntity) -> list[str]:
         """Get entitlement-aware default tools for a session entity type."""
@@ -2108,7 +2127,7 @@ class AgentSessionService(BaseWorkspaceService):
             workflow_id = AgentWorkflowID(run_id)
 
             workflow_args = AgentWorkflowArgs(
-                role=self.role,
+                role=self.execution_role,
                 agent_args=args,
                 title=agent_session.title,
                 entity_type=AgentSessionEntity(agent_session.entity_type),
@@ -2695,7 +2714,7 @@ class AgentSessionService(BaseWorkspaceService):
             ValueError: If the session entity type is unsupported.
             TracecatNotFoundError: If required resources are not found.
         """
-        agent_svc = AgentManagementService(self.session, self.role)
+        agent_svc = AgentManagementService(self.session, self.execution_role)
 
         if agent_session.entity_type is None:
             # No entity type - use the org's default model

--- a/tracecat/cases/agent_invocations/activities.py
+++ b/tracecat/cases/agent_invocations/activities.py
@@ -67,7 +67,7 @@ async def prepare_comment_agent_invocation_activity(
             actions=_without_comment_reply_actions(prepared_turn.config.actions),
         )
         workflow_args = AgentWorkflowArgs(
-            role=input.role,
+            role=session_service.execution_role,
             agent_args=RunAgentArgs(
                 user_prompt=prepared_turn.prompt,
                 session_id=prepared_turn.session_id,

--- a/tracecat/cases/agent_invocations/dispatcher.py
+++ b/tracecat/cases/agent_invocations/dispatcher.py
@@ -71,7 +71,9 @@ class CaseCommentAgentInvocationDispatcher(BaseWorkspaceService):
             if agent_session is None:
                 raise TracecatNotFoundError("Linked agent session not found")
         else:
-            preset_service = AgentPresetService(self.session, self.role)
+            preset_service = AgentPresetService(
+                self.session, session_service.execution_role
+            )
             preset_version = await preset_service.resolve_agent_preset_version(
                 preset_id=preset_id
             )


### PR DESCRIPTION
## Summary

- derive an agent-session execution role by unioning the caller's scopes with the required runtime set: `agent:read`, `secret:read`, `org:secret:read`, `action:*:execute`, and `workflow:execute`
- use the derived role for model/preset resolution, Temporal agent orchestration, case-comment agent invocations, subagents, and skill staging
- preserve the original caller role for chat admission and Workspace Chat action filtering, so the derived execution scopes do not make additional tools visible to the agent

## Why

Users with `agent:execute` could enter Case Chat but fail during agent startup when model or preset credential resolution required an additional read scope. Agent runs can also dispatch actions and workflows, while subagent and skill execution carry the workflow role across Temporal boundaries, so the complete runtime scope set must be present on the derived execution role throughout the run.

The broad action and workflow execution scopes exist only on the derived runtime role. The sandbox still receives scoped MCP/LLM tokens rather than that role. Registry and third-party MCP tool execution remain constrained by the compiled tool allowlist and the trusted `tracecat-mcp` service role.

## Testing

- `uv run pytest tests/unit/test_agent_session_preset_versioning.py tests/unit/test_agent_session_search_attributes.py tests/unit/test_case_comment_agent_invocation_activities.py -q`
- `uv run pytest tests/unit/test_agent_preset_activities.py tests/unit/test_agent_activities.py tests/unit/test_case_comments_service.py tests/unit/test_rbac_scopes.py -q`
- `uv run pytest tests/temporal/test_case_comment_agent_invocation_workflow.py::test_comment_mention_runs_agent_and_posts_reply -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- focused `uv run basedpyright` on all changed Python files: 0 errors, 0 warnings

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 27 | 4 |
| Tests | 152 | 3 |


## Linear

-  ENG-1664 https://linear.app/tracecat/issue/ENG-1664/missing-mcp-skills-subagent-granular-scopes