### PR TITLE
feat(cases): record agent case mutations

### DIFF
--- a/tests/integration/test_case_agent_session_mutations.py
+++ b/tests/integration/test_case_agent_session_mutations.py
@@ -233,6 +233,23 @@ async def test_non_agent_case_and_comment_mutations_do_not_record(
     assert await _list_interactions(session, svc_role.workspace_id) == []
 
 
+async def test_missing_agent_session_does_not_block_case_creation(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """A stale provenance ID does not veto the requested case mutation."""
+    assert svc_role.workspace_id is not None
+    cases = CasesService(session=session, role=svc_role)
+
+    context_token = ctx_agent_session_id.set(uuid.uuid4())
+    try:
+        await cases.create_case(_case_create("Stale agent session"))
+    finally:
+        ctx_agent_session_id.reset(context_token)
+
+    assert await _list_interactions(session, svc_role.workspace_id) == []
+
+
 async def test_failed_case_and_comment_transactions_leave_no_interactions(
     session: AsyncSession,
     svc_role: Role,

--- a/tests/integration/test_case_agent_session_mutations.py
+++ b/tests/integration/test_case_agent_session_mutations.py
@@ -1,0 +1,304 @@
+"""End-to-end persistence tests for agent case mutation interactions."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import event, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.cases.enums import (
+    CaseAgentSessionInteractionOperation,
+    CasePriority,
+    CaseSeverity,
+    CaseStatus,
+)
+from tracecat.cases.schemas import (
+    CaseCommentCreate,
+    CaseCommentUpdate,
+    CaseCreate,
+    CaseUpdate,
+)
+from tracecat.cases.service import CaseCommentsService, CasesService
+from tracecat.contexts import ctx_agent_session_id
+from tracecat.db.models import (
+    AgentSession,
+    Case,
+    CaseAgentSessionInteraction,
+    CaseComment,
+    Workspace,
+)
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.integration,
+    pytest.mark.usefixtures("db"),
+]
+
+
+@pytest.fixture(autouse=True)
+def isolate_case_side_effects() -> Iterator[None]:
+    """Keep the integration focused on case and interaction persistence."""
+    with (
+        patch.object(
+            CasesService,
+            "has_entitlement",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "tracecat.cases.events.enqueue_case_duration_sync_after_commit",
+            return_value=None,
+        ),
+        patch(
+            "tracecat.cases.events.publish_case_event_payload",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "tracecat.cases.service.publish_case_event_payload",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        yield
+
+
+def _case_create(summary: str) -> CaseCreate:
+    return CaseCreate(
+        summary=summary,
+        description=f"Description for {summary}",
+        status=CaseStatus.NEW,
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.LOW,
+    )
+
+
+async def _create_session_lineage(
+    session: AsyncSession,
+    role: Role,
+) -> tuple[AgentSession, AgentSession]:
+    assert role.workspace_id is not None
+    root = AgentSession(
+        workspace_id=role.workspace_id,
+        title="Case interaction root",
+        entity_type="workflow",
+        entity_id=uuid.uuid4(),
+    )
+    child = AgentSession(
+        workspace_id=role.workspace_id,
+        title="Case interaction continuation",
+        entity_type="approval",
+        entity_id=uuid.uuid4(),
+        parent_session=root,
+    )
+    session.add_all([root, child])
+    await session.commit()
+    return root, child
+
+
+async def _list_interactions(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> list[CaseAgentSessionInteraction]:
+    result = await session.scalars(
+        select(CaseAgentSessionInteraction)
+        .where(CaseAgentSessionInteraction.workspace_id == workspace_id)
+        .order_by(
+            CaseAgentSessionInteraction.case_id,
+            CaseAgentSessionInteraction.operation,
+        )
+    )
+    return list(result.all())
+
+
+async def test_agent_case_and_comment_mutations_record_root_interactions(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Case and comment mutations upsert case-level root-session interactions."""
+    assert svc_role.workspace_id is not None
+    root, child = await _create_session_lineage(session, svc_role)
+    cases = CasesService(session=session, role=svc_role)
+    comments = CaseCommentsService(session=session, role=svc_role)
+    read_then_no_op_case = await cases.create_case(_case_create("Read then no-op case"))
+
+    context_token = ctx_agent_session_id.set(child.id)
+    try:
+        assert await cases.get_case(read_then_no_op_case.id) is not None
+        assert await _list_interactions(session, svc_role.workspace_id) == []
+        await cases.update_case(read_then_no_op_case, CaseUpdate())
+
+        first_case = await cases.create_case(_case_create("First case"))
+        await cases.update_case(
+            first_case,
+            CaseUpdate(summary="Updated first case"),
+        )
+        await cases.update_case(
+            first_case,
+            CaseUpdate(summary="Updated first case"),
+        )
+        comment = await comments.create_comment(
+            first_case,
+            CaseCommentCreate(content="Agent comment"),
+        )
+        await comments.update_comment(
+            comment,
+            CaseCommentUpdate(content="Edited agent comment"),
+        )
+
+        second_case = await cases.create_case(_case_create("Second case"))
+        await comments.create_comment(
+            second_case,
+            CaseCommentCreate(content="Second case comment"),
+        )
+
+        third_case = await cases.create_case(_case_create("Third case"))
+        batch_response = await cases.batch_update_cases(
+            [third_case.id],
+            CaseUpdate(status=CaseStatus.IN_PROGRESS),
+        )
+        assert batch_response.succeeded == 1
+    finally:
+        ctx_agent_session_id.reset(context_token)
+
+    interactions = await _list_interactions(session, svc_role.workspace_id)
+    assert {
+        (interaction.case_id, interaction.operation, interaction.agent_session_id)
+        for interaction in interactions
+    } == {
+        (
+            read_then_no_op_case.id,
+            CaseAgentSessionInteractionOperation.UPDATE,
+            root.id,
+        ),
+        (
+            first_case.id,
+            CaseAgentSessionInteractionOperation.CREATE,
+            root.id,
+        ),
+        (
+            first_case.id,
+            CaseAgentSessionInteractionOperation.UPDATE,
+            root.id,
+        ),
+        (
+            second_case.id,
+            CaseAgentSessionInteractionOperation.CREATE,
+            root.id,
+        ),
+        (
+            second_case.id,
+            CaseAgentSessionInteractionOperation.UPDATE,
+            root.id,
+        ),
+        (
+            third_case.id,
+            CaseAgentSessionInteractionOperation.CREATE,
+            root.id,
+        ),
+        (
+            third_case.id,
+            CaseAgentSessionInteractionOperation.UPDATE,
+            root.id,
+        ),
+    }
+
+
+async def test_non_agent_case_and_comment_mutations_do_not_record(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Normal calls preserve case behavior without creating interactions."""
+    assert svc_role.workspace_id is not None
+    cases = CasesService(session=session, role=svc_role)
+    comments = CaseCommentsService(session=session, role=svc_role)
+
+    context_token = ctx_agent_session_id.set(None)
+    try:
+        case = await cases.create_case(_case_create("Non-agent case"))
+        await cases.update_case(case, CaseUpdate(status=CaseStatus.IN_PROGRESS))
+        comment = await comments.create_comment(
+            case,
+            CaseCommentCreate(content="Normal comment"),
+        )
+        await comments.update_comment(
+            comment,
+            CaseCommentUpdate(content="Edited normal comment"),
+        )
+    finally:
+        ctx_agent_session_id.reset(context_token)
+
+    assert await _list_interactions(session, svc_role.workspace_id) == []
+
+
+async def test_failed_case_and_comment_transactions_leave_no_interactions(
+    session: AsyncSession,
+    svc_role: Role,
+    svc_workspace: Workspace,
+) -> None:
+    """Commit failures leave neither mutations nor interaction upserts."""
+    assert svc_role.workspace_id is not None
+    _, child = await _create_session_lineage(session, svc_role)
+    child_id = child.id
+    cases = CasesService(session=session, role=svc_role)
+    comments = CaseCommentsService(session=session, role=svc_role)
+    target_case = await cases.create_case(_case_create("Rollback target"))
+    target_case_id = target_case.id
+    original_summary = target_case.summary
+
+    class ExpectedCommitFailure(RuntimeError):
+        pass
+
+    def fail_commit(*_: object) -> None:
+        raise ExpectedCommitFailure
+
+    event.listen(session.sync_session, "before_commit", fail_commit)
+
+    context_token = ctx_agent_session_id.set(child_id)
+    try:
+        with pytest.raises(ExpectedCommitFailure):
+            await cases.update_case(
+                target_case,
+                CaseUpdate(summary="Must roll back"),
+            )
+    finally:
+        ctx_agent_session_id.reset(context_token)
+        event.remove(session.sync_session, "before_commit", fail_commit)
+
+    refreshed_case = await session.scalar(select(Case).where(Case.id == target_case_id))
+    assert refreshed_case is not None
+    assert refreshed_case.summary == original_summary
+    assert await _list_interactions(session, svc_role.workspace_id) == []
+
+    event.listen(session.sync_session, "before_commit", fail_commit)
+
+    context_token = ctx_agent_session_id.set(child_id)
+    try:
+        with pytest.raises(ExpectedCommitFailure):
+            await comments.create_comment(
+                refreshed_case,
+                CaseCommentCreate(content="Must also roll back"),
+            )
+    finally:
+        ctx_agent_session_id.reset(context_token)
+        event.remove(session.sync_session, "before_commit", fail_commit)
+        await session.rollback()
+
+    interaction_count = await session.scalar(
+        select(func.count())
+        .select_from(CaseAgentSessionInteraction)
+        .where(CaseAgentSessionInteraction.workspace_id == svc_role.workspace_id)
+    )
+    comment_count = await session.scalar(
+        select(func.count())
+        .select_from(CaseComment)
+        .where(
+            CaseComment.workspace_id == svc_role.workspace_id,
+            CaseComment.content == "Must also roll back",
+        )
+    )
+    assert interaction_count == 0
+    assert comment_count == 0
+    await session.refresh(svc_workspace)

--- a/tests/integration/test_case_agent_session_mutations.py
+++ b/tests/integration/test_case_agent_session_mutations.py
@@ -11,6 +11,7 @@ from sqlalchemy import event, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
+from tracecat.cases.dropdowns.schemas import CaseDropdownValueInput
 from tracecat.cases.enums import (
     CaseAgentSessionInteractionOperation,
     CasePriority,
@@ -31,6 +32,8 @@ from tracecat.db.models import (
     Case,
     CaseAgentSessionInteraction,
     CaseComment,
+    CaseDropdownDefinition,
+    CaseDropdownOption,
     Workspace,
 )
 
@@ -66,13 +69,18 @@ def isolate_case_side_effects() -> Iterator[None]:
         yield
 
 
-def _case_create(summary: str) -> CaseCreate:
+def _case_create(
+    summary: str,
+    *,
+    dropdown_values: list[CaseDropdownValueInput] | None = None,
+) -> CaseCreate:
     return CaseCreate(
         summary=summary,
         description=f"Description for {summary}",
         status=CaseStatus.NEW,
         priority=CasePriority.MEDIUM,
         severity=CaseSeverity.LOW,
+        dropdown_values=dropdown_values,
     )
 
 
@@ -126,6 +134,20 @@ async def test_agent_case_and_comment_mutations_record_root_interactions(
     tags = CaseTagsService(session=session, role=svc_role)
     read_then_no_op_case = await cases.create_case(_case_create("Read then no-op case"))
     child_resource_case = await cases.create_case(_case_create("Child resource case"))
+    dropdown_definition = CaseDropdownDefinition(
+        workspace_id=svc_role.workspace_id,
+        name="Source",
+        ref="source",
+    )
+    session.add(dropdown_definition)
+    await session.flush()
+    dropdown_option = CaseDropdownOption(
+        definition_id=dropdown_definition.id,
+        label="Agent",
+        ref="agent",
+    )
+    session.add(dropdown_option)
+    await session.commit()
 
     context_token = ctx_agent_session_id.set(child.id)
     try:
@@ -134,6 +156,17 @@ async def test_agent_case_and_comment_mutations_record_root_interactions(
         await cases.update_case(read_then_no_op_case, CaseUpdate())
 
         first_case = await cases.create_case(_case_create("First case"))
+        dropdown_case = await cases.create_case(
+            _case_create(
+                "Dropdown case",
+                dropdown_values=[
+                    CaseDropdownValueInput(
+                        definition_id=dropdown_definition.id,
+                        option_id=dropdown_option.id,
+                    )
+                ],
+            )
+        )
         await cases.update_case(
             first_case,
             CaseUpdate(summary="Updated first case"),
@@ -189,6 +222,11 @@ async def test_agent_case_and_comment_mutations_record_root_interactions(
         (
             first_case.id,
             CaseAgentSessionInteractionOperation.UPDATE,
+            root.id,
+        ),
+        (
+            dropdown_case.id,
+            CaseAgentSessionInteractionOperation.CREATE,
             root.id,
         ),
         (

--- a/tests/integration/test_case_agent_session_mutations.py
+++ b/tests/integration/test_case_agent_session_mutations.py
@@ -24,6 +24,7 @@ from tracecat.cases.schemas import (
     CaseUpdate,
 )
 from tracecat.cases.service import CaseCommentsService, CasesService
+from tracecat.cases.tags.service import CaseTagsService
 from tracecat.contexts import ctx_agent_session_id
 from tracecat.db.models import (
     AgentSession,
@@ -122,7 +123,9 @@ async def test_agent_case_and_comment_mutations_record_root_interactions(
     root, child = await _create_session_lineage(session, svc_role)
     cases = CasesService(session=session, role=svc_role)
     comments = CaseCommentsService(session=session, role=svc_role)
+    tags = CaseTagsService(session=session, role=svc_role)
     read_then_no_op_case = await cases.create_case(_case_create("Read then no-op case"))
+    child_resource_case = await cases.create_case(_case_create("Child resource case"))
 
     context_token = ctx_agent_session_id.set(child.id)
     try:
@@ -160,6 +163,11 @@ async def test_agent_case_and_comment_mutations_record_root_interactions(
             CaseUpdate(status=CaseStatus.IN_PROGRESS),
         )
         assert batch_response.succeeded == 1
+        await tags.add_case_tag(
+            child_resource_case.id,
+            "agent-child-mutation",
+            create_if_missing=True,
+        )
     finally:
         ctx_agent_session_id.reset(context_token)
 
@@ -200,6 +208,11 @@ async def test_agent_case_and_comment_mutations_record_root_interactions(
         ),
         (
             third_case.id,
+            CaseAgentSessionInteractionOperation.UPDATE,
+            root.id,
+        ),
+        (
+            child_resource_case.id,
             CaseAgentSessionInteractionOperation.UPDATE,
             root.id,
         ),

--- a/tests/unit/test_case_agent_session_interactions.py
+++ b/tests/unit/test_case_agent_session_interactions.py
@@ -68,7 +68,7 @@ async def test_record_upserts_repeated_operation_and_preserves_first_seen(
     first = await service.record(
         case_id=case.id,
         agent_session_id=agent_session.id,
-        operation=CaseAgentSessionInteractionOperation.READ,
+        operation=CaseAgentSessionInteractionOperation.UPDATE,
     )
     first_seen_at = first.created_at
     old_last_seen_at = datetime(2020, 1, 1, tzinfo=UTC)
@@ -81,7 +81,7 @@ async def test_record_upserts_repeated_operation_and_preserves_first_seen(
     repeated = await service.record(
         case_id=case.id,
         agent_session_id=agent_session.id,
-        operation=CaseAgentSessionInteractionOperation.READ,
+        operation=CaseAgentSessionInteractionOperation.UPDATE,
     )
 
     count = await session.scalar(
@@ -103,7 +103,6 @@ async def test_record_preserves_distinct_operations(
     service = CaseAgentSessionInteractionService(session, svc_role)
 
     for operation in (
-        CaseAgentSessionInteractionOperation.READ,
         CaseAgentSessionInteractionOperation.CREATE,
         CaseAgentSessionInteractionOperation.UPDATE,
     ):
@@ -123,7 +122,6 @@ async def test_record_preserves_distinct_operations(
         ).all()
     )
     assert operations == {
-        CaseAgentSessionInteractionOperation.READ,
         CaseAgentSessionInteractionOperation.CREATE,
         CaseAgentSessionInteractionOperation.UPDATE,
     }
@@ -177,7 +175,7 @@ async def test_record_does_not_commit_callers_transaction(
     await service.record(
         case_id=case.id,
         agent_session_id=agent_session.id,
-        operation=CaseAgentSessionInteractionOperation.READ,
+        operation=CaseAgentSessionInteractionOperation.UPDATE,
     )
 
     commit.assert_not_awaited()
@@ -221,13 +219,13 @@ async def test_record_rejects_cross_workspace_case_and_session(
         await service.record(
             case_id=other_case.id,
             agent_session_id=own_session.id,
-            operation=CaseAgentSessionInteractionOperation.READ,
+            operation=CaseAgentSessionInteractionOperation.UPDATE,
         )
     with pytest.raises(TracecatNotFoundError):
         await service.record(
             case_id=own_case.id,
             agent_session_id=other_session.id,
-            operation=CaseAgentSessionInteractionOperation.READ,
+            operation=CaseAgentSessionInteractionOperation.UPDATE,
         )
 
     count = await session.scalar(

--- a/tracecat/cases/agent_sessions/service.py
+++ b/tracecat/cases/agent_sessions/service.py
@@ -76,6 +76,9 @@ class CaseAgentSessionInteractionService(BaseWorkspaceService):
                 AgentSession.workspace_id == self.workspace_id,
                 AgentSession.id == current_session_id,
             )
+            # Keep the verified lineage alive until the caller commits so a
+            # concurrent session deletion cannot invalidate the interaction FK.
+            statement = statement.with_for_update(read=True, key_share=True)
             result = (await self.session.execute(statement)).one_or_none()
             if result is None:
                 raise TracecatNotFoundError(

--- a/tracecat/cases/agent_sessions/service.py
+++ b/tracecat/cases/agent_sessions/service.py
@@ -37,11 +37,19 @@ class CaseAgentSessionInteractionService(BaseWorkspaceService):
         """
         if (agent_session_id := ctx_agent_session_id.get()) is None:
             return None
-        return await self.record(
-            case_id=case_id,
-            agent_session_id=agent_session_id,
-            operation=operation,
-        )
+        try:
+            return await self.record(
+                case_id=case_id,
+                agent_session_id=agent_session_id,
+                operation=operation,
+            )
+        except TracecatNotFoundError:
+            self.logger.warning(
+                "Skipping case interaction; agent session not found",
+                agent_session_id=agent_session_id,
+                case_id=case_id,
+            )
+            return None
 
     async def resolve_root_session_id(self, session_id: uuid.UUID) -> uuid.UUID:
         """Resolve a session or continuation to its Inbox-facing root session.

--- a/tracecat/cases/agent_sessions/service.py
+++ b/tracecat/cases/agent_sessions/service.py
@@ -8,6 +8,7 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from tracecat.cases.enums import CaseAgentSessionInteractionOperation
+from tracecat.contexts import ctx_agent_session_id
 from tracecat.db.models import AgentSession, Case, CaseAgentSessionInteraction
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.service import BaseWorkspaceService
@@ -17,6 +18,30 @@ class CaseAgentSessionInteractionService(BaseWorkspaceService):
     """Record the cases touched by Inbox-facing agent sessions."""
 
     service_name = "case_agent_session_interactions"
+
+    async def record_from_context(
+        self,
+        *,
+        case_id: uuid.UUID,
+        operation: CaseAgentSessionInteractionOperation,
+    ) -> CaseAgentSessionInteraction | None:
+        """Record a trusted request's case interaction when provenance is present.
+
+        Args:
+            case_id: Case touched by the current request.
+            operation: Type of case mutation performed.
+
+        Returns:
+            The inserted or refreshed interaction, or ``None`` when the request
+            has no verified agent-session provenance.
+        """
+        if (agent_session_id := ctx_agent_session_id.get()) is None:
+            return None
+        return await self.record(
+            case_id=case_id,
+            agent_session_id=agent_session_id,
+            operation=operation,
+        )
 
     async def resolve_root_session_id(self, session_id: uuid.UUID) -> uuid.UUID:
         """Resolve a session or continuation to its Inbox-facing root session.

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -419,6 +419,7 @@ class CaseDropdownValuesService(BaseWorkspaceService):
         case: Case,
         definition_id: uuid.UUID,
         params: CaseDropdownValueSet,
+        record_agent_interaction: bool = True,
     ) -> CaseDropdownValueRead:
         case_id = case.id
         # Resolve old value
@@ -495,7 +496,11 @@ class CaseDropdownValuesService(BaseWorkspaceService):
             wf_exec_id=wf_exec_id,
         )
         events_service = CaseEventsService(session=self.session, role=self.role)
-        await events_service.create_event(case=case, event=event)
+        await events_service.create_event(
+            case=case,
+            event=event,
+            record_agent_interaction=record_agent_interaction,
+        )
 
         return CaseDropdownValueRead(
             id=row.id,
@@ -574,6 +579,7 @@ class CaseDropdownValuesService(BaseWorkspaceService):
         values: Sequence[CaseDropdownValueInput],
         *,
         commit: bool = True,
+        record_agent_interaction: bool = True,
     ) -> list[CaseDropdownValueRead]:
         """Apply multiple dropdown selections to a case in a single transaction."""
         if isinstance(case, uuid.UUID):
@@ -605,6 +611,7 @@ class CaseDropdownValuesService(BaseWorkspaceService):
                 case=case,
                 definition_id=definition_id,
                 params=CaseDropdownValueSet(option_id=option_id),
+                record_agent_interaction=record_agent_interaction,
             )
             results.append(result)
 

--- a/tracecat/cases/enums.py
+++ b/tracecat/cases/enums.py
@@ -67,7 +67,6 @@ class CaseVersionField(StrEnum):
 class CaseAgentSessionInteractionOperation(StrEnum):
     """Operations that associate an agent session with a case."""
 
-    READ = "read"
     CREATE = "create"
     UPDATE = "update"
 

--- a/tracecat/cases/events.py
+++ b/tracecat/cases/events.py
@@ -10,11 +10,17 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
+from tracecat.cases.agent_sessions.service import (
+    CaseAgentSessionInteractionService,
+)
 from tracecat.cases.durations.materialization import sync_case_duration
 from tracecat.cases.durations.sync_queue import (
     enqueue_case_duration_sync_after_commit,
 )
-from tracecat.cases.enums import CaseEventType
+from tracecat.cases.enums import (
+    CaseAgentSessionInteractionOperation,
+    CaseEventType,
+)
 from tracecat.cases.schemas import CaseEventVariant, CaseViewedEvent
 from tracecat.cases.triggers.publisher import publish_case_event_payload
 from tracecat.db.models import Case, CaseEvent
@@ -22,6 +28,19 @@ from tracecat.db.session_events import AfterCommitQueue
 from tracecat.service import BaseWorkspaceService
 
 CASE_VIEW_EVENT_DEDUP_WINDOW = timedelta(minutes=5)
+_CHILD_MUTATION_EVENTS = frozenset(
+    {
+        CaseEventType.ATTACHMENT_CREATED,
+        CaseEventType.ATTACHMENT_DELETED,
+        CaseEventType.COMMENT_DELETED,
+        CaseEventType.COMMENT_REPLY_DELETED,
+        CaseEventType.DROPDOWN_VALUE_CHANGED,
+        CaseEventType.TABLE_ROW_LINKED,
+        CaseEventType.TABLE_ROW_UNLINKED,
+        CaseEventType.TAG_ADDED,
+        CaseEventType.TAG_REMOVED,
+    }
+)
 
 
 class CaseEventsService(BaseWorkspaceService):
@@ -31,6 +50,10 @@ class CaseEventsService(BaseWorkspaceService):
 
     def __init__(self, session: AsyncSession, role: Role | None = None):
         super().__init__(session, role)
+        self.agent_session_interactions = CaseAgentSessionInteractionService(
+            session=self.session,
+            role=self.role,
+        )
 
     async def list_events(self, case: Case) -> Sequence[CaseEvent]:
         """List all events for a case."""
@@ -61,6 +84,12 @@ class CaseEventsService(BaseWorkspaceService):
         )
         self.session.add(db_event)
         await self.session.flush()
