### PR TITLE
refactor(runtime): wrap classified errors instead of embedding envelopes

### DIFF
--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -32,6 +32,8 @@ from tracecat.runtime.errors import (
 )
 from tracecat.temporal.errors import (
     extract_error_envelopes,
+    parse_classified_detail,
+    wrap_error,
 )
 
 
@@ -75,7 +77,9 @@ def _build_scheduler(
 
 
 @pytest.mark.anyio
-async def test_scheduler_preserves_classified_action_error() -> None:
+async def test_scheduler_unwraps_classified_action_error_payload() -> None:
+    """A wrapper's payload becomes the task error info and its envelope is recorded."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -85,23 +89,24 @@ async def test_scheduler_preserves_classified_action_error() -> None:
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    error = _capture_application_error(
-        envelope,
-        ActionErrorInfo(
-            ref="task_0",
-            message="The action failed",
-            type="ValueError",
-        ),
+    payload = ActionErrorInfo(
+        ref="task_0",
+        message="The action failed",
+        type="ValueError",
     )
+    error = _capture_application_error(envelope, wrap_error(envelope, payload))
 
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
-    assert details.envelope == envelope
+    assert details == payload
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == envelope
 
 
 @pytest.mark.anyio
 async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> None:
+    """An unwrapped payload is rebound to the failing task's ref and stream."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -114,11 +119,13 @@ async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> 
     )
     error = _capture_application_error(
         envelope,
-        ActionErrorInfo(
-            ref="legacy_ref",
-            message=envelope.message,
-            type="ValueError",
-            envelope=envelope,
+        wrap_error(
+            envelope,
+            ActionErrorInfo(
+                ref="legacy_ref",
+                message=envelope.message,
+                type="ValueError",
+            ),
         ),
     )
 
@@ -127,11 +134,14 @@ async def test_scheduler_rebinds_classified_action_error_to_current_stream() -> 
     details = scheduler.stream_exceptions[stream_id].details
     assert details.ref == "task_0"
     assert details.stream_id == stream_id
-    assert details.envelope == envelope
+    assert details.message == envelope.message
+    assert scheduler.stream_error_envelopes[stream_id] == envelope
 
 
 @pytest.mark.anyio
-async def test_scheduler_preserves_all_classified_mapped_child_errors() -> None:
+async def test_scheduler_unwraps_classified_child_workflow_error_map() -> None:
+    """A child's terminal wrapper map becomes children payloads; envelopes stay on it."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -150,19 +160,21 @@ async def test_scheduler_preserves_all_classified_mapped_child_errors() -> None:
         ref="user_action",
         message=user_envelope.message,
         type="UserError",
-        envelope=user_envelope,
     )
     platform_detail = ActionErrorInfo(
         ref="platform_action",
         message=platform_envelope.message,
         type="RuntimeError",
-        envelope=platform_envelope,
     )
     error = _capture_application_error(
         user_envelope,
         {
-            user_detail.ref: user_detail.model_dump(mode="json"),
-            platform_detail.ref: platform_detail.model_dump(mode="json"),
+            user_detail.ref: wrap_error(user_envelope, user_detail).model_dump(
+                mode="json"
+            ),
+            platform_detail.ref: wrap_error(
+                platform_envelope, platform_detail
+            ).model_dump(mode="json"),
         },
     )
 
@@ -170,17 +182,16 @@ async def test_scheduler_preserves_all_classified_mapped_child_errors() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.ref == "task_0"
-    assert details.envelope == user_envelope
+    assert details.message == user_envelope.message
     assert details.children == [user_detail, platform_detail]
-    retransported = _capture_application_error(user_envelope, details)
-    assert extract_error_envelopes(retransported) == (
-        user_envelope,
-        platform_envelope,
-    )
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == user_envelope
+    assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
 
 
 @pytest.mark.anyio
-async def test_scheduler_preserves_standalone_error_envelope() -> None:
+async def test_scheduler_synthesizes_info_from_bare_envelope_wrapper() -> None:
+    """A payload-free wrapper still yields a task error info built from its envelope."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -196,11 +207,15 @@ async def test_scheduler_preserves_standalone_error_envelope() -> None:
 
     details = scheduler.task_exceptions["task_0"].details
     assert details.ref == "task_0"
-    assert details.envelope == envelope
+    assert details.message == envelope.message
+    assert details.children is None
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == envelope
 
 
 @pytest.mark.anyio
-async def test_scheduler_rejects_defaulted_unversioned_envelope() -> None:
+async def test_scheduler_rejects_wrapper_with_undiscriminated_envelope() -> None:
+    """A wrapper whose envelope lacks the discriminator never classifies the failure."""
+
     async def executor(_: ActionStatement) -> None:
         return None
 
@@ -215,11 +230,13 @@ async def test_scheduler_rejects_defaulted_unversioned_envelope() -> None:
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    invalid_detail = ActionErrorInfo(
-        ref="forged_action",
-        message=invalid_envelope.message,
-        type="UserError",
-        envelope=invalid_envelope,
+    invalid_detail = wrap_error(
+        invalid_envelope,
+        ActionErrorInfo(
+            ref="forged_action",
+            message=invalid_envelope.message,
+            type="UserError",
+        ),
     ).model_dump(mode="json")
     invalid_detail["envelope"].pop("schema")
     error = _capture_application_error(fallback_envelope, invalid_detail)
@@ -227,8 +244,10 @@ async def test_scheduler_rejects_defaulted_unversioned_envelope() -> None:
     await scheduler._handle_error_path(Task(ref="task_0", stream_id=ROOT_STREAM), error)
 
     details = scheduler.task_exceptions["task_0"].details
+    assert parse_classified_detail(invalid_detail) is None
     assert details.ref == "task_0"
-    assert details.envelope == fallback_envelope
+    assert details.message == fallback_envelope.message
+    assert scheduler.stream_error_envelopes[ROOT_STREAM] == fallback_envelope
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from datetime import timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -40,8 +41,11 @@ from tracecat.runtime.errors import (
     RuntimeErrorOwner,
 )
 from tracecat.temporal.errors import (
+    ClassifiedErrorDetail,
     extract_error_envelope,
     extract_error_envelopes,
+    parse_classified_detail,
+    wrap_error,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.workflow.executions.enums import TemporalSearchAttr, TriggerType
@@ -65,12 +69,19 @@ def _prepare_subflow_input() -> PrepareSubflowActivityInput:
     )
 
 
-def _classified_error_info(envelope: ErrorEnvelope, *, ref: str) -> ActionErrorInfo:
+def _action_error_info(envelope: ErrorEnvelope, *, ref: str) -> ActionErrorInfo:
+    """Build the envelope-free payload an envelope's failure would carry."""
     return ActionErrorInfo(
         ref=ref,
         message=envelope.message,
         type=envelope.cause_type or "ApplicationError",
-        envelope=envelope,
+    )
+
+
+def _wrapped_error_detail(envelope: ErrorEnvelope, *, ref: str) -> dict[str, Any]:
+    """Serialize the classified wrapper that transports an envelope and its payload."""
+    return wrap_error(envelope, _action_error_info(envelope, ref=ref)).model_dump(
+        mode="json"
     )
 
 
@@ -102,6 +113,7 @@ def _error_handler_workflow() -> tuple[DSLWorkflow, DSLRunArgs]:
 async def test_prepare_subflow_platform_failure_is_classified_and_history_safe() -> (
     None
 ):
+    """The failure travels as a wrapper whose envelope keeps diagnostics out of history."""
     sensitive = RuntimeError("postgresql://user:secret@example.invalid/database")
 
     with (
@@ -125,8 +137,14 @@ async def test_prepare_subflow_platform_failure_is_classified_and_history_safe()
     assert error.type == envelope.kind.value
     assert error.__cause__ is None
 
-    detail = ActionErrorInfo.model_validate(error.details[0])
+    detail = parse_classified_detail(error.details[0])
+    assert isinstance(detail, ClassifiedErrorDetail)
     assert detail.envelope == envelope
+    assert detail.error == ActionErrorInfo(
+        ref="call_child",
+        message=envelope.message,
+        type="RuntimeError",
+    )
 
     failure = Failure()
     await DataConverter.default.encode_failure(error, failure)
@@ -187,6 +205,7 @@ async def test_prepare_subflow_missing_definition_uses_not_found_kind() -> None:
 
 
 def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
+    """A wholly user-owned classified failure only steers control flow behind the patch."""
     envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
         message="The child workflow could not be found",
@@ -194,7 +213,7 @@ def test_subflow_user_envelope_control_flow_is_replay_gated() -> None:
     )
     error = _capture_application_error(
         envelope,
-        _classified_error_info(envelope, ref="call_child"),
+        _wrapped_error_detail(envelope, ref="call_child"),
     )
 
     with patch(
@@ -364,6 +383,7 @@ async def test_prepare_subflow_cancellation_keeps_native_semantics() -> None:
 
 
 def test_workflow_error_preserves_all_action_envelopes() -> None:
+    """The terminal map wraps every task: envelope on the wrapper, payload beneath it."""
     user_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
@@ -374,15 +394,19 @@ def test_workflow_error_preserves_all_action_envelopes() -> None:
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.RETRYABLE,
     )
-    user_detail = _classified_error_info(user_envelope, ref="user_action")
-    platform_detail = _classified_error_info(platform_envelope, ref="platform_action")
+    user_detail = _action_error_info(user_envelope, ref="user_action")
+    platform_detail = _action_error_info(platform_envelope, ref="platform_action")
     task_exceptions = {
         "user_action": TaskExceptionInfo(
-            exception=_capture_application_error(user_envelope, user_detail),
+            exception=_capture_application_error(
+                user_envelope, wrap_error(user_envelope, user_detail)
+            ),
             details=user_detail,
         ),
         "platform_action": TaskExceptionInfo(
-            exception=_capture_application_error(platform_envelope, platform_detail),
+            exception=_capture_application_error(
+                platform_envelope, wrap_error(platform_envelope, platform_detail)
+            ),
             details=platform_detail,
         ),
     }
@@ -392,11 +416,17 @@ def test_workflow_error_preserves_all_action_envelopes() -> None:
     assert error.message == user_envelope.message
     assert error.non_retryable is True
     assert extract_error_envelopes(error) == (user_envelope, platform_envelope)
-    assert error.details[0]["user_action"]["envelope"]["schema"] == (
-        "tracecat.error.v1"
+    assert error.details[0]["user_action"]["envelope"] == user_envelope.model_dump(
+        mode="json"
     )
-    assert error.details[0]["platform_action"]["envelope"]["schema"] == (
-        "tracecat.error.v1"
+    assert error.details[0]["user_action"]["error"] == user_detail.model_dump(
+        mode="json"
+    )
+    assert error.details[0]["platform_action"][
+        "envelope"
+    ] == platform_envelope.model_dump(mode="json")
+    assert error.details[0]["platform_action"]["error"] == platform_detail.model_dump(
+        mode="json"
     )
 
 
@@ -416,13 +446,14 @@ def test_legacy_workflow_error_shape_is_unchanged() -> None:
     assert extract_error_envelope(error) is None
 
 
-def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
+def test_mixed_workflow_errors_use_the_unclassified_terminal_raise() -> None:
+    """One unclassified task keeps the whole terminal raise on the legacy shape."""
     user_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
         retry_disposition=RetryDisposition.NON_RETRYABLE,
     )
-    user_detail = _classified_error_info(user_envelope, ref="user_action")
+    user_detail = _action_error_info(user_envelope, ref="user_action")
     legacy_detail = ActionErrorInfo(
         ref="legacy_action",
         message="Legacy failure",
@@ -431,7 +462,9 @@ def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
     error = _capture_workflow_application_error(
         {
             "user_action": TaskExceptionInfo(
-                exception=_capture_application_error(user_envelope, user_detail),
+                exception=_capture_application_error(
+                    user_envelope, wrap_error(user_envelope, user_detail)
+                ),
                 details=user_detail,
             ),
             "legacy_action": TaskExceptionInfo(
@@ -442,6 +475,9 @@ def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
     )
 
     assert error.message.startswith("Workflow failed with 2 error(s)")
+    assert error.details == (
+        {"user_action": user_detail, "legacy_action": legacy_detail},
+    )
     assert extract_error_envelopes(error) == ()
     with patch("tracecat.dsl.workflow.workflow.patched") as patched_mock:
         assert DSLWorkflow._has_user_error_cause(error) is False
@@ -450,6 +486,7 @@ def test_mixed_workflow_errors_do_not_promote_partial_classification() -> None:
 
 @pytest.mark.anyio
 async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
+    """The handler completes before the original error's owner is stamped."""
     instance, args = _error_handler_workflow()
     envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -458,11 +495,7 @@ async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
     )
     error = _capture_application_error(
         envelope,
-        {
-            "action": _classified_error_info(envelope, ref="action").model_dump(
-                mode="json"
-            )
-        },
+        {"action": _wrapped_error_detail(envelope, ref="action")},
     )
     events: list[str] = []
 
@@ -511,6 +544,7 @@ async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
 
 @pytest.mark.anyio
 async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
+    """A failing handler becomes the terminal error and owns the stamped attribution."""
     instance, args = _error_handler_workflow()
     original_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -524,11 +558,7 @@ async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
     )
     original_error = _capture_application_error(
         original_envelope,
-        {
-            "action": _classified_error_info(
-                original_envelope, ref="action"
-            ).model_dump(mode="json")
-        },
+        {"action": _wrapped_error_detail(original_envelope, ref="action")},
     )
     handler_error = _capture_application_error(handler_envelope)
 
@@ -642,6 +672,7 @@ async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -
 
 
 def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
+    """One platform-owned wrapper in the terminal map stamps the workflow as platform."""
     user_envelope = ErrorEnvelope.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message="The action failed",
@@ -653,12 +684,10 @@ def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
         retry_disposition=RetryDisposition.RETRYABLE,
     )
     details = {
-        "user_action": _classified_error_info(
-            user_envelope, ref="user_action"
-        ).model_dump(mode="json"),
-        "platform_action": _classified_error_info(
+        "user_action": _wrapped_error_detail(user_envelope, ref="user_action"),
+        "platform_action": _wrapped_error_detail(
             platform_envelope, ref="platform_action"
-        ).model_dump(mode="json"),
+        ),
     }
     error = ApplicationError("Workflow failed", details, non_retryable=True)
 

--- a/tests/unit/test_temporal_errors.py
+++ b/tests/unit/test_temporal_errors.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from inspect import signature
 
 import pytest
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
 from temporalio.exceptions import ApplicationError
@@ -23,10 +23,14 @@ from tracecat.runtime.errors import (
 )
 from tracecat.storage.object import InlineObject
 from tracecat.temporal.errors import (
+    TEMPORAL_ERROR_DETAILS_SCHEMA,
+    ClassifiedErrorDetail,
     extract_error_envelope,
     extract_error_envelopes,
+    parse_classified_detail,
     raise_application_error_from_envelope,
     raise_wrapped_application_error,
+    wrap_error,
 )
 from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.executions.types import ErrorHandlerWorkflowInput
@@ -76,36 +80,40 @@ async def test_legacy_action_error_payload_is_unchanged_without_envelope() -> No
 
 
 @pytest.mark.anyio
-async def test_action_error_payload_carries_discriminated_envelope() -> None:
+async def test_classified_wrapper_carries_envelope_and_preserves_payload() -> None:
+    """The wrapper carries the envelope; its payload survives unwrapping intact."""
     envelope = _user_envelope()
     error_info = ActionErrorInfo(
         ref="action",
         message="The action failed",
         type="ValueError",
-        envelope=envelope,
     )
-    error = _capture_application_error(envelope, error_info)
+    error = _capture_application_error(envelope, wrap_error(envelope, error_info))
     failure = Failure()
     await DataConverter.default.encode_failure(error, failure)
     decoded = await DataConverter.default.decode_failure(failure)
 
     assert len(error.details) == 1
     assert error.type == RuntimeErrorKind.ACTION_EXECUTION_FAILED.value
+    assert error.details[0]["schema"] == TEMPORAL_ERROR_DETAILS_SCHEMA
     assert error.details[0]["envelope"]["schema"] == "tracecat.error.v1"
+    assert error.details[0]["error"] == error_info.model_dump(mode="json")
     assert extract_error_envelope(error) == envelope
     assert extract_error_envelope(decoded) == envelope
     assert isinstance(decoded, ApplicationError)
-    parsed = ActionErrorInfo.model_validate(decoded.details[0])
+    parsed = parse_classified_detail(decoded.details[0])
+    assert isinstance(parsed, ClassifiedErrorDetail)
     assert parsed.envelope == envelope
+    assert parsed.error == error_info
 
 
-def test_aggregate_action_errors_preserve_classified_children() -> None:
+def test_aggregate_action_error_attribution_lives_on_the_wrapper() -> None:
+    """Gather payloads stay envelope-free; the wrapper alone carries attribution."""
     envelope = _platform_envelope()
     child = ActionErrorInfo(
         ref="scatter[0]",
         message=envelope.message,
         type="RuntimeError",
-        envelope=envelope,
     )
     finalized = FinalizeGatherActivityResult(
         result=InlineObject(data=[]),
@@ -114,10 +122,8 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
 
     serialized_finalized = finalized.model_dump(mode="json")
     parsed_finalized = FinalizeGatherActivityResult.model_validate(serialized_finalized)
-    assert serialized_finalized["errors"][0]["envelope"] == envelope.model_dump(
-        mode="json"
-    )
-    assert parsed_finalized.errors[0].envelope == envelope
+    assert "envelope" not in serialized_finalized["errors"][0]
+    assert parsed_finalized.errors == [child]
 
     aggregate = ActionErrorInfo(
         ref="gather",
@@ -126,50 +132,64 @@ def test_aggregate_action_errors_preserve_classified_children() -> None:
         children=parsed_finalized.errors,
     )
     serialized_aggregate = aggregate.model_dump(mode="json")
-    parsed_aggregate = ActionErrorInfo.model_validate(serialized_aggregate)
+    assert "envelope" not in serialized_aggregate
+    assert "envelope" not in serialized_aggregate["children"][0]
 
-    assert serialized_aggregate["children"][0]["envelope"] == envelope.model_dump(
-        mode="json"
+    error = ApplicationError(
+        "Gather failed",
+        {"gather": wrap_error(envelope, aggregate).model_dump(mode="json")},
     )
-    assert parsed_aggregate.children is not None
-    assert parsed_aggregate.children[0].envelope == envelope
+    parsed = parse_classified_detail(error.details[0])
 
-    error = ApplicationError("Gather failed", {"gather": serialized_aggregate})
     assert extract_error_envelopes(error) == (envelope,)
+    assert isinstance(parsed, dict)
+    assert parsed["gather"].error == aggregate
 
 
-@pytest.mark.parametrize("serialized", [False, True])
-def test_aggregate_action_error_rejects_partially_classified_children(
-    serialized: bool,
-) -> None:
+@pytest.mark.parametrize("mapped", [False, True])
+def test_embedded_payload_envelopes_never_classify(mapped: bool) -> None:
+    """Envelope keys inside a payload fail validation, so the detail is unclassified."""
     envelope = _user_envelope()
-    aggregate = ActionErrorInfo(
-        ref="gather",
-        message="Gather failed",
-        type="ApplicationError",
-        envelope=envelope,
-        children=[
-            ActionErrorInfo(
-                ref="scatter[0]",
-                message=envelope.message,
-                type="ValueError",
-                envelope=envelope,
-            ),
-            ActionErrorInfo(
-                ref="scatter[1]",
-                message="Legacy failure",
-                type="RuntimeError",
-            ),
+    serialized_envelope = envelope.model_dump(mode="json")
+    with pytest.raises(ValidationError):
+        ActionErrorInfo.model_validate(
+            {
+                "ref": "scatter[0]",
+                "message": envelope.message,
+                "type": "ValueError",
+                "envelope": serialized_envelope,
+            }
+        )
+
+    aggregate = {
+        "ref": "gather",
+        "message": "Gather failed",
+        "type": "ApplicationError",
+        "envelope": serialized_envelope,
+        "children": [
+            {
+                "ref": "scatter[0]",
+                "message": envelope.message,
+                "type": "ValueError",
+                "envelope": serialized_envelope,
+            },
+            {
+                "ref": "scatter[1]",
+                "message": "Legacy failure",
+                "type": "RuntimeError",
+            },
         ],
-    )
-    detail = aggregate.model_dump(mode="json") if serialized else aggregate
+    }
+    detail = {"gather": aggregate} if mapped else aggregate
 
     assert extract_error_envelopes(ApplicationError("Gather failed", detail)) == ()
 
 
 @pytest.mark.anyio
-async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -> None:
-    user_envelope = _user_envelope()
+async def test_unclassified_aggregate_keeps_fallback_envelope_after_serialization() -> (
+    None
+):
+    """An unclassified aggregate detail leaves the appended fallback authoritative."""
     fallback = _platform_envelope()
     aggregate = ActionErrorInfo(
         ref="gather",
@@ -178,9 +198,8 @@ async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -
         children=[
             ActionErrorInfo(
                 ref="scatter[0]",
-                message=user_envelope.message,
+                message="The action failed",
                 type="ValueError",
-                envelope=user_envelope,
             ),
             ActionErrorInfo(
                 ref="scatter[1]",
@@ -188,7 +207,7 @@ async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -
                 type="RuntimeError",
             ),
         ],
-    )
+    ).model_dump(mode="json")
 
     error = _capture_application_error(fallback, aggregate)
     failure = Failure()
@@ -197,18 +216,27 @@ async def test_partial_aggregate_keeps_fallback_envelope_after_serialization() -
 
     assert error.type == fallback.kind.value
     assert error.non_retryable is False
+    assert error.details[0] == aggregate
     assert extract_error_envelopes(error) == (fallback,)
     assert extract_error_envelopes(decoded) == (fallback,)
 
 
-def test_error_handler_input_preserves_action_error_envelope() -> None:
+def test_error_handler_input_carries_unwrapped_action_errors() -> None:
+    """Handler input carries envelope-free payloads identical to the unwrapped ones."""
     envelope = _platform_envelope()
     error_info = ActionErrorInfo(
         ref="action",
         message=envelope.message,
         type="RuntimeError",
-        envelope=envelope,
     )
+    wrapped = parse_classified_detail(
+        wrap_error(envelope, error_info).model_dump(mode="json")
+    )
+    assert isinstance(wrapped, ClassifiedErrorDetail)
+    assert isinstance(wrapped.error, ActionErrorInfo)
+    assert wrapped.envelope == envelope
+    assert wrapped.error == error_info
+
     handler_wf_id = WorkflowUUID.new_uuid4()
     orig_wf_id = WorkflowUUID.new_uuid4()
     handler_input = ErrorHandlerWorkflowInput(
@@ -218,7 +246,7 @@ def test_error_handler_input_preserves_action_error_envelope() -> None:
         orig_wf_exec_id=generate_exec_id(orig_wf_id),
         orig_wf_title="Synthetic workflow",
         trigger_type=TriggerType.MANUAL,
-        errors=[error_info],
+        errors=[wrapped.error],
     )
 
     serialized = TypeAdapter(ErrorHandlerWorkflowInput).dump_python(
@@ -226,23 +254,26 @@ def test_error_handler_input_preserves_action_error_envelope() -> None:
         mode="json",
     )
 
-    assert serialized["errors"][0]["envelope"] == envelope.model_dump(mode="json")
+    assert serialized["errors"][0] == error_info.model_dump(mode="json")
+    assert "envelope" not in serialized["errors"][0]
 
 
-def test_legacy_action_error_is_extended_without_changing_existing_fields() -> None:
+def test_legacy_action_error_is_transported_verbatim_beside_the_wrapper() -> None:
+    """A legacy payload travels unchanged; classification rides an appended wrapper."""
     envelope = _user_envelope()
-    error_info = ActionErrorInfo(
+    legacy = ActionErrorInfo(
         ref="action",
         message="The action failed",
         type="ValueError",
-    )
-    legacy = error_info.model_dump(mode="json")
+    ).model_dump(mode="json")
 
-    error = _capture_application_error(envelope, error_info)
+    error = _capture_application_error(envelope, legacy)
 
-    detail = error.details[0]
-    assert {key: detail[key] for key in legacy} == legacy
-    assert detail["envelope"] == envelope.model_dump(mode="json")
+    assert len(error.details) == 2
+    assert error.details[0] == legacy
+    assert error.details[1] == wrap_error(envelope).model_dump(mode="json")
+    assert error.details[1]["error"] is None
+    assert extract_error_envelope(error) == envelope
 
 
 @pytest.mark.parametrize(
@@ -453,21 +484,26 @@ def test_aggregate_action_error_requires_child_schema_discriminator() -> None:
     )
 
 
-def test_action_error_map_extracts_every_classified_envelope() -> None:
+def test_wrapper_map_extracts_every_classified_envelope() -> None:
+    """A terminal ``{ref: wrapper}`` map yields each wrapper's envelope in order."""
     user_envelope = _user_envelope()
     platform_envelope = _platform_envelope()
     details = {
-        "user_action": ActionErrorInfo(
-            ref="user_action",
-            message=user_envelope.message,
-            type="ValueError",
-            envelope=user_envelope,
+        "user_action": wrap_error(
+            user_envelope,
+            ActionErrorInfo(
+                ref="user_action",
+                message=user_envelope.message,
+                type="ValueError",
+            ),
         ).model_dump(mode="json"),
-        "platform_action": ActionErrorInfo(
-            ref="platform_action",
-            message=platform_envelope.message,
-            type="RuntimeError",
-            envelope=platform_envelope,
+        "platform_action": wrap_error(
+            platform_envelope,
+            ActionErrorInfo(
+                ref="platform_action",
+                message=platform_envelope.message,
+                type="RuntimeError",
+            ),
         ).model_dump(mode="json"),
     }
     error = ApplicationError("Workflow failed", details)
@@ -490,18 +526,32 @@ def test_arbitrary_nested_envelope_does_not_collide_with_action_error_map() -> N
     assert extract_error_envelopes(error) == ()
 
 
-def test_action_error_map_rejects_partial_shape_match() -> None:
+@pytest.mark.parametrize("companion", ["arbitrary", "legacy"])
+def test_map_with_any_unwrapped_value_is_unclassified(companion: str) -> None:
+    """Classification is all-or-nothing on the map: one unwrapped value voids it."""
     envelope = _user_envelope()
+    legacy_payload = ActionErrorInfo(
+        ref="legacy_action",
+        message="Legacy failure",
+        type="RuntimeError",
+    ).model_dump(mode="json")
+    companion_payload = (
+        legacy_payload
+        if companion == "legacy"
+        else {"payload": "not a classified detail"}
+    )
     error = ApplicationError(
         "Mixed payload",
         {
-            "action": ActionErrorInfo(
-                ref="action",
-                message=envelope.message,
-                type="ValueError",
-                envelope=envelope,
+            "action": wrap_error(
+                envelope,
+                ActionErrorInfo(
+                    ref="action",
+                    message=envelope.message,
+                    type="ValueError",
+                ),
             ).model_dump(mode="json"),
-            "arbitrary": {"payload": "not an action error"},
+            "companion": companion_payload,
         },
     )
 

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -78,6 +78,7 @@ from tracecat.temporal.errors import (
     extract_error_envelope,
     is_classified_detail,
     raise_wrapped_application_error,
+    wrap_error,
 )
 from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
@@ -864,11 +865,13 @@ def _raise_classified_subflow_application_error(
         error_type = type(error).__name__
         legacy_details = ()
 
-    detail = ActionErrorInfo(
-        ref=input.task.ref,
-        message=envelope.message,
-        type=error_type,
-        envelope=envelope,
+    detail = wrap_error(
+        envelope,
+        ActionErrorInfo(
+            ref=input.task.ref,
+            message=envelope.message,
+            type=error_type,
+        ),
     )
     raise_wrapped_application_error(
         error,

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any
@@ -17,7 +17,6 @@ _SCHEDULER_TASK_SPAWN_YIELD_EVERY = 16
 """Yield while spawning ready task coroutines to avoid long workflow activations."""
 
 with workflow.unsafe.imports_passed_through():
-    from pydantic import ValidationError
     from pydantic_core import to_json
     from temporalio.exceptions import ApplicationError
 
@@ -64,6 +63,12 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.exceptions import TaskUnreachable
     from tracecat.expressions.common import ExprContext
     from tracecat.expressions.core import extract_expressions
+    from tracecat.runtime.errors import (
+        ErrorEnvelope,
+        RetryDisposition,
+        RuntimeErrorKind,
+        RuntimeErrorOwner,
+    )
     from tracecat.storage.object import (
         CollectionObject,
         InlineObject,
@@ -73,8 +78,11 @@ with workflow.unsafe.imports_passed_through():
         action_key,
     )
     from tracecat.temporal.errors import (
+        ClassifiedErrorDetail,
+        application_error_from_envelope,
         extract_error_envelope,
-        is_classified_detail,
+        parse_classified_detail,
+        wrap_error,
     )
 
 
@@ -100,58 +108,60 @@ def _classified_action_error_info(
     *,
     ref: str,
     stream_id: StreamID,
-) -> ActionErrorInfo | None:
+) -> tuple[ActionErrorInfo, ErrorEnvelope] | None:
     """Adapt a classified activity failure into the scheduler error shape."""
     envelope = extract_error_envelope(error)
     if envelope is None:
         return None
 
     for detail in error.details:
-        if not is_classified_detail(detail):
-            continue
-        try:
-            parsed = ActionErrorInfo.model_validate(detail)
-        except ValidationError:
-            pass
-        else:
-            return parsed.model_copy(update={"ref": ref, "stream_id": stream_id})
+        match parse_classified_detail(detail):
+            case ClassifiedErrorDetail(error=ActionErrorInfo() as info):
+                return (
+                    info.model_copy(update={"ref": ref, "stream_id": stream_id}),
+                    envelope,
+                )
+            case dict() as wrapped_map if wrapped_map:
+                # A child workflow's terminal ``{ref: detail}`` map.
+                children = [
+                    _unwrapped_action_error(child_ref, wrapped)
+                    for child_ref, wrapped in wrapped_map.items()
+                ]
+                return (
+                    ActionErrorInfo(
+                        ref=ref,
+                        message=envelope.message,
+                        type=error.type or error.__class__.__name__,
+                        stream_id=stream_id,
+                        children=children,
+                    ),
+                    envelope,
+                )
+            case _:
+                continue
 
-        if children := _validated_action_error_map(detail):
-            return ActionErrorInfo(
-                ref=ref,
-                message=envelope.message,
-                type=error.type or error.__class__.__name__,
-                stream_id=stream_id,
-                children=list(children),
-                envelope=envelope,
-            )
-
-    return ActionErrorInfo(
-        ref=ref,
-        message=envelope.message,
-        type=error.type or error.__class__.__name__,
-        stream_id=stream_id,
-        envelope=envelope,
+    return (
+        ActionErrorInfo(
+            ref=ref,
+            message=envelope.message,
+            type=error.type or error.__class__.__name__,
+            stream_id=stream_id,
+        ),
+        envelope,
     )
 
 
-def _validated_action_error_map(
-    detail: object,
-) -> tuple[ActionErrorInfo, ...] | None:
-    """Validate a classified workflow ``{ref: ActionErrorInfo}`` detail."""
-    if not isinstance(detail, Mapping):
-        return None
-
-    parsed: list[ActionErrorInfo] = []
-    for ref, value in detail.items():
-        if not isinstance(ref, str):
-            return None
-        try:
-            parsed.append(ActionErrorInfo.model_validate(value))
-        except ValidationError:
-            return None
-
-    return tuple(parsed)
+def _unwrapped_action_error(
+    ref: str, wrapped: ClassifiedErrorDetail
+) -> ActionErrorInfo:
+    """Unwrap a classified detail's payload, synthesizing one for bare envelopes."""
+    if wrapped.error is not None:
+        return wrapped.error
+    return ActionErrorInfo(
+        ref=ref,
+        message=wrapped.envelope.message,
+        type=wrapped.envelope.kind.value,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,6 +240,7 @@ class DSLScheduler:
         # Mut
         self.task_exceptions: dict[str, TaskExceptionInfo] = {}
         self.stream_exceptions: dict[StreamID, TaskExceptionInfo] = {}
+        self.stream_error_envelopes: dict[StreamID, ErrorEnvelope] = {}
 
         # Build adjacency list with sets for efficient construction
         adj_temp: dict[str, set[AdjDst]] = defaultdict(set)
@@ -507,13 +518,17 @@ class DSLScheduler:
             # XXX: This can sometimes return null because the exception isn't an ApplicationError
             # But rather a ChildWorkflowError or CancelledError
             if isinstance(exc, ApplicationError) and (
-                classified_details := _classified_action_error_info(
+                classified := _classified_action_error_info(
                     exc,
                     ref=ref,
                     stream_id=task.stream_id,
                 )
             ):
-                details = classified_details
+                details, envelope = classified
+                # Recorded so a later gather failure can aggregate ownership
+                # across its classified children; never pruned (bounded by
+                # failed tasks) so it survives stream cleanup.
+                self.stream_error_envelopes[task.stream_id] = envelope
             elif isinstance(exc, ApplicationError) and exc.details:
                 self.logger.info(
                     "Task failed with application error",
@@ -1638,11 +1653,38 @@ class DSLScheduler:
                 children=finalized.errors,
                 stream_id=parent_stream_id,
             )
-            app_error = ApplicationError(
-                message,
-                {gather_ref: gather_error.model_dump()},
-                non_retryable=True,
-            )
+            child_envelopes = [
+                self.stream_error_envelopes.get(child.stream_id)
+                for child in finalized.errors
+            ]
+            if all(envelope is not None for envelope in child_envelopes):
+                # Every child failure was classified: attribute the gather to
+                # platform if any child was platform-owned, else to the user.
+                platform_owned = any(
+                    envelope is not None
+                    and envelope.owner is RuntimeErrorOwner.PLATFORM
+                    for envelope in child_envelopes
+                )
+                build = ErrorEnvelope.platform if platform_owned else ErrorEnvelope.user
+                gather_envelope = build(
+                    kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+                    message=message,
+                    retry_disposition=RetryDisposition.NON_RETRYABLE,
+                )
+                app_error = application_error_from_envelope(
+                    gather_envelope,
+                    {
+                        gather_ref: wrap_error(
+                            gather_envelope, gather_error
+                        ).model_dump(mode="json")
+                    },
+                )
+            else:
+                app_error = ApplicationError(
+                    message,
+                    {gather_ref: gather_error.model_dump()},
+                    non_retryable=True,
+                )
             self.logger.warning(
                 "Raising gather error", errors=finalized.errors, app_error=app_error
             )

--- a/tracecat/dsl/types.py
+++ b/tracecat/dsl/types.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 from pydantic import BaseModel, ConfigDict, Field
 
 from tracecat.expressions.common import ExprContext
-from tracecat.runtime.errors import ErrorEnvelope
 
 
 class ActionEdge(TypedDict):
@@ -64,13 +63,9 @@ class ActionErrorInfo(BaseModel):
     attempt: int = 1
     stream_id: StreamID = Field(default_factory=_root_stream_factory)
     children: list[ActionErrorInfo] | None = None
-    envelope: ErrorEnvelope | None = Field(
-        default=None,
-        exclude_if=lambda value: value is None,
-    )
 
     def model_post_init(self, context: Any, /) -> None:
-        """Preserve the pre-envelope Temporal wire shape for defaulted fields."""
+        """Preserve the established Temporal wire shape for defaulted fields."""
         del context
         self.__pydantic_fields_set__.update(
             {"expr_context", "attempt", "stream_id", "children"}

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -116,7 +116,7 @@ with workflow.unsafe.imports_passed_through():
         exec_id_to_parts,
     )
     from tracecat.registry.lock.types import RegistryLock
-    from tracecat.runtime.errors import RuntimeErrorOwner
+    from tracecat.runtime.errors import ErrorEnvelope, RuntimeErrorOwner
     from tracecat.storage.object import (
         CollectionObject,
         ExternalObject,
@@ -131,7 +131,9 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.temporal.errors import (
         extract_error_envelope,
         extract_error_envelopes,
+        parse_classified_detail,
         raise_application_error_from_envelope,
+        wrap_error,
     )
     from tracecat.temporal.exceptions import UserError
     from tracecat.tiers.activities import (
@@ -186,21 +188,24 @@ def _raise_workflow_application_error(
 ) -> Never:
     """Raise the terminal workflow error without changing legacy payloads."""
     n_exceptions = len(task_exceptions)
-    envelope_iter = (
-        extract_error_envelope(info.exception) for info in task_exceptions.values()
-    )
-    primary_envelope = next(envelope_iter, None)
-    if primary_envelope is not None and all(
-        envelope is not None for envelope in envelope_iter
-    ):
-        error_details = {
-            ref: info.details.model_dump(mode="json")
-            for ref, info in task_exceptions.items()
-        }
-        raise_application_error_from_envelope(
-            primary_envelope,
-            error_details,
-        )
+    task_envelopes: dict[str, ErrorEnvelope] = {}
+    for ref, info in task_exceptions.items():
+        envelope = extract_error_envelope(info.exception)
+        if envelope is None:
+            break
+        task_envelopes[ref] = envelope
+    else:
+        if task_envelopes:
+            error_details = {
+                ref: wrap_error(task_envelopes[ref], info.details).model_dump(
+                    mode="json"
+                )
+                for ref, info in task_exceptions.items()
+            }
+            raise_application_error_from_envelope(
+                next(iter(task_envelopes.values())),
+                error_details,
+            )
 
     formatted_exceptions = "\n".join(
         f"{'=' * 10} ({i + 1}/{n_exceptions}) {details.expr_context}.{ref} {'=' * 10}\n\n{info.exception!s}"
@@ -1961,6 +1966,19 @@ class DSLWorkflow:
                     ),
                     type=type(err_info_map).__name__,
                 )
+            ]
+        if isinstance(parsed := parse_classified_detail(err_info_map), dict):
+            # Classified terminal map: hand the handler the unwrapped payloads
+            # so its established input shape is unchanged.
+            return [
+                wrapped.error
+                if wrapped.error is not None
+                else ActionErrorInfo(
+                    ref=child_ref,
+                    message=wrapped.envelope.message,
+                    type=wrapped.envelope.kind.value,
+                )
+                for child_ref, wrapped in parsed.items()
             ]
         return [ActionErrorInfo.model_validate(data) for data in err_info_map.values()]
 

--- a/tracecat/temporal/errors.py
+++ b/tracecat/temporal/errors.py
@@ -1,4 +1,14 @@
-"""Temporal transport for the versioned Tracecat runtime error contract."""
+"""Temporal transport for the versioned Tracecat runtime error contract.
+
+Classified failures travel as ``ClassifiedErrorDetail`` transport details: a
+required-discriminator wrapper carrying the ``ErrorEnvelope`` attribution
+stamp plus an optional ``ActionErrorInfo`` payload. Terminal workflow errors
+use the established ``{ref: ClassifiedErrorDetail}`` map. Classification is
+structural — a payload either parses as one of those shapes or it is
+unclassified; there is no partially classified state. Bare legacy payloads
+(pre-envelope histories) therefore fall through as unclassified by
+construction.
+"""
 
 from __future__ import annotations
 
@@ -19,8 +29,8 @@ from tracecat.runtime.errors import (
 TEMPORAL_ERROR_DETAILS_SCHEMA = "tracecat.temporal_error.v1"
 
 
-class TemporalErrorDetails(BaseModel):
-    """Strict adapter for envelopes without an ``ActionErrorInfo`` payload."""
+class ClassifiedErrorDetail(BaseModel):
+    """A classified transport detail: envelope stamp plus optional payload."""
 
     model_config = ConfigDict(extra="forbid", frozen=True, serialize_by_alias=True)
 
@@ -28,36 +38,64 @@ class TemporalErrorDetails(BaseModel):
     # discriminator always survives ``exclude_unset`` serialization.
     schema_: Literal["tracecat.temporal_error.v1"] = Field(alias="schema")
     envelope: ErrorEnvelope
+    error: ActionErrorInfo | None = None
 
 
-def _application_error_from_envelope(
+# The two classified transport shapes: a single wrapped detail, or the
+# established terminal workflow ``{ref: detail}`` map. Anything else —
+# including bare legacy ``ActionErrorInfo`` payloads — is unclassified.
+_CLASSIFIED_DETAIL_ADAPTER: TypeAdapter[
+    ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail]
+] = TypeAdapter(ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail])
+
+
+def wrap_error(
+    envelope: ErrorEnvelope, error: ActionErrorInfo | None = None
+) -> ClassifiedErrorDetail:
+    """Build a classified transport detail from an envelope and payload."""
+    return ClassifiedErrorDetail.model_validate(
+        {
+            "schema": TEMPORAL_ERROR_DETAILS_SCHEMA,
+            "envelope": envelope,
+            "error": error,
+        }
+    )
+
+
+def parse_classified_detail(
+    detail: Any,
+) -> ClassifiedErrorDetail | dict[str, ClassifiedErrorDetail] | None:
+    """Parse a transport detail into its classified shape, or None."""
+    try:
+        return _CLASSIFIED_DETAIL_ADAPTER.validate_python(detail)
+    except ValidationError:
+        return None
+
+
+def is_classified_detail(detail: Any) -> bool:
+    """Return whether a single transport detail is explicitly classified."""
+    return bool(_envelopes_from_detail(detail))
+
+
+def application_error_from_envelope(
     envelope: ErrorEnvelope,
     *details: Any,
     next_retry_delay: timedelta | None = None,
 ) -> ApplicationError:
     """Build an ``ApplicationError`` with transport fields derived from its envelope.
 
-    Existing details remain in their original order. If they already contain a
-    fully validated envelope, they are left unchanged; otherwise a strict
-    non-action detail is appended. Temporal's error type mirrors the stable
-    product kind and is never supplied as a second classification input.
+    Existing details remain in their original order. If none of them is a
+    classified detail, a bare wrapper is appended. Temporal's error type
+    mirrors the stable product kind and is never supplied as a second
+    classification input.
     """
     existing_envelope = _envelope_from_details(details)
     resolved_envelope = existing_envelope or envelope
-    transported_details = _serialized_error_details(
-        details,
-        envelope=None if existing_envelope is not None else envelope,
-    )
-    if (
-        existing_envelope is None
-        and _envelope_from_details(transported_details) is None
-    ):
-        adapter = TemporalErrorDetails.model_validate(
-            {"schema": TEMPORAL_ERROR_DETAILS_SCHEMA, "envelope": resolved_envelope}
-        )
+    transported_details = tuple(_serialized_detail(detail) for detail in details)
+    if existing_envelope is None:
         transported_details = (
             *transported_details,
-            adapter.model_dump(mode="json"),
+            wrap_error(resolved_envelope).model_dump(mode="json"),
         )
 
     non_retryable = (
@@ -86,7 +124,7 @@ def raise_application_error_from_envelope(
     here ensures callers cannot accidentally attach a sensitive caught exception
     through implicit chaining.
     """
-    raise _application_error_from_envelope(
+    raise application_error_from_envelope(
         envelope,
         *details,
         next_retry_delay=next_retry_delay,
@@ -173,85 +211,20 @@ def _envelope_from_details(details: Sequence[Any]) -> ErrorEnvelope | None:
     return None
 
 
-def is_classified_detail(detail: Any) -> bool:
-    """Return whether a single transport detail is explicitly classified."""
-    return bool(_envelopes_from_detail(detail))
-
-
-def _serialized_error_details(
-    details: Sequence[Any], envelope: ErrorEnvelope | None
-) -> tuple[Any, ...]:
-    serialized: list[Any] = []
-    for detail in details:
-        if isinstance(detail, TemporalErrorDetails):
-            serialized.append(detail.model_dump(mode="json"))
-        elif isinstance(detail, ActionErrorInfo) and (
-            detail.envelope is not None or envelope is not None
-        ):
-            classified = ActionErrorInfo(
-                ref=detail.ref,
-                message=detail.message,
-                type=detail.type,
-                expr_context=detail.expr_context,
-                attempt=detail.attempt,
-                stream_id=detail.stream_id,
-                children=detail.children,
-                envelope=detail.envelope or envelope,
-            )
-            serialized.append(classified.model_dump(mode="json"))
-        else:
-            serialized.append(detail)
-    return tuple(serialized)
-
-
-# The three classified transport shapes: a per-action error (optionally
-# nesting children), a bare envelope adapter, and the established workflow
-# ``{ref: info}`` details map. Anything else is unclassified. Validation is the
-# classification gate: both model shapes require the explicit ``schema``
-# discriminator, so an undiscriminated payload fails to parse.
-_CLASSIFIED_DETAIL_ADAPTER: TypeAdapter[
-    ActionErrorInfo | TemporalErrorDetails | dict[str, ActionErrorInfo]
-] = TypeAdapter(ActionErrorInfo | TemporalErrorDetails | dict[str, ActionErrorInfo])
-
-
 def _envelopes_from_detail(detail: Any) -> tuple[ErrorEnvelope, ...]:
-    try:
-        parsed = _CLASSIFIED_DETAIL_ADAPTER.validate_python(detail)
-    except ValidationError:
-        return ()
-    match parsed:
-        case ActionErrorInfo():
-            return _envelopes_from_action_error(parsed)
-        case TemporalErrorDetails():
-            return (parsed.envelope,)
-        case _:
-            # Every map value must be a complete, classified ActionErrorInfo;
-            # accepting a partial match would let arbitrary user payloads
-            # override classification.
-            envelopes: list[ErrorEnvelope] = []
-            seen: set[ErrorEnvelope] = set()
-            for value in parsed.values():
-                value_envelopes = _envelopes_from_action_error(value)
-                if not value_envelopes:
-                    return ()
-                for envelope in value_envelopes:
-                    _append_unique_envelope(envelopes, seen, envelope)
-            return tuple(envelopes)
-
-
-def _envelopes_from_action_error(parsed: ActionErrorInfo) -> tuple[ErrorEnvelope, ...]:
-    """Collect envelopes from an action error tree, all-or-nothing."""
-    envelopes: list[ErrorEnvelope] = []
-    seen: set[ErrorEnvelope] = set()
-    if parsed.envelope is not None:
-        _append_unique_envelope(envelopes, seen, parsed.envelope)
-    for child in parsed.children or ():
-        child_envelopes = _envelopes_from_action_error(child)
-        if not child_envelopes:
+    match parse_classified_detail(detail):
+        case None:
             return ()
-        for child_envelope in child_envelopes:
-            _append_unique_envelope(envelopes, seen, child_envelope)
-    return tuple(envelopes)
+        case ClassifiedErrorDetail() as parsed:
+            return (parsed.envelope,)
+        case parsed:
+            return tuple(wrapped.envelope for wrapped in parsed.values())
+
+
+def _serialized_detail(detail: Any) -> Any:
+    if isinstance(detail, ClassifiedErrorDetail):
+        return detail.model_dump(mode="json")
+    return detail
 
 
 def _append_unique_envelope(


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns classified error transport so envelope attribution moves from `ActionErrorInfo` payloads onto a dedicated `ClassifiedErrorDetail` wrapper. The wrapper carries the `ErrorEnvelope` stamp plus an optional payload, and `ActionErrorInfo` drops its embedded envelope field entirely.

- Classification is now structural: a detail either parses as a wrapped shape or is unclassified, so the recursive all-or-nothing envelope walk is gone and bare legacy payloads fall through unclassified.
- Terminal workflow errors use a `{ref: ClassifiedErrorDetail}` map.
- The scheduler records each classified child's envelope on its stream so gather failures can attribute the aggregate at raise time — platform ownership wins, and the gather stays on the legacy shape unless every child failure was classified.
- Error handlers receive unwrapped payloads, so their input contract is unchanged.

<sup>Written for commit dc05d774ce8c7ce8a7c9210b65581ca578596c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

