### PR TITLE
feat(registry): add plaintext alternative body for HTML emails

### DIFF
--- a/docs/automations/core-actions/request-actions/email.mdx
+++ b/docs/automations/core-actions/request-actions/email.mdx
@@ -114,6 +114,14 @@ Default: `false`.
 
 </ParamField>
 
+<ParamField path="plaintext_alternative" type="string | null">
+
+Plaintext alternative body for html emails. Defaults to 'This email requires an HTML viewer to display properly.' if not provided.
+
+Default: `null`.
+
+</ParamField>
+
 <ParamField path="reply_to" type="string | array[string] | null">
 
 Email address(es) to be used in the Reply-To field

--- a/packages/tracecat-registry/tracecat_registry/core/email.py
+++ b/packages/tracecat-registry/tracecat_registry/core/email.py
@@ -44,6 +44,7 @@ def _build_email_message(
     headers: dict[str, str] | None = None,
     sender_prefix: str | None = None,
     allowed_attributes: dict[str, list[str]] | None = None,
+    plaintext_alternative: str | None = None,
 ) -> EmailMessage:
     msg = EmailMessage()
 
@@ -51,9 +52,13 @@ def _build_email_message(
     if content_type == "text/html":
         # Follow MIME standards for HTML emails
         # https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
-        msg.add_alternative(
-            "This email requires an HTML viewer to display properly.", subtype="plain"
-        )
+        if plaintext_alternative is not None:
+            msg.add_alternative(plaintext_alternative, subtype="plain")
+        else:
+            msg.add_alternative(
+                "This email requires an HTML viewer to display properly.",
+                subtype="plain",
+            )
         if allowed_attributes:
             attrs = deepcopy(nh3.ALLOWED_ATTRIBUTES)
             for tag, attributes in allowed_attributes.items():
@@ -122,6 +127,13 @@ def send_email_smtp(
             "Email content type ('text/plain' or 'text/html'). Defaults to 'text/plain'."
         ),
     ] = "text/plain",
+    plaintext_alternative: Annotated[
+        str | None,
+        Doc(
+            "Plaintext alternative body for html emails. Defaults to 'This email "
+            "requires an HTML viewer to display properly.' if not provided."
+        ),
+    ] = None,
     # Additional recipients
     bcc: Annotated[
         str | list[str] | None,
@@ -182,6 +194,9 @@ def send_email_smtp(
     Entry entry contains a tuple of the SMTP error code and the accompanying error message sent by the server.
     """
 
+    if content_type == "text/plain" and plaintext_alternative is not None:
+        raise ValueError("Plaintext alternative only supported for HTML emails")
+
     timeout = timeout or socket.getdefaulttimeout() or 10.0
     smtp_host = secrets.get("SMTP_HOST")
     smtp_port = secrets.get("SMTP_PORT")
@@ -207,6 +222,7 @@ def send_email_smtp(
         sender=sender,
         subject=subject,
         allowed_attributes=allowed_attributes,
+        plaintext_alternative=plaintext_alternative,
     )
 
     context = ssl.create_default_context()


### PR DESCRIPTION
## Summary

Adds an optional `plaintext_alternative` input to `core.send_email_smtp`. When
`content_type` is `text/html`, its value becomes the `text/plain` part of the
`multipart/alternative` message instead of the generic placeholder.

Behavior is unchanged when the input is omitted: HTML emails still fall back to
"This email requires an HTML viewer to display properly." Passing
`plaintext_alternative` with `content_type: text/plain` raises, since a
plain-text email has no alternative part to fill.

`docs/automations/core-actions/request-actions/email.mdx` is regenerated output
from `scripts/generate_core_action_docs.py`, not a hand edit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `plaintext_alternative` input to `core.send_email_smtp` so HTML emails can carry a real plaintext body instead of the generic fallback.

- Behavior is unchanged when the input is omitted; HTML emails still fall back to "This email requires an HTML viewer to display properly."
- Passing `plaintext_alternative` with `content_type: text/plain` raises a `ValueError`.
- The docs change is regenerated output from `scripts/generate_core_action_docs.py`, not a hand edit.

<sup>Written for commit e3855553967eaa9236a8723b6c5a7ce2104aa4e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

