### PR TITLE
feat(cases): add agent session interaction model

### DIFF
--- a/alembic/versions/25d9b13bfe67_add_case_agent_session_interactions.py
+++ b/alembic/versions/25d9b13bfe67_add_case_agent_session_interactions.py
@@ -1,0 +1,131 @@
+"""Add case-agent session interactions.
+
+Revision ID: 25d9b13bfe67
+Revises: 598b32358ec5
+Create Date: 2026-08-26 16:59:16.618927
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_workspace_table_rls,
+    enable_workspace_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "25d9b13bfe67"
+down_revision: str | None = "598b32358ec5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    sa.Enum(
+        "READ",
+        "CREATE",
+        "UPDATE",
+        name="caseagentsessioninteractionoperation",
+    ).create(op.get_bind())
+    op.create_table(
+        "case_agent_session_interaction",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("case_id", sa.UUID(), nullable=False),
+        sa.Column("agent_session_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "operation",
+            postgresql.ENUM(
+                "READ",
+                "CREATE",
+                "UPDATE",
+                name="caseagentsessioninteractionoperation",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_session_id"],
+            ["agent_session.id"],
+            name=op.f(
+                "fk_case_agent_session_interaction_agent_session_id_agent_session"
+            ),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["case.id"],
+            name=op.f("fk_case_agent_session_interaction_case_id_case"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_case_agent_session_interaction_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "surrogate_id",
+            name=op.f("pk_case_agent_session_interaction"),
+        ),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "case_id",
+            "agent_session_id",
+            "operation",
+            name="uq_case_agent_session_interaction_ws_case_session_operation",
+        ),
+    )
+    op.create_index(
+        op.f("ix_case_agent_session_interaction_agent_session_id"),
+        "case_agent_session_interaction",
+        ["agent_session_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_case_agent_session_interaction_case_id"),
+        "case_agent_session_interaction",
+        ["case_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_case_agent_session_interaction_case_timeline",
+        "case_agent_session_interaction",
+        ["workspace_id", "case_id", "updated_at", "agent_session_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_case_agent_session_interaction_id"),
+        "case_agent_session_interaction",
+        ["id"],
+        unique=True,
+    )
+    op.execute(enable_workspace_table_rls("case_agent_session_interaction"))
+
+
+def downgrade() -> None:
+    op.execute(disable_workspace_table_rls("case_agent_session_interaction"))
+    op.drop_table("case_agent_session_interaction")
+    sa.Enum(
+        "READ",
+        "CREATE",
+        "UPDATE",
+        name="caseagentsessioninteractionoperation",
+    ).drop(op.get_bind())

--- a/alembic/versions/44d7e75b6f4c_add_case_agent_session_interactions.py
+++ b/alembic/versions/44d7e75b6f4c_add_case_agent_session_interactions.py
@@ -1,15 +1,14 @@
 """Add case-agent session interactions.
 
-Revision ID: 25d9b13bfe67
+Revision ID: 44d7e75b6f4c
 Revises: 598b32358ec5
