### PR TITLE
fix(registry): form-encode Snowflake OAuth basic credentials

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/snowflake/cancel_statement.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/snowflake/cancel_statement.yml
@@ -57,7 +57,7 @@ definition:
 
               import base64
               import json
-              from urllib.parse import urlencode
+              from urllib.parse import quote_plus, urlencode
               from urllib.request import Request, urlopen
 
               form = {"grant_type": "client_credentials"}
@@ -68,8 +68,9 @@ definition:
 
               headers = {"Content-Type": "application/x-www-form-urlencoded"}
               if auth_method == "client_secret_basic":
+                  # RFC 6749 2.3.1: each component is form-encoded before the ":" join.
                   credentials = base64.b64encode(
-                      f"{client_id}:{client_secret}".encode()
+                      f"{quote_plus(client_id)}:{quote_plus(client_secret)}".encode()
                   ).decode()
                   headers["Authorization"] = f"Basic {credentials}"
               else:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/snowflake/execute_statement.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/snowflake/execute_statement.yml
@@ -73,7 +73,7 @@ definition:
 
               import base64
               import json
-              from urllib.parse import urlencode
+              from urllib.parse import quote_plus, urlencode
               from urllib.request import Request, urlopen
 
               form = {"grant_type": "client_credentials"}
@@ -84,8 +84,9 @@ definition:
 
               headers = {"Content-Type": "application/x-www-form-urlencoded"}
               if auth_method == "client_secret_basic":
+                  # RFC 6749 2.3.1: each component is form-encoded before the ":" join.
                   credentials = base64.b64encode(
-                      f"{client_id}:{client_secret}".encode()
+                      f"{quote_plus(client_id)}:{quote_plus(client_secret)}".encode()
                   ).decode()
                   headers["Authorization"] = f"Basic {credentials}"
               else:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/snowflake/get_statement.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/snowflake/get_statement.yml
@@ -61,7 +61,7 @@ definition:
 
               import base64
               import json
-              from urllib.parse import urlencode
+              from urllib.parse import quote_plus, urlencode
               from urllib.request import Request, urlopen
 
               form = {"grant_type": "client_credentials"}
@@ -72,8 +72,9 @@ definition:
 
               headers = {"Content-Type": "application/x-www-form-urlencoded"}
               if auth_method == "client_secret_basic":
+                  # RFC 6749 2.3.1: each component is form-encoded before the ":" join.
                   credentials = base64.b64encode(
-                      f"{client_id}:{client_secret}".encode()
+                      f"{quote_plus(client_id)}:{quote_plus(client_secret)}".encode()
                   ).decode()
                   headers["Authorization"] = f"Basic {credentials}"
               else:

--- a/tracecat/integrations/providers/snowflake/oauth.py
+++ b/tracecat/integrations/providers/snowflake/oauth.py
@@ -8,12 +8,8 @@ from tracecat.integrations.providers.base import (
 )
 from tracecat.integrations.schemas import ProviderMetadata, ProviderScopes
 
-SNOWFLAKE_AUTHORIZATION_ENDPOINT = (
-    "https://{snowflake-account}.snowflakecomputing.com/oauth/authorize"
-)
-SNOWFLAKE_TOKEN_ENDPOINT = (
-    "https://{snowflake-account}.snowflakecomputing.com/oauth/token-request"
-)
+SNOWFLAKE_AUTHORIZATION_ENDPOINT = "https://{snowflake-account-host}/oauth/authorize"
+SNOWFLAKE_TOKEN_ENDPOINT = "https://{snowflake-account-host}/oauth/token-request"
 SNOWFLAKE_OAUTH_DOCS_URL = "https://docs.snowflake.com/en/user-guide/oauth-custom"
 SNOWFLAKE_EXTERNAL_OAUTH_TOKEN_ENDPOINT = "https://{identity-provider}/oauth/token"
 
@@ -44,11 +40,13 @@ class SnowflakeACProvider(AuthorizationCodeOAuthProvider):
     )
     default_token_endpoint: ClassVar[str | None] = SNOWFLAKE_TOKEN_ENDPOINT
     authorization_endpoint_help: ClassVar[str | list[str] | None] = [
-        "Replace {snowflake-account} with your organization-account hostname.",
+        "Replace {snowflake-account-host} with your Snowflake account hostname, for example:",
+        "https://myorg-myaccount.snowflakecomputing.com/oauth/authorize",
         "The security integration must allow Tracecat's OAuth callback URL.",
     ]
     token_endpoint_help: ClassVar[str | list[str] | None] = [
-        "Replace {snowflake-account} with your organization-account hostname.",
+        "Replace {snowflake-account-host} with your Snowflake account hostname, for example:",
+        "https://myorg-myaccount.snowflakecomputing.com/oauth/token-request",
     ]
 
     def _use_pkce(self) -> bool:


### PR DESCRIPTION
Follow-up to #3331 (merged). Both defects were raised by the automated reviewer on that PR.

## Fix 1 — form-encode OAuth basic credentials

The three Snowflake templates built the `Authorization: Basic` header by concatenating `f"{client_id}:{client_secret}"` raw. RFC 6749 section 2.3.1 requires each component to be form-urlencoded *before* the `":"` join and the Base64 encoding, so any reserved character in the client ID or secret produced a credential the server rejects. A `":"` in the client ID is the pathological case: the server splits the credential in the wrong place and token minting fails outright.

