### PR TITLE
feat(cases): backfill agent mutation interactions

### DIFF
--- a/frontend/src/app/admin/maintenance/page.tsx
+++ b/frontend/src/app/admin/maintenance/page.tsx
@@ -45,8 +45,10 @@ export default function AdminMaintenancePage() {
         operationId: operationId as string,
       }),
     enabled: operationId !== undefined,
-    refetchInterval: (query) =>
-      query.state.data?.status === "running" ? 2000 : false,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      return status === "completed" || status === "failed" ? false : 2000
+    },
   })
 
   useEffect(() => {

--- a/frontend/src/app/admin/maintenance/page.tsx
+++ b/frontend/src/app/admin/maintenance/page.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import { DatabaseIcon, LoaderCircleIcon } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import {
-  adminMaintenanceBackfillCaseAgentSessionInteractions,
+  adminMaintenanceGetCaseAgentSessionInteractionBackfill,
+  adminMaintenanceStartCaseAgentSessionInteractionBackfill,
   type CaseAgentSessionInteractionBackfillResponse,
 } from "@/client"
 import {
@@ -27,32 +28,72 @@ import {
   ItemTitle,
 } from "@/components/ui/item"
 import { toast } from "@/components/ui/use-toast"
-import { useMutation } from "@/lib/query"
+import { useMutation, useQuery } from "@/lib/query"
 
 export default function AdminMaintenancePage() {
   const [lastReport, setLastReport] =
     useState<CaseAgentSessionInteractionBackfillResponse>()
-  const { mutateAsync: runBackfill, isPending } = useMutation({
-    mutationFn: adminMaintenanceBackfillCaseAgentSessionInteractions,
+  const [operationId, setOperationId] = useState<string>()
+  const [reportedOperationId, setReportedOperationId] = useState<string>()
+  const { mutateAsync: startBackfill, isPending: isStarting } = useMutation({
+    mutationFn: adminMaintenanceStartCaseAgentSessionInteractionBackfill,
+  })
+  const { data: operation } = useQuery({
+    queryKey: ["admin", "maintenance", "case-agent-interactions", operationId],
+    queryFn: () =>
+      adminMaintenanceGetCaseAgentSessionInteractionBackfill({
+        operationId: operationId as string,
+      }),
+    enabled: operationId !== undefined,
+    refetchInterval: (query) =>
+      query.state.data?.status === "running" ? 2000 : false,
   })
 
-  async function handleRunBackfill() {
-    try {
-      const report = await runBackfill()
-      setLastReport(report)
+  useEffect(() => {
+    if (!operationId || reportedOperationId === operationId) {
+      return
+    }
+    if (operation?.status === "completed" && operation.report) {
+      setLastReport(operation.report)
+      setReportedOperationId(operationId)
       toast({
         title: "Backfill complete",
-        description: `Created ${report.inserted} case interaction records.`,
+        description: `Created ${operation.report.inserted} case interaction records.`,
       })
-    } catch (error) {
-      console.error("Failed to backfill case agent interactions", error)
+    } else if (operation?.status === "failed") {
+      setReportedOperationId(operationId)
       toast({
         title: "Backfill failed",
         description: "The maintenance operation did not complete.",
         variant: "destructive",
       })
     }
+  }, [operation, operationId, reportedOperationId])
+
+  async function handleRunBackfill() {
+    try {
+      const started = await startBackfill()
+      setOperationId(started.operation_id)
+      setLastReport(undefined)
+      toast({
+        title: "Backfill started",
+        description: "The maintenance operation is running in the background.",
+      })
+    } catch (error) {
+      console.error("Failed to start case agent interaction backfill", error)
+      toast({
+        title: "Could not start backfill",
+        description: "The maintenance operation could not be started.",
+        variant: "destructive",
+      })
+    }
   }
+
+  const isRunning =
+    isStarting ||
+    (operationId !== undefined &&
+      operation?.status !== "completed" &&
+      operation?.status !== "failed")
 
   const skippedCount = lastReport
     ? Object.values(lastReport.skipped).reduce(
@@ -86,7 +127,12 @@ export default function AdminMaintenancePage() {
               persisted agent session history. Reads and failed tool calls are
               ignored, and the operation is safe to rerun.
             </ItemDescription>
-            {lastReport ? (
+            {isRunning ? (
+              <p className="mt-2 text-sm text-muted-foreground">
+                Backfill is running in the background. You can safely leave this
+                page.
+              </p>
+            ) : lastReport ? (
               <p className="mt-2 text-sm text-muted-foreground">
                 Last run: {lastReport.inserted} inserted, {lastReport.existing}{" "}
                 already present, and {skippedCount} skipped across{" "}
@@ -97,11 +143,11 @@ export default function AdminMaintenancePage() {
           <ItemActions>
             <AlertDialog>
               <AlertDialogTrigger asChild>
-                <Button size="sm" disabled={isPending}>
-                  {isPending ? (
+                <Button size="sm" disabled={isRunning}>
+                  {isRunning ? (
                     <LoaderCircleIcon className="mr-2 size-4 animate-spin" />
                   ) : null}
-                  {isPending ? "Running..." : "Run backfill"}
+                  {isRunning ? "Running..." : "Run backfill"}
                 </Button>
               </AlertDialogTrigger>
               <AlertDialogContent>

--- a/frontend/src/app/admin/maintenance/page.tsx
+++ b/frontend/src/app/admin/maintenance/page.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { DatabaseIcon, LoaderCircleIcon } from "lucide-react"
+import { useState } from "react"
+import {
+  adminMaintenanceBackfillCaseAgentSessionInteractions,
+  type CaseAgentSessionInteractionBackfillResponse,
+} from "@/client"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item"
+import { toast } from "@/components/ui/use-toast"
+import { useMutation } from "@/lib/query"
+
+export default function AdminMaintenancePage() {
+  const [lastReport, setLastReport] =
+    useState<CaseAgentSessionInteractionBackfillResponse>()
+  const { mutateAsync: runBackfill, isPending } = useMutation({
+    mutationFn: adminMaintenanceBackfillCaseAgentSessionInteractions,
+  })
+
+  async function handleRunBackfill() {
+    try {
+      const report = await runBackfill()
+      setLastReport(report)
+      toast({
+        title: "Backfill complete",
+        description: `Created ${report.inserted} case interaction records.`,
+      })
+    } catch (error) {
+      console.error("Failed to backfill case agent interactions", error)
+      toast({
+        title: "Backfill failed",
+        description: "The maintenance operation did not complete.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  const skippedCount = lastReport
+    ? Object.values(lastReport.skipped).reduce(
+        (total, count) => total + count,
+        0
+      )
+    : 0
+
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container flex h-full max-w-[1000px] flex-col space-y-12">
+        <div className="flex w-full">
+          <div className="items-start space-y-3 text-left">
+            <h2 className="text-2xl font-semibold tracking-tight">
+              Maintenance
+            </h2>
+            <p className="text-base text-muted-foreground">
+              Run platform-wide data maintenance operations.
+            </p>
+          </div>
+        </div>
+
+        <Item variant="outline" className="p-6">
+          <ItemMedia variant="icon">
+            <DatabaseIcon />
+          </ItemMedia>
+          <ItemContent>
+            <ItemTitle>Case agent interactions</ItemTitle>
+            <ItemDescription className="line-clamp-none">
+              Backfill successful historical case and comment mutations from
+              persisted agent session history. Reads and failed tool calls are
+              ignored, and the operation is safe to rerun.
+            </ItemDescription>
+            {lastReport ? (
+              <p className="mt-2 text-sm text-muted-foreground">
+                Last run: {lastReport.inserted} inserted, {lastReport.existing}{" "}
+                already present, and {skippedCount} skipped across{" "}
+                {lastReport.sessions_scanned} sessions.
+              </p>
+            ) : null}
+          </ItemContent>
+          <ItemActions>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button size="sm" disabled={isPending}>
+                  {isPending ? (
+                    <LoaderCircleIcon className="mr-2 size-4 animate-spin" />
+                  ) : null}
+                  {isPending ? "Running..." : "Run backfill"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    Run case interaction backfill?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This scans agent session history across every workspace and
+                    records successful historical case mutations. It may take
+                    several minutes on larger deployments.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleRunBackfill}>
+                    Run backfill
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </ItemActions>
+        </Item>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6441,6 +6441,13 @@ export const $CachePoint = {
   title: "CachePoint",
 } as const
 
+export const $CaseAgentSessionBackfillStatus = {
+  type: "string",
+  enum: ["running", "completed", "failed"],
+  title: "CaseAgentSessionBackfillStatus",
+  description: "Lifecycle state for the durable backfill operation.",
+} as const
+
 export const $CaseAgentSessionInteractionBackfillResponse = {
   properties: {
     batches_processed: {
@@ -6487,6 +6494,47 @@ export const $CaseAgentSessionInteractionBackfillResponse = {
   ],
   title: "CaseAgentSessionInteractionBackfillResponse",
   description: "Aggregate result of the historical interaction backfill.",
+} as const
+
+export const $CaseAgentSessionInteractionBackfillStartResponse = {
+  properties: {
+    operation_id: {
+      type: "string",
+      format: "uuid",
+      title: "Operation Id",
+    },
+  },
+  type: "object",
+  required: ["operation_id"],
+  title: "CaseAgentSessionInteractionBackfillStartResponse",
+  description: "Response after starting or joining the durable backfill.",
+} as const
+
+export const $CaseAgentSessionInteractionBackfillStatusResponse = {
+  properties: {
+    operation_id: {
+      type: "string",
+      format: "uuid",
+      title: "Operation Id",
+    },
+    status: {
+      $ref: "#/components/schemas/CaseAgentSessionBackfillStatus",
+    },
+    report: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseAgentSessionInteractionBackfillResponse",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  type: "object",
+  required: ["operation_id", "status"],
+  title: "CaseAgentSessionInteractionBackfillStatusResponse",
+  description: "Current state and optional result of the durable backfill.",
 } as const
 
 export const $CaseArtifact = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6441,6 +6441,54 @@ export const $CachePoint = {
   title: "CachePoint",
 } as const
 
+export const $CaseAgentSessionInteractionBackfillResponse = {
+  properties: {
+    batches_processed: {
+      type: "integer",
+      title: "Batches Processed",
+    },
+    sessions_scanned: {
+      type: "integer",
+      title: "Sessions Scanned",
+    },
+    history_rows_scanned: {
+      type: "integer",
+      title: "History Rows Scanned",
+    },
+    mutation_candidates: {
+      type: "integer",
+      title: "Mutation Candidates",
+    },
+    inserted: {
+      type: "integer",
+      title: "Inserted",
+    },
+    existing: {
+      type: "integer",
+      title: "Existing",
+    },
+    skipped: {
+      additionalProperties: {
+        type: "integer",
+      },
+      type: "object",
+      title: "Skipped",
+    },
+  },
+  type: "object",
+  required: [
+    "batches_processed",
+    "sessions_scanned",
+    "history_rows_scanned",
+    "mutation_candidates",
+    "inserted",
+    "existing",
+    "skipped",
+  ],
+  title: "CaseAgentSessionInteractionBackfillResponse",
+  description: "Aggregate result of the historical interaction backfill.",
+} as const
+
 export const $CaseArtifact = {
   properties: {
     id: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -64,7 +64,9 @@ import type {
   AdminListTiersData,
   AdminListTiersResponse,
   AdminListUsersResponse,
-  AdminMaintenanceBackfillCaseAgentSessionInteractionsResponse,
+  AdminMaintenanceGetCaseAgentSessionInteractionBackfillData,
+  AdminMaintenanceGetCaseAgentSessionInteractionBackfillResponse,
+  AdminMaintenanceStartCaseAgentSessionInteractionBackfillResponse,
   AdminPromoteOrgRepositoryVersionData,
   AdminPromoteOrgRepositoryVersionResponse,
   AdminPromoteToSuperuserData,
@@ -8022,18 +8024,41 @@ export const adminAgentListPlatformCatalog = (
 }
 
 /**
- * Backfill Case Agent Session Interactions
- * Backfill successful historical agent-driven case mutations.
- * @returns CaseAgentSessionInteractionBackfillResponse Successful Response
+ * Start Case Agent Session Interaction Backfill
+ * Start or join the durable historical case-mutation backfill.
+ * @returns CaseAgentSessionInteractionBackfillStartResponse Successful Response
  * @throws ApiError
  */
-export const adminMaintenanceBackfillCaseAgentSessionInteractions =
-  (): CancelablePromise<AdminMaintenanceBackfillCaseAgentSessionInteractionsResponse> => {
+export const adminMaintenanceStartCaseAgentSessionInteractionBackfill =
+  (): CancelablePromise<AdminMaintenanceStartCaseAgentSessionInteractionBackfillResponse> => {
     return __request(OpenAPI, {
       method: "POST",
       url: "/admin/maintenance/case-agent-session-interactions/backfill",
     })
   }
+
+/**
+ * Get Case Agent Session Interaction Backfill
+ * Poll a durable historical case-mutation backfill.
+ * @param data The data for the request.
+ * @param data.operationId
+ * @returns CaseAgentSessionInteractionBackfillStatusResponse Successful Response
+ * @throws ApiError
+ */
+export const adminMaintenanceGetCaseAgentSessionInteractionBackfill = (
+  data: AdminMaintenanceGetCaseAgentSessionInteractionBackfillData
+): CancelablePromise<AdminMaintenanceGetCaseAgentSessionInteractionBackfillResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/admin/maintenance/case-agent-session-interactions/backfill/{operation_id}",
+    path: {
+      operation_id: data.operationId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
 
 /**
  * List Platform Repositories

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -64,6 +64,7 @@ import type {
   AdminListTiersData,
   AdminListTiersResponse,
   AdminListUsersResponse,
+  AdminMaintenanceBackfillCaseAgentSessionInteractionsResponse,
   AdminPromoteOrgRepositoryVersionData,
   AdminPromoteOrgRepositoryVersionResponse,
   AdminPromoteToSuperuserData,
@@ -8019,6 +8020,20 @@ export const adminAgentListPlatformCatalog = (
     },
   })
 }
+
+/**
+ * Backfill Case Agent Session Interactions
+ * Backfill successful historical agent-driven case mutations.
+ * @returns CaseAgentSessionInteractionBackfillResponse Successful Response
+ * @throws ApiError
+ */
+export const adminMaintenanceBackfillCaseAgentSessionInteractions =
+  (): CancelablePromise<AdminMaintenanceBackfillCaseAgentSessionInteractionsResponse> => {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/admin/maintenance/case-agent-session-interactions/backfill",
+    })
+  }
 
 /**
  * List Platform Repositories

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1697,6 +1697,11 @@ export type CachePoint = {
 export type ttl = "5m" | "1h"
 
 /**
+ * Lifecycle state for the durable backfill operation.
+ */
+export type CaseAgentSessionBackfillStatus = "running" | "completed" | "failed"
+
+/**
  * Aggregate result of the historical interaction backfill.
  */
 export type CaseAgentSessionInteractionBackfillResponse = {
@@ -1709,6 +1714,22 @@ export type CaseAgentSessionInteractionBackfillResponse = {
   skipped: {
     [key: string]: number
   }
+}
+
+/**
+ * Response after starting or joining the durable backfill.
+ */
+export type CaseAgentSessionInteractionBackfillStartResponse = {
+  operation_id: string
+}
+
+/**
+ * Current state and optional result of the durable backfill.
+ */
+export type CaseAgentSessionInteractionBackfillStatusResponse = {
+  operation_id: string
+  status: CaseAgentSessionBackfillStatus
+  report?: CaseAgentSessionInteractionBackfillResponse | null
 }
 
 /**
@@ -12560,8 +12581,15 @@ export type AdminAgentListPlatformCatalogData = {
 
 export type AdminAgentListPlatformCatalogResponse = AgentCatalogListResponse
 
-export type AdminMaintenanceBackfillCaseAgentSessionInteractionsResponse =
-  CaseAgentSessionInteractionBackfillResponse
+export type AdminMaintenanceStartCaseAgentSessionInteractionBackfillResponse =
+  CaseAgentSessionInteractionBackfillStartResponse
+
+export type AdminMaintenanceGetCaseAgentSessionInteractionBackfillData = {
+  operationId: string
+}
+
+export type AdminMaintenanceGetCaseAgentSessionInteractionBackfillResponse =
+  CaseAgentSessionInteractionBackfillStatusResponse
 
 export type AdminRegistryListPlatformRepositoriesResponse =
   Array<RegistryRepositoryReadMinimal>
@@ -18209,7 +18237,22 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: CaseAgentSessionInteractionBackfillResponse
+        202: CaseAgentSessionInteractionBackfillStartResponse
+      }
+    }
+  }
+  "/admin/maintenance/case-agent-session-interactions/backfill/{operation_id}": {
+    get: {
+      req: AdminMaintenanceGetCaseAgentSessionInteractionBackfillData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseAgentSessionInteractionBackfillStatusResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
       }
     }
   }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1697,6 +1697,21 @@ export type CachePoint = {
 export type ttl = "5m" | "1h"
 
 /**
+ * Aggregate result of the historical interaction backfill.
+ */
+export type CaseAgentSessionInteractionBackfillResponse = {
+  batches_processed: number
+  sessions_scanned: number
+  history_rows_scanned: number
+  mutation_candidates: number
+  inserted: number
+  existing: number
+  skipped: {
+    [key: string]: number
+  }
+}
+
+/**
  * Case artifact shown in artifact-capable chat surfaces.
  */
 export type CaseArtifact = {
@@ -12545,6 +12560,9 @@ export type AdminAgentListPlatformCatalogData = {
 
 export type AdminAgentListPlatformCatalogResponse = AgentCatalogListResponse
 
+export type AdminMaintenanceBackfillCaseAgentSessionInteractionsResponse =
+  CaseAgentSessionInteractionBackfillResponse
+
 export type AdminRegistryListPlatformRepositoriesResponse =
   Array<RegistryRepositoryReadMinimal>
 
@@ -18182,6 +18200,16 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/maintenance/case-agent-session-interactions/backfill": {
+    post: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseAgentSessionInteractionBackfillResponse
       }
     }
   }

--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   LogsIcon,
   MousePointerClickIcon,
   UsersIcon,
+  WrenchIcon,
 } from "lucide-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -68,6 +69,12 @@ export function AdminSidebar({
       url: "/admin/audit",
       icon: LogsIcon,
       isActive: pathname?.includes("/admin/audit"),
+    },
+    {
+      title: "Maintenance",
+      url: "/admin/maintenance",
+      icon: WrenchIcon,
+      isActive: pathname?.includes("/admin/maintenance"),
     },
   ]
 

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -127,6 +127,10 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
         "tracecat.cases.agent_sessions.backfill._HISTORY_FETCH_SIZE",
         1,
     )
+    monkeypatch.setattr(
+        "tracecat.cases.agent_sessions.backfill._INTERACTION_INSERT_BATCH_SIZE",
+        1,
+    )
     assert svc_role.workspace_id is not None
     workspace_id = svc_role.workspace_id
     created, updated, commented, edited, associated = [

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -120,8 +120,13 @@ async def _interactions(
 async def test_backfill_reconstructs_mutations_safely_and_idempotently(
     session: AsyncSession,
     svc_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Exercise the backfill as one bounded, database-backed workflow."""
+    monkeypatch.setattr(
+        "tracecat.cases.agent_sessions.backfill._HISTORY_FETCH_SIZE",
+        1,
+    )
     assert svc_role.workspace_id is not None
     workspace_id = svc_role.workspace_id
     created, updated, commented, edited, associated = [
@@ -285,12 +290,19 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
     assert await _interactions(session, workspace_id) == {
         (updated.id, CaseAgentSessionInteractionOperation.UPDATE, root.id)
     }
-    applied = await backfill.run(batch_size=1)
+    progress_calls = 0
+
+    def on_progress() -> None:
+        nonlocal progress_calls
+        progress_calls += 1
+
+    applied = await backfill.run(batch_size=1, on_progress=on_progress)
     rerun = await backfill.run(batch_size=1)
 
     assert applied.batches_processed == 3
     assert applied.sessions_scanned == 3
     assert applied.history_rows_scanned == 5
+    assert progress_calls == applied.history_rows_scanned + applied.batches_processed
     assert applied.mutation_candidates == 7
     assert (applied.inserted, applied.existing) == (4, 2)
     assert (rerun.inserted, rerun.existing) == (0, 6)

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -11,6 +11,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.session.history import prepare_session_history
+from tracecat.agent.subagents import (
+    ResolvedAgentsConfig,
+    ResolvedAttachedSubagentRef,
+)
 from tracecat.auth.types import Role
 from tracecat.cases.agent_sessions.backfill import CaseAgentSessionBackfill
 from tracecat.cases.agent_sessions.types import CaseAgentSessionBackfillSkipReason
@@ -148,6 +152,18 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
         entity_type="approval",
         entity_id=uuid.uuid4(),
         parent_session=root,
+        agents_binding=ResolvedAgentsConfig(
+            enabled=True,
+            subagents=[
+                ResolvedAttachedSubagentRef(
+                    preset="analyst",
+                    name="analyst",
+                    preset_id=uuid.uuid4(),
+                    preset_version_id=uuid.uuid4(),
+                    preset_version=1,
+                )
+            ],
+        ).model_dump(mode="json"),
     )
     entity_only = AgentSession(
         workspace_id=workspace_id,
@@ -210,7 +226,12 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
         ),
         _use(
             "external-update",
-            "mcp__customer-server__core__cases__update_case",
+            "mcp__tracecat-registry-fake__core__cases__update_case",
+            case_id=str(updated.id),
+        ),
+        _use(
+            "subagent-update",
+            "mcp__tracecat-registry-analyst__core__cases__update_case",
             case_id=str(updated.id),
         ),
         _use(
@@ -241,6 +262,7 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
         _result("comment"),
         _result("legacy-update"),
         _result("external-update"),
+        _result("subagent-update"),
         _result("child-mutation"),
         _result(
             "create",
@@ -269,7 +291,7 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
     assert applied.batches_processed == 3
     assert applied.sessions_scanned == 3
     assert applied.history_rows_scanned == 5
-    assert applied.mutation_candidates == 6
+    assert applied.mutation_candidates == 7
     assert (applied.inserted, applied.existing) == (4, 2)
     assert (rerun.inserted, rerun.existing) == (0, 6)
     expected_skips = {

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -214,6 +214,12 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
             case_id=str(updated.id),
         ),
         _use(
+            "child-mutation",
+            "core.cases.add_case_tag",
+            case_id=str(associated.id),
+            tag="agent-mutated",
+        ),
+        _use(
             "incomplete",
             "core.cases.create_comment",
             case_id=str(commented.id),
@@ -235,6 +241,7 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
         _result("comment"),
         _result("legacy-update"),
         _result("external-update"),
+        _result("child-mutation"),
         _result(
             "create",
             [{"type": "text", "text": f'{{"id":"{created.id}"}}'}],
@@ -262,9 +269,9 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
     assert applied.batches_processed == 3
     assert applied.sessions_scanned == 3
     assert applied.history_rows_scanned == 5
-    assert applied.mutation_candidates == 5
-    assert (applied.inserted, applied.existing) == (3, 2)
-    assert (rerun.inserted, rerun.existing) == (0, 5)
+    assert applied.mutation_candidates == 6
+    assert (applied.inserted, applied.existing) == (4, 2)
+    assert (rerun.inserted, rerun.existing) == (0, 6)
     expected_skips = {
         CaseAgentSessionBackfillSkipReason.FAILED_TOOL_CALL: 1,
         CaseAgentSessionBackfillSkipReason.INCOMPLETE_TOOL_CALL: 1,
@@ -276,4 +283,5 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
         (updated.id, CaseAgentSessionInteractionOperation.UPDATE, root.id),
         (commented.id, CaseAgentSessionInteractionOperation.UPDATE, root.id),
         (edited.id, CaseAgentSessionInteractionOperation.UPDATE, root.id),
+        (associated.id, CaseAgentSessionInteractionOperation.UPDATE, root.id),
     }

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -250,10 +250,10 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
     assert await _interactions(session, workspace_id) == {
         (updated.id, CaseAgentSessionInteractionOperation.UPDATE, root.id)
     }
-    applied = await backfill.run(batch_size=1)
-    rerun = await backfill.run(batch_size=1)
+    applied = await backfill.run()
+    rerun = await backfill.run()
 
-    assert applied.batches_processed == 3
+    assert applied.batches_processed == 1
     assert applied.sessions_scanned == 3
     assert applied.history_rows_scanned == 5
     assert applied.mutation_candidates == 5

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -1,0 +1,273 @@
+"""Integration coverage for historical case-agent interaction backfills."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import orjson
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.agent.session.history import prepare_session_history
+from tracecat.auth.types import Role
+from tracecat.cases.agent_sessions.backfill import CaseAgentSessionBackfill
+from tracecat.cases.agent_sessions.types import CaseAgentSessionBackfillSkipReason
+from tracecat.cases.enums import (
+    CaseAgentSessionInteractionOperation,
+    CasePriority,
+    CaseSeverity,
+    CaseStatus,
+)
+from tracecat.db.models import (
+    AgentSession,
+    AgentSessionHistory,
+    Case,
+    CaseAgentSessionInteraction,
+    CaseComment,
+)
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.integration,
+    pytest.mark.usefixtures("db"),
+]
+
+
+def _case(workspace_id: uuid.UUID, case_number: int, summary: str) -> Case:
+    return Case(
+        workspace_id=workspace_id,
+        case_number=case_number,
+        summary=summary,
+        description=f"Description for {summary}",
+        status=CaseStatus.NEW,
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.LOW,
+    )
+
+
+def _use(tool_call_id: str, name: str, **arguments: object) -> dict[str, object]:
+    return {
+        "type": "tool_use",
+        "id": tool_call_id,
+        "name": name,
+        "input": arguments,
+    }
+
+
+def _result(
+    tool_call_id: str,
+    content: object = '{"success":true}',
+) -> dict[str, object]:
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_call_id,
+        "content": content,
+    }
+
+
+def _history(
+    agent_session: AgentSession,
+    message_type: str,
+    blocks: list[dict[str, object]],
+) -> AgentSessionHistory:
+    content: dict[str, Any] = {
+        "type": message_type,
+        "message": {"content": blocks},
+    }
+    prepared = prepare_session_history(content, raw_session_line=orjson.dumps(content))
+    return AgentSessionHistory(
+        workspace_id=agent_session.workspace_id,
+        session_id=agent_session.id,
+        content=prepared.content,
+        raw_session_line=prepared.raw_session_line,
+        kind="internal",
+    )
+
+
+def _turn(
+    agent_session: AgentSession,
+    uses: list[dict[str, object]],
+    results: list[dict[str, object]],
+) -> list[AgentSessionHistory]:
+    return [
+        _history(agent_session, "assistant", uses),
+        _history(agent_session, "user", results),
+    ]
+
+
+async def _interactions(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> set[tuple[uuid.UUID, CaseAgentSessionInteractionOperation, uuid.UUID]]:
+    rows = (
+        await session.execute(
+            select(
+                CaseAgentSessionInteraction.case_id,
+                CaseAgentSessionInteraction.operation,
+                CaseAgentSessionInteraction.agent_session_id,
+            ).where(CaseAgentSessionInteraction.workspace_id == workspace_id)
+        )
+    ).tuples()
+    return set(rows)
+
+
+async def test_backfill_reconstructs_mutations_safely_and_idempotently(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Exercise the backfill as one bounded, database-backed workflow."""
+    assert svc_role.workspace_id is not None
+    workspace_id = svc_role.workspace_id
+    created, updated, commented, edited, associated = [
+        _case(workspace_id, 101 + index, summary)
+        for index, summary in enumerate(
+            ["Created", "Updated", "Commented", "Edited", "Entity only"]
+        )
+    ]
+    session.add_all([created, updated, commented, edited, associated])
+    await session.flush()
+
+    edited_comment = CaseComment(
+        workspace_id=workspace_id,
+        case_id=edited.id,
+        content="Original comment",
+    )
+    root = AgentSession(
+        workspace_id=workspace_id,
+        title="Root",
+        entity_type="workflow",
+        entity_id=uuid.uuid4(),
+    )
+    session.add_all([edited_comment, root])
+    await session.flush()
+    child = AgentSession(
+        workspace_id=workspace_id,
+        title="Continuation",
+        entity_type="approval",
+        entity_id=uuid.uuid4(),
+        parent_session=root,
+    )
+    entity_only = AgentSession(
+        workspace_id=workspace_id,
+        title="Case entity without mutations",
+        entity_type="case",
+        entity_id=associated.id,
+    )
+    session.add_all([child, entity_only])
+    await session.flush()
+
+    session.add(
+        CaseAgentSessionInteraction(
+            workspace_id=workspace_id,
+            case_id=updated.id,
+            agent_session_id=root.id,
+            operation=CaseAgentSessionInteractionOperation.UPDATE,
+        )
+    )
+    session.add_all(
+        _turn(
+            root,
+            [
+                _use(
+                    "root-update",
+                    "core.cases.update_case",
+                    case_id=str(updated.id),
+                )
+            ],
+            [_result("root-update")],
+        )
+    )
+
+    uses = [
+        _use(
+            "create",
+            "mcp__tracecat-registry__core__cases__create_case",
+            summary="Created",
+        ),
+        _use(
+            "legacy-update",
+            "mcp__tracecat_registry__execute_tool",
+            tool_name="core.cases.update_case",
+            case_id=str(updated.id),
+        ),
+        _use(
+            "comment",
+            "mcp.tracecat-registry.core.cases.create_comment",
+            case_id=str(commented.id),
+            content="Contains\x00NUL",
+        ),
+        _use(
+            "edit-comment",
+            "core.cases.update_comment",
+            comment_id=str(edited_comment.id),
+        ),
+        _use(
+            "failed",
+            "core.cases.update_case",
+            case_id=str(updated.id),
+        ),
+        _use(
+            "incomplete",
+            "core.cases.create_comment",
+            case_id=str(commented.id),
+        ),
+        _use(
+            "bad-result",
+            "core.cases.create_case",
+            summary="Unparseable result",
+        ),
+        _use("read", "core.cases.list_cases"),
+    ]
+    results = [
+        _result("bad-result", "not JSON"),
+        _result(
+            "failed",
+            [{"type": "text", "text": '{"success":false,"error":"failure"}'}],
+        ),
+        _result("edit-comment"),
+        _result("comment"),
+        _result("legacy-update"),
+        _result(
+            "create",
+            [{"type": "text", "text": f'{{"id":"{created.id}"}}'}],
+        ),
+    ]
+    child_history = _turn(child, uses, results)
+    assert child_history[0].raw_session_line is not None
+    session.add_all(child_history)
+    session.add(
+        _history(
+            entity_only,
+            "user",
+            [{"type": "text", "text": "Summarize this case"}],
+        )
+    )
+    await session.commit()
+
+    backfill = CaseAgentSessionBackfill(session)
+    assert await _interactions(session, workspace_id) == {
+        (updated.id, CaseAgentSessionInteractionOperation.UPDATE, root.id)
+    }
+    applied = await backfill.run(batch_size=1)
+    rerun = await backfill.run(batch_size=1)
+
+    assert applied.batches_processed == 3
+    assert applied.sessions_scanned == 3
+    assert applied.history_rows_scanned == 5
+    assert applied.mutation_candidates == 5
+    assert (applied.inserted, applied.existing) == (3, 1)
+    assert (rerun.inserted, rerun.existing) == (0, 4)
+    expected_skips = {
+        CaseAgentSessionBackfillSkipReason.FAILED_TOOL_CALL: 1,
+        CaseAgentSessionBackfillSkipReason.INCOMPLETE_TOOL_CALL: 1,
+        CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL: 1,
+    }
+    assert applied.skipped == rerun.skipped == expected_skips
+    assert await _interactions(session, workspace_id) == {
+        (created.id, CaseAgentSessionInteractionOperation.CREATE, root.id),
+        (updated.id, CaseAgentSessionInteractionOperation.UPDATE, root.id),
+        (commented.id, CaseAgentSessionInteractionOperation.UPDATE, root.id),
+        (edited.id, CaseAgentSessionInteractionOperation.UPDATE, root.id),
+    }

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -250,15 +250,15 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
     assert await _interactions(session, workspace_id) == {
         (updated.id, CaseAgentSessionInteractionOperation.UPDATE, root.id)
     }
-    applied = await backfill.run()
-    rerun = await backfill.run()
+    applied = await backfill.run(batch_size=1)
+    rerun = await backfill.run(batch_size=1)
 
-    assert applied.batches_processed == 1
+    assert applied.batches_processed == 3
     assert applied.sessions_scanned == 3
     assert applied.history_rows_scanned == 5
     assert applied.mutation_candidates == 5
-    assert (applied.inserted, applied.existing) == (3, 1)
-    assert (rerun.inserted, rerun.existing) == (0, 4)
+    assert (applied.inserted, applied.existing) == (3, 2)
+    assert (rerun.inserted, rerun.existing) == (0, 5)
     expected_skips = {
         CaseAgentSessionBackfillSkipReason.FAILED_TOOL_CALL: 1,
         CaseAgentSessionBackfillSkipReason.INCOMPLETE_TOOL_CALL: 1,

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -131,6 +131,10 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
         "tracecat.cases.agent_sessions.backfill._INTERACTION_INSERT_BATCH_SIZE",
         1,
     )
+    monkeypatch.setattr(
+        "tracecat.cases.agent_sessions.backfill._TARGET_LOOKUP_BATCH_SIZE",
+        1,
+    )
     assert svc_role.workspace_id is not None
     workspace_id = svc_role.workspace_id
     created, updated, commented, edited, associated = [

--- a/tests/integration/test_case_agent_session_backfill.py
+++ b/tests/integration/test_case_agent_session_backfill.py
@@ -209,6 +209,11 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
             case_id=str(updated.id),
         ),
         _use(
+            "external-update",
+            "mcp__customer-server__core__cases__update_case",
+            case_id=str(updated.id),
+        ),
+        _use(
             "incomplete",
             "core.cases.create_comment",
             case_id=str(commented.id),
@@ -229,6 +234,7 @@ async def test_backfill_reconstructs_mutations_safely_and_idempotently(
         _result("edit-comment"),
         _result("comment"),
         _result("legacy-update"),
+        _result("external-update"),
         _result(
             "create",
             [{"type": "text", "text": f'{{"id":"{created.id}"}}'}],

--- a/tests/unit/api/test_api_admin_maintenance.py
+++ b/tests/unit/api/test_api_admin_maintenance.py
@@ -86,6 +86,10 @@ async def test_case_agent_session_interaction_backfill(
         },
     }
     start_call = temporal_client.start_workflow.await_args
+    assert (
+        start_call.kwargs["task_queue"]
+        == maintenance_router_module.config.TEMPORAL__CLUSTER_QUEUE
+    )
     assert start_call.kwargs["id_reuse_policy"] == (
         WorkflowIDReusePolicy.ALLOW_DUPLICATE
     )

--- a/tests/unit/api/test_api_admin_maintenance.py
+++ b/tests/unit/api/test_api_admin_maintenance.py
@@ -1,0 +1,54 @@
+"""HTTP coverage for platform maintenance endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+import tracecat.admin.maintenance.router as maintenance_router_module
+from tracecat.auth.types import Role
+from tracecat.cases.agent_sessions.types import (
+    CaseAgentSessionBackfillReport,
+    CaseAgentSessionBackfillSkipReason,
+)
+
+
+@pytest.mark.anyio
+async def test_case_agent_session_interaction_backfill(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    report = CaseAgentSessionBackfillReport(
+        batches_processed=2,
+        sessions_scanned=3,
+        history_rows_scanned=6,
+        mutation_candidates=4,
+        inserted=3,
+        existing=1,
+        skipped={CaseAgentSessionBackfillSkipReason.FAILED_TOOL_CALL: 1},
+    )
+
+    with patch.object(
+        maintenance_router_module,
+        "CaseAgentSessionBackfill",
+    ) as backfill_type:
+        backfill = AsyncMock()
+        backfill.run.return_value = report
+        backfill_type.return_value = backfill
+
+        response = client.post(
+            "/admin/maintenance/case-agent-session-interactions/backfill"
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "batches_processed": 2,
+        "sessions_scanned": 3,
+        "history_rows_scanned": 6,
+        "mutation_candidates": 4,
+        "inserted": 3,
+        "existing": 1,
+        "skipped": {"failed_tool_call": 1},
+    }
+    backfill.run.assert_awaited_once_with()

--- a/tests/unit/api/test_api_admin_maintenance.py
+++ b/tests/unit/api/test_api_admin_maintenance.py
@@ -1,10 +1,14 @@
 """HTTP coverage for platform maintenance endpoints."""
 
-from unittest.mock import AsyncMock, patch
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 
 import tracecat.admin.maintenance.router as maintenance_router_module
 from tracecat.auth.types import Role
@@ -28,27 +32,67 @@ async def test_case_agent_session_interaction_backfill(
         existing=1,
         skipped={CaseAgentSessionBackfillSkipReason.FAILED_TOOL_CALL: 1},
     )
+    operation_id = uuid.uuid4()
+    handle = SimpleNamespace(
+        result_run_id=str(operation_id),
+        describe=AsyncMock(
+            side_effect=[
+                SimpleNamespace(status=WorkflowExecutionStatus.RUNNING),
+                SimpleNamespace(status=WorkflowExecutionStatus.COMPLETED),
+            ]
+        ),
+        result=AsyncMock(return_value=report),
+    )
+    temporal_client = Mock(
+        start_workflow=AsyncMock(return_value=handle),
+        get_workflow_handle_for=Mock(return_value=handle),
+    )
 
     with patch.object(
         maintenance_router_module,
-        "CaseAgentSessionBackfill",
-    ) as backfill_type:
-        backfill = AsyncMock()
-        backfill.run.return_value = report
-        backfill_type.return_value = backfill
-
-        response = client.post(
+        "get_temporal_client",
+        AsyncMock(return_value=temporal_client),
+    ):
+        start_response = client.post(
             "/admin/maintenance/case-agent-session-interactions/backfill"
         )
+        running_response = client.get(
+            "/admin/maintenance/case-agent-session-interactions/backfill/"
+            f"{operation_id}"
+        )
+        completed_response = client.get(
+            "/admin/maintenance/case-agent-session-interactions/backfill/"
+            f"{operation_id}"
+        )
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {
-        "batches_processed": 2,
-        "sessions_scanned": 3,
-        "history_rows_scanned": 6,
-        "mutation_candidates": 4,
-        "inserted": 3,
-        "existing": 1,
-        "skipped": {"failed_tool_call": 1},
+    assert start_response.status_code == status.HTTP_202_ACCEPTED
+    assert start_response.json() == {"operation_id": str(operation_id)}
+    assert running_response.json() == {
+        "operation_id": str(operation_id),
+        "status": "running",
+        "report": None,
     }
-    backfill.run.assert_awaited_once_with()
+    assert completed_response.json() == {
+        "operation_id": str(operation_id),
+        "status": "completed",
+        "report": {
+            "batches_processed": 2,
+            "sessions_scanned": 3,
+            "history_rows_scanned": 6,
+            "mutation_candidates": 4,
+            "inserted": 3,
+            "existing": 1,
+            "skipped": {"failed_tool_call": 1},
+        },
+    }
+    start_call = temporal_client.start_workflow.await_args
+    assert start_call.kwargs["id_reuse_policy"] == (
+        WorkflowIDReusePolicy.ALLOW_DUPLICATE
+    )
+    assert start_call.kwargs["id_conflict_policy"] == (
+        WorkflowIDConflictPolicy.USE_EXISTING
+    )
+    assert temporal_client.get_workflow_handle_for.call_args.kwargs["run_id"] == str(
+        operation_id
+    )
+    handle.result.assert_awaited_once_with()

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -33,6 +33,7 @@ from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.socket_io import SocketStreamWriter
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
 from tracecat.agent.common.types import (
+    MCPServerConfig,
     MCPToolDefinition,
     SandboxAgentConfig,
     SandboxSubagentConfig,
@@ -253,6 +254,28 @@ def test_get_litellm_route_model_prefixes_provider_route(
 
 class TestClaudeAgentRuntimeRun:
     """Tests for ClaudeAgentRuntime.run()."""
+
+    def test_stdio_servers_cannot_claim_registry_names(self) -> None:
+        """Reserve trusted registry identities even without registry actions."""
+        configs: list[MCPServerConfig] = [
+            {
+                "type": "stdio",
+                "name": "tracecat-registry",
+                "command": "canonical-server",
+            },
+            {
+                "type": "stdio",
+                "name": "tracecat_registry",
+                "command": "legacy-server",
+            },
+        ]
+
+        spec = ClaudeAgentRuntime._stdio_mcp_server_spec(source_configs=configs)
+
+        assert set(spec.servers) == {
+            "tracecat-registry-2",
+            "tracecat_registry-2",
+        }
 
     def test_trusted_mcp_bridge_disables_response_compression(self) -> None:
         """The MCP SDK parses bridge responses itself, so request plain JSON."""

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -1460,7 +1460,19 @@ class TestClaudeAgentRuntimeRun:
                             "enabled": True,
                             "subagents": [{"preset": "analyst"}],
                         }
-                    )
+                    ),
+                    "mcp_servers": [
+                        {
+                            "type": "stdio",
+                            "name": "tracecat-registry-analyst",
+                            "command": "canonical-collision",
+                        },
+                        {
+                            "type": "stdio",
+                            "name": "tracecat_registry-analyst",
+                            "command": "legacy-collision",
+                        },
+                    ],
                 }
             ),
             subagents=[child],
@@ -1488,7 +1500,15 @@ class TestClaudeAgentRuntimeRun:
                     "Authorization": "Bearer test-jwt-token",
                     "Accept-Encoding": "identity",
                 },
-            }
+            },
+            "tracecat-registry-analyst-2": {
+                "type": "stdio",
+                "command": "canonical-collision",
+            },
+            "tracecat_registry-analyst-2": {
+                "type": "stdio",
+                "command": "legacy-collision",
+            },
         }
         agent_def = options.agents["analyst"]
         assert agent_def.model == "openai/gpt-5-mini"

--- a/tests/unit/test_superuser_admin_session_dependencies.py
+++ b/tests/unit/test_superuser_admin_session_dependencies.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 SUPERUSER_ADMIN_ROUTERS = (
     Path("tracecat/admin/agent/router.py"),
+    Path("tracecat/admin/maintenance/router.py"),
     Path("tracecat/admin/registry/router.py"),
     Path("packages/tracecat-ee/tracecat_ee/admin/organizations/router.py"),
     Path("packages/tracecat-ee/tracecat_ee/admin/users/router.py"),

--- a/tracecat/admin/maintenance/__init__.py
+++ b/tracecat/admin/maintenance/__init__.py
@@ -1,0 +1,1 @@
+"""Platform-level maintenance operations."""

--- a/tracecat/admin/maintenance/router.py
+++ b/tracecat/admin/maintenance/router.py
@@ -1,30 +1,100 @@
 """Superuser-only platform maintenance endpoints."""
 
-from fastapi import APIRouter
+import uuid
+from datetime import timedelta
 
+from fastapi import APIRouter, HTTPException, status
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
+from temporalio.service import RPCError, RPCStatusCode
+
+from tracecat import config
 from tracecat.admin.maintenance.schemas import (
+    CaseAgentSessionBackfillStatus,
     CaseAgentSessionInteractionBackfillResponse,
+    CaseAgentSessionInteractionBackfillStartResponse,
+    CaseAgentSessionInteractionBackfillStatusResponse,
 )
 from tracecat.auth.credentials import SuperuserRole
-from tracecat.cases.agent_sessions.backfill import (
-    CaseAgentSessionBackfill,
+from tracecat.cases.agent_sessions.workflow import (
+    CaseAgentSessionBackfillWorkflow,
 )
-from tracecat.db.dependencies import AsyncDBSessionBypass
+from tracecat.dsl.client import get_temporal_client
 
 router = APIRouter(prefix="/maintenance", tags=["admin:maintenance"])
+_BACKFILL_WORKFLOW_ID = "case-agent-session-interactions-backfill"
 
 
 @router.post(
     "/case-agent-session-interactions/backfill",
-    response_model=CaseAgentSessionInteractionBackfillResponse,
+    response_model=CaseAgentSessionInteractionBackfillStartResponse,
+    status_code=status.HTTP_202_ACCEPTED,
 )
-async def backfill_case_agent_session_interactions(
+async def start_case_agent_session_interaction_backfill(
     role: SuperuserRole,
-    session: AsyncDBSessionBypass,
-) -> CaseAgentSessionInteractionBackfillResponse:
-    """Backfill successful historical agent-driven case mutations."""
-    report = await CaseAgentSessionBackfill(session).run()
-    return CaseAgentSessionInteractionBackfillResponse.model_validate(
-        report,
-        from_attributes=True,
+) -> CaseAgentSessionInteractionBackfillStartResponse:
+    """Start or join the durable historical case-mutation backfill."""
+    client = await get_temporal_client()
+    handle = await client.start_workflow(
+        CaseAgentSessionBackfillWorkflow.run,
+        id=_BACKFILL_WORKFLOW_ID,
+        task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        execution_timeout=timedelta(days=1),
+        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+        id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+    )
+    if handle.result_run_id is None:
+        raise RuntimeError("Temporal did not return a backfill operation ID")
+    return CaseAgentSessionInteractionBackfillStartResponse(
+        operation_id=uuid.UUID(handle.result_run_id)
+    )
+
+
+@router.get(
+    "/case-agent-session-interactions/backfill/{operation_id}",
+    response_model=CaseAgentSessionInteractionBackfillStatusResponse,
+)
+async def get_case_agent_session_interaction_backfill(
+    role: SuperuserRole,
+    operation_id: uuid.UUID,
+) -> CaseAgentSessionInteractionBackfillStatusResponse:
+    """Poll a durable historical case-mutation backfill."""
+    client = await get_temporal_client()
+    handle = client.get_workflow_handle_for(
+        CaseAgentSessionBackfillWorkflow.run,
+        _BACKFILL_WORKFLOW_ID,
+        run_id=str(operation_id),
+    )
+    try:
+        description = await handle.describe()
+    except RPCError as exc:
+        if exc.status != RPCStatusCode.NOT_FOUND:
+            raise
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Backfill operation not found",
+        ) from exc
+
+    if description.status in {
+        WorkflowExecutionStatus.RUNNING,
+        WorkflowExecutionStatus.CONTINUED_AS_NEW,
+    }:
+        operation_status = CaseAgentSessionBackfillStatus.RUNNING
+    elif description.status == WorkflowExecutionStatus.COMPLETED:
+        operation_status = CaseAgentSessionBackfillStatus.COMPLETED
+    else:
+        operation_status = CaseAgentSessionBackfillStatus.FAILED
+
+    report = None
+    if operation_status == CaseAgentSessionBackfillStatus.COMPLETED:
+        result = await handle.result()
+        report = CaseAgentSessionInteractionBackfillResponse.model_validate(
+            result,
+            from_attributes=True,
+        )
+
+    return CaseAgentSessionInteractionBackfillStatusResponse(
+        operation_id=operation_id,
+        status=operation_status,
+        report=report,
     )

--- a/tracecat/admin/maintenance/router.py
+++ b/tracecat/admin/maintenance/router.py
@@ -38,7 +38,7 @@ async def start_case_agent_session_interaction_backfill(
     handle = await client.start_workflow(
         CaseAgentSessionBackfillWorkflow.run,
         id=_BACKFILL_WORKFLOW_ID,
-        task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        task_queue=config.TEMPORAL__CLUSTER_QUEUE,
         execution_timeout=timedelta(days=1),
         id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,

--- a/tracecat/admin/maintenance/router.py
+++ b/tracecat/admin/maintenance/router.py
@@ -1,0 +1,30 @@
+"""Superuser-only platform maintenance endpoints."""
+
+from fastapi import APIRouter
+
+from tracecat.admin.maintenance.schemas import (
+    CaseAgentSessionInteractionBackfillResponse,
+)
+from tracecat.auth.credentials import SuperuserRole
+from tracecat.cases.agent_sessions.backfill import (
+    CaseAgentSessionBackfill,
+)
+from tracecat.db.dependencies import AsyncDBSessionBypass
+
+router = APIRouter(prefix="/maintenance", tags=["admin:maintenance"])
+
+
+@router.post(
+    "/case-agent-session-interactions/backfill",
+    response_model=CaseAgentSessionInteractionBackfillResponse,
+)
+async def backfill_case_agent_session_interactions(
+    role: SuperuserRole,
+    session: AsyncDBSessionBypass,
+) -> CaseAgentSessionInteractionBackfillResponse:
+    """Backfill successful historical agent-driven case mutations."""
+    report = await CaseAgentSessionBackfill(session).run()
+    return CaseAgentSessionInteractionBackfillResponse.model_validate(
+        report,
+        from_attributes=True,
+    )

--- a/tracecat/admin/maintenance/schemas.py
+++ b/tracecat/admin/maintenance/schemas.py
@@ -1,0 +1,15 @@
+"""Schemas for platform maintenance operations."""
+
+from pydantic import BaseModel
+
+
+class CaseAgentSessionInteractionBackfillResponse(BaseModel):
+    """Aggregate result of the historical interaction backfill."""
+
+    batches_processed: int
+    sessions_scanned: int
+    history_rows_scanned: int
+    mutation_candidates: int
+    inserted: int
+    existing: int
+    skipped: dict[str, int]

--- a/tracecat/admin/maintenance/schemas.py
+++ b/tracecat/admin/maintenance/schemas.py
@@ -1,6 +1,23 @@
 """Schemas for platform maintenance operations."""
 
+import uuid
+from enum import StrEnum
+
 from pydantic import BaseModel
+
+
+class CaseAgentSessionBackfillStatus(StrEnum):
+    """Lifecycle state for the durable backfill operation."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class CaseAgentSessionInteractionBackfillStartResponse(BaseModel):
+    """Response after starting or joining the durable backfill."""
+
+    operation_id: uuid.UUID
 
 
 class CaseAgentSessionInteractionBackfillResponse(BaseModel):
@@ -13,3 +30,11 @@ class CaseAgentSessionInteractionBackfillResponse(BaseModel):
     inserted: int
     existing: int
     skipped: dict[str, int]
+
+
+class CaseAgentSessionInteractionBackfillStatusResponse(BaseModel):
+    """Current state and optional result of the durable backfill."""
+
+    operation_id: uuid.UUID
+    status: CaseAgentSessionBackfillStatus
+    report: CaseAgentSessionInteractionBackfillResponse | None = None

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -1686,9 +1686,17 @@ class ClaudeAgentRuntime:
             )
 
             stderr_queue: asyncio.Queue[str] = asyncio.Queue()
+            reserved_subagent_server_names = {
+                server_name
+                for subagent in payload.subagents
+                for server_name in (
+                    self._subagent_registry_server_name(subagent.alias),
+                    f"{LEGACY_REGISTRY_MCP_SERVER_NAME}-{subagent.alias}",
+                )
+            }
             stdio_mcp_spec = self._stdio_mcp_server_spec(
                 source_configs=payload.config.mcp_servers,
-                existing_names=set(mcp_servers),
+                existing_names=set(mcp_servers) | reserved_subagent_server_names,
             )
             self._stdio_approval_blocked_tools = stdio_mcp_spec.blocked_approval_tools
             stdio_mcp_servers = stdio_mcp_spec.servers

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -79,6 +79,8 @@ from tracecat.agent.mcp.metadata import (
     PROXY_TOOL_METADATA_KEY,
 )
 from tracecat.agent.mcp.utils import (
+    LEGACY_REGISTRY_MCP_SERVER_NAME,
+    REGISTRY_MCP_SERVER_NAME,
     STDIO_MCP_TOOL_NAME_RE,
     action_name_to_mcp_tool_name,
     normalize_mcp_tool_name,
@@ -250,12 +252,14 @@ COMMAND_LINE_TOOLS_PROMPT = (
 # interpolate into the system prompt.
 STDIO_MCP_TOOL_DESCRIPTION_MAX_CHARS = 500
 
-REGISTRY_MCP_SERVER_NAME = "tracecat-registry"
 REGISTRY_MCP_TOOL_PREFIX = f"mcp__{REGISTRY_MCP_SERVER_NAME}__"
 REGISTRY_MCP_DOT_PREFIX = f"mcp.{REGISTRY_MCP_SERVER_NAME}."
-LEGACY_REGISTRY_MCP_TOOL_PREFIX = "mcp__tracecat_registry__"
-LEGACY_REGISTRY_MCP_DOT_PREFIX = "mcp.tracecat_registry."
+LEGACY_REGISTRY_MCP_TOOL_PREFIX = f"mcp__{LEGACY_REGISTRY_MCP_SERVER_NAME}__"
+LEGACY_REGISTRY_MCP_DOT_PREFIX = f"mcp.{LEGACY_REGISTRY_MCP_SERVER_NAME}."
 SUBAGENT_REGISTRY_MCP_SERVER_PREFIX = "tracecat-registry-"
+RESERVED_MCP_SERVER_NAMES = frozenset(
+    {REGISTRY_MCP_SERVER_NAME, LEGACY_REGISTRY_MCP_SERVER_NAME}
+)
 TRUSTED_MCP_BRIDGE_URL = f"http://127.0.0.1:{TRACECAT__AGENT_MCP_BRIDGE_PORT}/mcp"
 
 # Increase the SDK's stdout/stderr capture buffer above its default 1 MiB so
@@ -496,7 +500,9 @@ class ClaudeAgentRuntime:
         servers: dict[str, McpStdioServerConfig] = {}
         tools_by_server: dict[str, list[MCPServerToolSummary]] = {}
         blocked_approval_tools: set[str] = set()
-        used_names = set(existing_names or ())
+        # Keep trusted registry identities unavailable to user-supplied servers,
+        # including turns that expose no registry actions.
+        used_names = set(RESERVED_MCP_SERVER_NAMES) | set(existing_names or ())
         if not source_configs:
             return _StdioMCPServerSpec(
                 servers=servers,

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -24,6 +24,7 @@ from tracecat_ee.watchtower.router import router as watchtower_router
 from tracecat import __version__ as APP_VERSION
 from tracecat import config
 from tracecat.admin.agent.router import router as admin_agent_router
+from tracecat.admin.maintenance.router import router as admin_maintenance_router
 from tracecat.admin.registry.router import router as admin_registry_router
 from tracecat.agent.access.router import router as agent_model_access_router
 from tracecat.agent.catalog.loader import load_platform_catalog_on_startup
@@ -506,6 +507,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(watchtower_router)
     app.include_router(admin_router)
     app.include_router(admin_agent_router, prefix="/admin")
+    app.include_router(admin_maintenance_router, prefix="/admin")
     app.include_router(admin_registry_router, prefix="/admin")
     _include_workspace_scoped_router(app, inbox_router)
     _include_workspace_scoped_router(app, editor_router)

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -6,6 +6,7 @@ import uuid
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from itertools import batched
 from typing import Any, Literal
 
 import orjson
@@ -38,6 +39,7 @@ from tracecat.logger import logger
 _CREATE_CASE = "core.cases.create_case"
 _UPDATE_COMMENT = "core.cases.update_comment"
 _HISTORY_FETCH_SIZE = 100
+_INTERACTION_INSERT_BATCH_SIZE = 1000
 # Successful case deletions leave no case row for the interaction foreign key.
 _CASE_ID_ACTIONS = frozenset(
     {
@@ -240,14 +242,21 @@ def _history_content(
 
 
 class _MutationParser:
-    """Incrementally match mutation tool calls with their results."""
+    """Match tool calls incrementally and retain only unique mutations."""
 
-    __slots__ = ("mutations", "pending", "skipped", "trusted_mcp_server_names")
+    __slots__ = (
+        "mutation_candidates",
+        "mutations",
+        "pending",
+        "skipped",
+        "trusted_mcp_server_names",
+    )
 
     def __init__(self, trusted_mcp_server_names: frozenset[str]) -> None:
         self.trusted_mcp_server_names = trusted_mcp_server_names
         self.pending: dict[str, _PendingMutation] = {}
-        self.mutations: list[_Mutation] = []
+        self.mutations: set[_Mutation] = set()
+        self.mutation_candidates = 0
         self.skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
 
     def add(
@@ -310,7 +319,8 @@ class _MutationParser:
                     CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL
                 ] += 1
                 continue
-            self.mutations.append(
+            self.mutation_candidates += 1
+            self.mutations.add(
                 _Mutation(
                     target=target,
                     target_id=target_id,
@@ -320,13 +330,17 @@ class _MutationParser:
 
     def finish(
         self,
-    ) -> tuple[list[_Mutation], Counter[CaseAgentSessionBackfillSkipReason]]:
+    ) -> tuple[
+        set[_Mutation],
+        int,
+        Counter[CaseAgentSessionBackfillSkipReason],
+    ]:
         if self.pending:
             self.skipped[CaseAgentSessionBackfillSkipReason.INCOMPLETE_TOOL_CALL] += (
                 len(self.pending)
             )
             self.pending.clear()
-        return self.mutations, self.skipped
+        return self.mutations, self.mutation_candidates, self.skipped
 
 
 class CaseAgentSessionBackfill:
@@ -380,6 +394,7 @@ class CaseAgentSessionBackfill:
     ) -> tuple[
         list[_SourceMutation],
         int,
+        int,
         Counter[CaseAgentSessionBackfillSkipReason],
     ]:
         """Stream history rows and parse mutations without retaining payloads."""
@@ -411,12 +426,14 @@ class CaseAgentSessionBackfill:
                 on_progress()
 
         source_mutations: list[_SourceMutation] = []
+        mutation_candidates = 0
         skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
         for source in sessions:
-            mutations, parse_skips = parsers[source.id].finish()
+            mutations, source_candidates, parse_skips = parsers[source.id].finish()
             source_mutations.extend((source, mutation) for mutation in mutations)
+            mutation_candidates += source_candidates
             skipped.update(parse_skips)
-        return source_mutations, history_rows_scanned, skipped
+        return source_mutations, mutation_candidates, history_rows_scanned, skipped
 
     async def _resolve_root_session_ids(
         self,
@@ -564,33 +581,32 @@ class CaseAgentSessionBackfill:
         if not interactions:
             return 0, 0
 
-        values = [
-            {
-                "id": uuid.uuid4(),
-                "workspace_id": workspace_id,
-                "agent_session_id": root_id,
-                "case_id": case_id,
-                "operation": operation,
-            }
-            for workspace_id, root_id, case_id, operation in sorted(
-                interactions,
-                key=lambda item: tuple(str(value) for value in item),
+        inserted = 0
+        for chunk in batched(interactions, _INTERACTION_INSERT_BATCH_SIZE):
+            values = [
+                {
+                    "id": uuid.uuid4(),
+                    "workspace_id": workspace_id,
+                    "agent_session_id": root_id,
+                    "case_id": case_id,
+                    "operation": operation,
+                }
+                for workspace_id, root_id, case_id, operation in chunk
+            ]
+            inserted_ids = await self.session.scalars(
+                pg_insert(CaseAgentSessionInteraction)
+                .values(values)
+                .on_conflict_do_nothing(
+                    index_elements=[
+                        "workspace_id",
+                        "case_id",
+                        "agent_session_id",
+                        "operation",
+                    ]
+                )
+                .returning(CaseAgentSessionInteraction.id)
             )
-        ]
-        inserted_ids = await self.session.scalars(
-            pg_insert(CaseAgentSessionInteraction)
-            .values(values)
-            .on_conflict_do_nothing(
-                index_elements=[
-                    "workspace_id",
-                    "case_id",
-                    "agent_session_id",
-                    "operation",
-                ]
-            )
-            .returning(CaseAgentSessionInteraction.id)
-        )
-        inserted = len(inserted_ids.all())
+            inserted += len(inserted_ids.all())
         return inserted, len(interactions) - inserted
 
     async def run(
@@ -618,6 +634,7 @@ class CaseAgentSessionBackfill:
         ):
             (
                 source_mutations,
+                batch_mutation_candidates,
                 batch_history_rows,
                 batch_skips,
             ) = await self._load_mutations(sessions, on_progress=on_progress)
@@ -633,7 +650,7 @@ class CaseAgentSessionBackfill:
             batches_processed += 1
             sessions_scanned += len(sessions)
             history_rows_scanned += batch_history_rows
-            mutation_candidates += len(source_mutations)
+            mutation_candidates += batch_mutation_candidates
             inserted += batch_inserted
             existing += batch_existing
             skipped.update(batch_skips)
@@ -647,7 +664,7 @@ class CaseAgentSessionBackfill:
                 batch_number=batches_processed,
                 sessions=len(sessions),
                 history_rows=batch_history_rows,
-                mutation_candidates=len(source_mutations),
+                mutation_candidates=batch_mutation_candidates,
                 inserted=batch_inserted,
                 existing=batch_existing,
                 skipped=sum(batch_skips.values()),

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from collections import Counter, defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -13,7 +13,11 @@ from sqlalchemy import exists, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+from tracecat.agent.mcp.utils import (
+    LEGACY_REGISTRY_MCP_SERVER_NAME,
+    REGISTRY_MCP_SERVER_NAME,
+    normalize_mcp_tool_name,
+)
 from tracecat.agent.session.history import decode_raw_session_line
 from tracecat.cases.agent_sessions.types import (
     CaseAgentSessionBackfillReport,
@@ -83,12 +87,30 @@ def _parse_uuid(value: object) -> uuid.UUID | None:
         return None
 
 
+def _is_tracecat_owned_tool(name: str) -> bool:
+    """Reject tools routed through MCP servers Tracecat does not own."""
+    for separator in ("__", "."):
+        if not name.startswith(f"mcp{separator}"):
+            continue
+        parts = name.split(separator, 2)
+        if len(parts) != 3:
+            return False
+        server_name = parts[1]
+        return server_name in {
+            REGISTRY_MCP_SERVER_NAME,
+            LEGACY_REGISTRY_MCP_SERVER_NAME,
+        } or server_name.startswith(
+            (f"{REGISTRY_MCP_SERVER_NAME}-", f"{LEGACY_REGISTRY_MCP_SERVER_NAME}-")
+        )
+    return True
+
+
 def _resolve_tool(
     block: Mapping[str, Any],
 ) -> tuple[str, Mapping[str, Any] | None] | None:
     """Resolve a supported direct or legacy wrapper tool call."""
     name = block.get("name")
-    if not isinstance(name, str):
+    if not isinstance(name, str) or not _is_tracecat_owned_tool(name):
         return None
 
     action = normalize_mcp_tool_name(name)
@@ -100,7 +122,9 @@ def _resolve_tool(
         if arguments is None:
             return None
         wrapped_name = arguments.get("tool_name")
-        if not isinstance(wrapped_name, str):
+        if not isinstance(wrapped_name, str) or not _is_tracecat_owned_tool(
+            wrapped_name
+        ):
             return None
         action = normalize_mcp_tool_name(wrapped_name)
         arguments = arguments.get("args", arguments)
@@ -490,7 +514,12 @@ class CaseAgentSessionBackfill:
         inserted = len(inserted_ids.all())
         return inserted, len(interactions) - inserted
 
-    async def run(self, *, batch_size: int = 100) -> CaseAgentSessionBackfillReport:
+    async def run(
+        self,
+        *,
+        batch_size: int = 100,
+        on_batch_complete: Callable[[], None] | None = None,
+    ) -> CaseAgentSessionBackfillReport:
         """Run the restart-safe backfill, committing after each session batch."""
         if batch_size < 1:
             raise ValueError("batch_size must be positive")
@@ -535,6 +564,8 @@ class CaseAgentSessionBackfill:
             after_surrogate_id = sessions[-1].surrogate_id
 
             await self.session.commit()
+            if on_batch_complete is not None:
+                on_batch_complete()
             logger.info(
                 "Processed case-agent interaction backfill batch",
                 batch_number=batches_processed,

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -1,0 +1,536 @@
+"""Historical reconstruction of agent-driven case mutation interactions."""
+
+from __future__ import annotations
+
+import uuid
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import orjson
+from sqlalchemy import exists, select, tuple_
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+from tracecat.agent.session.history import decode_raw_session_line
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.cases.agent_sessions.service import (
+    CaseAgentSessionInteractionService,
+)
+from tracecat.cases.agent_sessions.types import (
+    CaseAgentSessionBackfillReport,
+    CaseAgentSessionBackfillSkipReason,
+)
+from tracecat.cases.enums import CaseAgentSessionInteractionOperation
+from tracecat.db.models import (
+    AgentSession,
+    AgentSessionHistory,
+    Case,
+    CaseAgentSessionInteraction,
+    CaseComment,
+    Workspace,
+)
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.logger import logger
+
+_CREATE_CASE = "core.cases.create_case"
+_UPDATE_COMMENT = "core.cases.update_comment"
+_CASE_ID_ACTIONS = frozenset(
+    {
+        "core.cases.update_case",
+        "core.cases.create_comment",
+        "core.cases.reply_to_comment",
+    }
+)
+_SUPPORTED_ACTIONS = _CASE_ID_ACTIONS | {_CREATE_CASE, _UPDATE_COMMENT}
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingMutation:
+    operation: CaseAgentSessionInteractionOperation
+    target: Literal["case", "comment"] | None = None
+    target_id: uuid.UUID | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _Mutation:
+    target: Literal["case", "comment"]
+    target_id: uuid.UUID
+    operation: CaseAgentSessionInteractionOperation
+
+
+@dataclass(frozen=True, slots=True)
+class _Session:
+    surrogate_id: int
+    id: uuid.UUID
+    workspace_id: uuid.UUID
+    organization_id: uuid.UUID
+
+
+type _SourceMutation = tuple[_Session, _Mutation]
+type _ResolvedMutation = tuple[_Session, _Mutation, uuid.UUID]
+type _InteractionKey = tuple[
+    uuid.UUID,
+    uuid.UUID,
+    uuid.UUID,
+    CaseAgentSessionInteractionOperation,
+]
+
+
+def _parse_uuid(value: object) -> uuid.UUID | None:
+    if isinstance(value, uuid.UUID):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        return None
+
+
+def _resolve_tool(
+    block: Mapping[str, Any],
+) -> tuple[str, Mapping[str, Any] | None] | None:
+    """Resolve a supported direct or legacy wrapper tool call."""
+    name = block.get("name")
+    if not isinstance(name, str):
+        return None
+
+    action = normalize_mcp_tool_name(name)
+    arguments = block.get("input")
+    if not isinstance(arguments, dict):
+        arguments = None
+
+    if action == "execute_tool":
+        if arguments is None:
+            return None
+        wrapped_name = arguments.get("tool_name")
+        if not isinstance(wrapped_name, str):
+            return None
+        action = normalize_mcp_tool_name(wrapped_name)
+        arguments = arguments.get("args", arguments)
+        if not isinstance(arguments, dict):
+            arguments = None
+
+    if action not in _SUPPORTED_ACTIONS:
+        return None
+    return action, arguments
+
+
+def _pending_mutation(
+    action: str,
+    arguments: Mapping[str, Any] | None,
+) -> _PendingMutation | None:
+    if arguments is None:
+        return None
+    if action == _CREATE_CASE:
+        return _PendingMutation(CaseAgentSessionInteractionOperation.CREATE)
+
+    if action == _UPDATE_COMMENT:
+        target: Literal["case", "comment"] = "comment"
+        target_id = _parse_uuid(arguments.get("comment_id"))
+    else:
+        target = "case"
+        target_id = _parse_uuid(arguments.get("case_id"))
+    if target_id is None:
+        return None
+    return _PendingMutation(
+        operation=CaseAgentSessionInteractionOperation.UPDATE,
+        target=target,
+        target_id=target_id,
+    )
+
+
+def _result_mapping(value: object, *, depth: int = 0) -> Mapping[str, Any] | None:
+    """Unwrap JSON and MCP text-block result shapes stored by Claude."""
+    if depth > 3:
+        return None
+    match value:
+        case str() as text:
+            try:
+                decoded = orjson.loads(text)
+            except orjson.JSONDecodeError:
+                return None
+            return _result_mapping(decoded, depth=depth + 1)
+        case list() as items:
+            for item in items:
+                if mapping := _result_mapping(item, depth=depth + 1):
+                    return mapping
+            return None
+        case dict() as mapping:
+            if "id" in mapping or "success" in mapping:
+                return mapping
+            if mapping.get("type") == "text":
+                return _result_mapping(mapping.get("text"), depth=depth + 1)
+            if "content" in mapping:
+                return _result_mapping(mapping["content"], depth=depth + 1)
+            return mapping
+        case _:
+            return None
+
+
+def _is_failed_result(tool_result: Mapping[str, Any]) -> bool:
+    if tool_result.get("is_error") is True:
+        return True
+    result = _result_mapping(tool_result.get("content"))
+    return result is not None and result.get("success") is False
+
+
+def _history_content(entry: AgentSessionHistory) -> Mapping[str, Any]:
+    if entry.raw_session_line is not None:
+        try:
+            return decode_raw_session_line(entry.raw_session_line).content
+        except (UnicodeDecodeError, ValueError):
+            pass
+    return entry.content
+
+
+def _parse_mutations(
+    entries: Sequence[AgentSessionHistory],
+) -> tuple[list[_Mutation], Counter[CaseAgentSessionBackfillSkipReason]]:
+    """Extract successful case mutations from ordered session history."""
+    pending: dict[str, _PendingMutation] = {}
+    mutations: list[_Mutation] = []
+    skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
+
+    for entry in entries:
+        content = _history_content(entry)
+        message = content.get("message")
+        if not isinstance(message, dict):
+            continue
+        blocks = message.get("content")
+        if not isinstance(blocks, list):
+            continue
+
+        if content.get("type") == "assistant":
+            for block in blocks:
+                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    continue
+                tool = _resolve_tool(block)
+                if tool is None:
+                    continue
+                tool_call_id = block.get("id")
+                mutation = _pending_mutation(*tool)
+                if not isinstance(tool_call_id, str) or mutation is None:
+                    skipped[
+                        CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL
+                    ] += 1
+                    continue
+                if tool_call_id in pending:
+                    skipped[
+                        CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL
+                    ] += 1
+                pending[tool_call_id] = mutation
+            continue
+
+        if content.get("type") != "user":
+            continue
+        for block in blocks:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                continue
+            tool_call_id = block.get("tool_use_id")
+            if not isinstance(tool_call_id, str):
+                continue
+            mutation = pending.pop(tool_call_id, None)
+            if mutation is None:
+                continue
+            if _is_failed_result(block):
+                skipped[CaseAgentSessionBackfillSkipReason.FAILED_TOOL_CALL] += 1
+                continue
+
+            target = mutation.target
+            target_id = mutation.target_id
+            if mutation.operation == CaseAgentSessionInteractionOperation.CREATE:
+                target = "case"
+                result = _result_mapping(block.get("content"))
+                target_id = _parse_uuid(result.get("id")) if result else None
+            if target is None or target_id is None:
+                skipped[CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL] += 1
+                continue
+            mutations.append(
+                _Mutation(
+                    target=target,
+                    target_id=target_id,
+                    operation=mutation.operation,
+                )
+            )
+
+    if pending:
+        skipped[CaseAgentSessionBackfillSkipReason.INCOMPLETE_TOOL_CALL] = len(pending)
+    return mutations, skipped
+
+
+class CaseAgentSessionBackfill:
+    """Backfill historical case mutations in bounded transactions."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def _next_batch(
+        self,
+        *,
+        after_surrogate_id: int,
+        batch_size: int,
+    ) -> list[_Session]:
+        history_exists = exists(
+            select(AgentSessionHistory.surrogate_id).where(
+                AgentSessionHistory.session_id == AgentSession.id
+            )
+        )
+        rows = (
+            await self.session.execute(
+                select(
+                    AgentSession.surrogate_id,
+                    AgentSession.id,
+                    AgentSession.workspace_id,
+                    Workspace.organization_id,
+                )
+                .join(Workspace, Workspace.id == AgentSession.workspace_id)
+                .where(
+                    AgentSession.surrogate_id > after_surrogate_id,
+                    history_exists,
+                )
+                .order_by(AgentSession.surrogate_id)
+                .limit(batch_size)
+            )
+        ).tuples()
+        return [
+            _Session(
+                surrogate_id=surrogate_id,
+                id=session_id,
+                workspace_id=workspace_id,
+                organization_id=organization_id,
+            )
+            for surrogate_id, session_id, workspace_id, organization_id in rows
+        ]
+
+    async def _load_histories(
+        self,
+        sessions: Sequence[_Session],
+    ) -> dict[uuid.UUID, list[AgentSessionHistory]]:
+        entries = (
+            await self.session.scalars(
+                select(AgentSessionHistory)
+                .where(
+                    AgentSessionHistory.session_id.in_(
+                        session.id for session in sessions
+                    )
+                )
+                .order_by(
+                    AgentSessionHistory.session_id,
+                    AgentSessionHistory.surrogate_id,
+                )
+            )
+        ).all()
+        histories: dict[uuid.UUID, list[AgentSessionHistory]] = defaultdict(list)
+        for entry in entries:
+            histories[entry.session_id].append(entry)
+        return histories
+
+    def _interaction_service(
+        self,
+        source: _Session,
+    ) -> CaseAgentSessionInteractionService:
+        role = Role(
+            type="service",
+            service_id="tracecat-service",
+            workspace_id=source.workspace_id,
+            organization_id=source.organization_id,
+            scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-service"],
+        )
+        return CaseAgentSessionInteractionService(self.session, role)
+
+    async def _resolve_interactions(
+        self,
+        source_mutations: Sequence[_SourceMutation],
+        seen: set[_InteractionKey],
+    ) -> tuple[set[_InteractionKey], Counter[CaseAgentSessionBackfillSkipReason]]:
+        """Resolve comment targets, cases, and root sessions for one batch."""
+        comment_keys = {
+            (source.workspace_id, mutation.target_id)
+            for source, mutation in source_mutations
+            if mutation.target == "comment"
+        }
+        comment_cases: dict[tuple[uuid.UUID, uuid.UUID], uuid.UUID] = {}
+        if comment_keys:
+            rows = (
+                await self.session.execute(
+                    select(
+                        CaseComment.workspace_id,
+                        CaseComment.id,
+                        CaseComment.case_id,
+                    ).where(
+                        tuple_(CaseComment.workspace_id, CaseComment.id).in_(
+                            comment_keys
+                        )
+                    )
+                )
+            ).tuples()
+            comment_cases = {
+                (workspace_id, comment_id): case_id
+                for workspace_id, comment_id, case_id in rows
+            }
+
+        skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
+        resolved: list[_ResolvedMutation] = []
+        for source, mutation in source_mutations:
+            if mutation.target == "case":
+                case_id = mutation.target_id
+            else:
+                case_id = comment_cases.get((source.workspace_id, mutation.target_id))
+                if case_id is None:
+                    skipped[CaseAgentSessionBackfillSkipReason.MISSING_COMMENT] += 1
+                    continue
+            resolved.append((source, mutation, case_id))
+
+        case_keys = {(source.workspace_id, case_id) for source, _, case_id in resolved}
+        existing_cases: set[tuple[uuid.UUID, uuid.UUID]] = set()
+        if case_keys:
+            existing_cases = set(
+                (
+                    await self.session.execute(
+                        select(Case.workspace_id, Case.id).where(
+                            tuple_(Case.workspace_id, Case.id).in_(case_keys)
+                        )
+                    )
+                )
+                .tuples()
+                .all()
+            )
+
+        root_ids: dict[_Session, uuid.UUID | None] = {}
+        interactions: set[_InteractionKey] = set()
+        for source, mutation, case_id in resolved:
+            if (source.workspace_id, case_id) not in existing_cases:
+                skipped[CaseAgentSessionBackfillSkipReason.MISSING_CASE] += 1
+                continue
+            if source not in root_ids:
+                try:
+                    root_ids[source] = await self._interaction_service(
+                        source
+                    ).resolve_root_session_id(source.id)
+                except (TracecatNotFoundError, TracecatValidationError):
+                    root_ids[source] = None
+            root_id = root_ids[source]
+            if root_id is None:
+                skipped[CaseAgentSessionBackfillSkipReason.INVALID_SESSION_LINEAGE] += 1
+                continue
+
+            interaction = (
+                source.workspace_id,
+                root_id,
+                case_id,
+                mutation.operation,
+            )
+            if interaction not in seen:
+                seen.add(interaction)
+                interactions.add(interaction)
+
+        return interactions, skipped
+
+    async def _insert_interactions(
+        self,
+        interactions: set[_InteractionKey],
+    ) -> tuple[int, int]:
+        if not interactions:
+            return 0, 0
+
+        values = [
+            {
+                "id": uuid.uuid4(),
+                "workspace_id": workspace_id,
+                "agent_session_id": root_id,
+                "case_id": case_id,
+                "operation": operation,
+            }
+            for workspace_id, root_id, case_id, operation in sorted(
+                interactions,
+                key=lambda item: tuple(str(value) for value in item),
+            )
+        ]
+        inserted_ids = await self.session.scalars(
+            pg_insert(CaseAgentSessionInteraction)
+            .values(values)
+            .on_conflict_do_nothing(
+                index_elements=[
+                    "workspace_id",
+                    "case_id",
+                    "agent_session_id",
+                    "operation",
+                ]
+            )
+            .returning(CaseAgentSessionInteraction.id)
+        )
+        inserted = len(inserted_ids.all())
+        return inserted, len(interactions) - inserted
+
+    async def run(self, *, batch_size: int = 100) -> CaseAgentSessionBackfillReport:
+        """Run the restart-safe backfill, committing after each session batch."""
+        if batch_size < 1:
+            raise ValueError("batch_size must be positive")
+
+        after_surrogate_id = 0
+        batches_processed = 0
+        sessions_scanned = 0
+        history_rows_scanned = 0
+        mutation_candidates = 0
+        inserted = 0
+        existing = 0
+        skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
+        seen: set[_InteractionKey] = set()
+
+        while sessions := await self._next_batch(
+            after_surrogate_id=after_surrogate_id,
+            batch_size=batch_size,
+        ):
+            histories = await self._load_histories(sessions)
+            source_mutations: list[_SourceMutation] = []
+            batch_skips: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
+            for source in sessions:
+                mutations, parse_skips = _parse_mutations(histories.get(source.id, []))
+                source_mutations.extend((source, mutation) for mutation in mutations)
+                batch_skips.update(parse_skips)
+
+            interactions, resolution_skips = await self._resolve_interactions(
+                source_mutations,
+                seen,
+            )
+            batch_inserted, batch_existing = await self._insert_interactions(
+                interactions
+            )
+            batch_skips.update(resolution_skips)
+
+            batches_processed += 1
+            batch_history_rows = sum(len(entries) for entries in histories.values())
+            sessions_scanned += len(sessions)
+            history_rows_scanned += batch_history_rows
+            mutation_candidates += len(source_mutations)
+            inserted += batch_inserted
+            existing += batch_existing
+            skipped.update(batch_skips)
+            after_surrogate_id = sessions[-1].surrogate_id
+
+            await self.session.commit()
+            logger.info(
+                "Processed case-agent interaction backfill batch",
+                batch_number=batches_processed,
+                sessions=len(sessions),
+                history_rows=batch_history_rows,
+                mutation_candidates=len(source_mutations),
+                inserted=batch_inserted,
+                existing=batch_existing,
+                skipped=sum(batch_skips.values()),
+            )
+
+        return CaseAgentSessionBackfillReport(
+            batches_processed=batches_processed,
+            sessions_scanned=sessions_scanned,
+            history_rows_scanned=history_rows_scanned,
+            mutation_candidates=mutation_candidates,
+            inserted=inserted,
+            existing=existing,
+            skipped=dict(sorted(skipped.items(), key=lambda item: item[0].value)),
+        )

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -39,6 +39,7 @@ from tracecat.logger import logger
 _CREATE_CASE = "core.cases.create_case"
 _UPDATE_COMMENT = "core.cases.update_comment"
 _HISTORY_FETCH_SIZE = 100
+_TARGET_LOOKUP_BATCH_SIZE = 1000
 _INTERACTION_INSERT_BATCH_SIZE = 1000
 # Successful case deletions leave no case row for the interaction foreign key.
 _CASE_ID_ACTIONS = frozenset(
@@ -500,24 +501,22 @@ class CaseAgentSessionBackfill:
             if mutation.target == "comment"
         }
         comment_cases: dict[tuple[uuid.UUID, uuid.UUID], uuid.UUID] = {}
-        if comment_keys:
+        for chunk in batched(comment_keys, _TARGET_LOOKUP_BATCH_SIZE):
             rows = (
                 await self.session.execute(
                     select(
                         CaseComment.workspace_id,
                         CaseComment.id,
                         CaseComment.case_id,
-                    ).where(
-                        tuple_(CaseComment.workspace_id, CaseComment.id).in_(
-                            comment_keys
-                        )
-                    )
+                    ).where(tuple_(CaseComment.workspace_id, CaseComment.id).in_(chunk))
                 )
             ).tuples()
-            comment_cases = {
-                (workspace_id, comment_id): case_id
-                for workspace_id, comment_id, case_id in rows
-            }
+            comment_cases.update(
+                {
+                    (workspace_id, comment_id): case_id
+                    for workspace_id, comment_id, case_id in rows
+                }
+            )
 
         skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
         resolved: list[_ResolvedMutation] = []
@@ -533,12 +532,12 @@ class CaseAgentSessionBackfill:
 
         case_keys = {(source.workspace_id, case_id) for source, _, case_id in resolved}
         existing_cases: set[tuple[uuid.UUID, uuid.UUID]] = set()
-        if case_keys:
-            existing_cases = set(
+        for chunk in batched(case_keys, _TARGET_LOOKUP_BATCH_SIZE):
+            existing_cases.update(
                 (
                     await self.session.execute(
                         select(Case.workspace_id, Case.id)
-                        .where(tuple_(Case.workspace_id, Case.id).in_(case_keys))
+                        .where(tuple_(Case.workspace_id, Case.id).in_(chunk))
                         .order_by(Case.workspace_id, Case.id)
                         .with_for_update(read=True, key_share=True)
                     )

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections import Counter, defaultdict
+from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -37,6 +37,7 @@ from tracecat.logger import logger
 
 _CREATE_CASE = "core.cases.create_case"
 _UPDATE_COMMENT = "core.cases.update_comment"
+_HISTORY_FETCH_SIZE = 100
 # Successful case deletions leave no case row for the interaction foreign key.
 _CASE_ID_ACTIONS = frozenset(
     {
@@ -226,67 +227,76 @@ def _is_failed_result(tool_result: Mapping[str, Any]) -> bool:
     return result is not None and result.get("success") is False
 
 
-def _history_content(entry: AgentSessionHistory) -> Mapping[str, Any]:
-    if entry.raw_session_line is not None:
+def _history_content(
+    content: Mapping[str, Any],
+    raw_session_line: bytes | None,
+) -> Mapping[str, Any]:
+    if raw_session_line is not None:
         try:
-            return decode_raw_session_line(entry.raw_session_line).content
+            return decode_raw_session_line(raw_session_line).content
         except (UnicodeDecodeError, ValueError):
             pass
-    return entry.content
+    return content
 
 
-def _parse_mutations(
-    entries: Sequence[AgentSessionHistory],
-    trusted_mcp_server_names: frozenset[str],
-) -> tuple[list[_Mutation], Counter[CaseAgentSessionBackfillSkipReason]]:
-    """Extract successful case mutations from ordered session history."""
-    pending: dict[str, _PendingMutation] = {}
-    mutations: list[_Mutation] = []
-    skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
+class _MutationParser:
+    """Incrementally match mutation tool calls with their results."""
 
-    for entry in entries:
-        content = _history_content(entry)
+    __slots__ = ("mutations", "pending", "skipped", "trusted_mcp_server_names")
+
+    def __init__(self, trusted_mcp_server_names: frozenset[str]) -> None:
+        self.trusted_mcp_server_names = trusted_mcp_server_names
+        self.pending: dict[str, _PendingMutation] = {}
+        self.mutations: list[_Mutation] = []
+        self.skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
+
+    def add(
+        self,
+        content: Mapping[str, Any],
+        raw_session_line: bytes | None,
+    ) -> None:
+        content = _history_content(content, raw_session_line)
         message = content.get("message")
         if not isinstance(message, dict):
-            continue
+            return
         blocks = message.get("content")
         if not isinstance(blocks, list):
-            continue
+            return
 
         if content.get("type") == "assistant":
             for block in blocks:
                 if not isinstance(block, dict) or block.get("type") != "tool_use":
                     continue
-                tool = _resolve_tool(block, trusted_mcp_server_names)
+                tool = _resolve_tool(block, self.trusted_mcp_server_names)
                 if tool is None:
                     continue
                 tool_call_id = block.get("id")
                 mutation = _pending_mutation(*tool)
                 if not isinstance(tool_call_id, str) or mutation is None:
-                    skipped[
+                    self.skipped[
                         CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL
                     ] += 1
                     continue
-                if tool_call_id in pending:
-                    skipped[
+                if tool_call_id in self.pending:
+                    self.skipped[
                         CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL
                     ] += 1
-                pending[tool_call_id] = mutation
-            continue
+                self.pending[tool_call_id] = mutation
+            return
 
         if content.get("type") != "user":
-            continue
+            return
         for block in blocks:
             if not isinstance(block, dict) or block.get("type") != "tool_result":
                 continue
             tool_call_id = block.get("tool_use_id")
             if not isinstance(tool_call_id, str):
                 continue
-            mutation = pending.pop(tool_call_id, None)
+            mutation = self.pending.pop(tool_call_id, None)
             if mutation is None:
                 continue
             if _is_failed_result(block):
-                skipped[CaseAgentSessionBackfillSkipReason.FAILED_TOOL_CALL] += 1
+                self.skipped[CaseAgentSessionBackfillSkipReason.FAILED_TOOL_CALL] += 1
                 continue
 
             target = mutation.target
@@ -296,9 +306,11 @@ def _parse_mutations(
                 result = _result_mapping(block.get("content"))
                 target_id = _parse_uuid(result.get("id")) if result else None
             if target is None or target_id is None:
-                skipped[CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL] += 1
+                self.skipped[
+                    CaseAgentSessionBackfillSkipReason.UNPARSEABLE_TOOL_CALL
+                ] += 1
                 continue
-            mutations.append(
+            self.mutations.append(
                 _Mutation(
                     target=target,
                     target_id=target_id,
@@ -306,9 +318,15 @@ def _parse_mutations(
                 )
             )
 
-    if pending:
-        skipped[CaseAgentSessionBackfillSkipReason.INCOMPLETE_TOOL_CALL] = len(pending)
-    return mutations, skipped
+    def finish(
+        self,
+    ) -> tuple[list[_Mutation], Counter[CaseAgentSessionBackfillSkipReason]]:
+        if self.pending:
+            self.skipped[CaseAgentSessionBackfillSkipReason.INCOMPLETE_TOOL_CALL] += (
+                len(self.pending)
+            )
+            self.pending.clear()
+        return self.mutations, self.skipped
 
 
 class CaseAgentSessionBackfill:
@@ -354,28 +372,51 @@ class CaseAgentSessionBackfill:
             for surrogate_id, session_id, workspace_id, agents_binding in rows
         ]
 
-    async def _load_histories(
+    async def _load_mutations(
         self,
         sessions: Sequence[_Session],
-    ) -> dict[uuid.UUID, list[AgentSessionHistory]]:
-        entries = (
-            await self.session.scalars(
-                select(AgentSessionHistory)
-                .where(
-                    AgentSessionHistory.session_id.in_(
-                        session.id for session in sessions
-                    )
-                )
-                .order_by(
-                    AgentSessionHistory.session_id,
-                    AgentSessionHistory.surrogate_id,
-                )
+        *,
+        on_progress: Callable[[], None] | None,
+    ) -> tuple[
+        list[_SourceMutation],
+        int,
+        Counter[CaseAgentSessionBackfillSkipReason],
+    ]:
+        """Stream history rows and parse mutations without retaining payloads."""
+        parsers = {
+            source.id: _MutationParser(source.trusted_mcp_server_names)
+            for source in sessions
+        }
+        result = await self.session.stream(
+            select(
+                AgentSessionHistory.session_id,
+                AgentSessionHistory.content,
+                AgentSessionHistory.raw_session_line,
             )
-        ).all()
-        histories: dict[uuid.UUID, list[AgentSessionHistory]] = defaultdict(list)
-        for entry in entries:
-            histories[entry.session_id].append(entry)
-        return histories
+            .where(
+                AgentSessionHistory.session_id.in_(session.id for session in sessions)
+            )
+            .order_by(
+                AgentSessionHistory.session_id,
+                AgentSessionHistory.surrogate_id,
+            )
+            .execution_options(yield_per=_HISTORY_FETCH_SIZE)
+        )
+        history_rows_scanned = 0
+        async for partition in result.partitions(_HISTORY_FETCH_SIZE):
+            for session_id, content, raw_session_line in partition:
+                parsers[session_id].add(content, raw_session_line)
+            history_rows_scanned += len(partition)
+            if on_progress is not None:
+                on_progress()
+
+        source_mutations: list[_SourceMutation] = []
+        skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
+        for source in sessions:
+            mutations, parse_skips = parsers[source.id].finish()
+            source_mutations.extend((source, mutation) for mutation in mutations)
+            skipped.update(parse_skips)
+        return source_mutations, history_rows_scanned, skipped
 
     async def _resolve_root_session_ids(
         self,
@@ -397,11 +438,14 @@ class CaseAgentSessionBackfill:
                         AgentSession.workspace_id,
                         AgentSession.id,
                         AgentSession.parent_session_id,
-                    ).where(
+                    )
+                    .where(
                         tuple_(AgentSession.workspace_id, AgentSession.id).in_(
                             session_keys
                         )
                     )
+                    .order_by(AgentSession.workspace_id, AgentSession.id)
+                    .with_for_update(read=True, key_share=True)
                 )
             ).tuples()
             parents = {
@@ -476,9 +520,10 @@ class CaseAgentSessionBackfill:
             existing_cases = set(
                 (
                     await self.session.execute(
-                        select(Case.workspace_id, Case.id).where(
-                            tuple_(Case.workspace_id, Case.id).in_(case_keys)
-                        )
+                        select(Case.workspace_id, Case.id)
+                        .where(tuple_(Case.workspace_id, Case.id).in_(case_keys))
+                        .order_by(Case.workspace_id, Case.id)
+                        .with_for_update(read=True, key_share=True)
                     )
                 )
                 .tuples()
@@ -552,7 +597,7 @@ class CaseAgentSessionBackfill:
         self,
         *,
         batch_size: int = 100,
-        on_batch_complete: Callable[[], None] | None = None,
+        on_progress: Callable[[], None] | None = None,
     ) -> CaseAgentSessionBackfillReport:
         """Run the restart-safe backfill, committing after each session batch."""
         if batch_size < 1:
@@ -571,16 +616,11 @@ class CaseAgentSessionBackfill:
             after_surrogate_id=after_surrogate_id,
             batch_size=batch_size,
         ):
-            histories = await self._load_histories(sessions)
-            source_mutations: list[_SourceMutation] = []
-            batch_skips: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
-            for source in sessions:
-                mutations, parse_skips = _parse_mutations(
-                    histories.get(source.id, []),
-                    source.trusted_mcp_server_names,
-                )
-                source_mutations.extend((source, mutation) for mutation in mutations)
-                batch_skips.update(parse_skips)
+            (
+                source_mutations,
+                batch_history_rows,
+                batch_skips,
+            ) = await self._load_mutations(sessions, on_progress=on_progress)
 
             interactions, resolution_skips = await self._resolve_interactions(
                 source_mutations
@@ -591,7 +631,6 @@ class CaseAgentSessionBackfill:
             batch_skips.update(resolution_skips)
 
             batches_processed += 1
-            batch_history_rows = sum(len(entries) for entries in histories.values())
             sessions_scanned += len(sessions)
             history_rows_scanned += batch_history_rows
             mutation_candidates += len(source_mutations)
@@ -601,8 +640,8 @@ class CaseAgentSessionBackfill:
             after_surrogate_id = sessions[-1].surrogate_id
 
             await self.session.commit()
-            if on_batch_complete is not None:
-                on_batch_complete()
+            if on_progress is not None:
+                on_progress()
             logger.info(
                 "Processed case-agent interaction backfill batch",
                 batch_number=batches_processed,

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -373,7 +373,6 @@ class CaseAgentSessionBackfill:
     async def _resolve_interactions(
         self,
         source_mutations: Sequence[_SourceMutation],
-        seen: set[_InteractionKey],
     ) -> tuple[set[_InteractionKey], Counter[CaseAgentSessionBackfillSkipReason]]:
         """Resolve comment targets, cases, and root sessions for one batch."""
         comment_keys = {
@@ -451,9 +450,7 @@ class CaseAgentSessionBackfill:
                 case_id,
                 mutation.operation,
             )
-            if interaction not in seen:
-                seen.add(interaction)
-                interactions.add(interaction)
+            interactions.add(interaction)
 
         return interactions, skipped
 
@@ -506,7 +503,6 @@ class CaseAgentSessionBackfill:
         inserted = 0
         existing = 0
         skipped: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
-        seen: set[_InteractionKey] = set()
 
         while sessions := await self._next_batch(
             after_surrogate_id=after_surrogate_id,
@@ -521,8 +517,7 @@ class CaseAgentSessionBackfill:
                 batch_skips.update(parse_skips)
 
             interactions, resolution_skips = await self._resolve_interactions(
-                source_mutations,
-                seen,
+                source_mutations
             )
             batch_inserted, batch_existing = await self._insert_interactions(
                 interactions

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -35,11 +35,22 @@ from tracecat.logger import logger
 
 _CREATE_CASE = "core.cases.create_case"
 _UPDATE_COMMENT = "core.cases.update_comment"
+# Successful case deletions leave no case row for the interaction foreign key.
 _CASE_ID_ACTIONS = frozenset(
     {
-        "core.cases.update_case",
+        "core.cases.add_case_tag",
+        "core.cases.assign_user",
+        "core.cases.assign_user_by_email",
         "core.cases.create_comment",
+        "core.cases.delete_attachment",
+        "core.cases.insert_row",
+        "core.cases.link_row",
+        "core.cases.remove_case_tag",
         "core.cases.reply_to_comment",
+        "core.cases.unlink_row",
+        "core.cases.update_case",
+        "core.cases.upload_attachment",
+        "core.cases.upload_attachment_from_url",
     }
 )
 _SUPPORTED_ACTIONS = _CASE_ID_ACTIONS | {_CREATE_CASE, _UPDATE_COMMENT}

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -15,11 +15,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.mcp.utils import normalize_mcp_tool_name
 from tracecat.agent.session.history import decode_raw_session_line
-from tracecat.auth.types import Role
-from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
-from tracecat.cases.agent_sessions.service import (
-    CaseAgentSessionInteractionService,
-)
 from tracecat.cases.agent_sessions.types import (
     CaseAgentSessionBackfillReport,
     CaseAgentSessionBackfillSkipReason,
@@ -31,9 +26,7 @@ from tracecat.db.models import (
     Case,
     CaseAgentSessionInteraction,
     CaseComment,
-    Workspace,
 )
-from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.logger import logger
 
 _CREATE_CASE = "core.cases.create_case"
@@ -67,7 +60,6 @@ class _Session:
     surrogate_id: int
     id: uuid.UUID
     workspace_id: uuid.UUID
-    organization_id: uuid.UUID
 
 
 type _SourceMutation = tuple[_Session, _Mutation]
@@ -286,9 +278,7 @@ class CaseAgentSessionBackfill:
                     AgentSession.surrogate_id,
                     AgentSession.id,
                     AgentSession.workspace_id,
-                    Workspace.organization_id,
                 )
-                .join(Workspace, Workspace.id == AgentSession.workspace_id)
                 .where(
                     AgentSession.surrogate_id > after_surrogate_id,
                     history_exists,
@@ -302,9 +292,8 @@ class CaseAgentSessionBackfill:
                 surrogate_id=surrogate_id,
                 id=session_id,
                 workspace_id=workspace_id,
-                organization_id=organization_id,
             )
-            for surrogate_id, session_id, workspace_id, organization_id in rows
+            for surrogate_id, session_id, workspace_id in rows
         ]
 
     async def _load_histories(
@@ -330,18 +319,56 @@ class CaseAgentSessionBackfill:
             histories[entry.session_id].append(entry)
         return histories
 
-    def _interaction_service(
+    async def _resolve_root_session_ids(
         self,
-        source: _Session,
-    ) -> CaseAgentSessionInteractionService:
-        role = Role(
-            type="service",
-            service_id="tracecat-service",
-            workspace_id=source.workspace_id,
-            organization_id=source.organization_id,
-            scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-service"],
-        )
-        return CaseAgentSessionInteractionService(self.session, role)
+        sources: set[_Session],
+    ) -> dict[_Session, uuid.UUID | None]:
+        """Resolve one lineage level at a time for every source in the batch."""
+        unresolved = {source: source.id for source in sources}
+        visited = {source: {source.id} for source in sources}
+        roots: dict[_Session, uuid.UUID | None] = {}
+
+        while unresolved:
+            session_keys = {
+                (source.workspace_id, session_id)
+                for source, session_id in unresolved.items()
+            }
+            rows = (
+                await self.session.execute(
+                    select(
+                        AgentSession.workspace_id,
+                        AgentSession.id,
+                        AgentSession.parent_session_id,
+                    ).where(
+                        tuple_(AgentSession.workspace_id, AgentSession.id).in_(
+                            session_keys
+                        )
+                    )
+                )
+            ).tuples()
+            parents = {
+                (workspace_id, session_id): parent_id
+                for workspace_id, session_id, parent_id in rows
+            }
+
+            next_level: dict[_Session, uuid.UUID] = {}
+            for source, session_id in unresolved.items():
+                key = (source.workspace_id, session_id)
+                if key not in parents:
+                    roots[source] = None
+                    continue
+
+                parent_id = parents[key]
+                if parent_id is None:
+                    roots[source] = session_id
+                elif parent_id in visited[source]:
+                    roots[source] = None
+                else:
+                    visited[source].add(parent_id)
+                    next_level[source] = parent_id
+            unresolved = next_level
+
+        return roots
 
     async def _resolve_interactions(
         self,
@@ -401,19 +428,18 @@ class CaseAgentSessionBackfill:
                 .all()
             )
 
-        root_ids: dict[_Session, uuid.UUID | None] = {}
-        interactions: set[_InteractionKey] = set()
+        valid: list[_ResolvedMutation] = []
         for source, mutation, case_id in resolved:
             if (source.workspace_id, case_id) not in existing_cases:
                 skipped[CaseAgentSessionBackfillSkipReason.MISSING_CASE] += 1
                 continue
-            if source not in root_ids:
-                try:
-                    root_ids[source] = await self._interaction_service(
-                        source
-                    ).resolve_root_session_id(source.id)
-                except (TracecatNotFoundError, TracecatValidationError):
-                    root_ids[source] = None
+            valid.append((source, mutation, case_id))
+
+        root_ids = await self._resolve_root_session_ids(
+            {source for source, _, _ in valid}
+        )
+        interactions: set[_InteractionKey] = set()
+        for source, mutation, case_id in valid:
             root_id = root_ids[source]
             if root_id is None:
                 skipped[CaseAgentSessionBackfillSkipReason.INVALID_SESSION_LINEAGE] += 1

--- a/tracecat/cases/agent_sessions/backfill.py
+++ b/tracecat/cases/agent_sessions/backfill.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 import orjson
+from pydantic import ValidationError
 from sqlalchemy import exists, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,6 +20,7 @@ from tracecat.agent.mcp.utils import (
     normalize_mcp_tool_name,
 )
 from tracecat.agent.session.history import decode_raw_session_line
+from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.cases.agent_sessions.types import (
     CaseAgentSessionBackfillReport,
     CaseAgentSessionBackfillSkipReason,
@@ -75,6 +77,7 @@ class _Session:
     surrogate_id: int
     id: uuid.UUID
     workspace_id: uuid.UUID
+    trusted_mcp_server_names: frozenset[str]
 
 
 type _SourceMutation = tuple[_Session, _Mutation]
@@ -98,7 +101,26 @@ def _parse_uuid(value: object) -> uuid.UUID | None:
         return None
 
 
-def _is_tracecat_owned_tool(name: str) -> bool:
+def _trusted_mcp_server_names(
+    agents_binding: dict[str, Any] | None,
+) -> frozenset[str]:
+    names = {REGISTRY_MCP_SERVER_NAME, LEGACY_REGISTRY_MCP_SERVER_NAME}
+    if agents_binding is None:
+        return frozenset(names)
+    try:
+        subagents = ResolvedAgentsConfig.model_validate(agents_binding).subagents
+    except ValidationError:
+        return frozenset(names)
+    for subagent in subagents:
+        names.add(f"{REGISTRY_MCP_SERVER_NAME}-{subagent.alias}")
+        names.add(f"{LEGACY_REGISTRY_MCP_SERVER_NAME}-{subagent.alias}")
+    return frozenset(names)
+
+
+def _is_tracecat_owned_tool(
+    name: str,
+    trusted_mcp_server_names: frozenset[str],
+) -> bool:
     """Reject tools routed through MCP servers Tracecat does not own."""
     for separator in ("__", "."):
         if not name.startswith(f"mcp{separator}"):
@@ -106,22 +128,19 @@ def _is_tracecat_owned_tool(name: str) -> bool:
         parts = name.split(separator, 2)
         if len(parts) != 3:
             return False
-        server_name = parts[1]
-        return server_name in {
-            REGISTRY_MCP_SERVER_NAME,
-            LEGACY_REGISTRY_MCP_SERVER_NAME,
-        } or server_name.startswith(
-            (f"{REGISTRY_MCP_SERVER_NAME}-", f"{LEGACY_REGISTRY_MCP_SERVER_NAME}-")
-        )
+        return parts[1] in trusted_mcp_server_names
     return True
 
 
 def _resolve_tool(
     block: Mapping[str, Any],
+    trusted_mcp_server_names: frozenset[str],
 ) -> tuple[str, Mapping[str, Any] | None] | None:
     """Resolve a supported direct or legacy wrapper tool call."""
     name = block.get("name")
-    if not isinstance(name, str) or not _is_tracecat_owned_tool(name):
+    if not isinstance(name, str) or not _is_tracecat_owned_tool(
+        name, trusted_mcp_server_names
+    ):
         return None
 
     action = normalize_mcp_tool_name(name)
@@ -134,7 +153,8 @@ def _resolve_tool(
             return None
         wrapped_name = arguments.get("tool_name")
         if not isinstance(wrapped_name, str) or not _is_tracecat_owned_tool(
-            wrapped_name
+            wrapped_name,
+            trusted_mcp_server_names,
         ):
             return None
         action = normalize_mcp_tool_name(wrapped_name)
@@ -217,6 +237,7 @@ def _history_content(entry: AgentSessionHistory) -> Mapping[str, Any]:
 
 def _parse_mutations(
     entries: Sequence[AgentSessionHistory],
+    trusted_mcp_server_names: frozenset[str],
 ) -> tuple[list[_Mutation], Counter[CaseAgentSessionBackfillSkipReason]]:
     """Extract successful case mutations from ordered session history."""
     pending: dict[str, _PendingMutation] = {}
@@ -236,7 +257,7 @@ def _parse_mutations(
             for block in blocks:
                 if not isinstance(block, dict) or block.get("type") != "tool_use":
                     continue
-                tool = _resolve_tool(block)
+                tool = _resolve_tool(block, trusted_mcp_server_names)
                 if tool is None:
                     continue
                 tool_call_id = block.get("id")
@@ -313,6 +334,7 @@ class CaseAgentSessionBackfill:
                     AgentSession.surrogate_id,
                     AgentSession.id,
                     AgentSession.workspace_id,
+                    AgentSession.agents_binding,
                 )
                 .where(
                     AgentSession.surrogate_id > after_surrogate_id,
@@ -327,8 +349,9 @@ class CaseAgentSessionBackfill:
                 surrogate_id=surrogate_id,
                 id=session_id,
                 workspace_id=workspace_id,
+                trusted_mcp_server_names=_trusted_mcp_server_names(agents_binding),
             )
-            for surrogate_id, session_id, workspace_id in rows
+            for surrogate_id, session_id, workspace_id, agents_binding in rows
         ]
 
     async def _load_histories(
@@ -552,7 +575,10 @@ class CaseAgentSessionBackfill:
             source_mutations: list[_SourceMutation] = []
             batch_skips: Counter[CaseAgentSessionBackfillSkipReason] = Counter()
             for source in sessions:
-                mutations, parse_skips = _parse_mutations(histories.get(source.id, []))
+                mutations, parse_skips = _parse_mutations(
+                    histories.get(source.id, []),
+                    source.trusted_mcp_server_names,
+                )
                 source_mutations.extend((source, mutation) for mutation in mutations)
                 batch_skips.update(parse_skips)
 

--- a/tracecat/cases/agent_sessions/types.py
+++ b/tracecat/cases/agent_sessions/types.py
@@ -1,0 +1,31 @@
+"""Types for case-agent session interaction backfills."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class CaseAgentSessionBackfillSkipReason(StrEnum):
+    """Machine-readable reasons a historical mutation was not recorded."""
+
+    FAILED_TOOL_CALL = "failed_tool_call"
+    INCOMPLETE_TOOL_CALL = "incomplete_tool_call"
+    UNPARSEABLE_TOOL_CALL = "unparseable_tool_call"
+    MISSING_CASE = "missing_case"
+    MISSING_COMMENT = "missing_comment"
+    INVALID_SESSION_LINEAGE = "invalid_session_lineage"
+
+
+@dataclass(frozen=True, slots=True)
+class CaseAgentSessionBackfillReport:
+    """Aggregate, payload-free report for one backfill run."""
+
+    batches_processed: int
+    sessions_scanned: int
+    history_rows_scanned: int
+    mutation_candidates: int
+    inserted: int
+    existing: int
+    skipped: Mapping[CaseAgentSessionBackfillSkipReason, int]

--- a/tracecat/cases/agent_sessions/workflow.py
+++ b/tracecat/cases/agent_sessions/workflow.py
@@ -21,7 +21,9 @@ class CaseAgentSessionBackfillWorkflow:
             case_agent_session_backfill_activity,
             start_to_close_timeout=timedelta(days=1),
             heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=RetryPolicy(maximum_attempts=3),
+            # Each batch commits independently. Failing the operation keeps its
+            # report honest; a later explicit rerun remains safe and idempotent.
+            retry_policy=RetryPolicy(maximum_attempts=1),
         )
 
 

--- a/tracecat/cases/agent_sessions/workflow.py
+++ b/tracecat/cases/agent_sessions/workflow.py
@@ -1,0 +1,38 @@
+"""Durable workflow for the case-agent interaction backfill."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from tracecat.cases.agent_sessions.types import CaseAgentSessionBackfillReport
+
+
+@workflow.defn
+class CaseAgentSessionBackfillWorkflow:
+    """Run the restart-safe backfill outside the HTTP request lifecycle."""
+
+    @workflow.run
+    async def run(self) -> CaseAgentSessionBackfillReport:
+        return await workflow.execute_activity(
+            case_agent_session_backfill_activity,
+            start_to_close_timeout=timedelta(days=1),
+            heartbeat_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+
+@activity.defn
+async def case_agent_session_backfill_activity() -> CaseAgentSessionBackfillReport:
+    """Run the backfill with an unrestricted system database session."""
+    from tracecat.cases.agent_sessions.backfill import CaseAgentSessionBackfill
+    from tracecat.db.engine import get_async_session_bypass_rls_context_manager
+
+    def heartbeat() -> None:
+        activity.heartbeat()
+
+    async with get_async_session_bypass_rls_context_manager() as session:
+        return await CaseAgentSessionBackfill(session).run(on_batch_complete=heartbeat)

--- a/tracecat/cases/agent_sessions/workflow.py
+++ b/tracecat/cases/agent_sessions/workflow.py
@@ -37,4 +37,4 @@ async def case_agent_session_backfill_activity() -> CaseAgentSessionBackfillRepo
         activity.heartbeat()
 
     async with get_async_session_bypass_rls_context_manager() as session:
-        return await CaseAgentSessionBackfill(session).run(on_batch_complete=heartbeat)
+        return await CaseAgentSessionBackfill(session).run(on_progress=heartbeat)

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -25,6 +25,10 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_version_ref_activity,
     )
+    from tracecat.cases.agent_sessions.workflow import (
+        CaseAgentSessionBackfillWorkflow,
+        case_agent_session_backfill_activity,
+    )
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.init_activities import (
@@ -89,6 +93,7 @@ def new_sandbox_runner() -> SandboxedWorkflowRunner:
 
 def get_activities() -> list[Callable]:
     activities: list[Callable] = [
+        case_agent_session_backfill_activity,
         *DSLActivities.load(),
         *CollectionActivities.get_activities(),
         resolve_agent_preset_version_ref_activity,
@@ -163,7 +168,10 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
 
     try:
         with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
-            workflows: list[type] = [DSLWorkflow]
+            workflows: list[type] = [
+                CaseAgentSessionBackfillWorkflow,
+                DSLWorkflow,
+            ]
 
             async with Worker(
                 client,

--- a/tracecat/executor/worker.py
+++ b/tracecat/executor/worker.py
@@ -52,10 +52,6 @@ with workflow.unsafe.imports_passed_through():
     import uvloop
 
     from tracecat import config
-    from tracecat.cases.agent_sessions.workflow import (
-        CaseAgentSessionBackfillWorkflow,
-        case_agent_session_backfill_activity,
-    )
     from tracecat.dsl.client import get_temporal_client
     from tracecat.executor.action_gateway.server import ActionGateway
     from tracecat.executor.action_runner import get_action_runner
@@ -154,14 +150,12 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
 
         # Collect all activities from executor and registry sync
         activities = [
-            case_agent_session_backfill_activity,
             *ExecutorActivities.get_activities(),
             *RegistrySyncActivities.get_activities(),
         ]
 
         # Collect all workflows
         workflows = [
-            CaseAgentSessionBackfillWorkflow,
             RegistrySyncWorkflow,
             RegistryArtifactsBackfillWorkflow,
         ]

--- a/tracecat/executor/worker.py
+++ b/tracecat/executor/worker.py
@@ -52,6 +52,10 @@ with workflow.unsafe.imports_passed_through():
     import uvloop
 
     from tracecat import config
+    from tracecat.cases.agent_sessions.workflow import (
+        CaseAgentSessionBackfillWorkflow,
+        case_agent_session_backfill_activity,
+    )
     from tracecat.dsl.client import get_temporal_client
     from tracecat.executor.action_gateway.server import ActionGateway
     from tracecat.executor.action_runner import get_action_runner
@@ -150,12 +154,17 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
 
         # Collect all activities from executor and registry sync
         activities = [
+            case_agent_session_backfill_activity,
             *ExecutorActivities.get_activities(),
             *RegistrySyncActivities.get_activities(),
         ]
 
         # Collect all workflows
-        workflows = [RegistrySyncWorkflow, RegistryArtifactsBackfillWorkflow]
+        workflows = [
+            CaseAgentSessionBackfillWorkflow,
+            RegistrySyncWorkflow,
+            RegistryArtifactsBackfillWorkflow,
+        ]
 
         logger.debug(
             "Activities loaded",


### PR DESCRIPTION
## Summary

- Backfill successful historical agent-driven case and child-resource mutations from persisted session history.
- Normalize continuation sessions to their root agent session with batched lineage reads and resolve comment mutations to the associated case.
- Run the platform maintenance operation as a durable Temporal workflow on the regular cluster worker; the superuser UI starts it, polls by operation ID, and prevents overlapping runs.
- Keep processing bounded, restart-safe, and idempotent with chunked target lookups and inserts, batch-local deduplication, heartbeats, and aggregate reporting.
- Fail partially committed activity attempts instead of retrying with reset counters; explicit reruns remain safe and accurately reported.
- Accept only the Tracecat registry and subagent-registry aliases persisted on each session when reconstructing mutations.

<img width="946" height="401" alt="Screenshot 2026-08-28 at 12 04 13 PM" src="https://github.com/user-attachments/assets/307fc10b-a34b-44c5-9c3b-10871999d977" />

## Scope

Records case creation and updates plus comment, assignment, tag, attachment, and linked-row mutations against surviving cases. Reads, case deletion, failed calls, incomplete calls, malformed history, non-Tracecat MCP tools, and missing entities are ignored without exposing payload data.

This PR is stacked on #3329, which records new case mutation interactions at write time.

Closes ENG-1711.

## Testing

- Focused stacked backend suite: 13 passed.
- High-level integration coverage verifies supported mutations, chunked target resolution and inserts, batched root-session normalization, batch-local idempotency, rejected external MCP origins, ignored failures/reads, and safe reruns.
- API coverage verifies durable workflow dispatch to the regular cluster queue, overlap prevention, status polling, and completed reports.
- Ruff, formatting, Basedpyright, generated client verification, Biome, frontend type checking, Gitleaks, and repository pre-commit hooks passed.

## Screenshots / Recordings

<!-- Paste the Platform → Maintenance screenshot here. -->

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 1112 | 7 |
| Tests | 477 | 2 |
| Generated | 207 | 0 |
