### PR TITLE
refactor(agents): make preset topology head-owned

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,13 @@ repos:
           - --verbose
       - id: ruff-format
         verbose: true
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: 4.3.0
+    hooks:
+      - id: sqlfluff-lint
+        name: parse PostgreSQL migration assets
+        args: [--dialect, postgres, --rules, LT12]
+        files: ^alembic/sql/.*\.sql$
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.25.1
     hooks:

--- a/alembic/sql/a8e1f7c3b2d9/backfill.sql
+++ b/alembic/sql/a8e1f7c3b2d9/backfill.sql
@@ -1,3 +1,9 @@
+-- This asset runs after the migration has locked every topology source and
+-- existing target. All validation and writes share the Alembic transaction, so
+-- any raised exception rolls back the schema change and the entire backfill.
+
+-- A live head may only read topology from a current version that belongs to it
+-- and to the same workspace. Reject corrupt pointers before resolving edges.
 DO $$
 BEGIN
     IF EXISTS (
@@ -18,6 +24,10 @@ BEGIN
     END IF;
 END $$;
 
+-- Resolve the desired subagent head edges once into a transaction-local table.
+-- Prefer the immutable current-version projection; parent.agents supports heads
+-- that have not created a version yet. Explicit preset IDs take precedence over
+-- legacy slugs, and a slug is accepted only when it identifies exactly one head.
 CREATE TEMP TABLE _agent_preset_subagent_backfill
 ON COMMIT DROP AS
 WITH current_topology AS (
@@ -80,6 +90,9 @@ LEFT JOIN LATERAL (
         AND candidate.deleted_at IS NULL
 ) AS child_by_slug ON TRUE;
 
+-- Fail closed before inserting anything. NULL child IDs include missing,
+-- deleted, ambiguous, and cross-workspace references; aliases must also remain
+-- unique within the same parent because they are the runtime lookup key.
 DO $$
 BEGIN
     IF EXISTS (
@@ -101,6 +114,7 @@ BEGIN
     END IF;
 END $$;
 
+-- The target table is new, so this is a straight snapshot insert.
 INSERT INTO agent_preset_subagent (
     id,
     parent_preset_id,
@@ -121,6 +135,9 @@ SELECT
 FROM _agent_preset_subagent_backfill
 ORDER BY parent_id, alias;
 
+-- Skill edges already have a head-owned table. Validate every current-version
+-- edge and its concrete immutable skill version before replacing that table's
+-- active-parent projection.
 DO $$
 BEGIN
     IF EXISTS (
@@ -149,6 +166,9 @@ BEGIN
     END IF;
 END $$;
 
+-- Remove head edges no longer present in the current legacy projection. Keep
+-- rows for deleted heads and heads without a current version untouched; they do
+-- not participate in the live topology snapshot.
 DELETE FROM agent_preset_skill AS head_edge
 USING agent_preset AS preset
 WHERE preset.workspace_id = head_edge.workspace_id
@@ -163,6 +183,8 @@ WHERE preset.workspace_id = head_edge.workspace_id
             AND version_edge.skill_id = head_edge.skill_id
     );
 
+-- Insert missing head edges and update the concrete version pinned by existing
+-- ones. Legacy version-owned edges remain unchanged for application rollback.
 INSERT INTO agent_preset_skill (
     id,
     preset_id,

--- a/alembic/sql/a8e1f7c3b2d9/backfill.sql
+++ b/alembic/sql/a8e1f7c3b2d9/backfill.sql
@@ -1,0 +1,185 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM agent_preset AS preset
+        LEFT JOIN agent_preset_version AS current_version
+            ON current_version.id = preset.current_version_id
+        WHERE preset.deleted_at IS NULL
+            AND preset.current_version_id IS NOT NULL
+            AND (
+                current_version.id IS NULL
+                OR current_version.workspace_id <> preset.workspace_id
+                OR current_version.preset_id <> preset.id
+            )
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot normalize agent preset topology: invalid current preset version';
+    END IF;
+END $$;
+
+CREATE TEMP TABLE _agent_preset_subagent_backfill
+ON COMMIT DROP AS
+WITH current_topology AS (
+    SELECT
+        parent.id AS parent_id,
+        parent.workspace_id,
+        COALESCE(current_version.agents, parent.agents) AS agents
+    FROM agent_preset AS parent
+    LEFT JOIN agent_preset_version AS current_version
+        ON current_version.workspace_id = parent.workspace_id
+        AND current_version.id = parent.current_version_id
+    WHERE parent.deleted_at IS NULL
+),
+refs AS (
+    SELECT
+        topology.parent_id,
+        topology.workspace_id,
+        ref.value AS ref
+    FROM current_topology AS topology
+    CROSS JOIN LATERAL jsonb_array_elements(
+        CASE
+            WHEN jsonb_typeof(topology.agents -> 'subagents') = 'array'
+                THEN topology.agents -> 'subagents'
+            ELSE '[]'::jsonb
+        END
+    ) AS ref(value)
+)
+SELECT
+    refs.parent_id,
+    refs.workspace_id,
+    CASE
+        WHEN refs.ref ->> 'preset_id' IS NOT NULL THEN child_by_id.id
+        WHEN child_by_slug.match_count = 1 THEN child_by_slug.child_id
+        ELSE NULL
+    END AS child_id,
+    COALESCE(NULLIF(refs.ref ->> 'name', ''), refs.ref ->> 'preset') AS alias,
+    refs.ref ->> 'description' AS description,
+    CASE
+        WHEN jsonb_typeof(refs.ref -> 'max_turns') = 'number'
+            THEN (refs.ref ->> 'max_turns')::integer
+        ELSE NULL
+    END AS max_turns
+FROM refs
+LEFT JOIN agent_preset AS child_by_id
+    ON child_by_id.workspace_id = refs.workspace_id
+    AND child_by_id.deleted_at IS NULL
+    AND child_by_id.id = CASE
+        WHEN refs.ref ->> 'preset_id' ~*
+            '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+            THEN (refs.ref ->> 'preset_id')::uuid
+        ELSE NULL
+    END
+LEFT JOIN LATERAL (
+    SELECT
+        (array_agg(candidate.id ORDER BY candidate.id))[1] AS child_id,
+        count(*) AS match_count
+    FROM agent_preset AS candidate
+    WHERE candidate.workspace_id = refs.workspace_id
+        AND candidate.slug = refs.ref ->> 'preset'
+        AND candidate.deleted_at IS NULL
+) AS child_by_slug ON TRUE;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM _agent_preset_subagent_backfill
+        WHERE child_id IS NULL OR alias IS NULL
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot normalize agent preset topology: unresolved or cross-workspace subagent head';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM _agent_preset_subagent_backfill
+        GROUP BY workspace_id, parent_id, alias
+        HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot normalize agent preset topology: duplicate subagent alias';
+    END IF;
+END $$;
+
+INSERT INTO agent_preset_subagent (
+    id,
+    parent_preset_id,
+    child_preset_id,
+    alias,
+    description,
+    max_turns,
+    workspace_id
+)
+SELECT
+    gen_random_uuid(),
+    parent_id,
+    child_id,
+    alias,
+    description,
+    max_turns,
+    workspace_id
+FROM _agent_preset_subagent_backfill
+ORDER BY parent_id, alias;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM agent_preset AS preset
+        JOIN agent_preset_version_skill AS version_edge
+            ON version_edge.preset_version_id = preset.current_version_id
+        LEFT JOIN skill
+            ON skill.id = version_edge.skill_id
+        LEFT JOIN skill_version
+            ON skill_version.id = version_edge.skill_version_id
+        WHERE preset.deleted_at IS NULL
+            AND (
+                version_edge.workspace_id <> preset.workspace_id
+                OR skill.id IS NULL
+                OR skill.workspace_id <> preset.workspace_id
+                OR skill.deleted_at IS NOT NULL
+                OR skill.archived_at IS NOT NULL
+                OR skill_version.id IS NULL
+                OR skill_version.workspace_id <> preset.workspace_id
+                OR skill_version.skill_id <> skill.id
+            )
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot normalize agent preset topology: unresolved or cross-workspace skill head';
+    END IF;
+END $$;
+
+DELETE FROM agent_preset_skill AS head_edge
+USING agent_preset AS preset
+WHERE preset.workspace_id = head_edge.workspace_id
+    AND preset.id = head_edge.preset_id
+    AND preset.deleted_at IS NULL
+    AND preset.current_version_id IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM agent_preset_version_skill AS version_edge
+        WHERE version_edge.workspace_id = head_edge.workspace_id
+            AND version_edge.preset_version_id = preset.current_version_id
+            AND version_edge.skill_id = head_edge.skill_id
+    );
+
+INSERT INTO agent_preset_skill (
+    id,
+    preset_id,
+    skill_id,
+    skill_version_id,
+    workspace_id
+)
+SELECT
+    gen_random_uuid(),
+    preset.id,
+    version_edge.skill_id,
+    version_edge.skill_version_id,
+    preset.workspace_id
+FROM agent_preset AS preset
+JOIN agent_preset_version_skill AS version_edge
+    ON version_edge.workspace_id = preset.workspace_id
+    AND version_edge.preset_version_id = preset.current_version_id
+WHERE preset.deleted_at IS NULL
+ON CONFLICT (workspace_id, preset_id, skill_id)
+DO UPDATE SET skill_version_id = EXCLUDED.skill_version_id;

--- a/alembic/sql/a8e1f7c3b2d9/lock.sql
+++ b/alembic/sql/a8e1f7c3b2d9/lock.sql
@@ -1,0 +1,8 @@
+LOCK TABLE
+    agent_preset,
+    agent_preset_version,
+    agent_preset_version_skill,
+    agent_preset_skill,
+    skill,
+    skill_version
+IN SHARE ROW EXCLUSIVE MODE;

--- a/alembic/sql/a8e1f7c3b2d9/lock.sql
+++ b/alembic/sql/a8e1f7c3b2d9/lock.sql
@@ -1,8 +1,0 @@
-LOCK TABLE
-    agent_preset,
-    agent_preset_version,
-    agent_preset_version_skill,
-    agent_preset_skill,
-    skill,
-    skill_version
-IN SHARE ROW EXCLUSIVE MODE;

--- a/alembic/versions/a8e1f7c3b2d9_normalize_agent_preset_head_topology.py
+++ b/alembic/versions/a8e1f7c3b2d9_normalize_agent_preset_head_topology.py
@@ -10,6 +10,7 @@ New application code treats ``agent_preset_subagent`` and
 """
 
 from collections.abc import Sequence
+from pathlib import Path
 
 import sqlalchemy as sa
 
@@ -23,6 +24,16 @@ revision: str = "a8e1f7c3b2d9"
 down_revision: str | None = "44d7e75b6f4c"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
+
+_SQL_ASSET_DIR = Path(__file__).resolve().parent.parent / "sql" / revision
+
+
+def _execute_sql_asset(filename: str) -> None:
+    """Execute one immutable SQL asset in Alembic's active transaction."""
+
+    op.get_bind().exec_driver_sql(
+        (_SQL_ASSET_DIR / filename).read_text(encoding="utf-8")
+    )
 
 
 def _create_subagent_head_edges() -> None:
@@ -101,244 +112,13 @@ def _create_subagent_head_edges() -> None:
     )
 
 
-def _backfill_subagent_head_edges() -> None:
-    """Project every live head's current effective version topology."""
-
-    op.execute(
-        sa.text(
-            """
-            DO $$
-            BEGIN
-                IF EXISTS (
-                    SELECT 1
-                    FROM agent_preset AS preset
-                    LEFT JOIN agent_preset_version AS current_version
-                        ON current_version.id = preset.current_version_id
-                    WHERE preset.deleted_at IS NULL
-                        AND preset.current_version_id IS NOT NULL
-                        AND (
-                            current_version.id IS NULL
-                            OR current_version.workspace_id <> preset.workspace_id
-                            OR current_version.preset_id <> preset.id
-                        )
-                ) THEN
-                    RAISE EXCEPTION
-                        'Cannot normalize agent preset topology: invalid current preset version';
-                END IF;
-            END $$
-            """
-        )
-    )
-    op.execute(
-        sa.text(
-            """
-            CREATE TEMP TABLE _agent_preset_subagent_backfill
-            ON COMMIT DROP AS
-            WITH current_topology AS (
-                SELECT
-                    parent.id AS parent_id,
-                    parent.workspace_id,
-                    COALESCE(current_version.agents, parent.agents) AS agents
-                FROM agent_preset AS parent
-                LEFT JOIN agent_preset_version AS current_version
-                    ON current_version.workspace_id = parent.workspace_id
-                    AND current_version.id = parent.current_version_id
-                WHERE parent.deleted_at IS NULL
-            ),
-            refs AS (
-                SELECT
-                    topology.parent_id,
-                    topology.workspace_id,
-                    ref.value AS ref
-                FROM current_topology AS topology
-                CROSS JOIN LATERAL jsonb_array_elements(
-                    CASE
-                        WHEN jsonb_typeof(topology.agents -> 'subagents') = 'array'
-                        THEN topology.agents -> 'subagents'
-                        ELSE '[]'::jsonb
-                    END
-                ) AS ref(value)
-            )
-            SELECT
-                refs.parent_id,
-                refs.workspace_id,
-                CASE
-                    WHEN refs.ref ->> 'preset_id' IS NOT NULL THEN child_by_id.id
-                    WHEN child_by_slug.match_count = 1 THEN child_by_slug.child_id
-                    ELSE NULL
-                END AS child_id,
-                COALESCE(NULLIF(refs.ref ->> 'name', ''), refs.ref ->> 'preset')
-                    AS alias,
-                refs.ref ->> 'description' AS description,
-                CASE
-                    WHEN jsonb_typeof(refs.ref -> 'max_turns') = 'number'
-                    THEN (refs.ref ->> 'max_turns')::integer
-                    ELSE NULL
-                END AS max_turns
-            FROM refs
-            LEFT JOIN agent_preset AS child_by_id
-                ON child_by_id.workspace_id = refs.workspace_id
-                AND child_by_id.deleted_at IS NULL
-                AND child_by_id.id = CASE
-                    WHEN refs.ref ->> 'preset_id' ~*
-                        '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-                    THEN (refs.ref ->> 'preset_id')::uuid
-                    ELSE NULL
-                END
-            LEFT JOIN LATERAL (
-                SELECT
-                    (array_agg(candidate.id ORDER BY candidate.id))[1] AS child_id,
-                    count(*) AS match_count
-                FROM agent_preset AS candidate
-                WHERE candidate.workspace_id = refs.workspace_id
-                    AND candidate.slug = refs.ref ->> 'preset'
-                    AND candidate.deleted_at IS NULL
-            ) AS child_by_slug ON TRUE
-            """
-        )
-    )
-    op.execute(
-        sa.text(
-            """
-            DO $$
-            BEGIN
-                IF EXISTS (
-                    SELECT 1
-                    FROM _agent_preset_subagent_backfill
-                    WHERE child_id IS NULL OR alias IS NULL
-                ) THEN
-                    RAISE EXCEPTION
-                        'Cannot normalize agent preset topology: unresolved or cross-workspace subagent head';
-                END IF;
-                IF EXISTS (
-                    SELECT 1
-                    FROM _agent_preset_subagent_backfill
-                    GROUP BY workspace_id, parent_id, alias
-                    HAVING count(*) > 1
-                ) THEN
-                    RAISE EXCEPTION
-                        'Cannot normalize agent preset topology: duplicate subagent alias';
-                END IF;
-            END $$;
-
-            INSERT INTO agent_preset_subagent (
-                id,
-                parent_preset_id,
-                child_preset_id,
-                alias,
-                description,
-                max_turns,
-                workspace_id
-            )
-            SELECT
-                gen_random_uuid(),
-                parent_id,
-                child_id,
-                alias,
-                description,
-                max_turns,
-                workspace_id
-            FROM _agent_preset_subagent_backfill
-            ORDER BY parent_id, alias
-            """
-        )
-    )
-
-
-def _reconcile_skill_head_edges() -> None:
-    """Make existing head Skill edges match each head's current version."""
-
-    op.execute(
-        sa.text(
-            """
-            DO $$
-            BEGIN
-                IF EXISTS (
-                    SELECT 1
-                    FROM agent_preset AS preset
-                    JOIN agent_preset_version_skill AS version_edge
-                        ON version_edge.preset_version_id = preset.current_version_id
-                    LEFT JOIN skill
-                        ON skill.id = version_edge.skill_id
-                    LEFT JOIN skill_version
-                        ON skill_version.id = version_edge.skill_version_id
-                    WHERE preset.deleted_at IS NULL
-                        AND (
-                            version_edge.workspace_id <> preset.workspace_id
-                            OR skill.id IS NULL
-                            OR skill.workspace_id <> preset.workspace_id
-                            OR skill.deleted_at IS NOT NULL
-                            OR skill.archived_at IS NOT NULL
-                            OR skill_version.id IS NULL
-                            OR skill_version.workspace_id <> preset.workspace_id
-                            OR skill_version.skill_id <> skill.id
-                        )
-                ) THEN
-                    RAISE EXCEPTION
-                        'Cannot normalize agent preset topology: unresolved or cross-workspace skill head';
-                END IF;
-            END $$;
-
-            DELETE FROM agent_preset_skill AS head_edge
-            USING agent_preset AS preset
-            WHERE preset.workspace_id = head_edge.workspace_id
-                AND preset.id = head_edge.preset_id
-                AND preset.deleted_at IS NULL
-                AND preset.current_version_id IS NOT NULL
-                AND NOT EXISTS (
-                    SELECT 1
-                    FROM agent_preset_version_skill AS version_edge
-                    WHERE version_edge.workspace_id = head_edge.workspace_id
-                        AND version_edge.preset_version_id = preset.current_version_id
-                        AND version_edge.skill_id = head_edge.skill_id
-                );
-
-            INSERT INTO agent_preset_skill (
-                id,
-                preset_id,
-                skill_id,
-                skill_version_id,
-                workspace_id
-            )
-            SELECT
-                gen_random_uuid(),
-                preset.id,
-                version_edge.skill_id,
-                version_edge.skill_version_id,
-                preset.workspace_id
-            FROM agent_preset AS preset
-            JOIN agent_preset_version_skill AS version_edge
-                ON version_edge.workspace_id = preset.workspace_id
-                AND version_edge.preset_version_id = preset.current_version_id
-            WHERE preset.deleted_at IS NULL
-            ON CONFLICT (workspace_id, preset_id, skill_id)
-            DO UPDATE SET skill_version_id = EXCLUDED.skill_version_id
-            """
-        )
-    )
-
-
 def upgrade() -> None:
     # Freeze every legacy topology source and shadow target for the transaction.
-    # This makes the set-based snapshot deterministic even if an old application
-    # pod has not finished draining when the migration begins.
-    op.execute(
-        sa.text(
-            """
-            LOCK TABLE
-                agent_preset,
-                agent_preset_version,
-                agent_preset_version_skill,
-                agent_preset_skill,
-                skill,
-                skill_version
-            IN SHARE ROW EXCLUSIVE MODE
-            """
-        )
-    )
+    # Old topology writers should still be drained before deployment; the lock
+    # closes the race between that operational gate and the migration snapshot.
+    _execute_sql_asset("lock.sql")
     _create_subagent_head_edges()
-    _backfill_subagent_head_edges()
-    _reconcile_skill_head_edges()
+    _execute_sql_asset("backfill.sql")
     op.execute(enable_workspace_table_rls("agent_preset_subagent"))
 
 

--- a/alembic/versions/a8e1f7c3b2d9_normalize_agent_preset_head_topology.py
+++ b/alembic/versions/a8e1f7c3b2d9_normalize_agent_preset_head_topology.py
@@ -4,9 +4,14 @@ Revision ID: a8e1f7c3b2d9
 Revises: 44d7e75b6f4c
 Create Date: 2026-08-28 19:00:00.000000
 
-The legacy topology projections remain in place for rollback compatibility.
-New application code treats ``agent_preset_subagent`` and
-``agent_preset_skill`` as the canonical head-owned topology.
+This is a roll-forward data migration: it derives the initial head-owned
+topology from each preset's current legacy projection, while leaving every
+legacy field and version-owned edge intact for application rollback.
+
+The upgrade locks all source and target tables before taking the snapshot,
+creates the missing subagent edge table, then validates and backfills both
+subagent and skill head edges in the same transaction. Any invalid reference
+aborts the migration before the transaction commits.
 """
 
 from collections.abc import Sequence
@@ -113,16 +118,40 @@ def _create_subagent_head_edges() -> None:
 
 
 def upgrade() -> None:
-    # Freeze every legacy topology source and shadow target for the transaction.
-    # Old topology writers should still be drained before deployment; the lock
-    # closes the race between that operational gate and the migration snapshot.
-    _execute_sql_asset("lock.sql")
+    # Freeze every legacy topology source and existing head-edge target before
+    # deriving the canonical snapshot. Old topology writers should still be
+    # drained before deployment; this closes the remaining snapshot race.
+    op.execute(
+        sa.text(
+            """
+            LOCK TABLE
+                agent_preset,
+                agent_preset_version,
+                agent_preset_version_skill,
+                agent_preset_skill,
+                skill,
+                skill_version
+            IN SHARE ROW EXCLUSIVE MODE
+            """
+        )
+    )
+
+    # The SQL asset expects this table to exist and populates it alongside the
+    # already-existing agent_preset_skill head-edge table.
     _create_subagent_head_edges()
+
+    # Validate first and fail closed, then materialize the current desired
+    # topology. The revision-scoped asset remains part of this migration.
     _execute_sql_asset("backfill.sql")
+
+    # Backfill runs with migration privileges; application access is subject to
+    # workspace RLS only after the canonical table contains a complete snapshot.
     op.execute(enable_workspace_table_rls("agent_preset_subagent"))
 
 
 def downgrade() -> None:
+    # No reverse backfill is necessary: upgrade deliberately leaves all legacy
+    # version-owned topology untouched for the old application code to consume.
     op.execute(disable_workspace_table_rls("agent_preset_subagent"))
     op.drop_index(
         op.f("ix_agent_preset_subagent_child_preset_id"),

--- a/alembic/versions/a8e1f7c3b2d9_normalize_agent_preset_head_topology.py
+++ b/alembic/versions/a8e1f7c3b2d9_normalize_agent_preset_head_topology.py
@@ -1,0 +1,359 @@
+"""Normalize agent preset topology onto resource heads.
+
+Revision ID: a8e1f7c3b2d9
+Revises: 44d7e75b6f4c
+Create Date: 2026-08-28 19:00:00.000000
+
+The legacy topology projections remain in place for rollback compatibility.
+New application code treats ``agent_preset_subagent`` and
+``agent_preset_skill`` as the canonical head-owned topology.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_workspace_table_rls,
+    enable_workspace_table_rls,
+)
+
+revision: str = "a8e1f7c3b2d9"
+down_revision: str | None = "44d7e75b6f4c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _create_subagent_head_edges() -> None:
+    op.create_table(
+        "agent_preset_subagent",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("parent_preset_id", sa.UUID(), nullable=False),
+        sa.Column("child_preset_id", sa.UUID(), nullable=False),
+        sa.Column("alias", sa.String(length=80), nullable=False),
+        sa.Column("description", sa.String(length=1000), nullable=True),
+        sa.Column("max_turns", sa.Integer(), nullable=True),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), sa.Identity(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "max_turns IS NULL OR max_turns >= 1",
+            name=op.f("ck_agent_preset_subagent_max_turns_positive"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["parent_preset_id"],
+            ["agent_preset.id"],
+            name=op.f("fk_agent_preset_subagent_parent_preset_id_agent_preset"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["child_preset_id"],
+            ["agent_preset.id"],
+            name=op.f("fk_agent_preset_subagent_child_preset_id_agent_preset"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_agent_preset_subagent_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "surrogate_id",
+            name=op.f("pk_agent_preset_subagent"),
+        ),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "parent_preset_id",
+            "alias",
+            name="uq_agent_preset_subagent_workspace_parent_alias",
+        ),
+    )
+    op.create_index(
+        op.f("ix_agent_preset_subagent_id"),
+        "agent_preset_subagent",
+        ["id"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_agent_preset_subagent_parent_preset_id"),
+        "agent_preset_subagent",
+        ["parent_preset_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_agent_preset_subagent_child_preset_id"),
+        "agent_preset_subagent",
+        ["child_preset_id"],
+        unique=False,
+    )
+
+
+def _backfill_subagent_head_edges() -> None:
+    """Project every live head's current effective version topology."""
+
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM agent_preset AS preset
+                    LEFT JOIN agent_preset_version AS current_version
+                        ON current_version.id = preset.current_version_id
+                    WHERE preset.deleted_at IS NULL
+                        AND preset.current_version_id IS NOT NULL
+                        AND (
+                            current_version.id IS NULL
+                            OR current_version.workspace_id <> preset.workspace_id
+                            OR current_version.preset_id <> preset.id
+                        )
+                ) THEN
+                    RAISE EXCEPTION
+                        'Cannot normalize agent preset topology: invalid current preset version';
+                END IF;
+            END $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TEMP TABLE _agent_preset_subagent_backfill
+            ON COMMIT DROP AS
+            WITH current_topology AS (
+                SELECT
+                    parent.id AS parent_id,
+                    parent.workspace_id,
+                    COALESCE(current_version.agents, parent.agents) AS agents
+                FROM agent_preset AS parent
+                LEFT JOIN agent_preset_version AS current_version
+                    ON current_version.workspace_id = parent.workspace_id
+                    AND current_version.id = parent.current_version_id
+                WHERE parent.deleted_at IS NULL
+            ),
+            refs AS (
+                SELECT
+                    topology.parent_id,
+                    topology.workspace_id,
+                    ref.value AS ref
+                FROM current_topology AS topology
+                CROSS JOIN LATERAL jsonb_array_elements(
+                    CASE
+                        WHEN jsonb_typeof(topology.agents -> 'subagents') = 'array'
+                        THEN topology.agents -> 'subagents'
+                        ELSE '[]'::jsonb
+                    END
+                ) AS ref(value)
+            )
+            SELECT
+                refs.parent_id,
+                refs.workspace_id,
+                CASE
+                    WHEN refs.ref ->> 'preset_id' IS NOT NULL THEN child_by_id.id
+                    WHEN child_by_slug.match_count = 1 THEN child_by_slug.child_id
+                    ELSE NULL
+                END AS child_id,
+                COALESCE(NULLIF(refs.ref ->> 'name', ''), refs.ref ->> 'preset')
+                    AS alias,
+                refs.ref ->> 'description' AS description,
+                CASE
+                    WHEN jsonb_typeof(refs.ref -> 'max_turns') = 'number'
+                    THEN (refs.ref ->> 'max_turns')::integer
+                    ELSE NULL
+                END AS max_turns
+            FROM refs
+            LEFT JOIN agent_preset AS child_by_id
+                ON child_by_id.workspace_id = refs.workspace_id
+                AND child_by_id.deleted_at IS NULL
+                AND child_by_id.id = CASE
+                    WHEN refs.ref ->> 'preset_id' ~*
+                        '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+                    THEN (refs.ref ->> 'preset_id')::uuid
+                    ELSE NULL
+                END
+            LEFT JOIN LATERAL (
+                SELECT
+                    (array_agg(candidate.id ORDER BY candidate.id))[1] AS child_id,
+                    count(*) AS match_count
+                FROM agent_preset AS candidate
+                WHERE candidate.workspace_id = refs.workspace_id
+                    AND candidate.slug = refs.ref ->> 'preset'
+                    AND candidate.deleted_at IS NULL
+            ) AS child_by_slug ON TRUE
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM _agent_preset_subagent_backfill
+                    WHERE child_id IS NULL OR alias IS NULL
+                ) THEN
+                    RAISE EXCEPTION
+                        'Cannot normalize agent preset topology: unresolved or cross-workspace subagent head';
+                END IF;
+                IF EXISTS (
+                    SELECT 1
+                    FROM _agent_preset_subagent_backfill
+                    GROUP BY workspace_id, parent_id, alias
+                    HAVING count(*) > 1
+                ) THEN
+                    RAISE EXCEPTION
+                        'Cannot normalize agent preset topology: duplicate subagent alias';
+                END IF;
+            END $$;
+
+            INSERT INTO agent_preset_subagent (
+                id,
+                parent_preset_id,
+                child_preset_id,
+                alias,
+                description,
+                max_turns,
+                workspace_id
+            )
+            SELECT
+                gen_random_uuid(),
+                parent_id,
+                child_id,
+                alias,
+                description,
+                max_turns,
+                workspace_id
+            FROM _agent_preset_subagent_backfill
+            ORDER BY parent_id, alias
+            """
+        )
+    )
+
+
+def _reconcile_skill_head_edges() -> None:
+    """Make existing head Skill edges match each head's current version."""
+
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM agent_preset AS preset
+                    JOIN agent_preset_version_skill AS version_edge
+                        ON version_edge.preset_version_id = preset.current_version_id
+                    LEFT JOIN skill
+                        ON skill.id = version_edge.skill_id
+                    LEFT JOIN skill_version
+                        ON skill_version.id = version_edge.skill_version_id
+                    WHERE preset.deleted_at IS NULL
+                        AND (
+                            version_edge.workspace_id <> preset.workspace_id
+                            OR skill.id IS NULL
+                            OR skill.workspace_id <> preset.workspace_id
+                            OR skill.deleted_at IS NOT NULL
+                            OR skill.archived_at IS NOT NULL
+                            OR skill_version.id IS NULL
+                            OR skill_version.workspace_id <> preset.workspace_id
+                            OR skill_version.skill_id <> skill.id
+                        )
+                ) THEN
+                    RAISE EXCEPTION
+                        'Cannot normalize agent preset topology: unresolved or cross-workspace skill head';
+                END IF;
+            END $$;
+
+            DELETE FROM agent_preset_skill AS head_edge
+            USING agent_preset AS preset
+            WHERE preset.workspace_id = head_edge.workspace_id
+                AND preset.id = head_edge.preset_id
+                AND preset.deleted_at IS NULL
+                AND preset.current_version_id IS NOT NULL
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM agent_preset_version_skill AS version_edge
+                    WHERE version_edge.workspace_id = head_edge.workspace_id
+                        AND version_edge.preset_version_id = preset.current_version_id
+                        AND version_edge.skill_id = head_edge.skill_id
+                );
+
+            INSERT INTO agent_preset_skill (
+                id,
+                preset_id,
+                skill_id,
+                skill_version_id,
+                workspace_id
+            )
+            SELECT
+                gen_random_uuid(),
+                preset.id,
+                version_edge.skill_id,
+                version_edge.skill_version_id,
+                preset.workspace_id
+            FROM agent_preset AS preset
+            JOIN agent_preset_version_skill AS version_edge
+                ON version_edge.workspace_id = preset.workspace_id
+                AND version_edge.preset_version_id = preset.current_version_id
+            WHERE preset.deleted_at IS NULL
+            ON CONFLICT (workspace_id, preset_id, skill_id)
+            DO UPDATE SET skill_version_id = EXCLUDED.skill_version_id
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    # Freeze every legacy topology source and shadow target for the transaction.
+    # This makes the set-based snapshot deterministic even if an old application
+    # pod has not finished draining when the migration begins.
+    op.execute(
+        sa.text(
+            """
+            LOCK TABLE
+                agent_preset,
+                agent_preset_version,
+                agent_preset_version_skill,
+                agent_preset_skill,
+                skill,
+                skill_version
+            IN SHARE ROW EXCLUSIVE MODE
+            """
+        )
+    )
+    _create_subagent_head_edges()
+    _backfill_subagent_head_edges()
+    _reconcile_skill_head_edges()
+    op.execute(enable_workspace_table_rls("agent_preset_subagent"))
+
+
+def downgrade() -> None:
+    op.execute(disable_workspace_table_rls("agent_preset_subagent"))
+    op.drop_index(
+        op.f("ix_agent_preset_subagent_child_preset_id"),
+        table_name="agent_preset_subagent",
+    )
+    op.drop_index(
+        op.f("ix_agent_preset_subagent_parent_preset_id"),
+        table_name="agent_preset_subagent",
+    )
+    op.drop_index(
+        op.f("ix_agent_preset_subagent_id"),
+        table_name="agent_preset_subagent",
+    )
+    op.drop_table("agent_preset_subagent")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2641,9 +2641,6 @@ export const $AgentPresetRead = {
       ],
       title: "Mcp Integrations",
     },
-    agents: {
-      $ref: "#/components/schemas/AgentSubagentsConfig-Output",
-    },
     retries: {
       type: "integer",
       minimum: 0,
@@ -2713,6 +2710,9 @@ export const $AgentPresetRead = {
         },
       ],
       title: "Folder Id",
+    },
+    agents: {
+      $ref: "#/components/schemas/AgentSubagentsConfig-Output",
     },
     skills: {
       items: {
@@ -2868,70 +2868,6 @@ export const $AgentPresetSkillBindingBase = {
   description: "Shared fields for preset skill bindings.",
 } as const
 
-export const $AgentPresetSkillBindingChange = {
-  properties: {
-    skill_id: {
-      type: "string",
-      format: "uuid",
-      title: "Skill Id",
-    },
-    skill_name: {
-      type: "string",
-      title: "Skill Name",
-    },
-    old_skill_version_id: {
-      anyOf: [
-        {
-          type: "string",
-          format: "uuid",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Old Skill Version Id",
-    },
-    old_skill_version: {
-      anyOf: [
-        {
-          type: "integer",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Old Skill Version",
-    },
-    new_skill_version_id: {
-      anyOf: [
-        {
-          type: "string",
-          format: "uuid",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "New Skill Version Id",
-    },
-    new_skill_version: {
-      anyOf: [
-        {
-          type: "integer",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "New Skill Version",
-    },
-  },
-  type: "object",
-  required: ["skill_id", "skill_name"],
-  title: "AgentPresetSkillBindingChange",
-  description: "Diff entry for skill binding changes between preset versions.",
-} as const
-
 export const $AgentPresetSkillBindingRead = {
   properties: {
     skill_id: {
@@ -2993,7 +2929,7 @@ export const $AgentPresetSubagentEligibility = {
 
 export const $AgentPresetSubagentEligibilityReason = {
   type: "string",
-  enum: ["agents_enabled", "tool_approvals"],
+  enum: ["nested_subagents", "tool_approvals"],
 } as const
 
 export const $AgentPresetTagCreate = {
@@ -3309,13 +3245,6 @@ export const $AgentPresetVersionDiff = {
       type: "array",
       title: "Tool Approval Changes",
     },
-    skill_changes: {
-      items: {
-        $ref: "#/components/schemas/AgentPresetSkillBindingChange",
-      },
-      type: "array",
-      title: "Skill Changes",
-    },
     total_changes: {
       type: "integer",
       title: "Total Changes",
@@ -3446,9 +3375,6 @@ export const $AgentPresetVersionRead = {
       ],
       title: "Mcp Integrations",
     },
-    agents: {
-      $ref: "#/components/schemas/AgentSubagentsConfig-Output",
-    },
     retries: {
       type: "integer",
       minimum: 0,
@@ -3490,16 +3416,6 @@ export const $AgentPresetVersionRead = {
       },
       type: "array",
       title: "Capabilities",
-    },
-    subagent_eligibility: {
-      $ref: "#/components/schemas/AgentPresetSubagentEligibility",
-    },
-    skills: {
-      items: {
-        $ref: "#/components/schemas/AgentPresetSkillBindingRead",
-      },
-      type: "array",
-      title: "Skills",
     },
     created_at: {
       type: "string",
@@ -3554,9 +3470,6 @@ export const $AgentPresetVersionReadMinimal = {
       },
       type: "array",
       title: "Capabilities",
-    },
-    subagent_eligibility: {
-      $ref: "#/components/schemas/AgentPresetSubagentEligibility",
     },
     created_at: {
       type: "string",
@@ -4597,11 +4510,6 @@ export const $AgentSettingsUpdate = {
 
 export const $AgentSubagentsConfig_Input = {
   properties: {
-    enabled: {
-      type: "boolean",
-      title: "Enabled",
-      default: false,
-    },
     subagents: {
       items: {
         $ref: "#/components/schemas/AnyAttachedSubagentRef",
@@ -4613,17 +4521,11 @@ export const $AgentSubagentsConfig_Input = {
   additionalProperties: false,
   type: "object",
   title: "AgentSubagentsConfig",
-  description:
-    "User-facing agents toggle and optional preset-backed subagents.",
+  description: "User-facing preset-backed subagent attachments.",
 } as const
 
 export const $AgentSubagentsConfig_Output = {
   properties: {
-    enabled: {
-      type: "boolean",
-      title: "Enabled",
-      default: false,
-    },
     subagents: {
       items: {
         $ref: "#/components/schemas/AnyAttachedSubagentRef",
@@ -4635,8 +4537,7 @@ export const $AgentSubagentsConfig_Output = {
   additionalProperties: false,
   type: "object",
   title: "AgentSubagentsConfig",
-  description:
-    "User-facing agents toggle and optional preset-backed subagents.",
+  description: "User-facing preset-backed subagent attachments.",
 } as const
 
 export const $AgentTagRead = {
@@ -4709,7 +4610,7 @@ export const $AlertArtifact = {
 export const $AnyAttachedSubagentRef = {
   anyOf: [
     {
-      $ref: "#/components/schemas/ResolvedAttachedSubagentRef",
+      $ref: "#/components/schemas/HeadAttachedSubagentRef",
     },
     {
       $ref: "#/components/schemas/AttachedSubagentRef",
@@ -5349,18 +5250,6 @@ export const $AttachedSubagentRef = {
       maxLength: 160,
       minLength: 1,
       title: "Preset",
-    },
-    preset_version: {
-      anyOf: [
-        {
-          type: "integer",
-          minimum: 1,
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Preset Version",
     },
     name: {
       anyOf: [
@@ -15448,6 +15337,66 @@ export const $HarnessType = {
   description: "Supported agent harnesses.",
 } as const
 
+export const $HeadAttachedSubagentRef = {
+  properties: {
+    preset: {
+      type: "string",
+      maxLength: 160,
+      minLength: 1,
+      title: "Preset",
+    },
+    name: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 80,
+          minLength: 1,
+          pattern: "^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 1000,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    max_turns: {
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Turns",
+    },
+    preset_id: {
+      type: "string",
+      format: "uuid",
+      title: "Preset Id",
+    },
+  },
+  additionalProperties: false,
+  type: "object",
+  required: ["preset", "preset_id"],
+  title: "HeadAttachedSubagentRef",
+  description:
+    "Canonical head-owned subagent ref with stable child-head identity.",
+} as const
+
 export const $HealthResponse = {
   properties: {
     status: {
@@ -22213,11 +22162,6 @@ export const $RepositorySyncResult = {
 
 export const $ResolvedAgentsConfig = {
   properties: {
-    enabled: {
-      type: "boolean",
-      title: "Enabled",
-      default: false,
-    },
     subagents: {
       items: {
         $ref: "#/components/schemas/ResolvedAttachedSubagentRef",
@@ -22229,7 +22173,7 @@ export const $ResolvedAgentsConfig = {
   additionalProperties: false,
   type: "object",
   title: "ResolvedAgentsConfig",
-  description: "Persisted agents toggle with immutable resolved child refs.",
+  description: "Immutable resolved child refs for a compiled turn.",
 } as const
 
 export const $ResolvedAttachedSubagentRef = {
@@ -22239,18 +22183,6 @@ export const $ResolvedAttachedSubagentRef = {
       maxLength: 160,
       minLength: 1,
       title: "Preset",
-    },
-    preset_version: {
-      anyOf: [
-        {
-          type: "integer",
-          minimum: 1,
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Preset Version",
     },
     name: {
       anyOf: [
@@ -22299,6 +22231,18 @@ export const $ResolvedAttachedSubagentRef = {
       type: "string",
       format: "uuid",
       title: "Preset Version Id",
+    },
+    preset_version: {
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Preset Version",
     },
   },
   additionalProperties: false,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -690,7 +690,6 @@ export type AgentPresetRead = {
     [key: string]: boolean
   } | null
   mcp_integrations?: Array<string> | null
-  agents?: AgentSubagentsConfig_Output
   retries?: number
   enable_thinking?: boolean
   enable_internet_access?: boolean
@@ -701,6 +700,7 @@ export type AgentPresetRead = {
   description?: string | null
   current_version_id?: string | null
   folder_id?: string | null
+  agents?: AgentSubagentsConfig_Output
   skills?: Array<AgentPresetSkillBindingRead>
   created_at: string
   updated_at: string
@@ -734,18 +734,6 @@ export type AgentPresetSkillBindingBase = {
 }
 
 /**
- * Diff entry for skill binding changes between preset versions.
- */
-export type AgentPresetSkillBindingChange = {
-  skill_id: string
-  skill_name: string
-  old_skill_version_id?: string | null
-  old_skill_version?: number | null
-  new_skill_version_id?: string | null
-  new_skill_version?: number | null
-}
-
-/**
  * Resolved preset skill binding with metadata.
  */
 export type AgentPresetSkillBindingRead = {
@@ -765,7 +753,7 @@ export type AgentPresetSubagentEligibility = {
 }
 
 export type AgentPresetSubagentEligibilityReason =
-  | "agents_enabled"
+  | "nested_subagents"
   | "tool_approvals"
 
 /**
@@ -815,7 +803,6 @@ export type AgentPresetVersionDiff = {
   scalar_changes?: Array<ScalarFieldChange>
   list_changes?: Array<StringListFieldChange>
   tool_approval_changes?: Array<ToolApprovalFieldChange>
-  skill_changes?: Array<AgentPresetSkillBindingChange>
   total_changes?: number
 }
 
@@ -835,7 +822,6 @@ export type AgentPresetVersionRead = {
     [key: string]: boolean
   } | null
   mcp_integrations?: Array<string> | null
-  agents?: AgentSubagentsConfig_Output
   retries?: number
   enable_thinking?: boolean
   enable_internet_access?: boolean
@@ -844,8 +830,6 @@ export type AgentPresetVersionRead = {
   workspace_id: string
   version: number
   capabilities?: Array<AgentPresetCapability>
-  subagent_eligibility?: AgentPresetSubagentEligibility
-  skills?: Array<AgentPresetSkillBindingRead>
   created_at: string
   updated_at: string
 }
@@ -859,7 +843,6 @@ export type AgentPresetVersionReadMinimal = {
   workspace_id: string
   version: number
   capabilities?: Array<AgentPresetCapability>
-  subagent_eligibility?: AgentPresetSubagentEligibility
   created_at: string
   updated_at: string
 }
@@ -1122,18 +1105,16 @@ export type AgentSettingsUpdate = {
 }
 
 /**
- * User-facing agents toggle and optional preset-backed subagents.
+ * User-facing preset-backed subagent attachments.
  */
 export type AgentSubagentsConfig_Input = {
-  enabled?: boolean
   subagents?: Array<AnyAttachedSubagentRef>
 }
 
 /**
- * User-facing agents toggle and optional preset-backed subagents.
+ * User-facing preset-backed subagent attachments.
  */
 export type AgentSubagentsConfig_Output = {
-  enabled?: boolean
   subagents?: Array<AnyAttachedSubagentRef>
 }
 
@@ -1158,7 +1139,7 @@ export type AlertArtifact = {
 }
 
 export type AnyAttachedSubagentRef =
-  | ResolvedAttachedSubagentRef
+  | HeadAttachedSubagentRef
   | AttachedSubagentRef
 
 /**
@@ -1358,7 +1339,6 @@ export type AssistantMessage = {
  */
 export type AttachedSubagentRef = {
   preset: string
-  preset_version?: number | null
   name?: string | null
   description?: string | null
   max_turns?: number | null
@@ -4703,6 +4683,17 @@ export type HTTPValidationError = {
  */
 export type HarnessType = "pydantic-ai" | "claude_code"
 
+/**
+ * Canonical head-owned subagent ref with stable child-head identity.
+ */
+export type HeadAttachedSubagentRef = {
+  preset: string
+  name?: string | null
+  description?: string | null
+  max_turns?: number | null
+  preset_id: string
+}
+
 export type HealthResponse = {
   status: string
 }
@@ -6796,10 +6787,9 @@ export type RepositorySyncResult = {
 }
 
 /**
- * Persisted agents toggle with immutable resolved child refs.
+ * Immutable resolved child refs for a compiled turn.
  */
 export type ResolvedAgentsConfig = {
-  enabled?: boolean
   subagents?: Array<ResolvedAttachedSubagentRef>
 }
 
@@ -6808,12 +6798,12 @@ export type ResolvedAgentsConfig = {
  */
 export type ResolvedAttachedSubagentRef = {
   preset: string
-  preset_version?: number | null
   name?: string | null
   description?: string | null
   max_turns?: number | null
   preset_id: string
   preset_version_id: string
+  preset_version?: number | null
 }
 
 export type ResourcePullCount = {

--- a/frontend/src/components/agents/agent-preset-version-history.tsx
+++ b/frontend/src/components/agents/agent-preset-version-history.tsx
@@ -163,10 +163,15 @@ function AgentPresetVersionDiffContent({
     () =>
       presetVersion
         ? buildAgentPresetVirtualFiles(
-            agentPresetVersionToDocumentInput(presetVersion, skillNamesById)
+            agentPresetVersionToDocumentInput(
+              presetVersion,
+              draftPayload ?? { agents: undefined, skills: [] },
+              skillNamesById,
+              headSkillBindings
+            )
           )
         : null,
-    [presetVersion, skillNamesById]
+    [presetVersion, draftPayload, skillNamesById, headSkillBindings]
   )
 
   const files = useMemo(() => {

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -55,7 +55,6 @@ import type {
   AgentPresetReadMinimal,
   AgentPresetSubagentEligibility,
   AgentPresetUpdate,
-  AgentPresetVersionReadMinimal,
   AttachedSubagentRef,
   MCPIntegrationRead,
   SkillReadMinimal,
@@ -134,7 +133,6 @@ import {
   useAgentPresets,
   useAgentPresetVersion,
   useAgentPresetVersions,
-  useAgentPresetVersionsByPresetIds,
   useCreateAgentPreset,
   useUpdateAgentPreset,
 } from "@/hooks/use-agent-presets"
@@ -227,7 +225,6 @@ const agentPresetSchema = z
     actions: z.array(z.string()).default([]),
     namespaces: z.array(z.string()).default([]),
     mcpIntegrations: z.array(z.string()).default([]),
-    agentsEnabled: z.boolean().default(false),
     subagents: z
       .array(
         z.object({
@@ -235,8 +232,6 @@ const agentPresetSchema = z
           presetId: z.string().default(""),
           name: z.string().default(""),
           description: z.string().max(1000).default(""),
-          presetVersion: z.string().default(""),
-          presetVersionId: z.string().default(""),
           maxTurns: z.string().default(""),
         })
       )
@@ -302,76 +297,63 @@ const agentPresetSchema = z
       }
     }
 
-    if (data.agentsEnabled) {
-      const aliases = new Set<string>()
-      data.subagents.forEach((subagent, index) => {
-        const preset = subagent.preset.trim()
-        const alias = subagent.name.trim()
-        const effectiveAlias = alias || preset
+    const aliases = new Set<string>()
+    data.subagents.forEach((subagent, index) => {
+      const preset = subagent.preset.trim()
+      const alias = subagent.name.trim()
+      const effectiveAlias = alias || preset
 
-        if (!preset) {
-          ctx.addIssue({
-            path: ["subagents", index, "preset"],
-            code: z.ZodIssueCode.custom,
-            message: "Select a preset",
-          })
-        }
-        if (alias && !SUBAGENT_ALIAS_REGEX.test(alias)) {
-          ctx.addIssue({
-            path: ["subagents", index, "name"],
-            code: z.ZodIssueCode.custom,
-            message:
-              "Use lowercase letters, numbers, and hyphens; start and end with a letter or number",
-          })
-        }
-        if (effectiveAlias && RESERVED_SUBAGENT_ALIASES.has(effectiveAlias)) {
-          ctx.addIssue({
-            path: ["subagents", index, alias ? "name" : "preset"],
-            code: z.ZodIssueCode.custom,
-            message: "This alias is reserved",
-          })
-        }
-        if (effectiveAlias && aliases.has(effectiveAlias)) {
-          ctx.addIssue({
-            path: ["subagents", index, alias ? "name" : "preset"],
-            code: z.ZodIssueCode.custom,
-            message: "Subagent aliases must be unique",
-          })
-        }
-        if (effectiveAlias) {
-          aliases.add(effectiveAlias)
-        }
-        if (
-          subagent.presetVersion.trim() &&
-          !POSITIVE_INTEGER_REGEX.test(subagent.presetVersion.trim())
-        ) {
-          ctx.addIssue({
-            path: ["subagents", index, "presetVersion"],
-            code: z.ZodIssueCode.custom,
-            message: "Use a positive version number",
-          })
-        }
-        if (
-          subagent.maxTurns.trim() &&
-          !POSITIVE_INTEGER_REGEX.test(subagent.maxTurns.trim())
-        ) {
-          ctx.addIssue({
-            path: ["subagents", index, "maxTurns"],
-            code: z.ZodIssueCode.custom,
-            message: "Use a positive turn limit",
-          })
-        }
-      })
-    }
+      if (!preset) {
+        ctx.addIssue({
+          path: ["subagents", index, "preset"],
+          code: z.ZodIssueCode.custom,
+          message: "Select a preset",
+        })
+      }
+      if (alias && !SUBAGENT_ALIAS_REGEX.test(alias)) {
+        ctx.addIssue({
+          path: ["subagents", index, "name"],
+          code: z.ZodIssueCode.custom,
+          message:
+            "Use lowercase letters, numbers, and hyphens; start and end with a letter or number",
+        })
+      }
+      if (effectiveAlias && RESERVED_SUBAGENT_ALIASES.has(effectiveAlias)) {
+        ctx.addIssue({
+          path: ["subagents", index, alias ? "name" : "preset"],
+          code: z.ZodIssueCode.custom,
+          message: "This alias is reserved",
+        })
+      }
+      if (effectiveAlias && aliases.has(effectiveAlias)) {
+        ctx.addIssue({
+          path: ["subagents", index, alias ? "name" : "preset"],
+          code: z.ZodIssueCode.custom,
+          message: "Subagent aliases must be unique",
+        })
+      }
+      if (effectiveAlias) {
+        aliases.add(effectiveAlias)
+      }
+      if (
+        subagent.maxTurns.trim() &&
+        !POSITIVE_INTEGER_REGEX.test(subagent.maxTurns.trim())
+      ) {
+        ctx.addIssue({
+          path: ["subagents", index, "maxTurns"],
+          code: z.ZodIssueCode.custom,
+          message: "Use a positive turn limit",
+        })
+      }
+    })
   })
 
 type AgentPresetFormValues = z.infer<typeof agentPresetSchema>
 type SubagentFormValue = AgentPresetFormValues["subagents"][number]
 type SkillBindingFormValue = AgentPresetFormValues["skills"][number]
 type ToolApprovalFormValue = AgentPresetFormValues["toolApprovals"][number]
-type PreservedAttachedSubagentRef = AttachedSubagentRef & {
+type AuthoredAttachedSubagentRef = AttachedSubagentRef & {
   preset_id?: string
-  preset_version_id?: string
 }
 
 const LIVE_INTERNET_ACCESS_WARNING_MESSAGE =
@@ -415,7 +397,6 @@ const DEFAULT_FORM_VALUES: AgentPresetFormValues = {
   actions: [],
   namespaces: [],
   mcpIntegrations: [],
-  agentsEnabled: false,
   subagents: [],
   skills: [],
   toolApprovals: [],
@@ -1125,7 +1106,7 @@ function getAgentPresetErrorTab(
     return "skills"
   }
 
-  if (errors.agentsEnabled || errors.subagents) {
+  if (errors.subagents) {
     return "subagents"
   }
 
@@ -1177,7 +1158,6 @@ const AGENT_PRESET_FORM_FIELD_TO_BACKEND_FIELD: Record<
   actions: "actions",
   namespaces: "namespaces",
   mcpIntegrations: "mcp_integrations",
-  agentsEnabled: "agents",
   subagents: "agents",
   skills: "skills",
   toolApprovals: "tool_approvals",
@@ -1484,10 +1464,6 @@ function AgentPresetForm({
     mode: "onBlur",
     defaultValues: preset ? presetToFormValues(preset) : DEFAULT_FORM_VALUES,
   })
-  const watchedAgentsEnabled =
-    useWatch({ control: form.control, name: "agentsEnabled" }) ?? false
-  const watchedSubagents =
-    useWatch({ control: form.control, name: "subagents" }) ?? []
   const watchedMcpIntegrations =
     useWatch({ control: form.control, name: "mcpIntegrations" }) ?? []
   const hasStdioMcp = useMemo(
@@ -1503,26 +1479,6 @@ function AgentPresetForm({
     () => new Map(agentPresets.map((preset) => [preset.id, preset])),
     [agentPresets]
   )
-  const selectedPinnedSubagentPresetIds = useMemo(
-    () =>
-      getPinnedSubagentPresetIds({
-        subagents: watchedSubagents,
-        presetsBySlug: agentPresetsBySlug,
-      }),
-    [agentPresetsBySlug, watchedSubagents]
-  )
-  const {
-    versionsByPresetId: subagentVersionsByPresetId,
-    versionsByPresetIdIsLoading: subagentVersionsByPresetIdIsLoading,
-  } = useAgentPresetVersionsByPresetIds(
-    workspaceId,
-    selectedPinnedSubagentPresetIds,
-    {
-      enabled:
-        watchedAgentsEnabled && selectedPinnedSubagentPresetIds.length > 0,
-    }
-  )
-
   useEffect(() => {
     setActiveTab(initialTab)
   }, [initialTab])
@@ -1642,32 +1598,26 @@ function AgentPresetForm({
 
   const handleSubmit = form.handleSubmit(
     async (values) => {
-      if (values.agentsEnabled) {
-        const eligibilityIssue = getFirstSubagentEligibilityIssue({
-          subagents: values.subagents,
-          presetsById: agentPresetsById,
-          presetsBySlug: agentPresetsBySlug,
-          versionsByPresetId: subagentVersionsByPresetId,
-        })
-        if (eligibilityIssue) {
-          form.setError(
-            `subagents.${eligibilityIssue.index}.${eligibilityIssue.field}`,
-            {
-              type: "manual",
-              message: eligibilityIssue.message,
-            }
-          )
-          handleTabChange("subagents")
-          return
-        }
+      const eligibilityIssue = getFirstSubagentEligibilityIssue({
+        subagents: values.subagents,
+        presetsById: agentPresetsById,
+        presetsBySlug: agentPresetsBySlug,
+      })
+      if (eligibilityIssue) {
+        form.setError(
+          `subagents.${eligibilityIssue.index}.${eligibilityIssue.field}`,
+          {
+            type: "manual",
+            message: eligibilityIssue.message,
+          }
+        )
+        handleTabChange("subagents")
+        return
       }
 
       const payload = formValuesToPayload(
         values,
-        {
-          presetsBySlug: agentPresetsBySlug,
-          versionsByPresetId: subagentVersionsByPresetId,
-        },
+        { presetsBySlug: agentPresetsBySlug },
         {
           forceInternetAccess:
             hasStdioMcp ||
@@ -1697,21 +1647,17 @@ function AgentPresetForm({
   )
 
   const canSubmit =
-    !subagentVersionsByPresetIdIsLoading &&
-    (form.formState.isDirty ||
-      (mode === "create" &&
-        Boolean(form.watch("name")) &&
-        Boolean(form.watch("model_provider")) &&
-        Boolean(form.watch("model_name"))))
+    form.formState.isDirty ||
+    (mode === "create" &&
+      Boolean(form.watch("name")) &&
+      Boolean(form.watch("model_provider")) &&
+      Boolean(form.watch("model_name")))
 
   const getDraftPayload = useCallback((): AgentPresetCreate | null => {
     try {
       return formValuesToPayload(
         form.getValues(),
-        {
-          presetsBySlug: agentPresetsBySlug,
-          versionsByPresetId: subagentVersionsByPresetId,
-        },
+        { presetsBySlug: agentPresetsBySlug },
         { forceInternetAccess: hasStdioMcp }
       )
     } catch {
@@ -1719,7 +1665,7 @@ function AgentPresetForm({
       // schema, which legitimately throws while the user is mid-edit.
       return null
     }
-  }, [agentPresetsBySlug, form, hasStdioMcp, subagentVersionsByPresetId])
+  }, [agentPresetsBySlug, form, hasStdioMcp])
 
   // Wording only: the backend cuts a version only when a publishing field
   // changes, so a metadata-only edit reads as "Save changes". RHF marks array
@@ -1734,11 +1680,9 @@ function AgentPresetForm({
   // registration effect writes to provider state and this component consumes
   // that provider: an unstable dependency re-fires the effect on every render
   // and loops forever. Two callbacks here are unstable by nature —
-  // `form.handleSubmit(...)` returns a new function each render, and
-  // `getDraftPayload` closes over `subagentVersionsByPresetId`, a fresh Map on
-  // every render because `useQueries` returns a new `results` array. Route
-  // both through refs so the registered object only changes when the values
-  // the header actually renders change.
+  // `form.handleSubmit(...)` returns a new function each render. Route it and
+  // the draft reader through refs so the registered object only changes when
+  // values rendered by the header actually change.
   const handleSubmitRef = useRef(handleSubmit)
   const getDraftPayloadRef = useRef(getDraftPayload)
   useEffect(() => {
@@ -1805,8 +1749,6 @@ function AgentPresetForm({
       presetId: "",
       name: "",
       description: "",
-      presetVersion: "",
-      presetVersionId: "",
       maxTurns: "",
     })
   }, [appendSubagent])
@@ -1840,8 +1782,6 @@ function AgentPresetForm({
       preset={preset}
       workspaceId={workspaceId}
       agentPresets={agentPresets}
-      subagentVersionsByPresetId={subagentVersionsByPresetId}
-      subagentVersionsByPresetIdIsLoading={subagentVersionsByPresetIdIsLoading}
       builderPrompt={builderPrompt}
       form={form}
       isSaving={isSaving}
@@ -2042,8 +1982,6 @@ function AgentPresetRightPanel({
   preset,
   workspaceId,
   agentPresets,
-  subagentVersionsByPresetId,
-  subagentVersionsByPresetIdIsLoading,
   builderPrompt,
   form,
   isSaving,
@@ -2070,8 +2008,6 @@ function AgentPresetRightPanel({
   preset: AgentPresetRead | null
   workspaceId: string
   agentPresets: AgentPresetReadMinimal[]
-  subagentVersionsByPresetId: Map<string, AgentPresetVersionReadMinimal[]>
-  subagentVersionsByPresetIdIsLoading: boolean
   builderPrompt?: string
   form: UseFormReturn<AgentPresetFormValues>
   isSaving: boolean
@@ -2199,8 +2135,6 @@ function AgentPresetRightPanel({
               isSaving={isSaving}
               parentPreset={preset}
               agentPresets={agentPresets}
-              versionsByPresetId={subagentVersionsByPresetId}
-              versionsByPresetIdIsLoading={subagentVersionsByPresetIdIsLoading}
               subagentFields={subagentFields}
               onAddSubagent={onAddSubagent}
               onRemoveSubagent={onRemoveSubagent}
@@ -2267,7 +2201,6 @@ function AgentPresetConfigurationPanel({
   const baseUrl = form.watch("base_url")
   const thinkingEnabled = form.watch("enableThinking")
   const internetAccessEnabled = form.watch("enableInternetAccess")
-  const agentsEnabled = form.watch("agentsEnabled")
   const selectedModel = useMemo(
     () =>
       findEnabledModelOption(enabledModelOptions, {
@@ -2551,32 +2484,6 @@ function AgentPresetConfigurationPanel({
                 />
               )}
             </div>
-            <div className="border-t" />
-            <div className="flex items-start justify-between gap-4 px-4 py-3">
-              <div className="space-y-1">
-                <label
-                  htmlFor="enable-subagents"
-                  className="text-sm font-medium leading-none"
-                >
-                  Agent tool
-                </label>
-                <p className="text-xs text-muted-foreground">
-                  Allows the agent to call subagents. Must be enabled for
-                  configured subagents to be callable.
-                </p>
-              </div>
-              <Switch
-                id="enable-subagents"
-                checked={agentsEnabled}
-                onCheckedChange={(checked) =>
-                  form.setValue("agentsEnabled", checked, {
-                    shouldDirty: true,
-                    shouldValidate: true,
-                  })
-                }
-                disabled={isSaving}
-              />
-            </div>
           </div>
         </section>
 
@@ -2772,8 +2679,6 @@ function AgentPresetSubagentsPanel({
   isSaving,
   parentPreset,
   agentPresets,
-  versionsByPresetId,
-  versionsByPresetIdIsLoading,
   subagentFields,
   onAddSubagent,
   onRemoveSubagent,
@@ -2782,14 +2687,10 @@ function AgentPresetSubagentsPanel({
   isSaving: boolean
   parentPreset: AgentPresetRead | null
   agentPresets: AgentPresetReadMinimal[]
-  versionsByPresetId: Map<string, AgentPresetVersionReadMinimal[]>
-  versionsByPresetIdIsLoading: boolean
   subagentFields: Array<{ id: string }>
   onAddSubagent: () => void
   onRemoveSubagent: (index: number) => void
 }) {
-  const agentsEnabled =
-    useWatch({ control: form.control, name: "agentsEnabled" }) ?? false
   const parentInternetAccessEnabled =
     useWatch({ control: form.control, name: "enableInternetAccess" }) ?? false
   const selectedSubagents =
@@ -2814,19 +2715,14 @@ function AgentPresetSubagentsPanel({
       subagents: selectedSubagents,
       presetsById: presetOptionsById,
       presetsBySlug: presetOptionsBySlug,
-      versionsByPresetId,
     })
   const internetAccessWarningMessage = getInternetAccessWarningMessage({
-    agentsEnabled,
     parentInternetAccessEnabled,
     selectedInternetAccessSubagentAliases,
   })
 
   let addPresetDisabledReason: string | null = null
-  if (!agentsEnabled) {
-    addPresetDisabledReason =
-      "Turn on the Agent tool in the Tools tab to attach preset subagents."
-  } else if (presetOptions.length === 0) {
+  if (presetOptions.length === 0) {
     addPresetDisabledReason =
       "Create another agent preset first, then attach it here."
   }
@@ -2837,7 +2733,7 @@ function AgentPresetSubagentsPanel({
       size="sm"
       variant="outline"
       onClick={onAddSubagent}
-      disabled={isSaving || !agentsEnabled || presetOptions.length === 0}
+      disabled={isSaving || presetOptions.length === 0}
     >
       <Plus className="mr-2 size-4" />
       Add preset
@@ -2878,14 +2774,10 @@ function AgentPresetSubagentsPanel({
             </Alert>
           ) : null}
 
-          {!agentsEnabled ? (
-            <p className="rounded-md border border-dashed px-3 py-4 text-xs text-muted-foreground">
-              Turn on the Agent tool in the Tools tab to use subagents.
-            </p>
-          ) : presetOptions.length === 0 ? (
+          {presetOptions.length === 0 ? (
             <p className="rounded-md border border-dashed px-3 py-4 text-xs text-muted-foreground">
               Create another agent preset first, then attach it here. Dynamic
-              subagents are already available while the Agent tool is enabled.
+              subagents are always available.
             </p>
           ) : subagentFields.length === 0 ? (
             <p className="rounded-md border border-dashed px-3 py-4 text-xs text-muted-foreground">
@@ -2901,8 +2793,6 @@ function AgentPresetSubagentsPanel({
                   presetId: "",
                   name: "",
                   description: "",
-                  presetVersion: "",
-                  presetVersionId: "",
                   maxTurns: "",
                 }
                 const selectedPresetIsMissing =
@@ -2915,17 +2805,9 @@ function AgentPresetSubagentsPanel({
                 })
                 const selectedEligibilityIssue = selectedPresetOption
                   ? getSubagentEligibilityIssue({
-                      subagent: selectedSubagent,
                       preset: selectedPresetOption,
-                      versionsByPresetId,
                     })
                   : null
-                const isCheckingSelectedVersion = Boolean(
-                  selectedPresetOption &&
-                    selectedSubagent.presetVersion.trim() &&
-                    versionsByPresetIdIsLoading &&
-                    !versionsByPresetId.has(selectedPresetOption.id)
-                )
 
                 return (
                   <div
@@ -2944,20 +2826,14 @@ function AgentPresetSubagentsPanel({
                                 value={field.value}
                                 onValueChange={(value) => {
                                   field.onChange(value)
+                                  const selected =
+                                    presetOptionsBySlug.get(value)
                                   form.setValue(
                                     `subagents.${index}.presetId`,
-                                    ""
-                                  )
-                                  form.setValue(
-                                    `subagents.${index}.presetVersion`,
-                                    ""
-                                  )
-                                  form.setValue(
-                                    `subagents.${index}.presetVersionId`,
-                                    ""
+                                    selected?.id ?? ""
                                   )
                                 }}
-                                disabled={isSaving || !agentsEnabled}
+                                disabled={isSaving}
                               >
                                 <FormControl>
                                   <SelectTrigger>
@@ -3027,10 +2903,6 @@ function AgentPresetSubagentsPanel({
                                                     currentVersionEligibilityMessage
                                                   }
                                                 </p>
-                                                <p className="text-muted-foreground">
-                                                  Pin an eligible version to use
-                                                  this preset as a subagent.
-                                                </p>
                                               </div>
                                             </div>
                                           </TooltipContent>
@@ -3057,87 +2929,32 @@ function AgentPresetSubagentsPanel({
                           )}
                         />
 
-                        <div className="grid gap-4 md:grid-cols-2">
-                          <FormField
-                            control={form.control}
-                            name={`subagents.${index}.name`}
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Alias</FormLabel>
-                                <FormControl>
-                                  <Input
-                                    placeholder="triage-analyst"
-                                    value={field.value ?? ""}
-                                    onChange={field.onChange}
-                                    disabled={isSaving || !agentsEnabled}
-                                  />
-                                </FormControl>
-                                <FormDescription>
-                                  Optional. Defaults to the preset slug.
-                                </FormDescription>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                          <FormField
-                            control={form.control}
-                            name={`subagents.${index}.presetVersion`}
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Version</FormLabel>
-                                <FormControl>
-                                  <Input
-                                    type="number"
-                                    min={1}
-                                    placeholder="Current"
-                                    value={field.value ?? ""}
-                                    onChange={(event) => {
-                                      field.onChange(event)
-                                      const presetId =
-                                        normalizeOptional(
-                                          selectedSubagent.presetId
-                                        ) ?? selectedPresetOption?.id
-                                      const presetVersionId =
-                                        getSelectedSubagentVersionId({
-                                          presetId,
-                                          presetVersion:
-                                            event.currentTarget.value,
-                                          versionsByPresetId,
-                                        })
-                                      form.setValue(
-                                        `subagents.${index}.presetVersionId`,
-                                        presetVersionId ?? ""
-                                      )
-                                      if (presetId && presetVersionId) {
-                                        form.setValue(
-                                          `subagents.${index}.presetId`,
-                                          presetId
-                                        )
-                                      }
-                                    }}
-                                    disabled={isSaving || !agentsEnabled}
-                                  />
-                                </FormControl>
-                                <FormDescription>
-                                  Optional. Blank uses the current version.
-                                </FormDescription>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                        </div>
-
-                        {isCheckingSelectedVersion ? (
-                          <div className="flex items-center gap-2 rounded-md border px-3 py-2 text-xs text-muted-foreground">
-                            <Loader2 className="size-3.5 animate-spin" />
-                            Checking selected version...
-                          </div>
-                        ) : null}
+                        <FormField
+                          control={form.control}
+                          name={`subagents.${index}.name`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Alias</FormLabel>
+                              <FormControl>
+                                <Input
+                                  placeholder="triage-analyst"
+                                  value={field.value ?? ""}
+                                  onChange={field.onChange}
+                                  disabled={isSaving}
+                                />
+                              </FormControl>
+                              <FormDescription>
+                                Optional. Defaults to the preset slug.
+                              </FormDescription>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
 
                         {selectedEligibilityIssue ? (
                           <Alert variant="destructive" className="text-xs">
                             <AlertCircle className="size-4" />
-                            <AlertTitle>Cannot attach this version</AlertTitle>
+                            <AlertTitle>Cannot attach this preset</AlertTitle>
                             <AlertDescription>
                               {selectedEligibilityIssue.message}
                             </AlertDescription>
@@ -3155,7 +2972,7 @@ function AgentPresetSubagentsPanel({
                                   placeholder="When should the parent delegate to this subagent?"
                                   value={field.value ?? ""}
                                   onChange={field.onChange}
-                                  disabled={isSaving || !agentsEnabled}
+                                  disabled={isSaving}
                                 />
                               </FormControl>
                               <FormDescription>
@@ -3179,7 +2996,7 @@ function AgentPresetSubagentsPanel({
                                   placeholder="No limit"
                                   value={field.value ?? ""}
                                   onChange={field.onChange}
-                                  disabled={isSaving || !agentsEnabled}
+                                  disabled={isSaving}
                                 />
                               </FormControl>
                               <FormMessage />
@@ -3819,26 +3636,16 @@ function presetToFormValues(preset: AgentPresetRead): AgentPresetFormValues {
       ? null
       : preset.output_type
   const agents = preset.agents
-  const agentsEnabled = agents?.enabled === true
-  const subagents = agentsEnabled
-    ? (agents.subagents ?? []).map((subagent) => ({
-        preset: subagent.preset,
-        presetId: "preset_id" in subagent ? subagent.preset_id : "",
-        name: subagent.name ?? "",
-        description: subagent.description ?? "",
-        presetVersion:
-          subagent.preset_version === null ||
-          subagent.preset_version === undefined
-            ? ""
-            : String(subagent.preset_version),
-        presetVersionId:
-          "preset_version_id" in subagent ? subagent.preset_version_id : "",
-        maxTurns:
-          subagent.max_turns === null || subagent.max_turns === undefined
-            ? ""
-            : String(subagent.max_turns),
-      }))
-    : []
+  const subagents = (agents?.subagents ?? []).map((subagent) => ({
+    preset: subagent.preset,
+    presetId: "preset_id" in subagent ? subagent.preset_id : "",
+    name: subagent.name ?? "",
+    description: subagent.description ?? "",
+    maxTurns:
+      subagent.max_turns === null || subagent.max_turns === undefined
+        ? ""
+        : String(subagent.max_turns),
+  }))
 
   return {
     name: preset.name,
@@ -3871,7 +3678,6 @@ function presetToFormValues(preset: AgentPresetRead): AgentPresetFormValues {
         )
       : [],
     mcpIntegrations: preset.mcp_integrations ?? [],
-    agentsEnabled,
     subagents,
     skills:
       preset.skills?.map(
@@ -3930,38 +3736,25 @@ function formValuesToPayload(
 
 type SubagentResolutionContext = {
   presetsBySlug: Map<string, AgentPresetReadMinimal>
-  versionsByPresetId: Map<string, AgentPresetVersionReadMinimal[]>
 }
 
 function formValuesToAgentsPayload(
   values: AgentPresetFormValues,
-  { presetsBySlug, versionsByPresetId }: SubagentResolutionContext
+  { presetsBySlug }: SubagentResolutionContext
 ): AgentPresetCreate["agents"] {
-  if (!values.agentsEnabled) {
-    return { enabled: false }
-  }
-
   const subagents = values.subagents
-    .map((subagent): PreservedAttachedSubagentRef | null => {
+    .map((subagent): AuthoredAttachedSubagentRef | null => {
       const preset = subagent.preset.trim()
       if (!preset) {
         return null
       }
 
-      const payload: PreservedAttachedSubagentRef = { preset }
+      const payload: AuthoredAttachedSubagentRef = { preset }
       const name = normalizeOptional(subagent.name)
       const description = normalizeOptional(subagent.description)
-      const presetVersion = parseOptionalPositiveInteger(subagent.presetVersion)
       const maxTurns = parseOptionalPositiveInteger(subagent.maxTurns)
       const presetId = normalizeOptional(subagent.presetId)
       const resolvedPresetId = presetId ?? presetsBySlug.get(preset)?.id ?? null
-      const presetVersionId =
-        normalizeOptional(subagent.presetVersionId) ??
-        getSelectedSubagentVersionId({
-          presetId: resolvedPresetId,
-          presetVersion: subagent.presetVersion,
-          versionsByPresetId,
-        })
 
       if (name !== null) {
         payload.name = name
@@ -3969,25 +3762,20 @@ function formValuesToAgentsPayload(
       if (description !== null) {
         payload.description = description
       }
-      if (presetVersion !== null) {
-        payload.preset_version = presetVersion
-      }
       if (maxTurns !== null) {
         payload.max_turns = maxTurns
       }
-      if (resolvedPresetId !== null && presetVersionId !== null) {
+      if (resolvedPresetId !== null) {
         payload.preset_id = resolvedPresetId
-        payload.preset_version_id = presetVersionId
       }
 
       return payload
     })
     .filter(
-      (subagent): subagent is PreservedAttachedSubagentRef => subagent !== null
+      (subagent): subagent is AuthoredAttachedSubagentRef => subagent !== null
     )
 
   return {
-    enabled: true,
     subagents,
   }
 }
@@ -4004,41 +3792,14 @@ function getSubagentFormAlias(subagent: SubagentFormValue): string {
   return subagent.name.trim() || subagent.preset.trim()
 }
 
-function getPinnedSubagentPresetIds({
-  subagents,
-  presetsBySlug,
-}: {
-  subagents: SubagentFormValue[]
-  presetsBySlug: Map<string, AgentPresetReadMinimal>
-}): string[] {
-  const presetIds = new Set<string>()
-  for (const subagent of subagents) {
-    if (!subagent.presetVersion.trim()) {
-      continue
-    }
-    const presetId = normalizeOptional(subagent.presetId)
-    if (presetId) {
-      presetIds.add(presetId)
-      continue
-    }
-    const preset = presetsBySlug.get(subagent.preset.trim())
-    if (preset) {
-      presetIds.add(preset.id)
-    }
-  }
-  return [...presetIds]
-}
-
 function getFirstSubagentEligibilityIssue({
   subagents,
   presetsById,
   presetsBySlug,
-  versionsByPresetId,
 }: {
   subagents: SubagentFormValue[]
   presetsById: Map<string, AgentPresetReadMinimal>
   presetsBySlug: Map<string, AgentPresetReadMinimal>
-  versionsByPresetId: Map<string, AgentPresetVersionReadMinimal[]>
 }): (SubagentEligibilityIssue & { index: number }) | null {
   for (const [index, subagent] of subagents.entries()) {
     const preset = getSubagentPreset({
@@ -4049,11 +3810,7 @@ function getFirstSubagentEligibilityIssue({
     if (preset === null) {
       continue
     }
-    const issue = getSubagentEligibilityIssue({
-      subagent,
-      preset,
-      versionsByPresetId,
-    })
+    const issue = getSubagentEligibilityIssue({ preset })
     if (issue) {
       return { ...issue, index }
     }
@@ -4077,70 +3834,20 @@ function getSubagentPreset({
   return presetsBySlug.get(subagent.preset.trim()) ?? null
 }
 
-function getSelectedSubagentVersionId({
-  presetId,
-  presetVersion,
-  versionsByPresetId,
-}: {
-  presetId?: string | null
-  presetVersion?: string | null
-  versionsByPresetId: Map<string, AgentPresetVersionReadMinimal[]>
-}): string | null {
-  if (!presetId) {
-    return null
-  }
-
-  const version = parseOptionalPositiveInteger(presetVersion)
-  if (version === null) {
-    return null
-  }
-
-  return (
-    versionsByPresetId.get(presetId)?.find((item) => item.version === version)
-      ?.id ?? null
-  )
-}
-
 type SubagentEligibilityIssue = {
-  field: "preset" | "presetVersion"
+  field: "preset"
   message: string
 }
 
 function getSubagentEligibilityIssue({
-  subagent,
   preset,
-  versionsByPresetId,
 }: {
-  subagent: SubagentFormValue
   preset: AgentPresetReadMinimal
-  versionsByPresetId: Map<string, AgentPresetVersionReadMinimal[]>
 }): SubagentEligibilityIssue | null {
-  const presetVersionText = subagent.presetVersion.trim()
-  if (!presetVersionText) {
-    const message = getSubagentEligibilityMessage(
-      preset.current_version_subagent_eligibility
-    )
-    return message ? { field: "preset", message } : null
-  }
-  if (!POSITIVE_INTEGER_REGEX.test(presetVersionText)) {
-    return null
-  }
-
-  const versions = versionsByPresetId.get(preset.id)
-  if (!versions) {
-    return null
-  }
-  const presetVersion = Number.parseInt(presetVersionText, 10)
-  const version = versions.find((item) => item.version === presetVersion)
-  if (!version) {
-    return {
-      field: "presetVersion",
-      message: `Version ${presetVersion} was not found for ${preset.name}.`,
-    }
-  }
-
-  const message = getSubagentEligibilityMessage(version.subagent_eligibility)
-  return message ? { field: "presetVersion", message } : null
+  const message = getSubagentEligibilityMessage(
+    preset.current_version_subagent_eligibility
+  )
+  return message ? { field: "preset", message } : null
 }
 
 function getSubagentEligibilityMessage(
@@ -4206,12 +3913,10 @@ function getSelectedInternetAccessSubagentAliases({
   subagents,
   presetsById,
   presetsBySlug,
-  versionsByPresetId,
 }: {
   subagents: SubagentFormValue[]
   presetsById: Map<string, AgentPresetReadMinimal>
   presetsBySlug: Map<string, AgentPresetReadMinimal>
-  versionsByPresetId: Map<string, AgentPresetVersionReadMinimal[]>
 }): string[] {
   const aliases: string[] = []
 
@@ -4224,13 +3929,7 @@ function getSelectedInternetAccessSubagentAliases({
     if (preset === null) {
       continue
     }
-    const selectedVersion = getSelectedSubagentVersion({
-      subagent,
-      preset,
-      versionsByPresetId,
-    })
-    const capabilities =
-      selectedVersion?.capabilities ?? preset.capabilities ?? []
+    const capabilities = preset.capabilities ?? []
     if (capabilities.includes("internet_access")) {
       aliases.push(getSubagentFormAlias(subagent))
     }
@@ -4239,38 +3938,14 @@ function getSelectedInternetAccessSubagentAliases({
   return aliases
 }
 
-function getSelectedSubagentVersion({
-  subagent,
-  preset,
-  versionsByPresetId,
-}: {
-  subagent: SubagentFormValue
-  preset: AgentPresetReadMinimal
-  versionsByPresetId: Map<string, AgentPresetVersionReadMinimal[]>
-}): AgentPresetVersionReadMinimal | null {
-  const presetVersionText = subagent.presetVersion.trim()
-  if (!POSITIVE_INTEGER_REGEX.test(presetVersionText)) {
-    return null
-  }
-  const presetVersion = Number.parseInt(presetVersionText, 10)
-  return (
-    versionsByPresetId
-      .get(preset.id)
-      ?.find((version) => version.version === presetVersion) ?? null
-  )
-}
-
 function getInternetAccessWarningMessage({
-  agentsEnabled,
   parentInternetAccessEnabled,
   selectedInternetAccessSubagentAliases,
 }: {
-  agentsEnabled: boolean
   parentInternetAccessEnabled: boolean
   selectedInternetAccessSubagentAliases: string[]
 }): string | null {
   if (
-    !agentsEnabled ||
     parentInternetAccessEnabled ||
     selectedInternetAccessSubagentAliases.length === 0
   ) {

--- a/frontend/src/lib/agent-preset-document.ts
+++ b/frontend/src/lib/agent-preset-document.ts
@@ -47,17 +47,15 @@ export interface AgentPresetToolApproval {
 /**
  * A subagent attachment as rendered in the document.
  *
- * `preset_id` / `preset_version_id` are intentionally excluded: they are opaque
- * UUIDs that the draft may not have resolved yet, so including them would show a
- * change on every unsaved edit.
+ * `preset_id` is intentionally excluded: it is an opaque UUID that the draft
+ * may not have resolved yet, so including it would show a change on every
+ * unsaved edit.
  */
 export interface AgentPresetSubagentEntry {
   /** Display name override, or null to use the preset's own name. */
   name: string | null
   /** Preset slug the subagent is backed by. */
   preset: string
-  /** Pinned preset version, or null to track the latest. */
-  presetVersion: number | null
   /** Maximum turns allowed for this subagent, or null for the default. */
   maxTurns: number | null
   /** Description override, or null. */
@@ -67,10 +65,9 @@ export interface AgentPresetSubagentEntry {
 /**
  * A skill attachment as rendered in the document.
  *
- * The version matters: restoring a version copies its exact historical skill
- * pins back onto the preset head (`_restore_head_skill_bindings_from_version`
- * on the backend), so two sides pinning the same skill at different versions
- * must render differently or the diff hides a real change.
+ * The version is informational. Both sides of a version-history comparison use
+ * the current head topology because restoring an immutable config version does
+ * not restore or otherwise change topology.
  */
 export interface AgentPresetSkillEntry {
   /** Skill name, resolved through the current workspace skill names. */
@@ -107,9 +104,7 @@ export interface AgentPresetDocumentInput {
   mcpIntegrations: string[]
   /** Tool approvals, sorted by tool name. */
   toolApprovals: AgentPresetToolApproval[]
-  /** Whether subagents are enabled. */
-  subagentsEnabled: boolean
-  /** Attached subagents, sorted by name then preset. Empty when disabled. */
+  /** Attached subagents, sorted by name then preset. */
   subagents: AgentPresetSubagentEntry[]
   /** Attached skills with their version pins, sorted by name then version. */
   skills: AgentPresetSkillEntry[]
@@ -206,7 +201,6 @@ function normalizeSubagents(
     .map((subagent) => ({
       name: subagent.name ?? null,
       preset: subagent.preset,
-      presetVersion: subagent.preset_version ?? null,
       maxTurns: subagent.max_turns ?? null,
       description: subagent.description ?? null,
     }))
@@ -267,12 +261,7 @@ function agentPresetExecutionFieldsToDocumentInput(
   skillBindings: readonly RawSkillBinding[],
   skillNamesById: ReadonlyMap<string, string>
 ): AgentPresetDocumentInput {
-  const subagentsEnabled = fields.agents?.enabled ?? false
-  // Mirrors `formValuesToAgentsPayload` in the builder: a disabled toggle drops
-  // the attachments entirely, so a stale list must not show up in the diff.
-  const subagents = subagentsEnabled
-    ? normalizeSubagents(fields.agents?.subagents)
-    : []
+  const subagents = normalizeSubagents(fields.agents?.subagents)
 
   return {
     instructions: fields.instructions ?? "",
@@ -285,7 +274,6 @@ function agentPresetExecutionFieldsToDocumentInput(
     namespaces: sortStrings(fields.namespaces ?? []),
     mcpIntegrations: sortStrings(fields.mcp_integrations ?? []),
     toolApprovals: normalizeToolApprovals(fields.tool_approvals),
-    subagentsEnabled,
     subagents,
     skills: normalizeSkills(skillBindings, skillNamesById),
     // `form.getValues()` returns raw input and `retries` is a `z.coerce.number()`
@@ -297,22 +285,26 @@ function agentPresetExecutionFieldsToDocumentInput(
 }
 
 /**
- * Normalizes a saved preset version into the shared document input.
- *
- * Skill pins come straight from the version's bindings: restoring copies those
- * exact `skill_version` pins back to the head, so they are part of the diff.
+ * Normalizes a saved preset version into the shared document input. Topology is
+ * supplied from the current draft/head, because versions are config-only and a
+ * restore leaves the current topology untouched.
  */
 export function agentPresetVersionToDocumentInput(
   version: AgentPresetVersionRead,
-  skillNamesById: ReadonlyMap<string, string>
+  topology: Pick<AgentPresetCreate, "agents" | "skills">,
+  skillNamesById: ReadonlyMap<string, string>,
+  headBindingsBySkillId: ReadonlyMap<string, AgentPresetSkillBindingRead>
 ): AgentPresetDocumentInput {
   return agentPresetExecutionFieldsToDocumentInput(
-    version,
-    (version.skills ?? []).map((skill) => ({
-      skillId: skill.skill_id,
-      fallbackName: skill.skill_name,
-      version: skill.skill_version,
-    })),
+    { ...version, agents: topology.agents },
+    (topology.skills ?? []).map((skill) => {
+      const headBinding = headBindingsBySkillId.get(skill.skill_id)
+      return {
+        skillId: skill.skill_id,
+        fallbackName: headBinding?.skill_name ?? null,
+        version: headBinding?.skill_version ?? null,
+      }
+    }),
     skillNamesById
   )
 }
@@ -403,16 +395,12 @@ export function buildAgentPresetVirtualFiles(input: AgentPresetDocumentInput): {
       tool: approval.tool,
       allow: approval.allow,
     })),
-    subagents: {
-      enabled: input.subagentsEnabled,
-      agents: input.subagents.map((subagent) => ({
-        name: subagent.name,
-        preset: subagent.preset,
-        preset_version: subagent.presetVersion,
-        max_turns: subagent.maxTurns,
-        description: subagent.description,
-      })),
-    },
+    subagents: input.subagents.map((subagent) => ({
+      name: subagent.name,
+      preset: subagent.preset,
+      max_turns: subagent.maxTurns,
+      description: subagent.description,
+    })),
     skills: input.skills.map((skill) => ({
       name: skill.name,
       version: skill.version,

--- a/frontend/tests/agent-preset-document.test.ts
+++ b/frontend/tests/agent-preset-document.test.ts
@@ -76,34 +76,17 @@ const SHARED_EXECUTION = {
 const DRAFT_SUBAGENTS: AnyAttachedSubagentRef[] = [
   {
     preset: "triage",
-    preset_version: 2,
+    preset_id: "55555555-5555-5555-5555-555555555555",
     name: "Triage",
     description: "Triages alerts",
     max_turns: 4,
   },
   {
     preset: "writer",
-    preset_version: null,
+    preset_id: "33333333-3333-3333-3333-333333333333",
     name: "Alpha writer",
     description: null,
     max_turns: null,
-  },
-]
-
-/**
- * The same subagents as stored on a saved version: resolved UUIDs attached, and
- * in a different order.
- */
-const VERSION_SUBAGENTS: AnyAttachedSubagentRef[] = [
-  {
-    ...DRAFT_SUBAGENTS[1],
-    preset_id: "33333333-3333-3333-3333-333333333333",
-    preset_version_id: "44444444-4444-4444-4444-444444444444",
-  },
-  {
-    ...DRAFT_SUBAGENTS[0],
-    preset_id: "55555555-5555-5555-5555-555555555555",
-    preset_version_id: "66666666-6666-6666-6666-666666666666",
   },
 ]
 
@@ -112,8 +95,6 @@ function buildVersion(
 ): AgentPresetVersionRead {
   return {
     ...SHARED_EXECUTION,
-    agents: { enabled: true, subagents: VERSION_SUBAGENTS },
-    skills: VERSION_SKILLS,
     id: "version-1",
     preset_id: "preset-1",
     workspace_id: "workspace-1",
@@ -129,7 +110,7 @@ function buildPayload(
 ): AgentPresetCreate {
   return {
     ...SHARED_EXECUTION,
-    agents: { enabled: true, subagents: DRAFT_SUBAGENTS },
+    agents: { subagents: DRAFT_SUBAGENTS },
     skills: [{ skill_id: SKILL_ALPHA_ID }, { skill_id: SKILL_BETA_ID }],
     name: "Alert triage agent",
     slug: "alert-triage-agent",
@@ -140,10 +121,17 @@ function buildPayload(
 
 function renderVersion(
   version: AgentPresetVersionRead,
-  skillNames: ReadonlyMap<string, string> = SKILL_NAMES
+  skillNames: ReadonlyMap<string, string> = SKILL_NAMES,
+  topology: Pick<AgentPresetCreate, "agents" | "skills"> = buildPayload(),
+  headBindings: ReadonlyMap<string, AgentPresetSkillBindingRead> = HEAD_BINDINGS
 ) {
   return buildAgentPresetVirtualFiles(
-    agentPresetVersionToDocumentInput(version, skillNames)
+    agentPresetVersionToDocumentInput(
+      version,
+      topology,
+      skillNames,
+      headBindings
+    )
   )
 }
 
@@ -226,7 +214,6 @@ describe("buildAgentPresetVirtualFiles determinism", () => {
     const shuffled = renderPayload(
       buildPayload({
         agents: {
-          enabled: true,
           subagents: [...DRAFT_SUBAGENTS].reverse(),
         },
       })
@@ -316,18 +303,18 @@ describe("buildAgentPresetVirtualFiles normalization", () => {
     )
   })
 
-  it("excludes resolved subagent uuids", () => {
+  it("excludes resolved subagent uuids and version selectors", () => {
     const { config } = renderVersion(buildVersion())
     expect(config).not.toContain("preset_id")
     expect(config).not.toContain("preset_version_id")
-    expect(config).toContain("preset_version: 2")
+    expect(config).not.toContain("preset_version")
   })
 
-  it("forces an empty agent list when subagents are disabled", () => {
+  it("renders an empty list when no preset subagents are attached", () => {
     const { config } = renderPayload(
-      buildPayload({ agents: { enabled: false, subagents: DRAFT_SUBAGENTS } })
+      buildPayload({ agents: { subagents: [] } })
     )
-    expect(config).toContain("subagents:\n  enabled: false\n  agents: []\n")
+    expect(config).toContain("subagents: []\n")
   })
 
   it("emits explicit nulls and empty lists for a minimal preset", () => {
@@ -350,9 +337,7 @@ describe("buildAgentPresetVirtualFiles normalization", () => {
         "namespaces: []",
         "mcp_integrations: []",
         "tool_approvals: []",
-        "subagents:",
-        "  enabled: false",
-        "  agents: []",
+        "subagents: []",
         "skills: []",
         "runtime:",
         "  retries: 3",
@@ -364,25 +349,23 @@ describe("buildAgentPresetVirtualFiles normalization", () => {
   })
 })
 
-describe("buildAgentPresetVirtualFiles skill version pins", () => {
-  /**
-   * Regression: skills used to render as bare names, so a version pinning
-   * `alpha-skill@5` against a head pinned at `alpha-skill@2` produced
-   * byte-identical configs — and the restore dialog claimed nothing would
-   * change while `restore_version` silently rolled the skill back to v5.
-   */
-  it("diffs the same skill pinned at different versions", () => {
+describe("buildAgentPresetVirtualFiles head-owned skill topology", () => {
+  it("uses current head bindings on both sides of a version comparison", () => {
     const fromVersion = renderVersion(
-      buildVersion({
-        skills: [
+      buildVersion(),
+      SKILL_NAMES,
+      buildPayload({ skills: [{ skill_id: SKILL_ALPHA_ID }] }),
+      new Map([
+        [
+          SKILL_ALPHA_ID,
           {
             skill_id: SKILL_ALPHA_ID,
-            skill_version_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            skill_version_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
             skill_name: "alpha-skill",
-            skill_version: 5,
+            skill_version: 2,
           },
         ],
-      })
+      ])
     )
     const fromPayload = renderPayload(
       buildPayload({ skills: [{ skill_id: SKILL_ALPHA_ID }] }),
@@ -400,10 +383,7 @@ describe("buildAgentPresetVirtualFiles skill version pins", () => {
       ])
     )
 
-    expect(fromVersion.config).not.toBe(fromPayload.config)
-    expect(fromVersion.config).toContain(
-      "skills:\n  - name: alpha-skill\n    version: 5\n"
-    )
+    expect(fromVersion.config).toBe(fromPayload.config)
     expect(fromPayload.config).toContain(
       "skills:\n  - name: alpha-skill\n    version: 2\n"
     )

--- a/frontend/tests/agent-preset-version-history.test.tsx
+++ b/frontend/tests/agent-preset-version-history.test.tsx
@@ -94,7 +94,6 @@ const VERSION_READ: AgentPresetVersionRead = {
   preset_id: PRESET_ID,
   workspace_id: WORKSPACE_ID,
   version: 1,
-  skills: [],
   created_at: "2026-07-01T00:00:00Z",
   updated_at: "2026-07-01T00:00:00Z",
 }
@@ -251,11 +250,10 @@ describe("AgentPresetVersionHistory", () => {
     expect(within(tree).queryByText("Removed")).not.toBeInTheDocument()
   })
 
-  it("marks config.yaml modified when only the skill version pin differs", async () => {
+  it("keeps current head skill topology unchanged in a version diff", async () => {
     const skillId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-    // Head pins the skill at v2; the selected version pinned it at v5. The
-    // draft form tracks only the skill id, so the head bindings must supply
-    // the pin or the restore diff hides a real rollback of skill code.
+    // Versions are config-only. Both sides use the current head binding, so a
+    // restore cannot appear to roll topology backward.
     mockUseAgentPreset.mockReturnValue({
       preset: {
         name: "Triage agent",
@@ -272,22 +270,6 @@ describe("AgentPresetVersionHistory", () => {
       presetError: null,
       refetchPreset: jest.fn(),
     })
-    mockUseAgentPresetVersion.mockReturnValue({
-      presetVersion: {
-        ...VERSION_READ,
-        skills: [
-          {
-            skill_id: skillId,
-            skill_version_id: "cccccccc-cccc-cccc-cccc-cccccccccccc",
-            skill_name: "alpha-skill",
-            skill_version: 5,
-          },
-        ],
-      },
-      presetVersionIsLoading: false,
-      presetVersionError: null,
-      refetchPresetVersion: jest.fn(),
-    })
     mockUseSkills.mockReturnValue({
       skills: [{ id: skillId, name: "alpha-skill" }],
       skillsLoading: false,
@@ -303,7 +285,7 @@ describe("AgentPresetVersionHistory", () => {
     expect(items[0]).toHaveTextContent("instructions.md")
     expect(items[0]).not.toHaveTextContent("Modified")
     expect(items[1]).toHaveTextContent("config.yaml")
-    expect(items[1]).toHaveTextContent("Modified")
+    expect(items[1]).not.toHaveTextContent("Modified")
   })
 
   it("shows the load-error state and toasts when versions fail to load", async () => {

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -494,6 +494,7 @@ LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-histo
 PRESERVE_RESUMED_AGENT_BINDINGS_PATCH = (
     "durable-agent-preserve-resumed-agent-bindings-v1"
 )
+RESOLVE_HEAD_TOPOLOGY_PER_TURN_PATCH = "durable-agent-head-topology-per-turn-v1"
 
 
 def _agents_config_from_binding(
@@ -679,10 +680,8 @@ class DurableAgentWorkflow:
         follow_latest_versions: bool | None = None,
     ) -> ResolvedAgentsRuntimeConfig:
         agents_config = agents if agents is not None else cfg.agents
-        if not agents_config.enabled:
-            return ResolvedAgentsRuntimeConfig()
         if not agents_config.subagents:
-            return ResolvedAgentsRuntimeConfig(enabled=True)
+            return ResolvedAgentsRuntimeConfig()
         return await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(
@@ -1227,7 +1226,11 @@ class DurableAgentWorkflow:
             workflow.info().workflow_id
         ).session_id
         load_result: LoadSessionResult | None = None
-        if workflow.patched(PRESERVE_RESUMED_AGENT_BINDINGS_PATCH):
+        if workflow.patched(RESOLVE_HEAD_TOPOLOGY_PER_TURN_PATCH):
+            # Compile the head's current topology into this turn's durable
+            # runtime payload. A later turn resolves the head again.
+            agents_result = await self._resolve_agents_config(args, cfg)
+        elif workflow.patched(PRESERVE_RESUMED_AGENT_BINDINGS_PATCH):
             # Load session topology before resolving agents. A resumed session's
             # stored binding is the stable runtime contract, even if the preset
             # now follows a newer child version.

--- a/packages/tracecat-registry/tracecat_registry/core/presets.py
+++ b/packages/tracecat-registry/tracecat_registry/core/presets.py
@@ -107,7 +107,7 @@ async def create_preset(
     ] = None,
     agents: Annotated[
         dict[str, Any] | None,
-        Doc("Optional subagent configuration with `enabled` and `subagents` fields."),
+        Doc("Optional preset-backed subagent attachments."),
     ] = None,
     retries: Annotated[
         int | None,
@@ -284,9 +284,7 @@ async def update_preset(
     ] = None,
     agents: Annotated[
         dict[str, Any] | None,
-        Doc(
-            "The updated subagent configuration with `enabled` and `subagents` fields."
-        ),
+        Doc("The updated preset-backed subagent attachments."),
     ] = None,
     retries: Annotated[
         int | None,

--- a/tests/migration/test_agent_preset_head_topology_migration.py
+++ b/tests/migration/test_agent_preset_head_topology_migration.py
@@ -1,0 +1,646 @@
+"""Tests for normalizing agent preset topology onto resource heads."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection
+from sqlalchemy.pool import NullPool
+
+from tests.database import TEST_DB_CONFIG
+
+MIGRATION_REVISION = "a8e1f7c3b2d9"
+PREVIOUS_REVISION = "44d7e75b6f4c"
+
+
+def _run_alembic(db_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["TRACECAT__DB_URI"] = db_url
+    return subprocess.run(
+        ["uv", "run", "alembic", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _require_alembic_success(db_url: str, *args: str) -> None:
+    result = _run_alembic(db_url, *args)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Alembic command failed:\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+
+@pytest.fixture(scope="function")
+def migration_db_url() -> Iterator[str]:
+    default_engine = create_engine(
+        TEST_DB_CONFIG.sys_url_sync,
+        isolation_level="AUTOCOMMIT",
+        poolclass=NullPool,
+    )
+    db_name = f"test_agent_head_topology_{uuid.uuid4().hex[:8]}"
+    termination_query = text(
+        f"""
+        SELECT pg_terminate_backend(pg_stat_activity.pid)
+        FROM pg_stat_activity
+        WHERE pg_stat_activity.datname = '{db_name}'
+          AND pid <> pg_backend_pid();
+        """
+    )
+
+    try:
+        with default_engine.connect() as conn:
+            conn.execute(termination_query)
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+
+        db_url = TEST_DB_CONFIG.test_url_sync.replace(
+            TEST_DB_CONFIG.test_db_name, db_name
+        )
+        _require_alembic_success(db_url, "upgrade", PREVIOUS_REVISION)
+        yield db_url
+    finally:
+        with default_engine.connect() as conn:
+            conn.execute(termination_query)
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        default_engine.dispose()
+
+
+def _insert_workspace(
+    conn: Connection,
+    *,
+    workspace_id: uuid.UUID,
+    label: str,
+) -> None:
+    organization_id = uuid.uuid4()
+    conn.execute(
+        text(
+            """
+            INSERT INTO organization (id, name, slug, is_active)
+            VALUES (:id, :name, :slug, true)
+            """
+        ),
+        {
+            "id": organization_id,
+            "name": f"Agent topology org {label}",
+            "slug": f"agent-topology-org-{label}-{organization_id.hex[:8]}",
+        },
+    )
+    conn.execute(
+        text(
+            """
+            INSERT INTO workspace (id, organization_id, name)
+            VALUES (:id, :organization_id, :name)
+            """
+        ),
+        {
+            "id": workspace_id,
+            "organization_id": organization_id,
+            "name": f"Agent topology workspace {label}",
+        },
+    )
+
+
+def _insert_preset_with_current_version(
+    conn: Connection,
+    *,
+    workspace_id: uuid.UUID,
+    slug: str,
+    version_agents: dict[str, Any] | None = None,
+    head_agents: dict[str, Any] | None = None,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    preset_id = uuid.uuid4()
+    version_id = uuid.uuid4()
+    conn.execute(
+        text(
+            """
+            INSERT INTO agent_preset (
+                id,
+                workspace_id,
+                name,
+                slug,
+                instructions,
+                model_name,
+                model_provider,
+                retries,
+                agents
+            )
+            VALUES (
+                :id,
+                :workspace_id,
+                :name,
+                :slug,
+                'Preset instructions',
+                'gpt-5.5',
+                'openai',
+                3,
+                CAST(:agents AS jsonb)
+            )
+            """
+        ),
+        {
+            "id": preset_id,
+            "workspace_id": workspace_id,
+            "name": slug.replace("-", " ").title(),
+            "slug": slug,
+            "agents": json.dumps(head_agents or {"enabled": False}),
+        },
+    )
+    conn.execute(
+        text(
+            """
+            INSERT INTO agent_preset_version (
+                id,
+                preset_id,
+                workspace_id,
+                version,
+                instructions,
+                model_name,
+                model_provider,
+                retries,
+                agents
+            )
+            VALUES (
+                :id,
+                :preset_id,
+                :workspace_id,
+                1,
+                'Preset instructions',
+                'gpt-5.5',
+                'openai',
+                3,
+                CAST(:agents AS jsonb)
+            )
+            """
+        ),
+        {
+            "id": version_id,
+            "preset_id": preset_id,
+            "workspace_id": workspace_id,
+            "agents": json.dumps(version_agents or {"enabled": False}),
+        },
+    )
+    conn.execute(
+        text(
+            """
+            UPDATE agent_preset
+            SET current_version_id = :version_id
+            WHERE id = :preset_id
+            """
+        ),
+        {"preset_id": preset_id, "version_id": version_id},
+    )
+    return preset_id, version_id
+
+
+def _insert_skill_with_versions(
+    conn: Connection,
+    *,
+    workspace_id: uuid.UUID,
+) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    skill_id = uuid.uuid4()
+    old_version_id = uuid.uuid4()
+    current_version_id = uuid.uuid4()
+    conn.execute(
+        text(
+            """
+            INSERT INTO skill (
+                id,
+                workspace_id,
+                name,
+                slug,
+                draft_revision
+            )
+            VALUES (:id, :workspace_id, 'Evidence skill', 'evidence-skill', 0)
+            """
+        ),
+        {"id": skill_id, "workspace_id": workspace_id},
+    )
+    conn.execute(
+        text(
+            """
+            INSERT INTO skill_version (
+                id,
+                skill_id,
+                workspace_id,
+                version,
+                manifest_sha256,
+                file_count,
+                total_size_bytes,
+                name
+            )
+            VALUES
+                (
+                    :old_version_id,
+                    :skill_id,
+                    :workspace_id,
+                    1,
+                    :old_sha,
+                    1,
+                    10,
+                    'Evidence skill v1'
+                ),
+                (
+                    :current_version_id,
+                    :skill_id,
+                    :workspace_id,
+                    2,
+                    :current_sha,
+                    1,
+                    20,
+                    'Evidence skill v2'
+                )
+            """
+        ),
+        {
+            "old_version_id": old_version_id,
+            "current_version_id": current_version_id,
+            "skill_id": skill_id,
+            "workspace_id": workspace_id,
+            "old_sha": "1" * 64,
+            "current_sha": "2" * 64,
+        },
+    )
+    conn.execute(
+        text(
+            """
+            UPDATE skill
+            SET current_version_id = :current_version_id
+            WHERE id = :skill_id
+            """
+        ),
+        {"skill_id": skill_id, "current_version_id": current_version_id},
+    )
+    return skill_id, old_version_id, current_version_id
+
+
+def test_migration_backfills_head_topology_without_mutating_legacy_shadows(
+    migration_db_url: str,
+) -> None:
+    workspace_id = uuid.uuid4()
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            _insert_workspace(conn, workspace_id=workspace_id, label="happy")
+            child_id, _ = _insert_preset_with_current_version(
+                conn,
+                workspace_id=workspace_id,
+                slug="evidence-child",
+            )
+            parent_version_agents = {
+                "enabled": True,
+                "subagents": [
+                    {
+                        "preset": "evidence-child",
+                        "preset_id": str(child_id),
+                        "name": "evidence",
+                        "description": "Collect supporting evidence.",
+                        "max_turns": 7,
+                    }
+                ],
+            }
+            parent_id, parent_version_id = _insert_preset_with_current_version(
+                conn,
+                workspace_id=workspace_id,
+                slug="triage-parent",
+                version_agents=parent_version_agents,
+                head_agents={"enabled": False},
+            )
+            skill_id, old_skill_version_id, current_skill_version_id = (
+                _insert_skill_with_versions(conn, workspace_id=workspace_id)
+            )
+            version_skill_edge_id = uuid.uuid4()
+            head_skill_edge_id = uuid.uuid4()
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO agent_preset_version_skill (
+                        id,
+                        preset_version_id,
+                        skill_id,
+                        skill_version_id,
+                        workspace_id
+                    )
+                    VALUES (
+                        :id,
+                        :preset_version_id,
+                        :skill_id,
+                        :skill_version_id,
+                        :workspace_id
+                    )
+                    """
+                ),
+                {
+                    "id": version_skill_edge_id,
+                    "preset_version_id": parent_version_id,
+                    "skill_id": skill_id,
+                    "skill_version_id": current_skill_version_id,
+                    "workspace_id": workspace_id,
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO agent_preset_skill (
+                        id,
+                        preset_id,
+                        skill_id,
+                        skill_version_id,
+                        workspace_id
+                    )
+                    VALUES (
+                        :id,
+                        :preset_id,
+                        :skill_id,
+                        :skill_version_id,
+                        :workspace_id
+                    )
+                    """
+                ),
+                {
+                    "id": head_skill_edge_id,
+                    "preset_id": parent_id,
+                    "skill_id": skill_id,
+                    "skill_version_id": old_skill_version_id,
+                    "workspace_id": workspace_id,
+                },
+            )
+
+        _require_alembic_success(migration_db_url, "upgrade", MIGRATION_REVISION)
+
+        with engine.connect() as conn:
+            subagent_edge = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT
+                            parent_preset_id,
+                            child_preset_id,
+                            alias,
+                            description,
+                            max_turns,
+                            workspace_id
+                        FROM agent_preset_subagent
+                        """
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            assert subagent_edge == {
+                "parent_preset_id": parent_id,
+                "child_preset_id": child_id,
+                "alias": "evidence",
+                "description": "Collect supporting evidence.",
+                "max_turns": 7,
+                "workspace_id": workspace_id,
+            }
+
+            head_skill_edge = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT id, skill_version_id
+                        FROM agent_preset_skill
+                        WHERE preset_id = :preset_id
+                        """
+                    ),
+                    {"preset_id": parent_id},
+                )
+                .mappings()
+                .one()
+            )
+            assert head_skill_edge == {
+                "id": head_skill_edge_id,
+                "skill_version_id": current_skill_version_id,
+            }
+
+            legacy_agents = conn.execute(
+                text(
+                    """
+                    SELECT agents
+                    FROM agent_preset_version
+                    WHERE id = :version_id
+                    """
+                ),
+                {"version_id": parent_version_id},
+            ).scalar_one()
+            assert legacy_agents == parent_version_agents
+            legacy_skill_edge = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT id, skill_version_id
+                        FROM agent_preset_version_skill
+                        WHERE preset_version_id = :preset_version_id
+                        """
+                    ),
+                    {"preset_version_id": parent_version_id},
+                )
+                .mappings()
+                .one()
+            )
+            assert legacy_skill_edge == {
+                "id": version_skill_edge_id,
+                "skill_version_id": current_skill_version_id,
+            }
+            assert (
+                conn.execute(
+                    text(
+                        """
+                        SELECT count(*)
+                        FROM information_schema.columns
+                        WHERE table_name = 'agent_preset'
+                          AND column_name = 'subagents_enabled'
+                        """
+                    )
+                ).scalar_one()
+                == 0
+            )
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("invalid_refs", "expected_error"),
+    [
+        pytest.param(
+            [{"preset": "missing-child", "name": "evidence"}],
+            "unresolved or cross-workspace subagent head",
+            id="unresolved-child",
+        ),
+        pytest.param(
+            [
+                {"preset": "first-child", "name": "duplicate"},
+                {"preset": "second-child", "name": "duplicate"},
+            ],
+            "duplicate subagent alias",
+            id="duplicate-alias",
+        ),
+    ],
+)
+def test_migration_rejects_invalid_subagent_edges_atomically(
+    migration_db_url: str,
+    invalid_refs: list[dict[str, Any]],
+    expected_error: str,
+) -> None:
+    workspace_id = uuid.uuid4()
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            _insert_workspace(conn, workspace_id=workspace_id, label="invalid")
+            for slug in ("first-child", "second-child"):
+                _insert_preset_with_current_version(
+                    conn,
+                    workspace_id=workspace_id,
+                    slug=slug,
+                )
+            _insert_preset_with_current_version(
+                conn,
+                workspace_id=workspace_id,
+                slug="parent",
+                version_agents={"enabled": True, "subagents": invalid_refs},
+            )
+
+        result = _run_alembic(migration_db_url, "upgrade", MIGRATION_REVISION)
+
+        assert result.returncode != 0
+        assert expected_error in result.stderr
+        with engine.connect() as conn:
+            assert (
+                conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).scalar_one()
+                == PREVIOUS_REVISION
+            )
+            assert (
+                conn.execute(
+                    text("SELECT to_regclass('public.agent_preset_subagent')")
+                ).scalar_one()
+                is None
+            )
+    finally:
+        engine.dispose()
+
+
+def test_migration_rejects_cross_workspace_subagent_edge_atomically(
+    migration_db_url: str,
+) -> None:
+    parent_workspace_id = uuid.uuid4()
+    child_workspace_id = uuid.uuid4()
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            _insert_workspace(
+                conn,
+                workspace_id=parent_workspace_id,
+                label="parent",
+            )
+            _insert_workspace(
+                conn,
+                workspace_id=child_workspace_id,
+                label="child",
+            )
+            child_id, _ = _insert_preset_with_current_version(
+                conn,
+                workspace_id=child_workspace_id,
+                slug="foreign-child",
+            )
+            _insert_preset_with_current_version(
+                conn,
+                workspace_id=parent_workspace_id,
+                slug="parent",
+                version_agents={
+                    "enabled": True,
+                    "subagents": [
+                        {
+                            "preset": "foreign-child",
+                            "preset_id": str(child_id),
+                            "name": "foreign",
+                        }
+                    ],
+                },
+            )
+
+        result = _run_alembic(migration_db_url, "upgrade", MIGRATION_REVISION)
+
+        assert result.returncode != 0
+        assert "unresolved or cross-workspace subagent head" in result.stderr
+        with engine.connect() as conn:
+            assert (
+                conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).scalar_one()
+                == PREVIOUS_REVISION
+            )
+            assert (
+                conn.execute(
+                    text("SELECT to_regclass('public.agent_preset_subagent')")
+                ).scalar_one()
+                is None
+            )
+    finally:
+        engine.dispose()
+
+
+def test_migration_rejects_mismatched_current_preset_version_atomically(
+    migration_db_url: str,
+) -> None:
+    workspace_id = uuid.uuid4()
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            _insert_workspace(conn, workspace_id=workspace_id, label="version")
+            parent_id, _ = _insert_preset_with_current_version(
+                conn,
+                workspace_id=workspace_id,
+                slug="parent",
+            )
+            _, unrelated_version_id = _insert_preset_with_current_version(
+                conn,
+                workspace_id=workspace_id,
+                slug="unrelated",
+            )
+            conn.execute(
+                text(
+                    """
+                    UPDATE agent_preset
+                    SET current_version_id = :unrelated_version_id
+                    WHERE id = :parent_id
+                    """
+                ),
+                {
+                    "parent_id": parent_id,
+                    "unrelated_version_id": unrelated_version_id,
+                },
+            )
+
+        result = _run_alembic(migration_db_url, "upgrade", MIGRATION_REVISION)
+
+        assert result.returncode != 0
+        assert "invalid current preset version" in result.stderr
+        with engine.connect() as conn:
+            assert (
+                conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).scalar_one()
+                == PREVIOUS_REVISION
+            )
+            assert (
+                conn.execute(
+                    text("SELECT to_regclass('public.agent_preset_subagent')")
+                ).scalar_one()
+                is None
+            )
+    finally:
+        engine.dispose()

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -1397,7 +1397,7 @@ async def test_approval_wait_cancellation_defers_end_until_marker_and_finalize(
 
 @pytest.mark.anyio
 @pytest.mark.integration
-async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
+async def test_agent_workflow_resolves_current_subagent_binding_each_turn(
     svc_role: Role,
     temporal_client: Client,
     agent_worker_factory,
@@ -1419,8 +1419,8 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
         preset_id=child_preset_id,
         preset_version_id=latest_version_id,
     )
-    stored_binding = ResolvedAgentsConfig(enabled=True, subagents=[stored_ref])
-    latest_agents_config = AgentSubagentsConfig(enabled=True, subagents=[latest_ref])
+    stored_binding = ResolvedAgentsConfig(subagents=[stored_ref])
+    latest_agents_config = AgentSubagentsConfig(subagents=[latest_ref])
     resolve_inputs: list[ResolveAgentsConfigActivityInput] = []
     create_inputs: list[CreateSessionInput] = []
     agent_inputs: list[AgentExecutorInput] = []
@@ -1442,18 +1442,17 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
         input: ResolveAgentsConfigActivityInput,
     ) -> ResolvedAgentsRuntimeConfig:
         resolve_inputs.append(input)
-        assert input.follow_latest_versions is False
+        assert input.follow_latest_versions is None
         assert len(input.agents.subagents) == 1
         resolved_ref = input.agents.subagents[0]
         assert isinstance(resolved_ref, ResolvedAttachedSubagentRef)
-        assert resolved_ref.preset_version_id == stored_version_id
+        assert resolved_ref.preset_version_id == latest_version_id
 
         return ResolvedAgentsRuntimeConfig(
-            enabled=True,
             subagents=[
                 ResolvedSubagentConfig(
-                    binding=stored_ref,
-                    description="Stored analyst",
+                    binding=latest_ref,
+                    description="Current analyst",
                     prompt="Complete the delegated analysis.",
                     config=agent_config_to_payload(
                         AgentConfig(
@@ -1471,7 +1470,7 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
         input: CreateSessionInput,
     ) -> CreateSessionResult:
         create_inputs.append(input)
-        assert input.agents_binding == stored_binding
+        assert input.agents_binding == ResolvedAgentsConfig(subagents=[latest_ref])
         return CreateSessionResult(session_id=input.session_id, success=True)
 
     @activity.defn(name="run_agent_activity")
@@ -1526,9 +1525,11 @@ async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
     assert result.session_id == mock_session_id
     assert result.output == {"status": "ok"}
     assert len(resolve_inputs) == 1
-    assert resolve_inputs[0].agents.subagents == [stored_ref]
+    assert resolve_inputs[0].agents.subagents == [latest_ref]
     assert len(create_inputs) == 1
-    assert create_inputs[0].agents_binding == stored_binding
+    assert create_inputs[0].agents_binding == ResolvedAgentsConfig(
+        subagents=[latest_ref]
+    )
     assert len(agent_inputs) == 1
     assert agent_inputs[0].sdk_session_id == "sdk-session"
     assert [subagent.alias for subagent in agent_inputs[0].subagents] == ["analyst"]

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -687,6 +687,8 @@ class TestCreateSessionActivity:
         mock_agent_session.parent_session_id = None
         mock_service = AsyncMock()
         mock_service.get_or_create_session.return_value = (mock_agent_session, False)
+        mock_service.session = MagicMock()
+        mock_service.session.commit = AsyncMock()
 
         # Set up the context manager's __aenter__ to return the mock service
         mock_ctx = AsyncMock()
@@ -700,10 +702,10 @@ class TestCreateSessionActivity:
 
     @pytest.mark.anyio
     @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
-    async def test_backfills_disabled_agents_binding_for_legacy_existing_session(
+    async def test_backfills_empty_agents_binding_for_legacy_existing_session(
         self, mock_with_session, mock_role: Role, mock_session_id: uuid.UUID
     ):
-        """Legacy NULL bindings are persisted as the disabled binding."""
+        """Legacy NULL bindings are persisted as an empty binding."""
         agents_binding = ResolvedAgentsConfig()
         input = CreateSessionInput(
             role=mock_role,
@@ -742,83 +744,58 @@ class TestCreateSessionActivity:
         (
             "incoming_agents_binding",
             "persisted_agents_binding",
-            "sdk_session_id",
-            "parent_session_id",
-            "expected_success",
-            "expected_backfill",
+            "expected_write",
         ),
         [
             pytest.param(
                 ResolvedAgentsConfig.model_validate({"enabled": True, "subagents": []}),
                 None,
-                None,
-                None,
                 True,
-                True,
-                id="fresh-null-backfills-resolved-agents",
+                id="fresh-null-writes-current-binding",
             ),
             pytest.param(
                 ResolvedAgentsConfig.model_validate({"enabled": True, "subagents": []}),
-                None,
-                "sdk-session-1",
-                None,
-                False,
-                False,
-                id="resumable-null-cannot-enable-agents",
+                {"enabled": False},
+                True,
+                id="normalizes-legacy-empty-binding",
             ),
             pytest.param(
-                ResolvedAgentsConfig.model_validate({"enabled": True, "subagents": []}),
-                None,
-                None,
-                uuid.UUID("00000000-0000-0000-0000-000000000001"),
-                False,
-                False,
-                id="fork-null-cannot-enable-agents",
+                ResolvedAgentsConfig.model_validate(
+                    {
+                        "subagents": [
+                            {
+                                "preset": "current-child",
+                                "preset_id": "00000000-0000-4000-8000-000000000001",
+                                "preset_version_id": "00000000-0000-4000-8000-000000000002",
+                                "preset_version": 2,
+                            }
+                        ]
+                    }
+                ),
+                {"subagents": []},
+                True,
+                id="new-turn-replaces-prior-binding",
             ),
             pytest.param(
                 ResolvedAgentsConfig(),
-                {"enabled": False},
-                "sdk-session-1",
-                None,
-                True,
+                {"subagents": []},
                 False,
-                id="default-equivalent-jsonb",
-            ),
-            pytest.param(
-                ResolvedAgentsConfig.model_validate({"enabled": True, "subagents": []}),
-                {"enabled": False},
-                None,
-                None,
-                False,
-                False,
-                id="different-explicit-binding",
-            ),
-            pytest.param(
-                None,
-                {"enabled": True, "subagents": []},
-                None,
-                None,
-                False,
-                False,
-                id="missing-incoming-binding",
+                id="matching-current-binding-is-unchanged",
             ),
         ],
     )
     @pytest.mark.anyio
     @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
-    async def test_existing_session_agents_binding_must_match(
+    async def test_existing_session_tracks_current_turn_agents_binding(
         self,
         mock_with_session,
         mock_role: Role,
         mock_session_id: uuid.UUID,
         incoming_agents_binding: ResolvedAgentsConfig | None,
         persisted_agents_binding: dict[str, object] | None,
-        sdk_session_id: str | None,
-        parent_session_id: uuid.UUID | None,
-        expected_success: bool,
-        expected_backfill: bool,
+        expected_write: bool,
     ):
-        """Existing sessions reject binding changes once SDK/fork resume state exists."""
+        """Existing sessions shadow the binding compiled for the current turn."""
         input = CreateSessionInput(
             role=mock_role,
             session_id=mock_session_id,
@@ -829,8 +806,6 @@ class TestCreateSessionActivity:
 
         mock_agent_session = MagicMock()
         mock_agent_session.agents_binding = persisted_agents_binding
-        mock_agent_session.sdk_session_id = sdk_session_id
-        mock_agent_session.parent_session_id = parent_session_id
         mock_service = AsyncMock()
         mock_service.get_or_create_session.return_value = (
             mock_agent_session,
@@ -843,23 +818,14 @@ class TestCreateSessionActivity:
         mock_ctx.__aenter__.return_value = mock_service
         mock_with_session.return_value = mock_ctx
 
-        if expected_success:
-            result = await create_session_activity(input)
-            assert result.success is True
-            assert result.error is None
-        else:
-            with pytest.raises(ApplicationError) as exc_info:
-                await create_session_activity(input)
-            assert exc_info.value.message == (
-                "Agent session was created with a different agents binding"
-            )
-            assert exc_info.value.non_retryable is True
+        result = await create_session_activity(input)
+        assert result.success is True
+        assert result.error is None
 
-        if expected_backfill:
-            assert incoming_agents_binding is not None
-            assert (
-                mock_agent_session.agents_binding
-                == incoming_agents_binding.model_dump(mode="json")
+        if expected_write:
+            expected_binding = incoming_agents_binding or ResolvedAgentsConfig()
+            assert mock_agent_session.agents_binding == expected_binding.model_dump(
+                mode="json"
             )
             mock_service.session.add.assert_called_once_with(mock_agent_session)
             mock_service.session.commit.assert_awaited_once()
@@ -887,6 +853,8 @@ class TestCreateSessionActivity:
         mock_agent_session.sdk_session_id = None
         mock_agent_session.parent_session_id = None
         mock_service.get_session.return_value = mock_agent_session
+        mock_service.session = MagicMock()
+        mock_service.session.commit = AsyncMock()
 
         mock_ctx = AsyncMock()
         mock_ctx.__aenter__.return_value = mock_service
@@ -1011,6 +979,8 @@ class TestCreateSessionActivity:
         mock_service = AsyncMock()
         mock_service.get_or_create_session.return_value = (mock_agent_session, False)
         mock_service.auto_title_session_on_first_prompt = AsyncMock()
+        mock_service.session = MagicMock()
+        mock_service.session.commit = AsyncMock()
 
         mock_ctx = AsyncMock()
         mock_ctx.__aenter__.return_value = mock_service

--- a/tests/unit/test_agent_internal_router.py
+++ b/tests/unit/test_agent_internal_router.py
@@ -7,7 +7,7 @@ import pytest
 from tracecat.agent.internal_router import _resolve_run_config
 from tracecat.agent.schemas import AgentConfigSchema, InternalRunAgentRequest
 from tracecat.agent.service import AgentManagementService
-from tracecat.agent.subagents import AgentSubagentsConfig
+from tracecat.agent.subagents import AgentSubagentsConfig, AttachedSubagentRef
 
 
 @pytest.mark.anyio
@@ -17,7 +17,9 @@ async def test_resolve_run_config_rejects_subagents_on_internal_runner() -> None
         config=AgentConfigSchema(
             model_name="gpt-5",
             model_provider="openai",
-            agents=AgentSubagentsConfig(enabled=True),
+            agents=AgentSubagentsConfig(
+                subagents=[AttachedSubagentRef(preset="analyst")]
+            ),
         ),
     )
 

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -95,7 +95,6 @@ def test_resolve_agents_config_result_derives_session_binding() -> None:
         preset_version_id=uuid.uuid4(),
     )
     result = ResolvedAgentsRuntimeConfig(
-        enabled=True,
         subagents=[
             ResolvedSubagentConfig(
                 binding=binding,
@@ -113,7 +112,6 @@ def test_resolve_agents_config_result_derives_session_binding() -> None:
     assert result.subagents[0].alias == "analyst"
     assert result.subagents[0].max_turns == 5
     agents_binding = result.to_agents_binding()
-    assert agents_binding.enabled is True
     assert agents_binding.subagents == [binding]
 
 
@@ -136,11 +134,11 @@ async def test_resolve_preset_subagent_configs_resolves_version_id_ref() -> None
         tool_approvals={},
     )
     service.resolve_agent_preset_version = AsyncMock(return_value=version)
+    service.get_head_subagents_config = AsyncMock(return_value=AgentSubagentsConfig())
     service._lock_active_subagent_presets = AsyncMock()  # type: ignore[method-assign]
 
     result = await service._resolve_preset_subagent_configs(
         AgentSubagentsConfig(
-            enabled=True,
             subagents=[
                 ResolvedAttachedSubagentRef(
                     preset="old-analyst-slug",
@@ -187,6 +185,7 @@ async def test_resolve_agents_config_resolves_pinned_ref_by_version_id(
                 retries=3,
             )
         ),
+        get_head_subagents_config=AsyncMock(return_value=AgentSubagentsConfig()),
         use_latest_resource_versions=AsyncMock(return_value=False),
     )
     role = Role(
@@ -205,7 +204,6 @@ async def test_resolve_agents_config_resolves_pinned_ref_by_version_id(
         ResolveAgentsConfigActivityInput(
             role=role,
             agents=AgentSubagentsConfig(
-                enabled=True,
                 subagents=[
                     ResolvedAttachedSubagentRef(
                         preset="old-analyst-slug",
@@ -252,6 +250,7 @@ async def test_resolve_agents_config_explicitly_disables_latest_resolution(
                 retries=3,
             )
         ),
+        get_head_subagents_config=AsyncMock(return_value=AgentSubagentsConfig()),
         use_latest_resource_versions=AsyncMock(return_value=True),
     )
     role = Role(
@@ -270,7 +269,6 @@ async def test_resolve_agents_config_explicitly_disables_latest_resolution(
         ResolveAgentsConfigActivityInput(
             role=role,
             agents=AgentSubagentsConfig(
-                enabled=True,
                 subagents=[
                     ResolvedAttachedSubagentRef(
                         preset="old-analyst-slug",
@@ -305,6 +303,7 @@ async def test_resolve_agents_config_rejects_subagent_with_tool_approvals(
     )
     service = SimpleNamespace(
         resolve_agent_preset_version=AsyncMock(return_value=version),
+        get_head_subagents_config=AsyncMock(return_value=AgentSubagentsConfig()),
         use_latest_resource_versions=AsyncMock(return_value=False),
     )
     role = Role(

--- a/tests/unit/test_agent_preset_schemas.py
+++ b/tests/unit/test_agent_preset_schemas.py
@@ -19,7 +19,7 @@ from tracecat.agent.preset.schemas import (
     build_agent_preset_read_minimal,
     build_subagent_eligibility,
 )
-from tracecat.db.models import AgentPreset
+from tracecat.db.models import AgentPreset, AgentPresetSubagent, AgentPresetVersion
 
 
 def make_agent_preset(
@@ -29,23 +29,49 @@ def make_agent_preset(
     tool_approvals: dict[str, bool] | None = None,
     agents: dict[str, object] | None = None,
     enable_internet_access: bool = False,
+    has_subagents: bool = False,
 ) -> AgentPreset:
     timestamp = datetime(2026, 3, 9, tzinfo=UTC)
-    return AgentPreset(
-        id=uuid.uuid4(),
+    preset_id = uuid.uuid4()
+    version_id = uuid.uuid4()
+    preset = AgentPreset(
+        id=preset_id,
         workspace_id=uuid.uuid4(),
         name=name,
         slug=slug,
         description=None,
         model_provider="openai",
         model_name="gpt-4o-mini",
-        current_version_id=None,
+        current_version_id=version_id,
         tool_approvals=tool_approvals,
         agents=agents or {"enabled": False},
         enable_internet_access=enable_internet_access,
         created_at=timestamp,
         updated_at=timestamp,
     )
+    preset.current_version = AgentPresetVersion(
+        id=version_id,
+        workspace_id=preset.workspace_id,
+        preset_id=preset_id,
+        version=1,
+        instructions=None,
+        model_provider="openai",
+        model_name="gpt-4o-mini",
+        tool_approvals=tool_approvals,
+        enable_internet_access=enable_internet_access,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+    if has_subagents:
+        preset.subagent_bindings = [
+            AgentPresetSubagent(
+                workspace_id=preset.workspace_id,
+                parent_preset_id=preset_id,
+                child_preset_id=uuid.uuid4(),
+                alias="analyst",
+            )
+        ]
+    return preset
 
 
 def test_agent_preset_create_trims_required_fields() -> None:
@@ -250,14 +276,14 @@ def test_agent_preset_read_minimal_exposes_current_version_subagent_eligibility(
             name="Parent preset",
             slug="parent-preset",
             tool_approvals={"core.http_request": True},
-            agents={"enabled": True, "subagents": []},
+            has_subagents=True,
         )
     )
 
     dumped = payload.model_dump(mode="json")
     assert dumped["current_version_subagent_eligibility"] == {
         "eligible": False,
-        "reasons": ["agents_enabled", "tool_approvals"],
+        "reasons": ["nested_subagents", "tool_approvals"],
         "message": (
             "This version defines its own subagents and requires manual approvals, "
             "which are not supported for preset subagents yet."
@@ -269,7 +295,7 @@ def test_agent_preset_read_minimal_exposes_current_version_subagent_eligibility(
 
 def test_build_subagent_eligibility_allows_plain_versions() -> None:
     eligibility = build_subagent_eligibility(
-        agents_config={"enabled": False},
+        has_subagents=False,
         tool_approvals={"core.http_request": False},
     )
 

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -23,7 +23,6 @@ from tracecat.agent.preset.resolver import resolve_agents_config
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
     AgentPresetSkillBindingBase,
-    AgentPresetSkillBindingRead,
     AgentPresetUpdate,
 )
 from tracecat.agent.preset.service import AgentPresetService
@@ -36,6 +35,7 @@ from tracecat.agent.skill.schemas import (
 from tracecat.agent.skill.service import SkillService
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
+    HeadAttachedSubagentRef,
     ResolvedAgentsConfig,
     ResolvedAttachedSubagentRef,
 )
@@ -46,6 +46,7 @@ from tracecat.db.models import (
     AgentChannelToken,
     AgentModelAccess,
     AgentPreset,
+    AgentPresetSkill,
     AgentPresetVersion,
     AgentPresetVersionSkill,
     MCPIntegration,
@@ -977,12 +978,12 @@ class TestAgentPresetService:
         assert [version.version for version in page_2.items] == [1]
         assert page_2.has_more is False
 
-    async def test_list_versions_exposes_subagent_eligibility(
+    async def test_list_versions_excludes_head_topology_capabilities(
         self,
         agent_preset_service: AgentPresetService,
         agent_preset_create_params: AgentPresetCreate,
     ) -> None:
-        """Version list metadata includes version-specific subagent eligibility."""
+        """Version metadata is config-only and excludes current head topology."""
         created_preset = await agent_preset_service.create_preset(
             agent_preset_create_params.model_copy(
                 update={
@@ -1000,10 +1001,8 @@ class TestAgentPresetService:
 
         assert len(versions.items) == 1
         version = versions.items[0]
-        assert version.capabilities == ["subagents"]
-        assert version.subagent_eligibility.eligible is False
-        assert version.subagent_eligibility.reasons == ["agents_enabled"]
-        assert version.subagent_eligibility.message is not None
+        assert version.capabilities == []
+        assert "subagent_eligibility" not in version.model_dump()
 
     async def test_list_versions_rejects_invalid_cursor(
         self,
@@ -1213,10 +1212,16 @@ class TestAgentPresetService:
             created_preset
         )
         version_read = await agent_preset_service.build_version_read(current_version)
+        snapshot = (
+            await session.execute(
+                select(AgentPresetVersionSkill).where(
+                    AgentPresetVersionSkill.preset_version_id == current_version.id
+                )
+            )
+        ).scalar_one()
 
-        assert len(version_read.skills) == 1
-        assert version_read.skills[0].skill_version_id == skill_version.id
-        assert version_read.skills[0].skill_version == 1
+        assert "skills" not in version_read.model_dump()
+        assert snapshot.skill_version_id == skill_version.id
 
     async def test_create_preset_skill_binding_without_version_stores_current_version(
         self,
@@ -1251,7 +1256,7 @@ class TestAgentPresetService:
         version_read = await agent_preset_service.build_version_read(current_version)
 
         assert head_bindings[0].skill_version_id == skill_version.id
-        assert version_read.skills[0].skill_version_id == skill_version.id
+        assert "skills" not in version_read.model_dump()
 
     async def test_update_preset_skill_binding_without_version_uses_current_version(
         self,
@@ -1307,7 +1312,7 @@ class TestAgentPresetService:
         version_read = await agent_preset_service.build_version_read(updated_version)
 
         assert head_bindings[0].skill_version_id == current_version.id
-        assert version_read.skills[0].skill_version_id == current_version.id
+        assert "skills" not in version_read.model_dump()
 
     async def test_client_supplied_stale_skill_version_is_ignored(
         self,
@@ -1365,7 +1370,7 @@ class TestAgentPresetService:
         version_read = await agent_preset_service.build_version_read(current_version)
 
         assert head_bindings[0].skill_version_id == current_published_version.id
-        assert version_read.skills[0].skill_version_id == current_published_version.id
+        assert "skills" not in version_read.model_dump()
         assert current_published_version.id != stale_version.id
 
     async def test_create_preset_rejects_unpublished_skill_binding(
@@ -1397,7 +1402,7 @@ class TestAgentPresetService:
         assert detail["code"] == "skill_not_published"
         assert detail["skill_id"] == str(created_skill.id)
 
-    async def test_resolve_config_uses_latest_skill_versions_when_setting_enabled(
+    async def test_resolve_config_uses_current_skill_head_and_refreshes_shadow(
         self,
         configure_minio_for_skills,
         session: AsyncSession,
@@ -1405,7 +1410,7 @@ class TestAgentPresetService:
         svc_admin_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
-        """Latest-resource mode resolves skills by current version at execution time."""
+        """Execution resolves the Skill head while its rollback shadow stays current."""
 
         settings_service = SettingsService(session=session, role=svc_admin_role)
         await settings_service.update_app_settings(
@@ -1458,14 +1463,23 @@ class TestAgentPresetService:
         config = await agent_preset_service.resolve_agent_preset_config(
             preset_id=created_preset.id
         )
+        legacy_shadow = await session.scalar(
+            select(AgentPresetSkill).where(
+                AgentPresetSkill.workspace_id == svc_role.workspace_id,
+                AgentPresetSkill.preset_id == created_preset.id,
+                AgentPresetSkill.skill_id == created_skill.id,
+            )
+        )
 
         assert config.resolved_skills is not None
         assert len(config.resolved_skills) == 1
         resolved_skill = config.resolved_skills[0]
         assert resolved_skill.skill_version_id == skill_version_two.id
         assert resolved_skill.skill_name == "latest-skill-v2"
+        assert legacy_shadow is not None
+        assert legacy_shadow.skill_version_id == skill_version_two.id
 
-    async def test_resolve_config_rejects_archived_skill_in_latest_mode(
+    async def test_resolve_config_omits_archived_head_skill_in_latest_mode(
         self,
         configure_minio_for_skills,
         session: AsyncSession,
@@ -1473,7 +1487,7 @@ class TestAgentPresetService:
         svc_admin_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
-        """Latest-resource mode refuses archived skills from historical versions."""
+        """Archived skills are unlinked from head topology in latest mode."""
 
         settings_service = SettingsService(session=session, role=svc_admin_role)
         await settings_service.update_app_settings(
@@ -1505,24 +1519,16 @@ class TestAgentPresetService:
         historical_version = await agent_preset_service.get_current_version_for_preset(
             created_preset
         )
-        await agent_preset_service.update_preset(
-            created_preset,
-            AgentPresetUpdate(skills=None),
-        )
         await skill_service.archive_skill(created_skill.id)
 
-        with pytest.raises(TracecatValidationError) as exc_info:
-            await agent_preset_service.resolve_agent_preset_config(
-                preset_id=created_preset.id,
-                preset_version_id=historical_version.id,
-            )
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=created_preset.id,
+            preset_version_id=historical_version.id,
+        )
 
-        detail = exc_info.value.detail
-        assert detail is not None
-        assert detail["code"] == "skill_archived"
-        assert str(created_skill.id) in str(detail["skills"])
+        assert config.resolved_skills == []
 
-    async def test_resolve_config_rejects_archived_skill_in_pinned_mode(
+    async def test_resolve_config_omits_archived_head_skill_in_pinned_mode(
         self,
         configure_minio_for_skills,
         session: AsyncSession,
@@ -1530,7 +1536,7 @@ class TestAgentPresetService:
         svc_admin_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
-        """Pinned-resource mode refuses archived skills from historical versions."""
+        """Archived skills are unlinked from head topology in pinned mode."""
 
         settings_service = SettingsService(session=session, role=svc_admin_role)
         await settings_service.update_app_settings(
@@ -1562,22 +1568,14 @@ class TestAgentPresetService:
         historical_version = await agent_preset_service.get_current_version_for_preset(
             created_preset
         )
-        await agent_preset_service.update_preset(
-            created_preset,
-            AgentPresetUpdate(skills=None),
-        )
         await skill_service.archive_skill(created_skill.id)
 
-        with pytest.raises(TracecatValidationError) as exc_info:
-            await agent_preset_service.resolve_agent_preset_config(
-                preset_id=created_preset.id,
-                preset_version_id=historical_version.id,
-            )
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=created_preset.id,
+            preset_version_id=historical_version.id,
+        )
 
-        detail = exc_info.value.detail
-        assert detail is not None
-        assert detail["code"] == "skill_archived"
-        assert str(created_skill.id) in str(detail["skills"])
+        assert config.resolved_skills == []
 
     async def test_list_versions_returns_metadata_without_skill_lookups(
         self,
@@ -1638,18 +1636,6 @@ class TestAgentPresetService:
             ),
         )
 
-        async def fail_single_version_lookup(
-            version_id: uuid.UUID,
-        ) -> list[AgentPresetSkillBindingRead]:
-            del version_id
-            raise AssertionError("list endpoint should batch skill binding lookups")
-
-        monkeypatch.setattr(
-            agent_preset_service,
-            "_list_version_skill_bindings",
-            fail_single_version_lookup,
-        )
-
         version_reads = await agent_preset_service.list_versions(
             created_preset.id,
             CursorPaginationParams(limit=10),
@@ -1657,14 +1643,14 @@ class TestAgentPresetService:
 
         assert [version.version for version in version_reads.items] == [2, 1]
 
-    async def test_restore_version_restores_historical_skill_versions_on_head(
+    async def test_restore_version_preserves_current_skill_head_topology(
         self,
         configure_minio_for_skills,
         session: AsyncSession,
         svc_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
-        """Restoring a preset version copies historical skill versions onto the head."""
+        """Restoring config rolls forward while current Skill topology stays put."""
 
         skill_service = SkillService(session=session, role=svc_role)
         created_skill = await skill_service.create_skill(
@@ -1734,26 +1720,28 @@ class TestAgentPresetService:
             restored.id
         )
 
-        assert len(diff.skill_changes) == 1
-        assert diff.skill_changes[0].old_skill_version_id == skill_version_one.id
-        assert diff.skill_changes[0].new_skill_version_id == skill_version_two.id
+        assert "skill_changes" not in diff.model_dump()
+        assert restored.current_version_id not in {
+            preset_version_one.id,
+            preset_version_two.id,
+        }
         assert len(restored_bindings) == 1
-        assert restored_bindings[0].skill_version_id == skill_version_one.id
+        assert restored_bindings[0].skill_version_id == skill_version_two.id
 
-    async def test_build_version_read_uses_snapshot_skill_version_name(
+    async def test_build_version_read_excludes_skill_topology(
         self,
         configure_minio_for_skills,
         session: AsyncSession,
         svc_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
-        """Preset version reads expose the name from their Skill snapshot."""
+        """Preset version reads are config-only while the head uses current Skills."""
 
         skill_service = SkillService(session=session, role=svc_role)
         created_skill = await skill_service.create_skill(
             SkillCreate(name="version-one")
         )
-        skill_version_one = await skill_service.publish_skill(created_skill.id)
+        await skill_service.publish_skill(created_skill.id)
 
         created_preset = await agent_preset_service.create_preset(
             AgentPresetCreate(
@@ -1798,8 +1786,7 @@ class TestAgentPresetService:
             created_preset.id
         )
 
-        assert version_read.skills[0].skill_version_id == skill_version_one.id
-        assert version_read.skills[0].skill_name == "version-one"
+        assert "skills" not in version_read.model_dump()
         assert head_bindings[0].skill_version_id == skill_version_two.id
         assert head_bindings[0].skill_name == "version-two"
 
@@ -1859,11 +1846,18 @@ class TestAgentPresetService:
             created_preset.id
         )
         version_read = await agent_preset_service.build_version_read(current_version)
+        snapshot = (
+            await session.execute(
+                select(AgentPresetVersionSkill).where(
+                    AgentPresetVersionSkill.preset_version_id == current_version.id
+                )
+            )
+        ).scalar_one()
 
         assert head_bindings[0].skill_version_id == skill_version_two.id
         assert head_bindings[0].skill_name == "head-binding-v2"
-        assert version_read.skills[0].skill_version_id == skill_version_two.id
-        assert version_read.skills[0].skill_name == "head-binding-v2"
+        assert "skills" not in version_read.model_dump()
+        assert snapshot.skill_version_id == skill_version_two.id
 
     async def test_create_preset_rejects_duplicate_bound_skill_names(
         self,
@@ -2061,9 +2055,9 @@ class TestAgentPresetService:
         )
 
         session.add(
-            AgentPresetVersionSkill(
+            AgentPresetSkill(
                 workspace_id=agent_preset_service.workspace_id,
-                preset_version_id=preset_version.id,
+                preset_id=preset.id,
                 skill_id=skill_b.id,
                 skill_version_id=skill_b_shared.id,
             )
@@ -2179,7 +2173,7 @@ class TestAgentPresetService:
         version_read = await agent_preset_service.build_version_read(current_version)
 
         assert current_bindings == []
-        assert version_read.skills == []
+        assert "skills" not in version_read.model_dump()
 
     async def test_update_preset_locks_skill_bindings_during_validation(
         self,
@@ -2318,12 +2312,12 @@ class TestAgentPresetService:
         assert call_order[:3] == ["lock", "read_specs", "replace"]
         assert call_order.count("lock") == 1
 
-    async def test_restore_version_moves_current_pointer(
+    async def test_restore_version_rolls_config_forward(
         self,
         agent_preset_service: AgentPresetService,
         agent_preset_create_params: AgentPresetCreate,
     ) -> None:
-        """Restoring an old version repoints current without creating another row."""
+        """Restoring an old config creates a new immutable version."""
         created_preset = await agent_preset_service.create_preset(
             agent_preset_create_params
         )
@@ -2343,11 +2337,11 @@ class TestAgentPresetService:
             CursorPaginationParams(limit=10),
         )
 
-        assert restored_preset.current_version_id == version_1.id
+        assert restored_preset.current_version_id not in {None, version_1.id}
         assert restored_preset.instructions == agent_preset_create_params.instructions
-        assert [version.version for version in versions.items] == [2, 1]
+        assert [version.version for version in versions.items] == [3, 2, 1]
 
-    async def test_restore_version_locks_preset_before_replacing_skill_bindings(
+    async def test_restore_version_locks_preset_before_creating_rollforward(
         self,
         configure_minio_for_skills,
         session: AsyncSession,
@@ -2355,7 +2349,7 @@ class TestAgentPresetService:
         agent_preset_service: AgentPresetService,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Preset restore locks before replacing mutable head skill bindings."""
+        """Preset restore locks before creating the roll-forward version."""
 
         skill_service = SkillService(session=session, role=svc_role)
         created_skill = await skill_service.create_skill(
@@ -2387,20 +2381,18 @@ class TestAgentPresetService:
         )
 
         original_lock = agent_preset_service._lock_preset_row
-        original_restore = (
-            agent_preset_service._restore_head_skill_bindings_from_version
-        )
+        original_create = agent_preset_service._create_version_from_preset
         call_order: list[str] = []
 
         async def instrumented_lock(preset_id: uuid.UUID) -> None:
             call_order.append("lock")
             await original_lock(preset_id)
 
-        async def instrumented_restore(
-            *, preset_id: uuid.UUID, version_id: uuid.UUID
-        ) -> None:
-            call_order.append("restore_bindings")
-            await original_restore(preset_id=preset_id, version_id=version_id)
+        async def instrumented_create(
+            preset: AgentPreset, *, preset_locked: bool = False
+        ) -> AgentPresetVersion:
+            call_order.append("create_version")
+            return await original_create(preset, preset_locked=preset_locked)
 
         monkeypatch.setattr(
             agent_preset_service,
@@ -2409,23 +2401,23 @@ class TestAgentPresetService:
         )
         monkeypatch.setattr(
             agent_preset_service,
-            "_restore_head_skill_bindings_from_version",
-            instrumented_restore,
+            "_create_version_from_preset",
+            instrumented_create,
         )
 
         await agent_preset_service.restore_version(created_preset, version_1)
 
-        assert call_order[:2] == ["lock", "restore_bindings"]
+        assert call_order[:2] == ["lock", "create_version"]
         assert call_order.count("lock") == 1
 
-    async def test_restore_version_rejects_archived_skill_bindings(
+    async def test_restore_version_does_not_reattach_archived_skill_bindings(
         self,
         configure_minio_for_skills,
         session: AsyncSession,
         svc_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
-        """Restoring a version cannot reattach archived skills onto the mutable head."""
+        """Restoring config leaves the now-empty Skill topology unchanged."""
 
         skill_service = SkillService(session=session, role=svc_role)
         created_skill = await skill_service.create_skill(
@@ -2463,15 +2455,17 @@ class TestAgentPresetService:
         skill_row.deleted_at = archived_at
         await session.commit()
 
-        with pytest.raises(TracecatValidationError, match="not found"):
-            await agent_preset_service.restore_version(created_preset, version_1)
+        restored = await agent_preset_service.restore_version(created_preset, version_1)
 
-    async def test_restore_version_rejects_soft_deleted_subagent_bindings(
+        assert restored.current_version_id != version_1.id
+        assert await agent_preset_service._list_head_skill_bindings(restored.id) == []
+
+    async def test_restore_version_does_not_reattach_deleted_subagent_bindings(
         self,
         agent_preset_service: AgentPresetService,
         agent_preset_create_params: AgentPresetCreate,
     ) -> None:
-        """Restoring a version cannot make soft-deleted subagents active again."""
+        """Restoring config leaves current head topology unchanged."""
         child = await agent_preset_service.create_preset(
             agent_preset_create_params.model_copy(
                 update={"name": "Restored Child", "slug": "restored-child"}
@@ -2504,15 +2498,16 @@ class TestAgentPresetService:
 
         await agent_preset_service.delete_preset(child)
 
-        with pytest.raises(
-            TracecatValidationError,
-            match="soft-deleted or missing subagent",
-        ):
-            await agent_preset_service.restore_version(parent, version_with_child)
+        restored = await agent_preset_service.restore_version(
+            parent, version_with_child
+        )
 
         await agent_preset_service.session.refresh(parent)
-        assert parent.current_version_id == version_without_child.id
-        assert parent.agents == {"enabled": False, "subagents": []}
+        assert restored.current_version_id != version_without_child.id
+        assert (
+            await agent_preset_service.get_head_subagents_config(parent.id)
+        ).subagents == []
+        assert parent.agents == {"enabled": True, "subagents": []}
 
     async def test_restore_version_locks_skill_bindings_during_validation(
         self,
@@ -2554,22 +2549,20 @@ class TestAgentPresetService:
         )
 
         captured_for_update: list[bool] = []
-        original_validate_binding_inputs = (
-            agent_preset_service.skills.validate_binding_inputs
-        )
+        original_resolve = agent_preset_service._resolve_head_skill_binding_specs
 
-        async def instrumented_validate_binding_inputs(
-            bindings: list[AgentPresetSkillBindingBase],
+        async def instrumented_resolve(
+            preset_id: uuid.UUID,
             *,
             for_update: bool = False,
-        ) -> None:
+        ) -> list[SkillBindingSpec]:
             captured_for_update.append(for_update)
-            await original_validate_binding_inputs(bindings, for_update=for_update)
+            return await original_resolve(preset_id, for_update=for_update)
 
         monkeypatch.setattr(
-            agent_preset_service.skills,
-            "validate_binding_inputs",
-            instrumented_validate_binding_inputs,
+            agent_preset_service,
+            "_resolve_head_skill_binding_specs",
+            instrumented_resolve,
         )
 
         await agent_preset_service.restore_version(created_preset, version_1)
@@ -2888,56 +2881,44 @@ class TestAgentPresetService:
         with pytest.raises(TracecatNotFoundError, match="not found"):
             await agent_preset_service._create_version_from_preset(created_preset)
 
-    async def test_delete_preset_locks_target_before_subagent_reference_check(
+    async def test_delete_preset_locks_target_before_unlinking_topology(
         self,
         agent_preset_service: AgentPresetService,
         agent_preset_create_params: AgentPresetCreate,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Preset deletion serializes with restore before checking active refs."""
+        """Preset deletion serializes with concurrent topology mutations."""
         created_preset = await agent_preset_service.create_preset(
             agent_preset_create_params
         )
         call_order: list[str] = []
         original_lock = agent_preset_service._lock_preset_row
-        original_ensure = agent_preset_service._ensure_not_referenced_as_subagent
 
         async def instrumented_lock(preset_id: uuid.UUID) -> None:
             call_order.append("lock")
             await original_lock(preset_id)
-
-        async def instrumented_ensure(preset: AgentPreset) -> None:
-            call_order.append("reference_check")
-            await original_ensure(preset)
 
         monkeypatch.setattr(
             agent_preset_service,
             "_lock_preset_row",
             instrumented_lock,
         )
-        monkeypatch.setattr(
-            agent_preset_service,
-            "_ensure_not_referenced_as_subagent",
-            instrumented_ensure,
-        )
-
         await agent_preset_service.delete_preset(created_preset)
 
-        assert call_order[:2] == ["lock", "reference_check"]
-        assert call_order.count("lock") == 1
+        assert call_order == ["lock"]
 
-    async def test_delete_preset_blocks_when_referenced_as_subagent_in_head(
+    async def test_delete_preset_unlinks_references_from_parent_heads(
         self,
         agent_preset_service: AgentPresetService,
         agent_preset_create_params: AgentPresetCreate,
     ) -> None:
-        """Deleting a preset is blocked while another preset head references it."""
+        """Confirmed deletion soft-deletes the child and unlinks parent edges."""
         child = await agent_preset_service.create_preset(
             agent_preset_create_params.model_copy(
                 update={"name": "Child Agent", "slug": "child-agent"}
             )
         )
-        await agent_preset_service.create_preset(
+        parent = await agent_preset_service.create_preset(
             agent_preset_create_params.model_copy(
                 update={
                     "name": "Parent Agent",
@@ -2952,17 +2933,12 @@ class TestAgentPresetService:
             )
         )
 
-        with pytest.raises(
-            TracecatValidationError,
-            match="still referenced as a subagent",
-        ) as exc_info:
-            await agent_preset_service.delete_preset(child)
+        await agent_preset_service.delete_preset(child)
 
-        assert exc_info.value.detail == {
-            "code": "preset_in_use_as_subagent",
-            "head_reference_count": 1,
-        }
-        assert await agent_preset_service.get_preset(child.id) is not None
+        assert await agent_preset_service.get_preset(child.id) is None
+        assert (
+            await agent_preset_service.get_head_subagents_config(parent.id)
+        ).subagents == []
 
     async def test_delete_preset_soft_deletes_when_only_referenced_as_subagent_in_history(
         self,
@@ -3067,11 +3043,9 @@ class TestAgentPresetService:
             )
             is not None
         )
-        with pytest.raises(
-            TracecatValidationError,
-            match="still referenced as a subagent",
-        ):
-            await agent_preset_service.delete_preset(original_child)
+        await agent_preset_service.delete_preset(original_child)
+
+        assert await agent_preset_service.get_preset(original_child.id) is None
 
     async def test_get_preset_by_slug(
         self,
@@ -3439,11 +3413,10 @@ class TestAgentPresetService:
         )
 
         agents = AgentSubagentsConfig.model_validate(parent.agents)
-        assert agents.enabled is True
         assert isinstance(agents.subagents[0], ResolvedAttachedSubagentRef)
         assert agents.subagents[0].preset_id == child.id
 
-    async def test_resolve_config_uses_latest_subagent_version_when_setting_enabled(
+    async def test_resolve_config_returns_current_head_subagent_reference(
         self,
         session: AsyncSession,
         svc_role: Role,
@@ -3451,7 +3424,7 @@ class TestAgentPresetService:
         agent_preset_service: AgentPresetService,
         agent_preset_create_params: AgentPresetCreate,
     ) -> None:
-        """Latest-resource mode resolves preset-backed subagents by current version."""
+        """Runtime compilation receives head refs and resolves versions per turn."""
 
         settings_service = SettingsService(session=session, role=svc_admin_role)
         await settings_service.update_app_settings(
@@ -3501,13 +3474,10 @@ class TestAgentPresetService:
         )
 
         assert child_version_two.id != child_version_one.id
-        assert config.agents.enabled is True
         assert len(config.agents.subagents) == 1
         resolved_subagent = config.agents.subagents[0]
-        assert isinstance(resolved_subagent, ResolvedAttachedSubagentRef)
+        assert isinstance(resolved_subagent, HeadAttachedSubagentRef)
         assert resolved_subagent.preset_id == child.id
-        assert resolved_subagent.preset_version_id == child_version_two.id
-        assert resolved_subagent.preset_version == child_version_two.version
 
     async def test_update_parent_rejects_subagent_with_tool_approvals(
         self,

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -289,7 +289,7 @@ class TestClaudeAgentRuntimeRun:
         runtime = ClaudeAgentRuntime(
             mock_socket_writer, transport_factory=lambda _: MagicMock()
         )
-        runtime._agents_enabled = True
+        runtime._explicit_subagent_aliases = {"analyst"}
 
         prompt = runtime._build_system_prompt(None)
 
@@ -960,6 +960,8 @@ class TestClaudeAgentRuntimeRun:
         assert set(options.allowed_tools) == {
             "mcp__tracecat-registry__core__http_request",
             "mcp__local-tools__*",
+            "Agent",
+            "Task",
         }
         assert options.setting_sources == ["user"]
 
@@ -1089,6 +1091,8 @@ class TestClaudeAgentRuntimeRun:
         assert set(options.allowed_tools) == {
             "mcp__tracecat-registry__core__http_request",
             "mcp__sentinel-one__list_alerts",
+            "Agent",
+            "Task",
         }
         assert "Verified stdio MCP tools configured for this agent" in (
             options.system_prompt
@@ -1159,6 +1163,8 @@ class TestClaudeAgentRuntimeRun:
         assert set(options.allowed_tools) == {
             "mcp__tracecat-registry__core__http_request",
             "mcp__sentinel-one__quarantine_host",
+            "Agent",
+            "Task",
         }
         assert runtime._stdio_approval_blocked_tools == {
             "mcp__sentinel-one__quarantine_host"
@@ -1336,7 +1342,7 @@ class TestClaudeAgentRuntimeRun:
         assert "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS" not in env
 
     @pytest.mark.anyio
-    async def test_agents_toggle_adds_agent_tool_without_custom_subagents(
+    async def test_agent_tool_is_available_without_attached_subagents(
         self,
         mock_socket_writer: MagicMock,
         mock_claude_sdk_client: MagicMock,
@@ -1348,12 +1354,7 @@ class TestClaudeAgentRuntimeRun:
             captured_options.append(kwargs["options"])
             return mock_claude_sdk_client
 
-        payload = replace(
-            sample_init_payload,
-            config=sample_init_payload.config.model_copy(
-                update={"agents": AgentSubagentsConfig(enabled=True)}
-            ),
-        )
+        payload = sample_init_payload
 
         with (
             patch(
@@ -2498,7 +2499,6 @@ class TestClaudeAgentRuntimePreToolUseHook:
         runtime = ClaudeAgentRuntime(
             mock_socket_writer, transport_factory=lambda _: MagicMock()
         )
-        runtime._agents_enabled = True
         runtime._explicit_subagent_aliases = {"analyst"}
 
         result = await runtime._pre_tool_use_hook(
@@ -2527,7 +2527,6 @@ class TestClaudeAgentRuntimePreToolUseHook:
         runtime = ClaudeAgentRuntime(
             mock_socket_writer, transport_factory=lambda _: MagicMock()
         )
-        runtime._agents_enabled = True
         runtime._explicit_subagent_aliases = {"analyst"}
 
         result = await runtime._pre_tool_use_hook(
@@ -2554,7 +2553,6 @@ class TestClaudeAgentRuntimePreToolUseHook:
         runtime = ClaudeAgentRuntime(
             mock_socket_writer, transport_factory=lambda _: MagicMock()
         )
-        runtime._agents_enabled = True
         runtime._explicit_subagent_aliases = {"analyst"}
         tool_input = {
             "subagent_type": "analyst",
@@ -2597,7 +2595,6 @@ class TestClaudeAgentRuntimePreToolUseHook:
         runtime = ClaudeAgentRuntime(
             mock_socket_writer, transport_factory=lambda _: MagicMock()
         )
-        runtime._agents_enabled = True
         runtime._explicit_subagent_aliases = {"analyst"}
         runtime._registry_mcp_server_names = {
             "tracecat-registry",

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -2158,7 +2158,7 @@ async def test_run_agent_activity_plumbs_subagents_to_runtime_in_each_sandbox_mo
                 model_provider="openai",
                 agents=cast(
                     Any,
-                    {"enabled": True, "subagents": [{"preset": "analyst"}]},
+                    {"subagents": [{"preset": "analyst"}]},
                 ),
             ),
             "subagents": [
@@ -2178,7 +2178,6 @@ async def test_run_agent_activity_plumbs_subagents_to_runtime_in_each_sandbox_mo
         handler: LoopbackHandler,
         payload: RuntimeInitPayload,
     ) -> None:
-        assert payload.config.agents.enabled is True
         assert payload.config.agents.subagents[0].preset == "analyst"
         [subagent] = payload.subagents
         assert subagent.alias == "analyst"

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -377,7 +377,7 @@ async def test_create_session_persists_internal_agents_binding_without_preset() 
         agents_binding=agents_binding,
     )
 
-    assert created.agents_binding == {"enabled": True, "subagents": []}
+    assert created.agents_binding == {"subagents": []}
     agents_binding_mock.assert_not_called()
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(created)

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -4029,7 +4029,7 @@ class TestSkillService:
         svc_role: Role,
         skill_service: SkillService,
     ) -> None:
-        """Legacy archived-only skills remain unbindable and resolve as archived."""
+        """Legacy archived-only skills remain unbindable and are omitted."""
 
         created = await skill_service.create_skill(
             SkillCreate(name="legacy-resolution")
@@ -4050,8 +4050,6 @@ class TestSkillService:
                 ],
             )
         )
-        assert preset.current_version_id is not None
-
         await _legacy_archive_skill(session, created.id)
 
         with pytest.raises(TracecatValidationError) as bind_exc_info:
@@ -4066,16 +4064,10 @@ class TestSkillService:
         assert bind_detail is not None
         assert bind_detail["code"] == "skill_not_found"
 
-        for use_latest_versions in (False, True):
-            with pytest.raises(TracecatValidationError) as resolve_exc_info:
-                await skill_service.get_resolved_skill_refs_for_preset_version(
-                    preset.current_version_id,
-                    use_latest_versions=use_latest_versions,
-                )
-            resolve_detail = resolve_exc_info.value.detail
-            assert resolve_detail is not None
-            assert resolve_detail["code"] == "skill_archived"
-            assert str(created.id) in str(resolve_detail["skills"])
+        resolved = await skill_service.get_resolved_skill_refs_for_preset_head(
+            preset.id
+        )
+        assert resolved == []
 
     async def test_legacy_archived_skill_api_projection_reports_deleted_at(
         self,

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -97,7 +97,6 @@ from tracecat.workspace_sync.schemas import (
     ResourceRef,
     SkillFileSpec,
     SkillResourceSpec,
-    SkillVersionResourceSpec,
     WorkflowResourceSpec,
     WorkspaceManifest,
     WorkspaceProjection,
@@ -321,10 +320,9 @@ def test_selected_acceptance_fixture_models_transitive_closure() -> None:
     assert f"{WORKFLOW_ROOT}/qa-child/definition.yml" in files
     assert f"{WORKFLOW_ROOT}/qa-orphan/definition.yml" not in files
     assert f"{AGENT_PRESET_ROOT}/qa-triage-parent/preset.yml" in files
-    assert f"{AGENT_PRESET_ROOT}/qa-triage-parent/versions/1.yml" in files
     assert f"{AGENT_PRESET_ROOT}/qa-evidence-child/preset.yml" in files
-    assert f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/1.yml" in files
     assert f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml" in files
+    assert f"{SKILL_ROOT}/qa-enrichment-skill/files/SKILL.md" in files
     assert f"{TABLE_ROOT}/qa_indicators/table.yml" in files
     assert f"{CASE_TAG_ROOT}/qa-alert.yml" in files
     assert f"{VARIABLE_ROOT}/default/qa_config.yml" in files
@@ -366,15 +364,11 @@ def test_workflow_references_detects_preset_agent_preset_arg() -> None:
 
 def test_skill_fixture_records_file_sha256s() -> None:
     files = _expanded_full_git_tree(include_schedules=False)
-    version_spec = yaml.safe_load(
-        files[f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/version.yml"]
-    )
+    version_spec = yaml.safe_load(files[f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml"])
 
     recorded_hashes = {file["path"]: file["sha256"] for file in version_spec["files"]}
     for file_path, expected_hash in recorded_hashes.items():
-        content = files[
-            f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/files/{file_path}"
-        ]
+        content = files[f"{SKILL_ROOT}/qa-enrichment-skill/files/{file_path}"]
         assert hashlib.sha256(content.encode()).hexdigest() == expected_hash
 
 
@@ -624,18 +618,20 @@ async def test_missing_skill_binding_is_dependency_diagnostic(
 
 
 @pytest.mark.anyio
-async def test_missing_pinned_skill_version_is_dependency_diagnostic(
+async def test_version_pinned_skill_binding_is_rejected(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:
     files = _expanded_selected_git_tree()
-    del files[f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/version.yml"]
+    preset_path = f"{AGENT_PRESET_ROOT}/qa-triage-parent/preset.yml"
+    preset = yaml.safe_load(files[preset_path])
+    preset["skills"] = [{"slug": "qa-enrichment-skill", "version": 1}]
+    files[preset_path] = _yaml(preset)
 
     _, diagnostics = await workspace_sync_service.parse_files(files)
 
     assert any(
-        diagnostic.error_type == "dependency"
-        and "qa-enrichment-skill" in diagnostic.message
-        and "@1" in diagnostic.message
+        diagnostic.error_type == "validation"
+        and "skills.0.version" in diagnostic.message
         for diagnostic in diagnostics
     )
 
@@ -685,7 +681,7 @@ async def test_cyclic_preset_subagent_references_are_dependency_diagnostics(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:
     files = _expanded_selected_git_tree()
-    child_path = f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/1.yml"
+    child_path = f"{AGENT_PRESET_ROOT}/qa-evidence-child/preset.yml"
     child_preset = yaml.safe_load(files[child_path])
     child_preset["subagents"] = [{"slug": "qa-triage-parent"}]
     files[child_path] = _yaml(child_preset)
@@ -880,10 +876,8 @@ async def test_project_workspace_exports_supported_non_workflow_resources(
     table_spec = yaml.safe_load(files[f"{TABLE_ROOT}/qa_indicators/table.yml"])
     assert "rows_path" not in table_spec
     assert "rows" not in table_spec
-    skill_version = yaml.safe_load(
-        files[f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/version.yml"]
-    )
-    assert {file["path"] for file in skill_version["files"]} == {
+    skill = yaml.safe_load(files[f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml"])
+    assert {file["path"] for file in skill["files"]} == {
         "SKILL.md",
         "enrich.py",
     }
@@ -892,13 +886,10 @@ async def test_project_workspace_exports_supported_non_workflow_resources(
     )
     assert parent_preset["folder_path"] == "/QA/Agents/"
     assert parent_preset["tags"] == ["qa-sync"]
-    assert "instructions" not in parent_preset
-    parent_version = yaml.safe_load(
-        files[f"{AGENT_PRESET_ROOT}/qa-triage-parent/versions/1.yml"]
-    )
-    assert parent_version["instructions"] == (
+    assert parent_preset["instructions"] == (
         "Use the enrichment skill and escalate high severity."
     )
+    assert not any("/versions/" in path for path in files)
 
 
 @pytest.mark.anyio
@@ -961,7 +952,7 @@ async def test_large_agent_preset_workspace_preview_matches_export(
 
     expected_paths = set(source_files)
     assert preview.resource_counts[SyncResourceType.AGENT_PRESET.value] == 37
-    assert len(expected_paths) == 75
+    assert len(expected_paths) == 38
     assert set(preview.files) == expected_paths
     assert set(export.files) == expected_paths
     assert export.commit.sha is not None
@@ -973,7 +964,7 @@ async def test_agent_preset_projection_excludes_soft_deleted_presets(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
-    """Workspace export excludes soft-deleted presets and their versions."""
+    """Workspace export excludes soft-deleted preset heads."""
     service = WorkspaceSyncService(session=session, role=svc_role)
     snapshot, diagnostics = await service.parse_files(
         _expanded_full_git_tree(include_schedules=False),
@@ -998,21 +989,17 @@ async def test_agent_preset_projection_excludes_soft_deleted_presets(
     projection = await service.project_workspace()
 
     assert f"{AGENT_PRESET_ROOT}/qa-triage-parent/preset.yml" not in projection.files
-    assert not any(
-        path.startswith(f"{AGENT_PRESET_ROOT}/qa-triage-parent/versions/")
-        for path in projection.files
-    )
 
 
 @pytest.mark.anyio
-async def test_skill_projection_excludes_soft_deleted_preset_version_pins(
+async def test_skill_projection_exports_only_desired_head_content(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
-    """Skill version snapshots pinned only by soft-deleted presets are not exported."""
+    """Skill projection contains desired head content, not version history."""
     service = WorkspaceSyncService(session=session, role=svc_role)
     snapshot, diagnostics = await service.parse_files(
-        _versioned_agent_skill_git_tree(),
+        _expanded_full_git_tree(include_schedules=False),
         commit_sha="d" * 40,
     )
     assert diagnostics == []
@@ -1020,11 +1007,10 @@ async def test_skill_projection_excludes_soft_deleted_preset_version_pins(
         session=session,
         role=svc_role,
     ).import_non_workflow_resources(snapshot.spec)
-    # agent-x is the only preset pinning skill-a v1 (head is v2, agent-y pins v2).
     pinning_preset = await session.scalar(
         select(AgentPreset).where(
             AgentPreset.workspace_id == svc_role.workspace_id,
-            AgentPreset.slug == "agent-x",
+            AgentPreset.slug == "qa-triage-parent",
         )
     )
     assert pinning_preset is not None
@@ -1034,8 +1020,9 @@ async def test_skill_projection_excludes_soft_deleted_preset_version_pins(
 
     projection = await service.project_workspace()
 
-    assert f"{SKILL_ROOT}/skill-a/versions/1/version.yml" not in projection.files
-    assert f"{SKILL_ROOT}/skill-a/versions/2/version.yml" in projection.files
+    assert f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml" in projection.files
+    assert f"{SKILL_ROOT}/qa-enrichment-skill/files/SKILL.md" in projection.files
+    assert not any("/versions/" in path for path in projection.files)
 
 
 @pytest.mark.anyio
@@ -1610,15 +1597,10 @@ async def test_agent_preset_only_export_lazily_includes_dependency_closure(
     files = fake_vcs.repo_files(git_url, ref=export.commit.sha)
     assert not any(path.startswith(f"{WORKFLOW_ROOT}/") for path in files)
     assert f"{AGENT_PRESET_ROOT}/qa-triage-parent/preset.yml" in files
-    assert f"{AGENT_PRESET_ROOT}/qa-triage-parent/versions/1.yml" in files
     assert f"{AGENT_PRESET_ROOT}/qa-evidence-child/preset.yml" in files
-    assert f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/1.yml" in files
     assert f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml" in files
-    assert f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/version.yml" in files
-    assert f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/files/SKILL.md" in files
-    assert not any(
-        path.startswith(f"{SKILL_ROOT}/qa-enrichment-skill/files/") for path in files
-    )
+    assert f"{SKILL_ROOT}/qa-enrichment-skill/files/SKILL.md" in files
+    assert not any("/versions/" in path for path in files)
     assert f"{VARIABLE_ROOT}/default/qa_config.yml" in files
     assert f"{SECRET_METADATA_ROOT}/default/qa_threatintel.yml" in files
     assert f"{TABLE_ROOT}/qa_indicators/table.yml" not in files
@@ -1641,14 +1623,14 @@ async def test_agent_preset_only_export_lazily_includes_dependency_closure(
         pytest.param(WorkspaceSyncExportPreviewRequest(), id="full_export"),
     ],
 )
-async def test_export_merges_seen_subagent_versions(
+async def test_export_includes_current_subagent_head_only(
     preview_request: WorkspaceSyncExportPreviewRequest,
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
     service = WorkspaceSyncService(session=session, role=svc_role)
     snapshot, diagnostics = await service.parse_files(
-        _versioned_subagent_git_tree(),
+        _head_subagent_git_tree(),
         commit_sha="2" * 40,
     )
     assert diagnostics == []
@@ -1659,23 +1641,16 @@ async def test_export_merges_seen_subagent_versions(
 
     preview = await service.preview_export_workspace(preview_request)
 
-    assert f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/1.yml" in preview.files
-    assert f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/2.yml" in preview.files
+    assert f"{AGENT_PRESET_ROOT}/qa-evidence-child/preset.yml" in preview.files
+    assert not any("/versions/" in path for path in preview.files)
 
 
 @pytest.mark.anyio
-async def test_round_trip_preserves_presets_pinning_different_skill_versions(
+async def test_round_trip_preserves_head_owned_skill_topology(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
-    """Round-tripping presets that pin distinct skill versions keeps the pins.
-
-    The Git tree carries one skill (``skill-a``) with two published versions and
-    two presets that bind different versions of it: ``agent-x`` pins ``skill-a``
-    v1 while ``agent-y`` pins v2. Importing, exporting, then pulling into a fresh
-    workspace must reproduce both skill versions and both per-preset pins exactly
-    rather than collapsing them onto a single (e.g. latest) version.
-    """
+    """Round-tripping desired heads recreates current content and head edges."""
     repo_url = "git+ssh://git@github.com/TracecatHQ/git-sync-versioned-agent-qa.git"
     git_url = GitUrl(
         host="github.com",
@@ -1732,11 +1707,10 @@ async def test_round_trip_preserves_presets_pinning_different_skill_versions(
 
     assert export.commit.status is PushStatus.COMMITTED
     assert export.commit.sha is not None
-    # Both pinned skill version snapshots must travel with the export so the pin
-    # targets still exist when the commit is pulled elsewhere.
     exported_files = fake_vcs.repo_files(git_url, ref=export.commit.sha)
-    assert f"{SKILL_ROOT}/skill-a/versions/1/version.yml" in exported_files
-    assert f"{SKILL_ROOT}/skill-a/versions/2/version.yml" in exported_files
+    assert f"{SKILL_ROOT}/skill-a/skill.yml" in exported_files
+    assert f"{SKILL_ROOT}/skill-a/files/SKILL.md" in exported_files
+    assert not any("/versions/" in path for path in exported_files)
 
     # Pull the exported commit into the independent target workspace.
     pull = await target_service.pull(options=PullOptions(commit_sha=export.commit.sha))
@@ -1751,7 +1725,7 @@ async def test_round_trip_preserves_presets_pinning_different_skill_versions(
         )
     )
     assert skill is not None
-    # Both versions land in the target with their original names intact.
+    # Pulling desired head content mints one local version in the target.
     skill_versions = {
         version.version: version.name
         for version in (
@@ -1765,9 +1739,8 @@ async def test_round_trip_preserves_presets_pinning_different_skill_versions(
             )
         ).all()
     }
-    assert skill_versions == {1: "Skill A v1", 2: "Skill A v2"}
-    # Head bindings (``AgentPresetSkill``) wire each preset's live config to the
-    # skill version it pinned: agent-x -> v1, agent-y -> v2.
+    assert skill_versions == {1: "Skill A current"}
+    # Both mutable preset heads point to the imported skill's current version.
     binding_rows = await session.execute(
         select(AgentPreset.slug, SkillVersion.version)
         .select_from(AgentPreset)
@@ -1783,10 +1756,8 @@ async def test_round_trip_preserves_presets_pinning_different_skill_versions(
         .order_by(AgentPreset.slug.asc())
     )
     bindings = dict(binding_rows.tuples().all())
-    assert bindings == {"agent-x": 1, "agent-y": 2}
-    # The immutable version snapshot of each preset (``AgentPresetVersionSkill``
-    # under the preset's current version) must record the same pins, proving the
-    # versioned binding table round-trips too, not only the mutable head.
+    assert bindings == {"agent-x": 1, "agent-y": 1}
+    # Newly minted immutable versions retain rollback shadows for the same edge.
     version_binding_rows = await session.execute(
         select(AgentPreset.slug, SkillVersion.version)
         .select_from(AgentPreset)
@@ -1802,23 +1773,15 @@ async def test_round_trip_preserves_presets_pinning_different_skill_versions(
         .order_by(AgentPreset.slug.asc())
     )
     version_bindings = dict(version_binding_rows.tuples().all())
-    assert version_bindings == {"agent-x": 1, "agent-y": 2}
+    assert version_bindings == {"agent-x": 1, "agent-y": 1}
 
 
 @pytest.mark.anyio
-async def test_full_workspace_export_includes_workflow_pinned_version_closure(
+async def test_full_workspace_export_uses_desired_heads_for_workflow_dependencies(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
-    """A full export follows pinned versions transitively from workflow to skill.
-
-    The seeded workflow calls ``ai.preset_agent`` pinned to ``agent-x`` v1, while
-    that preset's head is v2; v1 pins ``skill-a`` v1 and v2 pins ``skill-a`` v2.
-    A whole-workspace export must walk this closure and emit both preset version
-    snapshots and both skill version snapshots, so the workflow's pinned-but-
-    non-head dependency (and the skill version it transitively pins) is not
-    dropped in favor of only the current head.
-    """
+    """A full export follows workflow dependencies without exporting history."""
     repo_url = "git+ssh://git@github.com/TracecatHQ/git-sync-workflow-pin-qa.git"
     git_url = GitUrl(
         host="github.com",
@@ -1846,7 +1809,7 @@ async def test_full_workspace_export_includes_workflow_pinned_version_closure(
     )
     seed_commit = await seed_transport.write_files(
         url=git_url,
-        files=_workflow_pinned_agent_version_git_tree(),
+        files=_workflow_agent_head_git_tree(),
         message="Seed workflow pinned agent version",
         branch="seed/workflow-pinned-agent",
         create_pr=False,
@@ -1877,13 +1840,10 @@ async def test_full_workspace_export_includes_workflow_pinned_version_closure(
     assert export.commit.status is PushStatus.COMMITTED
     assert export.commit.sha is not None
     exported_files = fake_vcs.repo_files(git_url, ref=export.commit.sha)
-    # The workflow itself, plus both preset versions (v1 is pinned by the
-    # workflow, v2 is the head) and both skill versions they pin transitively.
     assert f"{WORKFLOW_ROOT}/workflow-pins-agent/definition.yml" in exported_files
-    assert f"{AGENT_PRESET_ROOT}/agent-x/versions/1.yml" in exported_files
-    assert f"{AGENT_PRESET_ROOT}/agent-x/versions/2.yml" in exported_files
-    assert f"{SKILL_ROOT}/skill-a/versions/1/version.yml" in exported_files
-    assert f"{SKILL_ROOT}/skill-a/versions/2/version.yml" in exported_files
+    assert f"{AGENT_PRESET_ROOT}/agent-x/preset.yml" in exported_files
+    assert f"{SKILL_ROOT}/skill-a/skill.yml" in exported_files
+    assert not any("/versions/" in path for path in exported_files)
 
 
 @pytest.mark.anyio
@@ -1957,10 +1917,10 @@ async def test_single_workflow_export_includes_dependency_closure(
     assert f"{WORKFLOW_ROOT}/qa-root/definition.yml" in exported_files
     assert f"{WORKFLOW_ROOT}/qa-child/definition.yml" in exported_files
     assert f"{AGENT_PRESET_ROOT}/qa-triage-parent/preset.yml" in exported_files
-    assert f"{AGENT_PRESET_ROOT}/qa-triage-parent/versions/1.yml" in exported_files
     assert f"{AGENT_PRESET_ROOT}/qa-evidence-child/preset.yml" in exported_files
     assert f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml" in exported_files
-    assert f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/version.yml" in exported_files
+    assert f"{SKILL_ROOT}/qa-enrichment-skill/files/SKILL.md" in exported_files
+    assert not any("/versions/" in path for path in exported_files)
     assert f"{VARIABLE_ROOT}/default/qa_config.yml" in exported_files
     assert f"{SECRET_METADATA_ROOT}/default/qa_threatintel.yml" in exported_files
     assert f"{TABLE_ROOT}/qa_indicators/table.yml" in exported_files
@@ -3255,12 +3215,12 @@ async def test_pull_agent_preset_slug_rename_reuses_source_id_mapping(
 
 
 @pytest.mark.anyio
-async def test_pull_unpublished_agent_preset_clears_current_version(
+async def test_pull_older_agent_preset_content_rolls_forward_a_new_version(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
     service = WorkspaceSyncService(session=session, role=svc_role)
-    unpublished_files = {
+    older_files = {
         MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
         f"{AGENT_PRESET_ROOT}/qa-draft/preset.yml": _yaml(
             {
@@ -3269,7 +3229,7 @@ async def test_pull_unpublished_agent_preset_clears_current_version(
                 "id": "qa-draft",
                 "slug": "qa-draft",
                 "name": "QA draft",
-                "current_version": None,
+                "instructions": "Restore the older desired configuration.",
             }
         ),
     }
@@ -3287,7 +3247,7 @@ async def test_pull_unpublished_agent_preset_clears_current_version(
         VcsTreeSnapshot(
             commit_sha="e" * 40,
             tree_sha="tree-2",
-            files=unpublished_files,
+            files=older_files,
         ),
     ]
     service._workspace_git_url = AsyncMock(
@@ -3299,6 +3259,14 @@ async def test_pull_unpublished_agent_preset_clears_current_version(
         return_value=transport,
     ):
         first_result = await service.pull(options=PullOptions(commit_sha="d" * 40))
+        preset = await session.scalar(
+            select(AgentPreset).where(
+                AgentPreset.workspace_id == svc_role.workspace_id,
+                AgentPreset.slug == "qa-draft",
+            )
+        )
+        assert preset is not None
+        first_version_id = preset.current_version_id
         second_result = await service.pull(options=PullOptions(commit_sha="e" * 40))
 
     assert first_result.success is True
@@ -3310,16 +3278,18 @@ async def test_pull_unpublished_agent_preset_clears_current_version(
         )
     )
     assert preset is not None
-    assert preset.current_version_id is None
+    assert preset.current_version_id is not None
+    assert preset.current_version_id != first_version_id
+    assert preset.instructions == "Restore the older desired configuration."
 
 
 @pytest.mark.anyio
-async def test_pull_unversioned_skill_clears_current_version(
+async def test_pull_older_skill_content_rolls_forward_a_new_version(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
     service = WorkspaceSyncService(session=session, role=svc_role)
-    unversioned_files = {
+    older_files = {
         MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
         f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml": _yaml(
             {
@@ -3329,7 +3299,7 @@ async def test_pull_unversioned_skill_clears_current_version(
                 "slug": "qa-enrichment-skill",
                 "name": "QA enrichment skill",
                 "description": "Deterministic enrichment helper",
-                "current_version": None,
+                "files": [],
             }
         ),
     }
@@ -3347,7 +3317,7 @@ async def test_pull_unversioned_skill_clears_current_version(
         VcsTreeSnapshot(
             commit_sha="e" * 40,
             tree_sha="tree-2",
-            files=unversioned_files,
+            files=older_files,
         ),
     ]
     service._workspace_git_url = AsyncMock(
@@ -3381,6 +3351,7 @@ async def test_pull_unversioned_skill_clears_current_version(
         )
         assert skill is not None
         assert skill.current_version_id is not None
+        first_version_id = skill.current_version_id
         assert await draft_paths_for(skill.id) == ["SKILL.md"]
         second_result = await service.pull(options=PullOptions(commit_sha="e" * 40))
 
@@ -3393,7 +3364,8 @@ async def test_pull_unversioned_skill_clears_current_version(
         )
     )
     assert skill is not None
-    assert skill.current_version_id is None
+    assert skill.current_version_id is not None
+    assert skill.current_version_id != first_version_id
     assert await draft_paths_for(skill.id) == []
 
 
@@ -3545,11 +3517,20 @@ async def test_pull_skill_slug_rename_reuses_source_id_mapping(
         )
     )
     assert version is not None
-    assert version.name == "QA enrichment restored"
+    assert version.name == "QA enrichment skill"
+    current_version = await session.scalar(
+        select(SkillVersion).where(
+            SkillVersion.workspace_id == svc_role.workspace_id,
+            SkillVersion.id == skills[0].current_version_id,
+        )
+    )
+    assert current_version is not None
+    assert current_version.version == 2
+    assert current_version.name == "QA enrichment restored"
 
 
 @pytest.mark.anyio
-async def test_import_skill_version_rejects_missing_declared_file_content(
+async def test_import_skill_rejects_missing_declared_file_content(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
@@ -3559,20 +3540,13 @@ async def test_import_skill_version_rejects_missing_declared_file_content(
                 id="qa-enrichment-skill",
                 slug="qa-enrichment-skill",
                 name="QA enrichment skill",
-                current_version=1,
-                versions={
-                    1: SkillVersionResourceSpec(
-                        version_number=1,
-                        name="QA enrichment skill",
-                        files=[
-                            SkillFileSpec(
-                                path="SKILL.md",
-                                sha256=hashlib.sha256(b"missing").hexdigest(),
-                            )
-                        ],
-                        file_contents={},
+                files=[
+                    SkillFileSpec(
+                        path="SKILL.md",
+                        sha256=hashlib.sha256(b"missing").hexdigest(),
                     )
-                },
+                ],
+                file_contents={},
             )
         }
     )
@@ -3585,7 +3559,7 @@ async def test_import_skill_version_rejects_missing_declared_file_content(
 
 
 @pytest.mark.anyio
-async def test_project_workspace_preserves_binary_skill_version_file(
+async def test_project_workspace_preserves_binary_skill_file(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
@@ -3598,22 +3572,15 @@ async def test_project_workspace_preserves_binary_skill_version_file(
                 id="binary-skill",
                 slug="binary-skill",
                 name="Binary skill",
-                current_version=1,
-                versions={
-                    1: SkillVersionResourceSpec(
-                        version_number=1,
-                        name="Binary skill",
-                        files=[
-                            SkillFileSpec(
-                                path="assets/logo.png",
-                                sha256=binary_sha256,
-                                encoding="base64",
-                            )
-                        ],
-                        file_contents={
-                            "assets/logo.png": f"{encoded_content[:4]}\n{encoded_content[4:]}\n"
-                        },
+                files=[
+                    SkillFileSpec(
+                        path="assets/logo.png",
+                        sha256=binary_sha256,
+                        encoding="base64",
                     )
+                ],
+                file_contents={
+                    "assets/logo.png": f"{encoded_content[:4]}\n{encoded_content[4:]}\n"
                 },
             )
         }
@@ -3629,10 +3596,10 @@ async def test_project_workspace_preserves_binary_skill_version_file(
         role=svc_role,
     ).project_workspace()
 
-    version_path = f"{SKILL_ROOT}/binary-skill/versions/1/version.yml"
-    file_path = f"{SKILL_ROOT}/binary-skill/versions/1/files/assets/logo.png"
-    version_spec = yaml.safe_load(projection.files[version_path])
-    assert version_spec["files"] == [
+    skill_path = f"{SKILL_ROOT}/binary-skill/skill.yml"
+    file_path = f"{SKILL_ROOT}/binary-skill/files/assets/logo.png"
+    projected_spec = yaml.safe_load(projection.files[skill_path])
+    assert projected_spec["files"] == [
         {
             "path": "assets/logo.png",
             "sha256": binary_sha256,
@@ -4364,15 +4331,6 @@ async def test_agent_preset_import_resolves_parent_before_child_order(
                 "id": "a-parent",
                 "slug": "a-parent",
                 "name": "A parent",
-                "current_version": 1,
-            }
-        ),
-        f"{AGENT_PRESET_ROOT}/a-parent/versions/1.yml": _yaml(
-            {
-                "version": 1,
-                "type": "agent_preset_version",
-                "version_number": 1,
-                "name": "A parent",
                 "subagents": [{"slug": "z-child"}],
             }
         ),
@@ -4382,15 +4340,6 @@ async def test_agent_preset_import_resolves_parent_before_child_order(
                 "type": "agent_preset",
                 "id": "z-child",
                 "slug": "z-child",
-                "name": "Z child",
-                "current_version": 1,
-            }
-        ),
-        f"{AGENT_PRESET_ROOT}/z-child/versions/1.yml": _yaml(
-            {
-                "version": 1,
-                "type": "agent_preset_version",
-                "version_number": 1,
                 "name": "Z child",
             }
         ),
@@ -4439,19 +4388,9 @@ async def test_agent_preset_sync_preserves_subagent_options(
                 "id": "a-parent",
                 "slug": "a-parent",
                 "name": "A parent",
-                "current_version": 1,
-            }
-        ),
-        f"{AGENT_PRESET_ROOT}/a-parent/versions/1.yml": _yaml(
-            {
-                "version": 1,
-                "type": "agent_preset_version",
-                "version_number": 1,
-                "name": "A parent",
                 "subagents": [
                     {
                         "slug": "z-child",
-                        "version": 1,
                         "name": "evidence-child",
                         "description": "Collect evidence",
                         "max_turns": 3,
@@ -4465,15 +4404,6 @@ async def test_agent_preset_sync_preserves_subagent_options(
                 "type": "agent_preset",
                 "id": "z-child",
                 "slug": "z-child",
-                "name": "Z child",
-                "current_version": 1,
-            }
-        ),
-        f"{AGENT_PRESET_ROOT}/z-child/versions/1.yml": _yaml(
-            {
-                "version": 1,
-                "type": "agent_preset_version",
-                "version_number": 1,
                 "name": "Z child",
             }
         ),
@@ -4512,14 +4442,9 @@ async def test_agent_preset_sync_preserves_subagent_options(
     parent_spec = yaml.safe_load(
         projection.files[f"{AGENT_PRESET_ROOT}/a-parent/preset.yml"]
     )
-    assert "subagents" not in parent_spec
-    parent_version = yaml.safe_load(
-        projection.files[f"{AGENT_PRESET_ROOT}/a-parent/versions/1.yml"]
-    )
-    assert parent_version["subagents"] == [
+    assert parent_spec["subagents"] == [
         {
             "slug": "z-child",
-            "version": 1,
             "name": "evidence-child",
             "description": "Collect evidence",
             "max_turns": 3,
@@ -4613,7 +4538,7 @@ async def test_agent_preset_sync_preserves_enabled_local_catalog_id(
         slug="qa-catalog-backed",
         name="QA catalog backed",
     )
-    preset_path = f"{AGENT_PRESET_ROOT}/qa-catalog-backed/versions/1.yml"
+    preset_path = f"{AGENT_PRESET_ROOT}/qa-catalog-backed/preset.yml"
     preset_spec = yaml.safe_load(files[preset_path])
     preset_spec["catalog_id"] = str(catalog.id)
     preset_spec["model_provider"] = catalog.model_provider
@@ -4648,7 +4573,7 @@ async def test_agent_preset_sync_preserves_enabled_local_catalog_id(
 
 
 @pytest.mark.anyio
-async def test_agent_preset_sync_correlates_all_catalog_backed_versions(
+async def test_agent_preset_sync_correlates_catalog_backed_desired_head(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
@@ -4668,8 +4593,8 @@ async def test_agent_preset_sync_correlates_all_catalog_backed_versions(
         name="QA cross-environment catalog",
         version_number=2,
     )
-    current_path = f"{AGENT_PRESET_ROOT}/qa-cross-environment-catalog/versions/2.yml"
-    current_spec = _patch_yaml_file(
+    current_path = f"{AGENT_PRESET_ROOT}/qa-cross-environment-catalog/preset.yml"
+    _patch_yaml_file(
         files,
         current_path,
         {
@@ -4679,13 +4604,6 @@ async def test_agent_preset_sync_correlates_all_catalog_backed_versions(
             "base_url": source_base_url,
         },
     )
-    historical_spec = dict(current_spec)
-    historical_spec["version_number"] = 1
-    historical_spec["instructions"] = "Historical instructions"
-    files[f"{AGENT_PRESET_ROOT}/qa-cross-environment-catalog/versions/1.yml"] = _yaml(
-        historical_spec
-    )
-
     snapshot, diagnostics = await service.parse_files(files, commit_sha="m" * 40)
     assert diagnostics == []
     result = await service._import_snapshot(snapshot, sync_schedules=False)
@@ -4708,7 +4626,7 @@ async def test_agent_preset_sync_correlates_all_catalog_backed_versions(
             )
         ).all()
     )
-    assert [version.version for version in versions] == [1, 2]
+    assert [version.version for version in versions] == [1]
     assert {version.catalog_id for version in versions} == {local_catalog.id}
     assert {version.base_url for version in versions} == {None}
 
@@ -4737,7 +4655,7 @@ async def test_agent_preset_correlation_clears_source_base_url_for_openai(
         slug="qa-openai-cross-env",
         name="QA OpenAI cross-environment catalog",
     )
-    preset_path = f"{AGENT_PRESET_ROOT}/qa-openai-cross-env/versions/1.yml"
+    preset_path = f"{AGENT_PRESET_ROOT}/qa-openai-cross-env/preset.yml"
     _patch_yaml_file(
         files,
         preset_path,
@@ -4798,7 +4716,7 @@ async def test_agent_preset_dry_run_correlates_catalog_id_without_spurious_diff(
         slug="qa-preview-correlated",
         name="QA preview correlated",
     )
-    preset_path = f"{AGENT_PRESET_ROOT}/qa-preview-correlated/versions/1.yml"
+    preset_path = f"{AGENT_PRESET_ROOT}/qa-preview-correlated/preset.yml"
     _patch_yaml_file(
         files,
         preset_path,
@@ -4889,7 +4807,7 @@ async def test_agent_preset_sync_requires_an_ambiguous_catalog_choice_per_pull(
         slug=source_id,
         name="QA catalog choice",
     )
-    version_one_path = f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml"
+    version_one_path = f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml"
     _patch_yaml_file(
         files,
         version_one_path,
@@ -5046,7 +4964,7 @@ async def test_workspace_sync_catalog_mapping_rewrites_preset_and_workflow_toget
             },
         ),
     )
-    preset_version_path = f"{AGENT_PRESET_ROOT}/{preset_source_id}/versions/1.yml"
+    preset_version_path = f"{AGENT_PRESET_ROOT}/{preset_source_id}/preset.yml"
     _patch_yaml_file(
         files,
         preset_version_path,
@@ -5072,9 +4990,7 @@ async def test_workspace_sync_catalog_mapping_rewrites_preset_and_workflow_toget
 
     assert prepared.diagnostics == []
     assert prepared.catalog_mapping_requirements == []
-    prepared_version = prepared.snapshot.spec.agent_presets[preset_source_id].versions[
-        1
-    ]
+    prepared_version = prepared.snapshot.spec.agent_presets[preset_source_id]
     assert prepared_version.catalog_id == chosen_catalog.id
     assert prepared_version.base_url is None
     prepared_action_args = (
@@ -5406,7 +5322,7 @@ async def test_mcp_integration_exact_match_auto_resolves_without_interaction(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         {
             "mcp_integrations": [str(source_mcp_id)],
             "mcp_integration_hints": {
@@ -5421,7 +5337,7 @@ async def test_mcp_integration_exact_match_auto_resolves_without_interaction(
     prepared = await service._prepare_snapshot_for_import(snapshot)
     assert prepared.diagnostics == []
     assert prepared.mcp_integration_mapping_requirements == []
-    prepared_version = prepared.snapshot.spec.agent_presets[source_id].versions[1]
+    prepared_version = prepared.snapshot.spec.agent_presets[source_id]
     assert prepared_version.mcp_integrations == [str(local.id)]
     assert prepared_version.mcp_integration_hints == {
         local.id: McpIntegrationHint(
@@ -5477,7 +5393,7 @@ async def test_mcp_integration_hint_mismatch_requires_a_mapping_choice(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         {
             # server_type http vs the local stdio row: not an exact match.
             **_mcp_fields(source_mcp_id, slug="linear_mcp", name="Linear"),
@@ -5539,7 +5455,7 @@ async def test_mcp_integration_selection_applies_only_to_current_pull(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         _mcp_fields(source_mcp_id, slug="unmatched_mcp"),
     )
     service = WorkspaceSyncService(session=session, role=svc_role)
@@ -5597,7 +5513,7 @@ async def test_mcp_integration_legacy_manifest_requires_a_choice_per_pull(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         {"mcp_integrations": [str(source_mcp_id)]},
     )
     service = WorkspaceSyncService(session=session, role=svc_role)
@@ -5641,7 +5557,7 @@ async def test_repeat_preview_after_applied_mcp_pull_shows_no_diffs(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         {
             "model_name": "gpt-5.5",
             "model_provider": "openai",
@@ -5702,12 +5618,12 @@ async def test_mcp_integration_conflicting_meta_requires_choice_not_first_wins(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{first_source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{first_source_id}/preset.yml",
         _mcp_fields(source_mcp_id, slug="linear_mcp"),
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{second_source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{second_source_id}/preset.yml",
         _mcp_fields(source_mcp_id, slug="github_mcp"),
     )
     service = WorkspaceSyncService(session=session, role=svc_role)
@@ -5720,9 +5636,7 @@ async def test_mcp_integration_conflicting_meta_requires_choice_not_first_wins(
     assert requirements[0].reason == "conflicting_metadata"
     for preset_source_id in (first_source_id, second_source_id):
         assert _mcp_entry_ids(
-            prepared.snapshot.spec.agent_presets[preset_source_id]
-            .versions[1]
-            .mcp_integrations
+            prepared.snapshot.spec.agent_presets[preset_source_id].mcp_integrations
         ) == [str(source_mcp_id)]
 
     result = await service._import_snapshot(
@@ -5768,12 +5682,12 @@ async def test_mcp_integration_name_drift_preserves_exact_correlation(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{first_source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{first_source_id}/preset.yml",
         _mcp_fields(source_mcp_id, slug="linear_mcp", name="Linear"),
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{second_source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{second_source_id}/preset.yml",
         _mcp_fields(source_mcp_id, slug="linear_mcp", name="Linear renamed"),
     )
 
@@ -5786,9 +5700,7 @@ async def test_mcp_integration_name_drift_preserves_exact_correlation(
     assert prepared.mcp_integration_mapping_requirements == []
     for preset_source_id in (first_source_id, second_source_id):
         assert _mcp_entry_ids(
-            prepared.snapshot.spec.agent_presets[preset_source_id]
-            .versions[1]
-            .mcp_integrations
+            prepared.snapshot.spec.agent_presets[preset_source_id].mcp_integrations
         ) == [str(local.id)]
 
 
@@ -5805,7 +5717,7 @@ async def test_mcp_integration_zero_local_integrations_blocks_without_candidates
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         _mcp_fields(source_mcp_id, slug="linear_mcp"),
     )
     service = WorkspaceSyncService(session=session, role=svc_role)
@@ -5846,7 +5758,7 @@ async def test_mcp_preview_allows_two_sources_selecting_the_same_target(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         {
             "mcp_integrations": [
                 str(first_source_id),
@@ -5869,7 +5781,7 @@ async def test_mcp_preview_allows_two_sources_selecting_the_same_target(
     assert prepared.diagnostics == []
     assert prepared.mcp_integration_mapping_requirements == []
     assert _mcp_entry_ids(
-        prepared.snapshot.spec.agent_presets[source_id].versions[1].mcp_integrations
+        prepared.snapshot.spec.agent_presets[source_id].mcp_integrations
     ) == [str(local.id), str(local.id)]
 
     result = await service._import_snapshot(
@@ -5915,7 +5827,7 @@ async def test_mcp_integration_refs_in_workflow_agent_args_are_correlated(
     # The workflow ref reuses the preset's hint: source UUIDs are shared.
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{preset_source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{preset_source_id}/preset.yml",
         _mcp_fields(source_mcp_id, slug="linear_mcp", name="Linear"),
     )
     service = WorkspaceSyncService(session=session, role=svc_role)
@@ -6013,7 +5925,7 @@ async def test_mcp_integration_correlation_preserves_reference_order(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         {
             "mcp_integrations": [str(source_first), str(source_second)],
             "mcp_integration_hints": {
@@ -6029,7 +5941,7 @@ async def test_mcp_integration_correlation_preserves_reference_order(
     prepared = await service._prepare_snapshot_for_import(snapshot)
     assert prepared.diagnostics == []
     assert _mcp_entry_ids(
-        prepared.snapshot.spec.agent_presets[source_id].versions[1].mcp_integrations
+        prepared.snapshot.spec.agent_presets[source_id].mcp_integrations
     ) == [str(first.id), str(second.id)]
 
 
@@ -6053,7 +5965,7 @@ async def test_mcp_integration_unused_selection_reports_source_not_found(
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
         _mcp_fields(source_mcp_id, slug="linear_mcp", name="Linear"),
     )
     service = WorkspaceSyncService(session=session, role=svc_role)
@@ -6087,7 +5999,7 @@ async def test_agent_preset_export_emits_rollback_safe_mcp_hints(
     files = _agent_preset_git_tree(
         source_id=source_id, slug=source_id, name="QA MCP export"
     )
-    version_path = f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml"
+    version_path = f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml"
     _patch_yaml_file(files, version_path, {"mcp_integrations": [str(local.id)]})
     service = WorkspaceSyncService(session=session, role=svc_role)
     snapshot, diagnostics = await service.parse_files(files, commit_sha="y" * 40)
@@ -6125,7 +6037,7 @@ async def test_agent_preset_export_without_mcp_refs_stays_unchanged(
     files = _agent_preset_git_tree(
         source_id=source_id, slug=source_id, name="QA MCP none"
     )
-    version_path = f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml"
+    version_path = f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml"
     service = WorkspaceSyncService(session=session, role=svc_role)
     snapshot, diagnostics = await service.parse_files(files, commit_sha="z" * 40)
     assert diagnostics == []
@@ -6144,7 +6056,7 @@ def _untyped_catalog_preset_git_tree(
     files = _agent_preset_git_tree(
         source_id=source_id, slug=source_id, name="QA untyped catalog"
     )
-    version_path = f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml"
+    version_path = f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml"
     version_spec = yaml.safe_load(files[version_path])
     version_spec["catalog_id"] = catalog_id
     files[version_path] = _yaml(version_spec)
@@ -6246,7 +6158,7 @@ async def test_workspace_sync_rejects_enabled_catalog_model_identity_mismatch(
         )
         _patch_yaml_file(
             files,
-            f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml",
+            f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml",
             {
                 "catalog_id": str(local_catalog.id),
                 "model_provider": "manifest-provider",
@@ -6358,7 +6270,7 @@ async def test_workspace_sync_preserves_matching_enabled_catalog_identity_and_ur
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{preset_source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{preset_source_id}/preset.yml",
         {
             "catalog_id": str(selected_catalog.id),
             "model_provider": model_provider,
@@ -6374,9 +6286,7 @@ async def test_workspace_sync_preserves_matching_enabled_catalog_identity_and_ur
 
     assert prepared.diagnostics == []
     assert prepared.catalog_mapping_requirements == []
-    prepared_version = prepared.snapshot.spec.agent_presets[preset_source_id].versions[
-        1
-    ]
+    prepared_version = prepared.snapshot.spec.agent_presets[preset_source_id]
     assert prepared_version.catalog_id == selected_catalog.id
     assert prepared_version.base_url == preset_base_url
     prepared_args = (
@@ -6447,7 +6357,7 @@ async def test_workspace_sync_detects_catalog_identity_conflict_across_resources
     )
     _patch_yaml_file(
         files,
-        f"{AGENT_PRESET_ROOT}/{preset_source_id}/versions/1.yml",
+        f"{AGENT_PRESET_ROOT}/{preset_source_id}/preset.yml",
         {
             "catalog_id": str(source_catalog_id),
             "model_provider": "preset-provider",
@@ -6509,7 +6419,7 @@ async def test_agent_preset_sync_reports_unavailable_catalog_model_before_writes
         slug="qa-unavailable-catalog",
         name="QA unavailable catalog",
     )
-    preset_path = f"{AGENT_PRESET_ROOT}/qa-unavailable-catalog/versions/1.yml"
+    preset_path = f"{AGENT_PRESET_ROOT}/qa-unavailable-catalog/preset.yml"
     _patch_yaml_file(
         files,
         preset_path,
@@ -6552,7 +6462,7 @@ async def test_agent_preset_sync_dry_run_reports_unavailable_catalog_model(
         slug="qa-unavailable-catalog-preview",
         name="QA unavailable catalog preview",
     )
-    preset_path = f"{AGENT_PRESET_ROOT}/qa-unavailable-catalog-preview/versions/1.yml"
+    preset_path = f"{AGENT_PRESET_ROOT}/qa-unavailable-catalog-preview/preset.yml"
     _patch_yaml_file(
         files,
         preset_path,
@@ -8196,6 +8106,7 @@ def _agent_preset_git_tree(
     instructions: str | None = None,
     version_number: int = 1,
 ) -> dict[str, str]:
+    del version_number
     return {
         MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
         f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml": _yaml(
@@ -8204,15 +8115,6 @@ def _agent_preset_git_tree(
                 "type": "agent_preset",
                 "id": source_id,
                 "slug": slug,
-                "name": name,
-                "current_version": version_number,
-            }
-        ),
-        f"{AGENT_PRESET_ROOT}/{source_id}/versions/{version_number}.yml": _yaml(
-            {
-                "version": 1,
-                "type": "agent_preset_version",
-                "version_number": version_number,
                 "name": name,
                 "instructions": instructions,
             }
@@ -8328,16 +8230,6 @@ def _skill_git_tree(
                 "slug": slug,
                 "name": name,
                 "description": "Deterministic enrichment helper",
-                "current_version": 1,
-            }
-        ),
-        f"{SKILL_ROOT}/{source_id}/versions/1/version.yml": _yaml(
-            {
-                "version": 1,
-                "type": "skill_version",
-                "version_number": 1,
-                "name": name,
-                "description": "Deterministic enrichment helper",
                 "files": [
                     {
                         "path": "SKILL.md",
@@ -8346,61 +8238,30 @@ def _skill_git_tree(
                 ],
             }
         ),
-        f"{SKILL_ROOT}/{source_id}/versions/1/files/SKILL.md": content,
+        f"{SKILL_ROOT}/{source_id}/files/SKILL.md": content,
     }
 
 
 def _versioned_agent_skill_git_tree() -> dict[str, str]:
-    """Build a Git tree where two presets pin different versions of one skill.
+    """Build desired head state where two presets attach the same skill head."""
+    skill_content = "# Skill A\n\nCurrent behavior.\n"
 
-    Layout: ``skill-a`` publishes versions 1 and 2 (head at v2), ``agent-x`` pins
-    ``skill-a`` v1, and ``agent-y`` pins ``skill-a`` v2. Used to assert the import
-    -> export -> pull round trip preserves the divergent pins.
-    """
-    skill_v1 = "# Skill A\n\nVersion 1 behavior.\n"
-    skill_v2 = "# Skill A\n\nVersion 2 behavior.\n"
-
-    def skill_version(number: int, name: str, content: str) -> dict[str, Any]:
+    def preset(source_id: str, name: str) -> dict[str, str]:
         return {
-            "version": 1,
-            "type": "skill_version",
-            "version_number": number,
-            "name": name,
-            "files": [
+            f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml": _yaml(
                 {
-                    "path": "SKILL.md",
-                    "sha256": hashlib.sha256(content.encode()).hexdigest(),
+                    "version": 1,
+                    "type": "agent_preset",
+                    "id": source_id,
+                    "slug": source_id,
+                    "name": name,
+                    "instructions": "Use the current skill-a head.",
+                    "skills": [{"slug": "skill-a"}],
+                    "subagents": [],
+                    "model_name": "gpt-5.5",
+                    "model_provider": "openai",
                 }
-            ],
-        }
-
-    def preset(
-        source_id: str,
-        name: str,
-        skill_version: int,
-    ) -> dict[str, str]:
-        head = {
-            "version": 1,
-            "type": "agent_preset",
-            "id": source_id,
-            "slug": source_id,
-            "name": name,
-            "current_version": 1,
-        }
-        version = {
-            "version": 1,
-            "type": "agent_preset_version",
-            "version_number": 1,
-            "name": name,
-            "instructions": f"Use skill-a version {skill_version}.",
-            "skills": [{"slug": "skill-a", "version": skill_version}],
-            "subagents": [],
-            "model_name": "gpt-5.5",
-            "model_provider": "openai",
-        }
-        return {
-            f"{AGENT_PRESET_ROOT}/{source_id}/preset.yml": _yaml(head),
-            f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml": _yaml(version),
+            )
         }
 
     files = {
@@ -8411,126 +8272,65 @@ def _versioned_agent_skill_git_tree() -> dict[str, str]:
                 "type": "skill",
                 "id": "skill-a",
                 "slug": "skill-a",
-                "name": "Skill A v2",
+                "name": "Skill A current",
                 "description": "Versioned skill fixture",
-                "current_version": 2,
+                "files": [
+                    {
+                        "path": "SKILL.md",
+                        "sha256": hashlib.sha256(skill_content.encode()).hexdigest(),
+                    }
+                ],
             }
         ),
-        f"{SKILL_ROOT}/skill-a/versions/1/version.yml": _yaml(
-            skill_version(1, "Skill A v1", skill_v1)
-        ),
-        f"{SKILL_ROOT}/skill-a/versions/1/files/SKILL.md": skill_v1,
-        f"{SKILL_ROOT}/skill-a/versions/2/version.yml": _yaml(
-            skill_version(2, "Skill A v2", skill_v2)
-        ),
-        f"{SKILL_ROOT}/skill-a/versions/2/files/SKILL.md": skill_v2,
-        **preset("agent-x", "Agent X", 1),
-        **preset("agent-y", "Agent Y", 2),
+        f"{SKILL_ROOT}/skill-a/files/SKILL.md": skill_content,
+        **preset("agent-x", "Agent X"),
+        **preset("agent-y", "Agent Y"),
     }
     return dict(sorted(files.items()))
 
 
-def _versioned_subagent_git_tree() -> dict[str, str]:
-    """Build a Git tree where a parent pins a non-head subagent version."""
-    subagent_ref = [{"slug": "qa-evidence-child", "version": 1}]
-    parent_head = {
-        "version": 1,
-        "type": "agent_preset",
-        "id": "qa-triage-parent",
-        "slug": "qa-triage-parent",
-        "name": "QA triage parent",
-        "current_version": 1,
-    }
-    parent_version = {
-        "version": 1,
-        "type": "agent_preset_version",
-        "version_number": 1,
-        "name": "QA triage parent",
-        "instructions": "Delegate to the evidence child.",
-        "skills": [],
-        "subagents": subagent_ref,
-        "model_name": "gpt-5.5",
-        "model_provider": "openai",
-    }
-    child_head = {
-        "version": 1,
-        "type": "agent_preset",
-        "id": "qa-evidence-child",
-        "slug": "qa-evidence-child",
-        "name": "QA evidence child",
-        "current_version": 2,
-    }
-
-    def child_version(number: int, instructions: str) -> dict[str, Any]:
-        return {
-            "version": 1,
-            "type": "agent_preset_version",
-            "version_number": number,
-            "name": "QA evidence child",
-            "instructions": instructions,
-            "skills": [],
-            "subagents": [],
-            "model_name": "gpt-5.5",
-            "model_provider": "openai",
-        }
-
+def _head_subagent_git_tree() -> dict[str, str]:
+    """Build desired head state where a parent attaches a child preset head."""
     return dict(
         sorted(
             {
                 MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest()),
-                f"{AGENT_PRESET_ROOT}/qa-triage-parent/preset.yml": _yaml(parent_head),
-                f"{AGENT_PRESET_ROOT}/qa-triage-parent/versions/1.yml": _yaml(
-                    parent_version
+                f"{AGENT_PRESET_ROOT}/qa-triage-parent/preset.yml": _yaml(
+                    {
+                        "version": 1,
+                        "type": "agent_preset",
+                        "id": "qa-triage-parent",
+                        "slug": "qa-triage-parent",
+                        "name": "QA triage parent",
+                        "instructions": "Delegate to the evidence child.",
+                        "skills": [],
+                        "subagents": [{"slug": "qa-evidence-child"}],
+                        "model_name": "gpt-5.5",
+                        "model_provider": "openai",
+                    }
                 ),
-                f"{AGENT_PRESET_ROOT}/qa-evidence-child/preset.yml": _yaml(child_head),
-                f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/1.yml": _yaml(
-                    child_version(1, "Collect original evidence.")
-                ),
-                f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/2.yml": _yaml(
-                    child_version(2, "Collect current evidence.")
+                f"{AGENT_PRESET_ROOT}/qa-evidence-child/preset.yml": _yaml(
+                    {
+                        "version": 1,
+                        "type": "agent_preset",
+                        "id": "qa-evidence-child",
+                        "slug": "qa-evidence-child",
+                        "name": "QA evidence child",
+                        "instructions": "Collect current evidence.",
+                        "skills": [],
+                        "subagents": [],
+                        "model_name": "gpt-5.5",
+                        "model_provider": "openai",
+                    }
                 ),
             }.items()
         )
     )
 
 
-def _workflow_pinned_agent_version_git_tree() -> dict[str, str]:
-    """Build a Git tree whose workflow pins a non-head agent preset version.
-
-    Layout: a workflow calls ``ai.preset_agent`` pinned to ``agent-x`` v1, while
-    ``agent-x`` head is v2; v1 pins ``skill-a`` v1 and v2 pins ``skill-a`` v2.
-    Used to assert a full export walks the workflow -> preset version -> skill
-    version closure instead of exporting only the current heads.
-    """
-    skill_v1 = "# Skill A\n\nVersion 1 behavior.\n"
-    skill_v2 = "# Skill A\n\nVersion 2 behavior.\n"
-
-    def skill_version(number: int, name: str, content: str) -> dict[str, Any]:
-        return {
-            "version": 1,
-            "type": "skill_version",
-            "version_number": number,
-            "name": name,
-            "files": [
-                {
-                    "path": "SKILL.md",
-                    "sha256": hashlib.sha256(content.encode()).hexdigest(),
-                }
-            ],
-        }
-
-    def agent_version(number: int, skill_version: int) -> dict[str, Any]:
-        return {
-            "version": 1,
-            "type": "agent_preset_version",
-            "version_number": number,
-            "name": "Agent X",
-            "instructions": f"Use skill-a version {skill_version}.",
-            "skills": [{"slug": "skill-a", "version": skill_version}],
-            "subagents": [],
-            "model_name": "gpt-5.5",
-            "model_provider": "openai",
-        }
+def _workflow_agent_head_git_tree() -> dict[str, str]:
+    """Build desired head state for a workflow and its preset dependencies."""
+    skill_content = "# Skill A\n\nCurrent behavior.\n"
 
     return dict(
         sorted(
@@ -8548,8 +8348,7 @@ def _workflow_pinned_agent_version_git_tree() -> dict[str, str]:
                                 "action": "ai.preset_agent",
                                 "args": {
                                     "preset_slug": "agent-x",
-                                    "preset_version": 1,
-                                    "prompt": "Use the pinned preset version.",
+                                    "prompt": "Use the current preset head.",
                                 },
                             }
                         ],
@@ -8562,14 +8361,12 @@ def _workflow_pinned_agent_version_git_tree() -> dict[str, str]:
                         "id": "agent-x",
                         "slug": "agent-x",
                         "name": "Agent X",
-                        "current_version": 2,
+                        "instructions": "Use the current skill-a head.",
+                        "skills": [{"slug": "skill-a"}],
+                        "subagents": [],
+                        "model_name": "gpt-5.5",
+                        "model_provider": "openai",
                     }
-                ),
-                f"{AGENT_PRESET_ROOT}/agent-x/versions/1.yml": _yaml(
-                    agent_version(1, 1)
-                ),
-                f"{AGENT_PRESET_ROOT}/agent-x/versions/2.yml": _yaml(
-                    agent_version(2, 2)
                 ),
                 f"{SKILL_ROOT}/skill-a/skill.yml": _yaml(
                     {
@@ -8577,19 +8374,19 @@ def _workflow_pinned_agent_version_git_tree() -> dict[str, str]:
                         "type": "skill",
                         "id": "skill-a",
                         "slug": "skill-a",
-                        "name": "Skill A v2",
-                        "description": "Versioned skill fixture",
-                        "current_version": 2,
+                        "name": "Skill A current",
+                        "description": "Desired skill head fixture",
+                        "files": [
+                            {
+                                "path": "SKILL.md",
+                                "sha256": hashlib.sha256(
+                                    skill_content.encode()
+                                ).hexdigest(),
+                            }
+                        ],
                     }
                 ),
-                f"{SKILL_ROOT}/skill-a/versions/1/version.yml": _yaml(
-                    skill_version(1, "Skill A v1", skill_v1)
-                ),
-                f"{SKILL_ROOT}/skill-a/versions/1/files/SKILL.md": skill_v1,
-                f"{SKILL_ROOT}/skill-a/versions/2/version.yml": _yaml(
-                    skill_version(2, "Skill A v2", skill_v2)
-                ),
-                f"{SKILL_ROOT}/skill-a/versions/2/files/SKILL.md": skill_v2,
+                f"{SKILL_ROOT}/skill-a/files/SKILL.md": skill_content,
             }.items()
         )
     )
@@ -8809,21 +8606,12 @@ def _expanded_full_git_tree(*, include_schedules: bool) -> dict[str, str]:
                 "id": "qa-triage-parent",
                 "slug": "qa-triage-parent",
                 "name": "QA triage parent",
-                "current_version": 1,
                 "folder_path": "QA/Agents",
                 "tags": ["qa-sync"],
-            }
-        ),
-        f"{AGENT_PRESET_ROOT}/qa-triage-parent/versions/1.yml": _yaml(
-            {
-                "version": 1,
-                "type": "agent_preset_version",
-                "version_number": 1,
-                "name": "QA triage parent",
                 "instructions": "Use the enrichment skill and escalate high severity.",
                 "tool_approvals": {"tools.qa_enrichment.lookup": "always"},
                 "actions": ["tools.qa_enrichment.lookup"],
-                "skills": [{"slug": "qa-enrichment-skill", "version": 1}],
+                "skills": [{"slug": "qa-enrichment-skill"}],
                 "subagents": [{"slug": "qa-evidence-child"}],
                 "model_name": "gpt-5.5",
                 "model_provider": "openai",
@@ -8843,45 +8631,16 @@ def _expanded_full_git_tree(*, include_schedules: bool) -> dict[str, str]:
                 "id": "qa-evidence-child",
                 "slug": "qa-evidence-child",
                 "name": "QA evidence child",
-                "current_version": 1,
                 "folder_path": "QA/Agents",
                 "tags": ["qa-sync"],
-            }
-        ),
-        f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/1.yml": _yaml(
-            {
-                "version": 1,
-                "type": "agent_preset_version",
-                "version_number": 1,
-                "name": "QA evidence child",
                 "instructions": "Collect concise evidence.",
                 "skills": [],
                 "subagents": [],
             }
         ),
         f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml": _yaml(_skill_spec(skill_files)),
-        f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/version.yml": _yaml(
-            {
-                "version": 1,
-                "type": "skill_version",
-                "version_number": 1,
-                "name": "QA enrichment skill",
-                "description": "Deterministic enrichment helper",
-                "files": [
-                    {
-                        "path": path,
-                        "sha256": hashlib.sha256(content.encode()).hexdigest(),
-                    }
-                    for path, content in sorted(skill_files.items())
-                ],
-            }
-        ),
-        f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/files/SKILL.md": skill_files[
-            "SKILL.md"
-        ],
-        f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/files/enrich.py": skill_files[
-            "enrich.py"
-        ],
+        f"{SKILL_ROOT}/qa-enrichment-skill/files/SKILL.md": skill_files["SKILL.md"],
+        f"{SKILL_ROOT}/qa-enrichment-skill/files/enrich.py": skill_files["enrich.py"],
         f"{TABLE_ROOT}/qa_indicators/table.yml": _yaml(
             {
                 "version": 1,
@@ -8986,15 +8745,6 @@ def _large_agent_preset_git_tree() -> dict[str, str]:
                 "id": source_id,
                 "slug": source_id,
                 "name": name,
-                "current_version": 1,
-            }
-        )
-        files[f"{AGENT_PRESET_ROOT}/{source_id}/versions/1.yml"] = _yaml(
-            {
-                "version": 1,
-                "type": "agent_preset_version",
-                "version_number": 1,
-                "name": name,
                 "instructions": f"Handle generated test workload {index:02d}.",
                 "skills": [],
                 "subagents": [],
@@ -9022,13 +8772,10 @@ def _expected_full_paths() -> set[str]:
         f"{WORKFLOW_ROOT}/qa-child/definition.yml",
         f"{WORKFLOW_ROOT}/qa-orphan/definition.yml",
         f"{AGENT_PRESET_ROOT}/qa-triage-parent/preset.yml",
-        f"{AGENT_PRESET_ROOT}/qa-triage-parent/versions/1.yml",
         f"{AGENT_PRESET_ROOT}/qa-evidence-child/preset.yml",
-        f"{AGENT_PRESET_ROOT}/qa-evidence-child/versions/1.yml",
         f"{SKILL_ROOT}/qa-enrichment-skill/skill.yml",
-        f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/version.yml",
-        f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/files/SKILL.md",
-        f"{SKILL_ROOT}/qa-enrichment-skill/versions/1/files/enrich.py",
+        f"{SKILL_ROOT}/qa-enrichment-skill/files/SKILL.md",
+        f"{SKILL_ROOT}/qa-enrichment-skill/files/enrich.py",
         f"{TABLE_ROOT}/qa_indicators/table.yml",
         f"{CASE_TAG_ROOT}/qa-alert.yml",
         f"{CASE_DROPDOWN_ROOT}/qa_resolution_reason.yml",
@@ -9095,7 +8842,13 @@ def _skill_spec(skill_files: dict[str, str]) -> dict[str, Any]:
         "slug": "qa-enrichment-skill",
         "name": "QA enrichment skill",
         "description": "Deterministic enrichment helper",
-        "current_version": 1,
+        "files": [
+            {
+                "path": path,
+                "sha256": hashlib.sha256(content.encode()).hexdigest(),
+            }
+            for path, content in sorted(skill_files.items())
+        ],
     }
 
 

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -41,7 +41,6 @@ from tracecat.workspace_sync.schemas import (
     MANIFEST_FILENAME,
     AgentPresetResourceSpec,
     AgentPresetSkillBinding,
-    AgentPresetVersionResourceSpec,
     CaseDropdownResourceSpec,
     ResourceRef,
     SecretMetadataResourceSpec,
@@ -900,7 +899,7 @@ def test_sync_operation_scope_accepts_legacy_or_workspace_sync_grant() -> None:
 
 
 @pytest.mark.anyio
-async def test_preview_export_rejects_missing_pinned_skill_version(
+async def test_preview_export_accepts_head_only_skill_reference(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:
     workspace_sync_service.project_workspace = AsyncMock(
@@ -912,19 +911,7 @@ async def test_preview_export_rejects_missing_pinned_skill_version(
                         id="qa-triage",
                         slug="qa-triage",
                         name="QA triage",
-                        current_version=1,
-                        versions={
-                            1: AgentPresetVersionResourceSpec(
-                                version_number=1,
-                                name="QA triage",
-                                skills=[
-                                    AgentPresetSkillBinding(
-                                        slug="qa-enrichment-skill",
-                                        version=1,
-                                    )
-                                ],
-                            )
-                        },
+                        skills=[AgentPresetSkillBinding(slug="qa-enrichment-skill")],
                     )
                 },
                 skills={
@@ -932,7 +919,6 @@ async def test_preview_export_rejects_missing_pinned_skill_version(
                         id="qa-enrichment-skill",
                         slug="qa-enrichment-skill",
                         name="QA enrichment skill",
-                        current_version=2,
                     )
                 },
             ),
@@ -940,10 +926,12 @@ async def test_preview_export_rejects_missing_pinned_skill_version(
         )
     )
 
-    with pytest.raises(TracecatValidationError, match="missing skill version"):
-        await workspace_sync_service.preview_export_workspace(
-            WorkspaceSyncExportPreviewRequest()
-        )
+    preview = await workspace_sync_service.preview_export_workspace(
+        WorkspaceSyncExportPreviewRequest()
+    )
+
+    assert preview.resource_counts[SyncResourceType.AGENT_PRESET.value] == 1
+    assert preview.resource_counts[SyncResourceType.SKILL.value] == 1
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/internal_router.py
+++ b/tracecat/agent/internal_router.py
@@ -26,7 +26,8 @@ from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_role, ctx_session_id
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.logger import logger
-from tracecat.tiers.entitlements import Entitlement, check_entitlement
+from tracecat.tiers.entitlements import check_entitlement
+from tracecat.tiers.enums import Entitlement
 
 router = APIRouter(
     prefix="/internal/agent",
@@ -67,7 +68,7 @@ async def _resolve_run_config(
 
 def _reject_unsupported_agents_config(config: AgentConfig) -> None:
     """Reject subagent config on the legacy internal agent runner."""
-    if config.agents.enabled:
+    if config.agents.subagents:
         raise ValueError(
             "Subagents are not supported by the internal agent run endpoint yet. "
             "Use agent sessions for subagent-enabled runs."

--- a/tracecat/agent/preset/internal_router.py
+++ b/tracecat/agent/preset/internal_router.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Mapping
-from typing import Annotated, Any, cast
+from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field, StringConstraints
@@ -15,11 +14,11 @@ from tracecat.agent.preset.schemas import (
     AgentPresetReadMinimal,
     AgentPresetSkillBindingBase,
     AgentPresetUpdate,
-    build_subagent_eligibility,
+    build_agent_preset_read_minimal,
 )
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.service import AgentManagementService
-from tracecat.agent.subagents import AgentSubagentsConfig, has_manual_tool_approvals
+from tracecat.agent.subagents import AgentSubagentsConfig
 from tracecat.agent.types import OutputType
 from tracecat.auth.dependencies import ExecutorWorkspaceRole
 from tracecat.authz.controls import require_scope
@@ -174,30 +173,7 @@ async def list_presets(
     """List all agent presets for the workspace."""
     service = AgentPresetService(session, role=role)
     presets = await service.list_presets()
-    results: list[AgentPresetReadMinimal] = []
-    for preset in presets:
-        read = AgentPresetReadMinimal.model_validate(preset)
-        agents = AgentSubagentsConfig.model_validate(preset.agents or {})
-        tool_approvals = cast(Mapping[str, bool] | None, preset.tool_approvals)
-        capabilities = []
-        if has_manual_tool_approvals(tool_approvals):
-            capabilities.append("approvals")
-        if agents.enabled:
-            capabilities.append("subagents")
-        if preset.enable_internet_access:
-            capabilities.append("internet_access")
-        results.append(
-            read.model_copy(
-                update={
-                    "capabilities": capabilities,
-                    "current_version_subagent_eligibility": build_subagent_eligibility(
-                        agents_config=agents,
-                        tool_approvals=tool_approvals,
-                    ),
-                }
-            )
-        )
-    return results
+    return [build_agent_preset_read_minimal(preset) for preset in presets]
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)

--- a/tracecat/agent/preset/resolver.py
+++ b/tracecat/agent/preset/resolver.py
@@ -6,11 +6,12 @@ import uuid
 from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Protocol
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
     AttachedSubagentRef,
+    HeadAttachedSubagentRef,
     ResolvedAgentsConfig,
     ResolvedAttachedSubagentRef,
     has_manual_tool_approvals,
@@ -36,6 +37,10 @@ class AgentPresetResolutionService(Protocol):
     ) -> Awaitable[AgentPresetVersion]: ...
 
     def get_preset(self, preset_id: uuid.UUID) -> Awaitable[AgentPreset | None]: ...
+
+    def get_head_subagents_config(
+        self, preset_id: uuid.UUID
+    ) -> Awaitable[AgentSubagentsConfig]: ...
 
     def resolve_agent_preset_config(
         self,
@@ -86,18 +91,22 @@ class ResolvedSubagentResolution(BaseModel):
 class ResolvedAgentsConfigResult(BaseModel):
     """Resolved preset-backed subagent bindings."""
 
-    enabled: bool = False
     subagents: list[ResolvedSubagentResolution] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def discard_legacy_enabled(cls, value: Any) -> Any:
+        if isinstance(value, dict) and "enabled" in value:
+            return {key: item for key, item in value.items() if key != "enabled"}
+        return value
 
     def to_agents_binding(self) -> ResolvedAgentsConfig:
         return ResolvedAgentsConfig(
-            enabled=self.enabled,
             subagents=[subagent.binding for subagent in self.subagents],
         )
 
     def to_runtime_config(self) -> ResolvedAgentsRuntimeConfig:
         return ResolvedAgentsRuntimeConfig(
-            enabled=self.enabled,
             subagents=[
                 subagent.require_runtime_config() for subagent in self.subagents
             ],
@@ -107,12 +116,17 @@ class ResolvedAgentsConfigResult(BaseModel):
 class ResolvedAgentsRuntimeConfig(BaseModel):
     """Runtime-ready resolved preset-backed subagent config."""
 
-    enabled: bool = False
     subagents: list[ResolvedSubagentConfig] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def discard_legacy_enabled(cls, value: Any) -> Any:
+        if isinstance(value, dict) and "enabled" in value:
+            return {key: item for key, item in value.items() if key != "enabled"}
+        return value
 
     def to_agents_binding(self) -> ResolvedAgentsConfig:
         return ResolvedAgentsConfig(
-            enabled=self.enabled,
             subagents=[subagent.binding for subagent in self.subagents],
         )
 
@@ -129,9 +143,6 @@ async def resolve_agents_config(
     """Resolve and validate preset-backed subagent refs."""
 
     config = AgentSubagentsConfig.model_validate({} if agents is None else agents)
-    if not config.enabled:
-        return ResolvedAgentsConfigResult()
-
     aliases: set[str] = set()
     resolved_subagents: list[ResolvedSubagentResolution] = []
     for ref in config.subagents:
@@ -146,9 +157,10 @@ async def resolve_agents_config(
             )
         aliases.add(alias)
 
-        # Resolved refs carry immutable preset/version UUIDs; unresolved refs
-        # only carry a slug + optional version int. Matching narrows the union
-        # so we read the right identifiers without runtime getattr() lookups.
+        # Resolved refs carry immutable preset/version UUIDs, canonical head
+        # refs carry stable child-head UUIDs, and unresolved refs carry a slug.
+        # Matching narrows the union so we
+        # read the right identifiers without runtime getattr() lookups.
         # Order matters: ResolvedAttachedSubagentRef subclasses
         # AttachedSubagentRef, so the resolved case must come first or resolved
         # refs would silently fall into the base-class branch.
@@ -167,18 +179,16 @@ async def resolve_agents_config(
                     version = await service.resolve_agent_preset_version(
                         preset_version_id=preset_version_id,
                     )
-            case AttachedSubagentRef(preset=preset_slug, preset_version=preset_version):
-                # Unresolved ref has no persisted UUID; resolve by slug.
+            case HeadAttachedSubagentRef(preset_id=preset_id):
+                # Head topology always resolves the child's current version.
                 preset_version_id = None
-                if follow_latest_versions:
-                    version = await service.resolve_agent_preset_version(
-                        slug=preset_slug
-                    )
-                else:
-                    version = await service.resolve_agent_preset_version(
-                        slug=preset_slug,
-                        preset_version=preset_version,
-                    )
+                version = await service.resolve_agent_preset_version(
+                    preset_id=preset_id,
+                )
+            case AttachedSubagentRef(preset=preset_slug):
+                # Authored refs always resolve the child head's current version.
+                preset_version_id = None
+                version = await service.resolve_agent_preset_version(slug=preset_slug)
         references_parent_id = (
             parent_preset_id is not None and version.preset_id == parent_preset_id
         )
@@ -190,8 +200,8 @@ async def resolve_agents_config(
         if references_parent_id or references_parent_slug:
             raise TracecatValidationError("Agent presets cannot reference themselves")
 
-        child_agents = AgentSubagentsConfig.model_validate(version.agents)
-        if child_agents.enabled:
+        child_agents = await service.get_head_subagents_config(version.preset_id)
+        if child_agents.subagents:
             raise TracecatValidationError(
                 f"Subagent preset '{ref.preset}' cannot define its own agents in v1"
             )
@@ -231,7 +241,7 @@ async def resolve_agents_config(
         else:
             resolved_subagents.append(ResolvedSubagentResolution(binding=binding))
 
-    return ResolvedAgentsConfigResult(enabled=True, subagents=resolved_subagents)
+    return ResolvedAgentsConfigResult(subagents=resolved_subagents)
 
 
 def build_subagent_prompt(instructions: str | None) -> str:

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
@@ -20,7 +20,9 @@ if TYPE_CHECKING:
 
 
 type AgentPresetCapability = Literal["approvals", "subagents", "internet_access"]
-type AgentPresetSubagentEligibilityReason = Literal["agents_enabled", "tool_approvals"]
+type AgentPresetSubagentEligibilityReason = Literal[
+    "nested_subagents", "tool_approvals"
+]
 
 
 class AgentPresetSubagentEligibility(BaseModel):
@@ -44,17 +46,6 @@ class AgentPresetSkillBindingRead(Schema):
     skill_version_id: uuid.UUID
     skill_name: str
     skill_version: int
-
-
-class AgentPresetSkillBindingChange(BaseModel):
-    """Diff entry for skill binding changes between preset versions."""
-
-    skill_id: uuid.UUID
-    skill_name: str
-    old_skill_version_id: uuid.UUID | None = None
-    old_skill_version: int | None = None
-    new_skill_version_id: uuid.UUID | None = None
-    new_skill_version: int | None = None
 
 
 PresetName = Annotated[
@@ -88,7 +79,6 @@ class AgentPresetExecutionConfig(Schema):
     namespaces: list[str] | None = Field(default=None)
     tool_approvals: dict[str, bool] | None = Field(default=None)
     mcp_integrations: list[str] | None = Field(default=None)
-    agents: AgentSubagentsConfig = Field(default_factory=AgentSubagentsConfig)
     retries: int = Field(default=3, ge=0)
     enable_thinking: bool = Field(default=True)
     enable_internet_access: bool = Field(default=False)
@@ -181,39 +171,49 @@ def build_agent_preset_read_minimal(
     preset: AgentPreset,
 ) -> AgentPresetReadMinimal:
     """Build a minimal preset response without exposing approval rule details."""
-    read = AgentPresetReadMinimal.model_validate(preset)
-    agents_config = cast(
-        AgentSubagentsConfig | Mapping[str, object] | None, preset.agents
-    )
-    tool_approvals = cast(Mapping[str, bool] | None, preset.tool_approvals)
-    return read.model_copy(
-        update={
-            "capabilities": _agent_preset_capabilities(
-                agents_config=agents_config,
-                tool_approvals=tool_approvals,
-                enable_internet_access=bool(preset.enable_internet_access),
-            ),
-            "current_version_subagent_eligibility": build_subagent_eligibility(
-                agents_config=agents_config,
-                tool_approvals=tool_approvals,
-            ),
-        }
+    version = preset.current_version
+    if version is None:
+        raise ValueError(f"Agent preset {preset.id} has no current version")
+    has_subagents = bool(preset.subagent_bindings)
+    tool_approvals = version.tool_approvals
+    enable_internet_access = version.enable_internet_access
+    return AgentPresetReadMinimal(
+        id=preset.id,
+        workspace_id=preset.workspace_id,
+        name=preset.name,
+        slug=preset.slug,
+        description=preset.description,
+        model_provider=version.model_provider,
+        model_name=version.model_name,
+        folder_id=preset.folder_id,
+        tags=[TagRead.model_validate(tag) for tag in preset.tags],
+        current_version_id=preset.current_version_id,
+        capabilities=_agent_preset_capabilities(
+            has_subagents=has_subagents,
+            tool_approvals=tool_approvals,
+            enable_internet_access=enable_internet_access,
+        ),
+        current_version_subagent_eligibility=build_subagent_eligibility(
+            has_subagents=has_subagents,
+            tool_approvals=tool_approvals,
+        ),
+        created_at=preset.created_at,
+        updated_at=preset.updated_at,
     )
 
 
 def _agent_preset_capabilities(
     *,
-    agents_config: AgentSubagentsConfig | Mapping[str, object] | None,
+    has_subagents: bool,
     tool_approvals: Mapping[str, bool] | None,
     enable_internet_access: bool,
 ) -> list[AgentPresetCapability]:
     """Return lightweight capability flags for preset list UIs."""
 
     capabilities: list[AgentPresetCapability] = []
-    agents = AgentSubagentsConfig.model_validate(agents_config or {})
     if has_manual_tool_approvals(tool_approvals):
         capabilities.append("approvals")
-    if agents.enabled:
+    if has_subagents:
         capabilities.append("subagents")
     if enable_internet_access:
         capabilities.append("internet_access")
@@ -222,15 +222,14 @@ def _agent_preset_capabilities(
 
 def build_subagent_eligibility(
     *,
-    agents_config: AgentSubagentsConfig | Mapping[str, object] | None,
+    has_subagents: bool,
     tool_approvals: Mapping[str, bool] | None,
 ) -> AgentPresetSubagentEligibility:
     """Return whether this preset version can be attached as a subagent."""
 
     reasons: list[AgentPresetSubagentEligibilityReason] = []
-    agents = AgentSubagentsConfig.model_validate(agents_config or {})
-    if agents.enabled:
-        reasons.append("agents_enabled")
+    if has_subagents:
+        reasons.append("nested_subagents")
     if has_manual_tool_approvals(tool_approvals):
         reasons.append("tool_approvals")
     return AgentPresetSubagentEligibility(
@@ -246,10 +245,9 @@ def _subagent_eligibility_message(
     if not reasons:
         return None
     reason_set = set(reasons)
-    if reason_set == {"agents_enabled"}:
+    if reason_set == {"nested_subagents"}:
         return (
-            "This version defines its own subagents. Disable the Agent tool on "
-            "that version before attaching it as a subagent."
+            "This preset defines its own preset subagents, which cannot be nested yet."
         )
     if reason_set == {"tool_approvals"}:
         return (
@@ -272,6 +270,7 @@ class AgentPresetRead(AgentPresetExecutionConfig):
     description: str | None = Field(default=None, max_length=1000)
     current_version_id: uuid.UUID | None = None
     folder_id: uuid.UUID | None = None
+    agents: AgentSubagentsConfig = Field(default_factory=AgentSubagentsConfig)
     skills: list[AgentPresetSkillBindingRead] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
@@ -316,9 +315,6 @@ class AgentPresetVersionReadMinimal(Schema):
     workspace_id: WorkspaceID
     version: int
     capabilities: list[AgentPresetCapability] = Field(default_factory=list)
-    subagent_eligibility: AgentPresetSubagentEligibility = Field(
-        default_factory=AgentPresetSubagentEligibility
-    )
     created_at: datetime
     updated_at: datetime
 
@@ -333,10 +329,6 @@ class AgentPresetVersionRead(AgentPresetExecutionConfig):
     workspace_id: WorkspaceID
     version: int
     capabilities: list[AgentPresetCapability] = Field(default_factory=list)
-    subagent_eligibility: AgentPresetSubagentEligibility = Field(
-        default_factory=AgentPresetSubagentEligibility
-    )
-    skills: list[AgentPresetSkillBindingRead] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 
@@ -380,5 +372,4 @@ class AgentPresetVersionDiff(BaseModel):
     scalar_changes: list[ScalarFieldChange] = Field(default_factory=list)
     list_changes: list[StringListFieldChange] = Field(default_factory=list)
     tool_approval_changes: list[ToolApprovalFieldChange] = Field(default_factory=list)
-    skill_changes: list[AgentPresetSkillBindingChange] = Field(default_factory=list)
     total_changes: int = 0

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -10,9 +10,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 import sqlalchemy as sa
 from slugify import slugify
-from sqlalchemy import column, func, literal, select
-from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import selectinload
+from sqlalchemy import func, select
+from sqlalchemy.orm import aliased, selectinload
 
 from tracecat.agent.access.service import AgentModelAccessService
 from tracecat.agent.channels.service import AgentChannelService
@@ -28,7 +27,6 @@ from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
     AgentPresetRead,
     AgentPresetSkillBindingBase,
-    AgentPresetSkillBindingChange,
     AgentPresetSkillBindingRead,
     AgentPresetUpdate,
     AgentPresetVersionDiff,
@@ -38,12 +36,12 @@ from tracecat.agent.preset.schemas import (
     StringListFieldChange,
     ToolApprovalFieldChange,
     _agent_preset_capabilities,
-    build_subagent_eligibility,
 )
 from tracecat.agent.preset.types import SkillBindingSpec
 from tracecat.agent.skill.service import SkillService
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
+    HeadAttachedSubagentRef,
     ResolvedAgentsConfig,
     ResolvedAttachedSubagentRef,
 )
@@ -57,6 +55,7 @@ from tracecat.db.models import (
     AgentCatalog,
     AgentPreset,
     AgentPresetSkill,
+    AgentPresetSubagent,
     AgentPresetVersion,
     AgentPresetVersionSkill,
     MCPIntegration,
@@ -112,7 +111,6 @@ class AgentPresetService(BaseWorkspaceService):
         "namespaces",
         "tool_approvals",
         "mcp_integrations",
-        "agents",
         "retries",
         "enable_thinking",
         "enable_internet_access",
@@ -140,33 +138,36 @@ class AgentPresetService(BaseWorkspaceService):
             .where(AgentPreset.workspace_id == self.workspace_id)
             .where(AgentPreset.deleted_at.is_(None))
             .order_by(AgentPreset.created_at.desc())
-            .options(selectinload(AgentPreset.tags))
+            .options(
+                selectinload(AgentPreset.tags),
+                selectinload(AgentPreset.current_version),
+                selectinload(AgentPreset.subagent_bindings),
+            )
         )
         result = await self.session.execute(stmt)
         return result.scalars().all()
 
-    async def _list_skill_bindings(
-        self,
-        *,
-        binding_model: type[AgentPresetSkill] | type[AgentPresetVersionSkill],
-        owner_column: Any,
-        owner_id: uuid.UUID,
+    async def _list_head_skill_bindings(
+        self, preset_id: uuid.UUID
     ) -> list[AgentPresetSkillBindingRead]:
-        """Return resolved skill bindings for a preset head or immutable version."""
+        """Resolve mutable head bindings through each Skill's current version."""
 
         stmt = (
             select(
-                binding_model.skill_id,
+                AgentPresetSkill.skill_id,
                 SkillVersion.name,
-                binding_model.skill_version_id,
+                Skill.current_version_id,
                 SkillVersion.version,
             )
-            .join(SkillVersion, binding_model.skill_version_id == SkillVersion.id)
+            .join(Skill, AgentPresetSkill.skill_id == Skill.id)
+            .join(SkillVersion, Skill.current_version_id == SkillVersion.id)
             .where(
-                binding_model.workspace_id == self.workspace_id,
-                owner_column == owner_id,
+                AgentPresetSkill.workspace_id == self.workspace_id,
+                AgentPresetSkill.preset_id == preset_id,
+                Skill.deleted_at.is_(None),
+                Skill.archived_at.is_(None),
             )
-            .order_by(SkillVersion.name.asc(), binding_model.skill_id.asc())
+            .order_by(SkillVersion.name.asc(), AgentPresetSkill.skill_id.asc())
         )
         rows = (await self.session.execute(stmt)).tuples().all()
         return [
@@ -177,35 +178,14 @@ class AgentPresetService(BaseWorkspaceService):
                 skill_version=skill_version,
             )
             for skill_id, skill_name, skill_version_id, skill_version in rows
-            if skill_name is not None
+            if skill_name is not None and skill_version_id is not None
         ]
-
-    async def _list_head_skill_bindings(
-        self, preset_id: uuid.UUID
-    ) -> list[AgentPresetSkillBindingRead]:
-        """Return mutable skill bindings for a preset head."""
-
-        return await self._list_skill_bindings(
-            binding_model=AgentPresetSkill,
-            owner_column=AgentPresetSkill.preset_id,
-            owner_id=preset_id,
-        )
-
-    async def _list_version_skill_bindings(
-        self, version_id: uuid.UUID
-    ) -> list[AgentPresetSkillBindingRead]:
-        """Return exact skill version refs for an immutable preset version."""
-
-        return await self._list_skill_bindings(
-            binding_model=AgentPresetVersionSkill,
-            owner_column=AgentPresetVersionSkill.preset_version_id,
-            owner_id=version_id,
-        )
 
     async def build_preset_read(self, preset: AgentPreset) -> AgentPresetRead:
         """Build the response model for a preset."""
 
-        agents = AgentSubagentsConfig.model_validate(preset.agents)
+        version = await self.get_current_version_for_preset(preset)
+        agents = await self.get_head_subagents_config(preset.id)
         return AgentPresetRead(
             id=preset.id,
             workspace_id=preset.workspace_id,
@@ -214,20 +194,20 @@ class AgentPresetService(BaseWorkspaceService):
             description=preset.description,
             current_version_id=preset.current_version_id,
             folder_id=preset.folder_id,
-            instructions=preset.instructions,
-            model_name=preset.model_name,
-            model_provider=preset.model_provider,
-            catalog_id=preset.catalog_id,
-            base_url=preset.base_url,
-            output_type=cast(OutputType | None, preset.output_type),
-            actions=preset.actions,
-            namespaces=preset.namespaces,
-            tool_approvals=preset.tool_approvals,
-            mcp_integrations=preset.mcp_integrations,
+            instructions=version.instructions,
+            model_name=version.model_name,
+            model_provider=version.model_provider,
+            catalog_id=version.catalog_id,
+            base_url=version.base_url,
+            output_type=cast(OutputType | None, version.output_type),
+            actions=version.actions,
+            namespaces=version.namespaces,
+            tool_approvals=version.tool_approvals,
+            mcp_integrations=version.mcp_integrations,
             agents=agents,
-            retries=preset.retries,
-            enable_thinking=preset.enable_thinking,
-            enable_internet_access=preset.enable_internet_access,
+            retries=version.retries,
+            enable_thinking=version.enable_thinking,
+            enable_internet_access=version.enable_internet_access,
             created_at=preset.created_at,
             updated_at=preset.updated_at,
             skills=await self._list_head_skill_bindings(preset.id),
@@ -236,9 +216,8 @@ class AgentPresetService(BaseWorkspaceService):
     async def build_version_read(
         self, version: AgentPresetVersion
     ) -> AgentPresetVersionRead:
-        """Build the response model for an immutable preset version."""
+        """Build a config-only immutable version response."""
 
-        agents = AgentSubagentsConfig.model_validate(version.agents)
         return AgentPresetVersionRead(
             id=version.id,
             preset_id=version.preset_id,
@@ -254,22 +233,16 @@ class AgentPresetService(BaseWorkspaceService):
             namespaces=version.namespaces,
             tool_approvals=version.tool_approvals,
             mcp_integrations=version.mcp_integrations,
-            agents=agents,
             retries=version.retries,
             enable_thinking=version.enable_thinking,
             enable_internet_access=version.enable_internet_access,
             capabilities=_agent_preset_capabilities(
-                agents_config=agents,
+                has_subagents=False,
                 tool_approvals=version.tool_approvals,
                 enable_internet_access=version.enable_internet_access,
             ),
-            subagent_eligibility=build_subagent_eligibility(
-                agents_config=agents,
-                tool_approvals=version.tool_approvals,
-            ),
             created_at=version.created_at,
             updated_at=version.updated_at,
-            skills=await self._list_version_skill_bindings(version.id),
         )
 
     @require_scope("agent:create")
@@ -318,7 +291,7 @@ class AgentPresetService(BaseWorkspaceService):
             namespaces=params.namespaces,
             tool_approvals=params.tool_approvals,
             mcp_integrations=params.mcp_integrations,
-            agents=AgentSubagentsConfig().model_dump(mode="json"),
+            agents={"enabled": True, "subagents": []},
             enable_thinking=params.enable_thinking,
             enable_internet_access=(
                 params.enable_internet_access or requires_internet_access
@@ -327,11 +300,12 @@ class AgentPresetService(BaseWorkspaceService):
         )
         self.session.add(preset)
         await self.session.flush()
-        preset.agents = await self._resolve_preset_subagent_configs(
+        agents = await self._resolve_preset_subagent_configs(
             params.agents,
             parent_preset_id=preset.id,
             parent_slug=slug,
         )
+        await self._replace_head_subagent_bindings(preset, agents)
         if params.skills is not None:
             binding_specs = await self._binding_specs_from_inputs(
                 params.skills,
@@ -396,6 +370,7 @@ class AgentPresetService(BaseWorkspaceService):
     ) -> AgentPreset:
         """Update an existing preset."""
         await self._lock_preset_row(preset.id)
+        current_version = await self.get_current_version_for_preset(preset)
         set_fields = params.model_dump(exclude_unset=True, exclude={"skills"})
         execution_changed = False
         requested_skills = None
@@ -418,29 +393,22 @@ class AgentPresetService(BaseWorkspaceService):
         # Validate actions if provided
         if "actions" in set_fields:
             # Select in RegistryAction actions that are in the list of actions
-            if actions := set_fields.pop("actions"):
+            if actions := set_fields["actions"]:
                 await self._validate_actions(actions)
-            # If we reach this point, all actions are valid or was empty
-            if preset.actions != actions:
-                preset.actions = actions
-                execution_changed = True
 
         if "mcp_integrations" in set_fields:
-            mcp_integrations = set_fields.pop("mcp_integrations")
+            mcp_integrations = set_fields["mcp_integrations"]
             requires_internet_access = await self._has_stdio_mcp_integration(
                 mcp_integrations
             )
-            if preset.mcp_integrations != mcp_integrations:
-                preset.mcp_integrations = mcp_integrations
-                execution_changed = True
         else:
             requires_internet_access = False
             if (
                 set_fields.get("enable_internet_access") is False
-                or not preset.enable_internet_access
+                or not current_version.enable_internet_access
             ):
                 requires_internet_access = await self._has_stdio_mcp_integration(
-                    preset.mcp_integrations,
+                    current_version.mcp_integrations,
                     raise_on_missing=False,
                 )
 
@@ -453,9 +421,7 @@ class AgentPresetService(BaseWorkspaceService):
                 parent_preset_id=preset.id,
                 parent_slug=preset.slug,
             )
-            if preset.agents != agents:
-                preset.agents = agents
-                execution_changed = True
+            await self._replace_head_subagent_bindings(preset, agents)
 
         if requested_skills is not None:
             await self.skills.validate_binding_inputs(
@@ -473,12 +439,11 @@ class AgentPresetService(BaseWorkspaceService):
                     requested_skills,
                     binding_specs=requested_specs,
                 )
-                execution_changed = True
         effective_catalog_id = None
         if "catalog_id" in set_fields:
             effective_catalog_id = set_fields["catalog_id"]
         elif "model_name" in set_fields or "model_provider" in set_fields:
-            effective_catalog_id = preset.catalog_id
+            effective_catalog_id = current_version.catalog_id
         if effective_catalog_id is not None:
             catalog_entry = await self._get_enabled_catalog_entry(effective_catalog_id)
             set_fields["model_name"] = catalog_entry.model_name
@@ -486,9 +451,12 @@ class AgentPresetService(BaseWorkspaceService):
 
         # Update remaining fields
         for field, value in set_fields.items():
-            if getattr(preset, field) != value:
-                if field in self.EXECUTION_FIELDS:
+            if field in self.EXECUTION_FIELDS:
+                if getattr(current_version, field) != value:
                     execution_changed = True
+                # Retain the old head columns as a minimal rollback shadow.
+                setattr(preset, field, value)
+            elif getattr(preset, field) != value:
                 setattr(preset, field, value)
 
         self.session.add(preset)
@@ -507,76 +475,40 @@ class AgentPresetService(BaseWorkspaceService):
     @audit_log(resource_type="agent_preset", action="delete")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def delete_preset(self, preset: AgentPreset) -> None:
-        """Soft-delete a preset without deleting its published versions."""
+        """Soft-delete a preset and unlink its mutable head topology."""
         await self._lock_preset_row(preset.id)
-        await self._ensure_not_referenced_as_subagent(preset)
+        parent_stmt = select(AgentPresetSubagent.parent_preset_id).where(
+            AgentPresetSubagent.workspace_id == self.workspace_id,
+            AgentPresetSubagent.child_preset_id == preset.id,
+        )
+        affected_parent_ids = set(
+            (await self.session.execute(parent_stmt)).scalars().all()
+        )
+        await self.session.execute(
+            sa.delete(AgentPresetSubagent).where(
+                AgentPresetSubagent.workspace_id == self.workspace_id,
+                sa.or_(
+                    AgentPresetSubagent.parent_preset_id == preset.id,
+                    AgentPresetSubagent.child_preset_id == preset.id,
+                ),
+            )
+        )
+        await self.session.execute(
+            sa.delete(AgentPresetSkill).where(
+                AgentPresetSkill.workspace_id == self.workspace_id,
+                AgentPresetSkill.preset_id == preset.id,
+            )
+        )
         channel_service = AgentChannelService(self.session, role=self.role)
         await channel_service.deactivate_tokens_for_preset(preset.id)
         preset.deleted_at = datetime.now(UTC)
         self.session.add(preset)
+        for parent_id in affected_parent_ids:
+            parent = await self.get_preset(parent_id)
+            if parent is not None:
+                agents = await self.get_head_subagents_config(parent.id)
+                await self._write_legacy_subagent_shadow(parent, agents)
         await self.session.commit()
-
-    async def _ensure_not_referenced_as_subagent(self, preset: AgentPreset) -> None:
-        """Block deletion while other preset heads still reference this preset."""
-        reference_count = await self._count_head_subagent_references(preset)
-        if reference_count > 0:
-            raise TracecatValidationError(
-                "Cannot delete an agent preset that is still referenced as a subagent",
-                detail={
-                    "code": "preset_in_use_as_subagent",
-                    "head_reference_count": reference_count,
-                },
-            )
-
-    async def _count_head_subagent_references(self, preset: AgentPreset) -> int:
-        subagent_ref_exists = self._subagent_reference_exists(
-            AgentPreset.agents,
-            preset_id=preset.id,
-            slug=preset.slug,
-        )
-        stmt = (
-            select(func.count())
-            .select_from(AgentPreset)
-            .where(
-                AgentPreset.workspace_id == self.workspace_id,
-                AgentPreset.id != preset.id,
-                AgentPreset.deleted_at.is_(None),
-                subagent_ref_exists,
-            )
-        )
-        return (await self.session.execute(stmt)).scalar_one()
-
-    @staticmethod
-    def _subagent_reference_exists(
-        agents: sa.SQLColumnExpression[dict[str, Any]],
-        *,
-        preset_id: uuid.UUID,
-        slug: str,
-    ) -> sa.ColumnElement[bool]:
-        subagents_value = agents["subagents"]
-        subagents_array = sa.case(
-            (func.jsonb_typeof(subagents_value) == "array", subagents_value),
-            else_=literal([], type_=JSONB),
-        )
-        subagents = (
-            func.jsonb_array_elements(subagents_array)
-            .table_valued(column("value", JSONB))
-            .alias("subagent")
-        )
-        return (
-            select(literal(True))
-            .select_from(subagents)
-            .where(
-                sa.or_(
-                    subagents.c.value["preset_id"].astext == str(preset_id),
-                    sa.and_(
-                        subagents.c.value["preset_id"].astext.is_(None),
-                        subagents.c.value["preset"].astext == slug,
-                    ),
-                )
-            )
-            .exists()
-        )
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def resolve_agent_preset_config(
@@ -728,7 +660,7 @@ class AgentPresetService(BaseWorkspaceService):
         ]
         if persisted_refs:
             await self._lock_active_subagent_presets(
-                ResolvedAgentsConfig(enabled=True, subagents=persisted_refs)
+                ResolvedAgentsConfig(subagents=persisted_refs)
             )
         resolved = await resolve_agents_config(
             self,
@@ -739,6 +671,89 @@ class AgentPresetService(BaseWorkspaceService):
         binding = resolved.to_agents_binding()
         await self._lock_active_subagent_presets(binding)
         return binding.model_dump(mode="json")
+
+    async def get_head_subagents_config(
+        self, preset_id: uuid.UUID
+    ) -> AgentSubagentsConfig:
+        """Return canonical subagent topology owned by a preset head."""
+
+        preset = await self.get_preset(preset_id)
+        if preset is None:
+            raise TracecatNotFoundError(f"Agent preset '{preset_id}' not found")
+
+        child = aliased(AgentPreset)
+        stmt = (
+            select(
+                AgentPresetSubagent.child_preset_id,
+                child.slug,
+                AgentPresetSubagent.alias,
+                AgentPresetSubagent.description,
+                AgentPresetSubagent.max_turns,
+            )
+            .join(child, AgentPresetSubagent.child_preset_id == child.id)
+            .where(
+                AgentPresetSubagent.workspace_id == self.workspace_id,
+                AgentPresetSubagent.parent_preset_id == preset_id,
+                child.workspace_id == self.workspace_id,
+                child.deleted_at.is_(None),
+            )
+            .order_by(AgentPresetSubagent.alias.asc())
+        )
+        rows = (await self.session.execute(stmt)).tuples().all()
+        return AgentSubagentsConfig(
+            subagents=[
+                HeadAttachedSubagentRef(
+                    preset=slug,
+                    preset_id=child_preset_id,
+                    name=alias,
+                    description=description,
+                    max_turns=max_turns,
+                )
+                for child_preset_id, slug, alias, description, max_turns in rows
+            ],
+        )
+
+    async def _replace_head_subagent_bindings(
+        self,
+        preset: AgentPreset,
+        agents: dict[str, Any],
+    ) -> None:
+        """Replace canonical head edges and refresh rollback shadows."""
+
+        binding = ResolvedAgentsConfig.model_validate(agents)
+        await self.session.execute(
+            sa.delete(AgentPresetSubagent).where(
+                AgentPresetSubagent.workspace_id == self.workspace_id,
+                AgentPresetSubagent.parent_preset_id == preset.id,
+            )
+        )
+        for subagent in binding.subagents:
+            self.session.add(
+                AgentPresetSubagent(
+                    workspace_id=self.workspace_id,
+                    parent_preset_id=preset.id,
+                    child_preset_id=subagent.preset_id,
+                    alias=subagent.alias,
+                    description=subagent.description,
+                    max_turns=subagent.max_turns,
+                )
+            )
+        await self.session.flush()
+        await self._write_legacy_subagent_shadow(preset, binding)
+
+    async def _write_legacy_subagent_shadow(
+        self,
+        preset: AgentPreset,
+        agents: AgentSubagentsConfig | ResolvedAgentsConfig,
+    ) -> None:
+        """Dual-write the mutable head JSON retained solely for rollback."""
+
+        preset.agents = {
+            "enabled": True,
+            "subagents": [
+                subagent.model_dump(mode="json") for subagent in agents.subagents
+            ],
+        }
 
     async def _lock_active_subagent_presets(self, agents: ResolvedAgentsConfig) -> None:
         """Lock active child presets before saving head subagent bindings."""
@@ -1342,7 +1357,6 @@ class AgentPresetService(BaseWorkspaceService):
             AgentPresetVersion.preset_id,
             AgentPresetVersion.workspace_id,
             AgentPresetVersion.version,
-            AgentPresetVersion.agents,
             AgentPresetVersion.tool_approvals,
             AgentPresetVersion.enable_internet_access,
             AgentPresetVersion.created_at,
@@ -1400,13 +1414,9 @@ class AgentPresetService(BaseWorkspaceService):
                 workspace_id=workspace_id,
                 version=version_number,
                 capabilities=_agent_preset_capabilities(
-                    agents_config=agents,
+                    has_subagents=False,
                     tool_approvals=tool_approvals,
                     enable_internet_access=enable_internet_access,
-                ),
-                subagent_eligibility=build_subagent_eligibility(
-                    agents_config=agents,
-                    tool_approvals=tool_approvals,
                 ),
                 created_at=created_at,
                 updated_at=updated_at,
@@ -1416,7 +1426,6 @@ class AgentPresetService(BaseWorkspaceService):
                 row_preset_id,
                 workspace_id,
                 version_number,
-                agents,
                 tool_approvals,
                 enable_internet_access,
                 created_at,
@@ -1517,19 +1526,27 @@ class AgentPresetService(BaseWorkspaceService):
     async def _get_head_skill_binding_specs(
         self, preset_id: uuid.UUID
     ) -> list[SkillBindingSpec]:
-        """Return the current head bindings for a preset."""
+        """Resolve canonical Skill head edges to current versions."""
 
-        stmt = select(
-            AgentPresetSkill.skill_id,
-            AgentPresetSkill.skill_version_id,
-        ).where(
-            AgentPresetSkill.workspace_id == self.workspace_id,
-            AgentPresetSkill.preset_id == preset_id,
+        stmt = (
+            select(
+                AgentPresetSkill.skill_id,
+                Skill.current_version_id,
+            )
+            .join(Skill, AgentPresetSkill.skill_id == Skill.id)
+            .where(
+                AgentPresetSkill.workspace_id == self.workspace_id,
+                AgentPresetSkill.preset_id == preset_id,
+                Skill.deleted_at.is_(None),
+                Skill.archived_at.is_(None),
+                Skill.current_version_id.is_not(None),
+            )
         )
         rows = (await self.session.execute(stmt)).tuples().all()
         return sorted(
             SkillBindingSpec(skill_id, skill_version_id)
             for skill_id, skill_version_id in rows
+            if skill_version_id is not None
         )
 
     async def _current_skill_binding_specs(
@@ -1700,93 +1717,6 @@ class AgentPresetService(BaseWorkspaceService):
             )
         await self.session.flush()
 
-    async def _restore_head_skill_bindings_from_version(
-        self, *, preset_id: uuid.UUID, version_id: uuid.UUID
-    ) -> None:
-        """Copy exact historical skill versions back to the mutable preset head."""
-
-        stmt = select(
-            AgentPresetVersionSkill.skill_id,
-            AgentPresetVersionSkill.skill_version_id,
-        ).where(
-            AgentPresetVersionSkill.workspace_id == self.workspace_id,
-            AgentPresetVersionSkill.preset_version_id == version_id,
-        )
-        rows = (await self.session.execute(stmt)).tuples().all()
-        await self.skills.validate_binding_inputs(
-            [
-                AgentPresetSkillBindingBase(skill_id=skill_id)
-                for skill_id, _skill_version_id in rows
-            ],
-            for_update=True,
-        )
-        await self.session.execute(
-            sa.delete(AgentPresetSkill).where(
-                AgentPresetSkill.workspace_id == self.workspace_id,
-                AgentPresetSkill.preset_id == preset_id,
-            )
-        )
-        for skill_id, skill_version_id in rows:
-            self.session.add(
-                AgentPresetSkill(
-                    workspace_id=self.workspace_id,
-                    preset_id=preset_id,
-                    skill_id=skill_id,
-                    skill_version_id=skill_version_id,
-                )
-            )
-        await self.session.flush()
-
-    async def _compare_version_skill_bindings(
-        self, base_version_id: uuid.UUID, compare_version_id: uuid.UUID
-    ) -> list[AgentPresetSkillBindingChange]:
-        """Return a diff of exact skill version refs between preset versions."""
-
-        base_bindings = {
-            binding.skill_id: binding
-            for binding in await self._list_version_skill_bindings(base_version_id)
-        }
-        compare_bindings = {
-            binding.skill_id: binding
-            for binding in await self._list_version_skill_bindings(compare_version_id)
-        }
-        skill_changes: list[AgentPresetSkillBindingChange] = []
-        for skill_id in sorted(set(base_bindings) | set(compare_bindings)):
-            base_binding = base_bindings.get(skill_id)
-            compare_binding = compare_bindings.get(skill_id)
-            if (
-                base_binding is not None
-                and compare_binding is not None
-                and base_binding.skill_version_id == compare_binding.skill_version_id
-            ):
-                continue
-            skill_name = (
-                base_binding.skill_name
-                if base_binding is not None
-                else compare_binding.skill_name
-                if compare_binding is not None
-                else str(skill_id)
-            )
-            skill_changes.append(
-                AgentPresetSkillBindingChange(
-                    skill_id=skill_id,
-                    skill_name=skill_name,
-                    old_skill_version_id=(
-                        base_binding.skill_version_id if base_binding else None
-                    ),
-                    old_skill_version=base_binding.skill_version
-                    if base_binding
-                    else None,
-                    new_skill_version_id=(
-                        compare_binding.skill_version_id if compare_binding else None
-                    ),
-                    new_skill_version=(
-                        compare_binding.skill_version if compare_binding else None
-                    ),
-                )
-            )
-        return skill_changes
-
     async def _lock_preset_row(self, preset_id: uuid.UUID) -> None:
         """Serialize preset mutations using a row-level lock."""
         stmt = (
@@ -1837,41 +1767,23 @@ class AgentPresetService(BaseWorkspaceService):
     async def restore_version(
         self, preset: AgentPreset, version: AgentPresetVersion
     ) -> AgentPreset:
-        """Restore a historical version as the current preset head."""
+        """Roll historical config forward without changing head topology."""
         if version.preset_id != preset.id:
             raise TracecatValidationError(
                 "Preset version does not belong to the selected preset"
             )
 
         await self._lock_preset_row(preset.id)
-        restored_agents = await self._resolve_restored_agents_config(preset, version)
-        self._sync_preset_head_from_version(
+        self._sync_preset_head_from_version(preset, version)
+        restored_version = await self._create_version_from_preset(
             preset,
-            version,
-            agents=restored_agents,
+            preset_locked=True,
         )
-        await self._restore_head_skill_bindings_from_version(
-            preset_id=preset.id,
-            version_id=version.id,
-        )
-        preset.current_version_id = version.id
+        preset.current_version_id = restored_version.id
         self.session.add(preset)
         await self.session.commit()
         await self.session.refresh(preset)
         return preset
-
-    async def _resolve_restored_agents_config(
-        self,
-        preset: AgentPreset,
-        version: AgentPresetVersion,
-    ) -> dict[str, Any]:
-        """Resolve historical agents config before making it active again."""
-        agents = await self._resolve_preset_subagent_configs(
-            version.agents,
-            parent_preset_id=preset.id,
-            parent_slug=preset.slug,
-        )
-        return agents
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def compare_versions(
@@ -1893,7 +1805,6 @@ class AgentPresetService(BaseWorkspaceService):
             "retries",
             "enable_thinking",
             "enable_internet_access",
-            "agents",
         ):
             old_value = getattr(base_version, field)
             new_value = getattr(compare_version, field)
@@ -1936,17 +1847,12 @@ class AgentPresetService(BaseWorkspaceService):
                     )
                 )
 
-        skill_changes = await self._compare_version_skill_bindings(
-            base_version.id,
-            compare_version.id,
-        )
         instructions_changed = base_version.instructions != compare_version.instructions
         total_changes = (
             int(instructions_changed)
             + len(scalar_changes)
             + len(list_changes)
             + len(tool_approval_changes)
-            + len(skill_changes)
         )
 
         return AgentPresetVersionDiff(
@@ -1960,23 +1866,20 @@ class AgentPresetService(BaseWorkspaceService):
             scalar_changes=scalar_changes,
             list_changes=list_changes,
             tool_approval_changes=tool_approval_changes,
-            skill_changes=skill_changes,
             total_changes=total_changes,
         )
 
     async def _version_to_agent_config(
         self, version: AgentPresetVersion
     ) -> AgentConfig:
-        use_latest_resource_versions = await self.use_latest_resource_versions()
         # Resolve refs only — no headers / stdio env. The resulting
         # AgentConfig is safe to cross Temporal boundaries. Trusted callers
         # (build_tool_definitions, trusted MCP server) re-resolve secrets
         # per use via resolve_mcp_integration_secrets.
         mcp_servers = await self.resolve_mcp_integration_refs(version.mcp_integrations)
         model_settings: dict[str, Any] = {}
-        resolved_skills = await self.skills.get_resolved_skill_refs_for_preset_version(
-            version.id,
-            use_latest_versions=use_latest_resource_versions,
+        resolved_skills = await self.skills.get_resolved_skill_refs_for_preset_head(
+            version.preset_id,
         )
         duplicate_skill_names = sorted(
             name
@@ -1997,20 +1900,7 @@ class AgentPresetService(BaseWorkspaceService):
         # Only disable parallel tool calls if tools will be present
         if version.actions or mcp_servers:
             model_settings["parallel_tool_calls"] = False
-        agents = AgentSubagentsConfig.model_validate(version.agents)
-        if use_latest_resource_versions:
-            resolved_agents = await resolve_agents_config(
-                self,
-                agents=agents,
-                parent_preset_id=version.preset_id,
-                include_runtime_config=False,
-                follow_latest_versions=True,
-            )
-            binding = resolved_agents.to_agents_binding()
-            agents = AgentSubagentsConfig(
-                enabled=binding.enabled,
-                subagents=list(binding.subagents),
-            )
+        agents = await self.get_head_subagents_config(version.preset_id)
         return AgentConfig(
             model_name=version.model_name,
             model_provider=version.model_provider,
@@ -2089,10 +1979,8 @@ class AgentPresetService(BaseWorkspaceService):
         self,
         preset: AgentPreset,
         version: AgentPresetVersion,
-        *,
-        agents: dict[str, Any],
     ) -> None:
-        """Copy versioned execution fields onto the mutable preset head."""
+        """Copy version-owned config onto the head; leave topology untouched."""
         preset.instructions = version.instructions
         preset.model_name = version.model_name
         preset.model_provider = version.model_provider
@@ -2103,7 +1991,6 @@ class AgentPresetService(BaseWorkspaceService):
         preset.namespaces = version.namespaces
         preset.tool_approvals = version.tool_approvals
         preset.mcp_integrations = version.mcp_integrations
-        preset.agents = agents
         preset.retries = version.retries
         preset.enable_thinking = version.enable_thinking
         preset.enable_internet_access = version.enable_internet_access

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -207,8 +207,6 @@ DISALLOWED_TOOLS = [
     "AskUserQuestion",
     "TodoRead",
     "TodoWrite",
-    "Agent",
-    "Task",
     "TaskOutput",
     "SlashCommand",
 ]
@@ -302,7 +300,6 @@ class ClaudeAgentRuntime:
         self._runtime_internet_access_enabled: bool = False
         self._explicit_subagent_aliases: set[str] = set()
         self._registry_mcp_server_names: set[str] = {REGISTRY_MCP_SERVER_NAME}
-        self._agents_enabled: bool = False
         self._pending_approval_tool_ids: set[str] = set()
         self.client: ClaudeSDKClient | None = None
         self._was_interrupted: bool = False
@@ -627,8 +624,6 @@ class ClaudeAgentRuntime:
         """Return denial reason for invalid Agent/Task tool use, else None."""
         if tool_name not in AGENT_TOOL_NAMES:
             return None
-        if not self._agents_enabled:
-            return "Subagents are disabled for this agent configuration."
         if self._is_subagent_scope(input_data):
             return "Subagents cannot invoke other subagents."
 
@@ -1309,7 +1304,7 @@ class ClaudeAgentRuntime:
         if instructions:
             prompt_parts.append(instructions)
         prompt_parts.extend(self._system_prompt_fragments)
-        if self._agents_enabled:
+        if self._explicit_subagent_aliases:
             prompt_parts.append(
                 "prefer the most specific attached alias; use `general-purpose` only "
                 "when none matches."
@@ -1395,7 +1390,6 @@ class ClaudeAgentRuntime:
         self.registry_tools = payload.allowed_actions
         self.tool_approvals = payload.config.tool_approvals
         self._stdio_approval_blocked_tools = set()
-        self._agents_enabled = payload.config.agents.enabled
         self._explicit_subagent_aliases = {
             subagent.alias for subagent in payload.subagents
         }
@@ -1422,11 +1416,7 @@ class ClaudeAgentRuntime:
 
     def _root_disallowed_tools(self) -> list[str]:
         """Return root Claude tools blocked for this turn."""
-        disallowed_tools = [
-            tool
-            for tool in DISALLOWED_TOOLS
-            if not (self._agents_enabled and tool in AGENT_TOOL_NAMES)
-        ]
+        disallowed_tools = list(DISALLOWED_TOOLS)
         # Internet access is a runtime-wide sandbox/network capability for the
         # turn, so the root setting also governs explicit subagents.
         if not self._runtime_internet_access_enabled:
@@ -1447,8 +1437,7 @@ class ClaudeAgentRuntime:
             stdio_server_names=stdio_server_names,
             stdio_tools_by_server=stdio_tools_by_server,
         )
-        if self._agents_enabled:
-            allowed_tools.extend(sorted(AGENT_TOOL_NAMES))
+        allowed_tools.extend(sorted(AGENT_TOOL_NAMES))
         return allowed_tools
 
     @staticmethod

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -163,47 +163,17 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                     agents_binding=input.agents_binding,
                 )
 
-            # Reconcile agents_binding for pre-existing sessions. Chat-created
-            # sessions may be inserted before the durable workflow resolves the
-            # current preset's subagent bindings, so a fresh session can have a
-            # NULL binding even though this run already has a concrete binding.
-            # Backfill that first-run case. Once an SDK session exists, or the
-            # row forks from a parent SDK history, the binding is part of the
-            # resumable runtime topology and explicit mismatches must continue
-            # to fail.
+            # Keep the session row as a shadow of the binding compiled for this
+            # turn. The runtime payload in Temporal history freezes the executing
+            # turn, while a later turn is expected to resolve current head
+            # topology again and replace this diagnostic shadow.
             if not created:
-                disabled_agents_binding = ResolvedAgentsConfig()
                 requested_agents_binding = (
-                    input.agents_binding or disabled_agents_binding
+                    input.agents_binding or ResolvedAgentsConfig()
                 )
-                if agent_session.agents_binding is None:
-                    has_resume_state = (
-                        agent_session.sdk_session_id is not None
-                        or agent_session.parent_session_id is not None
-                    )
-                    should_backfill_agents_binding = input.agents_binding is not None
-                    stored_agents_binding = (
-                        requested_agents_binding
-                        if should_backfill_agents_binding and not has_resume_state
-                        else disabled_agents_binding
-                    )
-                else:
-                    stored_agents_binding = ResolvedAgentsConfig.model_validate(
-                        agent_session.agents_binding
-                    )
-                    should_backfill_agents_binding = False
-
-                if stored_agents_binding != requested_agents_binding:
-                    # Non-retryable: retrying with the same mismatched input
-                    # will deterministically fail; surface to the caller.
-                    raise ApplicationError(
-                        "Agent session was created with a different agents binding",
-                        non_retryable=True,
-                    )
-                if should_backfill_agents_binding:
-                    agent_session.agents_binding = stored_agents_binding.model_dump(
-                        mode="json"
-                    )
+                requested_agents_json = requested_agents_binding.model_dump(mode="json")
+                if agent_session.agents_binding != requested_agents_json:
+                    agent_session.agents_binding = requested_agents_json
                     service.session.add(agent_session)
                     await service.session.commit()
 

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -66,6 +66,7 @@ from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.llm import LLMCompletionError
 from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.preset.prompts import AgentPresetBuilderPrompt
+from tracecat.agent.preset.resolver import resolve_agents_config
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.runtime.claude_code.session_lines import (
     APPROVAL_INTERRUPT_CONTENT_EXACT,
@@ -645,7 +646,7 @@ class AgentSessionService(BaseWorkspaceService):
     async def _resolve_agents_binding_for_preset_version_id(
         self, preset_version_id: uuid.UUID | None
     ) -> dict[str, Any] | None:
-        """Resolve the normalized subagent binding for a pinned preset version."""
+        """Resolve the preset head's current topology for a session shadow."""
         if preset_version_id is None:
             return None
 
@@ -653,9 +654,14 @@ class AgentSessionService(BaseWorkspaceService):
         version = await preset_service.resolve_agent_preset_version(
             preset_version_id=preset_version_id
         )
-        return ResolvedAgentsConfig.model_validate(version.agents).model_dump(
-            mode="json"
+        head_agents = await preset_service.get_head_subagents_config(version.preset_id)
+        resolved = await resolve_agents_config(
+            preset_service,
+            agents=head_agents,
+            parent_preset_id=version.preset_id,
+            follow_latest_versions=True,
         )
+        return resolved.to_agents_binding().model_dump(mode="json")
 
     async def get_session(
         self,

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -19,7 +19,7 @@ import yaml
 from asyncpg import UniqueViolationError as AsyncpgUniqueViolationError
 from psycopg.errors import UniqueViolation as PsycopgUniqueViolation
 from pydantic import TypeAdapter, ValidationError
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
@@ -57,9 +57,7 @@ from tracecat.agent.skill.schemas import (
 from tracecat.agent.skill.types import ResolvedSkillRef
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
-    AgentPreset,
     AgentPresetSkill,
-    AgentPresetVersionSkill,
     Skill,
     SkillBlob,
     SkillDraftFile,
@@ -1560,6 +1558,16 @@ class SkillService(BaseWorkspaceService):
         skill.name = manifest_name
         skill.description = validation.description
         self.session.add(skill)
+        # The canonical edge targets the Skill head by ``skill_id``. Keep the
+        # retained version column current as a rollback-only dual-write shadow.
+        await self.session.execute(
+            sa.update(AgentPresetSkill)
+            .where(
+                AgentPresetSkill.workspace_id == self.workspace_id,
+                AgentPresetSkill.skill_id == skill.id,
+            )
+            .values(skill_version_id=version.id)
+        )
         await self.session.commit()
         return await self.get_version_read(skill_id=skill.id, version_id=version.id)
 
@@ -3142,33 +3150,17 @@ class SkillService(BaseWorkspaceService):
     @require_scope("agent:delete")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def archive_skill(self, skill_id: uuid.UUID) -> None:
-        """Archive a skill unless any preset head still references it."""
+        """Soft-delete a skill and unlink incoming preset-head edges."""
 
         skill = await self._get_skill_for_update(skill_id)
         if skill is None:
             raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
-        binding_stmt = (
-            select(func.count())
-            .select_from(AgentPresetSkill)
-            .join(
-                AgentPreset,
-                AgentPreset.id == AgentPresetSkill.preset_id,
-            )
-            .where(
+        await self.session.execute(
+            sa.delete(AgentPresetSkill).where(
                 AgentPresetSkill.workspace_id == self.workspace_id,
                 AgentPresetSkill.skill_id == skill.id,
-                AgentPreset.workspace_id == self.workspace_id,
-                AgentPreset.deleted_at.is_(None),
             )
         )
-        binding_count = int(
-            (await self.session.execute(binding_stmt)).scalar_one() or 0
-        )
-        if binding_count > 0:
-            raise TracecatValidationError(
-                "Cannot delete a skill that is still referenced by a preset",
-                detail={"code": "skill_in_use"},
-            )
         archived_at = datetime.now(UTC)
         skill.archived_at = archived_at
         skill.deleted_at = archived_at
@@ -3213,168 +3205,40 @@ class SkillService(BaseWorkspaceService):
                 )
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
-    async def get_resolved_skill_refs_for_preset_version(
-        self,
-        preset_version_id: uuid.UUID,
-        *,
-        use_latest_versions: bool = False,
+    async def get_resolved_skill_refs_for_preset_head(
+        self, preset_id: uuid.UUID
     ) -> list[ResolvedSkillRef]:
-        """Return skill refs for an immutable preset version."""
-
-        if use_latest_versions:
-            return await self._get_latest_skill_refs_for_preset_version(
-                preset_version_id
-            )
+        """Resolve canonical preset-head edges to current Skill versions."""
 
         stmt = (
             select(
-                AgentPresetVersionSkill.skill_id,
+                AgentPresetSkill.skill_id,
                 SkillVersion.name,
-                AgentPresetVersionSkill.skill_version_id,
-                SkillVersion.manifest_sha256,
-                Skill.deleted_at,
-                Skill.archived_at,
-            )
-            .join(
-                SkillVersion,
-                AgentPresetVersionSkill.skill_version_id == SkillVersion.id,
-            )
-            .join(
-                Skill,
-                sa.and_(
-                    AgentPresetVersionSkill.workspace_id == Skill.workspace_id,
-                    AgentPresetVersionSkill.skill_id == Skill.id,
-                ),
-            )
-            .where(
-                AgentPresetVersionSkill.workspace_id == self.workspace_id,
-                AgentPresetVersionSkill.preset_version_id == preset_version_id,
-            )
-            .order_by(SkillVersion.name.asc(), AgentPresetVersionSkill.skill_id.asc())
-        )
-        rows = (await self.session.execute(with_deleted(stmt))).tuples().all()
-        resolved: list[ResolvedSkillRef] = []
-        archived_skills: list[str] = []
-        for (
-            skill_id,
-            skill_name,
-            skill_version_id,
-            manifest_sha256,
-            deleted_at,
-            archived_at,
-        ) in rows:
-            if skill_name is None:
-                continue
-            if deleted_at is not None or archived_at is not None:
-                archived_skills.append(f"{skill_name} ({skill_id})")
-                continue
-            resolved.append(
-                ResolvedSkillRef(
-                    skill_id=skill_id,
-                    skill_name=skill_name,
-                    skill_version_id=skill_version_id,
-                    manifest_sha256=manifest_sha256,
-                )
-            )
-        self._raise_if_archived_skills(archived_skills, preset_version_id)
-        return resolved
-
-    @staticmethod
-    def _raise_if_archived_skills(
-        archived_skills: list[str], preset_version_id: uuid.UUID
-    ) -> None:
-        """Reject resolution when any referenced skill is archived."""
-        if archived_skills:
-            raise TracecatValidationError(
-                "Some skills are archived and cannot be resolved",
-                detail={
-                    "code": "skill_archived",
-                    "skills": sorted(archived_skills),
-                    "preset_version_id": str(preset_version_id),
-                },
-            )
-
-    async def _get_latest_skill_refs_for_preset_version(
-        self, preset_version_id: uuid.UUID
-    ) -> list[ResolvedSkillRef]:
-        """Return current skill versions for a preset version's skill IDs."""
-
-        stmt = (
-            select(
-                AgentPresetVersionSkill.skill_id,
-                Skill.name,
                 Skill.current_version_id,
-                Skill.deleted_at,
-                Skill.archived_at,
-                SkillVersion.name,
                 SkillVersion.manifest_sha256,
             )
-            .join(
-                Skill,
-                sa.and_(
-                    AgentPresetVersionSkill.workspace_id == Skill.workspace_id,
-                    AgentPresetVersionSkill.skill_id == Skill.id,
-                ),
-            )
-            .outerjoin(
-                SkillVersion,
-                sa.and_(
-                    SkillVersion.workspace_id == Skill.workspace_id,
-                    SkillVersion.skill_id == Skill.id,
-                    SkillVersion.id == Skill.current_version_id,
-                ),
-            )
+            .join(Skill, AgentPresetSkill.skill_id == Skill.id)
+            .join(SkillVersion, Skill.current_version_id == SkillVersion.id)
             .where(
-                AgentPresetVersionSkill.workspace_id == self.workspace_id,
-                AgentPresetVersionSkill.preset_version_id == preset_version_id,
+                AgentPresetSkill.workspace_id == self.workspace_id,
+                AgentPresetSkill.preset_id == preset_id,
+                Skill.workspace_id == self.workspace_id,
+                Skill.deleted_at.is_(None),
+                Skill.archived_at.is_(None),
             )
-            .order_by(
-                SkillVersion.name.asc().nulls_last(),
-                Skill.name.asc(),
-                AgentPresetVersionSkill.skill_id.asc(),
-            )
+            .order_by(SkillVersion.name.asc(), AgentPresetSkill.skill_id.asc())
         )
-        rows = (await self.session.execute(with_deleted(stmt))).tuples().all()
-        resolved: list[ResolvedSkillRef] = []
-        archived_skills: list[str] = []
-        missing_current: list[str] = []
-        for (
-            skill_id,
-            skill_name,
-            current_version_id,
-            deleted_at,
-            archived_at,
-            current_version_name,
-            manifest_sha256,
-        ) in rows:
-            if deleted_at is not None or archived_at is not None:
-                archived_skills.append(f"{skill_name} ({skill_id})")
-                continue
-            if current_version_id is None:
-                missing_current.append(f"{skill_name} ({skill_id})")
-                continue
-            if current_version_name is None:
-                self._raise_missing_version_name(skill_version_id=current_version_id)
-            resolved.append(
-                ResolvedSkillRef(
-                    skill_id=skill_id,
-                    skill_name=current_version_name,
-                    skill_version_id=current_version_id,
-                    manifest_sha256=manifest_sha256,
-                )
+        rows = (await self.session.execute(stmt)).tuples().all()
+        return [
+            ResolvedSkillRef(
+                skill_id=skill_id,
+                skill_name=skill_name,
+                skill_version_id=skill_version_id,
+                manifest_sha256=manifest_sha256,
             )
-
-        self._raise_if_archived_skills(archived_skills, preset_version_id)
-        if missing_current:
-            raise TracecatValidationError(
-                "Some skills have no current published version",
-                detail={
-                    "code": "skill_not_published",
-                    "skills": sorted(missing_current),
-                    "preset_version_id": str(preset_version_id),
-                },
-            )
-        return resolved
+            for skill_id, skill_name, skill_version_id, manifest_sha256 in rows
+            if skill_name is not None and skill_version_id is not None
+        ]
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_resolved_skill_ref(

--- a/tracecat/agent/subagents.py
+++ b/tracecat/agent/subagents.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Mapping
-from typing import Annotated, Self
+from typing import Annotated, Any
 
 from pydantic import (
     BaseModel,
@@ -15,6 +15,7 @@ from pydantic import (
     ValidationError,
     model_validator,
 )
+from pydantic.json_schema import SkipJsonSchema
 
 AgentAlias = Annotated[
     str,
@@ -48,10 +49,24 @@ class AttachedSubagentRef(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     preset: PresetRef
-    preset_version: int | None = Field(default=None, ge=1)
     name: AgentAlias | None = Field(default=None)
     description: str | None = Field(default=None, max_length=1000)
     max_turns: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="before")
+    @classmethod
+    def ignore_legacy_version_selector(cls, data: object) -> object:
+        """Ignore the retired authored selector without weakening extra checks."""
+
+        if (
+            isinstance(data, Mapping)
+            and "preset_version" in data
+            and "preset_version_id" not in data
+        ):
+            normalized = dict(data)
+            normalized.pop("preset_version", None)
+            return normalized
+        return data
 
     @property
     def alias(self) -> str:
@@ -59,45 +74,56 @@ class AttachedSubagentRef(BaseModel):
         return self.name or self.preset
 
 
-class ResolvedAttachedSubagentRef(AttachedSubagentRef):
-    """Persisted subagent ref with immutable preset/version identifiers."""
+class HeadAttachedSubagentRef(AttachedSubagentRef):
+    """Canonical head-owned subagent ref with stable child-head identity."""
 
     preset_id: uuid.UUID
+
+
+class ResolvedAttachedSubagentRef(HeadAttachedSubagentRef):
+    """Persisted subagent ref with immutable preset/version identifiers."""
+
     preset_version_id: uuid.UUID
     preset_version: int | None = Field(default=None, ge=1)
 
 
-type AnyAttachedSubagentRef = ResolvedAttachedSubagentRef | AttachedSubagentRef
+type AnyAttachedSubagentRef = (
+    SkipJsonSchema[ResolvedAttachedSubagentRef]
+    | HeadAttachedSubagentRef
+    | AttachedSubagentRef
+)
 
 
 class AgentSubagentsConfig(BaseModel):
-    """User-facing agents toggle and optional preset-backed subagents."""
+    """User-facing preset-backed subagent attachments."""
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = False
     subagents: list[AnyAttachedSubagentRef] = Field(default_factory=list)
 
-    @model_validator(mode="after")
-    def validate_subagents_enabled(self) -> Self:
-        if not self.enabled and self.subagents:
-            raise ValueError("subagents require enabled=true")
-        return self
+    @model_validator(mode="before")
+    @classmethod
+    def discard_legacy_enabled(cls, value: Any) -> Any:
+        """Keep old Temporal/API payloads readable; Agent is now always on."""
+        if isinstance(value, Mapping) and "enabled" in value:
+            return {key: item for key, item in value.items() if key != "enabled"}
+        return value
 
 
 class ResolvedAgentsConfig(BaseModel):
-    """Persisted agents toggle with immutable resolved child refs."""
+    """Immutable resolved child refs for a compiled turn."""
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = False
     subagents: list[ResolvedAttachedSubagentRef] = Field(default_factory=list)
 
-    @model_validator(mode="after")
-    def validate_subagents_enabled(self) -> Self:
-        if not self.enabled and self.subagents:
-            raise ValueError("subagents require enabled=true")
-        return self
+    @model_validator(mode="before")
+    @classmethod
+    def discard_legacy_enabled(cls, value: Any) -> Any:
+        """Keep stored bindings replayable while ignoring the retired toggle."""
+        if isinstance(value, Mapping) and "enabled" in value:
+            return {key: item for key, item in value.items() if key != "enabled"}
+        return value
 
 
 def validate_subagent_alias(alias: str) -> None:

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3082,7 +3082,7 @@ class AgentSession(WorkspaceModel):
     agents_binding: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB,
         nullable=True,
-        doc="Normalized subagent bindings for this session",
+        doc="Resolved subagent binding shadow for the session's latest turn",
     )
     # Agent harness fields
     harness_type: Mapped[str | None] = mapped_column(
@@ -3823,7 +3823,7 @@ class AgentPreset(SoftDeleteMixin, WorkspaceModel):
         default=lambda: {"enabled": False},
         server_default=text("'{\"enabled\": false}'::jsonb"),
         nullable=False,
-        doc="Subagent configuration for this preset",
+        doc="Rollback-only JSON shadow of canonical head subagent edges",
     )
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"
@@ -3865,6 +3865,12 @@ class AgentPreset(SoftDeleteMixin, WorkspaceModel):
         "AgentPresetSkill",
         back_populates="preset",
         cascade="all, delete-orphan",
+    )
+    subagent_bindings: Mapped[list[AgentPresetSubagent]] = relationship(
+        "AgentPresetSubagent",
+        back_populates="parent_preset",
+        cascade="all, delete-orphan",
+        foreign_keys="[AgentPresetSubagent.parent_preset_id]",
     )
     current_version: Mapped[AgentPresetVersion | None] = relationship(
         "AgentPresetVersion",
@@ -3958,7 +3964,7 @@ class AgentPresetVersion(WorkspaceModel):
         default=lambda: {"enabled": False},
         server_default=text("'{\"enabled\": false}'::jsonb"),
         nullable=False,
-        doc="Subagent configuration for this preset version",
+        doc="Immutable legacy subagent shadow retained only for rollback",
     )
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"
@@ -3987,6 +3993,55 @@ class AgentPresetVersion(WorkspaceModel):
         "AgentPresetVersionSkill",
         back_populates="preset_version",
         cascade="all, delete-orphan",
+    )
+
+
+class AgentPresetSubagent(WorkspaceModel):
+    """Mutable topology edge from one preset head to another."""
+
+    __tablename__ = "agent_preset_subagent"
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "parent_preset_id",
+            "alias",
+            name="uq_agent_preset_subagent_workspace_parent_alias",
+        ),
+        CheckConstraint(
+            "max_turns IS NULL OR max_turns >= 1",
+            name="max_turns_positive",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    parent_preset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("agent_preset.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    child_preset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("agent_preset.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    alias: Mapped[str] = mapped_column(String(80), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    max_turns: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    parent_preset: Mapped[AgentPreset] = relationship(
+        back_populates="subagent_bindings",
+        foreign_keys=[parent_preset_id],
+    )
+    child_preset: Mapped[AgentPreset] = relationship(
+        foreign_keys=[child_preset_id],
     )
 
 
@@ -4390,7 +4445,7 @@ class SkillVersionFile(WorkspaceModel):
 
 
 class AgentPresetSkill(WorkspaceModel):
-    """Mutable skill binding for the current preset head."""
+    """Mutable topology edge from an AgentPreset head to a Skill head."""
 
     __tablename__ = "agent_preset_skill"
     __table_args__ = (
@@ -4426,7 +4481,7 @@ class AgentPresetSkill(WorkspaceModel):
         ForeignKey("skill_version.id", ondelete="RESTRICT"),
         nullable=False,
         index=True,
-        doc="Exact published skill version selected on the mutable preset head",
+        doc="Rollback-only shadow of the Skill head's current version",
     )
 
     preset: Mapped[AgentPreset] = relationship(back_populates="skill_bindings")
@@ -4438,7 +4493,7 @@ class AgentPresetSkill(WorkspaceModel):
 
 
 class AgentPresetVersionSkill(WorkspaceModel):
-    """Exact skill version snapshot bound to an immutable preset version."""
+    """Immutable legacy Skill edge retained only for rollback."""
 
     __tablename__ = "agent_preset_version_skill"
     __table_args__ = (

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -88,6 +88,7 @@ POST_RLS_WORKSPACE_SCOPED_TABLES = (
     "skill_version_file",
     "agent_preset_skill",
     "agent_preset_version_skill",
+    "agent_preset_subagent",
     "workspace_sync_resource_mapping",
 )
 

--- a/tracecat/workspace_sync/adapters/agent_preset.py
+++ b/tracecat/workspace_sync/adapters/agent_preset.py
@@ -4,23 +4,26 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any
 
 import sqlalchemy as sa
-import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 from slugify import slugify
 from sqlalchemy import select
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 
 from tracecat.agent.catalog.service import AgentCatalogService
 from tracecat.agent.catalog.types import ModelKey
-from tracecat.agent.subagents import AgentSubagentsConfig
+from tracecat.agent.subagents import (
+    ResolvedAgentsConfig,
+    ResolvedAttachedSubagentRef,
+)
 from tracecat.authz.controls import check_scopes
 from tracecat.db.models import (
     AgentFolder,
     AgentPreset,
     AgentPresetSkill,
+    AgentPresetSubagent,
     AgentPresetVersion,
     AgentPresetVersionSkill,
     AgentTag,
@@ -29,7 +32,6 @@ from tracecat.db.models import (
     Skill,
     SkillVersion,
 )
-from tracecat.db.soft_delete import with_deleted
 from tracecat.dsl.enums import PlatformAction
 from tracecat.exceptions import TracecatValidationError
 from tracecat.sync import (
@@ -44,7 +46,6 @@ from tracecat.sync import (
     McpIntegrationMappingRequirement,
     McpIntegrationMappingRequirementReason,
     PullDiagnostic,
-    serializable_validation_errors,
 )
 from tracecat.workspace_sync.adapters.base import (
     DirectoryManifestAdapter,
@@ -54,7 +55,6 @@ from tracecat.workspace_sync.adapters.base import (
     ResourceDependencyRefs,
     ResourceProjection,
     SyncMappingService,
-    path_parts,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
 from tracecat.workspace_sync.schemas import (
@@ -68,7 +68,6 @@ from tracecat.workspace_sync.schemas import (
     WorkspaceManifestResources,
     WorkspaceSpec,
 )
-from tracecat.workspace_sync.serialization import serialize_yaml_model
 from tracecat.workspace_sync.types import (
     AgentPresetCatalogReference,
     AgentPresetMcpIntegrationReference,
@@ -83,7 +82,6 @@ from tracecat.workspace_sync.types import (
 from tracecat.workspace_sync.workflow import workflow_source_path
 
 AGENT_PRESET_FILENAME = "preset.yml"
-AGENT_PRESET_VERSIONS_DIR = "versions"
 DEFAULT_AGENT_MODEL_NAME = "gpt-5.5"
 
 
@@ -96,6 +94,62 @@ def _parse_uuid(value: object) -> uuid.UUID | None:
 
 
 DEFAULT_AGENT_MODEL_PROVIDER = "openai"
+
+
+def _head_version_spec(
+    spec: AgentPresetResourceSpec,
+) -> AgentPresetVersionResourceSpec:
+    """Build the internal config projection for one desired head snapshot."""
+
+    return AgentPresetVersionResourceSpec(
+        version_number=1,
+        name=spec.name,
+        instructions=spec.instructions,
+        tool_approvals=spec.tool_approvals,
+        actions=spec.actions,
+        skills=spec.skills,
+        subagents=spec.subagents,
+        catalog_id=spec.catalog_id,
+        model_name=spec.model_name,
+        model_provider=spec.model_provider,
+        base_url=spec.base_url,
+        output_type=spec.output_type,
+        namespaces=spec.namespaces,
+        mcp_integrations=spec.mcp_integrations,
+        mcp_integration_hints=spec.mcp_integration_hints,
+        retries=spec.retries,
+        enable_thinking=spec.enable_thinking,
+        enable_internet_access=spec.enable_internet_access,
+    )
+
+
+def _with_head_config(
+    spec: AgentPresetResourceSpec,
+    config: AgentPresetVersionResourceSpec,
+) -> AgentPresetResourceSpec:
+    """Return ``spec`` with its Git-owned head config replaced."""
+
+    return spec.model_copy(
+        update={
+            "name": config.name,
+            "instructions": config.instructions,
+            "tool_approvals": config.tool_approvals,
+            "actions": config.actions,
+            "skills": config.skills,
+            "subagents": config.subagents,
+            "catalog_id": config.catalog_id,
+            "model_name": config.model_name,
+            "model_provider": config.model_provider,
+            "base_url": config.base_url,
+            "output_type": config.output_type,
+            "namespaces": config.namespaces,
+            "mcp_integrations": config.mcp_integrations,
+            "mcp_integration_hints": config.mcp_integration_hints,
+            "retries": config.retries,
+            "enable_thinking": config.enable_thinking,
+            "enable_internet_access": config.enable_internet_access,
+        }
+    )
 
 
 class AgentPresetAdapter(DirectoryManifestAdapter):
@@ -112,42 +166,21 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
     import_identity_attrs = ("slug",)
     import_identity_noun = "slug"
 
-    def _version_source_path(self, source_id: str, version: int) -> str:
-        """Return the repository path for an agent preset version manifest."""
-        return f"{self.root}/{source_id}/{AGENT_PRESET_VERSIONS_DIR}/{version}.yml"
-
     def extra_path_from_path(
         self,
         path: str,
         roots: WorkspaceManifestResources,
     ) -> tuple[str, str] | None:
-        """Map ``versions/<n>.yml`` companion files to ``(source_id, relpath)``."""
-        parts = path_parts(path)
-        root_parts = path_parts(roots.agent_presets)
-        if len(parts) != len(root_parts) + 3:
-            return None
-        if parts[: len(root_parts)] != root_parts:
-            return None
-        source_id = parts[len(root_parts)]
-        versions_dir = parts[len(root_parts) + 1]
-        filename = parts[len(root_parts) + 2]
-        if not source_id or versions_dir != AGENT_PRESET_VERSIONS_DIR:
-            return None
-        return (source_id, f"{versions_dir}/{filename}") if filename else None
+        """Agent preset desired state has no companion history files."""
+        return None
 
     def serialize_extra_files(
         self,
         source_id: str,
         spec: BaseModel,
     ) -> dict[str, str]:
-        """Serialize immutable preset versions to companion YAML files."""
-        preset = cast(AgentPresetResourceSpec, spec)
-        return {
-            self._version_source_path(source_id, version_number): serialize_yaml_model(
-                version
-            )
-            for version_number, version in sorted(preset.versions.items())
-        }
+        """Agent preset desired state is fully contained in ``preset.yml``."""
+        return {}
 
     def attach_extra_files(
         self,
@@ -155,51 +188,8 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         extra_files: Mapping[tuple[str, str], str],
         diagnostics: list[PullDiagnostic],
     ) -> dict[str, BaseModel]:
-        """Fold parsed preset version YAML files back into preset specs."""
-        version_files_by_source: dict[str, dict[int, str]] = {}
-        for (source_id, relpath), content in extra_files.items():
-            version_number = _parse_preset_version_relpath(relpath)
-            if version_number is None:
-                continue
-            version_files_by_source.setdefault(source_id, {})[version_number] = content
-
-        updated: dict[str, BaseModel] = {}
-        for source_id, base_spec in specs.items():
-            spec = cast(AgentPresetResourceSpec, base_spec)
-            versions = dict(spec.versions)
-            for version_number, content in sorted(
-                version_files_by_source.get(source_id, {}).items()
-            ):
-                version = _parse_agent_preset_version_manifest(
-                    self,
-                    source_id=source_id,
-                    version_number=version_number,
-                    content=content,
-                    diagnostics=diagnostics,
-                )
-                if version is not None:
-                    versions[version_number] = version
-            if (
-                spec.current_version is not None
-                and spec.current_version not in versions
-            ):
-                diagnostics.append(
-                    PullDiagnostic(
-                        workflow_path=self.source_path(source_id),
-                        workflow_title=spec.name,
-                        error_type="dependency",
-                        message=(
-                            f"Agent preset {spec.slug!r} current version "
-                            f"{spec.current_version} is missing"
-                        ),
-                        details={
-                            "preset_slug": spec.slug,
-                            "preset_version": spec.current_version,
-                        },
-                    )
-                )
-            updated[source_id] = spec.model_copy(update={"versions": versions})
-        return updated
+        """Return head specs unchanged; they have no companion history files."""
+        return specs
 
     async def project(
         self, workspace_service: SyncMappingService
@@ -251,19 +241,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         else:
             stmt = stmt.where(AgentPreset.slug.in_(slugs))
         presets = list((await workspace_service.session.execute(stmt)).scalars().all())
-        versions_by_slug: dict[str, set[int]] = {}
-        for slug, version in refs.versioned_slugs:
-            versions_by_slug.setdefault(slug, set()).add(version)
-        versions_by_preset_id = {
-            preset.id: versions_by_slug[preset.slug]
-            for preset in presets
-            if preset.slug in versions_by_slug
-        }
-        return await self._projection_from_presets(
-            workspace_service,
-            presets,
-            versions_by_preset_id=versions_by_preset_id,
-        )
+        return await self._projection_from_presets(workspace_service, presets)
 
     def _projection_stmt(
         self, workspace_service: SyncMappingService
@@ -287,36 +265,133 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         self,
         workspace_service: SyncMappingService,
         presets: list[AgentPreset],
-        versions_by_preset_id: Mapping[uuid.UUID, set[int]] | None = None,
     ) -> ResourceProjection:
-        """Build sync specs from eager-loaded preset rows."""
+        """Build one Git-owned desired head snapshot per preset."""
         assigner = await self.source_id_assigner(workspace_service)
         specs: dict[str, BaseModel] = {}
         resources: list[ProjectedResource] = []
         for preset in presets:
             source_id = assigner.assign(preset.id, preset.slug)
             current_version = preset.current_version
-            version_numbers = set((versions_by_preset_id or {}).get(preset.id, set()))
             if current_version is not None:
-                version_numbers.add(current_version.version)
-            versions = await self._version_specs_for_preset(
-                workspace_service,
-                preset=preset,
-                version_numbers=version_numbers,
+                version_specs = await self._version_specs_for_preset(
+                    workspace_service,
+                    preset=preset,
+                    version_numbers={current_version.version},
+                )
+                desired = version_specs[current_version.version]
+            else:
+                desired = AgentPresetVersionResourceSpec(
+                    version_number=1,
+                    name=preset.name,
+                    instructions=preset.instructions,
+                    tool_approvals=preset.tool_approvals or {},
+                    actions=sorted(preset.actions or []),
+                    catalog_id=preset.catalog_id,
+                    model_name=preset.model_name,
+                    model_provider=preset.model_provider,
+                    base_url=preset.base_url,
+                    output_type=preset.output_type,
+                    namespaces=sorted(preset.namespaces or []),
+                    mcp_integrations=sorted(preset.mcp_integrations or []),
+                    retries=preset.retries,
+                    enable_thinking=preset.enable_thinking,
+                    enable_internet_access=preset.enable_internet_access,
+                )
+            desired = desired.model_copy(
+                update={
+                    "skills": await self._head_skill_bindings(
+                        workspace_service, preset.id
+                    ),
+                    "subagents": await self._head_subagent_refs(
+                        workspace_service, preset.id
+                    ),
+                }
             )
-            specs[source_id] = AgentPresetResourceSpec(
+            head_spec = AgentPresetResourceSpec(
                 id=source_id,
                 slug=preset.slug,
                 name=preset.name,
-                current_version=(
-                    current_version.version if current_version is not None else None
-                ),
                 folder_path=preset.folder.path if preset.folder else None,
                 tags=sorted(tag.name for tag in preset.tags),
-                versions=versions,
+                instructions=desired.instructions,
+                tool_approvals=desired.tool_approvals,
+                actions=desired.actions,
+                skills=desired.skills,
+                subagents=desired.subagents,
+                catalog_id=desired.catalog_id,
+                model_name=desired.model_name,
+                model_provider=desired.model_provider,
+                base_url=desired.base_url,
+                output_type=desired.output_type,
+                namespaces=desired.namespaces,
+                mcp_integrations=desired.mcp_integrations,
+                mcp_integration_hints=desired.mcp_integration_hints,
+                retries=desired.retries,
+                enable_thinking=desired.enable_thinking,
+                enable_internet_access=desired.enable_internet_access,
             )
+            specs[source_id] = head_spec
             resources.append(self.projected_resource(source_id, preset.id))
         return ResourceProjection(specs=specs, resources=resources)
+
+    async def _head_skill_bindings(
+        self,
+        workspace_service: SyncMappingService,
+        preset_id: uuid.UUID,
+    ) -> list[AgentPresetSkillBinding]:
+        """Return portable Skill-head refs for a preset head."""
+
+        stmt = (
+            select(Skill.name)
+            .join(AgentPresetSkill, AgentPresetSkill.skill_id == Skill.id)
+            .where(
+                AgentPresetSkill.workspace_id == workspace_service.workspace_id,
+                AgentPresetSkill.preset_id == preset_id,
+                Skill.deleted_at.is_(None),
+                Skill.archived_at.is_(None),
+            )
+            .order_by(Skill.name.asc())
+        )
+        return [
+            AgentPresetSkillBinding(slug=slug)
+            for slug in (await workspace_service.session.scalars(stmt)).all()
+        ]
+
+    async def _head_subagent_refs(
+        self,
+        workspace_service: SyncMappingService,
+        preset_id: uuid.UUID,
+    ) -> list[AgentPresetSubagentRef]:
+        """Return portable child-head refs for a preset head."""
+
+        child = aliased(AgentPreset)
+        stmt = (
+            select(
+                child.slug,
+                AgentPresetSubagent.alias,
+                AgentPresetSubagent.description,
+                AgentPresetSubagent.max_turns,
+            )
+            .join(child, AgentPresetSubagent.child_preset_id == child.id)
+            .where(
+                AgentPresetSubagent.workspace_id == workspace_service.workspace_id,
+                AgentPresetSubagent.parent_preset_id == preset_id,
+                child.deleted_at.is_(None),
+            )
+            .order_by(AgentPresetSubagent.alias.asc())
+        )
+        return [
+            AgentPresetSubagentRef(
+                slug=slug,
+                name=alias,
+                description=description,
+                max_turns=max_turns,
+            )
+            for slug, alias, description, max_turns in (
+                await workspace_service.session.execute(stmt)
+            ).tuples()
+        ]
 
     async def _version_specs_for_preset(
         self,
@@ -338,10 +413,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             .order_by(AgentPresetVersion.version.asc())
         )
         version_rows = list((await workspace_service.session.scalars(stmt)).all())
-        skill_bindings_by_version_id = await self._skill_bindings_for_versions(
-            workspace_service,
-            [version.id for version in version_rows],
-        )
         mcp_hints_by_id = await self._mcp_integration_hints(
             workspace_service,
             {
@@ -366,8 +437,8 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                 instructions=version.instructions,
                 tool_approvals=version.tool_approvals or {},
                 actions=sorted(version.actions or []),
-                skills=skill_bindings_by_version_id.get(version.id, []),
-                subagents=_subagent_refs(version.agents),
+                skills=[],
+                subagents=[],
                 catalog_id=version.catalog_id,
                 model_name=version.model_name,
                 model_provider=version.model_provider,
@@ -420,44 +491,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             ).tuples()
         }
 
-    async def _skill_bindings_for_versions(
-        self,
-        workspace_service: SyncMappingService,
-        version_ids: list[uuid.UUID],
-    ) -> dict[uuid.UUID, list[AgentPresetSkillBinding]]:
-        """Return slug/version skill bindings grouped by preset version id."""
-        if not version_ids:
-            return {}
-        stmt = (
-            select(
-                AgentPresetVersionSkill.preset_version_id,
-                Skill.name,
-                SkillVersion.version,
-            )
-            .select_from(AgentPresetVersionSkill)
-            .join(Skill, AgentPresetVersionSkill.skill_id == Skill.id)
-            .join(
-                SkillVersion,
-                AgentPresetVersionSkill.skill_version_id == SkillVersion.id,
-            )
-            .where(
-                AgentPresetVersionSkill.workspace_id == workspace_service.workspace_id,
-                AgentPresetVersionSkill.preset_version_id.in_(version_ids),
-            )
-            .order_by(
-                AgentPresetVersionSkill.preset_version_id.asc(),
-                Skill.name.asc(),
-            )
-        )
-        bindings: dict[uuid.UUID, list[AgentPresetSkillBinding]] = {}
-        for preset_version_id, slug, version_number in (
-            await workspace_service.session.execute(with_deleted(stmt))
-        ).tuples():
-            bindings.setdefault(preset_version_id, []).append(
-                AgentPresetSkillBinding(slug=slug, version=version_number)
-            )
-        return bindings
-
     async def correlate_catalog_ids(
         self,
         workspace_service: SyncMappingService,
@@ -490,7 +523,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         missing_tuple_diagnostics: list[tuple[uuid.UUID, PullDiagnostic]] = []
 
         for source_id, preset in sorted(presets.items()):
-            for version_number, version in sorted(preset.versions.items()):
+            for version_number, version in ((1, _head_version_spec(preset)),):
                 catalog_id = version.catalog_id
                 if catalog_id is None:
                     continue
@@ -502,9 +535,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                         (
                             catalog_id,
                             PullDiagnostic(
-                                workflow_path=self._version_source_path(
-                                    source_id, version_number
-                                ),
+                                workflow_path=self.source_path(source_id),
                                 workflow_title=preset.name,
                                 error_type="validation",
                                 message=(
@@ -525,7 +556,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                     continue
                 references_by_catalog_id.setdefault(catalog_id, []).append(
                     AgentPresetCatalogReference(
-                        path=self._version_source_path(source_id, version_number),
+                        path=self.source_path(source_id),
                         preset_slug=preset.slug,
                         preset_name=preset.name,
                         version_number=version_number,
@@ -744,23 +775,21 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
         correlated_presets: dict[str, AgentPresetResourceSpec] = {}
         for source_id, preset in sorted(presets.items()):
-            correlated_versions: dict[int, AgentPresetVersionResourceSpec] = {}
-            for version_number, version in sorted(preset.versions.items()):
-                local_catalog_id = (
-                    resolved_catalog_ids.get(version.catalog_id)
-                    if version.catalog_id is not None
-                    else None
-                )
-                correlated_versions[version_number] = (
-                    version
-                    if local_catalog_id is None
-                    else version.model_copy(
+            config = _head_version_spec(preset)
+            local_catalog_id = (
+                resolved_catalog_ids.get(config.catalog_id)
+                if config.catalog_id is not None
+                else None
+            )
+            correlated_presets[source_id] = (
+                preset
+                if local_catalog_id is None
+                else _with_head_config(
+                    preset,
+                    config.model_copy(
                         update={"catalog_id": local_catalog_id, "base_url": None}
-                    )
+                    ),
                 )
-
-            correlated_presets[source_id] = preset.model_copy(
-                update={"versions": correlated_versions}
             )
 
         correlated_workflows: dict[str, WorkflowResourceSpec] = {}
@@ -988,7 +1017,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         conflicting_meta_ids: set[uuid.UUID] = set()
 
         for source_id, preset in sorted(presets.items()):
-            for version_number, version in sorted(preset.versions.items()):
+            for version_number, version in ((1, _head_version_spec(preset)),):
                 for ref in version.mcp_integrations:
                     integration_id = _parse_uuid(ref)
                     if integration_id is None:
@@ -1015,7 +1044,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                             conflicting_meta_ids.add(integration_id)
                     references.setdefault(integration_id, []).append(
                         AgentPresetMcpIntegrationReference(
-                            path=self._version_source_path(source_id, version_number),
+                            path=self.source_path(source_id),
                             preset_slug=preset.slug,
                             preset_name=preset.name,
                             version_number=version_number,
@@ -1180,37 +1209,36 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         }
         correlated_presets: dict[str, AgentPresetResourceSpec] = {}
         for source_id, preset in sorted(presets.items()):
-            correlated_versions: dict[int, AgentPresetVersionResourceSpec] = {}
-            for version_number, version in sorted(preset.versions.items()):
-                # Resolved ids and hints take the local shape so repeat previews
-                # converge on the local projection.
-                rewritten: list[str] = []
-                rewritten_hints: dict[uuid.UUID, McpIntegrationHint] = {}
-                for ref in version.mcp_integrations:
-                    ref_id = _parse_uuid(ref)
-                    if ref_id is not None and ref_id in resolved:
-                        local_id = resolved[ref_id]
-                        rewritten.append(str(local_id))
-                        rewritten_hints[local_id] = local_hint_by_id[local_id]
-                    else:
-                        rewritten.append(ref)
-                        if ref_id is not None and (
-                            hint := version.mcp_integration_hints.get(ref_id)
-                        ):
-                            rewritten_hints[ref_id] = hint
-                correlated_versions[version_number] = (
-                    version
-                    if rewritten == version.mcp_integrations
-                    and rewritten_hints == version.mcp_integration_hints
-                    else version.model_copy(
+            config = _head_version_spec(preset)
+            # Resolved ids and hints take the local shape so repeat previews
+            # converge on the local projection.
+            rewritten: list[str] = []
+            rewritten_hints: dict[uuid.UUID, McpIntegrationHint] = {}
+            for ref in config.mcp_integrations:
+                ref_id = _parse_uuid(ref)
+                if ref_id is not None and ref_id in resolved:
+                    local_id = resolved[ref_id]
+                    rewritten.append(str(local_id))
+                    rewritten_hints[local_id] = local_hint_by_id[local_id]
+                else:
+                    rewritten.append(ref)
+                    if ref_id is not None and (
+                        hint := config.mcp_integration_hints.get(ref_id)
+                    ):
+                        rewritten_hints[ref_id] = hint
+            correlated_presets[source_id] = (
+                preset
+                if rewritten == config.mcp_integrations
+                and rewritten_hints == config.mcp_integration_hints
+                else _with_head_config(
+                    preset,
+                    config.model_copy(
                         update={
                             "mcp_integrations": rewritten,
                             "mcp_integration_hints": rewritten_hints,
                         }
-                    )
+                    ),
                 )
-            correlated_presets[source_id] = preset.model_copy(
-                update={"versions": correlated_versions}
             )
 
         correlated_workflows: dict[str, WorkflowResourceSpec] = {}
@@ -1447,7 +1475,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
                     name=spec.name,
                     model_name=DEFAULT_AGENT_MODEL_NAME,
                     model_provider=DEFAULT_AGENT_MODEL_PROVIDER,
-                    agents=AgentSubagentsConfig().model_dump(mode="json"),
+                    agents={"enabled": True, "subagents": []},
                 )
             else:
                 preset.slug = spec.slug
@@ -1467,89 +1495,44 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         for source_id in import_order:
             spec = presets[source_id]
             preset = preset_by_source_id[source_id]
-            version_specs = dict(spec.versions)
-            head_spec = None
-            if spec.current_version is not None:
-                head_spec = version_specs.get(spec.current_version)
-                if head_spec is None:
-                    raise TracecatValidationError(
-                        f"Agent preset {spec.slug!r} current version "
-                        f"{spec.current_version} is missing from the version snapshots."
-                    )
+            head_spec = _head_version_spec(spec)
 
-            # Resolve current-version config to the live preset head now that all
-            # child presets have already been imported.
-            if head_spec is not None:
-                self._apply_preset_version_spec(preset, head_spec)
-                preset.agents = await self._resolved_subagents_config(
-                    workspace_service, head_spec
-                )
-            else:
-                preset.agents = AgentSubagentsConfig().model_dump(mode="json")
+            # Apply desired config and topology after every child head exists.
+            self._apply_preset_version_spec(preset, head_spec)
+            resolved_subagents = await self._resolved_subagents_config(
+                workspace_service, head_spec
+            )
+            preset.agents = {
+                "enabled": True,
+                **resolved_subagents.model_dump(mode="json"),
+            }
             workspace_service.session.add(preset)
             await workspace_service.session.flush()
-            skill_targets = (
-                await self._skill_binding_targets_for_spec(
-                    workspace_service,
-                    head_spec,
-                )
-                if head_spec is not None
-                else []
+            skill_targets = await self._skill_binding_targets_for_spec(
+                workspace_service,
+                head_spec,
             )
 
-            imported_versions: dict[int, AgentPresetVersion] = {}
-            for version_number, version_spec in sorted(version_specs.items()):
-                version = await self._upsert_agent_preset_version(
-                    workspace_service,
-                    preset=preset,
-                    version=version_spec,
-                )
-                version_skill_targets = await self._skill_binding_targets_for_spec(
-                    workspace_service,
-                    version_spec,
-                )
-                await self._replace_version_skill_bindings(
-                    workspace_service,
-                    version,
-                    version_skill_targets,
-                )
-                imported_versions[version_number] = version
-
-            if spec.current_version is None:
-                await self._replace_head_skill_bindings(
-                    workspace_service,
-                    preset,
-                    [],
-                )
-                preset.current_version_id = None
-                workspace_service.session.add(preset)
-                await workspace_service.session.flush()
-                imported.append(self.imported_resource(source_id, preset.id))
-                continue
-
-            current_version = imported_versions.get(spec.current_version)
-            if current_version is None:
-                current_version = await self._current_version_for_preset(
-                    workspace_service, preset
-                )
-            if current_version is None or not await self._version_matches_preset(
-                workspace_service,
-                current_version,
-                preset,
-                skill_targets,
+            current_version = await self._current_version_for_preset(
+                workspace_service, preset
+            )
+            if current_version is None or not self._version_matches_preset(
+                current_version, preset
             ):
                 current_version = await self._create_agent_preset_version(
                     workspace_service, preset
                 )
+                # Legacy topology fields are written once with a newly inserted
+                # immutable version, never updated on an existing version.
                 await self._replace_version_skill_bindings(
                     workspace_service, current_version, skill_targets
                 )
-            # Head bindings track the live preset; refresh them every pass since
-            # a reused version skips the version-binding replacement above.
             await self._replace_head_skill_bindings(
                 workspace_service, preset, skill_targets
             )
-            # Pin the preset to the resolved version as its current head.
+            await self._replace_head_subagent_bindings(
+                workspace_service, preset, resolved_subagents
+            )
             preset.current_version_id = current_version.id
             workspace_service.session.add(preset)
             await workspace_service.session.flush()
@@ -1597,10 +1580,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             # done and append so children always precede this parent.
             visiting.add(source_id)
             spec = presets[source_id]
-            subagents: list[AgentPresetSubagentRef] = []
-            for version in spec.versions.values():
-                subagents.extend(version.subagents)
-            for subagent in sorted(subagents, key=lambda item: item.slug):
+            for subagent in sorted(spec.subagents, key=lambda item: item.slug):
                 # Ignore refs to slugs not present in this sync batch.
                 if child_source_id := slug_to_source_id.get(subagent.slug):
                     visit(child_source_id)
@@ -1779,42 +1759,34 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         self,
         workspace_service: SyncMappingService,
         spec: AgentPresetResourceSpec | AgentPresetVersionResourceSpec,
-    ) -> dict[str, Any]:
-        """Build the subagents config dict for ``spec``.
+    ) -> ResolvedAgentsConfig:
+        """Resolve ``spec`` subagents for canonical edges and rollback shadows.
 
-        Resolves each subagent reference to its current preset version, skipping
-        any that are missing or unpublished. Returns the default disabled config
-        when the spec declares no subagents.
+        Resolves each child head to its current version for the rollback shadow.
         """
-        # No subagents declared: emit the default (disabled) config.
         if not spec.subagents:
-            return AgentSubagentsConfig().model_dump(mode="json")
+            return ResolvedAgentsConfig()
 
-        subagents: list[dict[str, Any]] = []
+        subagents: list[ResolvedAttachedSubagentRef] = []
         for subagent in spec.subagents:
-            # Skip refs whose child preset or version can't be resolved
-            # (missing or unpublished) so the config only contains live links.
             target = await self._resolved_subagent_target(workspace_service, subagent)
             if target is None:
-                continue
+                raise TracecatValidationError(
+                    f"Subagent preset {subagent.slug!r} is missing or unpublished"
+                )
             child, version = target
             subagents.append(
-                {
-                    "preset": child.slug,
-                    "preset_id": str(child.id),
-                    "preset_version_id": str(version.id),
-                    # Pin a concrete version only when the ref requested one;
-                    # otherwise leave it floating on the child's current version.
-                    "preset_version": version.version
-                    if subagent.version is not None
-                    else None,
-                    "name": subagent.name,
-                    "description": subagent.description,
-                    "max_turns": subagent.max_turns,
-                }
+                ResolvedAttachedSubagentRef(
+                    preset=child.slug,
+                    preset_id=child.id,
+                    preset_version_id=version.id,
+                    preset_version=version.version,
+                    name=subagent.name,
+                    description=subagent.description,
+                    max_turns=subagent.max_turns,
+                )
             )
-        # Enabled only if at least one subagent actually resolved.
-        return {"enabled": bool(subagents), "subagents": subagents}
+        return ResolvedAgentsConfig(subagents=subagents)
 
     async def _resolved_subagent_target(
         self,
@@ -1835,18 +1807,13 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         if child is None:
             return None
 
+        if child.current_version_id is None:
+            return None
         stmt = select(AgentPresetVersion).where(
             AgentPresetVersion.workspace_id == workspace_service.workspace_id,
             AgentPresetVersion.preset_id == child.id,
+            AgentPresetVersion.id == child.current_version_id,
         )
-        # Pin the explicitly requested version when given; otherwise track the
-        # child's current version. Bail if the child has no published version.
-        if subagent.version is not None:
-            stmt = stmt.where(AgentPresetVersion.version == subagent.version)
-        elif child.current_version_id is not None:
-            stmt = stmt.where(AgentPresetVersion.id == child.current_version_id)
-        else:
-            return None
 
         # Treat an unresolvable version (e.g. requested number not found) as a
         # skip rather than an error.
@@ -1871,44 +1838,16 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             )
         )
 
-    async def _version_matches_preset(
-        self,
-        workspace_service: SyncMappingService,
-        version: AgentPresetVersion,
-        preset: AgentPreset,
-        skill_targets: list[tuple[Skill, SkillVersion]],
+    def _version_matches_preset(
+        self, version: AgentPresetVersion, preset: AgentPreset
     ) -> bool:
-        """Return whether ``version`` already captures ``preset``'s state.
-
-        Compares every versioned attribute and the version's skill bindings
-        against the preset, so a matching version can be reused instead of
-        cutting a new one.
-        """
-        # Any differing versioned attribute means a new version is required.
+        """Return whether a version captures the head's version-owned config."""
         for key, value in self._version_attrs_from_preset(preset).items():
+            if key == "agents":
+                continue
             if getattr(version, key) != value:
                 return False
-        # Attributes match; the skill-binding set must match too. Compare the
-        # desired (skill, version) id pairs against those stored on the version.
-        desired_skill_targets = {
-            (skill.id, skill_version.id) for skill, skill_version in skill_targets
-        }
-        existing_skill_targets = {
-            (skill_id, skill_version_id)
-            for skill_id, skill_version_id in (
-                await workspace_service.session.execute(
-                    select(
-                        AgentPresetVersionSkill.skill_id,
-                        AgentPresetVersionSkill.skill_version_id,
-                    ).where(
-                        AgentPresetVersionSkill.workspace_id
-                        == workspace_service.workspace_id,
-                        AgentPresetVersionSkill.preset_version_id == version.id,
-                    )
-                )
-            ).tuples()
-        }
-        return existing_skill_targets == desired_skill_targets
+        return True
 
     async def _create_agent_preset_version(
         self,
@@ -1937,40 +1876,6 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         workspace_service.session.add(version)
         await workspace_service.session.flush()
         return version
-
-    async def _upsert_agent_preset_version(
-        self,
-        workspace_service: SyncMappingService,
-        *,
-        preset: AgentPreset,
-        version: AgentPresetVersionResourceSpec,
-    ) -> AgentPresetVersion:
-        """Create or update one exact-number preset version."""
-        existing = await workspace_service.session.scalar(
-            select(AgentPresetVersion).where(
-                AgentPresetVersion.workspace_id == workspace_service.workspace_id,
-                AgentPresetVersion.preset_id == preset.id,
-                AgentPresetVersion.version == version.version_number,
-            )
-        )
-        attrs = self._version_attrs_from_spec(version)
-        attrs["agents"] = await self._resolved_subagents_config(
-            workspace_service,
-            version,
-        )
-        if existing is None:
-            existing = AgentPresetVersion(
-                workspace_id=workspace_service.workspace_id,
-                preset_id=preset.id,
-                version=version.version_number,
-                **attrs,
-            )
-        else:
-            for key, value in attrs.items():
-                setattr(existing, key, value)
-        workspace_service.session.add(existing)
-        await workspace_service.session.flush()
-        return existing
 
     def _version_attrs_from_preset(self, preset: AgentPreset) -> dict[str, Any]:
         """Return the versioned preset attributes to snapshot or compare."""
@@ -2038,6 +1943,33 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             )
         await workspace_service.session.flush()
 
+    async def _replace_head_subagent_bindings(
+        self,
+        workspace_service: SyncMappingService,
+        preset: AgentPreset,
+        binding: ResolvedAgentsConfig,
+    ) -> None:
+        """Replace canonical preset-head edges from the resolved sync spec."""
+
+        await workspace_service.session.execute(
+            sa.delete(AgentPresetSubagent).where(
+                AgentPresetSubagent.workspace_id == workspace_service.workspace_id,
+                AgentPresetSubagent.parent_preset_id == preset.id,
+            )
+        )
+        for subagent in binding.subagents:
+            workspace_service.session.add(
+                AgentPresetSubagent(
+                    workspace_id=workspace_service.workspace_id,
+                    parent_preset_id=preset.id,
+                    child_preset_id=subagent.preset_id,
+                    alias=subagent.alias,
+                    description=subagent.description,
+                    max_turns=subagent.max_turns,
+                )
+            )
+        await workspace_service.session.flush()
+
     async def _replace_version_skill_bindings(
         self,
         workspace_service: SyncMappingService,
@@ -2079,10 +2011,10 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
             skill, skill_version = await self._skill_binding_targets(
                 workspace_service, binding
             )
-            # Drop bindings that don't fully resolve so callers only see live
-            # (skill, version) pairs.
             if skill is None or skill_version is None:
-                continue
+                raise TracecatValidationError(
+                    f"Skill {binding.slug!r} is missing or unpublished"
+                )
             targets.append((skill, skill_version))
         return targets
 
@@ -2091,12 +2023,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         workspace_service: SyncMappingService,
         binding: AgentPresetSkillBinding,
     ) -> tuple[Skill | None, SkillVersion | None]:
-        """Resolve one skill binding to its ``(skill, version)`` pair.
-
-        Looks up the skill by slug, then the requested version (or the skill's
-        current version when ``binding.version`` is unset). Returns
-        ``(None, None)`` when the skill or version cannot be found.
-        """
+        """Resolve one Skill-head binding to its current version shadow."""
         # Resolve the skill by its slug (stored as `name`) in this workspace.
         skill = await workspace_service.session.scalar(
             select(Skill).where(
@@ -2110,124 +2037,13 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         )
         if skill is None:
             return None, None
-        version_number = binding.version
         stmt = select(SkillVersion).where(
             SkillVersion.workspace_id == workspace_service.workspace_id,
             SkillVersion.skill_id == skill.id,
+            SkillVersion.id == skill.current_version_id,
         )
-        # Use the requested version when pinned; otherwise the skill's current
-        # version. A missing match returns None and the binding is dropped.
-        if version_number is not None:
-            stmt = stmt.where(SkillVersion.version == version_number)
-        else:
-            stmt = stmt.where(SkillVersion.id == skill.current_version_id)
         version = await workspace_service.session.scalar(stmt)
         return skill, version
-
-
-def _subagent_refs(agents: dict[str, Any]) -> list[AgentPresetSubagentRef]:
-    """Extract slug-only subagent refs from a preset's ``agents`` config.
-
-    Returns an empty list when the config is missing or fails to validate.
-    """
-    # Treat a malformed/legacy config as having no subagents rather than failing
-    # the whole projection.
-    try:
-        config = AgentSubagentsConfig.model_validate(agents or {"enabled": False})
-    except Exception:
-        return []
-    # Project to slug-keyed refs, sorted by slug for deterministic output.
-    return [
-        AgentPresetSubagentRef(
-            slug=subagent.preset,
-            version=subagent.preset_version,
-            name=subagent.name,
-            description=subagent.description,
-            max_turns=subagent.max_turns,
-        )
-        for subagent in sorted(config.subagents, key=lambda item: item.preset)
-    ]
-
-
-def _parse_preset_version_relpath(relpath: str) -> int | None:
-    """Parse ``versions/<n>.yml`` relpaths for preset companion files."""
-    parts = path_parts(relpath)
-    if len(parts) != 2 or parts[0] != AGENT_PRESET_VERSIONS_DIR:
-        return None
-    filename = parts[1]
-    if not filename.endswith(".yml"):
-        return None
-    try:
-        version_number = int(filename.removesuffix(".yml"))
-    except ValueError:
-        return None
-    return version_number if version_number >= 1 else None
-
-
-def _parse_agent_preset_version_manifest(
-    adapter: AgentPresetAdapter,
-    *,
-    source_id: str,
-    version_number: int,
-    content: str,
-    diagnostics: list[PullDiagnostic],
-) -> AgentPresetVersionResourceSpec | None:
-    """Parse one agent preset version manifest or append a diagnostic."""
-    path = adapter._version_source_path(source_id, version_number)
-    try:
-        raw = yaml.safe_load(content)
-        if not isinstance(raw, dict) or not raw:
-            diagnostics.append(
-                PullDiagnostic(
-                    workflow_path=path,
-                    workflow_title=None,
-                    error_type="parse",
-                    message="Empty or invalid agent preset version YAML file",
-                    details={},
-                )
-            )
-            return None
-        version = AgentPresetVersionResourceSpec.model_validate(raw)
-        if version.version_number != version_number:
-            diagnostics.append(
-                PullDiagnostic(
-                    workflow_path=path,
-                    workflow_title=version.name,
-                    error_type="validation",
-                    message=(
-                        "Agent preset version number does not match its repository path"
-                    ),
-                    details={
-                        "path_version": version_number,
-                        "spec_version": version.version_number,
-                    },
-                )
-            )
-            return None
-        return version
-    except yaml.YAMLError as e:
-        diagnostics.append(
-            PullDiagnostic(
-                workflow_path=path,
-                workflow_title=None,
-                error_type="parse",
-                message=f"YAML parsing error: {str(e)}",
-                details={"yaml_error": str(e)},
-            )
-        )
-    except ValidationError as e:
-        diagnostics.append(
-            PullDiagnostic(
-                workflow_path=path,
-                workflow_title=None,
-                error_type="validation",
-                message=f"Validation error: {str(e)}",
-                details={
-                    "validation_errors": serializable_validation_errors(e.errors())
-                },
-            )
-        )
-    return None
 
 
 def _tool_approvals(value: dict[str, Any]) -> dict[str, bool] | None:

--- a/tracecat/workspace_sync/adapters/skill.py
+++ b/tracecat/workspace_sync/adapters/skill.py
@@ -12,16 +12,12 @@ from typing import Literal, cast
 
 import orjson
 import sqlalchemy as sa
-import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from tracecat.agent.skill.service import SkillFileBlobRef, SkillService
 from tracecat.db.models import (
-    AgentPreset,
-    AgentPresetSkill,
-    AgentPresetVersionSkill,
     Skill,
     SkillBlob,
     SkillVersion,
@@ -29,7 +25,7 @@ from tracecat.db.models import (
 )
 from tracecat.exceptions import TracecatValidationError
 from tracecat.storage import blob
-from tracecat.sync import PullDiagnostic, serializable_validation_errors
+from tracecat.sync import PullDiagnostic
 from tracecat.workspace_sync.adapters.base import (
     DirectoryManifestAdapter,
     ImportedResource,
@@ -49,12 +45,9 @@ from tracecat.workspace_sync.schemas import (
     WorkspaceManifestResources,
     WorkspaceSpec,
 )
-from tracecat.workspace_sync.serialization import serialize_yaml_model
 
 SKILL_FILENAME = "skill.yml"
 SKILL_FILES_DIR = "files"
-SKILL_VERSIONS_DIR = "versions"
-SKILL_VERSION_FILENAME = "version.yml"
 
 
 class SkillAdapter(DirectoryManifestAdapter):
@@ -71,46 +64,25 @@ class SkillAdapter(DirectoryManifestAdapter):
     import_identity_attrs = ("slug",)
     import_identity_noun = "slug"
 
-    def _version_manifest_path(self, source_id: str, version: int) -> str:
-        """Return the repository path for a skill version manifest."""
-        return (
-            f"{self.root}/{source_id}/{SKILL_VERSIONS_DIR}/"
-            f"{version}/{SKILL_VERSION_FILENAME}"
-        )
-
-    def _version_file_source_path(
-        self,
-        source_id: str,
-        version: int,
-        file_path: str,
-    ) -> str:
-        """Return the repository path for a versioned skill file blob."""
-        return (
-            f"{self.root}/{source_id}/{SKILL_VERSIONS_DIR}/"
-            f"{version}/{SKILL_FILES_DIR}/{file_path}"
-        )
+    def _file_source_path(self, source_id: str, file_path: str) -> str:
+        """Return the repository path for desired Skill-head file content."""
+        return f"{self.root}/{source_id}/{SKILL_FILES_DIR}/{file_path}"
 
     def extra_path_from_path(
         self,
         path: str,
         roots: WorkspaceManifestResources,
     ) -> tuple[str, str] | None:
-        """Map a skill companion path to ``(source_id, relpath)``.
-
-        Versioned snapshots live under ``versions/<n>/``. The returned relpath
-        is interpreted by :meth:`attach_extra_files`.
-        """
+        """Map desired head file content to ``(source_id, relpath)``."""
         parts = path_parts(path)
         root_parts = path_parts(roots.skills)
         # The leading segments must match the configured skills root exactly.
         if parts[: len(root_parts)] != root_parts:
             return None
-        # A companion file needs at least root + <source_id> + one nested
-        # segment; the primary "skill.yml" lives directly below the source id.
         if len(parts) < len(root_parts) + 3:
             return None
         source_id = parts[len(root_parts)]
-        if not source_id:
+        if not source_id or parts[len(root_parts) + 1] != SKILL_FILES_DIR:
             return None
         relpath = "/".join(parts[len(root_parts) + 1 :])
         return (source_id, relpath) if relpath else None
@@ -120,24 +92,12 @@ class SkillAdapter(DirectoryManifestAdapter):
         source_id: str,
         spec: BaseModel,
     ) -> dict[str, str]:
-        """Serialize a skill's versioned file blobs to their repository paths."""
+        """Serialize the desired Skill-head file contents."""
         skill = cast(SkillResourceSpec, spec)
-        files: dict[str, str] = {}
-        for version_number, version in sorted(skill.versions.items()):
-            files[self._version_manifest_path(source_id, version_number)] = (
-                serialize_yaml_model(version)
-            )
-            files.update(
-                {
-                    self._version_file_source_path(
-                        source_id,
-                        version_number,
-                        file_path,
-                    ): content
-                    for file_path, content in sorted(version.file_contents.items())
-                }
-            )
-        return files
+        return {
+            f"{self.root}/{source_id}/{SKILL_FILES_DIR}/{file_path}": content
+            for file_path, content in sorted(skill.file_contents.items())
+        }
 
     def attach_extra_files(
         self,
@@ -145,84 +105,36 @@ class SkillAdapter(DirectoryManifestAdapter):
         extra_files: Mapping[tuple[str, str], str],
         diagnostics: list[PullDiagnostic],
     ) -> dict[str, BaseModel]:
-        """Fold parsed skill file blobs back into each skill spec.
-
-        Attaches version file contents by source id and emits a
-        :class:`PullDiagnostic` for any declared version file that is missing or
-        whose SHA256 does not match the manifest.
-        """
-        # Group the flat (source_id, relpath) blob map by skill so each version
-        # spec can look up only its own files below.
-        version_manifest_by_source: dict[str, dict[int, str]] = defaultdict(dict)
-        version_contents_by_source: dict[str, dict[int, dict[str, str]]] = defaultdict(
-            lambda: defaultdict(dict)
-        )
+        """Attach and validate desired Skill-head file contents."""
+        contents_by_source: dict[str, dict[str, str]] = defaultdict(dict)
         for (source_id, relpath), content in extra_files.items():
-            parsed = _parse_skill_version_relpath(relpath)
-            if parsed is None:
+            parts = path_parts(relpath)
+            if len(parts) < 2 or parts[0] != SKILL_FILES_DIR:
                 continue
-            version_number, kind, file_path = parsed
-            if kind == "manifest":
-                version_manifest_by_source[source_id][version_number] = content
-            elif file_path:
-                version_contents_by_source[source_id][version_number][file_path] = (
-                    content
-                )
+            contents_by_source[source_id]["/".join(parts[1:])] = content
 
         updated: dict[str, BaseModel] = {}
         for source_id, base_spec in specs.items():
             spec = cast(SkillResourceSpec, base_spec)
-            versions: dict[int, SkillVersionResourceSpec] = dict(spec.versions)
-            for version_number, content in sorted(
-                version_manifest_by_source.get(source_id, {}).items()
-            ):
-                version_spec = _parse_skill_version_manifest(
-                    self,
-                    source_id=source_id,
-                    version_number=version_number,
-                    content=content,
-                    diagnostics=diagnostics,
-                )
-                if version_spec is None:
-                    continue
-                version_contents = version_contents_by_source[source_id].get(
-                    version_number, {}
-                )
-                self._validate_version_files(
-                    source_id=source_id,
-                    spec=spec,
-                    version=version_spec,
-                    contents=version_contents,
-                    diagnostics=diagnostics,
-                )
-                versions[version_number] = version_spec.model_copy(
-                    update={"file_contents": version_contents}
-                )
-
-            if (
-                spec.current_version is not None
-                and spec.current_version not in versions
-            ):
-                diagnostics.append(
-                    PullDiagnostic(
-                        workflow_path=self.source_path(source_id),
-                        workflow_title=spec.name,
-                        error_type="dependency",
-                        message=(
-                            f"Skill {spec.slug!r} current version "
-                            f"{spec.current_version} is missing"
-                        ),
-                        details={
-                            "skill_slug": spec.slug,
-                            "skill_version": spec.current_version,
-                        },
-                    )
-                )
-
-            # Attach the resolved version contents even when diagnostics fired
-            # so the caller has whatever did parse; diagnostics gate acceptance.
+            contents = contents_by_source.get(source_id, {})
+            desired = SkillVersionResourceSpec(
+                version_number=1,
+                name=spec.name,
+                description=spec.description,
+                files=spec.files,
+                file_contents=contents,
+            )
+            self._validate_version_files(
+                source_id=source_id,
+                spec=spec,
+                version=desired,
+                contents=contents,
+                diagnostics=diagnostics,
+            )
             updated[source_id] = spec.model_copy(
-                update={"files": [], "file_contents": {}, "versions": versions}
+                update={
+                    "file_contents": contents,
+                }
             )
         return updated
 
@@ -241,10 +153,7 @@ class SkillAdapter(DirectoryManifestAdapter):
             if content is None:
                 diagnostics.append(
                     PullDiagnostic(
-                        workflow_path=self._version_manifest_path(
-                            source_id,
-                            version.version_number,
-                        ),
+                        workflow_path=self.source_path(source_id),
                         workflow_title=version.name,
                         error_type="dependency",
                         message=(
@@ -264,11 +173,7 @@ class SkillAdapter(DirectoryManifestAdapter):
             except ValueError as e:
                 diagnostics.append(
                     PullDiagnostic(
-                        workflow_path=self._version_file_source_path(
-                            source_id,
-                            version.version_number,
-                            file_spec.path,
-                        ),
+                        workflow_path=self._file_source_path(source_id, file_spec.path),
                         workflow_title=version.name,
                         error_type="validation",
                         message=(
@@ -288,11 +193,7 @@ class SkillAdapter(DirectoryManifestAdapter):
             if actual_hash != file_spec.sha256:
                 diagnostics.append(
                     PullDiagnostic(
-                        workflow_path=self._version_file_source_path(
-                            source_id,
-                            version.version_number,
-                            file_spec.path,
-                        ),
+                        workflow_path=self._file_source_path(source_id, file_spec.path),
                         workflow_title=version.name,
                         error_type="validation",
                         message=(
@@ -312,17 +213,10 @@ class SkillAdapter(DirectoryManifestAdapter):
     async def project(
         self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
-        """Project skills and the version snapshots needed to preserve pins."""
+        """Project each Skill's current desired head content."""
         stmt = self._projection_stmt(workspace_service)
         skills = list((await workspace_service.session.execute(stmt)).scalars().all())
-        versions_by_skill_id = await self._exported_bound_versions_by_skill(
-            workspace_service
-        )
-        return await self._projection_from_skills(
-            workspace_service,
-            skills,
-            versions_by_skill_id=versions_by_skill_id,
-        )
+        return await self._projection_from_skills(workspace_service, skills)
 
     async def project_dependency_refs(
         self,
@@ -355,19 +249,7 @@ class SkillAdapter(DirectoryManifestAdapter):
         else:
             stmt = stmt.where(Skill.name.in_(slugs))
         skills = list((await workspace_service.session.execute(stmt)).scalars().all())
-        versions_by_slug: dict[str, set[int]] = defaultdict(set)
-        for slug, version in refs.versioned_slugs:
-            versions_by_slug[slug].add(version)
-        versions_by_skill_id = {
-            skill.id: versions_by_slug[skill.name]
-            for skill in skills
-            if skill.name in versions_by_slug
-        }
-        return await self._projection_from_skills(
-            workspace_service,
-            skills,
-            versions_by_skill_id=versions_by_skill_id,
-        )
+        return await self._projection_from_skills(workspace_service, skills)
 
     def _projection_stmt(
         self, workspace_service: SyncMappingService
@@ -390,85 +272,34 @@ class SkillAdapter(DirectoryManifestAdapter):
         self,
         workspace_service: SyncMappingService,
         skills: list[Skill],
-        versions_by_skill_id: Mapping[uuid.UUID, set[int]] | None = None,
     ) -> ResourceProjection:
-        """Build sync specs from eager-loaded skill rows."""
+        """Build one desired head spec from each current Skill version."""
         assigner = await self.source_id_assigner(workspace_service)
         specs: dict[str, BaseModel] = {}
         resources: list[ProjectedResource] = []
         for skill in skills:
             source_id = assigner.assign(skill.id, skill.name)
-            # Keep the top-level manifest as metadata only, then emit immutable
-            # file snapshots below ``versions/`` for current and pinned versions.
             version = skill.current_version
-            version_numbers = set((versions_by_skill_id or {}).get(skill.id, set()))
+            desired = None
             if version is not None:
-                version_numbers.add(version.version)
-            versions = await self._version_specs_for_skill(
-                workspace_service,
-                skill=skill,
-                version_numbers=version_numbers,
-            )
+                desired = (
+                    await self._version_specs_for_skill(
+                        workspace_service,
+                        skill=skill,
+                        version_numbers={version.version},
+                    )
+                )[version.version]
 
             specs[source_id] = SkillResourceSpec(
                 id=source_id,
                 slug=skill.name,
                 name=version.name if version is not None else skill.name,
-                current_version=version.version if version is not None else None,
                 description=skill.description,
-                versions=versions,
+                files=desired.files if desired is not None else [],
+                file_contents=(desired.file_contents if desired is not None else {}),
             )
             resources.append(self.projected_resource(source_id, skill.id))
         return ResourceProjection(specs=specs, resources=resources)
-
-    async def _exported_bound_versions_by_skill(
-        self,
-        workspace_service: SyncMappingService,
-    ) -> dict[uuid.UUID, set[int]]:
-        """Return skill versions bound by exported agent preset state."""
-        # Soft-deleted presets keep their skill bindings but are excluded from the
-        # preset projection, so their pins must not keep versions exported.
-        head_stmt = (
-            select(SkillVersion.skill_id, SkillVersion.version)
-            .join(
-                AgentPresetSkill,
-                AgentPresetSkill.skill_version_id == SkillVersion.id,
-            )
-            .join(
-                AgentPreset,
-                AgentPresetSkill.preset_id == AgentPreset.id,
-            )
-            .where(
-                AgentPresetSkill.workspace_id == workspace_service.workspace_id,
-                AgentPreset.workspace_id == workspace_service.workspace_id,
-                AgentPreset.deleted_at.is_(None),
-            )
-        )
-        current_version_stmt = (
-            select(SkillVersion.skill_id, SkillVersion.version)
-            .select_from(AgentPresetVersionSkill)
-            .join(
-                AgentPreset,
-                AgentPreset.current_version_id
-                == AgentPresetVersionSkill.preset_version_id,
-            )
-            .join(
-                SkillVersion,
-                AgentPresetVersionSkill.skill_version_id == SkillVersion.id,
-            )
-            .where(
-                AgentPresetVersionSkill.workspace_id == workspace_service.workspace_id,
-                AgentPreset.workspace_id == workspace_service.workspace_id,
-                AgentPreset.deleted_at.is_(None),
-            )
-        )
-        versions_by_skill_id: dict[uuid.UUID, set[int]] = defaultdict(set)
-        for stmt in (head_stmt, current_version_stmt):
-            for skill_id, version_number in (
-                await workspace_service.session.execute(stmt)
-            ).tuples():
-                versions_by_skill_id[skill_id].add(version_number)
-        return versions_by_skill_id
 
     async def _version_specs_for_skill(
         self,
@@ -602,48 +433,100 @@ class SkillAdapter(DirectoryManifestAdapter):
                 skill.name = spec.slug
                 skill.description = getattr(spec, "description", None)
 
-            version_specs = dict(spec.versions)
-            if (
-                spec.current_version is not None
-                and spec.current_version not in version_specs
-            ):
-                raise TracecatValidationError(
-                    f"Skill {spec.slug!r} current version {spec.current_version} "
-                    "is missing from the version snapshots."
+            desired = SkillVersionResourceSpec(
+                version_number=1,
+                name=spec.name,
+                description=spec.description,
+                files=spec.files,
+                file_contents=spec.file_contents,
+            )
+            current = None
+            if skill.current_version_id is not None:
+                current = await workspace_service.session.scalar(
+                    select(SkillVersion).where(
+                        SkillVersion.workspace_id == workspace_service.workspace_id,
+                        SkillVersion.skill_id == skill.id,
+                        SkillVersion.id == skill.current_version_id,
+                    )
                 )
-
-            imported_versions: dict[int, SkillVersion] = {}
-            imported_version_file_refs: dict[int, dict[str, SkillFileBlobRef]] = {}
-            for version_number, version_spec in sorted(version_specs.items()):
-                imported_version, file_refs = await self._upsert_skill_version(
+            if current is None or not await self._version_matches_desired(
+                workspace_service,
+                skill_service,
+                current=current,
+                desired=desired,
+            ):
+                max_version = await workspace_service.session.scalar(
+                    select(sa.func.max(SkillVersion.version)).where(
+                        SkillVersion.workspace_id == workspace_service.workspace_id,
+                        SkillVersion.skill_id == skill.id,
+                    )
+                )
+                current, file_refs = await self._upsert_skill_version(
                     workspace_service,
                     skill_service,
                     skill=skill,
-                    version=version_spec,
+                    version=desired.model_copy(
+                        update={"version_number": (max_version or 0) + 1}
+                    ),
                 )
-                imported_versions[version_number] = imported_version
-                imported_version_file_refs[version_number] = file_refs
-
-            if spec.current_version is not None:
-                if current := imported_versions.get(spec.current_version):
-                    skill.current_version_id = current.id
-                    await skill_service._replace_draft_with_blob_map(
-                        skill=skill,
-                        path_to_blob=imported_version_file_refs[spec.current_version],
-                    )
             else:
-                # Git says the skill is unversioned: drop any stale head pin so an
-                # existing skill stops pointing at a version it no longer declares,
-                # and clear draft files copied from the previously pinned version.
-                skill.current_version_id = None
-                await skill_service._replace_draft_with_blob_map(
-                    skill=skill,
-                    path_to_blob={},
+                file_refs = await self._file_refs_for_version(
+                    workspace_service,
+                    current.id,
                 )
+            skill.current_version_id = current.id
+            await skill_service._replace_draft_with_blob_map(
+                skill=skill,
+                path_to_blob=file_refs,
+            )
             workspace_service.session.add(skill)
             await workspace_service.session.flush()
             imported.append(self.imported_resource(source_id, skill.id))
         return imported
+
+    async def _version_matches_desired(
+        self,
+        workspace_service: SyncMappingService,
+        skill_service: SkillService,
+        *,
+        current: SkillVersion,
+        desired: SkillVersionResourceSpec,
+    ) -> bool:
+        """Return whether the current immutable version matches desired Git state."""
+
+        if current.name != desired.name or current.description != desired.description:
+            return False
+        rows = await self._skill_version_rows(workspace_service, current.id)
+        current_files = [
+            (version_file.path, blob_row.sha256, version_file.content_type)
+            for version_file, blob_row in rows
+        ]
+        desired_files = [
+            (
+                file.path,
+                file.sha256,
+                skill_service._guess_content_type(file.path),
+            )
+            for file in sorted(desired.files, key=lambda item: item.path)
+        ]
+        return current_files == desired_files
+
+    async def _file_refs_for_version(
+        self,
+        workspace_service: SyncMappingService,
+        version_id: uuid.UUID,
+    ) -> dict[str, SkillFileBlobRef]:
+        """Load immutable file refs for resetting the mutable draft shadow."""
+
+        return {
+            version_file.path: SkillFileBlobRef(
+                blob=blob_row,
+                content_type=version_file.content_type,
+            )
+            for version_file, blob_row in await self._skill_version_rows(
+                workspace_service, version_id
+            )
+        }
 
     async def _upsert_skill_version(
         self,
@@ -792,89 +675,6 @@ class SkillAdapter(DirectoryManifestAdapter):
             model=Skill,
             row_predicates=(Skill.deleted_at.is_(None), Skill.archived_at.is_(None)),
         )
-
-
-def _parse_skill_version_relpath(relpath: str) -> tuple[int, str, str | None] | None:
-    """Parse ``versions/<n>/...`` relpaths for skill companion files."""
-    parts = path_parts(relpath)
-    if len(parts) < 3 or parts[0] != SKILL_VERSIONS_DIR:
-        return None
-    try:
-        version_number = int(parts[1])
-    except ValueError:
-        return None
-    if version_number < 1:
-        return None
-    if len(parts) == 3 and parts[2] == SKILL_VERSION_FILENAME:
-        return version_number, "manifest", None
-    if len(parts) >= 4 and parts[2] == SKILL_FILES_DIR:
-        file_path = "/".join(parts[3:])
-        return (version_number, "file", file_path) if file_path else None
-    return None
-
-
-def _parse_skill_version_manifest(
-    adapter: SkillAdapter,
-    *,
-    source_id: str,
-    version_number: int,
-    content: str,
-    diagnostics: list[PullDiagnostic],
-) -> SkillVersionResourceSpec | None:
-    """Parse one skill version manifest or append a diagnostic."""
-    path = adapter._version_manifest_path(source_id, version_number)
-    try:
-        raw = yaml.safe_load(content)
-        if not isinstance(raw, dict) or not raw:
-            diagnostics.append(
-                PullDiagnostic(
-                    workflow_path=path,
-                    workflow_title=None,
-                    error_type="parse",
-                    message="Empty or invalid skill version YAML file",
-                    details={},
-                )
-            )
-            return None
-        version = SkillVersionResourceSpec.model_validate(raw)
-        if version.version_number != version_number:
-            diagnostics.append(
-                PullDiagnostic(
-                    workflow_path=path,
-                    workflow_title=version.name,
-                    error_type="validation",
-                    message="Skill version number does not match its repository path",
-                    details={
-                        "path_version": version_number,
-                        "spec_version": version.version_number,
-                    },
-                )
-            )
-            return None
-        return version
-    except yaml.YAMLError as e:
-        diagnostics.append(
-            PullDiagnostic(
-                workflow_path=path,
-                workflow_title=None,
-                error_type="parse",
-                message=f"YAML parsing error: {str(e)}",
-                details={"yaml_error": str(e)},
-            )
-        )
-    except ValidationError as e:
-        diagnostics.append(
-            PullDiagnostic(
-                workflow_path=path,
-                workflow_title=None,
-                error_type="validation",
-                message=f"Validation error: {str(e)}",
-                details={
-                    "validation_errors": serializable_validation_errors(e.errors())
-                },
-            )
-        )
-    return None
 
 
 def _skill_file_content_for_git(content: bytes) -> tuple[str, Literal["base64"] | None]:

--- a/tracecat/workspace_sync/resources.py
+++ b/tracecat/workspace_sync/resources.py
@@ -182,7 +182,7 @@ def validate_workspace_dependencies(spec: WorkspaceSpec) -> list[PullDiagnostic]
                         },
                     )
                 )
-        for preset_slug, preset_version in sorted(references.versioned_preset_slugs):
+        for preset_slug, _ in sorted(references.versioned_preset_slugs):
             if preset_slug not in preset_slugs:
                 diagnostics.append(
                     PullDiagnostic(
@@ -197,35 +197,11 @@ def validate_workspace_dependencies(spec: WorkspaceSpec) -> list[PullDiagnostic]
                     )
                 )
                 continue
-            if preset_version not in _preset_available_versions(
-                preset_specs_by_slug[preset_slug]
-            ):
-                diagnostics.append(
-                    PullDiagnostic(
-                        workflow_path=WORKFLOW_RESOURCE_ADAPTER.source_path(source_id),
-                        workflow_title=workflow.definition.title,
-                        error_type="dependency",
-                        message=(
-                            "Workflow references missing agent preset version "
-                            f"{preset_slug!r}@{preset_version}"
-                        ),
-                        details={
-                            "workflow_source_id": source_id,
-                            "preset_slug": preset_slug,
-                            "preset_version": preset_version,
-                        },
-                    )
-                )
 
     preset_graph: dict[str, list[str]] = {}
     for source_id, preset in sorted(spec.agent_presets.items()):
-        subagent_refs = []
-        skill_refs = []
-        for version in preset.versions.values():
-            subagent_refs.extend(version.subagents)
-            skill_refs.extend(version.skills)
-        preset_graph[preset.slug] = [subagent.slug for subagent in subagent_refs]
-        for skill in skill_refs:
+        preset_graph[preset.slug] = [subagent.slug for subagent in preset.subagents]
+        for skill in preset.skills:
             if skill.slug not in skill_slugs:
                 diagnostics.append(
                     PullDiagnostic(
@@ -238,30 +214,7 @@ def validate_workspace_dependencies(spec: WorkspaceSpec) -> list[PullDiagnostic]
                         details={"preset_slug": preset.slug, "skill_slug": skill.slug},
                     )
                 )
-                continue
-            available_versions = _skill_available_versions(
-                skill_specs_by_slug[skill.slug]
-            )
-            if skill.version is not None and skill.version not in available_versions:
-                diagnostics.append(
-                    PullDiagnostic(
-                        workflow_path=AGENT_PRESET_RESOURCE_ADAPTER.source_path(
-                            source_id
-                        ),
-                        workflow_title=preset.name,
-                        error_type="dependency",
-                        message=(
-                            "Agent preset references missing skill version "
-                            f"{skill.slug!r}@{skill.version}"
-                        ),
-                        details={
-                            "preset_slug": preset.slug,
-                            "skill_slug": skill.slug,
-                            "skill_version": skill.version,
-                        },
-                    )
-                )
-        for subagent in subagent_refs:
+        for subagent in preset.subagents:
             if subagent.slug not in preset_slugs:
                 diagnostics.append(
                     PullDiagnostic(
@@ -274,28 +227,6 @@ def validate_workspace_dependencies(spec: WorkspaceSpec) -> list[PullDiagnostic]
                         details={
                             "preset_slug": preset.slug,
                             "subagent_slug": subagent.slug,
-                        },
-                    )
-                )
-                continue
-            if subagent.version is not None and subagent.version not in (
-                _preset_available_versions(preset_specs_by_slug[subagent.slug])
-            ):
-                diagnostics.append(
-                    PullDiagnostic(
-                        workflow_path=AGENT_PRESET_RESOURCE_ADAPTER.source_path(
-                            source_id
-                        ),
-                        workflow_title=preset.name,
-                        error_type="dependency",
-                        message=(
-                            "Agent preset references missing subagent version "
-                            f"{subagent.slug!r}@{subagent.version}"
-                        ),
-                        details={
-                            "preset_slug": preset.slug,
-                            "subagent_slug": subagent.slug,
-                            "subagent_version": subagent.version,
                         },
                     )
                 )
@@ -404,16 +335,6 @@ def workflow_references(definition: DSLInput) -> WorkflowReferences:
         preset_slugs,
         versioned_preset_slugs,
     )
-
-
-def _skill_available_versions(skill: Any) -> set[int]:
-    """Return skill versions represented by the parsed spec."""
-    return set(skill.versions)
-
-
-def _preset_available_versions(preset: Any) -> set[int]:
-    """Return agent preset versions represented by the parsed spec."""
-    return set(preset.versions)
 
 
 def _parse_yaml_resource[ModelT: BaseModel](

--- a/tracecat/workspace_sync/schemas.py
+++ b/tracecat/workspace_sync/schemas.py
@@ -176,30 +176,20 @@ class WorkflowResourceSpec(BaseModel):
 
 
 class AgentPresetSkillBinding(BaseModel):
-    """Reference from an agent preset to a skill, optionally version-pinned."""
+    """Portable head-to-head reference from an agent preset to a skill."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     slug: str = Field(min_length=1, description="Slug of the referenced skill.")
-    version: int | None = Field(
-        default=None,
-        ge=1,
-        description="Pinned skill version, or ``None`` to track the latest.",
-    )
 
 
 class AgentPresetSubagentRef(BaseModel):
     """Reference from an agent preset to another preset used as a subagent."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     slug: str = Field(
         min_length=1, description="Slug of the preset used as a subagent."
-    )
-    version: int | None = Field(
-        default=None,
-        ge=1,
-        description="Pinned child preset version, or ``None`` to track the latest.",
     )
     name: str | None = Field(
         default=None, description="Optional runtime alias for the subagent."
@@ -229,7 +219,7 @@ class McpIntegrationHint(BaseModel):
 
 
 class AgentPresetVersionResourceSpec(BaseModel):
-    """Immutable agent preset snapshot stored under a preset's versions dir."""
+    """Internal config shape used while projecting a preset head."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -345,96 +335,93 @@ class AgentPresetResourceSpec(BaseModel):
         min_length=1, description="Unique preset slug used for cross-references."
     )
     name: str = Field(min_length=1, description="Human-readable preset name.")
-    current_version: int | None = Field(
-        default=None,
-        ge=1,
-        description="Current preset version, or ``None`` if unpublished.",
-    )
     folder_path: str | None = Field(
         default=None, description="Workspace folder the preset lives under, if any."
     )
     tags: list[str] = Field(default_factory=list, description="Free-form preset tags.")
     instructions: str | None = Field(
         default=None,
-        exclude=True,
         description="System prompt / instructions for the agent.",
     )
     tool_approvals: dict[str, Any] = Field(
         default_factory=dict,
-        exclude=True,
         description="Per-tool approval policy keyed by tool name.",
     )
     actions: list[str] = Field(
         default_factory=list,
-        exclude=True,
         description="Registry action names the agent may call.",
     )
     skills: list[AgentPresetSkillBinding] = Field(
         default_factory=list,
-        exclude=True,
-        description="Skills bound to the preset, optionally version-pinned.",
+        description="Skill heads bound to this preset head.",
     )
     subagents: list[AgentPresetSubagentRef] = Field(
         default_factory=list,
-        exclude=True,
-        description="Other presets invoked as subagents.",
+        description="Preset heads invoked as subagents.",
     )
     catalog_id: uuid.UUID | None = Field(
         default=None,
-        exclude=True,
         description="Source model catalog entry id, if model is catalog-backed.",
     )
     model_name: str | None = Field(
         default=None,
-        exclude=True,
         description="Override model name, or ``None`` to inherit defaults.",
     )
     model_provider: str | None = Field(
         default=None,
-        exclude=True,
         description="Override model provider, or ``None`` to inherit defaults.",
     )
     base_url: str | None = Field(
         default=None,
-        exclude=True,
         description="Override provider base URL, if any.",
     )
     output_type: Any | None = Field(
         default=None,
-        exclude=True,
         description="Structured output schema, if the agent returns structured data.",
     )
     namespaces: list[str] = Field(
         default_factory=list,
-        exclude=True,
         description="Registry namespaces the agent's tools are drawn from.",
     )
     mcp_integrations: list[str] = Field(
         default_factory=list,
-        exclude=True,
-        description="MCP integration slugs available to the agent.",
+        description="Source MCP integration ids available to the agent.",
+    )
+    mcp_integration_hints: dict[uuid.UUID, McpIntegrationHint] = Field(
+        default_factory=dict,
+        exclude_if=lambda value: not value,
+        description="Portable identity hints keyed by source MCP integration id.",
     )
     retries: int = Field(
         default=3,
         ge=0,
-        exclude=True,
         description="Maximum agent run retries.",
     )
     enable_thinking: bool = Field(
         default=True,
-        exclude=True,
         description="Whether extended thinking is enabled.",
     )
     enable_internet_access: bool = Field(
         default=False,
-        exclude=True,
         description="Whether the agent may access the internet.",
     )
-    versions: dict[int, AgentPresetVersionResourceSpec] = Field(
-        default_factory=dict,
-        exclude=True,
-        description="In-memory preset version snapshots keyed by version number.",
-    )
+
+    @model_validator(mode="after")
+    def validate_mcp_integration_hints(self) -> AgentPresetResourceSpec:
+        """Reject hints that do not describe an integration in this head."""
+        integration_ids: set[uuid.UUID] = set()
+        for integration in self.mcp_integrations:
+            try:
+                integration_ids.add(uuid.UUID(integration))
+            except ValueError:
+                continue
+        if stale_ids := set(self.mcp_integration_hints) - integration_ids:
+            formatted_ids = ", ".join(str(source_id) for source_id in sorted(stale_ids))
+            raise ValueError(
+                "MCP integration hints must reference ids in mcp_integrations: "
+                f"{formatted_ids}"
+            )
+        return self
 
 
 class SkillFileSpec(BaseModel):
@@ -455,7 +442,7 @@ class SkillFileSpec(BaseModel):
 
 
 class SkillVersionResourceSpec(BaseModel):
-    """Immutable skill snapshot stored under a skill's versions dir."""
+    """Internal config shape used while projecting a skill head."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -501,11 +488,6 @@ class SkillResourceSpec(BaseModel):
     description: str | None = Field(
         default=None, description="Optional skill description."
     )
-    current_version: int | None = Field(
-        default=None,
-        ge=1,
-        description="Published skill version, or ``None`` if unversioned.",
-    )
     files: list[SkillFileSpec] = Field(
         default_factory=list,
         description="Manifest of the skill's files and their content hashes.",
@@ -514,11 +496,6 @@ class SkillResourceSpec(BaseModel):
         default_factory=dict,
         exclude=True,
         description="In-memory file contents keyed by path; excluded from serialization.",
-    )
-    versions: dict[int, SkillVersionResourceSpec] = Field(
-        default_factory=dict,
-        exclude=True,
-        description="In-memory skill version snapshots keyed by version number.",
     )
 
 

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -57,7 +57,6 @@ from tracecat.workspace_sync.adapters import (
     CASE_TAG_RESOURCE_ADAPTER,
     NON_WORKFLOW_RESOURCE_ADAPTERS,
     RESOURCE_ADAPTERS_BY_TYPE,
-    SKILL_RESOURCE_ADAPTER,
     WORKFLOW_RESOURCE_ADAPTER,
     WORKSPACE_RESOURCE_ADAPTERS,
     ResourceAdapter,
@@ -67,7 +66,6 @@ from tracecat.workspace_sync.adapters.base import (
     DirectoryManifestAdapter,
     ResourceDependencyRefs,
     SyncMappingService,
-    VersionedSlug,
 )
 from tracecat.workspace_sync.enums import SyncResourceType, VcsProvider
 from tracecat.workspace_sync.importer import (
@@ -90,9 +88,7 @@ from tracecat.workspace_sync.schemas import (
     AgentPresetResourceSpec,
     AgentPresetSkillBinding,
     AgentPresetSubagentRef,
-    AgentPresetVersionResourceSpec,
     ResourceRef,
-    SkillResourceSpec,
     WorkflowResourceSpec,
     WorkspaceManifest,
     WorkspaceManifestResources,
@@ -1421,15 +1417,11 @@ class WorkspaceSyncService(SyncMappingService):
     ) -> WorkspaceResourceProjection:
         """Project non-workflow resources reached by the export dependency graph."""
         if full_workspace_export:
-            projection = await WorkspaceResourceProjector(
+            return await WorkspaceResourceProjector(
                 session=self.session,
                 role=self.role,
                 mapping_provider=self._mapping_provider,
             ).project_non_workflow_resources(resource_types=entitled_resource_types)
-            return await self._augment_full_workspace_version_closure(
-                projection,
-                workflow_specs=workflow_specs,
-            )
 
         specs_by_attr: dict[str, dict[str, BaseModel]] = {
             adapter.spec_attr: {} for adapter in NON_WORKFLOW_RESOURCE_ADAPTERS
@@ -1510,39 +1502,6 @@ class WorkspaceSyncService(SyncMappingService):
                 if resource := resources_by_source_id.get(source_id):
                     resources_by_key[key] = resource
                 if key in seen:
-                    existing = specs_by_attr[adapter.spec_attr].get(source_id)
-                    if (
-                        resource_type == SyncResourceType.AGENT_PRESET
-                        and existing is not None
-                    ):
-                        incoming_preset = cast(AgentPresetResourceSpec, spec)
-                        existing_preset = cast(AgentPresetResourceSpec, existing)
-                        missing_versions = _missing_agent_preset_versions(
-                            existing_preset, incoming_preset
-                        )
-                        if missing_versions:
-                            specs_by_attr[adapter.spec_attr][source_id] = (
-                                _merge_agent_preset_versions(
-                                    existing_preset, incoming_preset
-                                )
-                            )
-                            new_presets.append(
-                                _agent_preset_version_scan_spec(
-                                    incoming_preset, missing_versions
-                                )
-                            )
-                    elif (
-                        resource_type == SyncResourceType.SKILL and existing is not None
-                    ):
-                        incoming_skill = cast(SkillResourceSpec, spec)
-                        existing_skill = cast(SkillResourceSpec, existing)
-                        if any(
-                            version_number not in existing_skill.versions
-                            for version_number in incoming_skill.versions
-                        ):
-                            specs_by_attr[adapter.spec_attr][source_id] = (
-                                _merge_skill_versions(existing_skill, incoming_skill)
-                            )
                     continue
                 seen.add(key)
                 specs_by_attr[adapter.spec_attr][source_id] = spec
@@ -1561,13 +1520,6 @@ class WorkspaceSyncService(SyncMappingService):
                         subagent.slug
                         for preset in new_presets
                         for subagent in _agent_preset_subagent_refs(preset)
-                        if subagent.version is None
-                    },
-                    versioned_slugs={
-                        VersionedSlug(subagent.slug, subagent.version)
-                        for preset in new_presets
-                        for subagent in _agent_preset_subagent_refs(preset)
-                        if subagent.version is not None
                     },
                 ),
             )
@@ -1578,148 +1530,13 @@ class WorkspaceSyncService(SyncMappingService):
                         binding.slug
                         for preset in new_presets
                         for binding in _agent_preset_skill_refs(preset)
-                        if binding.version is None
-                    },
-                    versioned_slugs={
-                        VersionedSlug(binding.slug, binding.version)
-                        for preset in new_presets
-                        for binding in _agent_preset_skill_refs(preset)
-                        if binding.version is not None
                     },
                 ),
             )
             self._enqueue_payload_dependency_refs(
                 queue,
-                [
-                    payload
-                    for preset in new_presets
-                    for payload in (preset, *preset.versions.values())
-                ],
+                list(new_presets),
             )
-
-        return WorkspaceResourceProjection(
-            spec=workspace_spec_from_maps(specs_by_attr),
-            resources=[
-                resources_by_key[key]
-                for key in sorted(
-                    resources_by_key,
-                    key=lambda item: (item[0].value, item[1]),
-                )
-            ],
-        )
-
-    async def _augment_full_workspace_version_closure(
-        self,
-        projection: WorkspaceResourceProjection,
-        *,
-        workflow_specs: dict[str, WorkflowResourceSpec],
-    ) -> WorkspaceResourceProjection:
-        """Add workflow-pinned preset/skill versions to a full-workspace export.
-
-        A full export already includes every live resource, but versioned
-        workflow refs can point at non-current preset versions. Pull those
-        exact preset versions into the projected specs, then pull the exact
-        skill versions those preset snapshots bind.
-        """
-        projected_presets = list(projection.spec.agent_presets.values())
-        pending_preset_refs = deque(
-            sorted(
-                {
-                    ref
-                    for workflow in workflow_specs.values()
-                    for ref in workflow_references(
-                        workflow.definition
-                    ).versioned_preset_slugs
-                }
-                | {
-                    VersionedSlug(subagent.slug, subagent.version)
-                    for preset in projected_presets
-                    for subagent in _agent_preset_subagent_refs(preset)
-                    if subagent.version is not None
-                }
-            )
-        )
-        skill_refs: set[VersionedSlug] = {
-            VersionedSlug(binding.slug, binding.version)
-            for preset in projected_presets
-            for binding in _agent_preset_skill_refs(preset)
-            if binding.version is not None
-        }
-        if not pending_preset_refs and not skill_refs:
-            return projection
-
-        specs_by_attr: dict[str, dict[str, BaseModel]] = {
-            adapter.spec_attr: dict(adapter.specs(projection.spec))
-            for adapter in NON_WORKFLOW_RESOURCE_ADAPTERS
-        }
-        resources_by_key = {
-            (resource.resource_type, resource.source_id): resource
-            for resource in projection.resources
-        }
-        seen_preset_refs: set[VersionedSlug] = set()
-
-        while pending_preset_refs:
-            batch: set[VersionedSlug] = set()
-            while pending_preset_refs:
-                ref = pending_preset_refs.popleft()
-                if ref in seen_preset_refs:
-                    continue
-                seen_preset_refs.add(ref)
-                batch.add(ref)
-            if not batch:
-                continue
-
-            preset_projection = (
-                await AGENT_PRESET_RESOURCE_ADAPTER.project_dependency_refs(
-                    self,
-                    ResourceDependencyRefs(versioned_slugs=batch),
-                )
-            )
-            for resource in preset_projection.resources:
-                resources_by_key[(resource.resource_type, resource.source_id)] = (
-                    resource
-                )
-
-            for source_id, projected_spec in preset_projection.specs.items():
-                incoming = cast(AgentPresetResourceSpec, projected_spec)
-                existing = cast(
-                    AgentPresetResourceSpec | None,
-                    specs_by_attr[AGENT_PRESET_RESOURCE_ADAPTER.spec_attr].get(
-                        source_id
-                    ),
-                )
-                merged = _merge_agent_preset_versions(existing, incoming)
-                specs_by_attr[AGENT_PRESET_RESOURCE_ADAPTER.spec_attr][source_id] = (
-                    merged
-                )
-
-                for version in incoming.versions.values():
-                    for subagent in version.subagents:
-                        if subagent.version is not None:
-                            pending_preset_refs.append(
-                                VersionedSlug(subagent.slug, subagent.version)
-                            )
-                    for binding in version.skills:
-                        if binding.version is not None:
-                            skill_refs.add(VersionedSlug(binding.slug, binding.version))
-
-        if skill_refs:
-            skill_projection = await SKILL_RESOURCE_ADAPTER.project_dependency_refs(
-                self,
-                ResourceDependencyRefs(versioned_slugs=skill_refs),
-            )
-            for resource in skill_projection.resources:
-                resources_by_key[(resource.resource_type, resource.source_id)] = (
-                    resource
-                )
-            for source_id, projected_spec in skill_projection.specs.items():
-                incoming = cast(SkillResourceSpec, projected_spec)
-                existing = cast(
-                    SkillResourceSpec | None,
-                    specs_by_attr[SKILL_RESOURCE_ADAPTER.spec_attr].get(source_id),
-                )
-                merged = _merge_skill_versions(existing, incoming)
-                specs_by_attr[SKILL_RESOURCE_ADAPTER.spec_attr][source_id] = merged
 
         return WorkspaceResourceProjection(
             spec=workspace_spec_from_maps(specs_by_attr),
@@ -2165,69 +1982,15 @@ def _has_dependency_refs(refs: ResourceDependencyRefs) -> bool:
 def _agent_preset_skill_refs(
     preset: AgentPresetResourceSpec,
 ) -> list[AgentPresetSkillBinding]:
-    """Return skill refs from the head preset and any projected versions."""
-    refs = list(preset.skills)
-    for version in preset.versions.values():
-        refs.extend(version.skills)
-    return refs
+    """Return skill-head refs from a preset's desired head topology."""
+    return list(preset.skills)
 
 
 def _agent_preset_subagent_refs(
     preset: AgentPresetResourceSpec,
 ) -> list[AgentPresetSubagentRef]:
-    """Return subagent refs from the head preset and any projected versions."""
-    refs = list(preset.subagents)
-    for version in preset.versions.values():
-        refs.extend(version.subagents)
-    return refs
-
-
-def _merge_agent_preset_versions(
-    existing: AgentPresetResourceSpec | None,
-    incoming: AgentPresetResourceSpec,
-) -> AgentPresetResourceSpec:
-    """Return ``existing`` with any incoming preset versions added."""
-    if existing is None:
-        return incoming
-    versions = {**existing.versions, **incoming.versions}
-    return existing.model_copy(update={"versions": versions})
-
-
-def _missing_agent_preset_versions(
-    existing: AgentPresetResourceSpec,
-    incoming: AgentPresetResourceSpec,
-) -> dict[int, AgentPresetVersionResourceSpec]:
-    """Return preset versions carried only by ``incoming``."""
-    return {
-        version_number: version
-        for version_number, version in incoming.versions.items()
-        if version_number not in existing.versions
-    }
-
-
-def _agent_preset_version_scan_spec(
-    preset: AgentPresetResourceSpec,
-    versions: Mapping[int, AgentPresetVersionResourceSpec],
-) -> AgentPresetResourceSpec:
-    """Build a synthetic spec for scanning newly merged version payloads."""
-    return preset.model_copy(
-        update={
-            "skills": [],
-            "subagents": [],
-            "versions": dict(versions),
-        }
-    )
-
-
-def _merge_skill_versions(
-    existing: SkillResourceSpec | None,
-    incoming: SkillResourceSpec,
-) -> SkillResourceSpec:
-    """Return ``existing`` with any incoming skill versions added."""
-    if existing is None:
-        return incoming
-    versions = {**existing.versions, **incoming.versions}
-    return existing.model_copy(update={"versions": versions})
+    """Return child-head refs from a preset's desired head topology."""
+    return list(preset.subagents)
 
 
 def _preview_resources_from_spec(


### PR DESCRIPTION
## Outcome

Preset dependency topology is owned exclusively by ResourceHeads. Immutable ResourceVersions remain append-only value snapshots and never define cross-resource topology.

This is the clean replacement implementation for ENG-1530 and supersedes the previous topology/runtime stack. The old branches are intentionally left untouched.

## Architecture

- Add canonical head-to-head preset-to-subagent and preset-to-Skill edges.
- Resolve current root, Skill, and subagent heads at the start of every `DurableAgentWorkflow` turn.
- Freeze the resulting exact version IDs and `ResolvedAgentsRuntimeConfig` in Temporal history for that turn; the next turn resolves again.
- Soft-delete referenced heads and unlink incoming topology after user confirmation. Already-compiled turns retain their frozen runtime configuration.
- Keep legacy topology fields for rollback and minimally dual-write them, but never dual-read them.
- Remove `subagents_enabled`; availability is derived from attached head edges.

## Workspace Sync

- Export desired head content only, not local version history.
- Pull mints new local versions and advances heads.
- Applying an older Git commit is rollback by roll-forward.
- Portable dependency references use head slugs and resolve to stable local head IDs during import.

## Migration and deployment

The atomic SQL migration converts legacy Version-to-Head relationships into canonical Head-to-Head topology while retaining legacy fields for rollback. It fails the migration on unresolved, cross-workspace, or duplicate edges.

**Deployment requirement:** drain old topology writers before running the migration, or explicitly lock the affected tables. A transaction alone does not prevent stale writers from racing the migration snapshot.

## Supersession

- Supersedes #3017, #3006, #3008, and the previous #3038 implementation.
- #3025 / ENG-1532 remains separate Skill-slug work.
- #3007 queryable DB provenance is intentionally excluded; Temporal history is the durable execution record. It can be revived independently if an audit-query use case appears.

Linear: [ENG-1530](https://linear.app/tracecat/issue/ENG-1530/refactoragents-replace-resource-pins-with-workspace-deployments)

## Verification

- Migration upgrade/downgrade and validation matrix
- Focused AgentPreset, Skill, session, runtime, API, and Workspace Sync tests
- Temporal workflow tests, including per-turn resolution and replay behavior
- Generated frontend client parity
- Ruff check and format
- BasedPyright
- Frontend Biome and TypeScript checks
- Repository pre-commit suite
- SQLFluff PostgreSQL parsing for revision-scoped migration assets

## LOC breakdown

| Category | + | - |
|---|---:|---:|
| Logic | 1,099 | 2,377 |
| Tests | 1,146 | 841 |
| Database migration | 332 | 0 |
| Generated | 98 | 164 |
| Infra/config | 7 | 0 |
