### PR TITLE
fix(api): supervise in-process lifespan background tasks

### DIFF
--- a/tests/unit/test_api_lifespan.py
+++ b/tests/unit/test_api_lifespan.py
@@ -155,6 +155,85 @@ async def test_drain_completes_with_failed_finite_task() -> None:
 
 
 @pytest.mark.anyio
+async def test_drain_stops_stoppable_consumer_gracefully() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+    started = asyncio.Event()
+    batch_done = asyncio.Event()
+    stop_event = asyncio.Event()
+    batch_gate = asyncio.Event()
+
+    async def consume() -> None:
+        while not stop_event.is_set():
+            started.set()
+            # Simulate an in-flight batch being processed.
+            await batch_gate.wait()
+        # Current batch finishes after the stop signal.
+        batch_done.set()
+
+    task = supervisor.spawn(
+        consume(),
+        name="stoppable_consumer",
+        kind="long_running",
+        stop_event=stop_event,
+    )
+    await started.wait()
+
+    drain_task = asyncio.create_task(supervisor.drain())
+    # Let drain signal the stop event, then let the in-flight batch finish.
+    await asyncio.sleep(0)
+    batch_gate.set()
+    await asyncio.wait_for(drain_task, timeout=5.0)
+
+    assert batch_done.is_set()
+    assert not task.cancelled()
+
+
+@pytest.mark.anyio
+async def test_drain_cancels_stoppable_consumer_past_the_deadline() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=0.0)
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+    stop_event = asyncio.Event()
+    hang_gate = asyncio.Event()
+
+    async def consume() -> None:
+        started.set()
+        # Ignores the stop event; the drain deadline must cancel it.
+        await hang_gate.wait()
+        stopped.set()
+
+    task = supervisor.spawn(
+        consume(),
+        name="stubborn_consumer",
+        kind="long_running",
+        stop_event=stop_event,
+    )
+    await started.wait()
+    await supervisor.drain()
+
+    assert task.cancelled()
+    assert not stopped.is_set()
+
+
+@pytest.mark.anyio
+async def test_stop_event_requires_long_running_kind() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+
+    async def noop() -> None:
+        await asyncio.sleep(0)
+
+    coro = noop()
+    with pytest.raises(ValueError, match="long_running"):
+        supervisor.spawn(
+            coro,
+            name="finite_with_stop",
+            kind="finite",
+            stop_event=asyncio.Event(),
+        )
+    coro.close()
+
+
+@pytest.mark.anyio
 async def test_drain_surfaces_completed_task_errors() -> None:
     supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
 

--- a/tests/unit/test_api_lifespan.py
+++ b/tests/unit/test_api_lifespan.py
@@ -1,0 +1,166 @@
+import asyncio
+
+import pytest
+
+from tracecat.api.lifespan import LifespanTaskSupervisor
+
+
+@pytest.mark.anyio
+async def test_drain_awaits_finite_task_completion() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+    completed = asyncio.Event()
+
+    async def task() -> None:
+        await asyncio.sleep(0)
+        completed.set()
+
+    supervisor.spawn(task(), name="finite_task")
+    await supervisor.drain()
+
+    assert completed.is_set()
+    assert supervisor.draining
+
+
+@pytest.mark.anyio
+async def test_drain_cancels_long_running_consumers() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+    keep_running = asyncio.Event()
+
+    async def consume() -> None:
+        started.set()
+        try:
+            await keep_running.wait()
+        finally:
+            stopped.set()
+
+    supervisor.spawn(consume(), name="consumer", kind="long_running")
+    await started.wait()
+    await supervisor.drain()
+
+    assert stopped.is_set()
+
+
+@pytest.mark.anyio
+async def test_drain_cancels_finite_tasks_past_the_deadline() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=0.0)
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    keep_running = asyncio.Event()
+
+    async def slow_task() -> None:
+        started.set()
+        try:
+            await keep_running.wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    supervisor.spawn(slow_task(), name="slow_finite_task")
+    await started.wait()
+    await supervisor.drain()
+
+    assert cancelled.is_set()
+
+
+@pytest.mark.anyio
+async def test_drain_abandons_tasks_that_ignore_cancellation() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=0.0)
+    started = asyncio.Event()
+    swallow_gate = asyncio.Event()
+    released = asyncio.Event()
+
+    async def stubborn_task() -> None:
+        started.set()
+        try:
+            await swallow_gate.wait()
+        except asyncio.CancelledError:
+            # Simulate a task that ignores cancellation past the deadline.
+            await released.wait()
+            raise
+
+    task = supervisor.spawn(stubborn_task(), name="stubborn_task")
+    await started.wait()
+
+    async def release_later() -> None:
+        await asyncio.sleep(0)
+        released.set()
+
+    # Unblock the stubborn task while drain waits in phase 3.
+    asyncio.get_running_loop().create_task(release_later())  # noqa: RUF006
+    await asyncio.wait_for(supervisor.drain(), timeout=5.0)
+
+    assert task.done()
+
+
+@pytest.mark.anyio
+async def test_spawn_is_rejected_after_drain_starts() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=0.0)
+
+    async def noop() -> None:
+        await asyncio.sleep(0)
+
+    coro = noop()
+    await supervisor.drain()
+    with pytest.raises(RuntimeError, match="draining"):
+        supervisor.spawn(coro, name="late_task")
+    # The rejected coroutine never becomes a task; close it explicitly.
+    coro.close()
+
+
+@pytest.mark.anyio
+async def test_drain_with_no_tasks_is_a_noop() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=0.0)
+    await supervisor.drain()
+    assert supervisor.draining
+
+
+@pytest.mark.anyio
+async def test_unexpected_task_failure_is_surfaced_without_unretrieved_warning(
+    recwarn: pytest.WarningsRecorder,
+) -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+
+    async def failing_task() -> None:
+        await asyncio.sleep(0)
+        raise ValueError("boom")
+
+    supervisor.spawn(failing_task(), name="failing_task")
+    await supervisor.drain()
+    # Let done callbacks run.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert not any(
+        "Task exception was never retrieved" in str(warning.message)
+        for warning in recwarn.list
+    )
+
+
+@pytest.mark.anyio
+async def test_drain_completes_with_failed_finite_task() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+    ran_after = asyncio.Event()
+
+    async def failing_task() -> None:
+        raise ValueError("boom")
+
+    supervisor.spawn(failing_task(), name="failing_task")
+    await supervisor.drain()
+
+    # Drain must not raise or hang when a finite task fails.
+    ran_after.set()
+    assert ran_after.is_set()
+
+
+@pytest.mark.anyio
+async def test_drain_surfaces_completed_task_errors() -> None:
+    supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+
+    async def failing_task() -> None:
+        raise ValueError("boom")
+
+    supervisor.spawn(failing_task(), name="failing_task")
+    # Drain must not raise or hang when a finite task fails.
+    await supervisor.drain()

--- a/tests/unit/test_api_lifespan.py
+++ b/tests/unit/test_api_lifespan.py
@@ -159,28 +159,35 @@ async def test_drain_stops_stoppable_consumer_gracefully() -> None:
     supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
     started = asyncio.Event()
     batch_done = asyncio.Event()
-    stop_event = asyncio.Event()
     batch_gate = asyncio.Event()
+    injected_stop_event: asyncio.Event | None = None
 
-    async def consume() -> None:
-        while not stop_event.is_set():
-            started.set()
-            # Simulate an in-flight batch being processed.
-            await batch_gate.wait()
-        # Current batch finishes after the stop signal.
-        batch_done.set()
+    def factory(stop_event: asyncio.Event):
+        nonlocal injected_stop_event
+        injected_stop_event = stop_event
 