-Create Date: 2026-08-26 16:59:16.618927
+Create Date: 2026-08-26 17:17:55.915972
 
 """
 
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 from alembic import op
 from tracecat.db.tenant_rls import (
@@ -18,35 +17,19 @@ from tracecat.db.tenant_rls import (
 )
 
 # revision identifiers, used by Alembic.
-revision: str = "25d9b13bfe67"
+revision: str = "44d7e75b6f4c"
 down_revision: str | None = "598b32358ec5"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    sa.Enum(
-        "READ",
-        "CREATE",
-        "UPDATE",
-        name="caseagentsessioninteractionoperation",
-    ).create(op.get_bind())
     op.create_table(
         "case_agent_session_interaction",
         sa.Column("id", sa.UUID(), nullable=False),
         sa.Column("case_id", sa.UUID(), nullable=False),
         sa.Column("agent_session_id", sa.UUID(), nullable=False),
-        sa.Column(
-            "operation",
-            postgresql.ENUM(
-                "READ",
-                "CREATE",
-                "UPDATE",
-                name="caseagentsessioninteractionoperation",
-                create_type=False,
-            ),
-            nullable=False,
-        ),
+        sa.Column("operation", sa.String(), nullable=False),
         sa.Column("workspace_id", sa.UUID(), nullable=False),
         sa.Column("surrogate_id", sa.Integer(), nullable=False),
         sa.Column(
@@ -106,12 +89,6 @@ def upgrade() -> None:
         unique=False,
     )
     op.create_index(
-        "ix_case_agent_session_interaction_case_timeline",
-        "case_agent_session_interaction",
-        ["workspace_id", "case_id", "updated_at", "agent_session_id"],
-        unique=False,
-    )
-    op.create_index(
         op.f("ix_case_agent_session_interaction_id"),
         "case_agent_session_interaction",
         ["id"],
@@ -123,9 +100,3 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.execute(disable_workspace_table_rls("case_agent_session_interaction"))
     op.drop_table("case_agent_session_interaction")
-    sa.Enum(
-        "READ",
-        "CREATE",
-        "UPDATE",
-        name="caseagentsessioninteractionoperation",
-    ).drop(op.get_bind())

--- a/tests/unit/test_case_agent_session_interactions.py
+++ b/tests/unit/test_case_agent_session_interactions.py
@@ -1,0 +1,260 @@
+"""Tests for durable case-to-agent-session interactions."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.cases.agent_sessions.service import (
+    CaseAgentSessionInteractionService,
+)
+from tracecat.cases.enums import (
+    CaseAgentSessionInteractionOperation,
+    CasePriority,
+    CaseSeverity,
+    CaseStatus,
+)
+from tracecat.db.models import (
+    AgentSession,
+    Case,
+    CaseAgentSessionInteraction,
+    Workspace,
+)
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+
+pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("db")]
+
+
+async def _create_case_and_session(
+    session: AsyncSession,
+    role: Role,
+) -> tuple[Case, AgentSession]:
+    assert role.workspace_id is not None
+    case = Case(
+        id=uuid.uuid4(),
+        workspace_id=role.workspace_id,
+        case_number=1,
+        summary="Interaction test case",
+        description="Case used to test agent-session interactions",
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.LOW,
+        status=CaseStatus.NEW,
+    )
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        workspace_id=role.workspace_id,
+        title="Interaction test session",
+        entity_type="workflow",
+        entity_id=uuid.uuid4(),
+    )
+    session.add_all([case, agent_session])
+    await session.commit()
+    return case, agent_session
+
+
+async def test_record_upserts_repeated_operation_and_preserves_first_seen(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    case, agent_session = await _create_case_and_session(session, svc_role)
+    service = CaseAgentSessionInteractionService(session, svc_role)
+
+    first = await service.record(
+        case_id=case.id,
+        agent_session_id=agent_session.id,
+        operation=CaseAgentSessionInteractionOperation.READ,
+    )
+    first_seen_at = first.created_at
+    old_last_seen_at = datetime(2020, 1, 1, tzinfo=UTC)
+    await session.execute(
+        update(CaseAgentSessionInteraction)
+        .where(CaseAgentSessionInteraction.id == first.id)
+        .values(updated_at=old_last_seen_at)
+    )
+
+    repeated = await service.record(
+        case_id=case.id,
+        agent_session_id=agent_session.id,
+        operation=CaseAgentSessionInteractionOperation.READ,
+    )
+
+    count = await session.scalar(
+        select(func.count())
+        .select_from(CaseAgentSessionInteraction)
+        .where(CaseAgentSessionInteraction.case_id == case.id)
+    )
+    assert count == 1
+    assert repeated.id == first.id
+    assert repeated.created_at == first_seen_at
+    assert repeated.updated_at > old_last_seen_at
+
+
+async def test_record_preserves_distinct_operations(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    case, agent_session = await _create_case_and_session(session, svc_role)
+    service = CaseAgentSessionInteractionService(session, svc_role)
+
+    for operation in (
+        CaseAgentSessionInteractionOperation.READ,
+        CaseAgentSessionInteractionOperation.CREATE,
+        CaseAgentSessionInteractionOperation.UPDATE,
+    ):
+        await service.record(
+            case_id=case.id,
+            agent_session_id=agent_session.id,
+            operation=operation,
+        )
+
+    operations = set(
+        (
+            await session.scalars(
+                select(CaseAgentSessionInteraction.operation).where(
+                    CaseAgentSessionInteraction.case_id == case.id
+                )
+            )
+        ).all()
+    )
+    assert operations == {
+        CaseAgentSessionInteractionOperation.READ,
+        CaseAgentSessionInteractionOperation.CREATE,
+        CaseAgentSessionInteractionOperation.UPDATE,
+    }
+
+
+async def test_record_normalizes_nested_fork_to_root_session(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    case, root_session = await _create_case_and_session(session, svc_role)
+    assert svc_role.workspace_id is not None
+    child_session = AgentSession(
+        id=uuid.uuid4(),
+        workspace_id=svc_role.workspace_id,
+        title="Child session",
+        entity_type="approval",
+        entity_id=uuid.uuid4(),
+        parent_session_id=root_session.id,
+    )
+    grandchild_session = AgentSession(
+        id=uuid.uuid4(),
+        workspace_id=svc_role.workspace_id,
+        title="Grandchild session",
+        entity_type="approval",
+        entity_id=uuid.uuid4(),
+        parent_session_id=child_session.id,
+    )
+    session.add_all([child_session, grandchild_session])
+    await session.commit()
+    service = CaseAgentSessionInteractionService(session, svc_role)
+
+    interaction = await service.record(
+        case_id=case.id,
+        agent_session_id=grandchild_session.id,
+        operation=CaseAgentSessionInteractionOperation.UPDATE,
+    )
+
+    assert interaction.agent_session_id == root_session.id
+
+
+async def test_record_does_not_commit_callers_transaction(
+    session: AsyncSession,
+    svc_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case, agent_session = await _create_case_and_session(session, svc_role)
+    service = CaseAgentSessionInteractionService(session, svc_role)
+    commit = AsyncMock()
+    monkeypatch.setattr(session, "commit", commit)
+
+    await service.record(
+        case_id=case.id,
+        agent_session_id=agent_session.id,
+        operation=CaseAgentSessionInteractionOperation.READ,
+    )
+
+    commit.assert_not_awaited()
+
+
+async def test_record_rejects_cross_workspace_case_and_session(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    own_case, own_session = await _create_case_and_session(session, svc_role)
+    assert svc_role.organization_id is not None
+    other_workspace = Workspace(
+        id=uuid.uuid4(),
+        name=f"interaction-test-{uuid.uuid4()}",
+        organization_id=svc_role.organization_id,
+    )
+    session.add(other_workspace)
+    await session.flush()
+    other_case = Case(
+        id=uuid.uuid4(),
+        workspace_id=other_workspace.id,
+        case_number=1,
+        summary="Other workspace case",
+        description="Case outside the service workspace",
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.LOW,
+        status=CaseStatus.NEW,
+    )
+    other_session = AgentSession(
+        id=uuid.uuid4(),
+        workspace_id=other_workspace.id,
+        title="Other workspace session",
+        entity_type="workflow",
+        entity_id=uuid.uuid4(),
+    )
+    session.add_all([other_case, other_session])
+    await session.commit()
+    service = CaseAgentSessionInteractionService(session, svc_role)
+
+    with pytest.raises(TracecatNotFoundError):
+        await service.record(
+            case_id=other_case.id,
+            agent_session_id=own_session.id,
+            operation=CaseAgentSessionInteractionOperation.READ,
+        )
+    with pytest.raises(TracecatNotFoundError):
+        await service.record(
+            case_id=own_case.id,
+            agent_session_id=other_session.id,
+            operation=CaseAgentSessionInteractionOperation.READ,
+        )
+
+    count = await session.scalar(
+        select(func.count()).select_from(CaseAgentSessionInteraction)
+    )
+    assert count == 0
+
+
+async def test_root_resolution_rejects_session_lineage_cycle(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    _, first_session = await _create_case_and_session(session, svc_role)
+    assert svc_role.workspace_id is not None
+    second_session = AgentSession(
+        id=uuid.uuid4(),
+        workspace_id=svc_role.workspace_id,
+        title="Second cyclic session",
+        entity_type="approval",
+        entity_id=uuid.uuid4(),
+        parent_session_id=first_session.id,
+    )
+    session.add(second_session)
+    await session.commit()
+    first_session.parent_session_id = second_session.id
+    await session.commit()
+    service = CaseAgentSessionInteractionService(session, svc_role)
+
+    with pytest.raises(TracecatValidationError, match="lineage contains a cycle"):
+        await service.resolve_root_session_id(first_session.id)

--- a/tracecat/cases/agent_sessions/__init__.py
+++ b/tracecat/cases/agent_sessions/__init__.py
@@ -1,0 +1,1 @@
+"""Case-to-agent-session interaction persistence."""

--- a/tracecat/cases/agent_sessions/service.py
+++ b/tracecat/cases/agent_sessions/service.py
@@ -1,0 +1,109 @@
+"""Persistence service for case-to-agent-session interactions."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from tracecat.cases.enums import CaseAgentSessionInteractionOperation
+from tracecat.db.models import AgentSession, Case, CaseAgentSessionInteraction
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.service import BaseWorkspaceService
+
+
+class CaseAgentSessionInteractionService(BaseWorkspaceService):
+    """Record the cases touched by Inbox-facing agent sessions."""
+
+    service_name = "case_agent_session_interactions"
+
+    async def resolve_root_session_id(self, session_id: uuid.UUID) -> uuid.UUID:
+        """Resolve a session or continuation to its Inbox-facing root session.
+
+        Args:
+            session_id: Agent session to resolve.
+
+        Returns:
+            The root agent session ID.
+
+        Raises:
+            TracecatNotFoundError: If the session lineage leaves the workspace.
+            TracecatValidationError: If the session lineage contains a cycle.
+        """
+        current_session_id = session_id
+        visited: set[uuid.UUID] = set()
+
+        while current_session_id not in visited:
+            visited.add(current_session_id)
+            statement = select(
+                AgentSession.id,
+                AgentSession.parent_session_id,
+            ).where(
+                AgentSession.workspace_id == self.workspace_id,
+                AgentSession.id == current_session_id,
+            )
+            result = (await self.session.execute(statement)).one_or_none()
+            if result is None:
+                raise TracecatNotFoundError(
+                    f"Agent session '{session_id}' not found in this workspace"
+                )
+
+            resolved_session_id, parent_session_id = result
+            if parent_session_id is None:
+                return resolved_session_id
+            current_session_id = parent_session_id
+
+        raise TracecatValidationError("Agent session lineage contains a cycle")
+
+    async def record(
+        self,
+        *,
+        case_id: uuid.UUID,
+        agent_session_id: uuid.UUID,
+        operation: CaseAgentSessionInteractionOperation,
+    ) -> CaseAgentSessionInteraction:
+        """Upsert one case interaction without committing the caller's transaction.
+
+        Args:
+            case_id: Case touched by the agent session.
+            agent_session_id: Session that performed the operation.
+            operation: Type of case operation performed.
+
+        Returns:
+            The inserted or refreshed interaction.
+
+        Raises:
+            TracecatNotFoundError: If the case or session is outside the workspace.
+        """
+        case_exists = await self.session.scalar(
+            select(Case.id).where(
+                Case.workspace_id == self.workspace_id,
+                Case.id == case_id,
+            )
+        )
+        if case_exists is None:
+            raise TracecatNotFoundError(f"Case '{case_id}' not found in this workspace")
+
+        root_session_id = await self.resolve_root_session_id(agent_session_id)
+        statement = pg_insert(CaseAgentSessionInteraction).values(
+            id=uuid.uuid4(),
+            workspace_id=self.workspace_id,
+            case_id=case_id,
+            agent_session_id=root_session_id,
+            operation=operation,
+        )
+        statement = statement.on_conflict_do_update(
+            index_elements=[
+                "workspace_id",
+                "case_id",
+                "agent_session_id",
+                "operation",
+            ],
+            set_={"updated_at": func.now()},
+        )
+        result = await self.session.scalars(
+            statement.returning(CaseAgentSessionInteraction),
+            execution_options={"populate_existing": True},
+        )
+        return result.one()

--- a/tracecat/cases/enums.py
+++ b/tracecat/cases/enums.py
@@ -64,6 +64,14 @@ class CaseVersionField(StrEnum):
     DESCRIPTION = "description"
 
 
+class CaseAgentSessionInteractionOperation(StrEnum):
+    """Operations that associate an agent session with a case."""
+
+    READ = "read"
+    CREATE = "create"
+    UPDATE = "update"
+
+
 class CaseEventType(StrEnum):
     """Case activity type values."""
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -55,6 +55,7 @@ from tracecat.authz.enums import ScopeSource
 from tracecat.cases.agent_invocations.types import CaseCommentAgentInvocationError
 from tracecat.cases.durations.schemas import CaseDurationAnchorSelection
 from tracecat.cases.enums import (
+    CaseAgentSessionInteractionOperation,
     CaseCommentAgentInvocationStatus,
     CaseEventType,
     CasePriority,
@@ -84,6 +85,10 @@ CASE_SEVERITY_ENUM = Enum(CaseSeverity, name="caseseverity")
 CASE_STATUS_ENUM = Enum(CaseStatus, name="casestatus")
 CASE_TASK_STATUS_ENUM = Enum(CaseTaskStatus, name="casetaskstatus")
 CASE_VERSION_FIELD_ENUM = Enum(CaseVersionField, name="caseversionfield")
+CASE_AGENT_SESSION_INTERACTION_OPERATION_ENUM = Enum(
+    CaseAgentSessionInteractionOperation,
+    name="caseagentsessioninteractionoperation",
+)
 INTERACTION_STATUS_ENUM = Enum(InteractionStatus, name="interactionstatus")
 APPROVAL_STATUS_ENUM = Enum(ApprovalStatus, name="approvalstatus")
 INVITATION_STATUS_ENUM = Enum(InvitationStatus, name="invitationstatus")
@@ -3161,6 +3166,59 @@ class AgentSession(WorkspaceModel):
         back_populates="session",
         cascade="all, delete-orphan",
         order_by="AgentSessionHistory.surrogate_id",
+    )
+
+
+class CaseAgentSessionInteraction(WorkspaceModel):
+    """Durable association between a case and an Inbox-facing agent session."""
+
+    # Inherited created_at/updated_at are the first-seen/last-seen timestamps.
+    __tablename__ = "case_agent_session_interaction"
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "case_id",
+            "agent_session_id",
+            "operation",
+            name="uq_case_agent_session_interaction_ws_case_session_operation",
+        ),
+        Index(
+            "ix_case_agent_session_interaction_case_timeline",
+            "workspace_id",
+            "case_id",
+            "updated_at",
+            "agent_session_id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    case_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("case.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    agent_session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("agent_session.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    operation: Mapped[CaseAgentSessionInteractionOperation] = mapped_column(
+        CASE_AGENT_SESSION_INTERACTION_OPERATION_ENUM,
+        nullable=False,
+    )
+
+    case: Mapped[Case] = relationship("Case", lazy="raise")
+    agent_session: Mapped[AgentSession] = relationship(
+        "AgentSession",
+        lazy="raise",
     )
 
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -85,10 +85,6 @@ CASE_SEVERITY_ENUM = Enum(CaseSeverity, name="caseseverity")
 CASE_STATUS_ENUM = Enum(CaseStatus, name="casestatus")
 CASE_TASK_STATUS_ENUM = Enum(CaseTaskStatus, name="casetaskstatus")
 CASE_VERSION_FIELD_ENUM = Enum(CaseVersionField, name="caseversionfield")
-CASE_AGENT_SESSION_INTERACTION_OPERATION_ENUM = Enum(
-    CaseAgentSessionInteractionOperation,
-    name="caseagentsessioninteractionoperation",
-)
 INTERACTION_STATUS_ENUM = Enum(InteractionStatus, name="interactionstatus")
 APPROVAL_STATUS_ENUM = Enum(ApprovalStatus, name="approvalstatus")
 INVITATION_STATUS_ENUM = Enum(InvitationStatus, name="invitationstatus")
@@ -3182,13 +3178,6 @@ class CaseAgentSessionInteraction(WorkspaceModel):
             "operation",
             name="uq_case_agent_session_interaction_ws_case_session_operation",
         ),
-        Index(
-            "ix_case_agent_session_interaction_case_timeline",
-            "workspace_id",
-            "case_id",
-            "updated_at",
-            "agent_session_id",
-        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -3211,7 +3200,7 @@ class CaseAgentSessionInteraction(WorkspaceModel):
         index=True,
     )
     operation: Mapped[CaseAgentSessionInteractionOperation] = mapped_column(
-        CASE_AGENT_SESSION_INTERACTION_OPERATION_ENUM,
+        String,
         nullable=False,
     )
 

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -72,6 +72,7 @@ INITIAL_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
 # Tables introduced after the initial RLS rollout. Their creating or follow-up
 # revisions must apply policy SQL explicitly.
 POST_RLS_WORKSPACE_SCOPED_TABLES = (
+    "case_agent_session_interaction",
     "case_table_row",
     "case_version",
     "case_comment_agent_invocation",


### PR DESCRIPTION
## Summary

- add a workspace-scoped case-to-agent-session interaction table with read, create, and update operations stored as strings
- add a transaction-neutral, concurrency-safe recorder that normalizes continuation sessions to the Inbox root session
- keep the table's indexes limited to its unique interaction key and direct foreign-key lookups
- add coverage for repeated upserts, operation separation, transaction ownership, workspace isolation, nested forks, and lineage cycles

Linear: ENG-1708

## Testing

- `uv run pytest tests/unit/test_case_agent_session_interactions.py tests/unit/test_tenant_rls_registry.py tests/unit/test_db_model.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- pre-commit hooks
- verified the local database was at parent revision `598b32358ec5`, then applied regenerated revision `44d7e75b6f4c`
- inspected the applied PostgreSQL schema: `operation` is `varchar`, no operation enum or timeline index exists, and workspace RLS is active

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 166 | 0 |
| Tests | 260 | 0 |
| Generated migration | 102 | 0 |