+
+        if not system_generated and event.type in _CHILD_MUTATION_EVENTS:
+            await self.agent_session_interactions.record_from_context(
+                case_id=case.id,
+                operation=CaseAgentSessionInteractionOperation.UPDATE,
+            )
 
         event_id = str(db_event.id)
         event_type = (

--- a/tracecat/cases/events.py
+++ b/tracecat/cases/events.py
@@ -73,6 +73,7 @@ class CaseEventsService(BaseWorkspaceService):
         publish_case_trigger: bool = True,
         sync_durations: bool = True,
         system_generated: bool = False,
+        record_agent_interaction: bool = True,
     ) -> CaseEvent:
         """Create a non-committing activity record for a case."""
         db_event = CaseEvent(
@@ -85,7 +86,11 @@ class CaseEventsService(BaseWorkspaceService):
         self.session.add(db_event)
         await self.session.flush()
 
-        if not system_generated and event.type in _CHILD_MUTATION_EVENTS:
+        if (
+            record_agent_interaction
+            and not system_generated
+            and event.type in _CHILD_MUTATION_EVENTS
+        ):
             await self.agent_session_interactions.record_from_context(
                 case_id=case.id,
                 operation=CaseAgentSessionInteractionOperation.UPDATE,

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -827,6 +827,7 @@ class CasesService(BaseWorkspaceService):
                     case.id,
                     params.dropdown_values,
                     commit=False,
+                    record_agent_interaction=False,
                 )
 
             # Flush all related writes before entering the gapless counter's short

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -2966,6 +2966,13 @@ class CaseTasksService(BaseWorkspaceService):
 
     service_name = "case_tasks"
 
+    def __init__(self, session: AsyncSession, role: Role | None = None):
+        super().__init__(session, role)
+        self.agent_session_interactions = CaseAgentSessionInteractionService(
+            session=self.session,
+            role=self.role,
+        )
+
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def list_tasks(self, case_id: uuid.UUID) -> Sequence[CaseTask]:
         """List all tasks for a case.
@@ -3128,6 +3135,10 @@ class CaseTasksService(BaseWorkspaceService):
         # Update parent case's updated_at timestamp
         case.updated_at = datetime.now(UTC)
 
+        await self.agent_session_interactions.record_from_context(
+            case_id=case.id,
+            operation=CaseAgentSessionInteractionOperation.UPDATE,
+        )
         await self.session.commit()
         await self.session.refresh(task)
         return task
@@ -3267,6 +3278,10 @@ class CaseTasksService(BaseWorkspaceService):
         # Update parent case's updated_at timestamp
         case.updated_at = datetime.now(UTC)
 
+        await self.agent_session_interactions.record_from_context(
+            case_id=case.id,
+            operation=CaseAgentSessionInteractionOperation.UPDATE,
+        )
         await self.session.commit()
         await self.session.refresh(task)
         return task
@@ -3310,4 +3325,8 @@ class CaseTasksService(BaseWorkspaceService):
         case.updated_at = datetime.now(UTC)
 
         await self.session.delete(task)
+        await self.agent_session_interactions.record_from_context(
+            case_id=case.id,
+            operation=CaseAgentSessionInteractionOperation.UPDATE,
+        )
         await self.session.commit()

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -30,6 +30,9 @@ from tracecat.cases.agent_invocations.queue import (
 from tracecat.cases.agent_invocations.service import (
     CaseCommentAgentInvocationService,
 )
+from tracecat.cases.agent_sessions.service import (
+    CaseAgentSessionInteractionService,
+)
 from tracecat.cases.attachments import CaseAttachmentService
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownValueInput,
@@ -38,6 +41,7 @@ from tracecat.cases.dropdowns.schemas import (
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
 from tracecat.cases.durations.schemas import CaseDurationRead
 from tracecat.cases.enums import (
+    CaseAgentSessionInteractionOperation,
     CasePriority,
     CaseSeverity,
     CaseStatus,
@@ -226,6 +230,10 @@ class CasesService(BaseWorkspaceService):
         self.attachments = CaseAttachmentService(session=self.session, role=self.role)
         self.tags = CaseTagsService(session=self.session, role=self.role)
         self.dropdowns = CaseDropdownValuesService(session=self.session, role=self.role)
+        self.agent_session_interactions = CaseAgentSessionInteractionService(
+            session=self.session,
+            role=self.role,
+        )
 
     async def get_task_counts(
         self, case_ids: list[uuid.UUID]
@@ -827,6 +835,11 @@ class CasesService(BaseWorkspaceService):
             await self.session.flush()
             await self._assign_next_case_number(case)
 
+            await self.agent_session_interactions.record_from_context(
+                case_id=case.id,
+                operation=CaseAgentSessionInteractionOperation.CREATE,
+            )
+
             # Commit once to persist case, fields, and event atomically
             await self.session.commit()
             # Make sure to refresh the case to get the fields relationship loaded
@@ -962,6 +975,10 @@ class CasesService(BaseWorkspaceService):
                 case,
                 params,
                 force_version_fields=force_version_fields,
+            )
+            await self.agent_session_interactions.record_from_context(
+                case_id=case.id,
+                operation=CaseAgentSessionInteractionOperation.UPDATE,
             )
             # Commit once to persist all updates and emitted events atomically
             await self.session.commit()
@@ -1263,6 +1280,10 @@ class CasesService(BaseWorkspaceService):
                             with queue.checkpointed():
                                 async with self.session.begin_nested():
                                     await self._apply_case_update(case, params)
+                                    await self.agent_session_interactions.record_from_context(
+                                        case_id=case.id,
+                                        operation=CaseAgentSessionInteractionOperation.UPDATE,
+                                    )
                         except TracecatNotFoundError as exc:
                             results.append(
                                 CaseBatchItemResult(
@@ -1968,6 +1989,13 @@ class CaseCommentsService(BaseWorkspaceService):
     """Service for managing case comments."""
 
     service_name = "case_comments"
+
+    def __init__(self, session: AsyncSession, role: Role | None = None):
+        super().__init__(session, role)
+        self.agent_session_interactions = CaseAgentSessionInteractionService(
+            session=self.session,
+            role=self.role,
+        )
 
     async def _get_case(self, case_id: uuid.UUID) -> Case:
         statement = select(Case).where(
@@ -2717,6 +2745,10 @@ class CaseCommentsService(BaseWorkspaceService):
                         "triggered_by_service_id": self.role.service_id,
                     },
                 }
+            await self.agent_session_interactions.record_from_context(
+                case_id=case.id,
+                operation=CaseAgentSessionInteractionOperation.UPDATE,
+            )
             await self.session.commit()
             await self.session.refresh(comment)
         except Exception:
@@ -2825,6 +2857,10 @@ class CaseCommentsService(BaseWorkspaceService):
                     comment_id=comment.id,
                     parent_id=comment.parent_id,
                 ),
+            )
+            await self.agent_session_interactions.record_from_context(
+                case_id=comment.case_id,
+                operation=CaseAgentSessionInteractionOperation.UPDATE,
             )
             await self.session.commit()
             await self.session.refresh(comment)


### PR DESCRIPTION
## Summary

- Record case mutations when a verified agent-session context is present, normalizing continuation sessions to their root session.
- Cover case creates and updates plus agent-driven comment, tag, task, attachment, linked-row, and dropdown mutations.
- Avoid classifying dropdown values initialized during case creation as a separate update.
- Remove the unused `READ` operation; read-only case access remains unrecorded.
- Treat stale agent-session provenance as optional metadata so it cannot veto the requested case mutation.
- Hold a key-share lock on verified session lineage so concurrent session deletion cannot roll back the case mutation.

## Interaction mapping

| Service operation | Recorded interaction |
| --- | --- |
| Case create | `CREATE` |
| Case update, including no-op and batch updates | `UPDATE` |
| Comment or reply create, edit, or delete | `UPDATE` on the containing case |
| Tag, task, attachment, linked-row, or dropdown mutation | `UPDATE` on the containing case |
| No or stale agent provenance, or read-only operation | None |

Interaction upserts run inside the existing service transaction or per-case batch savepoint. The helper never commits independently, so a failed mutation cannot leave a durable interaction behind.

## Testing

- `uv run pytest tests/unit/test_case_agent_session_interactions.py tests/integration/test_case_agent_session_mutations.py -q` — 10 passed
- Focused case event, task, tag, and attachment service tests — 74 passed
- `uv run pytest tests/unit/test_cases_service.py tests/unit/test_case_comments_service.py -q` — 107 passed
- Ruff, formatting, Basedpyright, Gitleaks, and repository pre-commit hooks passed

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 135 | 3 |
| Tests | 377 | 7 |

Linear: [ENG-1710](https://linear.app/tracecat/issue/ENG-1710/record-agent-case-and-comment-mutations-in-case-services)
