### PR TITLE
feat(inbox): filter agent runs by case

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -8295,6 +8295,7 @@ export const inboxGetPendingCount = (
  * @param data.orderBy Column name to order by (created_at, updated_at)
  * @param data.sort Sort direction (asc or desc)
  * @param data.search Case-insensitive search on item title
+ * @param data.caseId Filter items to root sessions associated with this case
  * @param data.group Filter items to a single display group
  * @param data.entityType Filter items to a single entity type
  * @param data.createdAfter Only items created at or after this time (ISO 8601)
@@ -8318,6 +8319,7 @@ export const inboxListItems = (
       order_by: data.orderBy,
       sort: data.sort,
       search: data.search,
+      case_id: data.caseId,
       group: data.group,
       entity_type: data.entityType,
       created_after: data.createdAfter,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -12661,6 +12661,10 @@ export type InboxGetPendingCountResponse = InboxPendingCount
 
 export type InboxListItemsData = {
   /**
+   * Filter items to root sessions associated with this case
+   */
+  caseId?: string | null
+  /**
    * Only items created at or after this time (ISO 8601)
    */
   createdAfter?: string | null

--- a/packages/tracecat-ee/tracecat_ee/inbox/providers/agent_runs.py
+++ b/packages/tracecat-ee/tracecat_ee/inbox/providers/agent_runs.py
@@ -18,7 +18,13 @@ from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.db.models import AgentSession, Approval, User, Workflow
+from tracecat.db.models import (
+    AgentSession,
+    Approval,
+    CaseAgentSessionInteraction,
+    User,
+    Workflow,
+)
 from tracecat.dsl.client import get_temporal_client
 from tracecat.inbox.schemas import InboxItemRead, UserSummary, WorkflowSummary
 from tracecat.inbox.types import InboxGroup, InboxItemStatus, InboxItemType
@@ -175,6 +181,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
         self,
         search: str | None,
         *,
+        case_id: uuid.UUID | None = None,
         entity_type: AgentSessionEntity | None = None,
         created_after: datetime | None = None,
         updated_after: datetime | None = None,
@@ -201,6 +208,18 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
                 has_approvals,
             ),
         )
+
+        if case_id is not None:
+            has_case_interaction = (
+                select(CaseAgentSessionInteraction.id)
+                .where(
+                    CaseAgentSessionInteraction.workspace_id == self.workspace_id,
+                    CaseAgentSessionInteraction.case_id == case_id,
+                    CaseAgentSessionInteraction.agent_session_id == AgentSession.id,
+                )
+                .exists()
+            )
+            base_stmt = base_stmt.where(has_case_interaction)
 
         if entity_type is not None:
             base_stmt = base_stmt.where(AgentSession.entity_type == entity_type)
@@ -264,6 +283,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
         search: str | None = None,
+        case_id: uuid.UUID | None = None,
         group: InboxGroup | None = None,
         entity_type: AgentSessionEntity | None = None,
         created_after: datetime | None = None,
@@ -278,6 +298,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
                 order_by=order_by,
                 sort=sort,
                 search=search,
+                case_id=case_id,
                 group=group,
                 entity_type=entity_type,
                 created_after=created_after,
@@ -286,6 +307,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
 
         base_stmt = self._base_query(
             search,
+            case_id=case_id,
             entity_type=entity_type,
             created_after=created_after,
             updated_after=updated_after,
@@ -535,6 +557,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
         sort: Literal["asc", "desc"] | None,
         search: str | None,
         group: InboxGroup,
+        case_id: uuid.UUID | None = None,
         entity_type: AgentSessionEntity | None = None,
         created_after: datetime | None = None,
         updated_after: datetime | None = None,
@@ -563,6 +586,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
 
         base_stmt = self._base_query(
             search,
+            case_id=case_id,
             entity_type=entity_type,
             created_after=created_after,
             updated_after=updated_after,

--- a/tests/integration/test_agent_runs_inbox_case_filter.py
+++ b/tests/integration/test_agent_runs_inbox_case_filter.py
@@ -1,0 +1,169 @@
+"""Integration coverage for case-filtered agent runs."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.inbox.providers.agent_runs import AgentRunsInboxProvider
+
+from tracecat.agent.common.stream_types import HarnessType
+from tracecat.auth.types import Role
+from tracecat.cases.enums import (
+    CaseAgentSessionInteractionOperation,
+    CasePriority,
+    CaseSeverity,
+    CaseStatus,
+)
+from tracecat.db.models import (
+    AgentSession,
+    Case,
+    CaseAgentSessionInteraction,
+    Workspace,
+)
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.integration,
+    pytest.mark.usefixtures("db"),
+]
+
+
+def _case(workspace_id: uuid.UUID, case_number: int) -> Case:
+    return Case(
+        workspace_id=workspace_id,
+        case_number=case_number,
+        summary=f"Case {case_number}",
+        description="Inbox case-filter test",
+        status=CaseStatus.NEW,
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.LOW,
+    )
+
+
+def _agent_session(
+    workspace_id: uuid.UUID,
+    title: str,
+    created_at: datetime,
+    *,
+    entity_id: uuid.UUID,
+) -> AgentSession:
+    return AgentSession(
+        workspace_id=workspace_id,
+        title=title,
+        entity_type="case",
+        entity_id=entity_id,
+        harness_type=HarnessType.CLAUDE_CODE,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+async def test_case_filter_is_scoped_deduplicated_and_paginated(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Exercise filtering, deduplication, and keyset paging in one DB scenario."""
+    assert svc_role.workspace_id is not None
+    assert svc_role.organization_id is not None
+    workspace_id = svc_role.workspace_id
+    target_case = _case(workspace_id, 1712)
+    other_case = _case(workspace_id, 1713)
+    session.add_all([target_case, other_case])
+    await session.flush()
+
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    first, second, unrelated = [
+        _agent_session(
+            workspace_id,
+            title,
+            base_time + timedelta(minutes=index),
+            entity_id=target_case.id if index < 2 else other_case.id,
+        )
+        for index, title in enumerate(["First", "Second", "Unrelated"])
+    ]
+    session.add_all([first, second, unrelated])
+    await session.flush()
+
+    for agent_session in [first, second]:
+        session.add(
+            CaseAgentSessionInteraction(
+                workspace_id=workspace_id,
+                case_id=target_case.id,
+                agent_session_id=agent_session.id,
+                operation=CaseAgentSessionInteractionOperation.UPDATE,
+            )
+        )
+    # A second operation for one session must not duplicate the inbox row.
+    session.add(
+        CaseAgentSessionInteraction(
+            workspace_id=workspace_id,
+            case_id=target_case.id,
+            agent_session_id=second.id,
+            operation=CaseAgentSessionInteractionOperation.CREATE,
+        )
+    )
+    session.add(
+        CaseAgentSessionInteraction(
+            workspace_id=workspace_id,
+            case_id=other_case.id,
+            agent_session_id=unrelated.id,
+            operation=CaseAgentSessionInteractionOperation.UPDATE,
+        )
+    )
+
+    foreign_workspace = Workspace(
+        name="other-workspace",
+        organization_id=svc_role.organization_id,
+    )
+    session.add(foreign_workspace)
+    await session.flush()
+    foreign_case = _case(foreign_workspace.id, 1712)
+    session.add(foreign_case)
+    await session.flush()
+    foreign_session = _agent_session(
+        foreign_workspace.id,
+        "Foreign",
+        base_time,
+        entity_id=foreign_case.id,
+    )
+    session.add(foreign_session)
+    await session.flush()
+    session.add(
+        CaseAgentSessionInteraction(
+            workspace_id=foreign_workspace.id,
+            case_id=foreign_case.id,
+            agent_session_id=foreign_session.id,
+            operation=CaseAgentSessionInteractionOperation.UPDATE,
+        )
+    )
+    await session.commit()
+
+    provider = AgentRunsInboxProvider(session, svc_role)
+
+    first_page = await provider.list_items(
+        case_id=target_case.id,
+        limit=1,
+        order_by="created_at",
+        sort="asc",
+    )
+    assert [item.source_id for item in first_page.items] == [first.id]
+    assert first_page.has_more is True
+    assert first_page.next_cursor is not None
+
+    second_page = await provider.list_items(
+        case_id=target_case.id,
+        limit=1,
+        cursor=first_page.next_cursor,
+        order_by="created_at",
+        sort="asc",
+    )
+    assert [item.source_id for item in second_page.items] == [second.id]
+    assert second_page.has_more is False
+
+    unfiltered = await provider.list_items(limit=10)
+    assert unrelated.id in {item.source_id for item in unfiltered.items}
+    isolated = await provider.list_items(case_id=foreign_case.id)
+    assert isolated.items == []

--- a/tests/unit/api/test_api_inbox.py
+++ b/tests/unit/api/test_api_inbox.py
@@ -1,0 +1,50 @@
+"""HTTP coverage for Inbox endpoints."""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+import tracecat.inbox.router as inbox_router_module
+from tracecat.auth.types import Role
+from tracecat.pagination import CursorPaginatedResponse
+
+
+@pytest.mark.anyio
+async def test_list_items_forwards_optional_case_filter(
+    client: TestClient,
+    test_role: Role,
+) -> None:
+    """The router parses case_id as a UUID and preserves the unfiltered path."""
+    assert test_role.workspace_id is not None
+    case_id = uuid.uuid4()
+    provider = SimpleNamespace(
+        list_items=AsyncMock(
+            return_value=CursorPaginatedResponse(
+                items=[],
+                next_cursor=None,
+                prev_cursor=None,
+                has_more=False,
+                has_previous=False,
+                total_estimate=None,
+            )
+        )
+    )
+    path = f"/workspaces/{test_role.workspace_id}/inbox/items"
+
+    with patch.object(
+        inbox_router_module,
+        "get_inbox_provider",
+        return_value=provider,
+    ):
+        filtered = client.get(path, params={"case_id": str(case_id)})
+        unfiltered = client.get(path)
+
+    assert filtered.status_code == status.HTTP_200_OK
+    assert unfiltered.status_code == status.HTTP_200_OK
+    calls = provider.list_items.await_args_list
+    assert calls[0].kwargs["case_id"] == case_id
+    assert calls[1].kwargs["case_id"] is None

--- a/tests/unit/test_agent_runs_inbox_provider.py
+++ b/tests/unit/test_agent_runs_inbox_provider.py
@@ -116,11 +116,13 @@ async def test_grouped_list_items_passes_reverse(
     )
     grouped = AsyncMock(return_value=expected)
     monkeypatch.setattr(provider, "_list_items_grouped", grouped)
+    case_id = uuid.uuid4()
 
     page = await provider.list_items(
         limit=10,
         cursor="cursor",
         reverse=True,
+        case_id=case_id,
         group=InboxGroup.COMPLETED,
     )
 
@@ -129,6 +131,7 @@ async def test_grouped_list_items_passes_reverse(
     await_args = grouped.await_args
     assert await_args is not None
     assert await_args.kwargs["reverse"] is True
+    assert await_args.kwargs["case_id"] == case_id
 
 
 @pytest.mark.anyio
@@ -417,8 +420,10 @@ async def test_ungrouped_list_applies_entity_type_and_date_filters() -> None:
 
     created_after = datetime(2026, 1, 1, tzinfo=UTC)
     updated_after = datetime(2026, 2, 1, tzinfo=UTC)
+    case_id = uuid.uuid4()
     await provider.list_items(
         limit=10,
+        case_id=case_id,
         entity_type=AgentSessionEntity.CASE,
         created_after=created_after,
         updated_after=updated_after,
@@ -428,6 +433,37 @@ async def test_ungrouped_list_applies_entity_type_and_date_filters() -> None:
     assert "agent_session.entity_type =" in compiled
     assert "agent_session.created_at >=" in compiled
     assert "agent_session.updated_at >=" in compiled
+    assert "case_agent_session_interaction.workspace_id =" in compiled
+    assert "case_agent_session_interaction.case_id =" in compiled
+    assert "case_agent_session_interaction.agent_session_id = agent_session.id" in (
+        compiled
+    )
+
+
+@pytest.mark.parametrize("group", list(InboxGroup))
+@pytest.mark.anyio
+async def test_grouped_list_applies_case_filter(group: InboxGroup) -> None:
+    """Every grouped scan inherits the case EXISTS predicate."""
+    session = _RecordingSession()
+    provider = AgentRunsInboxProvider(cast(AsyncSession, session), _role())
+
+    await provider._list_items_grouped(
+        limit=10,
+        cursor=None,
+        reverse=False,
+        order_by=None,
+        sort=None,
+        search=None,
+        case_id=uuid.uuid4(),
+        group=group,
+    )
+
+    compiled = str(session.statements[-1].compile())
+    assert "case_agent_session_interaction.workspace_id =" in compiled
+    assert "case_agent_session_interaction.case_id =" in compiled
+    assert "case_agent_session_interaction.agent_session_id = agent_session.id" in (
+        compiled
+    )
 
 
 @pytest.mark.anyio
@@ -546,3 +582,4 @@ async def test_unfiltered_list_omits_optional_predicates() -> None:
     assert "agent_session.entity_type =" not in compiled
     assert "agent_session.created_at >=" not in compiled
     assert "agent_session.updated_at >=" not in compiled
+    assert "case_agent_session_interaction" not in compiled

--- a/tests/unit/test_inbox_service.py
+++ b/tests/unit/test_inbox_service.py
@@ -36,6 +36,7 @@ class _InboxProvider:
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
         search: str | None = None,
+        case_id: uuid.UUID | None = None,
         group: InboxGroup | None = None,
         entity_type: AgentSessionEntity | None = None,
         created_after: datetime | None = None,
@@ -49,6 +50,7 @@ class _InboxProvider:
                 "order_by": order_by,
                 "sort": sort,
                 "search": search,
+                "case_id": case_id,
                 "group": group,
                 "entity_type": entity_type,
                 "created_after": created_after,
@@ -120,6 +122,7 @@ async def test_list_items_passes_arguments_through_to_provider() -> None:
 
     created_after = datetime(2026, 1, 1, tzinfo=UTC)
     updated_after = datetime(2026, 2, 1, tzinfo=UTC)
+    case_id = uuid.uuid4()
     page = await service.list_items(
         limit=5,
         cursor="cur",
@@ -127,6 +130,7 @@ async def test_list_items_passes_arguments_through_to_provider() -> None:
         order_by="updated_at",
         sort="asc",
         search="needle",
+        case_id=case_id,
         group=InboxGroup.COMPLETED,
         entity_type=AgentSessionEntity.CASE,
         created_after=created_after,
@@ -143,6 +147,7 @@ async def test_list_items_passes_arguments_through_to_provider() -> None:
             "order_by": "updated_at",
             "sort": "asc",
             "search": "needle",
+            "case_id": case_id,
             "group": InboxGroup.COMPLETED,
             "entity_type": AgentSessionEntity.CASE,
             "created_after": created_after,

--- a/tracecat/inbox/router.py
+++ b/tracecat/inbox/router.py
@@ -1,5 +1,6 @@
 """Inbox API router."""
 
+import uuid
 from datetime import datetime
 from typing import Literal
 
@@ -58,6 +59,10 @@ async def list_items(
         max_length=200,
         description="Case-insensitive search on item title",
     ),
+    case_id: uuid.UUID | None = Query(
+        default=None,
+        description="Filter items to root sessions associated with this case",
+    ),
     group: InboxGroup | None = Query(
         default=None,
         description="Filter items to a single display group",
@@ -103,6 +108,7 @@ async def list_items(
             order_by=order_by,
             sort=sort,
             search=search,
+            case_id=case_id,
             group=group,
             entity_type=entity_type,
             created_after=created_after,

--- a/tracecat/inbox/service.py
+++ b/tracecat/inbox/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING, Literal
 
 from tracecat.service import BaseWorkspaceService
@@ -46,6 +47,7 @@ class InboxService(BaseWorkspaceService):
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
         search: str | None = None,
+        case_id: uuid.UUID | None = None,
         group: InboxGroup | None = None,
         entity_type: AgentSessionEntity | None = None,
         created_after: datetime | None = None,
@@ -59,6 +61,7 @@ class InboxService(BaseWorkspaceService):
             order_by=order_by,
             sort=sort,
             search=search,
+            case_id=case_id,
             group=group,
             entity_type=entity_type,
             created_after=created_after,

--- a/tracecat/inbox/types.py
+++ b/tracecat/inbox/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from enum import StrEnum
 from typing import TYPE_CHECKING, Literal, Protocol
 
@@ -61,6 +62,7 @@ class InboxProvider(Protocol):
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
         search: str | None = None,
+        case_id: uuid.UUID | None = None,
         group: InboxGroup | None = None,
         entity_type: AgentSessionEntity | None = None,
         created_after: datetime | None = None,


### PR DESCRIPTION
## Summary

- Add an optional `case_id` filter to `GET /inbox/items` and thread it through the Inbox service/provider boundary.
- Filter agent runs with a workspace-scoped correlated `EXISTS` query before grouping and cursor pagination.
- Preserve the unfiltered response and avoid duplicate runs when a session has multiple case interactions.
- Regenerate the typed frontend client with the new query parameter.

## Testing

- Database integration coverage for filtering, deduplication, pagination, omitted-filter behavior, and workspace isolation.
- Parameterized provider coverage for review-required, running, error, and completed groups.
- HTTP forwarding coverage for present and omitted `case_id` values.
- Focused test suite: 22 passed.
- Ruff, basedpyright, Biome, and TypeScript checks passed.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 36 | 1 |
| Tests | 261 | 0 |
| Generated | 6 | 0 |

## Stack

- Depends on #3335.

## Related issue

- [ENG-1712](https://linear.app/tracecat/issue/ENG-1712/add-case-filtering-to-the-inbox-agent-runs-api)