-    task = supervisor.spawn(
-        consume(),
+        async def consume() -> None:
+            while not stop_event.is_set():
+                started.set()
+                # Simulate an in-flight batch being processed.
+                await batch_gate.wait()
+            # Current batch finishes after the stop signal.
+            batch_done.set()
+
+        return consume()
+
+    task = supervisor.spawn_stoppable(
+        factory,
         name="stoppable_consumer",
-        kind="long_running",
-        stop_event=stop_event,
     )
     await started.wait()
+    assert injected_stop_event is not None
+    assert not injected_stop_event.is_set()
 
     drain_task = asyncio.create_task(supervisor.drain())
     # Let drain signal the stop event, then let the in-flight batch finish.
     await asyncio.sleep(0)
+    assert injected_stop_event.is_set()
     batch_gate.set()
     await asyncio.wait_for(drain_task, timeout=5.0)
 
@@ -193,20 +200,22 @@ async def test_drain_cancels_stoppable_consumer_past_the_deadline() -> None:
     supervisor = LifespanTaskSupervisor(drain_timeout=0.0)
     started = asyncio.Event()
     stopped = asyncio.Event()
-    stop_event = asyncio.Event()
     hang_gate = asyncio.Event()
 
-    async def consume() -> None:
-        started.set()
-        # Ignores the stop event; the drain deadline must cancel it.
-        await hang_gate.wait()
-        stopped.set()
+    def factory(stop_event: asyncio.Event):
+        assert not stop_event.is_set()
 
-    task = supervisor.spawn(
-        consume(),
+        async def consume() -> None:
+            started.set()
+            # Ignore the injected stop event; the deadline must cancel this.
+            await hang_gate.wait()
+            stopped.set()
+
+        return consume()
+
+    task = supervisor.spawn_stoppable(
+        factory,
         name="stubborn_consumer",
-        kind="long_running",
-        stop_event=stop_event,
     )
     await started.wait()
     await supervisor.drain()
@@ -216,26 +225,39 @@ async def test_drain_cancels_stoppable_consumer_past_the_deadline() -> None:
 
 
 @pytest.mark.anyio
-async def test_stop_event_requires_long_running_kind() -> None:
+async def test_spawn_stoppable_rejects_after_drain_without_invoking_factory() -> None:
     supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+    factory_called = False
 
-    async def noop() -> None:
-        await asyncio.sleep(0)
+    def factory(stop_event: asyncio.Event):
+        nonlocal factory_called
+        factory_called = True
 
-    coro = noop()
-    with pytest.raises(ValueError, match="long_running"):
-        supervisor.spawn(
-            coro,
-            name="finite_with_stop",
-            kind="finite",
-            stop_event=asyncio.Event(),
-        )
-    coro.close()
+        async def consume() -> None:
+            await stop_event.wait()
+
+        return consume()
+
+    await supervisor.drain()
+    with pytest.raises(RuntimeError, match="draining"):
+        supervisor.spawn_stoppable(factory, name="late_stoppable_task")
+
+    assert not factory_called
 
 
 @pytest.mark.anyio
-async def test_drain_surfaces_completed_task_errors() -> None:
+async def test_drain_surfaces_completed_task_errors_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tracecat.api import lifespan as lifespan_module
+
     supervisor = LifespanTaskSupervisor(drain_timeout=5.0)
+    logged_errors: list[tuple[str, dict[str, object]]] = []
+
+    def capture_error(message: str, **kwargs: object) -> None:
+        logged_errors.append((message, kwargs))
+
+    monkeypatch.setattr(lifespan_module.logger, "error", capture_error)
 
     async def failing_task() -> None:
         raise ValueError("boom")
@@ -243,3 +265,10 @@ async def test_drain_surfaces_completed_task_errors() -> None:
     supervisor.spawn(failing_task(), name="failing_task")
     # Drain must not raise or hang when a finite task fails.
     await supervisor.drain()
+    await asyncio.sleep(0)
+
+    assert len(logged_errors) == 1
+    message, context = logged_errors[0]
+    assert message == "Supervised lifespan task failed"
+    assert context["task"] == "failing_task"
+    assert isinstance(context["err"], ValueError)

--- a/tests/unit/test_case_duration_sync_consumer.py
+++ b/tests/unit/test_case_duration_sync_consumer.py
@@ -29,6 +29,8 @@ class FakeRedisClient:
         self.acked: list[list[str]] = []
         self.deleted: list[list[str]] = []
         self.calls: list[tuple[str, list[str]]] = []
+        # Declared so tests can drive the run loop via the stream read.
+        self.xreadgroup: AsyncMock = AsyncMock(return_value=[])
 
     async def xack(
         self,
@@ -1306,3 +1308,61 @@ async def test_consumer_resets_backoff_after_successful_iteration(
         await consumer.run()
 
     assert [call.args[0] for call in sleep_mock.await_args_list] == [1.0, 0, 1.0]
+
+
+@pytest.mark.anyio
+async def test_consumer_finishes_batch_on_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SIGTERM stop signal lets the in-flight batch finish before exit.
+
+    Rolling upgrades cancel the API pod with SIGTERM; the consumer must not
+    strand the batch it is processing — it should complete handling (and ack)
+    the entries it already read, then exit its loop gracefully.
+    """
+    stop_event = asyncio.Event()
+    client = FakeRedisClient()
+
+    async def fake_xreadgroup(
+        **kwargs: object,
+    ) -> list[tuple[str, list[tuple[str, dict[str, str]]]]]:
+        del kwargs
+        return [
+            (
+                "stream",
+                [
+                    (
+                        "1-0",
+                        {
+                            "workspace_id": str(uuid.uuid4()),
+                            "case_id": str(uuid.uuid4()),
+                            "reason": "case_event",
+                            "event_type": "case_updated",
+                        },
+                    )
+                ],
+            )
+        ]
+
+    async def fake_handle_entries(entries: object) -> None:
+        # SIGTERM arrives while the batch is in flight; the stop signal
+        # arrives mid-processing but must not abort the batch.
+        stop_event.set()
+        await asyncio.sleep(0)
+        del entries
+
+    handle_entries_mock = AsyncMock(side_effect=fake_handle_entries)
+
+    consumer = CaseDurationSyncConsumer(
+        cast(RedisClient, client), stop_event=stop_event
+    )
+    monkeypatch.setattr(consumer, "_ensure_group", AsyncMock())
+    monkeypatch.setattr(consumer, "_handle_entries", handle_entries_mock)
+    xreadgroup_mock = AsyncMock(side_effect=fake_xreadgroup)
+    client.xreadgroup = xreadgroup_mock
+
+    await asyncio.wait_for(consumer.run(), timeout=5.0)
+
+    assert stop_event.is_set()
+    assert xreadgroup_mock.await_count == 1
+    assert handle_entries_mock.await_count == 1

--- a/tests/unit/test_case_duration_sync_consumer.py
+++ b/tests/unit/test_case_duration_sync_consumer.py
@@ -1422,3 +1422,42 @@ async def test_claim_idle_messages_stops_claiming_after_stop_event(
 
     assert client.claim_calls == 1
     handle_mock.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_run_does_not_start_pending_recovery_after_stop_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A due pending-check must not fire once the stop signal is set.
+
+    The signal can arrive while the consumer is blocked in xreadgroup() or
+    handling new-stream entries; the loop body then reaches the due
+    pending-check. Starting recovery there would claim fresh work the
+    terminating pod never had in flight.
+    """
+    stop_event = asyncio.Event()
+    client = FakeRedisClient()
+
+    async def fake_handle_entries(entries: object) -> None:
+        # SIGTERM arrives while new-stream entries are being handled; the
+        # pending-check interval is due on this same iteration.
+        stop_event.set()
+        del entries
+
+    client.xreadgroup = AsyncMock(
+        side_effect=lambda **kwargs: [("stream", [("1-0", {"workspace_id": "w"})])]
+    )
+    consumer = CaseDurationSyncConsumer(
+        cast(RedisClient, client), stop_event=stop_event
+    )
+    consumer._pending_check_interval = 0.0
+    monkeypatch.setattr(consumer, "_ensure_group", AsyncMock())
+    monkeypatch.setattr(
+        consumer, "_handle_entries", AsyncMock(side_effect=fake_handle_entries)
+    )
+    claim_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(consumer, "_claim_idle_messages", claim_mock)
+
+    await asyncio.wait_for(consumer.run(), timeout=5.0)
+
+    claim_mock.assert_not_awaited()

--- a/tests/unit/test_case_duration_sync_consumer.py
+++ b/tests/unit/test_case_duration_sync_consumer.py
@@ -1132,6 +1132,41 @@ async def test_claim_idle_messages_drains_all_available_batches(
 
 
 @pytest.mark.anyio
+async def test_claim_idle_messages_does_not_claim_after_stop_during_pending_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_event = asyncio.Event()
+    pending_started = asyncio.Event()
+    finish_pending = asyncio.Event()
+    client = AsyncMock()
+
+    async def pending_during_shutdown(
+        *args: object, **kwargs: object
+    ) -> list[dict[str, str]]:
+        del args, kwargs
+        pending_started.set()
+        await finish_pending.wait()
+        return [{"message_id": "1-0"}]
+
+    client.xpending_range = AsyncMock(side_effect=pending_during_shutdown)
+    client.xclaim = AsyncMock()
+    consumer = CaseDurationSyncConsumer(
+        cast(RedisClient, client), stop_event=stop_event
+    )
+    handle_entries_mock = AsyncMock()
+    monkeypatch.setattr(consumer, "_handle_entries", handle_entries_mock)
+
+    claim_task = asyncio.create_task(consumer._claim_idle_messages())
+    await asyncio.wait_for(pending_started.wait(), timeout=5.0)
+    stop_event.set()
+    finish_pending.set()
+    await asyncio.wait_for(claim_task, timeout=5.0)
+
+    client.xclaim.assert_not_awaited()
+    handle_entries_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_consumer_retries_transient_read_failure_and_processes_next_batch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_case_duration_sync_consumer.py
+++ b/tests/unit/test_case_duration_sync_consumer.py
@@ -1366,3 +1366,59 @@ async def test_consumer_finishes_batch_on_stop_event(
     assert stop_event.is_set()
     assert xreadgroup_mock.await_count == 1
     assert handle_entries_mock.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_claim_idle_messages_stops_claiming_after_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shutdown mid-claim must not keep claiming fresh pending batches.
+
+    A large or continuously replenished pending list would otherwise keep
+    the consumer working until the drain deadline cancels it midway through
+    a claimed batch, recreating the unacked-job delay the graceful stop is
+    meant to avoid. Only the batch already claimed may complete.
+    """
+    stop_event = asyncio.Event()
+
+    class ClaimingFakeClient:
+        def __init__(self) -> None:
+            self.claim_calls = 0
+
+        async def xpending_range(
+            self, *args: object, **kwargs: object
+        ) -> list[dict[str, str]]:
+            # Always report a full pending batch: a continuously replenished
+            # pending list must not keep the shutdown-bound consumer busy.
+            return [{"message_id": f"{i}-0"} for i in range(10)]
+
+        async def xclaim(
+            self, *args: object, **kwargs: object
+        ) -> list[tuple[str, dict[str, str]]]:
+            self.claim_calls += 1
+            if self.claim_calls == 1:
+                # SIGTERM arrives as the first claimed batch completes.
+                stop_event.set()
+            return [
+                (
+                    f"{self.claim_calls}-0",
+                    {
+                        "workspace_id": str(uuid.uuid4()),
+                        "case_id": str(uuid.uuid4()),
+                        "reason": "case_event",
+                        "event_type": "case_updated",
+                    },
+                )
+            ]
+
+    client = ClaimingFakeClient()
+    consumer = CaseDurationSyncConsumer(
+        cast(RedisClient, client), stop_event=stop_event
+    )
+    handle_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(consumer, "_handle_entries", handle_mock)
+
+    await consumer._claim_idle_messages()
+
+    assert client.claim_calls == 1
+    handle_mock.assert_awaited_once()

--- a/tests/unit/test_case_duration_sync_consumer.py
+++ b/tests/unit/test_case_duration_sync_consumer.py
@@ -1369,6 +1369,39 @@ async def test_consumer_finishes_batch_on_stop_event(
 
 
 @pytest.mark.anyio
+async def test_consumer_does_not_read_after_stop_during_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+    rollout_backfill_mock: AsyncMock,
+) -> None:
+    """Shutdown during pre-read initialization must not claim a fresh batch."""
+    stop_event = asyncio.Event()
+    initialization_started = asyncio.Event()
+    finish_initialization = asyncio.Event()
+
+    async def initialize_rollout() -> bool:
+        initialization_started.set()
+        await finish_initialization.wait()
+        return True
+
+    rollout_backfill_mock.side_effect = initialize_rollout
+    client = FakeRedisClient()
+    consumer = CaseDurationSyncConsumer(
+        cast(RedisClient, client), stop_event=stop_event
+    )
+    ensure_group_mock = AsyncMock()
+    monkeypatch.setattr(consumer, "_ensure_group", ensure_group_mock)
+
+    run_task = asyncio.create_task(consumer.run())
+    await asyncio.wait_for(initialization_started.wait(), timeout=5.0)
+    stop_event.set()
+    finish_initialization.set()
+    await asyncio.wait_for(run_task, timeout=5.0)
+
+    ensure_group_mock.assert_awaited_once()
+    client.xreadgroup.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_claim_idle_messages_stops_claiming_after_stop_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -19,6 +19,7 @@ from tracecat.cases.schemas import CaseCommentWorkflowStatus, CaseCreate
 from tracecat.cases.service import CasesService
 from tracecat.cases.triggers.consumer import CaseTriggerConsumer
 from tracecat.db.models import Case, CaseComment, CaseEvent, CaseTrigger, Workflow
+from tracecat.redis.client import RedisClient
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -898,3 +899,54 @@ async def test_dispatch_selected_workflow_treats_already_started_as_success(
     persisted = comment
     assert persisted.workflow_status == CaseCommentWorkflowStatus.RUNNING.value
     assert cast(AuditEventStatus, audit_calls[-1]["status"]).value == "SUCCESS"
+
+
+@pytest.mark.anyio
+async def test_case_trigger_consumer_finishes_batch_on_stop_event():
+    """A SIGTERM stop signal lets the in-flight batch finish before exit.
+
+    Rolling upgrades cancel the API pod with SIGTERM; the consumer must not
+    strand the batch it is processing — it should complete handling (and ack)
+    the messages it already read, then exit its loop gracefully.
+    """
+    stop_event = asyncio.Event()
+    handled = asyncio.Event()
+    client = MagicMock()
+
+    async def fake_xreadgroup(
+        **kwargs: object,
+    ) -> list[tuple[str, list[tuple[str, dict[str, str]]]]]:
+        del kwargs
+        return [
+            (
+                "stream",
+                [
+                    (
+                        "1-1",
+                        {
+                            "event_id": "e",
+                            "case_id": "c",
+                            "workspace_id": "w",
+                            "event_type": "t",
+                        },
+                    )
+                ],
+            )
+        ]
+
+    async def fake_handle_message(message_id: str, fields: dict[str, str]) -> None:
+        # SIGTERM arrives while the batch is in flight; the stop signal
+        # arrives mid-processing but must not abort the batch.
+        stop_event.set()
+        del message_id, fields
+        handled.set()
+
+    client.xreadgroup = AsyncMock(side_effect=fake_xreadgroup)
+    consumer = CaseTriggerConsumer(cast(RedisClient, client), stop_event=stop_event)
+    consumer._ensure_group = AsyncMock()
+    consumer._handle_message = AsyncMock(side_effect=fake_handle_message)
+
+    await asyncio.wait_for(consumer.run(), timeout=5.0)
+
+    assert handled.is_set()
+    assert client.xreadgroup.await_count == 1

--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -953,6 +953,39 @@ async def test_case_trigger_consumer_finishes_batch_on_stop_event():
 
 
 @pytest.mark.anyio
+async def test_claim_idle_messages_does_not_claim_after_stop_during_pending_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_event = asyncio.Event()
+    pending_started = asyncio.Event()
+    finish_pending = asyncio.Event()
+    client = MagicMock()
+
+    async def pending_during_shutdown(
+        *args: object, **kwargs: object
+    ) -> list[dict[str, str]]:
+        del args, kwargs
+        pending_started.set()
+        await finish_pending.wait()
+        return [{"message_id": "1-0"}]
+
+    client.xpending_range = AsyncMock(side_effect=pending_during_shutdown)
+    client.xclaim = AsyncMock()
+    consumer = CaseTriggerConsumer(cast(RedisClient, client), stop_event=stop_event)
+    handle_message_mock = AsyncMock()
+    monkeypatch.setattr(consumer, "_handle_message", handle_message_mock)
+
+    claim_task = asyncio.create_task(consumer._claim_idle_messages())
+    await asyncio.wait_for(pending_started.wait(), timeout=5.0)
+    stop_event.set()
+    finish_pending.set()
+    await asyncio.wait_for(claim_task, timeout=5.0)
+
+    client.xclaim.assert_not_awaited()
+    handle_message_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_run_does_not_claim_pending_after_stop_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -950,3 +950,36 @@ async def test_case_trigger_consumer_finishes_batch_on_stop_event():
 
     assert handled.is_set()
     assert client.xreadgroup.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_run_does_not_claim_pending_after_stop_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A due pending-check must not fire once the stop signal is set.
+
+    The signal can arrive while the consumer is blocked in xreadgroup(); on
+    an empty read the loop body reaches the due pending-check. Starting
+    recovery there would claim fresh work the terminating pod never had in
+    flight.
+    """
+    stop_event = asyncio.Event()
+    client = MagicMock()
+
+    async def fake_xreadgroup(**kwargs: object) -> list:
+        # SIGTERM arrives during the blocked read; the read returns empty so
+        # the loop body reaches the due pending-check.
+        stop_event.set()
+        del kwargs
+        return []
+
+    client.xreadgroup = AsyncMock(side_effect=fake_xreadgroup)
+    consumer = CaseTriggerConsumer(cast(RedisClient, client), stop_event=stop_event)
+    consumer._pending_check_interval = 0.0
+    consumer._ensure_group = AsyncMock()
+    claim_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(consumer, "_claim_idle_messages", claim_mock)
+
+    await asyncio.wait_for(consumer.run(), timeout=5.0)
+
+    claim_mock.assert_not_awaited()

--- a/tests/unit/test_registry_platform_startup.py
+++ b/tests/unit/test_registry_platform_startup.py
@@ -167,7 +167,7 @@ async def test_startup_sync_skips_when_version_already_current(
     session: AsyncSession,
 ) -> None:
     """Test that startup sync skips when target version is already current."""
-    from tracecat.registry.sync.jobs import _sync_as_leader
+    from tracecat.registry.sync.jobs import _ArtifactBuildRequest, _sync_as_leader
 
     # Get or create platform repo (may already exist from conftest seeding)
     repo = await _get_or_create_platform_repo(session)
@@ -191,19 +191,14 @@ async def test_startup_sync_skips_when_version_already_current(
         mock_registry.__version__ = "0.1.0"
 
         # Should complete without calling sync
-        with (
-            patch(
-                "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
-            ) as mock_sync_service,
-            patch(
-                "tracecat.registry.sync.jobs._schedule_platform_registry_artifact_build"
-            ) as schedule_build,
-        ):
-            await _sync_as_leader(session, "0.1.0")
+        with patch(
+            "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
+        ) as mock_sync_service:
+            artifact_build = await _sync_as_leader(session, "0.1.0")
             # Sync service should not be instantiated
             mock_sync_service.assert_not_called()
-            schedule_build.assert_called_once_with(
-                "0.1.0",
+            assert artifact_build == _ArtifactBuildRequest(
+                target_version="0.1.0",
                 promote_version_id=version.id,
                 expected_current_version_id=version.id,
             )
@@ -248,10 +243,11 @@ async def test_startup_sync_does_not_promote_existing_non_current_version(
     with patch(
         "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
     ) as mock_sync_service:
-        await _sync_as_leader(session, "2.0.0")
+        artifact_build = await _sync_as_leader(session, "2.0.0")
 
         # Should NOT call sync service (version exists)
         mock_sync_service.assert_not_called()
+        assert artifact_build is None
 
     # Verify current version is still version 1
     await session.refresh(repo)
@@ -263,7 +259,7 @@ async def test_startup_sync_defers_existing_target_when_no_current_version(
     session: AsyncSession,
 ) -> None:
     """Test startup sync waits for artifacts before repairing a missing pointer."""
-    from tracecat.registry.sync.jobs import _sync_as_leader
+    from tracecat.registry.sync.jobs import _ArtifactBuildRequest, _sync_as_leader
 
     repo = await _get_or_create_platform_repo(session)
     repo.current_version_id = None
@@ -279,18 +275,13 @@ async def test_startup_sync_defers_existing_target_when_no_current_version(
     session.add(version)
     await session.commit()
 
-    with (
-        patch(
-            "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
-        ) as mock_sync_service,
-        patch(
-            "tracecat.registry.sync.jobs._schedule_platform_registry_artifact_build"
-        ) as schedule_build,
-    ):
-        await _sync_as_leader(session, "1.0.0")
+    with patch(
+        "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
+    ) as mock_sync_service:
+        artifact_build = await _sync_as_leader(session, "1.0.0")
         mock_sync_service.assert_not_called()
-        schedule_build.assert_called_once_with(
-            "1.0.0",
+        assert artifact_build == _ArtifactBuildRequest(
+            target_version="1.0.0",
             promote_version_id=version.id,
             expected_current_version_id=None,
         )
@@ -326,10 +317,11 @@ async def test_startup_sync_refuses_downgrade(
     with patch(
         "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
     ) as mock_sync_service:
-        await _sync_as_leader(session, "1.0.0")
+        artifact_build = await _sync_as_leader(session, "1.0.0")
 
         # Should NOT call sync service (downgrade refused)
         mock_sync_service.assert_not_called()
+        assert artifact_build is None
 
     # Verify current version is still 2.0.0
     await session.refresh(repo)
@@ -341,7 +333,7 @@ async def test_startup_sync_calls_sync_for_new_version(
     session: AsyncSession,
 ) -> None:
     """Test fresh startup sync promotes immediately for first-install UX."""
-    from tracecat.registry.sync.jobs import _sync_as_leader
+    from tracecat.registry.sync.jobs import _ArtifactBuildRequest, _sync_as_leader
 
     repo = await _get_or_create_platform_repo(session)
     repo.current_version_id = None
@@ -361,19 +353,14 @@ async def test_startup_sync_calls_sync_for_new_version(
         actions=[],
     )
 
-    with (
-        patch(
-            "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
-        ) as mock_sync_cls,
-        patch(
-            "tracecat.registry.sync.jobs._schedule_platform_registry_artifact_build"
-        ) as schedule_build,
-    ):
+    with patch(
+        "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
+    ) as mock_sync_cls:
         mock_sync_service = AsyncMock()
         mock_sync_service.sync_repository_v2.return_value = mock_result
         mock_sync_cls.return_value = mock_sync_service
 
-        await _sync_as_leader(session, "1.0.0")
+        artifact_build = await _sync_as_leader(session, "1.0.0")
 
         # Sync service should be called with bypass_temporal=True
         mock_sync_service.sync_repository_v2.assert_called_once()
@@ -382,8 +369,8 @@ async def test_startup_sync_calls_sync_for_new_version(
         assert call_kwargs["bypass_temporal"] is True
         assert call_kwargs["defer_artifact_build"] is True
         assert call_kwargs["promote"] is True
-        schedule_build.assert_called_once_with(
-            "1.0.0",
+        assert artifact_build == _ArtifactBuildRequest(
+            target_version="1.0.0",
             promote_version_id=None,
             expected_current_version_id=None,
         )
@@ -394,7 +381,7 @@ async def test_startup_sync_defers_promotion_for_new_upgrade_version(
     session: AsyncSession,
 ) -> None:
     """Test upgrade startup sync promotes only after artifact upload."""
-    from tracecat.registry.sync.jobs import _sync_as_leader
+    from tracecat.registry.sync.jobs import _ArtifactBuildRequest, _sync_as_leader
 
     repo = await _get_or_create_platform_repo(session)
     old_version = PlatformRegistryVersion(
@@ -417,35 +404,30 @@ async def test_startup_sync_defers_promotion_for_new_upgrade_version(
         actions=[],
     )
 
-    with (
-        patch(
-            "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
-        ) as mock_sync_cls,
-        patch(
-            "tracecat.registry.sync.jobs._schedule_platform_registry_artifact_build"
-        ) as schedule_build,
-    ):
+    with patch(
+        "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
+    ) as mock_sync_cls:
         mock_sync_service = AsyncMock()
         mock_sync_service.sync_repository_v2.return_value = mock_result
         mock_sync_cls.return_value = mock_sync_service
 
-        await _sync_as_leader(session, "2.0.0")
+        artifact_build = await _sync_as_leader(session, "2.0.0")
 
         call_kwargs = mock_sync_service.sync_repository_v2.call_args.kwargs
         assert call_kwargs["defer_artifact_build"] is True
         assert call_kwargs["promote"] is False
-        schedule_build.assert_called_once_with(
-            "2.0.0",
+        assert artifact_build == _ArtifactBuildRequest(
+            target_version="2.0.0",
             promote_version_id=new_version_id,
             expected_current_version_id=old_version.id,
         )
 
 
 @pytest.mark.anyio
-async def test_startup_sync_schedules_artifact_for_resolved_version(
+async def test_startup_sync_returns_artifact_build_for_resolved_version(
     session: AsyncSession,
 ) -> None:
-    from tracecat.registry.sync.jobs import _sync_as_leader
+    from tracecat.registry.sync.jobs import _ArtifactBuildRequest, _sync_as_leader
 
     repo = await _get_or_create_platform_repo(session)
     repo.current_version_id = None
@@ -465,22 +447,17 @@ async def test_startup_sync_schedules_artifact_for_resolved_version(
         actions=[],
     )
 
-    with (
-        patch(
-            "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
-        ) as mock_sync_cls,
-        patch(
-            "tracecat.registry.sync.jobs._schedule_platform_registry_artifact_build"
-        ) as schedule_build,
-    ):
+    with patch(
+        "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
+    ) as mock_sync_cls:
         mock_sync_service = AsyncMock()
         mock_sync_service.sync_repository_v2.return_value = mock_result
         mock_sync_cls.return_value = mock_sync_service
 
-        await _sync_as_leader(session, "1.0.0")
+        artifact_build = await _sync_as_leader(session, "1.0.0")
 
-        schedule_build.assert_called_once_with(
-            "1.0.0+collision.20260522140000.123456",
+        assert artifact_build == _ArtifactBuildRequest(
+            target_version="1.0.0+collision.20260522140000.123456",
             promote_version_id=None,
             expected_current_version_id=None,
         )
@@ -652,15 +629,31 @@ async def test_promote_after_artifact_build_skips_when_current_changed(
 
 
 @pytest.mark.anyio
-async def test_schedule_platform_registry_artifact_build_keeps_task_reference(
+async def test_startup_sync_awaits_artifact_build_after_releasing_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from tracecat.registry.sync import jobs
+    from tracecat.registry.sync.jobs import _ArtifactBuildRequest
 
-    started = asyncio.Event()
-    release = asyncio.Event()
+    build_started = asyncio.Event()
+    release_build = asyncio.Event()
+    lock_released = asyncio.Event()
+    artifact_build = _ArtifactBuildRequest(target_version="1.0.0")
 
-    async def fake_build_platform_registry_artifact(
+    async def fake_sync_as_leader(
+        session: AsyncSession,
+        target_version: str,
+    ) -> _ArtifactBuildRequest:
+        del session
+        assert target_version == "1.0.0"
+        return artifact_build
+
+    async def fake_release_lock(session: AsyncSession, lock_key: int) -> None:
+        del session
+        assert lock_key == jobs.PLATFORM_SYNC_LOCK_KEY
+        lock_released.set()
+
+    async def fake_build(
         target_version: str,
         *,
         promote_version_id: uuid.UUID | None = None,
@@ -669,24 +662,24 @@ async def test_schedule_platform_registry_artifact_build_keeps_task_reference(
         assert target_version == "1.0.0"
         assert promote_version_id is None
         assert expected_current_version_id is None
-        started.set()
-        await release.wait()
+        assert lock_released.is_set()
+        build_started.set()
+        await release_build.wait()
 
-    monkeypatch.setattr(
-        jobs,
-        "_build_platform_registry_artifact",
-        fake_build_platform_registry_artifact,
-    )
+    monkeypatch.setattr(jobs.tracecat_registry, "__version__", "1.0.0")
+    monkeypatch.setattr(jobs, "try_pg_advisory_lock", AsyncMock(return_value=True))
+    monkeypatch.setattr(jobs, "_sync_as_leader", fake_sync_as_leader)
+    monkeypatch.setattr(jobs, "pg_advisory_unlock", fake_release_lock)
+    monkeypatch.setattr(jobs, "_build_platform_registry_artifact", fake_build)
 
-    jobs._schedule_platform_registry_artifact_build("1.0.0")
+    startup_task = asyncio.create_task(jobs.sync_platform_registry_on_startup())
+    await build_started.wait()
 
-    await started.wait()
-    tasks = set(jobs._platform_registry_artifact_build_tasks)
-    assert len(tasks) == 1
+    assert lock_released.is_set()
+    assert not startup_task.done()
 
-    release.set()
-    await asyncio.gather(*tasks)
-    assert jobs._platform_registry_artifact_build_tasks == set()
+    release_build.set()
+    await startup_task
 
 
 @pytest.mark.anyio

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 
@@ -53,6 +52,7 @@ from tracecat.api.common import (
     http_exception_handler,
     tracecat_exception_handler,
 )
+from tracecat.api.lifespan import LifespanTaskSupervisor
 from tracecat.auth.credentials import authenticated_user_only
 from tracecat.auth.dependencies import (
     require_any_auth_type_enabled,
@@ -210,33 +210,40 @@ async def lifespan(app: FastAPI):
     async with get_async_session_bypass_rls_context_manager() as session:
         await setup_rbac_defaults(session)
 
+    # All in-process background tasks run under a lifespan-owned supervisor.
+    # On SIGTERM, uvicorn drains ASGI requests but not these tasks; the
+    # supervisor keeps strong references to them and drains them in a bounded
+    # period so they are not silently dropped or garbage collected at
+    # shutdown. Critical work must still checkpoint to durable storage.
+    supervisor = LifespanTaskSupervisor(
+        drain_timeout=config.TRACECAT__API_TASK_DRAIN_TIMEOUT
+    )
+
     # Spawn platform registry sync as background task (non-blocking)
     # Uses leader election to prevent race conditions across multiple API processes
-    registry_sync_task = asyncio.create_task(
+    supervisor.spawn(
         sync_platform_registry_on_startup(),
         name="platform_registry_sync",
+        kind="finite",
     )
-    logger.debug("Spawned background task for platform registry sync")
-
-    platform_catalog_task = asyncio.create_task(
+    supervisor.spawn(
         load_platform_catalog_on_startup(),
         name="platform_catalog_load",
+        kind="finite",
     )
-    logger.debug("Spawned background task for platform catalog load")
 
-    case_trigger_task = None
     if config.TRACECAT__CASE_TRIGGERS_ENABLED:
-        case_trigger_task = asyncio.create_task(
+        supervisor.spawn(
             start_case_trigger_consumer(),
             name="case_trigger_consumer",
+            kind="long_running",
         )
-        logger.debug("Spawned background task for case trigger consumer")
 
-    case_duration_sync_task = asyncio.create_task(
+    supervisor.spawn(
         start_case_duration_sync_consumer(),
         name="case_duration_sync_consumer",
+        kind="long_running",
     )
-    logger.debug("Spawned background task for case duration sync consumer")
 
     logger.info(
         "Feature flags", feature_flags=[f.value for f in config.TRACECAT__FEATURE_FLAGS]
@@ -246,76 +253,7 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    # Gracefully handle the registry sync task during shutdown
-    if not registry_sync_task.done():
-        logger.info("Waiting for platform registry sync task to complete...")
-        try:
-            # Give the task a reasonable time to complete
-            await asyncio.wait_for(registry_sync_task, timeout=10.0)
-            logger.info("Platform registry sync task completed")
-        except TimeoutError:
-            logger.warning(
-                "Platform registry sync task did not complete in time, cancelling"
-            )
-            registry_sync_task.cancel()
-            try:
-                await registry_sync_task
-            except asyncio.CancelledError:
-                logger.debug("Platform registry sync task cancelled")
-        except Exception as e:
-            logger.warning(
-                "Platform registry sync task failed during shutdown", error=e
-            )
-    else:
-        # Task already completed - retrieve result to surface any exceptions
-        try:
-            registry_sync_task.result()
-            logger.debug("Platform registry sync task had already completed")
-        except Exception as e:
-            logger.warning(
-                "Platform registry sync task failed before shutdown", error=e
-            )
-
-    if not platform_catalog_task.done():
-        logger.info("Waiting for platform catalog load task to complete...")
-        try:
-            await asyncio.wait_for(platform_catalog_task, timeout=10.0)
-            logger.info("Platform catalog load task completed")
-        except TimeoutError:
-            logger.warning(
-                "Platform catalog load task did not complete in time, cancelling"
-            )
-            platform_catalog_task.cancel()
-            try:
-                await platform_catalog_task
-            except asyncio.CancelledError:
-                logger.debug("Platform catalog load task cancelled")
-        except Exception as e:
-            logger.warning("Platform catalog load task failed during shutdown", error=e)
-    else:
-        try:
-            platform_catalog_task.result()
-            logger.debug("Platform catalog load task had already completed")
-        except Exception as e:
-            logger.warning("Platform catalog load task failed before shutdown", error=e)
-
-    if case_trigger_task is not None:
-        case_trigger_task.cancel()
-        try:
-            await case_trigger_task
-        except asyncio.CancelledError:
-            logger.debug("Case trigger consumer task cancelled")
-        except Exception as e:
-            logger.warning("Case trigger consumer stopped with error", error=e)
-
-    case_duration_sync_task.cancel()
-    try:
-        await case_duration_sync_task
-    except asyncio.CancelledError:
-        logger.debug("Case duration sync consumer task cancelled")
-    except Exception as e:
-        logger.warning("Case duration sync consumer stopped with error", error=e)
-
+    await supervisor.drain()
     await close_storage_client_cache()
 
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 
@@ -234,20 +233,14 @@ async def lifespan(app: FastAPI):
     )
 
     if config.TRACECAT__CASE_TRIGGERS_ENABLED:
-        case_trigger_stop = asyncio.Event()
-        supervisor.spawn(
-            start_case_trigger_consumer(case_trigger_stop),
+        supervisor.spawn_stoppable(
+            start_case_trigger_consumer,
             name="case_trigger_consumer",
-            kind="long_running",
-            stop_event=case_trigger_stop,
         )
 
-    case_duration_sync_stop = asyncio.Event()
-    supervisor.spawn(
-        start_case_duration_sync_consumer(case_duration_sync_stop),
+    supervisor.spawn_stoppable(
+        start_case_duration_sync_consumer,
         name="case_duration_sync_consumer",
-        kind="long_running",
-        stop_event=case_duration_sync_stop,
     )
 
     logger.info(

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 
@@ -233,16 +234,20 @@ async def lifespan(app: FastAPI):
     )
 
     if config.TRACECAT__CASE_TRIGGERS_ENABLED:
+        case_trigger_stop = asyncio.Event()
         supervisor.spawn(
-            start_case_trigger_consumer(),
+            start_case_trigger_consumer(case_trigger_stop),
             name="case_trigger_consumer",
             kind="long_running",
+            stop_event=case_trigger_stop,
         )
 
+    case_duration_sync_stop = asyncio.Event()
     supervisor.spawn(
-        start_case_duration_sync_consumer(),
+        start_case_duration_sync_consumer(case_duration_sync_stop),
         name="case_duration_sync_consumer",
         kind="long_running",
+        stop_event=case_duration_sync_stop,
     )
 
     logger.info(

--- a/tracecat/api/lifespan.py
+++ b/tracecat/api/lifespan.py
@@ -8,9 +8,11 @@ cover them. This module owns that task lifecycle explicitly:
 - Every supervised task is kept in a strong reference set (asyncio only keeps
   weak references, so unowned tasks can be garbage collected mid-flight).
 - Once shutdown begins, no new tasks are spawned.
-- On shutdown, long-running consumers are cancelled immediately (cancellation
-  is their stop signal), and finite startup tasks are awaited for a bounded
-  drain period before the deadline cancels whatever remains.
+- On shutdown, stoppable consumers (case triggers, case duration sync) are
+  signalled via a stop event so they finish their in-flight batch — including
+  Redis stream acks — and exit cleanly; this prevents rolling upgrades from
+  stranding unacked events behind the terminating pod. Consumers without a
+  stop event, and any stragglers past the drain deadline, are cancelled.
 
 This protects in-process work during graceful shutdown (SIGTERM). Nothing
 survives SIGKILL, OOM kills, or node loss — correctness-critical work must be
@@ -40,12 +42,21 @@ class LifespanTaskSupervisor:
       triggers. Drain cancels these immediately; cancellation is their stop
       signal and they must clean up in response to it.
 
+    Long-running tasks may instead be spawned with a ``stop_event``: on
+    shutdown the supervisor sets the event and waits (bounded by
+    ``drain_timeout``) for the task to finish its in-flight work and exit on
+    its own, cancelling it only if it exceeds the deadline. This is the
+    preferred shutdown path for stream consumers: the last batch is fully
+    processed and acked instead of being redelivered to another pod after
+    the idle-claim window.
+
     The supervisor never resurrects or reschedules work. Tasks whose failure
     must not lose data should checkpoint to durable storage themselves.
     """
 
     def __init__(self, *, drain_timeout: float) -> None:
         self._tasks: dict[asyncio.Task[None], TaskKind] = {}
+        self._stop_events: dict[asyncio.Task[None], asyncio.Event] = {}
         self._drain_timeout = drain_timeout
         self._draining = False
 
@@ -60,24 +71,42 @@ class LifespanTaskSupervisor:
         *,
         name: str,
         kind: TaskKind = "finite",
+        stop_event: asyncio.Event | None = None,
     ) -> asyncio.Task[None]:
         """Create a task under supervision.
 
+        Args:
+            coro: Coroutine to run as a supervised task.
+            name: Unique name used for log lines and cancellation reporting.
+            kind: Whether the task is expected to finish ("finite") or run
+                until shutdown ("long_running").
+            stop_event: For long-running tasks only. When set, the supervisor
+                signals the task to finish its in-flight work and exit
+                gracefully instead of cancelling it.
+
         Raises:
+            ValueError: If a stop event is given for a finite task.
             RuntimeError: If called after drain has started.
         """
         if self._draining:
             raise RuntimeError(
                 f"Refusing to spawn task {name!r}: the supervisor is draining"
             )
+        if stop_event is not None and kind != "long_running":
+            raise ValueError(
+                f"Task {name!r}: a stop event requires kind='long_running'"
+            )
         task = asyncio.create_task(coro, name=name)
         self._tasks[task] = kind
+        if stop_event is not None:
+            self._stop_events[task] = stop_event
         task.add_done_callback(self._on_task_done)
         logger.debug("Spawned supervised lifespan task", task=name, kind=kind)
         return task
 
     def _on_task_done(self, task: asyncio.Task[None]) -> None:
         self._tasks.pop(task, None)
+        self._stop_events.pop(task, None)
         if task.cancelled():
             return
         # Surface unexpected failures of tasks that exit on their own while
@@ -91,30 +120,38 @@ class LifespanTaskSupervisor:
     async def drain(self) -> None:
         """Stop accepting tasks and drain supervised tasks in a bounded period.
 
-        Phase 1 cancels long-running consumers so they stop accepting work.
-        Phase 2 lets finite tasks finish within ``drain_timeout`` and cancels
-        the stragglers. Phase 3 awaits every task's cancellation for the same
-        budget so cleanup code runs before the process exits; tasks that
-        ignore cancellation past the deadline are reported and abandoned to
-        the process teardown.
+        Phase 1 signals stoppable consumers (they finish their in-flight
+        batch and exit) and immediately cancels consumers without a stop
+        event. Phase 2 lets finite tasks and stoppable consumers finish
+        within ``drain_timeout`` and cancels the stragglers. Phase 3 awaits
+        every task's cancellation for the same budget so cleanup code runs
+        before the process exits; tasks that ignore cancellation past the
+        deadline are reported and abandoned to the process teardown.
         """
         self._draining = True
         if not self._tasks:
             return
 
-        long_running = [
-            task for task, kind in self._tasks.items() if kind == "long_running"
-        ]
-        finite = [task for task, kind in self._tasks.items() if kind == "finite"]
+        stoppable: list[asyncio.Task[None]] = []
+        finite: list[asyncio.Task[None]] = []
+        for task, kind in self._tasks.items():
+            if kind == "long_running":
+                stop_event = self._stop_events.get(task)
+                if stop_event is not None:
+                    stop_event.set()
+                    stoppable.append(task)
+                else:
+                    # Cancellation is the only stop signal for consumers
+                    # without a stop event.
+                    task.cancel()
+            else:
+                finite.append(task)
 
-        # Phase 1: stop consumers immediately. They are expected to respond to
-        # cancellation promptly.
-        for task in long_running:
-            task.cancel()
-
-        # Phase 2: give finite tasks the full drain budget to complete.
-        if finite:
-            done, pending = await asyncio.wait(finite, timeout=self._drain_timeout)
+        # Phase 2: give tasks that should exit on their own the full drain
+        # budget to complete.
+        draining = finite + stoppable
+        if draining:
+            done, pending = await asyncio.wait(draining, timeout=self._drain_timeout)
             for task in pending:
                 logger.warning(
                     "Lifespan task did not complete within the drain timeout; cancelling",

--- a/tracecat/api/lifespan.py
+++ b/tracecat/api/lifespan.py
@@ -1,0 +1,148 @@
+"""Lifespan-owned supervision for API in-process background tasks.
+
+The API server runs several asyncio tasks alongside request handling, e.g.
+registry sync on startup, case trigger consumers, and case duration sync.
+These tasks are not ASGI requests, so uvicorn's connection drain does not
+cover them. This module owns that task lifecycle explicitly:
+
+- Every supervised task is kept in a strong reference set (asyncio only keeps
+  weak references, so unowned tasks can be garbage collected mid-flight).
+- Once shutdown begins, no new tasks are spawned.
+- On shutdown, long-running consumers are cancelled immediately (cancellation
+  is their stop signal), and finite startup tasks are awaited for a bounded
+  drain period before the deadline cancels whatever remains.
+
+This protects in-process work during graceful shutdown (SIGTERM). Nothing
+survives SIGKILL, OOM kills, or node loss — correctness-critical work must be
+persisted in PostgreSQL, Temporal, or a durable queue so another pod can
+resume it. The deployment's termination grace period must be longer than the
+drain budget for the bounded await to have any effect.
+"""
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any, Literal
+
+from tracecat.logger import logger
+
+type TaskKind = Literal["finite", "long_running"]
+
+
+class LifespanTaskSupervisor:
+    """Owns and drains the API lifespan's in-process background tasks.
+
+    Each task is spawned with a kind:
+
+    - ``"finite"``: startup work expected to complete, e.g. registry sync or
+      catalog load. Drain awaits these up to ``drain_timeout`` seconds before
+      cancelling the stragglers.
+    - ``"long_running"``: consumers that run until shutdown, e.g. case
+      triggers. Drain cancels these immediately; cancellation is their stop
+      signal and they must clean up in response to it.
+
+    The supervisor never resurrects or reschedules work. Tasks whose failure
+    must not lose data should checkpoint to durable storage themselves.
+    """
+
+    def __init__(self, *, drain_timeout: float) -> None:
+        self._tasks: dict[asyncio.Task[None], TaskKind] = {}
+        self._drain_timeout = drain_timeout
+        self._draining = False
+
+    @property
+    def draining(self) -> bool:
+        """Whether shutdown has started and new spawns are rejected."""
+        return self._draining
+
+    def spawn(
+        self,
+        coro: Coroutine[Any, Any, None],
+        *,
+        name: str,
+        kind: TaskKind = "finite",
+    ) -> asyncio.Task[None]:
+        """Create a task under supervision.
+
+        Raises:
+            RuntimeError: If called after drain has started.
+        """
+        if self._draining:
+            raise RuntimeError(
+                f"Refusing to spawn task {name!r}: the supervisor is draining"
+            )
+        task = asyncio.create_task(coro, name=name)
+        self._tasks[task] = kind
+        task.add_done_callback(self._on_task_done)
+        logger.debug("Spawned supervised lifespan task", task=name, kind=kind)
+        return task
+
+    def _on_task_done(self, task: asyncio.Task[None]) -> None:
+        self._tasks.pop(task, None)
+        if task.cancelled():
+            return
+        # Surface unexpected failures of tasks that exit on their own while
+        # the server is running; retrieve the exception so asyncio does not
+        # log it as "Task exception was never retrieved".
+        if (exc := task.exception()) is not None:
+            logger.error(
+                "Supervised lifespan task failed", task=task.get_name(), err=exc
+            )
+
+    async def drain(self) -> None:
+        """Stop accepting tasks and drain supervised tasks in a bounded period.
+
+        Phase 1 cancels long-running consumers so they stop accepting work.
+        Phase 2 lets finite tasks finish within ``drain_timeout`` and cancels
+        the stragglers. Phase 3 awaits every task's cancellation for the same
+        budget so cleanup code runs before the process exits; tasks that
+        ignore cancellation past the deadline are reported and abandoned to
+        the process teardown.
+        """
+        self._draining = True
+        if not self._tasks:
+            return
+
+        long_running = [
+            task for task, kind in self._tasks.items() if kind == "long_running"
+        ]
+        finite = [task for task, kind in self._tasks.items() if kind == "finite"]
+
+        # Phase 1: stop consumers immediately. They are expected to respond to
+        # cancellation promptly.
+        for task in long_running:
+            task.cancel()
+
+        # Phase 2: give finite tasks the full drain budget to complete.
+        if finite:
+            done, pending = await asyncio.wait(finite, timeout=self._drain_timeout)
+            for task in pending:
+                logger.warning(
+                    "Lifespan task did not complete within the drain timeout; cancelling",
+                    task=task.get_name(),
+                    timeout=self._drain_timeout,
+                )
+                task.cancel()
+            _log_completed_errors(done)
+
+        # Phase 3: await cancellation-completion for everything, bounded.
+        remaining = [task for task in self._tasks if not task.done()]
+        if not remaining:
+            return
+        done, pending = await asyncio.wait(remaining, timeout=self._drain_timeout)
+        _log_completed_errors(done)
+        for task in pending:
+            logger.warning(
+                "Lifespan task did not shut down within the grace period",
+                task=task.get_name(),
+                timeout=self._drain_timeout,
+            )
+
+
+def _log_completed_errors(tasks: set[asyncio.Task[None]]) -> None:
+    for task in tasks:
+        if task.cancelled():
+            continue
+        if (exc := task.exception()) is not None:
+            logger.warning(
+                "Lifespan task stopped with error", task=task.get_name(), err=exc
+            )

--- a/tracecat/api/lifespan.py
+++ b/tracecat/api/lifespan.py
@@ -22,12 +22,13 @@ drain budget for the bounded await to have any effect.
 """
 
 import asyncio
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from typing import Any, Literal
 
 from tracecat.logger import logger
 
 type TaskKind = Literal["finite", "long_running"]
+type StoppableTaskFactory = Callable[[asyncio.Event], Coroutine[Any, Any, None]]
 
 
 class LifespanTaskSupervisor:
@@ -42,13 +43,13 @@ class LifespanTaskSupervisor:
       triggers. Drain cancels these immediately; cancellation is their stop
       signal and they must clean up in response to it.
 
-    Long-running tasks may instead be spawned with a ``stop_event``: on
-    shutdown the supervisor sets the event and waits (bounded by
-    ``drain_timeout``) for the task to finish its in-flight work and exit on
-    its own, cancelling it only if it exceeds the deadline. This is the
-    preferred shutdown path for stream consumers: the last batch is fully
-    processed and acked instead of being redelivered to another pod after
-    the idle-claim window.
+    ``spawn_stoppable()`` creates a stop event and injects it into a
+    long-running task factory atomically. On shutdown the supervisor sets the
+    event and waits (bounded by ``drain_timeout``) for the task to finish its
+    in-flight work and exit on its own, cancelling it only if it exceeds the
+    deadline. This is the preferred shutdown path for stream consumers: the
+    last batch is fully processed and acked instead of being redelivered to
+    another pod after the idle-claim window.
 
     The supervisor never resurrects or reschedules work. Tasks whose failure
     must not lose data should checkpoint to durable storage themselves.
@@ -71,7 +72,6 @@ class LifespanTaskSupervisor:
         *,
         name: str,
         kind: TaskKind = "finite",
-        stop_event: asyncio.Event | None = None,
     ) -> asyncio.Task[None]:
         """Create a task under supervision.
 
@@ -80,22 +80,57 @@ class LifespanTaskSupervisor:
             name: Unique name used for log lines and cancellation reporting.
             kind: Whether the task is expected to finish ("finite") or run
                 until shutdown ("long_running").
-            stop_event: For long-running tasks only. When set, the supervisor
-                signals the task to finish its in-flight work and exit
-                gracefully instead of cancelling it.
 
         Raises:
-            ValueError: If a stop event is given for a finite task.
             RuntimeError: If called after drain has started.
         """
+        self._raise_if_draining(name)
+        return self._create_task(coro, name=name, kind=kind)
+
+    def spawn_stoppable(
+        self,
+        factory: StoppableTaskFactory,
+        *,
+        name: str,
+    ) -> asyncio.Task[None]:
+        """Create a stoppable long-running task under supervision.
+
+        The supervisor creates the stop event and passes the exact same object
+        to the task factory and its shutdown registry, so callers cannot wire
+        the consumer to a different event than the one drain signals.
+
+        Args:
+            factory: Callable that accepts the supervisor-owned stop event and
+                returns the consumer coroutine.
+            name: Unique name used for log lines and cancellation reporting.
+
+        Raises:
+            RuntimeError: If called after drain has started. The factory is not
+                invoked when registration is rejected.
+        """
+        self._raise_if_draining(name)
+        stop_event = asyncio.Event()
+        return self._create_task(
+            factory(stop_event),
+            name=name,
+            kind="long_running",
+            stop_event=stop_event,
+        )
+
+    def _raise_if_draining(self, name: str) -> None:
         if self._draining:
             raise RuntimeError(
                 f"Refusing to spawn task {name!r}: the supervisor is draining"
             )
-        if stop_event is not None and kind != "long_running":
-            raise ValueError(
-                f"Task {name!r}: a stop event requires kind='long_running'"
-            )
+
+    def _create_task(
+        self,
+        coro: Coroutine[Any, Any, None],
+        *,
+        name: str,
+        kind: TaskKind,
+        stop_event: asyncio.Event | None = None,
+    ) -> asyncio.Task[None]:
         task = asyncio.create_task(coro, name=name)
         self._tasks[task] = kind
         if stop_event is not None:
@@ -151,7 +186,7 @@ class LifespanTaskSupervisor:
         # budget to complete.
         draining = finite + stoppable
         if draining:
-            done, pending = await asyncio.wait(draining, timeout=self._drain_timeout)
+            _, pending = await asyncio.wait(draining, timeout=self._drain_timeout)
             for task in pending:
                 logger.warning(
                     "Lifespan task did not complete within the drain timeout; cancelling",
@@ -159,27 +194,15 @@ class LifespanTaskSupervisor:
                     timeout=self._drain_timeout,
                 )
                 task.cancel()
-            _log_completed_errors(done)
 
         # Phase 3: await cancellation-completion for everything, bounded.
         remaining = [task for task in self._tasks if not task.done()]
         if not remaining:
             return
-        done, pending = await asyncio.wait(remaining, timeout=self._drain_timeout)
-        _log_completed_errors(done)
+        _, pending = await asyncio.wait(remaining, timeout=self._drain_timeout)
         for task in pending:
             logger.warning(
                 "Lifespan task did not shut down within the grace period",
                 task=task.get_name(),
                 timeout=self._drain_timeout,
-            )
-
-
-def _log_completed_errors(tasks: set[asyncio.Task[None]]) -> None:
-    for task in tasks:
-        if task.cancelled():
-            continue
-        if (exc := task.exception()) is not None:
-            logger.warning(
-                "Lifespan task stopped with error", task=task.get_name(), err=exc
             )

--- a/tracecat/cases/durations/consumer.py
+++ b/tracecat/cases/durations/consumer.py
@@ -135,6 +135,10 @@ class CaseDurationSyncConsumer:
                         consumer=self.consumer_name,
                     )
                     started = True
+                # Initialization awaits can yield after the loop condition has
+                # passed. Do not claim a new batch if shutdown began meanwhile.
+                if self._stop_signalled():
+                    break
                 try:
                     messages = await self.client.xreadgroup(
                         group_name=self.group,
@@ -178,10 +182,9 @@ class CaseDurationSyncConsumer:
                 )
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, RETRY_BACKOFF_MAX_SECONDS)
-        else:
-            # Loop condition satisfied: the stop event was set and the last
-            # iteration (including the current batch) completed.
-            logger.info("Case duration sync consumer stopped gracefully")
+        # The stop event was set either between iterations or during pre-read
+        # initialization, and any batch already read completed.
+        logger.info("Case duration sync consumer stopped gracefully")
 
     async def _ensure_group(self) -> None:
         # Read from the start of the stream ("0") rather than only new

--- a/tracecat/cases/durations/consumer.py
+++ b/tracecat/cases/durations/consumer.py
@@ -110,13 +110,17 @@ class CaseDurationSyncConsumer:
         self._pending_check_interval = max(self.claim_idle_ms / 1000.0, 30.0)
         self._stop_event = stop_event
 
+    def _stop_signalled(self) -> bool:
+        """Whether a graceful shutdown signal has been received."""
+        return self._stop_event is not None and self._stop_event.is_set()
+
     async def run(self) -> None:
         last_pending_check = monotonic()
         retry_delay = RETRY_BACKOFF_BASE_SECONDS
         group_ready = False
         rollout_enqueued = False
         started = False
-        while self._stop_event is None or not self._stop_event.is_set():
+        while not self._stop_signalled():
             try:
                 if not rollout_enqueued:
                     rollout_enqueued = await enqueue_rollout_backfill_once()
@@ -152,7 +156,13 @@ class CaseDurationSyncConsumer:
                     for _stream, entries in messages:
                         await self._handle_entries(entries)
                 now = monotonic()
-                if now - last_pending_check >= self._pending_check_interval:
+                # Do not start pending-message recovery past the stop signal:
+                # recovery claims fresh work the terminating pod never had in
+                # flight, and a claimed batch can exceed the drain deadline.
+                if (
+                    not self._stop_signalled()
+                    and now - last_pending_check >= self._pending_check_interval
+                ):
                     await self._claim_idle_messages()
                     last_pending_check = now
                 await asyncio.sleep(0)
@@ -443,7 +453,7 @@ class CaseDurationSyncConsumer:
             # not claim further pending work past the stop signal — otherwise
             # a large or continuously replenished pending list keeps the
             # consumer working until the drain deadline cancels it mid-batch.
-            if self._stop_event is not None and self._stop_event.is_set():
+            if self._stop_signalled():
                 return
             if len(pending) < self.batch:
                 return

--- a/tracecat/cases/durations/consumer.py
+++ b/tracecat/cases/durations/consumer.py
@@ -437,6 +437,8 @@ class CaseDurationSyncConsumer:
                 count=self.batch,
                 idle=self.claim_idle_ms,
             )
+            if self._stop_signalled():
+                return
             if not pending:
                 return
 

--- a/tracecat/cases/durations/consumer.py
+++ b/tracecat/cases/durations/consumer.py
@@ -439,6 +439,12 @@ class CaseDurationSyncConsumer:
                 message_ids,
             )
             await self._handle_entries(claimed)
+            # Graceful shutdown: complete the batch already claimed, but do
+            # not claim further pending work past the stop signal — otherwise
+            # a large or continuously replenished pending list keeps the
+            # consumer working until the drain deadline cancels it mid-batch.
+            if self._stop_event is not None and self._stop_event.is_set():
+                return
             if len(pending) < self.batch:
                 return
             await asyncio.sleep(0)

--- a/tracecat/cases/durations/consumer.py
+++ b/tracecat/cases/durations/consumer.py
@@ -93,7 +93,11 @@ class CaseDurationSyncConsumer:
     """Consume and coalesce case duration sync jobs."""
 
     def __init__(
-        self, client: RedisClient, *, consumer_name: str | None = None
+        self,
+        client: RedisClient,
+        *,
+        consumer_name: str | None = None,
+        stop_event: asyncio.Event | None = None,
     ) -> None:
         self.client = client
         self.stream_key = config.TRACECAT__CASE_DURATION_SYNC_STREAM_KEY
@@ -104,6 +108,7 @@ class CaseDurationSyncConsumer:
         self.backfill_batch = config.TRACECAT__CASE_DURATION_SYNC_BACKFILL_BATCH
         self.consumer_name = consumer_name or f"{socket.gethostname()}:{os.getpid()}"
         self._pending_check_interval = max(self.claim_idle_ms / 1000.0, 30.0)
+        self._stop_event = stop_event
 
     async def run(self) -> None:
         last_pending_check = monotonic()
@@ -111,7 +116,7 @@ class CaseDurationSyncConsumer:
         group_ready = False
         rollout_enqueued = False
         started = False
-        while True:
+        while self._stop_event is None or not self._stop_event.is_set():
             try:
                 if not rollout_enqueued:
                     rollout_enqueued = await enqueue_rollout_backfill_once()
@@ -163,6 +168,10 @@ class CaseDurationSyncConsumer:
                 )
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, RETRY_BACKOFF_MAX_SECONDS)
+        else:
+            # Loop condition satisfied: the stop event was set and the last
+            # iteration (including the current batch) completed.
+            logger.info("Case duration sync consumer stopped gracefully")
 
     async def _ensure_group(self) -> None:
         # Read from the start of the stream ("0") rather than only new
@@ -435,7 +444,16 @@ class CaseDurationSyncConsumer:
             await asyncio.sleep(0)
 
 
-async def start_case_duration_sync_consumer() -> None:
+async def start_case_duration_sync_consumer(
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run the case duration sync consumer until cancelled or stopped.
+
+    The stop event enables graceful shutdown: setting it finishes the current
+    batch (including acks) and exits the loop without cancellation, so the
+    pod's terminating consumer does not strand jobs in the pending list
+    during rolling upgrades.
+    """
     client = await get_redis_client()
-    consumer = CaseDurationSyncConsumer(client)
+    consumer = CaseDurationSyncConsumer(client, stop_event=stop_event)
     await consumer.run()

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -41,7 +41,11 @@ class CaseTriggerConsumer:
     """Consume case events and dispatch workflows based on configured triggers."""
 
     def __init__(
-        self, client: RedisClient, *, consumer_name: str | None = None
+        self,
+        client: RedisClient,
+        *,
+        consumer_name: str | None = None,
+        stop_event: asyncio.Event | None = None,
     ) -> None:
         self.client = client
         self.stream_key = config.TRACECAT__CASE_TRIGGERS_STREAM_KEY
@@ -54,6 +58,7 @@ class CaseTriggerConsumer:
         self.consumer_name = consumer_name or f"{socket.gethostname()}:{os.getpid()}"
         self._workspace_role_cache: dict[uuid.UUID, Role] = {}
         self._pending_check_interval = max(self.claim_idle_ms / 1000.0, 30.0)
+        self._stop_event = stop_event
 
     async def run(self) -> None:
         if not config.TRACECAT__CASE_TRIGGERS_ENABLED:
@@ -69,7 +74,7 @@ class CaseTriggerConsumer:
         )
         last_pending_check = monotonic()
         try:
-            while True:
+            while self._stop_event is None or not self._stop_event.is_set():
                 try:
                     messages = await self.client.xreadgroup(
                         group_name=self.group,
@@ -105,6 +110,8 @@ class CaseTriggerConsumer:
         except Exception as e:
             logger.error("Case trigger consumer stopped due to error", error=str(e))
             raise
+        else:
+            logger.info("Case trigger consumer stopped gracefully")
 
     def _is_nogroup_error(self, error: Exception) -> bool:
         if isinstance(error, ResponseError):
@@ -829,7 +836,16 @@ class CaseTriggerConsumer:
             await self._handle_message(message_id, fields)
 
 
-async def start_case_trigger_consumer() -> None:
+async def start_case_trigger_consumer(
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run the case trigger consumer until cancelled or stopped.
+
+    The stop event enables graceful shutdown: setting it finishes the current
+    batch (including acks) and exits the loop without cancellation, so the
+    pod's terminating consumer does not strand messages in the pending list
+    during rolling upgrades.
+    """
     client = await get_redis_client()
-    consumer = CaseTriggerConsumer(client)
+    consumer = CaseTriggerConsumer(client, stop_event=stop_event)
     await consumer.run()

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -820,6 +820,8 @@ class CaseTriggerConsumer:
             count=self.batch,
             idle=self.claim_idle_ms,
         )
+        if self._stop_signalled():
+            return
         if not pending:
             return
 

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -60,6 +60,10 @@ class CaseTriggerConsumer:
         self._pending_check_interval = max(self.claim_idle_ms / 1000.0, 30.0)
         self._stop_event = stop_event
 
+    def _stop_signalled(self) -> bool:
+        """Whether a graceful shutdown signal has been received."""
+        return self._stop_event is not None and self._stop_event.is_set()
+
     async def run(self) -> None:
         if not config.TRACECAT__CASE_TRIGGERS_ENABLED:
             logger.info("Case triggers disabled; skipping consumer")
@@ -74,7 +78,7 @@ class CaseTriggerConsumer:
         )
         last_pending_check = monotonic()
         try:
-            while self._stop_event is None or not self._stop_event.is_set():
+            while not self._stop_signalled():
                 try:
                     messages = await self.client.xreadgroup(
                         group_name=self.group,
@@ -100,7 +104,14 @@ class CaseTriggerConsumer:
                             await self._handle_message(message_id, fields)
                 else:
                     now = monotonic()
-                    if now - last_pending_check >= self._pending_check_interval:
+                    # Do not start pending-message recovery past the stop
+                    # signal: recovery claims fresh work the terminating pod
+                    # never had in flight, and a claimed batch can exceed the
+                    # drain deadline.
+                    if (
+                        not self._stop_signalled()
+                        and now - last_pending_check >= self._pending_check_interval
+                    ):
                         await self._claim_idle_messages()
                         last_pending_check = now
                 await asyncio.sleep(0)

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1079,10 +1079,12 @@ TRACECAT__API_TASK_DRAIN_TIMEOUT = float(
 )
 """Seconds to let finite in-process API tasks finish during shutdown.
 
-Long-running consumers (e.g. case triggers) are cancelled as soon as shutdown
-begins; this bounds how long finite startup tasks (e.g. registry sync) are
-awaited, and how long cancelled tasks may run cleanup. The deployment's
-termination grace period must exceed twice this value for full coverage.
+Stoppable consumers (e.g. case triggers) are signalled to finish in-flight
+work and are awaited alongside finite startup tasks (e.g. registry sync) for
+this duration. Stragglers are then cancelled and get the same duration again
+for cleanup; non-stoppable long-running tasks are cancelled immediately. The
+deployment's termination grace period must exceed twice this value for full
+coverage.
 """
 
 # === Context Compression === #

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1073,6 +1073,18 @@ TRACECAT__LIMIT_TABLE_DOWNLOAD_MAX = 1000
 TRACECAT__LIMIT_TABLE_DOWNLOAD_DEFAULT = TRACECAT__LIMIT_TABLE_DOWNLOAD_MAX
 """Default row count for internal table download."""
 
+# === API Lifecycle === #
+TRACECAT__API_TASK_DRAIN_TIMEOUT = float(
+    os.environ.get("TRACECAT__API_TASK_DRAIN_TIMEOUT") or 10.0
+)
+"""Seconds to let finite in-process API tasks finish during shutdown.
+
+Long-running consumers (e.g. case triggers) are cancelled as soon as shutdown
+begins; this bounds how long finite startup tasks (e.g. registry sync) are
+awaited, and how long cancelled tasks may run cleanup. The deployment's
+termination grace period must exceed twice this value for full coverage.
+"""
+
 # === Context Compression === #
 TRACECAT__CONTEXT_COMPRESSION_ENABLED = env_bool(
     "TRACECAT__CONTEXT_COMPRESSION_ENABLED", default=False

--- a/tracecat/registry/sync/jobs.py
+++ b/tracecat/registry/sync/jobs.py
@@ -7,8 +7,8 @@ to prevent race conditions when multiple API processes start simultaneously.
 
 from __future__ import annotations
 
-import asyncio
 import re
+from dataclasses import dataclass
 from uuid import UUID
 
 import tracecat_registry
@@ -33,7 +33,6 @@ from tracecat.registry.versions.service import PlatformRegistryVersionsService
 
 MAX_SYNC_RETRIES = 3
 PLATFORM_SYNC_LOCK_KEY = derive_lock_key_from_parts("platform_registry_sync")
-_platform_registry_artifact_build_tasks: set[asyncio.Task[None]] = set()
 _RELEASE_TAG_PATTERN = re.compile(
     r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
     r"(?:-(?P<stage>alpha|a|beta|b|rc|dev|post)\.(?P<number>\d+)"
@@ -49,6 +48,15 @@ _STAGE_RANK = {
     "final": 4,
     "post": 5,
 }
+
+
+@dataclass(frozen=True, slots=True)
+class _ArtifactBuildRequest:
+    """Artifact work to run after releasing the startup leader lock."""
+
+    target_version: str
+    promote_version_id: UUID | None = None
+    expected_current_version_id: UUID | None = None
 
 
 def _release_tag_key(version: str) -> tuple[int, int, int, int, int, int, int]:
@@ -96,12 +104,14 @@ async def sync_platform_registry_on_startup() -> None:
        b. If target exists with no current version → build artifact then promote
        c. If version exists but is not current → preserve rollback → done
        d. If version doesn't exist → run sync with retries
-    3. If lock not acquired (non-leader) → exit immediately
+    3. Release the leader lock and session, then await any artifact build
+    4. If lock not acquired (non-leader) → exit immediately
     """
     target_version = tracecat_registry.__version__
     logger.info("Attempting platform registry sync", target_version=target_version)
 
     try:
+        artifact_build: _ArtifactBuildRequest | None = None
         async with get_async_session_bypass_rls_context_manager() as session:
             # Leader election: try to acquire lock (non-blocking)
             acquired = await try_pg_advisory_lock(session, PLATFORM_SYNC_LOCK_KEY)
@@ -112,10 +122,22 @@ async def sync_platform_registry_on_startup() -> None:
                 return
 
             try:
-                await _sync_as_leader(session, target_version)
+                artifact_build = await _sync_as_leader(session, target_version)
             finally:
                 # Always release lock
                 await pg_advisory_unlock(session, PLATFORM_SYNC_LOCK_KEY)
+
+        # This coroutine itself is supervised by the API lifespan. Awaiting the
+        # artifact build here keeps it inside that lifecycle while still
+        # releasing the advisory lock and database session before the build.
+        if artifact_build is not None:
+            await _build_platform_registry_artifact(
+                artifact_build.target_version,
+                promote_version_id=artifact_build.promote_version_id,
+                expected_current_version_id=(
+                    artifact_build.expected_current_version_id
+                ),
+            )
 
     except Exception as e:
         logger.warning(
@@ -126,8 +148,10 @@ async def sync_platform_registry_on_startup() -> None:
         # Don't re-raise - API should continue
 
 
-async def _sync_as_leader(session: AsyncSession, target_version: str) -> None:
-    """Leader-only sync logic with retries."""
+async def _sync_as_leader(
+    session: AsyncSession, target_version: str
+) -> _ArtifactBuildRequest | None:
+    """Run leader-only sync and return deferred artifact work, if any."""
     repos_service = PlatformRegistryReposService(session)
     versions_service = PlatformRegistryVersionsService(session)
 
@@ -150,27 +174,25 @@ async def _sync_as_leader(session: AsyncSession, target_version: str) -> None:
                 "Platform registry already at target version",
                 version=target_version,
             )
-            _schedule_platform_registry_artifact_build(
-                target_version,
+            return _ArtifactBuildRequest(
+                target_version=target_version,
                 promote_version_id=existing_version.id,
                 expected_current_version_id=existing_version.id,
             )
-            return
 
         # If this repo has versions but no current selection, wait until the
         # referenced artifact is present before repairing the pointer.
         if repo.current_version_id is None:
             logger.info(
-                "Target platform registry version exists with no current selection; scheduling artifact build before promotion",
+                "Target platform registry version exists with no current selection; deferring artifact build before promotion",
                 target_version=target_version,
                 version_id=str(existing_version.id),
             )
-            _schedule_platform_registry_artifact_build(
-                target_version,
+            return _ArtifactBuildRequest(
+                target_version=target_version,
                 promote_version_id=existing_version.id,
                 expected_current_version_id=None,
             )
-            return
 
         # Version exists but is not current - don't auto-promote
         # There may be a deliberate reason it's not current (e.g., manual rollback)
@@ -233,12 +255,11 @@ async def _sync_as_leader(session: AsyncSession, target_version: str) -> None:
 
             # Seed registry scopes for the synced actions
             await _seed_registry_scopes(session, result.actions)
-            _schedule_platform_registry_artifact_build(
-                result.version_string,
+            return _ArtifactBuildRequest(
+                target_version=result.version_string,
                 promote_version_id=None if is_fresh_install else result.version.id,
                 expected_current_version_id=expected_current_version_id,
             )
-            return
 
         except Exception as e:
             logger.warning(
@@ -280,44 +301,6 @@ async def _seed_registry_scopes(
         logger.warning("Failed to seed registry scopes", error=str(e))
         # Don't fail the sync if scope seeding fails due to DB errors
         await session.rollback()
-
-
-def _schedule_platform_registry_artifact_build(
-    target_version: str,
-    *,
-    promote_version_id: UUID | None = None,
-    expected_current_version_id: UUID | None = None,
-) -> None:
-    """Ensure the current builtin registry SquashFS artifact in the background."""
-    try:
-        task = asyncio.create_task(
-            _build_platform_registry_artifact(
-                target_version,
-                promote_version_id=promote_version_id,
-                expected_current_version_id=expected_current_version_id,
-            ),
-            name=f"platform_registry_artifact_{target_version}",
-        )
-    except RuntimeError as e:
-        logger.warning(
-            "Failed to schedule platform registry artifact build",
-            target_version=target_version,
-            error=str(e),
-        )
-        return
-
-    _platform_registry_artifact_build_tasks.add(task)
-    task.add_done_callback(_log_platform_registry_artifact_build_result)
-
-
-def _log_platform_registry_artifact_build_result(task: asyncio.Task[None]) -> None:
-    _platform_registry_artifact_build_tasks.discard(task)
-    try:
-        task.result()
-    except asyncio.CancelledError:
-        logger.warning("Platform registry artifact build was cancelled")
-    except Exception as e:
-        logger.warning("Platform registry artifact build failed", error=str(e))
 
 
 async def _build_platform_registry_artifact(


### PR DESCRIPTION
## Summary

Uvicorn's graceful shutdown drains ASGI requests — but not the API's in-process asyncio tasks (platform registry sync, platform catalog load, case trigger consumer, case duration sync consumer). Those were handled with ad-hoc per-task shutdown code, and the shutdown path only covered tasks that happened to be wired there. Detached `create_task()` calls are only weakly referenced by asyncio and can be garbage collected mid-flight.

This PR adds a lifespan-owned `LifespanTaskSupervisor` (`tracecat/api/lifespan.py`) and routes all API background tasks through it:

1. **Strong references** — every supervised task lives in a supervisor-owned registry.
2. **No new tasks after shutdown** — `spawn()` raises once draining starts.
3. **Bounded drain** — on SIGTERM, finite startup tasks (registry sync, catalog load) are awaited for a configurable drain period, then cancelled at the deadline.
4. **Graceful consumer drain** — case triggers and case duration sync consumers are spawned with a stop event. Drain signals the event, and the consumer finishes its in-flight batch (including Redis stream acks) and exits cleanly; the deadline cancels any straggler.
5. **Deadline cancel + bounded cleanup await** — cancelled tasks get a bounded period to run cleanup before the process exits; tasks that ignore cancellation are reported and abandoned to teardown.
6. **Failure surfacing** — task failures are logged instead of being lost to "exception was never retrieved" warnings.

## Why this matters for rolling upgrades

Kubernetes SIGTERMs the API pod on every rollout. Previously, cancellation mid-batch stranded unacked case trigger messages in the Redis pending-entries list behind the terminating pod; another pod only redelivered them after the idle-claim window (≥30s poll), delaying trigger dispatches across every deploy. Now the terminating pod finishes and acks its current batch before exiting.

Redelivery via the pending-entries list remains the backstop for SIGKILL, OOM kills, and deadline overruns — at-least-once delivery is unchanged.

The drain budget is `TRACECAT__API_TASK_DRAIN_TIMEOUT` (default 10s). With a 2s stream block, worst-case stop latency fits comfortably inside it. Deployment termination grace periods must exceed twice that value for full coverage.

### Limits

- Nothing survives SIGKILL, OOM, process crash, or node loss.
- Correctness-critical work must still be persisted in PostgreSQL, Temporal, or a durable queue so another pod can resume it.

### Follow-ups

- Kubernetes: set `terminationGracePeriodSeconds` > 2 × `TRACECAT__API_TASK_DRAIN_TIMEOUT` on the API deployment (separate k8s repo change).
- Other deployment targets (docker-compose, Fargate) may want the drain timeout exposed as an env override.

## Test plan

- `tests/unit/test_api_lifespan.py` — 12 unit tests covering finite drain, graceful stop-event drain, consumer cancellation, deadline cancels, cancellation-ignoring stragglers, spawn rejection after drain, and failure surfacing.
- `tests/unit/test_case_trigger_consumer.py` / `tests/unit/test_case_duration_sync_consumer.py` — new tests proving the run loops finish their in-flight batch on the stop signal and exit gracefully.
- `uv run pytest tests/unit/test_api_lifespan.py tests/unit/test_case_trigger_consumer.py tests/unit/test_case_duration_sync_consumer.py tests/unit/test_config.py` — 117 passed.
- `uv run ruff check .` / `uv run ruff format --check .` clean; basedpyright clean on changed files.

## LOC breakdown

| Category | + | − |
|---|---|---|
| Logic | 264 | 90 |
| Tests | 357 | 0 |

