### PR TITLE
perf(tests): avoid reloading registry templates

### DIFF
--- a/tests/registry/test_templates.py
+++ b/tests/registry/test_templates.py
@@ -85,9 +85,9 @@ async def test_base_registry_validate_template_actions():
     ids=lambda path: str(path.parts[-2:]),
 )
 async def test_template_action_validation(file_path):
-    # Initialize the repository
+    # Initialize an empty repository; each parameter registers only its template.
     repo = Repository()
-    repo.init(include_base=False, include_templates=True)
+    repo.init(include_base=False, include_templates=False)
 
     # Test parsing
     action = TemplateAction.from_yaml(file_path)


### PR DESCRIPTION
## Summary

- initialize an empty repository for each parameterized template test
- parse and register only the template under test
- keep the full-corpus load in `test_base_registry_validate_template_actions`

## Why

`test_template_action_validation` is parameterized across 1,015 YAML files, but each case initialized the repository with `include_templates=True`. That reloaded and registered the complete template corpus before the test parsed and registered its individual template.

In the motivating CI job, pytest took 736.83 seconds, and 1,016 of the registry shard's 1,612 cases came from `test_templates.py`.

## Performance

| Measurement | Result |
| --- | ---: |
| Existing CI registry job | 12m53s |
| This PR's CI registry job | 56s |
| Existing CI `Run tests` step | 12m28s |
| This PR's CI `Run tests` step | 34s |
| Focused template suite after this change | 1,016 passed in 29.84s |
| Local wall time after this change | 31.77s |

The CI test step is about 22 times faster after the change.

Motivating job: https://github.com/TracecatHQ/tracecat/actions/runs/33026613039/job/98369352204

This PR's registry job: https://github.com/TracecatHQ/tracecat/actions/runs/33027879672/job/98373380387

## Testing

- `uv run pytest --confcutdir=tests/registry tests/registry/test_templates.py -q -n auto`
- `uv run ruff check tests/registry/test_templates.py`
- `uv run ruff format --check tests/registry/test_templates.py`
- `uv run basedpyright tests/registry/test_templates.py`
- pre-commit hooks

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Tests | 2 | 2 |
