### PR TITLE
feat(agent): propagate agent session provenance

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -22907,6 +22907,18 @@ export const $RunActionInput = {
       ],
       title: "Session Id",
     },
+    agent_session_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Agent Session Id",
+    },
     registry_lock: {
       $ref: "#/components/schemas/RegistryLock",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -7000,6 +7000,7 @@ export type RunActionInput = {
   interaction_context?: InteractionContext | null
   stream_id?: string
   session_id?: string | null
+  agent_session_id?: string | null
   registry_lock: RegistryLock
 }
 

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -182,6 +182,7 @@ def _build_approved_tool_run_input(
     run_id: uuid.UUID,
     execution_id: uuid.UUID,
     logical_time: datetime,
+    agent_session_id: uuid.UUID,
 ):
     action_name = normalize_mcp_tool_name(tool_call.tool_name)
     return build_run_input(
@@ -192,6 +193,7 @@ def _build_approved_tool_run_input(
         run_id=run_id,
         execution_id=execution_id,
         logical_time=logical_time,
+        agent_session_id=agent_session_id,
     )
 
 
@@ -257,6 +259,7 @@ def _start_registry_tool_call(
     registry_lock: RegistryLock,
     service_role: Role,
     logical_time: datetime,
+    agent_session_id: uuid.UUID,
 ) -> workflow.ActivityHandle[Any]:
     """Execute an approved registry action on the executor task queue."""
     return workflow.start_activity(
@@ -269,6 +272,7 @@ def _start_registry_tool_call(
                 run_id=workflow.uuid4(),
                 execution_id=workflow.uuid4(),
                 logical_time=logical_time,
+                agent_session_id=agent_session_id,
             ),
             service_role,
         ],
@@ -1902,6 +1906,7 @@ class DurableAgentWorkflow:
                             registry_lock=registry_lock,
                             service_role=service_role,
                             logical_time=logical_time,
+                            agent_session_id=self.session_id,
                         )
                     )
                     result = PendingToolResult(

--- a/tests/unit/test_agent_mcp_executor.py
+++ b/tests/unit/test_agent_mcp_executor.py
@@ -39,6 +39,7 @@ async def test_execute_action_starts_registry_tool_workflow_with_alias_correlati
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     claims = _build_claims()
+    untrusted_session_id = uuid.UUID("00000000-0000-0000-0000-000000000099")
     monkeypatch.setattr(
         executor, "build_agent_tool_workflow_id", lambda: "agent-tool/tool-wf-123"
     )
@@ -58,7 +59,10 @@ async def test_execute_action_starts_registry_tool_workflow_with_alias_correlati
 
     result = await executor.execute_action(
         "core.http_request",
-        {"url": "https://example.com"},
+        {
+            "url": "https://example.com",
+            "agent_session_id": str(untrusted_session_id),
+        },
         claims,
         _build_registry_lock(),
         tool_call_id="toolu_123",
@@ -66,6 +70,11 @@ async def test_execute_action_starts_registry_tool_workflow_with_alias_correlati
 
     call = fake_client.execute_workflow.await_args
     assert call.kwargs["id"] == "agent-tool/tool-wf-123"
+    workflow_input = call.args[1]
+    assert workflow_input.run_input.agent_session_id == claims.session_id
+    assert workflow_input.run_input.task.args["agent_session_id"] == str(
+        untrusted_session_id
+    )
     assert call.kwargs["memo"] == {
         "parent_agent_workflow_id": f"agent/{claims.session_id}",
         "parent_agent_run_id": "run-123",

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -24,7 +24,7 @@ from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
 from tracecat.authz.enums import WorkspaceRole
 from tracecat.authz.service import MembershipWithOrg
-from tracecat.contexts import ctx_role
+from tracecat.contexts import ctx_agent_session_id, ctx_role
 from tracecat.db.models import (
     Membership,
     Organization,
@@ -72,7 +72,8 @@ async def test_authenticated_user_only_does_not_activate_superuser_privileges() 
         assert role.is_platform_superuser is False
         return frozenset()
 
-    token = ctx_role.set(None)
+    role_token = ctx_role.set(None)
+    agent_session_token = ctx_agent_session_id.set(uuid.uuid4())
     try:
         with patch(
             "tracecat.auth.credentials.compute_effective_scopes",
@@ -86,9 +87,11 @@ async def test_authenticated_user_only_does_not_activate_superuser_privileges() 
         assert role.is_platform_superuser is False
         assert role.scopes == frozenset()
         assert ctx_role.get() == role
+        assert ctx_agent_session_id.get() is None
         mock_compute_scopes.assert_awaited_once()
     finally:
-        ctx_role.reset(token)
+        ctx_agent_session_id.reset(agent_session_token)
+        ctx_role.reset(role_token)
 
 
 @pytest.mark.anyio
@@ -144,6 +147,47 @@ async def test_role_dependency_rebinds_rls_context_on_session(
 
     assert result == validated_role
     mock_set_rls.assert_awaited_once_with(session, validated_role)
+
+
+@pytest.mark.anyio
+async def test_user_role_dependency_clears_agent_session_context() -> None:
+    workspace_id = uuid.uuid4()
+    user = MagicMock(spec=User)
+    role = Role(
+        type="user",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+    context_token = ctx_agent_session_id.set(uuid.uuid4())
+    try:
+        with (
+            patch("tracecat.auth.credentials.set_rls_context", new=AsyncMock()),
+            patch(
+                "tracecat.auth.credentials._authenticate_user",
+                new=AsyncMock(return_value=role),
+            ),
+            patch(
+                "tracecat.auth.credentials._validate_role",
+                new=AsyncMock(return_value=role),
+            ),
+        ):
+            await _role_dependency(
+                request=MagicMock(spec=Request),
+                session=AsyncMock(),
+                workspace_id=workspace_id,
+                user=user,
+                api_key=None,
+                allow_user=True,
+                allow_service=False,
+                allow_executor=False,
+                require_workspace="yes",
+            )
+
+        assert ctx_agent_session_id.get() is None
+    finally:
+        ctx_agent_session_id.reset(context_token)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -876,6 +876,7 @@ def test_build_approved_tool_run_input_is_deterministic() -> None:
     run_id = uuid.UUID("00000000-0000-4000-8000-000000000456")
     execution_id = uuid.UUID("00000000-0000-4000-8000-000000000789")
     logical_time = datetime(2026, 3, 17, tzinfo=UTC)
+    agent_session_id = uuid.UUID("00000000-0000-4000-8000-000000000999")
     registry_lock = RegistryLock(
         origins={"tracecat_registry": "test-version"},
         actions={"core.http_request": "tracecat_registry"},
@@ -893,6 +894,7 @@ def test_build_approved_tool_run_input_is_deterministic() -> None:
         run_id=run_id,
         execution_id=execution_id,
         logical_time=logical_time,
+        agent_session_id=agent_session_id,
     )
 
     assert result.task.action == "core_http_request"
@@ -904,6 +906,7 @@ def test_build_approved_tool_run_input_is_deterministic() -> None:
         == f"{WorkflowUUID.from_uuid(workflow_id).short()}/{ExecutionUUID.from_uuid(execution_id).short()}"
     )
     assert result.run_context.logical_time == logical_time
+    assert result.agent_session_id == agent_session_id
 
 
 def test_build_approved_tool_run_input_strips_proxy_metadata() -> None:
@@ -911,6 +914,7 @@ def test_build_approved_tool_run_input_strips_proxy_metadata() -> None:
     run_id = uuid.UUID("00000000-0000-4000-8000-000000000456")
     execution_id = uuid.UUID("00000000-0000-4000-8000-000000000789")
     logical_time = datetime(2026, 3, 17, tzinfo=UTC)
+    agent_session_id = uuid.UUID("00000000-0000-4000-8000-000000000999")
     registry_lock = RegistryLock(
         origins={"tracecat_registry": "test-version"},
         actions={"core.cases.create_case": "tracecat_registry"},
@@ -931,7 +935,9 @@ def test_build_approved_tool_run_input_strips_proxy_metadata() -> None:
         run_id=run_id,
         execution_id=execution_id,
         logical_time=logical_time,
+        agent_session_id=agent_session_id,
     )
 
     assert result.task.action == "core.cases.create_case"
     assert result.task.args == {"summary": "hello"}
+    assert result.agent_session_id == agent_session_id

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -206,6 +206,7 @@ async def test_template_step_token_preserves_root_execution_claims(
     )
     root_action = "testing.template"
     step_action = "core.script.run_python"
+    agent_session_id = uuid.uuid4()
     action_impl = ActionImplementation(
         type="udf",
         action_name=step_action,
@@ -225,6 +226,7 @@ async def test_template_step_token_preserves_root_execution_claims(
         task=ActionStatement(ref="template", action=root_action, args={}),
         exec_context=create_default_execution_context(),
         run_context=mock_run_context,
+        agent_session_id=agent_session_id,
         registry_lock=make_registry_lock(step_action),
     )
     parent_resolved = executor_service.ResolvedContext(
@@ -251,6 +253,37 @@ async def test_template_step_token_preserves_root_execution_claims(
     claims = verify_executor_token(step_resolved.executor_token)
     assert claims.execution_origin == "agent"
     assert claims.root_action == root_action
+    assert claims.agent_session_id == agent_session_id
+
+
+def test_workflow_token_omits_untrusted_agent_session_id(
+    mock_run_context: RunContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
+    role = Role(
+        type="service",
+        service_id="tracecat-executor",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    input = RunActionInput(
+        task=ActionStatement(
+            ref="action",
+            action="core.http_request",
+            args={"agent_session_id": str(uuid.uuid4())},
+        ),
+        exec_context=create_default_execution_context(),
+        run_context=mock_run_context,
+        agent_session_id=uuid.uuid4(),
+        registry_lock=make_registry_lock("core.http_request"),
+    )
+
+    token = executor_service._mint_action_executor_token(input, role)
+
+    claims = verify_executor_token(token)
+    assert claims.execution_origin == "workflow"
+    assert claims.agent_session_id is None
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/test_executor_tokens.py
+++ b/tests/unit/test_executor_tokens.py
@@ -18,6 +18,8 @@ from tracecat.auth.executor_tokens import (
     mint_executor_token,
     verify_executor_token,
 )
+from tracecat.contexts import ctx_agent_session_id
+from tracecat.identifiers import InternalServiceID
 
 
 def _make_request(token: str | None) -> Request:
@@ -52,6 +54,7 @@ def test_mint_and_verify_executor_token_roundtrip(monkeypatch: pytest.MonkeyPatc
     assert verified.wf_exec_id == wf_exec_id
     assert verified.execution_origin is None
     assert verified.root_action is None
+    assert verified.agent_session_id is None
 
 
 @pytest.mark.parametrize("execution_origin", ["agent", "workflow"])
@@ -74,6 +77,81 @@ def test_executor_token_preserves_execution_origin(
 
     assert verified.execution_origin == execution_origin
     assert verified.root_action == "core.script.run_python"
+
+
+def test_executor_token_preserves_agent_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
+    agent_session_id = uuid.uuid4()
+
+    token = mint_executor_token(
+        workspace_id=uuid.uuid4(),
+        user_id=None,
+        service_id="tracecat-mcp",
+        execution_origin="agent",
+        agent_session_id=agent_session_id,
+        wf_id="wf-1",
+        wf_exec_id="run-1",
+    )
+
+    verified = verify_executor_token(token)
+
+    assert verified.agent_session_id == agent_session_id
+
+
+@pytest.mark.parametrize(
+    ("service_id", "execution_origin"),
+    [
+        pytest.param("tracecat-mcp", "workflow", id="workflow-origin"),
+        pytest.param("tracecat-executor", "agent", id="non-mcp-service"),
+    ],
+)
+def test_executor_token_rejects_untrusted_agent_session_origin(
+    monkeypatch: pytest.MonkeyPatch,
+    service_id: InternalServiceID,
+    execution_origin: ExecutionOrigin,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
+
+    with pytest.raises(
+        ValueError,
+        match="agent_session_id requires the tracecat-mcp agent execution origin",
+    ):
+        mint_executor_token(
+            workspace_id=uuid.uuid4(),
+            user_id=None,
+            service_id=service_id,
+            execution_origin=execution_origin,
+            agent_session_id=uuid.uuid4(),
+            wf_id="wf-1",
+            wf_exec_id="run-1",
+        )
+
+
+def test_verify_executor_token_rejects_inconsistent_agent_session_claims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service_key = "test-service-key"
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", service_key)
+    now = datetime.now(UTC)
+    payload = {
+        "iss": EXECUTOR_TOKEN_ISSUER,
+        "aud": EXECUTOR_TOKEN_AUDIENCE,
+        "sub": "tracecat-executor",
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(seconds=60)).timestamp()),
+        "workspace_id": str(uuid.uuid4()),
+        "service_id": "tracecat-executor",
+        "execution_origin": "agent",
+        "agent_session_id": str(uuid.uuid4()),
+        "wf_id": "wf-1",
+        "wf_exec_id": "run-1",
+    }
+    token = jwt.encode(payload, service_key, algorithm="HS256")
+
+    with pytest.raises(ValueError, match="Executor token payload is invalid"):
+        verify_executor_token(token)
 
 
 def test_verify_executor_token_expired(monkeypatch: pytest.MonkeyPatch):
@@ -148,6 +226,7 @@ async def test_role_dependency_executor_token_populates_org_context(
     workspace_id = uuid.uuid4()
     user_id = uuid.uuid4()
     organization_id = uuid.uuid4()
+    agent_session_id = uuid.uuid4()
 
     # Mock the cached workspace->org lookup
     async def mock_get_workspace_org_id(ws_id: uuid.UUID) -> uuid.UUID | None:
@@ -158,6 +237,9 @@ async def test_role_dependency_executor_token_populates_org_context(
     token = mint_executor_token(
         workspace_id=workspace_id,
         user_id=user_id,
+        service_id="tracecat-mcp",
+        execution_origin="agent",
+        agent_session_id=agent_session_id,
         wf_id="wf-1",
         wf_exec_id="run-1",
         ttl_seconds=60,
@@ -179,10 +261,48 @@ async def test_role_dependency_executor_token_populates_org_context(
     )
 
     assert resolved.type == "service"
-    assert resolved.service_id == "tracecat-executor"
+    assert resolved.service_id == "tracecat-mcp"
     assert resolved.workspace_id == workspace_id
     assert resolved.user_id == user_id
     assert resolved.organization_id == organization_id
+    assert ctx_agent_session_id.get() == agent_session_id
+
+
+@pytest.mark.anyio
+async def test_role_dependency_workflow_token_clears_agent_session_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+
+    async def mock_get_workspace_org_id(ws_id: uuid.UUID) -> uuid.UUID | None:
+        return organization_id if ws_id == workspace_id else None
+
+    monkeypatch.setattr(credentials, "_get_workspace_org_id", mock_get_workspace_org_id)
+    token = mint_executor_token(
+        workspace_id=workspace_id,
+        user_id=None,
+        wf_id="wf-1",
+        wf_exec_id="run-1",
+    )
+    context_token = ctx_agent_session_id.set(uuid.uuid4())
+    try:
+        await _role_dependency(
+            request=_make_request(token),
+            session=AsyncMock(),
+            workspace_id=workspace_id,
+            user=None,
+            api_key=None,
+            allow_user=False,
+            allow_service=False,
+            allow_executor=True,
+            require_workspace="yes",
+        )
+
+        assert ctx_agent_session_id.get() is None
+    finally:
+        ctx_agent_session_id.reset(context_token)
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/mcp/executor.py
+++ b/tracecat/agent/mcp/executor.py
@@ -114,7 +114,12 @@ async def execute_action(
 
     logger.info("Executing action via executor workflow", action_name=action_name)
 
-    run_input = build_run_input(action_name, args, registry_lock)
+    run_input = build_run_input(
+        action_name,
+        args,
+        registry_lock,
+        agent_session_id=claims.session_id,
+    )
     stored = await _execute_action_workflow(
         ExecuteRegistryToolWorkflowInput(role=role, run_input=run_input),
         workflow_id=build_agent_tool_workflow_id(),
@@ -147,6 +152,7 @@ def build_run_input(
     execution_id: UUID | None = None,
     logical_time: datetime | None = None,
     environment: str = "default",
+    agent_session_id: UUID | None = None,
 ) -> RunActionInput:
     """Build a minimal RunActionInput for ActionRunner.
 
@@ -154,6 +160,7 @@ def build_run_input(
         action_name: The action to execute
         args: Arguments for the action
         registry_lock: Registry lock with origin→version mappings for action resolution
+        agent_session_id: Verified agent session provenance, when available.
     """
     task = ActionStatement(
         ref=f"mcp_{action_name.replace('.', '_')}",
@@ -174,6 +181,7 @@ def build_run_input(
         task=task,
         run_context=run_context,
         exec_context=ExecutionContext(ACTIONS={}, TRIGGER=None),
+        agent_session_id=agent_session_id,
         registry_lock=registry_lock,
     )
 

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -46,7 +46,7 @@ from tracecat.auth.users import (
 from tracecat.authz.controls import has_scope
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.authz.service import MembershipService, MembershipWithOrg
-from tracecat.contexts import ctx_role
+from tracecat.contexts import ctx_agent_session_id, ctx_role
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.engine import AuthSession, get_async_session_auth_context_manager
 from tracecat.db.models import (
@@ -823,6 +823,7 @@ async def _authenticate_executor(
                 status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
             )
 
+    ctx_agent_session_id.set(token_payload.agent_session_id)
     return role
 
 
@@ -874,6 +875,11 @@ async def _role_dependency(
     Delegates to the appropriate auth handler based on credentials and allowed
     auth types, then validates the resulting role.
     """
+    # Authentication dependencies may be called more than once in one async
+    # context in tests and internal callers. Only a verified executor token may
+    # repopulate this value below.
+    ctx_agent_session_id.set(None)
+
     # Dispatch to appropriate auth handler
     role: Role | None = None
     service_key = internal_service_key or api_key
@@ -1535,6 +1541,7 @@ async def authenticated_user_only(
     This intentionally does not activate platform-superuser privileges; use
     SuperuserRole for routes that need platform admin access.
     """
+    ctx_agent_session_id.set(None)
     role = Role(
         type="user",
         user_id=user.id,

--- a/tracecat/auth/executor_tokens.py
+++ b/tracecat/auth/executor_tokens.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 import jwt
 from jwt import PyJWTError
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, model_validator
 
 from tracecat import config
 from tracecat.auth.secrets import get_service_key
-from tracecat.identifiers import InternalServiceID, UserID, WorkspaceID
+from tracecat.identifiers import InternalServiceID, SessionID, UserID, WorkspaceID
 
 ExecutionOrigin = Literal["agent", "workflow"]
 """Trusted entry point that initiated an executor action."""
@@ -37,8 +37,20 @@ class ExecutorTokenPayload(BaseModel):
     service_id: InternalServiceID | None = None
     execution_origin: ExecutionOrigin | None = None
     root_action: str | None = None
+    agent_session_id: SessionID | None = None
     wf_id: str
     wf_exec_id: str
+
+    @model_validator(mode="after")
+    def validate_agent_session_provenance(self) -> Self:
+        """Require agent-session claims to originate from the trusted MCP service."""
+        if self.agent_session_id is not None and (
+            self.execution_origin != "agent" or self.service_id != "tracecat-mcp"
+        ):
+            raise ValueError(
+                "agent_session_id requires the tracecat-mcp agent execution origin"
+            )
+        return self
 
 
 def mint_executor_token(
@@ -48,11 +60,19 @@ def mint_executor_token(
     service_id: InternalServiceID = "tracecat-executor",
     execution_origin: ExecutionOrigin | None = None,
     root_action: str | None = None,
+    agent_session_id: SessionID | None = None,
     wf_id: str,
     wf_exec_id: str,
     ttl_seconds: int | None = None,
 ) -> str:
     """Create a signed executor JWT scoped to a specific workflow execution."""
+    if agent_session_id is not None and (
+        execution_origin != "agent" or service_id != "tracecat-mcp"
+    ):
+        raise ValueError(
+            "agent_session_id requires the tracecat-mcp agent execution origin"
+        )
+
     now = datetime.now(UTC)
     ttl = ttl_seconds or config.TRACECAT__EXECUTOR_TOKEN_TTL_SECONDS
     payload: dict[str, Any] = {
@@ -71,6 +91,8 @@ def mint_executor_token(
         payload["execution_origin"] = execution_origin
     if root_action is not None:
         payload["root_action"] = root_action
+    if agent_session_id is not None:
+        payload["agent_session_id"] = str(agent_session_id)
 
     return jwt.encode(payload, get_service_key(), algorithm="HS256")
 

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -21,6 +21,7 @@ __all__ = [
     "ctx_stream_id",
     "ctx_session",
     "ctx_request_audit",
+    "ctx_agent_session_id",
     "ctx_logical_time",
     "get_env",
     "RequestAuditContext",
@@ -49,6 +50,11 @@ ctx_env: ContextVar[dict[str, str] | None] = ContextVar("env", default=None)
 ctx_session: ContextVar[AsyncSession | None] = ContextVar("session", default=None)
 ctx_session_id: ContextVar[uuid.UUID | None] = ContextVar("session-id", default=None)
 """ID for a streamable session, if any."""
+
+ctx_agent_session_id: ContextVar[uuid.UUID | None] = ContextVar(
+    "agent-session-id", default=None
+)
+"""Verified agent session associated with the current request, if any."""
 
 ctx_logical_time: ContextVar[datetime | None] = ContextVar("logical-time", default=None)
 """Current logical time = time_anchor + elapsed workflow time. Used by FN.now()."""

--- a/tracecat/dsl/schemas.py
+++ b/tracecat/dsl/schemas.py
@@ -575,6 +575,8 @@ class RunActionInput(BaseModel):
     stream_id: StreamID = ROOT_STREAM
     session_id: uuid.UUID | None = None
     """ID for a streamable session, if any."""
+    agent_session_id: uuid.UUID | None = None
+    """Trusted agent session provenance supplied by the MCP execution boundary."""
     registry_lock: RegistryLock
     """Registry version lock from workflow definition. Required and must be non-empty."""
 

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -98,12 +98,16 @@ def _mint_action_executor_token(input: RunActionInput, role: Role) -> str:
     """Mint SDK credentials carrying the root action's trusted provenance."""
     if role.workspace_id is None:
         raise ValueError("workspace_id is required for action execution")
+    execution_origin = _execution_origin_for_role(role)
     return mint_executor_token(
         workspace_id=role.workspace_id,
         user_id=role.user_id,
         service_id=role.service_id,
-        execution_origin=_execution_origin_for_role(role),
+        execution_origin=execution_origin,
         root_action=input.task.action,
+        agent_session_id=(
+            input.agent_session_id if execution_origin == "agent" else None
+        ),
         wf_id=str(input.run_context.wf_id),
         wf_exec_id=str(input.run_context.wf_run_id),
     )


### PR DESCRIPTION
## Summary

- propagate verified MCP agent session IDs through direct and approval-gated registry action execution
- carry the provenance in signed executor tokens and restore it in request-local Case API context
- reject inconsistent session provenance unless the signed origin is `agent` and the service is `tracecat-mcp`
- clear agent session context for workflow and user authentication paths and update the generated API client

This prepares Case API calls for interaction recording in ENG-1710 without adding fields to case records.

Linear: [ENG-1709](https://linear.app/tracecat/issue/ENG-1709/propagate-trusted-agent-session-provenance-into-case-api-calls)
Parent: [ENG-1683](https://linear.app/tracecat/issue/ENG-1683)

## Testing

- 189 relevant tests passed; 1 skipped
- Case characterization suite: 68 passed
- Ruff lint and formatting passed
- Basedpyright passed with 0 errors and 0 warnings
- Pre-commit hooks passed, including generated client sync and frontend typechecking

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 60 | 6 |
| Tests | 217 | 5 |
| Generated | 13 | 0 |

