### PR TITLE
fix(workflow): preserve runtime error attribution

### DIFF
--- a/tests/temporal/runtime_error_attribution_child_harness.py
+++ b/tests/temporal/runtime_error_attribution_child_harness.py
@@ -22,10 +22,17 @@ from tests.temporal.runtime_error_attribution_harness import (
 )
 from tracecat import config
 from tracecat.dsl import action as action_module
-from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.common import (
+    DSLEntrypoint,
+    DSLInput,
+    DSLRunArgs,
+    PreparedSubflowResult,
+)
 from tracecat.dsl.enums import (
     FailStrategy,
+    PlatformAction,
     StreamErrorHandlingStrategy,
+    WaitStrategy,
 )
 from tracecat.dsl.init_activities import (
     resolve_time_anchor_activity,
@@ -39,6 +46,7 @@ from tracecat.dsl.schemas import (
 )
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.executor.activities import ExecutorActivities
+from tracecat.expressions.schemas import ExpectedField
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.object import InlineObject
@@ -579,4 +587,153 @@ async def run_successful_error_handler_does_not_inherit_terminal_owner(
         root=parent_handle,
         failure=exc_info.value,
         children=(handler_handle,),
+    )
+
+
+async def run_invalid_child_input_with_successful_error_handler_sets_user_owner(
+    env: WorkflowEnvironment,
+    test_worker_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> ScenarioObservation:
+    """Invalid child input attributes both failed child and terminal parent."""
+    handler_wf_id = WorkflowUUID.new_uuid4()
+    handler_dsl = DSLInput(
+        title="Trigger validation error handler",
+        description="Complete successfully after invalid child input",
+        entrypoint=DSLEntrypoint(ref="handle"),
+        actions=[
+            ActionStatement(
+                ref="handle",
+                action="core.noop",
+                args={},
+                retry_policy=ActionRetryPolicy(max_attempts=1, timeout=10),
+            )
+        ],
+    )
+    handler_lock = RegistryLock(
+        origins={"tracecat_registry": "test"},
+        actions={"core.noop": "tracecat_registry"},
+    )
+    handler_definition = AsyncMock(
+        return_value=SimpleNamespace(
+            content=handler_dsl.model_dump(),
+            registry_lock=handler_lock.model_dump(),
+        )
+    )
+    monkeypatch.setattr(
+        WorkflowDefinitionsService,
+        "get_definition_by_workflow_id",
+        handler_definition,
+    )
+
+    child_wf_id = WorkflowUUID.new_uuid4()
+    child_dsl = DSLInput(
+        title="Validated child",
+        description="Reject invalid trigger input before action execution",
+        entrypoint=DSLEntrypoint(
+            ref="child_action",
+            expects={"number": ExpectedField(type="int")},
+        ),
+        actions=[
+            ActionStatement(
+                ref="child_action",
+                action="core.noop",
+                args={},
+                retry_policy=ActionRetryPolicy(max_attempts=1, timeout=10),
+            )
+        ],
+    )
+    prepared = PreparedSubflowResult(
+        wf_id=child_wf_id,
+        dsl=child_dsl,
+        registry_lock=handler_lock,
+    )
+    prepare_subflow = AsyncMock(return_value=prepared)
+
+    parent_wf_id = WorkflowUUID.new_uuid4()
+    run_args = DSLRunArgs(
+        role=_role(),
+        wf_id=parent_wf_id,
+        dsl=DSLInput(
+            title="Invalid child input parent",
+            description="Run a successful handler after child validation fails",
+            entrypoint=DSLEntrypoint(ref="call_child"),
+            actions=[
+                ActionStatement(
+                    ref="call_child",
+                    action=PlatformAction.CHILD_WORKFLOW_EXECUTE,
+                    args={
+                        "workflow_id": child_wf_id.short(),
+                        "trigger_inputs": {"number": "not-an-int"},
+                        "wait_strategy": WaitStrategy.WAIT.value,
+                    },
+                )
+            ],
+            error_handler=handler_wf_id.short(),
+        ),
+        trigger_inputs=InlineObject(data={}),
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test"},
+            actions={},
+        ),
+    )
+    dispatch = _ChildDispatch(
+        user_diagnostic="unused user diagnostic",
+        platform_diagnostic="unused platform diagnostic",
+        calls=[],
+    )
+    dsl_queue = f"runtime-error-attribution-{uuid.uuid4()}"
+
+    with (
+        patch("tracecat.dsl.action._prepare_subflow", new=prepare_subflow),
+        patch(
+            "tracecat.executor.activities.get_executor_backend",
+            return_value=object(),
+        ),
+        patch(
+            "tracecat.executor.activities.dispatch_action",
+            new=dispatch.dispatch,
+        ),
+    ):
+        async with (
+            test_worker_factory(
+                env.client,
+                activities=[
+                    resolve_time_anchor_activity,
+                    resolve_workflow_concurrency_limits_enabled_activity,
+                    WorkflowsManagementService.get_error_handler_workflow_id,
+                    get_workflow_definition_activity,
+                    action_module.DSLActivities.prepare_subflow_activity,
+                    action_module.DSLActivities.evaluate_templated_object_activity,
+                    action_module.DSLActivities.normalize_trigger_inputs_activity,
+                ],
+                task_queue=dsl_queue,
+            ),
+            test_worker_factory(
+                env.client,
+                activities=[ExecutorActivities.execute_action_activity],
+                task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+            ),
+        ):
+            parent_handle = await env.client.start_workflow(
+                DSLWorkflow.run,
+                run_args,
+                id=generate_exec_id(parent_wf_id),
+                task_queue=dsl_queue,
+            )
+            with pytest.raises(WorkflowFailureError) as exc_info:
+                await parent_handle.result()
+
+    child_handles = [
+        env.client.get_workflow_handle(child_id)
+        for child_id in await child_workflow_ids(parent_handle)
+    ]
+    assert len(child_handles) == 2
+    assert handler_definition.await_count == 1
+    assert prepare_subflow.await_count == 1
+    assert dispatch.calls == ["success"]
+    return ScenarioObservation(
+        root=parent_handle,
+        failure=exc_info.value,
+        children=tuple(child_handles),
     )

--- a/tests/temporal/runtime_error_attribution_child_harness.py
+++ b/tests/temporal/runtime_error_attribution_child_harness.py
@@ -2,23 +2,31 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
+from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 
 from tests.temporal.runtime_error_attribution_harness import (
     ScenarioObservation,
     _ChildDispatch,
+    _ConcurrentChildDispatch,
     _inline_run_args,
     _role,
+    child_workflow_action,
     child_workflow_ids,
     describe_status,
+    fanout_dsl,
     fanout_run_args,
+    prepared_child,
     prepared_fanout,
+    subflow_run_args,
+    wait_for_child_workflow_ids,
 )
 from tracecat import config
 from tracecat.dsl import action as action_module
@@ -34,6 +42,7 @@ from tracecat.dsl.enums import (
     StreamErrorHandlingStrategy,
     WaitStrategy,
 )
+from tracecat.dsl.error_transport import parse_classified_action_error_payload
 from tracecat.dsl.init_activities import (
     resolve_time_anchor_activity,
     resolve_workflow_concurrency_limits_enabled_activity,
@@ -50,6 +59,9 @@ from tracecat.expressions.schemas import ExpectedField
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.object import InlineObject
+from tracecat.temporal.errors import (
+    iter_error_chain,
+)
 from tracecat.workflow.management.definitions import (
     WorkflowDefinitionsService,
     get_workflow_definition_activity,
@@ -465,6 +477,159 @@ async def run_fail_all_preserves_mixed_child_attribution(
         root=parent_handle,
         failure=exc_info.value,
         children=tuple(child_handles),
+    )
+
+
+async def run_concurrent_sibling_cancellation_preserves_causal_owner(
+    env: WorkflowEnvironment,
+    test_worker_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> ScenarioObservation:
+    """A fanout aggregates a causal leaf failure with a cancelled sibling."""
+    leaf_wf_id = WorkflowUUID.new_uuid4()
+    intermediary_wf_id = WorkflowUUID.new_uuid4()
+    intermediary_dsl = fanout_dsl(
+        child_wf_id=leaf_wf_id,
+        fail_strategy=FailStrategy.ALL,
+    )
+    intermediary_lock = RegistryLock(
+        origins={"tracecat_registry": "test"},
+        actions={},
+    )
+
+    async def prepare_subflow(
+        input: action_module.PrepareSubflowActivityInput,
+    ) -> PreparedSubflowResult:
+        match input.task.ref:
+            case "run_intermediary":
+                return prepared_child(
+                    child_wf_id=intermediary_wf_id,
+                    dsl=intermediary_dsl,
+                    registry_lock=intermediary_lock,
+                )
+            case "fanout":
+                return prepared_fanout(
+                    child_wf_id=leaf_wf_id,
+                    modes=["user", "slow"],
+                )
+            case _:
+                raise AssertionError(f"Unexpected subflow task: {input.task.ref}")
+
+    root_wf_id = WorkflowUUID.new_uuid4()
+    run_args = subflow_run_args(
+        wf_id=root_wf_id,
+        title="Concurrent attribution root",
+        description="Propagate causal attribution through an intermediary",
+        actions=[
+            child_workflow_action(
+                ref="run_intermediary",
+                child_wf_id=intermediary_wf_id,
+                trigger_inputs={"items": ["user", "slow"]},
+            )
+        ],
+    )
+    prepare_subflow_mock = AsyncMock(side_effect=prepare_subflow)
+    dispatch = _ConcurrentChildDispatch(
+        user_diagnostic="causal leaf diagnostic must not enter history",
+        calls=[],
+        slow_started=asyncio.Event(),
+    )
+    dsl_queue = f"runtime-error-attribution-{uuid.uuid4()}"
+    monkeypatch.setattr(config, "TRACECAT__ACTIVITY_HEARTBEAT_INTERVAL", 1)
+
+    with (
+        patch("tracecat.dsl.action._prepare_subflow", new=prepare_subflow_mock),
+        patch(
+            "tracecat.executor.activities.get_executor_backend",
+            return_value=object(),
+        ),
+        patch(
+            "tracecat.executor.activities.dispatch_action",
+            new=dispatch.dispatch,
+        ),
+    ):
+        async with (
+            test_worker_factory(
+                env.client,
+                activities=[
+                    resolve_time_anchor_activity,
+                    resolve_workflow_concurrency_limits_enabled_activity,
+                    WorkflowsManagementService.get_error_handler_workflow_id,
+                    action_module.DSLActivities.prepare_subflow_activity,
+                    action_module.DSLActivities.evaluate_templated_object_activity,
+                ],
+                task_queue=dsl_queue,
+            ),
+            test_worker_factory(
+                env.client,
+                activities=[ExecutorActivities.execute_action_activity],
+                task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+            ),
+        ):
+            root_handle = await env.client.start_workflow(
+                DSLWorkflow.run,
+                run_args,
+                id=generate_exec_id(root_wf_id),
+                task_queue=dsl_queue,
+            )
+            [intermediary_id] = await wait_for_child_workflow_ids(
+                root_handle,
+                count=1,
+            )
+            intermediary_handle = env.client.get_workflow_handle(intermediary_id)
+            leaf_ids = await wait_for_child_workflow_ids(
+                intermediary_handle,
+                count=2,
+            )
+            leaf_handles = [
+                env.client.get_workflow_handle(child_id) for child_id in leaf_ids
+            ]
+            for _ in range(200):
+                statuses = [await describe_status(child) for child in leaf_handles]
+                if WorkflowExecutionStatus.FAILED in statuses:
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                raise AssertionError("Expected the causal leaf workflow to fail")
+
+            [slow_leaf_handle] = [
+                child
+                for child, status in zip(leaf_handles, statuses, strict=True)
+                if status == WorkflowExecutionStatus.RUNNING
+            ]
+            await slow_leaf_handle.cancel()
+            with pytest.raises(WorkflowFailureError) as root_exc_info:
+                await root_handle.result()
+
+    with pytest.raises(WorkflowFailureError) as intermediary_exc_info:
+        await intermediary_handle.result()
+    terminal_error = next(
+        error
+        for error in iter_error_chain(intermediary_exc_info.value)
+        if isinstance(error, ApplicationError)
+    )
+    payload = parse_classified_action_error_payload(terminal_error.details[0])
+    assert isinstance(payload, dict)
+    assert set(payload) == {"fanout"}
+    aggregate = payload["fanout"].diagnostic
+    assert aggregate is not None
+    assert aggregate.children is not None
+    assert {child.ref for child in aggregate.children} == {"fanout[0]", "fanout[1]"}
+    assert {child.type for child in aggregate.children} >= {"ChildWorkflowError"}
+
+    histories = [
+        (await root_handle.fetch_history()).to_json(),
+        (await intermediary_handle.fetch_history()).to_json(),
+    ]
+    for child in leaf_handles:
+        histories.append((await child.fetch_history()).to_json())
+    assert dispatch.user_diagnostic not in "\n".join(histories)
+    assert sorted(dispatch.calls) == ["slow", "user"]
+    assert prepare_subflow_mock.await_count == 2
+    return ScenarioObservation(
+        root=root_handle,
+        failure=root_exc_info.value,
+        children=(intermediary_handle, *leaf_handles),
     )
 
 

--- a/tests/temporal/runtime_error_attribution_harness.py
+++ b/tests/temporal/runtime_error_attribution_harness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
@@ -159,6 +160,37 @@ class _ChildDispatch:
         raise ExecutionError(info=info) from cause
 
 
+@dataclass(slots=True)
+class _ConcurrentChildDispatch:
+    """Fail one child only after its cancellable sibling has started."""
+
+    user_diagnostic: str
+    calls: list[str]
+    slow_started: asyncio.Event
+
+    async def dispatch(self, *, backend: object, input: RunActionInput) -> object:
+        del backend
+        trigger = input.exec_context.get("TRIGGER")
+        mode = trigger.get("mode") if isinstance(trigger, dict) else None
+        self.calls.append(mode if isinstance(mode, str) else "success")
+        if mode == "slow":
+            self.slow_started.set()
+            await asyncio.Event().wait()
+            return {"ok": True}  # pragma: no cover - cancelled by Temporal
+        if mode == "user":
+            await self.slow_started.wait()
+            cause = ValueError(self.user_diagnostic)
+            info = ExecutorActionErrorInfo(
+                type=type(cause).__name__,
+                message="masked child action failure",
+                action_name="core.noop",
+                filename="<executor>",
+                function="dispatch",
+            )
+            raise ExecutionError(info=info) from cause
+        return {"ok": True}
+
+
 @dataclass(frozen=True, slots=True)
 class ScenarioObservation:
     """Execution handles and outcomes consumed by the shared matrix assertion."""
@@ -243,19 +275,113 @@ async def child_workflow_ids(handle: WorkflowHandle[Any, Any]) -> list[str]:
     ]
 
 
-def _child_dsl() -> DSLInput:
+async def wait_for_child_workflow_ids(
+    handle: WorkflowHandle[Any, Any],
+    *,
+    count: int,
+    attempts: int = 200,
+) -> list[str]:
+    """Wait until a running topology has started the requested child count."""
+    for _ in range(attempts):
+        child_ids = await child_workflow_ids(handle)
+        if len(child_ids) >= count:
+            return child_ids
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"Expected {count} child workflows to start")
+
+
+def child_dsl(
+    *,
+    title: str = "Attribution child",
+    description: str = "Exercise attribution across a real child workflow",
+    action_ref: str = "child_action",
+    start_delay: float = 0,
+) -> DSLInput:
+    """Build a one-action child definition for real-Worker topology tests."""
     return DSLInput(
-        title="Attribution child",
-        description="Exercise attribution across a real child workflow",
-        entrypoint=DSLEntrypoint(ref="child_action"),
+        title=title,
+        description=description,
+        entrypoint=DSLEntrypoint(ref=action_ref),
         actions=[
             ActionStatement(
-                ref="child_action",
+                ref=action_ref,
                 action="core.noop",
                 args={},
+                start_delay=start_delay,
                 retry_policy=ActionRetryPolicy(max_attempts=1, timeout=10),
             )
         ],
+    )
+
+
+def prepared_child(
+    *,
+    child_wf_id: WorkflowUUID,
+    dsl: DSLInput,
+    registry_lock: RegistryLock,
+) -> PreparedSubflowResult:
+    """Build one prepared child result for a patched preparation activity."""
+    return PreparedSubflowResult(
+        wf_id=child_wf_id,
+        dsl=dsl,
+        registry_lock=registry_lock,
+    )
+
+
+def child_workflow_action(
+    *,
+    ref: str,
+    child_wf_id: WorkflowUUID,
+    trigger_inputs: dict[str, object],
+) -> ActionStatement:
+    """Build one waiting child-workflow action for a topology test."""
+    return ActionStatement(
+        ref=ref,
+        action=PlatformAction.CHILD_WORKFLOW_EXECUTE,
+        args={
+            "workflow_id": child_wf_id.short(),
+            "trigger_inputs": trigger_inputs,
+            "wait_strategy": WaitStrategy.WAIT.value,
+        },
+    )
+
+
+def subflow_dsl(
+    *,
+    title: str,
+    description: str,
+    actions: list[ActionStatement],
+) -> DSLInput:
+    """Build a parent definition from concurrent child-workflow actions."""
+    return DSLInput(
+        title=title,
+        description=description,
+        entrypoint=DSLEntrypoint(ref=actions[0].ref),
+        actions=actions,
+    )
+
+
+def subflow_run_args(
+    *,
+    wf_id: WorkflowUUID,
+    title: str,
+    description: str,
+    actions: list[ActionStatement],
+) -> DSLRunArgs:
+    """Build run arguments for a parent composed only of subflows."""
+    return DSLRunArgs(
+        role=_role(),
+        wf_id=wf_id,
+        dsl=subflow_dsl(
+            title=title,
+            description=description,
+            actions=actions,
+        ),
+        trigger_inputs=InlineObject(data={}),
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test"},
+            actions={},
+        ),
     )
 
 
@@ -264,7 +390,7 @@ def prepared_fanout(
 ) -> PreparedSubflowResult:
     return PreparedSubflowResult(
         wf_id=child_wf_id,
-        dsl=_child_dsl(),
+        dsl=child_dsl(),
         registry_lock=RegistryLock(
             origins={"tracecat_registry": "test"},
             actions={"core.noop": "tracecat_registry"},
@@ -277,29 +403,37 @@ def prepared_fanout(
     )
 
 
+def fanout_dsl(*, child_wf_id: WorkflowUUID, fail_strategy: FailStrategy) -> DSLInput:
+    """Build a parent definition that fans out over trigger input items."""
+    return DSLInput(
+        title="Attribution fanout parent",
+        description="Exercise real child terminal attribution",
+        entrypoint=DSLEntrypoint(ref="fanout"),
+        actions=[
+            ActionStatement(
+                ref="fanout",
+                action=PlatformAction.CHILD_WORKFLOW_EXECUTE,
+                for_each="${{ for var.item in TRIGGER.items }}",
+                args={
+                    "workflow_id": child_wf_id.short(),
+                    "trigger_inputs": "${{ var.item }}",
+                    "wait_strategy": WaitStrategy.WAIT.value,
+                    "fail_strategy": fail_strategy.value,
+                },
+            )
+        ],
+    )
+
+
 def fanout_run_args(
     *, child_wf_id: WorkflowUUID, modes: list[str], fail_strategy: FailStrategy
 ) -> DSLRunArgs:
     return DSLRunArgs(
         role=_role(),
         wf_id=WorkflowUUID.new_uuid4(),
-        dsl=DSLInput(
-            title="Attribution fanout parent",
-            description="Exercise real child terminal attribution",
-            entrypoint=DSLEntrypoint(ref="fanout"),
-            actions=[
-                ActionStatement(
-                    ref="fanout",
-                    action=PlatformAction.CHILD_WORKFLOW_EXECUTE,
-                    for_each="${{ for var.item in TRIGGER.items }}",
-                    args={
-                        "workflow_id": child_wf_id.short(),
-                        "trigger_inputs": "${{ var.item }}",
-                        "wait_strategy": WaitStrategy.WAIT.value,
-                        "fail_strategy": fail_strategy.value,
-                    },
-                )
-            ],
+        dsl=fanout_dsl(
+            child_wf_id=child_wf_id,
+            fail_strategy=fail_strategy,
         ),
         trigger_inputs=InlineObject(data={"items": modes}),
         registry_lock=RegistryLock(

--- a/tests/temporal/test_runtime_error_attribution.py
+++ b/tests/temporal/test_runtime_error_attribution.py
@@ -428,6 +428,23 @@ ATTRIBUTION_SCENARIOS: tuple[_AttributionScenario, ...] = (
         ),
     ),
     _AttributionScenario(
+        id="error_handler.invalid_child_input",
+        topology=_Topology.ERROR_HANDLER,
+        fault_point=_FaultPoint.CHILD_EXECUTION,
+        fault="invalid child trigger input + successful handler",
+        root=_ExecutionExpectation(_FAILED, RuntimeErrorOwner.USER),
+        children=(
+            _ExecutionExpectation(_FAILED, RuntimeErrorOwner.USER),
+            _ExecutionExpectation(_COMPLETED, None),
+        ),
+        envelope_owners=frozenset({RuntimeErrorOwner.USER}),
+        kind=RuntimeErrorKind.WORKFLOW_TRIGGER_INPUT_INVALID,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        runner=_monkeypatch_runner(
+            child_harness.run_invalid_child_input_with_successful_error_handler_sets_user_owner
+        ),
+    ),
+    _AttributionScenario(
         id="subflow_preparation.unhandled_platform_failure",
         topology=_Topology.SINGLE_ACTION,
         fault_point=_FaultPoint.SUBFLOW_PREPARATION,

--- a/tests/temporal/test_runtime_error_attribution.py
+++ b/tests/temporal/test_runtime_error_attribution.py
@@ -414,6 +414,24 @@ ATTRIBUTION_SCENARIOS: tuple[_AttributionScenario, ...] = (
         ),
     ),
     _AttributionScenario(
+        id="subflows.concurrent_cancellation.preserves_causal_owner",
+        topology=_Topology.FANOUT,
+        fault_point=_FaultPoint.CHILD_EXECUTION,
+        fault="user leaf failure + cancelled sibling",
+        root=_ExecutionExpectation(_FAILED, RuntimeErrorOwner.USER),
+        children=(
+            _ExecutionExpectation(_FAILED, RuntimeErrorOwner.USER),
+            _ExecutionExpectation(_FAILED, RuntimeErrorOwner.USER),
+            _ExecutionExpectation(_CANCELED, None),
+        ),
+        envelope_owners=frozenset({RuntimeErrorOwner.USER}),
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        runner=_monkeypatch_runner(
+            child_harness.run_concurrent_sibling_cancellation_preserves_causal_owner
+        ),
+    ),
+    _AttributionScenario(
         id="error_handler.successful_child",
         topology=_Topology.ERROR_HANDLER,
         fault_point=_FaultPoint.CHILD_EXECUTION,

--- a/tests/unit/test_dsl_error_policy.py
+++ b/tests/unit/test_dsl_error_policy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ApplicationError, CancelledError
 
 from tests.shared import capture_application_error as _capture_application_error
 from tracecat.dsl.error_policy import raise_child_failures_application_error
@@ -314,6 +314,36 @@ def test_mixed_child_failures_use_unclassified_aggregate_with_every_child() -> N
     patched_mock.assert_not_called()
 
 
+def test_child_cancellation_does_not_erase_classified_causal_failure() -> None:
+    user_classification = RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The child action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+
+    error = _capture_child_failures_application_error(
+        task_ref="fanout",
+        failures=[
+            (3, _capture_application_error(user_classification)),
+            (4, CancelledError()),
+        ],
+    )
+
+    classification = extract_error_classification(error)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.cause_type == "ChildWorkflowAggregateError"
+    aggregate_transport = parse_classified_action_error_payload(error.details[0])
+    assert isinstance(aggregate_transport, ActionErrorTransportDetail)
+    assert aggregate_transport.diagnostic is not None
+    assert aggregate_transport.diagnostic.children is not None
+    assert [child.ref for child in aggregate_transport.diagnostic.children] == [
+        "fanout[3]",
+        "fanout[4]",
+    ]
+    assert aggregate_transport.diagnostic.children[1].type == "CancelledError"
+
+
 def test_legacy_workflow_error_shape_is_unchanged() -> None:
     detail = ActionErrorInfo(ref="action", message="Failed", type="ValueError")
     error = _capture_workflow_application_error(
@@ -367,3 +397,37 @@ def test_mixed_workflow_errors_use_the_unclassified_terminal_raise() -> None:
     with patch("tracecat.dsl.workflow.workflow.patched") as patched_mock:
         assert DSLWorkflow._has_user_error_cause(error) is False
     patched_mock.assert_not_called()
+
+
+def test_terminal_cancellation_does_not_erase_classified_causal_failure() -> None:
+    user_classification = RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    user_detail = _action_error_info(user_classification, ref="user_action")
+    cancelled_detail = ActionErrorInfo(
+        ref="cancelled_action",
+        message="Cancelled",
+        type="CancelledError",
+    )
+
+    error = _capture_workflow_application_error(
+        {
+            "user_action": TaskExceptionInfo(
+                exception=_capture_application_error(user_classification),
+                details=user_detail,
+            ),
+            "cancelled_action": TaskExceptionInfo(
+                exception=CancelledError(),
+                details=cancelled_detail,
+            ),
+        }
+    )
+
+    assert extract_error_classification(error) == user_classification
+    assert error.details[0] == {
+        "user_action": user_detail,
+        "cancelled_action": cancelled_detail,
+    }
+    assert len(error.details) == 2

--- a/tests/unit/test_dsl_error_policy.py
+++ b/tests/unit/test_dsl_error_policy.py
@@ -431,3 +431,56 @@ def test_terminal_cancellation_does_not_erase_classified_causal_failure() -> Non
         "cancelled_action": cancelled_detail,
     }
     assert len(error.details) == 2
+
+
+def test_terminal_cancellation_preserves_every_causal_classification() -> None:
+    user_classification = RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    platform_classification = RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not execute the action",
+        retry_disposition=RetryDisposition.RETRYABLE,
+    )
+    user_detail = _action_error_info(user_classification, ref="user_action")
+    platform_detail = _action_error_info(
+        platform_classification,
+        ref="platform_action",
+    )
+    cancelled_detail = ActionErrorInfo(
+        ref="cancelled_action",
+        message="Cancelled",
+        type="CancelledError",
+    )
+
+    error = _capture_workflow_application_error(
+        {
+            "user_action": TaskExceptionInfo(
+                exception=_capture_application_error(user_classification),
+                details=user_detail,
+            ),
+            "platform_action": TaskExceptionInfo(
+                exception=_capture_application_error(platform_classification),
+                details=platform_detail,
+            ),
+            "cancelled_action": TaskExceptionInfo(
+                exception=CancelledError(),
+                details=cancelled_detail,
+            ),
+        }
+    )
+
+    assert error.message == platform_classification.message
+    assert error.type == platform_classification.kind.value
+    assert error.details[0] == {
+        "user_action": user_detail,
+        "platform_action": platform_detail,
+        "cancelled_action": cancelled_detail,
+    }
+    assert extract_error_classifications(error) == (
+        user_classification,
+        platform_classification,
+    )
+    assert len(error.details) == 3

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -16,6 +16,7 @@ from tests.shared import capture_application_error as _capture_application_error
 from tracecat.auth.types import Role
 from tracecat.dsl.action import (
     DSLActivities,
+    NormalizeTriggerInputsActivityInputs,
     PrepareSubflowActivityInput,
     SubflowDefinitionNotFoundError,
 )
@@ -36,6 +37,7 @@ from tracecat.dsl.workflow import (
     ERROR_OWNER_SEARCH_ATTRIBUTE_PATCH,
     DSLWorkflow,
 )
+from tracecat.expressions.schemas import ExpectedField
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.runtime.errors import (
     RetryDisposition,
@@ -43,6 +45,8 @@ from tracecat.runtime.errors import (
     RuntimeErrorKind,
     RuntimeErrorOwner,
 )
+from tracecat.storage.backends.inline import InlineObjectStorage
+from tracecat.storage.object import InlineObject
 from tracecat.temporal.errors import (
     build_error_transport_detail,
     extract_error_classification,
@@ -126,6 +130,49 @@ def test_scheduler_adapts_non_action_classification_to_error_info() -> None:
     assert detail.message == classification.message
     assert detail.type == classification.kind.value
     assert adapted_classification == classification
+
+
+def test_trigger_input_validation_is_classified_and_history_safe() -> None:
+    sensitive = "rejected-value-must-not-enter-history"
+
+    with (
+        patch(
+            "tracecat.dsl.action.get_object_storage",
+            return_value=InlineObjectStorage(),
+        ),
+        patch("tracecat.dsl.action.logger.info") as logger_info_mock,
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        DSLActivities.normalize_trigger_inputs_activity(
+            NormalizeTriggerInputsActivityInputs(
+                input_schema={"number": ExpectedField(type="int")},
+                trigger_inputs=InlineObject(data={"number": sensitive}),
+                key="test/normalized-trigger",
+            )
+        )
+
+    error = exc_info.value
+    classification = extract_error_classification(error)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.WORKFLOW_TRIGGER_INPUT_INVALID
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert classification.cause_type == ValidationError.__name__
+    assert error.non_retryable is True
+
+    payload = parse_classified_action_error_payload(error.details[0])
+    assert isinstance(payload, dict)
+    detail = payload["__workflow_trigger__"]
+    assert detail.classification == classification
+    assert detail.diagnostic is not None
+    assert detail.diagnostic.ref == "__workflow_trigger__"
+
+    failure = Failure()
+    asyncio.run(DataConverter.default.encode_failure(error, failure))
+    assert sensitive not in str(failure)
+    logger_info_mock.assert_called_once()
+    assert "error" not in logger_info_mock.call_args.kwargs
+    assert sensitive not in str(logger_info_mock.call_args)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import asyncio
 import uuid
 from datetime import timedelta
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from botocore.exceptions import HTTPClientError
 from pydantic import ValidationError
 from temporalio.api.failure.v1 import Failure
 from temporalio.converter import DataConverter
@@ -173,6 +174,60 @@ def test_trigger_input_validation_is_classified_and_history_safe() -> None:
     logger_info_mock.assert_called_once()
     assert "error" not in logger_info_mock.call_args.kwargs
     assert sensitive not in str(logger_info_mock.call_args)
+
+
+@pytest.mark.parametrize(
+    ("fault_point", "expected_kind"),
+    [
+        (
+            "retrieve",
+            RuntimeErrorKind.STORAGE_MATERIALIZATION_TRANSPORT_UNAVAILABLE,
+        ),
+        (
+            "store",
+            RuntimeErrorKind.STORAGE_PERSISTENCE_TRANSPORT_UNAVAILABLE,
+        ),
+    ],
+)
+def test_trigger_input_storage_failure_is_platform_owned_and_history_safe(
+    fault_point: Literal["retrieve", "store"],
+    expected_kind: RuntimeErrorKind,
+) -> None:
+    sensitive = "trigger storage diagnostic must not enter history"
+    transport_error = HTTPClientError(error=RuntimeError(sensitive))
+    storage = MagicMock()
+    storage.retrieve = AsyncMock(return_value={"number": 1})
+    storage.store = AsyncMock(return_value=InlineObject(data={"number": 1}))
+    match fault_point:
+        case "retrieve":
+            storage.retrieve.side_effect = transport_error
+        case "store":
+            storage.store.side_effect = transport_error
+
+    with (
+        patch("tracecat.dsl.action.get_object_storage", return_value=storage),
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        DSLActivities.normalize_trigger_inputs_activity(
+            NormalizeTriggerInputsActivityInputs(
+                input_schema={"number": ExpectedField(type="int")},
+                trigger_inputs=InlineObject(data={"number": 1}),
+                key="test/normalized-trigger",
+            )
+        )
+
+    error = exc_info.value
+    classification = extract_error_classification(error)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.kind is expected_kind
+    assert classification.retry_disposition is RetryDisposition.RETRYABLE
+    assert classification.cause_type == HTTPClientError.__name__
+    assert error.non_retryable is False
+
+    failure = Failure()
+    asyncio.run(DataConverter.default.encode_failure(error, failure))
+    assert sensitive not in str(failure)
 
 
 @pytest.mark.anyio

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -38,7 +38,10 @@ from tracecat.dsl.schemas import (
     TaskResult,
 )
 from tracecat.dsl.types import ActionErrorInfo
-from tracecat.dsl.validation import normalize_trigger_inputs
+from tracecat.dsl.validation import (
+    format_input_schema_validation_error,
+    normalize_trigger_inputs,
+)
 from tracecat.exceptions import TracecatExpressionError, TracecatValidationError
 from tracecat.executor.service import get_workspace_variables
 from tracecat.expressions.common import ExprContext
@@ -79,6 +82,7 @@ from tracecat.temporal.errors import (
     activity_error_boundary,
     build_error_transport_detail,
     extract_error_classification,
+    raise_application_error_from_classification,
     raise_wrapped_application_error,
 )
 from tracecat.temporal.exceptions import UserError
@@ -745,13 +749,33 @@ class DSLActivities:
             stored = run_sync(storage.store(inputs.key, normalized))
             return stored
         except ValidationError as e:
-            logger.info("Validation error when normalizing trigger inputs", error=e)
-            raise ApplicationError(
-                "Failed to validate trigger inputs",
-                ValidationDetail.list_from_pydantic(e),
-                non_retryable=True,
-                type=e.__class__.__name__,
-            ) from e
+            details = ValidationDetail.list_from_pydantic(e)
+            message = format_input_schema_validation_error(details)
+            classification = RuntimeErrorClassification.user(
+                kind=RuntimeErrorKind.WORKFLOW_TRIGGER_INPUT_INVALID,
+                message=message,
+                retry_disposition=RetryDisposition.NON_RETRYABLE,
+                cause=e,
+            )
+            diagnostic = ActionErrorInfo(
+                ref="__workflow_trigger__",
+                message=message,
+                type=type(e).__name__,
+            )
+            logger.info(
+                "Validation error when normalizing trigger inputs",
+                error_type=type(e).__name__,
+                error_count=len(details),
+            )
+            raise_application_error_from_classification(
+                classification,
+                {
+                    diagnostic.ref: build_error_transport_detail(
+                        classification,
+                        diagnostic,
+                    ).model_dump(mode="json")
+                },
+            )
         except Exception as e:
             logger.warning(
                 "Unexpected error cause when normalizing trigger inputs",

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -380,6 +380,37 @@ def _materialization_error_classification(
     )
 
 
+def _trigger_input_storage_initialization_error_classification(
+    error: Exception,
+) -> RuntimeErrorClassification:
+    """Classify failure to initialize trigger-input object storage."""
+    return RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not initialize workflow input storage",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=error,
+    )
+
+
+def _trigger_input_persistence_error_classification(
+    error: Exception,
+) -> RuntimeErrorClassification:
+    """Classify one normalized trigger-input persistence failure."""
+    retryable = is_retryable_storage_transport_error(error)
+    return RuntimeErrorClassification.platform(
+        kind=(
+            RuntimeErrorKind.STORAGE_PERSISTENCE_TRANSPORT_UNAVAILABLE
+            if retryable
+            else RuntimeErrorKind.RUNTIME_UNCLASSIFIED
+        ),
+        message="Tracecat could not persist normalized workflow inputs",
+        retry_disposition=(
+            RetryDisposition.RETRYABLE if retryable else RetryDisposition.NON_RETRYABLE
+        ),
+        cause=error,
+    )
+
+
 async def materialize_context(ctx: ExecutionContext) -> MaterializedExecutionContext:
     """Retrieve StoredObjects and replace with raw values in context copy.
 
@@ -740,14 +771,18 @@ class DSLActivities:
         inputs: NormalizeTriggerInputsActivityInputs,
     ) -> StoredObject:
         """Return trigger inputs with defaults applied according to DSL expects."""
-        try:
-            value = {}
+        with activity_error_boundary(
+            _trigger_input_storage_initialization_error_classification
+        ):
             storage = get_object_storage()
-            if inputs.trigger_inputs is not None:
+
+        value = {}
+        if inputs.trigger_inputs is not None:
+            with activity_error_boundary(_materialization_error_classification):
                 value = run_sync(storage.retrieve(inputs.trigger_inputs))
+
+        try:
             normalized = normalize_trigger_inputs(inputs.input_schema, value)
-            stored = run_sync(storage.store(inputs.key, normalized))
-            return stored
         except ValidationError as e:
             details = ValidationDetail.list_from_pydantic(e)
             message = format_input_schema_validation_error(details)
@@ -776,16 +811,9 @@ class DSLActivities:
                     ).model_dump(mode="json")
                 },
             )
-        except Exception as e:
-            logger.warning(
-                "Unexpected error cause when normalizing trigger inputs",
-                error=e,
-            )
-            raise ApplicationError(
-                "Unexpected error when normalizing trigger inputs",
-                non_retryable=True,
-                type=e.__class__.__name__,
-            ) from e
+
+        with activity_error_boundary(_trigger_input_persistence_error_classification):
+            return run_sync(storage.store(inputs.key, normalized))
 
     @staticmethod
     @activity.defn

--- a/tracecat/dsl/error_policy.py
+++ b/tracecat/dsl/error_policy.py
@@ -28,6 +28,7 @@ def raise_child_failures_application_error(
     """Raise child failures without letting cancellation erase their cause."""
     child_details: list[ActionErrorInfo] = []
     child_classifications: list[RuntimeErrorClassification | None] = []
+    has_unclassified_non_cancellation = False
     for child_index, failure in failures:
         classifications = extract_error_classifications(failure)
         if classifications:
@@ -36,6 +37,7 @@ def raise_child_failures_application_error(
             child_type = classification.cause_type or type(failure).__name__
         else:
             classification = None
+            has_unclassified_non_cancellation |= not is_cancelled_exception(failure)
             child_message = str(failure)
             child_type = type(failure).__name__
         child_classifications.append(classification)
@@ -59,16 +61,7 @@ def raise_child_failures_application_error(
         for classification in child_classifications
         if classification is not None
     ]
-    unclassified_failures = [
-        failure
-        for (_, failure), classification in zip(
-            failures, child_classifications, strict=True
-        )
-        if classification is None
-    ]
-    if not classified_failures or any(
-        not is_cancelled_exception(failure) for failure in unclassified_failures
-    ):
+    if not classified_failures or has_unclassified_non_cancellation:
         raise ApplicationError(
             message,
             {task_ref: aggregate},
@@ -103,21 +96,23 @@ def build_terminal_application_error(
     """Build the terminal error, treating concurrent cancellation as fallout."""
     n_exceptions = len(task_exceptions)
     task_classifications: dict[str, RuntimeErrorClassification] = {}
-    unclassified_task_exceptions: list[BaseException] = []
+    has_unclassified = False
+    has_unclassified_non_cancellation = False
     for ref, info in task_exceptions.items():
         classifications = extract_error_classifications(info.exception)
         if not classifications:
-            unclassified_task_exceptions.append(info.exception)
+            has_unclassified = True
+            has_unclassified_non_cancellation |= not is_cancelled_exception(
+                info.exception
+            )
             continue
         task_classifications[ref] = select_error_classification(classifications)
 
-    if task_classifications and all(
-        is_cancelled_exception(error) for error in unclassified_task_exceptions
-    ):
+    if task_classifications and not has_unclassified_non_cancellation:
         terminal_classification = select_error_classification(
             task_classifications.values()
         )
-        if not unclassified_task_exceptions:
+        if not has_unclassified:
             error_details = {
                 ref: build_error_transport_detail(
                     task_classifications[ref],

--- a/tracecat/dsl/error_policy.py
+++ b/tracecat/dsl/error_policy.py
@@ -120,14 +120,25 @@ def build_terminal_application_error(
                 ).model_dump(mode="json")
                 for ref, info in task_exceptions.items()
             }
-        else:
-            # A concurrent cancellation is diagnostic fallout, not a competing
-            # causal classification. Keep the complete legacy map for the error
-            # handler and append only the selected causal classification.
-            error_details = {ref: info.details for ref, info in task_exceptions.items()}
+            return application_error_from_classification(
+                terminal_classification,
+                error_details,
+            )
+
+        # A concurrent cancellation is diagnostic fallout, not a competing
+        # causal classification. Keep the complete legacy map for the error
+        # handler and append every causal task classification.
         return application_error_from_classification(
             terminal_classification,
-            error_details,
+            {ref: info.details for ref, info in task_exceptions.items()},
+            *(
+                build_error_transport_detail(
+                    task_classifications[ref],
+                    info.details,
+                )
+                for ref, info in task_exceptions.items()
+                if ref in task_classifications
+            ),
         )
 
     formatted_exceptions = "\n".join(

--- a/tracecat/dsl/error_policy.py
+++ b/tracecat/dsl/error_policy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, Never
 
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ApplicationError, is_cancelled_exception
 
 from tracecat.dsl.error_transport import parse_classified_action_error_payload
 from tracecat.dsl.types import ActionErrorInfo, TaskExceptionInfo
@@ -25,7 +25,7 @@ from tracecat.temporal.errors import (
 def raise_child_failures_application_error(
     *, task_ref: str, failures: list[tuple[int, BaseException]]
 ) -> Never:
-    """Raise child failures, classifying the aggregate only when all qualify."""
+    """Raise child failures without letting cancellation erase their cause."""
     child_details: list[ActionErrorInfo] = []
     child_classifications: list[RuntimeErrorClassification | None] = []
     for child_index, failure in failures:
@@ -54,7 +54,21 @@ def raise_child_failures_application_error(
         type="ChildWorkflowAggregateError",
         children=child_details,
     )
-    if not all(classification is not None for classification in child_classifications):
+    classified_failures = [
+        classification
+        for classification in child_classifications
+        if classification is not None
+    ]
+    unclassified_failures = [
+        failure
+        for (_, failure), classification in zip(
+            failures, child_classifications, strict=True
+        )
+        if classification is None
+    ]
+    if not classified_failures or any(
+        not is_cancelled_exception(failure) for failure in unclassified_failures
+    ):
         raise ApplicationError(
             message,
             {task_ref: aggregate},
@@ -62,11 +76,7 @@ def raise_child_failures_application_error(
             type=ApplicationError.__name__,
         )
 
-    primary_classification = select_error_classification(
-        classification
-        for classification in child_classifications
-        if classification is not None
-    )
+    primary_classification = select_error_classification(classified_failures)
     aggregate_classification = primary_classification.model_copy(
         update={
             "message": message,
@@ -90,19 +100,24 @@ def raise_child_failures_application_error(
 def build_terminal_application_error(
     task_exceptions: Mapping[str, TaskExceptionInfo],
 ) -> ApplicationError:
-    """Build the terminal workflow error without changing legacy payloads."""
+    """Build the terminal error, treating concurrent cancellation as fallout."""
     n_exceptions = len(task_exceptions)
     task_classifications: dict[str, RuntimeErrorClassification] = {}
+    unclassified_task_exceptions: list[BaseException] = []
     for ref, info in task_exceptions.items():
         classifications = extract_error_classifications(info.exception)
         if not classifications:
-            break
+            unclassified_task_exceptions.append(info.exception)
+            continue
         task_classifications[ref] = select_error_classification(classifications)
-    else:
-        if task_classifications:
-            terminal_classification = select_error_classification(
-                task_classifications.values()
-            )
+
+    if task_classifications and all(
+        is_cancelled_exception(error) for error in unclassified_task_exceptions
+    ):
+        terminal_classification = select_error_classification(
+            task_classifications.values()
+        )
+        if not unclassified_task_exceptions:
             error_details = {
                 ref: build_error_transport_detail(
                     task_classifications[ref],
@@ -110,10 +125,15 @@ def build_terminal_application_error(
                 ).model_dump(mode="json")
                 for ref, info in task_exceptions.items()
             }
-            return application_error_from_classification(
-                terminal_classification,
-                error_details,
-            )
+        else:
+            # A concurrent cancellation is diagnostic fallout, not a competing
+            # causal classification. Keep the complete legacy map for the error
+            # handler and append only the selected causal classification.
+            error_details = {ref: info.details for ref, info in task_exceptions.items()}
+        return application_error_from_classification(
+            terminal_classification,
+            error_details,
+        )
 
     formatted_exceptions = "\n".join(
         f"{'=' * 10} ({i + 1}/{n_exceptions}) {details.expr_context}.{ref} {'=' * 10}\n\n{info.exception!s}"

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -543,6 +543,8 @@ class DSLWorkflow:
                 )
             except ActivityError as e:
                 match cause := e.cause:
+                    case ApplicationError() if extract_error_classification(cause):
+                        raise cause from None
                     case ApplicationError(type=t, details=details) if (
                         t == ValidationError.__name__
                     ):

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -66,6 +66,7 @@ class RuntimeErrorKind(StrEnum):
     WORKFLOW_DEFINITION_NOT_FOUND = "workflow.definition.not_found"
     WORKFLOW_DEFINITION_LOOKUP_UNAVAILABLE = "workflow.definition.lookup_unavailable"
     WORKFLOW_DEFINITION_INVALID_DATA = "workflow.definition.invalid_data"
+    WORKFLOW_TRIGGER_INPUT_INVALID = "workflow.trigger.input_invalid"
     WORKFLOW_SUBFLOW_INPUT_INVALID = "workflow.subflow.input_invalid"
     WORKFLOW_SUBFLOW_PREPARATION_FAILED = "workflow.subflow.preparation_failed"
 


### PR DESCRIPTION
## Summary

- preserve a classified causal failure when concurrent cancellation joins a child or terminal aggregate
- classify invalid workflow trigger input as user-owned and non-retryable with `workflow.trigger.input_invalid`
- classify trigger-input storage initialization, retrieval, and persistence failures at their exact activity boundaries
- extend the shared real-Worker attribution harness with a leaf/intermediary/root cancellation regression
- preserve every causal task classification when cancellation joins a terminal aggregate
- keep successful error-handler children unstamped while attributing the failed child and terminal parent
- retain the legacy unclassified behavior for genuine mixed classified and unclassified failures

## Why

EU rollout QA found two attribution gaps: cancellation fallout could erase an existing causal classification, and trigger-input failures could cross the Temporal boundary without a classification. Both cases left failed executions without the expected `TracecatErrorOwner` search attribute.

## Verification

- `34 passed`: focused error-policy and runtime steel-thread unit tests
- `26 passed`: complete Temporal runtime-attribution matrix
- real-Worker cancellation case proves the user-owned stamp on the failing leaf, intermediary, and root while the sibling remains natively canceled and unstamped
- Ruff check and format check passed
- focused BasedPyright passed with 0 errors
- commit hooks passed, including hardcoded-secret detection and the repository Python type check

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 118 | 37 |
| Tests | 736 | 26 |

Fixes ENG-1725.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, concurrent cancellation could erase a classified child or terminal failure, and invalid workflow trigger input crossed the Temporal boundary without attribution. This preserves the causal classification and reports invalid input as user-owned, non-retryable `workflow.trigger.input_invalid` failures, attributing the failed child and terminal parent while leaving successful error handlers unstamped.

**Bug Fixes**

- Keeps complete legacy diagnostic details when cancellation is only fallout.
- Retains unclassified aggregate behavior for genuine mixes of classified and unclassified failures.
- Prevents rejected input values from entering Temporal history or logs.
- Adds coverage for child validation, cancellation, terminal aggregation, and error-handler behavior.

Fixes ENG-1725.

<sup>Written for commit 2f1520d48b8203a116a8ea987a3173f498c86b5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
