### PR TITLE
fix(mcp): support regional Datadog OAuth endpoints

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -329,22 +329,35 @@
     },
     {
       "slug": "datadog-mcp",
-      "docs": "https://docs.datadoghq.com/bits_ai/mcp_server/",
+      "docs": "https://docs.datadoghq.com/mcp_server/setup/",
       "connection_spec": {
         "server_type": "http",
         "auth_type": "OAUTH2",
-        "server_uri": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+        "server_uri": "https://mcp.datadoghq.com/v1/mcp",
         "scopes": [],
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
-        "credentials": [],
+        "credentials": [
+          {
+            "key": "server_url",
+            "label": "Datadog MCP Region Endpoint",
+            "description": "The regional Datadog MCP endpoint matching your Datadog site. US1: https://mcp.datadoghq.com/v1/mcp , US3: https://mcp.us3.datadoghq.com/v1/mcp , US5: https://mcp.us5.datadoghq.com/v1/mcp , EU: https://mcp.datadoghq.eu/v1/mcp , AP1: https://mcp.ap1.datadoghq.com/v1/mcp , AP2: https://mcp.ap2.datadoghq.com/v1/mcp , UK1: https://mcp.uk1.datadoghq.com/v1/mcp . The US1-FED / GovCloud site (app.ddog-gov.com) is NOT supported. An optional ?toolsets= query parameter may be appended to select tools, e.g. ?toolsets=core (default), ?toolsets=all, or a comma-separated list such as ?toolsets=apm,llmobs. Authentication is handled via OAuth browser sign-in; no token is pasted by the user.",
+            "required": true,
+            "secret": false,
+            "default_value": "https://mcp.datadoghq.com/v1/mcp",
+            "placeholder": "https://mcp.datadoghq.com/v1/mcp",
+            "type": "url",
+            "target": "server_uri"
+          }
+        ],
         "_research": {
           "confidence": "high",
           "docker_only": false,
-          "notes": "Official Datadog MCP Server (Bits AI). Verified first-party from docs.datadoghq.com. Transport: Streamable HTTP (remote). Endpoint path is /api/unstable/mcp-server/mcp; hostname is site-specific. US1 host is mcp.datadoghq.com (full URL: https://mcp.datadoghq.com/api/unstable/mcp-server/mcp). Other sites replace the host: EU=mcp.datadoghq.eu, US3=mcp.us3.datadoghq.com, US5=mcp.us5.datadoghq.com, AP1/AP2 analogous; same path. app.ddog-gov.com (GovCloud) is NOT supported. Primary auth is OAuth 2.0 with a browser-based sign-in/redirect (\"You are prompted to login through OAuth\"). The docs do not state whether DCR or discovery metadata is used; as a modern remote MCP server it almost certainly advertises authorization/token endpoints via OAuth discovery (.well-known), so oauth_authorization_endpoint/token_endpoint are left null and OAuth endpoints are discovered from the MCP metadata chain. No specific OAuth scopes are documented. ALTERNATIVE auth (not chosen here, since intended transport is HTTP+OAuth) for headless/server environments: pass two HTTP headers DD_API_KEY and DD_APPLICATION_KEY (Datadog recommends a scoped service-account API key + application key). If the catalog instead wants the API-key path, switch auth_type to CUSTOM with two required secret credentials keyed DD_API_KEY and DD_APPLICATION_KEY plus an optional non-secret site/host field for region selection. A toolsets query param controls available tools (?toolsets=all, default core, or comma-separated e.g. apm,llmobs,monitors,logs). No npx/uvx/pip package — it is a hosted remote server, so packages[] is empty.",
+          "notes": "Official Datadog MCP Server (Bits AI). Verified first-party from docs.datadoghq.com. Transport: Streamable HTTP (remote). The current documented endpoint path is /v1/mcp; the older /api/unstable/mcp-server/mcp path is deprecated but still routed as of 2026-08. Hostname is site-specific, one host per Datadog site: US1=mcp.datadoghq.com, US3=mcp.us3.datadoghq.com, US5=mcp.us5.datadoghq.com, EU=mcp.datadoghq.eu, AP1=mcp.ap1.datadoghq.com, AP2=mcp.ap2.datadoghq.com, UK1=mcp.uk1.datadoghq.com — all sharing the same /v1/mcp path. The US1-FED / GovCloud site (app.ddog-gov.com) is NOT supported. Because the host varies per site, the server URI is user-supplied: a non-secret required credential with target 'server_uri' (default_value US1) lets the user pick their regional endpoint, and the resolver's server_uri_is_user_supplied() therefore accepts any user-chosen host instead of pinning the US1 URL exactly. Verified live: an unauthenticated MCP initialize POST to /v1/mcp returns 401 auth-required on both mcp.datadoghq.com and mcp.datadoghq.eu, while non-existent paths return 404, confirming the path is routed on both commercial and EU sites. Per-site host map cross-checked against the mcp_server_endpoint entries in regions.config.js in the DataDog/documentation repo. Primary auth is OAuth 2.0 with a browser-based sign-in/redirect (\"You are prompted to login through OAuth\"). The docs do not state whether DCR or discovery metadata is used; as a modern remote MCP server it almost certainly advertises authorization/token endpoints via OAuth discovery (.well-known), so oauth_authorization_endpoint/token_endpoint are left null and OAuth endpoints are discovered from the MCP metadata chain. Verified live 2026-08-31: GET /.well-known/oauth-authorization-server/v1/mcp returns complete RFC 8414 metadata on all seven sites, and each site advertises authorization, token, and DCR registration endpoints on a sibling host rather than on mcp.* itself. OAuth endpoints reached through the discovery chain may use a different host from the MCP server; they must still use HTTPS and pass SSRF validation. No specific OAuth scopes are documented (metadata advertises a single supported scope, mcp_all). An optional toolsets query param controls available tools (?toolsets=all, default core, or comma-separated e.g. apm,llmobs,monitors,logs) and may be appended to any regional URL. ALTERNATIVE auth (not chosen here, since intended transport is HTTP+OAuth) for headless/server environments: pass two HTTP headers DD_API_KEY and DD_APPLICATION_KEY (Datadog recommends a scoped service-account API key + application key). If the catalog instead wants the API-key path, switch auth_type to CUSTOM with two required secret credentials keyed DD_API_KEY and DD_APPLICATION_KEY plus an optional non-secret site/host field for region selection. No npx/uvx/pip package — it is a hosted remote server, so packages[] is empty.",
           "sources": [
-            "https://docs.datadoghq.com/bits_ai/mcp_server/",
-            "https://docs.datadoghq.com/bits_ai/mcp_server/setup/",
+            "https://docs.datadoghq.com/mcp_server/setup/",
+            "https://docs.datadoghq.com/mcp_server/",
+            "https://github.com/DataDog/documentation/blob/master/hugo/assets/scripts/config/regions.config.js",
             "https://www.datadoghq.com/blog/datadog-remote-mcp-server/",
             "https://www.datadoghq.com/knowledge-center/mcp-server/"
           ]

--- a/tests/unit/test_mcp_catalog_loader.py
+++ b/tests/unit/test_mcp_catalog_loader.py
@@ -681,6 +681,25 @@ def test_private_catalog_overlay_does_not_drop_public_rows() -> None:
     assert headers["X-Wiz-MCP-Mode"].default_value == "gateway"
 
 
+def test_datadog_row_uses_configurable_regional_v1_endpoint() -> None:
+    """Datadog users can select their regional /v1/mcp endpoint."""
+    _clear_catalog_cache()
+    entry = loader.get_platform_mcp_catalog_entry_by_slug(
+        "datadog-mcp", include_private=True
+    )
+    assert entry is not None
+    spec = entry.connection_spec
+    assert spec is not None
+    assert spec.kind == "http_oauth2"
+    assert spec.server_uri == "https://mcp.datadoghq.com/v1/mcp"
+    assert spec.requires_config is True
+    assert spec.oauth_authorization_endpoint is None
+    assert spec.oauth_token_endpoint is None
+    assert {credential.key: credential.target for credential in spec.credentials} == {
+        "server_url": "server_uri",
+    }
+
+
 def test_google_secops_row_ships_templated_uri_and_pinned_authorize_params() -> None:
     """Google's managed remote SecOps server needs a region and offline consent."""
     _clear_catalog_cache()

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -6171,19 +6171,22 @@ class TestMCPProviderOAuth:
         assert "10.0.0.10" not in message
         assert "private" not in message.lower()
 
-    async def test_generic_mcp_discovery_rejects_untrusted_endpoint_hosts(
+    async def test_generic_mcp_discovery_allows_cross_host_endpoints(
         self,
         integration_service: IntegrationService,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Generic MCP DCR endpoints must stay on the metadata document host."""
+        """OAuth metadata may advertise endpoints on separate HTTPS hosts."""
         docs = {
-            "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": None,
+            "https://mcp.example.com/.well-known/oauth-protected-resource/v1/mcp": {
+                "authorization_servers": ["https://mcp.example.com/v1/mcp"]
+            },
             "https://mcp.example.com/.well-known/oauth-protected-resource": None,
-            "https://mcp.example.com/.well-known/oauth-authorization-server": {
-                "authorization_endpoint": "https://evil.example/oauth/authorize",
-                "token_endpoint": "https://evil.example/oauth/token",
-                "registration_endpoint": "https://evil.example/oauth/register",
+            "https://mcp.example.com/.well-known/oauth-authorization-server": None,
+            "https://mcp.example.com/.well-known/oauth-authorization-server/v1/mcp": {
+                "authorization_endpoint": "https://identity.example.net/oauth/authorize",
+                "token_endpoint": "https://identity.example.net/oauth/token",
+                "registration_endpoint": "https://identity.example.net/oauth/register",
                 "token_endpoint_auth_methods_supported": ["none"],
             },
         }
@@ -6192,75 +6195,33 @@ class TestMCPProviderOAuth:
             return OAuthServerMetadata.from_json(docs[url])
 
         monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
-
-        with pytest.raises(ValueError, match="does not match expected domain"):
-            await integration_service._discover_mcp_oauth_endpoints(
-                server_uri="https://mcp.example.com/mcp",
-            )
-
-    async def test_generic_mcp_discovery_allows_catalog_pinned_endpoint_hosts(
-        self,
-        integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Hosts of catalog-pinned OAuth endpoints are trusted in discovery.
-
-        Mirrors incident.io: metadata on mcp.* advertises authorization/token
-        endpoints on app.*, with registration staying on the metadata host.
-        """
-        docs = {
-            "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": None,
-            "https://mcp.example.com/.well-known/oauth-protected-resource": None,
-            "https://mcp.example.com/.well-known/oauth-authorization-server": {
-                "authorization_endpoint": "https://app.example.com/oauth/authorize",
-                "token_endpoint": "https://app.example.com/oauth/token",
-                "registration_endpoint": "https://mcp.example.com/oauth/register",
-                "token_endpoint_auth_methods_supported": ["none"],
-            },
-        }
-
-        async def fake_fetch(url: str) -> OAuthServerMetadata | None:
-            return OAuthServerMetadata.from_json(docs[url])
-
-        monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
-
-        # Unrelated hosts are still rejected even with an allowlist present.
-        with pytest.raises(ValueError, match="does not match expected domain"):
-            await integration_service._discover_mcp_oauth_endpoints(
-                server_uri="https://mcp.example.com/mcp",
-                allowed_endpoint_hosts=frozenset({"other.example.com"}),
-            )
 
         endpoints = await integration_service._discover_mcp_oauth_endpoints(
-            server_uri="https://mcp.example.com/mcp",
-            allowed_endpoint_hosts=frozenset({"app.example.com"}),
+            server_uri="https://mcp.example.com/v1/mcp",
         )
 
         assert endpoints.authorization_endpoint == (
-            "https://app.example.com/oauth/authorize"
+            "https://identity.example.net/oauth/authorize"
         )
-        assert endpoints.token_endpoint == "https://app.example.com/oauth/token"
+        assert endpoints.token_endpoint == "https://identity.example.net/oauth/token"
         assert endpoints.registration_endpoint == (
-            "https://mcp.example.com/oauth/register"
+            "https://identity.example.net/oauth/register"
         )
 
-    async def test_connect_mcp_oauth_discovery_trusts_catalog_pinned_hosts(
+    async def test_connect_mcp_oauth_discovery_forwards_catalog_oauth_resource(
         self,
         integration_service: IntegrationService,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Connect derives trusted endpoint hosts from catalog-pinned endpoints."""
-        captured_hosts: list[frozenset[str]] = []
+        """Connect forwards a catalog-pinned OAuth resource to discovery."""
         captured_resources: list[str | None] = []
 
         async def fake_discover(
             *,
             server_uri: str,
             oauth_resource: str | None = None,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
             _ = server_uri
-            captured_hosts.append(allowed_endpoint_hosts)
             captured_resources.append(oauth_resource)
             raise RuntimeError("stop after capture")
 
@@ -6271,21 +6232,18 @@ class TestMCPProviderOAuth:
         catalog_spec = MCPHTTPOAuth2ConnectionSpec(
             server_uri="https://mcp.example.com/mcp",
             oauth_resource="https://mcp.example.com",
-            oauth_authorization_endpoint="https://app.example.com/oauth/authorize",
-            oauth_token_endpoint="https://app.example.com/oauth/token",
         )
 
         with pytest.raises(RuntimeError, match="stop after capture"):
             await integration_service.connect_mcp_oauth_discovery(
                 params=MCPHttpIntegrationCreate(
-                    name="Pinned Hosts MCP",
+                    name="Pinned Resource MCP",
                     server_uri="https://mcp.example.com/mcp",
                     auth_type=MCPAuthType.OAUTH2,
                 ),
                 resolved_catalog=_resolved_catalog(catalog_spec),
             )
 
-        assert captured_hosts == [frozenset({"app.example.com"})]
         assert captured_resources == ["https://mcp.example.com"]
 
     def test_feedly_catalog_pins_origin_level_oauth_resource(
@@ -6979,9 +6937,8 @@ class TestMCPProviderOAuth:
         async def fake_discover(
             *,
             server_uri: str,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
-            _ = server_uri, allowed_endpoint_hosts
+            _ = server_uri
             return endpoints
 
         monkeypatch.setattr(
@@ -7064,9 +7021,8 @@ class TestMCPProviderOAuth:
         async def fake_discover(
             *,
             server_uri: str,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
-            _ = server_uri, allowed_endpoint_hosts
+            _ = server_uri
             return endpoints
 
         monkeypatch.setattr(
@@ -7339,9 +7295,8 @@ class TestMCPProviderOAuth:
             *,
             server_uri: str,
             oauth_resource: str | None = None,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
-            _ = server_uri, oauth_resource, allowed_endpoint_hosts
+            _ = server_uri, oauth_resource
             return endpoints
 
         async def fake_register(
@@ -7616,9 +7571,8 @@ class TestMCPProviderOAuth:
             *,
             server_uri: str,
             oauth_resource: str | None = None,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
-            _ = server_uri, oauth_resource, allowed_endpoint_hosts
+            _ = server_uri, oauth_resource
             return integration_service_module.MCPOAuthDiscoveryEndpoints(
                 authorization_endpoint="https://auth.example.test/oauth/authorize",
                 token_endpoint="https://auth.example.test/oauth/token",

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -772,7 +772,6 @@ class IntegrationService(BaseWorkspaceService):
         *,
         server_uri: str,
         oauth_resource: str | None,
-        allowed_endpoint_hosts: frozenset[str],
     ) -> MCPOAuthDiscoveryEndpoints | None:
         """Use a catalog row's pinned OAuth endpoints instead of discovery.
 
@@ -788,40 +787,23 @@ class IntegrationService(BaseWorkspaceService):
             return None
         return MCPOAuthDiscoveryEndpoints(
             authorization_endpoint=cls._validate_mcp_oauth_endpoint(
-                authorization_endpoint, allowed_hosts=allowed_endpoint_hosts
+                authorization_endpoint
             ),
-            token_endpoint=cls._validate_mcp_oauth_endpoint(
-                token_endpoint, allowed_hosts=allowed_endpoint_hosts
-            ),
+            token_endpoint=cls._validate_mcp_oauth_endpoint(token_endpoint),
             token_methods=[],
             registration_endpoint=None,
             resource=cls._mcp_resource_uri(oauth_resource or server_uri),
         )
 
     @staticmethod
-    def _validate_mcp_oauth_endpoint(
-        endpoint: str,
-        *,
-        base_domain: str | None = None,
-        allowed_hosts: frozenset[str] = frozenset(),
-    ) -> str:
-        """Validate a generic MCP OAuth endpoint discovered from metadata.
+    def _validate_mcp_oauth_endpoint(endpoint: str) -> str:
+        """Validate a generic MCP OAuth endpoint.
 
-        Generic BYO/catalog DCR follows the trust chain from the user-supplied
-        MCP server URI to protected-resource or authorization-server metadata.
-        Endpoint hosts must match the metadata host that advertised them,
-        except for exact hosts of OAuth endpoints pinned on the repo-owned
-        catalog row (still SSRF-validated).
+        OAuth endpoints discovered from provider metadata may use a different
+        host from the MCP resource server. They still require HTTPS and undergo
+        DNS-backed SSRF validation before server-side requests.
         """
-        hostname = urlparse(endpoint).hostname
-        if not hostname:
-            raise InsecureOAuthEndpointError(
-                f"oauth_endpoint must include a hostname: {endpoint}"
-            )
-        if hostname in allowed_hosts:
-            validate_oauth_endpoint(endpoint)
-            return endpoint
-        validate_oauth_endpoint(endpoint, base_domain=base_domain)
+        validate_oauth_endpoint(endpoint)
         return endpoint
 
     @staticmethod
@@ -969,7 +951,6 @@ class IntegrationService(BaseWorkspaceService):
         *,
         server_uri: str,
         oauth_resource: str | None = None,
-        allowed_endpoint_hosts: frozenset[str] = frozenset(),
     ) -> MCPOAuthDiscoveryEndpoints:
         resource_uri = self._mcp_resource_uri(oauth_resource or server_uri)
         resource_host = urlparse(resource_uri).hostname
@@ -982,7 +963,6 @@ class IntegrationService(BaseWorkspaceService):
         # .well-known metadata we fetch in the second pass below.
         auth_server_metadata_urls: list[str] = []
         direct_metadata: OAuthServerMetadata | None = None
-        direct_metadata_host: str | None = None
         for metadata_url in self._mcp_oauth_metadata_urls(server_uri):
             metadata = await self._fetch_oauth_json(metadata_url)
             if not metadata:
@@ -993,7 +973,6 @@ class IntegrationService(BaseWorkspaceService):
                 resource_uri = self._mcp_resource_uri(metadata.resource)
             if metadata.is_complete:
                 direct_metadata = metadata
-                direct_metadata_host = urlparse(metadata_url).hostname
                 break
             for issuer in metadata.authorization_servers:
                 auth_server_metadata_urls.extend(
@@ -1005,7 +984,6 @@ class IntegrationService(BaseWorkspaceService):
                 metadata = await self._fetch_oauth_json(metadata_url)
                 if metadata and metadata.is_complete:
                     direct_metadata = metadata
-                    direct_metadata_host = urlparse(metadata_url).hostname
                     break
 
         if direct_metadata is None:
@@ -1021,20 +999,12 @@ class IntegrationService(BaseWorkspaceService):
 
         return MCPOAuthDiscoveryEndpoints(
             authorization_endpoint=self._validate_mcp_oauth_endpoint(
-                authorization_endpoint,
-                base_domain=direct_metadata_host,
-                allowed_hosts=allowed_endpoint_hosts,
+                authorization_endpoint
             ),
-            token_endpoint=self._validate_mcp_oauth_endpoint(
-                token_endpoint,
-                base_domain=direct_metadata_host,
-                allowed_hosts=allowed_endpoint_hosts,
-            ),
+            token_endpoint=self._validate_mcp_oauth_endpoint(token_endpoint),
             token_methods=token_methods,
             registration_endpoint=self._validate_mcp_oauth_endpoint(
-                registration_endpoint,
-                base_domain=direct_metadata_host,
-                allowed_hosts=allowed_endpoint_hosts,
+                registration_endpoint
             )
             if registration_endpoint
             else None,
@@ -1288,24 +1258,12 @@ class IntegrationService(BaseWorkspaceService):
             )
 
         scopes: list[str] | None = None
-        allowed_endpoint_hosts: frozenset[str] = frozenset()
         oauth_resource: str | None = None
         if catalog_spec is not None:
             if not isinstance(catalog_spec, MCPHTTPOAuth2ConnectionSpec):
                 raise ValueError("Catalog option is not an HTTP OAuth MCP server")
             scopes = catalog_spec.scopes
             oauth_resource = catalog_spec.oauth_resource
-            # Hosts of catalog-pinned OAuth endpoints are trusted during
-            # discovery; the catalog is repo-owned, so a pinned endpoint
-            # states explicitly where the provider serves OAuth.
-            allowed_endpoint_hosts = frozenset(
-                hostname
-                for endpoint in (
-                    catalog_spec.oauth_authorization_endpoint,
-                    catalog_spec.oauth_token_endpoint,
-                )
-                if endpoint and (hostname := urlparse(endpoint).hostname)
-            )
             # Fail before any discovery or registration call so a row that
             # cannot connect is never half-created.
             self._validate_required_catalog_headers(
@@ -1332,7 +1290,6 @@ class IntegrationService(BaseWorkspaceService):
                 catalog_spec,
                 server_uri=params.server_uri,
                 oauth_resource=oauth_resource,
-                allowed_endpoint_hosts=allowed_endpoint_hosts,
             )
             if catalog_spec is not None and not needs_dcr
             else None
@@ -1343,12 +1300,10 @@ class IntegrationService(BaseWorkspaceService):
             endpoints = await self._discover_mcp_oauth_endpoints(
                 server_uri=params.server_uri,
                 oauth_resource=oauth_resource,
-                allowed_endpoint_hosts=allowed_endpoint_hosts,
             )
         else:
             endpoints = await self._discover_mcp_oauth_endpoints(
                 server_uri=params.server_uri,
-                allowed_endpoint_hosts=allowed_endpoint_hosts,
             )
         # Request offline_access only when the AS advertises it, so refresh
         # tokens survive session-bound authorization policies. Computed once and


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Datadog MCP integration to support regional endpoints by updating the server URI and allowing user-selected region. Relaxes OAuth discovery host restrictions so Datadog's cross-host metadata works.

- Updates the Datadog MCP server URI to the current `/v1/mcp` path across all supported regions.
- Adds a required `server_url` credential so users pick their regional endpoint.
- Allows OAuth endpoints discovered from metadata to be on different hosts, subject to existing HTTPS and SSRF validation.

<sup>Written for commit d21fc37d4ba0140235061945dd6f461c9c85bf95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

