### PR TITLE
feat(integrations): add a user OAuth grant to google_admin

### DIFF
--- a/docs/automations/core-concepts/secrets.mdx
+++ b/docs/automations/core-concepts/secrets.mdx
@@ -102,11 +102,14 @@ Workspace app actions (`tools.google_drive`, `tools.gmail`, `tools.google_sheets
 3. The `google_api` credential, key `GOOGLE_API_CREDENTIALS`, with domain-wide delegation through `GOOGLE_API_SUBJECT`.
 4. The `google` (Google Cloud) service-account integration, token `GOOGLE_SERVICE_TOKEN`.
 
-Admin SDK actions (`tools.google_directory`, `tools.google_reports`, `tools.google_alert_center`):
+Directory and Reports actions (`tools.google_directory`, `tools.google_reports`):
 
-1. The `google_admin` service-account integration, `${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}`, with domain-wide delegation through its subject.
-2. The `google_api` credential, key `GOOGLE_API_CREDENTIALS`, with domain-wide delegation through `GOOGLE_API_SUBJECT`.
-3. The `google` (Google Cloud) service-account integration, token `GOOGLE_SERVICE_TOKEN`.
+1. The `google_admin` user OAuth integration (`authorization_code`), `${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN }}`. The signed-in account must be a Workspace administrator.
+2. The `google_admin` service-account integration (`client_credentials`), `${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}`, with domain-wide delegation through its subject.
+3. The `google_api` credential, key `GOOGLE_API_CREDENTIALS`, with domain-wide delegation through `GOOGLE_API_SUBJECT`.
+4. The `google` (Google Cloud) service-account integration, token `GOOGLE_SERVICE_TOKEN`.
+
+Alert Center actions (`tools.google_alert_center`) start at step 2: the Alert Center API requires a service account with domain-wide delegation.
 
 ### Supported keys
 

--- a/docs/automations/core-concepts/secrets.mdx
+++ b/docs/automations/core-concepts/secrets.mdx
@@ -91,7 +91,7 @@ This applies to any registry action (built-in or custom) that declares a secret 
 
 ## Google credentials
 
-Google Workspace actions resolve credentials from a chain and use the first credential that exists. An integration that is configured but not connected has no token, so the chain moves on to the next source.
+Google Workspace actions resolve credentials from a chain and use the first credential that exists. An integration that is configured but not connected has no token, so the chain moves on to the next source. The chain is a priority order, not failover: an expired or revoked connection keeps its place, so re-authorize or disconnect it to move on.
 
 ### Credential resolution order
 

--- a/docs/tools/google_directory.mdx
+++ b/docs/tools/google_directory.mdx
@@ -16,6 +16,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -61,6 +62,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -90,6 +92,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -119,6 +122,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -142,6 +146,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -171,6 +176,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -202,6 +208,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -231,6 +238,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -262,6 +270,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -293,6 +302,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -316,6 +326,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -339,6 +350,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -368,6 +380,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -407,6 +420,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -444,6 +458,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -469,6 +484,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -500,6 +516,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -523,6 +540,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -552,6 +570,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -591,6 +610,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -620,6 +640,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -651,6 +672,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -682,6 +704,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -713,6 +736,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -760,6 +784,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -783,6 +808,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -836,6 +862,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -867,6 +894,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -918,6 +946,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -949,6 +978,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -972,6 +1002,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1017,6 +1048,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1040,6 +1072,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1129,6 +1162,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1154,6 +1188,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1235,6 +1270,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1290,6 +1326,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1363,6 +1400,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1386,6 +1424,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1427,6 +1466,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1452,6 +1492,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1517,6 +1558,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1558,6 +1600,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1581,6 +1624,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1686,6 +1730,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1709,6 +1754,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1738,6 +1784,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1775,6 +1822,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1820,6 +1868,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1849,6 +1898,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1894,6 +1944,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1931,6 +1982,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1960,6 +2012,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -1997,6 +2050,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -2020,6 +2074,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -2043,6 +2098,7 @@ Reference: [https://developers.google.com/workspace/admin/directory/reference/re
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 

--- a/docs/tools/google_reports.mdx
+++ b/docs/tools/google_reports.mdx
@@ -16,6 +16,7 @@ Reference: [https://developers.google.com/workspace/admin/reports/reference/rest
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -63,6 +64,7 @@ Reference: [https://developers.google.com/workspace/admin/reports/reference/rest
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -138,6 +140,7 @@ Reference: [https://developers.google.com/workspace/admin/reports/reference/rest
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 
@@ -225,6 +228,7 @@ Reference: [https://developers.google.com/workspace/admin/reports/reference/rest
 
 Optional secrets:
 
+- `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_USER_TOKEN`.
 - `google_admin_oauth`: OAuth token `GOOGLE_ADMIN_SERVICE_TOKEN`.
 - `google_api`: required values `GOOGLE_API_CREDENTIALS`; optional values `GOOGLE_API_SUBJECT`.
 

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/asps/delete_asp.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/asps/delete_asp.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -32,7 +36,7 @@ definition:
         version: directory_v1
         resource: asps
         method_name: delete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/asps/get_asp.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/asps/get_asp.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -32,7 +36,7 @@ definition:
         version: directory_v1
         resource: asps
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/asps/list_asps.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/asps/list_asps.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -28,7 +32,7 @@ definition:
         version: directory_v1
         resource: asps
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/batch_change_chromeos_device_status.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/batch_change_chromeos_device_status.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -73,7 +77,7 @@ definition:
         version: directory_v1
         resource: customer.devices.chromeos
         method_name: batchChangeStatus
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.chromeos"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/get_chromeos_device.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/get_chromeos_device.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -44,7 +48,7 @@ definition:
         version: directory_v1
         resource: chromeosdevices
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/get_chromeos_device_command.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/get_chromeos_device_command.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -34,7 +38,7 @@ definition:
         version: directory_v1
         resource: customer.devices.chromeos.commands
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/issue_chromeos_device_command.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/issue_chromeos_device_command.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -69,7 +73,7 @@ definition:
         version: directory_v1
         resource: customer.devices.chromeos
         method_name: issueCommand
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.chromeos"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/list_chromeos_devices.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/list_chromeos_devices.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -81,7 +85,7 @@ definition:
         version: directory_v1
         resource: chromeosdevices
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/move_chromeos_devices_to_ou.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/move_chromeos_devices_to_ou.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -34,7 +38,7 @@ definition:
         version: directory_v1
         resource: chromeosdevices
         method_name: moveDevicesToOu
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.chromeos"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/patch_chromeos_device.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/chromeos_devices/patch_chromeos_device.yml
@@ -12,6 +12,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -56,7 +60,7 @@ definition:
         version: directory_v1
         resource: chromeosdevices
         method_name: patch
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.chromeos"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/customers/get_customer.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/customers/get_customer.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -30,7 +34,7 @@ definition:
         version: directory_v1
         resource: customers
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.customer.readonly"]
         params:
           customerKey: ${{ inputs.customer_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/domains/get_domain.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/domains/get_domain.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -35,7 +39,7 @@ definition:
         version: directory_v1
         resource: domains
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.domain.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/domains/list_domains.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/domains/list_domains.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -32,7 +36,7 @@ definition:
         version: directory_v1
         resource: domains
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.domain.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/delete_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/delete_group.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -29,7 +33,7 @@ definition:
         version: directory_v1
         resource: groups
         method_name: delete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/get_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/get_group.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -29,7 +33,7 @@ definition:
         version: directory_v1
         resource: groups
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group.readonly"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/insert_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/insert_group.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -33,7 +37,7 @@ definition:
         version: directory_v1
         resource: groups
         method_name: insert
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group"]
         params:
           body: ${{ inputs.body }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/list_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/list_groups.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -70,7 +74,7 @@ definition:
         version: directory_v1
         resource: groups
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/patch_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/groups/patch_group.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -38,7 +42,7 @@ definition:
         version: directory_v1
         resource: groups
         method_name: patch
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/delete_member.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/delete_member.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -35,7 +39,7 @@ definition:
         version: directory_v1
         resource: members
         method_name: delete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group.member"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/get_member.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/get_member.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -35,7 +39,7 @@ definition:
         version: directory_v1
         resource: members
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group.member.readonly"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/has_member.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/has_member.yml
@@ -12,6 +12,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -37,7 +41,7 @@ definition:
         version: directory_v1
         resource: members
         method_name: hasMember
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group.member.readonly"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/insert_member.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/insert_member.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -70,7 +74,7 @@ definition:
         version: directory_v1
         resource: members
         method_name: insert
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group.member"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/list_members.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/list_members.yml
@@ -10,6 +10,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -48,7 +52,7 @@ definition:
         version: directory_v1
         resource: members
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group.member.readonly"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/patch_member.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/members/patch_member.yml
@@ -11,6 +11,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -64,7 +68,7 @@ definition:
         version: directory_v1
         resource: members
         method_name: patch
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.group.member"]
         params:
           groupKey: ${{ inputs.group_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/mobile_devices/action_mobile_device.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/mobile_devices/action_mobile_device.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -40,7 +44,7 @@ definition:
         version: directory_v1
         resource: mobiledevices
         method_name: action
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.mobile.action"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/mobile_devices/delete_mobile_device.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/mobile_devices/delete_mobile_device.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -34,7 +38,7 @@ definition:
         version: directory_v1
         resource: mobiledevices
         method_name: delete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.mobile"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/mobile_devices/get_mobile_device.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/mobile_devices/get_mobile_device.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -42,7 +46,7 @@ definition:
         version: directory_v1
         resource: mobiledevices
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.mobile.readonly"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/mobile_devices/list_mobile_devices.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/mobile_devices/list_mobile_devices.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -68,7 +72,7 @@ definition:
         version: directory_v1
         resource: mobiledevices
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.device.mobile.readonly"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/delete_orgunit.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/delete_orgunit.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -35,7 +39,7 @@ definition:
         version: directory_v1
         resource: orgunits
         method_name: delete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.orgunit"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/get_orgunit.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/get_orgunit.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -35,7 +39,7 @@ definition:
         version: directory_v1
         resource: orgunits
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.orgunit.readonly"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/insert_orgunit.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/insert_orgunit.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -39,7 +43,7 @@ definition:
         version: directory_v1
         resource: orgunits
         method_name: insert
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.orgunit"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/list_orgunits.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/list_orgunits.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -42,7 +46,7 @@ definition:
         version: directory_v1
         resource: orgunits
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.orgunit.readonly"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/patch_orgunit.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/orgunits/patch_orgunit.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -44,7 +48,7 @@ definition:
         version: directory_v1
         resource: orgunits
         method_name: patch
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.orgunit"]
         params:
           customerId: ${{ inputs.customer_id }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/privileges/list_privileges.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/privileges/list_privileges.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -32,7 +36,7 @@ definition:
         version: directory_v1
         resource: privileges
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/role_assignments/delete_role_assignment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/role_assignments/delete_role_assignment.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -31,7 +35,7 @@ definition:
         version: directory_v1
         resource: roleAssignments
         method_name: delete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.rolemanagement"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/role_assignments/get_role_assignment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/role_assignments/get_role_assignment.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -35,7 +39,7 @@ definition:
         version: directory_v1
         resource: roleAssignments
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/role_assignments/insert_role_assignment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/role_assignments/insert_role_assignment.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -68,7 +72,7 @@ definition:
         version: directory_v1
         resource: roleAssignments
         method_name: insert
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.rolemanagement"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/role_assignments/list_role_assignments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/role_assignments/list_role_assignments.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -61,7 +65,7 @@ definition:
         version: directory_v1
         resource: roleAssignments
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/roles/get_role.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/roles/get_role.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -35,7 +39,7 @@ definition:
         version: directory_v1
         resource: roles
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/roles/list_roles.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/roles/list_roles.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -40,7 +44,7 @@ definition:
         version: directory_v1
         resource: roles
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/tokens/delete_token.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/tokens/delete_token.yml
@@ -11,6 +11,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -34,7 +38,7 @@ definition:
         version: directory_v1
         resource: tokens
         method_name: delete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/tokens/get_token.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/tokens/get_token.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -32,7 +36,7 @@ definition:
         version: directory_v1
         resource: tokens
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/tokens/list_tokens.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/tokens/list_tokens.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -28,7 +32,7 @@ definition:
         version: directory_v1
         resource: tokens
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/two_step_verification/turn_off_two_step_verification.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/two_step_verification/turn_off_two_step_verification.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -28,7 +32,7 @@ definition:
         version: directory_v1
         resource: twoStepVerification
         method_name: turnOff
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/delete_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/delete_user.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -29,7 +33,7 @@ definition:
         version: directory_v1
         resource: users
         method_name: delete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/get_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/get_user.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -47,7 +51,7 @@ definition:
         version: directory_v1
         resource: users
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.readonly"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/insert_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/insert_user.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -41,7 +45,7 @@ definition:
         version: directory_v1
         resource: users
         method_name: insert
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user"]
         params:
           resolveConflictAccount: ${{ inputs.resolve_conflict_account }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/list_user_aliases.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/list_user_aliases.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -29,7 +33,7 @@ definition:
         version: directory_v1
         resource: users.aliases
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.alias.readonly"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/list_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/list_users.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -89,7 +93,7 @@ definition:
         version: directory_v1
         resource: users
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.readonly"]
         params:
           customer: ${{ inputs.customer }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/make_user_admin.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/make_user_admin.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -32,7 +36,7 @@ definition:
         version: directory_v1
         resource: users
         method_name: makeAdmin
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/patch_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/patch_user.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -40,7 +44,7 @@ definition:
         version: directory_v1
         resource: users
         method_name: patch
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/sign_out_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/sign_out_user.yml
@@ -11,6 +11,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -31,7 +35,7 @@ definition:
         version: directory_v1
         resource: users
         method_name: signOut
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/undelete_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/users/undelete_user.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -30,7 +34,7 @@ definition:
         version: directory_v1
         resource: users
         method_name: undelete
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/verification_codes/generate_verification_codes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/verification_codes/generate_verification_codes.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -28,7 +32,7 @@ definition:
         version: directory_v1
         resource: verificationCodes
         method_name: generate
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/verification_codes/invalidate_verification_codes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/verification_codes/invalidate_verification_codes.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -28,7 +32,7 @@ definition:
         version: directory_v1
         resource: verificationCodes
         method_name: invalidate
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/verification_codes/list_verification_codes.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_directory/verification_codes/list_verification_codes.yml
@@ -9,6 +9,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -28,7 +32,7 @@ definition:
         version: directory_v1
         resource: verificationCodes
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.directory.user.security"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_reports/activities/list_activities.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_reports/activities/list_activities.yml
@@ -13,6 +13,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -113,7 +117,7 @@ definition:
         version: reports_v1
         resource: activities
         method_name: list
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.reports.audit.readonly"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_reports/usage/get_customer_usage_report.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_reports/usage/get_customer_usage_report.yml
@@ -11,6 +11,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -49,7 +53,7 @@ definition:
         version: reports_v1
         resource: customerUsageReports
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.reports.usage.readonly"]
         params:
           date: ${{ inputs.date }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_reports/usage/get_entity_usage_report.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_reports/usage/get_entity_usage_report.yml
@@ -11,6 +11,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -70,7 +74,7 @@ definition:
         version: reports_v1
         resource: entityUsageReports
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.reports.usage.readonly"]
         params:
           entityType: ${{ inputs.entity_type }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/google_reports/usage/get_user_usage_report.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/google_reports/usage/get_user_usage_report.yml
@@ -11,6 +11,10 @@ definition:
   secrets:
     - type: oauth
       provider_id: google_admin
+      grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: google_admin
       grant_type: client_credentials
       optional: true
     - name: google_api
@@ -79,7 +83,7 @@ definition:
         version: reports_v1
         resource: userUsageReport
         method_name: get
-        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
+        access_token: ${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}
         scopes: ["https://www.googleapis.com/auth/admin.reports.usage.readonly"]
         params:
           userKey: ${{ inputs.user_key }}

--- a/tests/unit/test_google_providers.py
+++ b/tests/unit/test_google_providers.py
@@ -6,7 +6,10 @@ from google.auth.exceptions import GoogleAuthError, RefreshError
 from tracecat.integrations.enums import OAuthGrantType
 from tracecat.integrations.providers import PROVIDER_REGISTRY
 from tracecat.integrations.providers.base import BaseOAuthProvider
-from tracecat.integrations.providers.google.admin import GOOGLE_ADMIN_SCOPES
+from tracecat.integrations.providers.google.admin import (
+    GOOGLE_ADMIN_AC_SCOPES,
+    GOOGLE_ADMIN_SCOPES,
+)
 from tracecat.integrations.providers.google.service_account import (
     _is_unauthorized_client,
 )
@@ -17,7 +20,7 @@ CC = OAuthGrantType.CLIENT_CREDENTIALS
 
 EXPECTED_GRANT_TYPES: dict[str, set[OAuthGrantType]] = {
     "google": {CC},
-    "google_admin": {CC},
+    "google_admin": {AC, CC},
     "google_docs": {AC, CC},
     "google_drive": {AC, CC},
     "google_forms": {AC, CC},
@@ -84,6 +87,15 @@ def test_google_admin_default_scopes() -> None:
         scope.rsplit("/", 1)[1].startswith(("admin.", "apps.alerts"))
         for scope in GOOGLE_ADMIN_SCOPES
     )
+
+
+def test_google_admin_ac_scopes_exclude_alert_center() -> None:
+    """The user OAuth flow covers Directory and Reports, never Alert Center."""
+    ac_cls = PROVIDER_REGISTRY[ProviderKey(id="google_admin", grant_type=AC)]
+    cc_cls = PROVIDER_REGISTRY[ProviderKey(id="google_admin", grant_type=CC)]
+    assert ac_cls.scopes.default == GOOGLE_ADMIN_AC_SCOPES
+    assert not any(scope.endswith("apps.alerts") for scope in GOOGLE_ADMIN_AC_SCOPES)
+    assert set(GOOGLE_ADMIN_AC_SCOPES) < set(cc_cls.scopes.default)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_google_templates_contract.py
+++ b/tests/unit/test_google_templates_contract.py
@@ -7,7 +7,9 @@ silently in a single YAML file:
 - every declared secret is optional, or the `||` chain never evaluates;
 - every `call_api` step passes `scopes`, which is what places the
   `GOOGLE_API_CREDENTIALS` key ahead of the generic `GOOGLE_SERVICE_TOKEN`;
-- `google_admin` is the credential of the Admin SDK namespaces only.
+- `google_admin` is the credential of the Admin SDK namespaces only, as a user
+  OAuth token first for Directory and Reports and as the service account only
+  for Alert Center.
 """
 
 from pathlib import Path
@@ -73,11 +75,18 @@ def test_google_template_credential_chain(path: Path) -> None:
         s.provider_id for s in secrets if isinstance(s, RegistryOAuthSecret)
     }
     namespace = path.relative_to(TEMPLATES).parts[0]
-    if namespace in ADMIN_SDK_NAMESPACES:
+    if namespace == "google_alert_center":
+        # Alert Center needs a service account with domain-wide delegation.
         assert oauth_providers == {"google_admin"}
         assert (
             access_token
             == "${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}"
+        )
+    elif namespace in ADMIN_SDK_NAMESPACES:
+        assert oauth_providers == {"google_admin"}
+        assert access_token == (
+            "${{ SECRETS.google_admin_oauth.GOOGLE_ADMIN_USER_TOKEN"
+            " || SECRETS.google_admin_oauth.GOOGLE_ADMIN_SERVICE_TOKEN }}"
         )
     else:
         assert "google_admin" not in oauth_providers, (

--- a/tracecat/integrations/providers/__init__.py
+++ b/tracecat/integrations/providers/__init__.py
@@ -4,6 +4,7 @@ from tracecat.integrations.providers.base import BaseOAuthProvider
 from tracecat.integrations.providers.github.mcp import GitHubMCPProvider
 from tracecat.integrations.providers.github.oauth import GitHubOAuthProvider
 from tracecat.integrations.providers.google import (
+    GoogleAdminACProvider,
     GoogleAdminCCProvider,
     GoogleDocsACProvider,
     GoogleDocsCCProvider,
@@ -52,6 +53,7 @@ from tracecat.integrations.schemas import ProviderKey
 _PROVIDER_CLASSES: list[type[BaseOAuthProvider]] = [
     GitHubOAuthProvider,
     GitHubMCPProvider,
+    GoogleAdminACProvider,
     GoogleAdminCCProvider,
     GoogleDocsACProvider,
     GoogleDocsCCProvider,

--- a/tracecat/integrations/providers/google/__init__.py
+++ b/tracecat/integrations/providers/google/__init__.py
@@ -1,6 +1,6 @@
 """Google OAuth providers."""
 
-from .admin import GoogleAdminCCProvider
+from .admin import GoogleAdminACProvider, GoogleAdminCCProvider
 from .common import (
     GoogleAuthorizationCodeOAuthProvider,
     get_google_ac_metadata,
@@ -15,6 +15,7 @@ from .sheets import GoogleSheetsACProvider, GoogleSheetsCCProvider
 from .slides import GoogleSlidesACProvider, GoogleSlidesCCProvider
 
 __all__ = [
+    "GoogleAdminACProvider",
     "GoogleAdminCCProvider",
     "GoogleAuthorizationCodeOAuthProvider",
     "GoogleDocsACProvider",

--- a/tracecat/integrations/providers/google/admin.py
+++ b/tracecat/integrations/providers/google/admin.py
@@ -1,19 +1,29 @@
-"""Google Workspace Admin service account provider.
+"""Google Workspace Admin providers.
 
-Credential for the Admin SDK namespaces (`tools.google_directory`,
-`tools.google_reports`, `tools.google_alert_center`). The Workspace app
-namespaces use their own per-service providers.
+Credential for the Admin SDK namespaces. The Directory and Reports namespaces
+(`tools.google_directory`, `tools.google_reports`) accept either grant: a
+Workspace administrator's user OAuth connection or the service account with
+domain-wide delegation. Alert Center (`tools.google_alert_center`) requires the
+service account. The Workspace app namespaces use their own per-service
+providers.
 """
 
 from typing import ClassVar
 
-from tracecat.integrations.providers.google.common import get_google_cc_metadata
+from tracecat.integrations.providers.google.common import (
+    GoogleAuthorizationCodeOAuthProvider,
+    get_google_ac_metadata,
+    get_google_cc_metadata,
+)
 from tracecat.integrations.providers.google.service_account import (
     GoogleServiceAccountOAuthProvider,
 )
 from tracecat.integrations.schemas import ProviderMetadata, ProviderScopes
 
-GOOGLE_ADMIN_SCOPES = [
+ADMIN_API_DOCS_URL = "https://developers.google.com/workspace/admin"
+ADMIN_TROUBLESHOOT_URL = "https://developers.google.com/workspace/admin/directory/v1/guides/troubleshoot-error-codes"
+
+GOOGLE_DIRECTORY_SCOPES = [
     f"https://www.googleapis.com/auth/{scope}"
     for scope in (
         "admin.directory.user",
@@ -28,11 +38,44 @@ GOOGLE_ADMIN_SCOPES = [
         "admin.directory.device.chromeos",
         "admin.directory.domain.readonly",
         "admin.directory.customer.readonly",
-        "admin.reports.audit.readonly",
-        "admin.reports.usage.readonly",
-        "apps.alerts",
     )
 ]
+
+GOOGLE_REPORTS_SCOPES = [
+    f"https://www.googleapis.com/auth/{scope}"
+    for scope in (
+        "admin.reports.audit.readonly",
+        "admin.reports.usage.readonly",
+    )
+]
+
+GOOGLE_ALERT_CENTER_SCOPES = [
+    f"https://www.googleapis.com/auth/{scope}" for scope in ("apps.alerts",)
+]
+
+GOOGLE_ADMIN_AC_SCOPES = GOOGLE_DIRECTORY_SCOPES + GOOGLE_REPORTS_SCOPES
+
+GOOGLE_ADMIN_SCOPES = (
+    GOOGLE_DIRECTORY_SCOPES + GOOGLE_REPORTS_SCOPES + GOOGLE_ALERT_CENTER_SCOPES
+)
+
+
+class GoogleAdminACProvider(GoogleAuthorizationCodeOAuthProvider):
+    """Google Workspace Admin provider using the authorization code flow for an administrator."""
+
+    id: ClassVar[str] = "google_admin"
+    scopes: ClassVar[ProviderScopes] = ProviderScopes(default=GOOGLE_ADMIN_AC_SCOPES)
+    metadata: ClassVar[ProviderMetadata] = get_google_ac_metadata(
+        id="google_admin",
+        name="Google Workspace Admin",
+        description=(
+            "Connect a Google Workspace administrator account with OAuth to call the "
+            "Admin SDK Directory and Reports APIs as that administrator. The Alert "
+            "Center API needs the service account integration instead."
+        ),
+        api_docs_url=ADMIN_API_DOCS_URL,
+        troubleshooting_url=ADMIN_TROUBLESHOOT_URL,
+    )
 
 
 class GoogleAdminCCProvider(GoogleServiceAccountOAuthProvider):
@@ -50,7 +93,7 @@ class GoogleAdminCCProvider(GoogleServiceAccountOAuthProvider):
             "match exactly the scopes delegated to this client ID in the Admin "
             "console."
         ),
-        api_docs_url="https://developers.google.com/workspace/admin",
+        api_docs_url=ADMIN_API_DOCS_URL,
         setup_guide_url="https://developers.google.com/workspace/guides/create-credentials#optional_set_up_domain-wide_delegation_for_a_service_account",
-        troubleshooting_url="https://developers.google.com/workspace/admin/directory/v1/guides/troubleshoot-error-codes",
+        troubleshooting_url=ADMIN_TROUBLESHOOT_URL,
     )


### PR DESCRIPTION
Closes ENG-1714. Follow-up to #3310.

## Summary

`google_admin` gains a user OAuth (`authorization_code`) grant. Google's Directory and Reports quickstarts authenticate with a user OAuth client signed in as a Workspace administrator, so `tools.google_directory` and `tools.google_reports` now resolve `GOOGLE_ADMIN_USER_TOKEN || GOOGLE_ADMIN_SERVICE_TOKEN` before falling back to `google_api` inside `call_api`. `tools.google_alert_center` stays service-account only: the Alert Center API requires a service account with domain-wide delegation.

## What changed

- `tracecat/integrations/providers/google/admin.py`: `GoogleAdminACProvider` (id `google_admin`, PKCE + offline + consent like the other Google user-OAuth providers). Default scopes are the Directory and Reports scopes; `apps.alerts` is left to the service-account grant. The scope list is split into `GOOGLE_DIRECTORY_SCOPES`, `GOOGLE_REPORTS_SCOPES` and `GOOGLE_ALERT_CENTER_SCOPES`; `GOOGLE_ADMIN_SCOPES` (the service-account default) is unchanged.
- Registered next to `GoogleAdminCCProvider` in `providers/google/__init__.py` and `providers/__init__.py`.
- 60 templates (56 Directory, 4 Reports) declare the `google_admin` `authorization_code` secret (optional) and chain `USER || SERVICE`. Alert Center's 9 templates are untouched.
- `tests/unit/test_google_templates_contract.py` pins the chain per namespace; `tests/unit/test_google_providers.py` expects both grants for `google_admin` and checks the user-OAuth default scopes exclude `apps.alerts` and are a subset of the service-account defaults.
- `docs/automations/core-concepts/secrets.mdx` credential resolution order; `docs/tools/google_directory.mdx` and `google_reports.mdx` regenerated.

## Credential resolution across the Google namespaces

After this PR, every Google namespace resolves credentials as follows. The first credential that exists is used; `google_api` (`GOOGLE_API_CREDENTIALS` JSON, optional `GOOGLE_API_SUBJECT`) and the `google` (GCP) service-account token are fallbacks inside `tools.google_api.call_api`.

| Namespace | Chain | Why |
|---|---|---|
| `google_drive`, `gmail`, `google_sheets`, `google_docs`, `google_slides`, `google_forms` | `<svc> USER \|\| <svc> SERVICE` → `google_api` → `google` | per-service user OAuth and service-account grants (#3310) |
| `google_directory`, `google_reports` | `google_admin USER \|\| google_admin SERVICE` → `google_api` → `google` | this PR; the signed-in user must be a Workspace administrator |
| `google_alert_center` | `google_admin SERVICE` → `google_api` → `google` | Alert Center requires a service account with domain-wide delegation |
| `google_scc`, `tools.google_api.*` | `google` SERVICE → `google_api` | GCP IAM; no Workspace user flow |
| `google_secops_detection` (15 UDFs) | `google` SERVICE token, required, read directly | outlier: no `google_api` fallback and no chain; left for the Chronicle API consolidation rework |
| `google_secops_soar` (11 UDFs) | `GOOGLE_SECOPS_API_KEY` | Siemplify API key by design |
| `google_maps` | `GOOGLE_MAPS_API_KEY` | API key by design |

## Compatibility

- Additive. Existing `google_admin` service-account integrations keep their provider id, grant type, scopes and tokens; the new grant is a second row for the same id, as with the other Google providers.
- Existing workflows on Directory/Reports actions behave the same until a workspace connects the user-OAuth integration, at which point that admin's token takes precedence over the service account.
- The chain is a priority order, not failover: an expired or revoked user connection keeps its place and is not silently replaced by the service account (that would change the acting principal without anyone choosing it). Re-authorize or disconnect it to fall back.
- `admin.directory.*` and `admin.reports.*` are sensitive scopes: an external-facing OAuth client needs Google's verification for them; an internal Workspace client does not.

## Testing

- `tests/unit/test_google_providers.py`, `test_google_templates_contract.py`, `test_google_api_credentials.py`, `test_integrations_service.py`, `test_integrations_api.py`: 266 passed.
- `tests/registry/test_templates.py`: whole-registry validator (1015 templates) and per-file validation covering all 60 changed templates (129 selected, all passed), against the local dev stack.
- ruff, basedpyright, pre-commit.
- Not exercised against a live Workspace tenant; the admin consent flow needs a smoke test before this is relied on.

## LOC breakdown

| Category | + | - |
|---|---|---|
| Logic | 356 | 70 |
| Tests | 25 | 4 |
| Docs | 67 | 4 |
