### PR TITLE
fix(api): restore fail-open Temporal attribute registration

### DIFF
--- a/tests/unit/test_temporal_search_attribute_registration.py
+++ b/tests/unit/test_temporal_search_attribute_registration.py
@@ -139,11 +139,12 @@ async def test_add_temporal_search_attributes_propagates_registration_failure(
         await single_attempt_add()
 
 
-def test_api_lifespan_waits_for_temporal_search_attributes() -> None:
+def test_api_lifespan_supervises_temporal_search_attribute_registration() -> None:
     source = inspect.getsource(lifespan)
 
-    assert "await add_temporal_search_attributes()" in source
-    assert "create_task(add_temporal_search_attributes())" not in source
+    assert "supervisor.spawn(\n        add_temporal_search_attributes()" in source
+    assert 'name="temporal_search_attribute_registration"' in source
+    assert "await add_temporal_search_attributes()" not in source
 
 
 @pytest.mark.anyio

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -184,12 +184,6 @@ async def lifespan(app: FastAPI):
     get_user_auth_secret()
     assert_soft_delete_listener_registered()
 
-    # Temporal
-    # Workflows may upsert these attributes as soon as the API accepts requests.
-    # Gate startup so a failed registration is retried and remains visible.
-    await add_temporal_search_attributes()
-    logger.debug("Temporal search attributes are ready")
-
     # Storage
     await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS)
     await ensure_bucket_exists(config.TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY)
@@ -217,6 +211,16 @@ async def lifespan(app: FastAPI):
     # shutdown. Critical work must still checkpoint to durable storage.
     supervisor = LifespanTaskSupervisor(
         drain_timeout=config.TRACECAT__API_TASK_DRAIN_TIMEOUT
+    )
+
+    # Temporal Cloud runtime credentials may not have operator-service access
+    # to inspect or register namespace search attributes. Keep registration
+    # supervised and visible without making that administrative permission a
+    # prerequisite for API availability.
+    supervisor.spawn(
+        add_temporal_search_attributes(),
+        name="temporal_search_attribute_registration",
+        kind="finite",
     )
 
     # Spawn platform registry sync as background task (non-blocking)


### PR DESCRIPTION
## Summary

- Restore fail-open Temporal search-attribute registration during API startup.
- Keep registration retries and failures visible through the lifespan task supervisor.
- Avoid requiring Temporal operator-service permissions before the API can become healthy.

## Root cause

The EU rc13 rollout made search-attribute registration blocking. The runtime Temporal credential could connect to Temporal but was not authorized to list namespace search attributes, so each new API pod remained in startup retries until its liveness probe terminated it. Older API pods continued serving traffic, which is why the UI received the previous global S3 upload URL even though the rc13 UI and MCP pods were healthy.

`TracecatErrorOwner` is already provisioned in EU Cloud. Registration should remain best-effort startup reconciliation, not a fail-closed availability gate. This change supervises that finite task so errors remain logged and shutdown remains bounded without blocking API readiness.

## Verification

- `uv run pytest tests/unit/test_temporal_search_attribute_registration.py tests/unit/test_api_lifespan.py -q` (19 passed)
- `uv run ruff check tracecat/api/app.py tests/unit/test_temporal_search_attribute_registration.py`
- `uv run ruff format --check tracecat/api/app.py tests/unit/test_temporal_search_attribute_registration.py`
- `uv run basedpyright tracecat/api/app.py tests/unit/test_temporal_search_attribute_registration.py` (0 errors)
- Commit hooks, including OpenAPI client generation and Python type checking

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 10 | 6 |
| Tests | 4 | 3 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores fail-open Temporal search-attribute registration so API startup no longer blocks when Cloud credentials lack operator access. Registration now runs as a supervised background task that logs failures without gating API readiness.

<sup>Written for commit a0dcbf5e9854d756de58f8d152e372c6059c628a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