Fixed with `quote_plus` on both components in `execute_statement.yml`, `cancel_statement.yml`, and `get_statement.yml`. `quote_plus` (not `quote`) is the faithful implementation of the algorithm the RFC names, since it encodes space as `+`.

Reachability is narrow: this path runs only through the stored-credential fallback with `SNOWFLAKE_OAUTH_TOKEN_ENDPOINT_AUTH_METHOD=client_secret_basic`, because `SnowflakeCCProvider` pins `client_secret_post`.

## Fix 2 — the endpoint template appended a second domain

`SNOWFLAKE_AUTHORIZATION_ENDPOINT` and `SNOWFLAKE_TOKEN_ENDPOINT` baked in `.snowflakecomputing.com` while the help text asked the operator for a "hostname". Following that literally yielded `myorg-myaccount.snowflakecomputing.com.snowflakecomputing.com`, which does not resolve — breaking both the authorization redirect and the token exchange.

The placeholder is now the complete host, matching the Databricks precedent (`https://{databricks-instance}/oidc/v1/authorize`):

```python
SNOWFLAKE_AUTHORIZATION_ENDPOINT = "https://{snowflake-account-host}/oauth/authorize"
SNOWFLAKE_TOKEN_ENDPOINT = "https://{snowflake-account-host}/oauth/token-request"
```

This is about the prefilled default, not about capability. The authorization and token endpoints are free-text fields in the OAuth config form (`frontend/src/components/provider-config-form.tsx`), and whatever the operator types is stored per-integration, so no deployment was ever unreachable. What the baked-in suffix did was mislead: the placeholder read as an identifier slot, so following the help text literally produced the dead doubled host above, and anyone on a PrivateLink (`*.privatelink.snowflakecomputing.com`), legacy account-locator (`<locator>.<region>.<cloud>.snowflakecomputing.com`), gov-cloud, proxy, or China-region (`.snowflakecomputing.cn`) host had to notice the trailing domain was wrong and delete it. Now there is one clearly-delimited token to replace, and the help text matches it.

No host validation, suffix allowlist, or regex was added — `packages/tracecat-registry/CLAUDE.md` is explicit that domain allowlists break exactly these deployments. The one existing constraint is `_validate_https_endpoint` (`tracecat/integrations/schemas.py`), which requires HTTPS with a netloc; that is scheme-level, not a domain allowlist.

Configured integrations are unaffected. `default_authorization_endpoint` / `default_token_endpoint` are last-resort fallbacks surfaced as UI defaults (`discovered or configured or default`, `tracecat/integrations/providers/base.py`), and Snowflake sets `requires_config=True`, so stored endpoints take precedence.

`SnowflakeCCProvider` is untouched — its `{identity-provider}` placeholder was already a bare host.

## Risk

Against an identity provider that does **not** form-decode the Basic header, percent-encoding a secret containing `+`, `/`, or `=` would change a credential that currently works. Okta, Entra ID, and Ping all decode per spec. Exposure is narrow: the path requires explicitly opting into `client_secret_basic`.

## Verification

- All three templates parse as YAML and their embedded `resolve_access_token` scripts compile; the three scripts are byte-identical.
- Encoding round-trip, exercising the template's real `main()` with the network call stubbed. Client ID `acme:client id/with+reserved`, secret `s3cr3t+value/with=chars`:
  ```
  decoded credential: 'acme%3Aclient+id%2Fwith%2Breserved:s3cr3t%2Bvalue%2Fwith%3Dchars'
  ```
  Exactly one `":"` separator, both halves `unquote_plus` back to the originals.
- The `client_secret_post` branch is unchanged and still sends raw values in the form body, so no double-encoding was introduced.
- `ruff check`, `ruff format --check`, `basedpyright --warnings` clean on the provider file.
- `pytest tests/unit/test_databricks_snowflake_providers.py` — 8 passed.
- `rg snowflakecomputing tracecat/integrations/providers/snowflake/oauth.py` hits only the two help-text example URLs.

## LOC breakdown

| Category | + | - |
|---|---|---|
| Logic | 15 | 14 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Snowflake OAuth defects that could break token minting and authorization redirects in specific configurations: Basic credentials are now form-encoded per RFC 6749, and endpoint templates accept the full account host instead of appending a hardcoded `.snowflakecomputing.com` suffix. `client_secret_post` flows and stored custom endpoints are unaffected.

- Form-encodes the client ID and secret with `quote_plus` when building the Basic header in the three Snowflake statement templates; raw concatenation broke on reserved characters, and a `:` in a client ID made the server split the credential incorrectly.
- Changes the authorization and token endpoint placeholders from `{snowflake-account}` to `{snowflake-account-host}`; the old hardcoded `.snowflakecomputing.com` suffix produced doubled hostnames and blocked PrivateLink, legacy locator/region hosts, the China region, and proxy or gov-cloud endpoints.
- Only secrets containing `+`, `/`, or `=` change behavior, and only against identity providers that do not form-decode the Basic header; the path requires `client_secret_basic` opt-in.

<sup>Written for commit 44d2e1eb58d20a8ae3d788938ab429953709b564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->