### PR TITLE
fix(integrations): calculate initial OAuth token expiry in UTC

### DIFF
--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -252,6 +252,37 @@ class TestIntegrationService:
         assert retrieved.provider_id == provider_key.id
         assert retrieved.grant_type == provider_key.grant_type
 
+    async def test_store_integration_expires_at_is_utc_aware(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Test that expires_at is calculated in UTC, not naive local time.
+
+        Regression test for #3202: datetime.now() without UTC caused tokens
+        to be instantly expired on non-UTC servers.
+        """
+        provider_key = ProviderKey(
+            id="test_utc_expiry",
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        )
+        expires_in = 3600  # 1 hour
+
+        before = datetime.now(UTC)
+        integration = await integration_service.store_integration(
+            provider_key=provider_key,
+            access_token=SecretStr("test_token"),
+            expires_in=expires_in,
+        )
+        after = datetime.now(UTC)
+
+        assert integration.expires_at is not None
+        # expires_at must be timezone-aware (not naive)
+        assert integration.expires_at.tzinfo is not None
+        # expires_at should be approximately now + expires_in
+        expected_min = before + timedelta(seconds=expires_in)
+        expected_max = after + timedelta(seconds=expires_in)
+        assert expected_min <= integration.expires_at <= expected_max
+
     async def test_update_existing_integration(
         self,
         integration_service: IntegrationService,

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1885,7 +1885,7 @@ class IntegrationService(BaseWorkspaceService):
         # Calculate expiration time if expires_in is provided
         expires_at = None
         if expires_in is not None:
-            expires_at = datetime.now() + timedelta(seconds=expires_in)
+            expires_at = datetime.now(UTC) + timedelta(seconds=expires_in)
 
         provider_impl = get_provider_class(provider_key)
         default_authorization = (


### PR DESCRIPTION
## Problem

In `store_integration`, the initial token expiration `expires_at` was calculated using naive local time (`datetime.now()`). When this is written to a `TIMESTAMP WITH TIME ZONE` column in PostgreSQL, the naive value is interpreted as the database session timezone (usually UTC) without offset translation.

On non-UTC servers this causes:
- **Americas (behind UTC):** tokens instantly marked expired (e.g. 10:30 AM EDT stored as 10:30 UTC, but real UTC is 14:30)
- **Asia/Pacific (ahead of UTC):** tokens expire later than they should, causing silent 401 failures

This is the only `datetime.now()` without UTC in the entire integrations module — every other `expires_at` calculation (lines 692, 1220, 1827, 2315) already uses `datetime.now(UTC)`.

## Fix

One-line change: `datetime.now()` → `datetime.now(UTC)` in `tracecat/integrations/service.py:1888`.

## Tests

Added `test_store_integration_expires_at_is_utc_aware` — regression test verifying `expires_at` is timezone-aware and approximately `now + expires_in`.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 1 | 1 |
| Tests | 31 | 0 |

Supersedes #3202 (original PR by 57hemanth — rebased onto current `main` with a regression test added).

Co-authored-by: 57hemanth <hemanthchowdary1234@gmail.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calculates OAuth token expiry in UTC instead of local time so tokens are not incorrectly expired or extended on non-UTC servers.

Switches `datetime.now()` to `datetime.now(UTC)` in `store_integration` so the initial `expires_at` is timezone-aware and matches how the database interprets timestamptz. Adds a regression test verifying the expiry is timezone-aware and approximately `now + expires_in`.

<sup>Written for commit cb9953d55a75bd159c066497959e37afedb0e739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

