### PR TITLE
feat(engine): add object, parsing, and regex functions

### DIFF
--- a/docs/snippets/functions-reference.mdx
+++ b/docs/snippets/functions-reference.mdx
@@ -42,11 +42,27 @@
 
 </ResponseField>
 
+<ResponseField name="FN.collect" type="function">
+
+  `FN.collect(mappings: Sequence[Mapping[Any, Any]], remove_duplicates: bool = False) -> dict[Any, list[Any]]`
+
+  Group values from a sequence of objects by key into an object of arrays.
+
+</ResponseField>
+
 <ResponseField name="FN.compact" type="function">
 
   `FN.compact(x: list[Any]) -> list[Any]`
 
   Drop null values from a list. Similar to compact function in Terraform.
+
+</ResponseField>
+
+<ResponseField name="FN.compact_object" type="function">
+
+  `FN.compact_object(x: dict[Any, Any]) -> dict[Any, Any]`
+
+  Drop null values from an object. The object equivalent of `compact`.
 
 </ResponseField>
 
@@ -776,6 +792,14 @@
 
 </ResponseField>
 
+<ResponseField name="FN.omit_keys" type="function">
+
+  `FN.omit_keys(x: dict[Any, Any], keys: Sequence[Any]) -> dict[Any, Any]`
+
+  Return a copy of an object without the given keys.
+
+</ResponseField>
+
 <ResponseField name="FN.or" type="function">
 
   `FN.or(a: bool, b: bool) -> bool`
@@ -800,11 +824,43 @@
 
 </ResponseField>
 
+<ResponseField name="FN.parse_email_addresses" type="function">
+
+  `FN.parse_email_addresses(headers: str | list[str]) -> list[EmailAddress]`
+
+  Parse email address headers (e.g. `To`, `From`) into a list of mailboxes.
+
+</ResponseField>
+
+<ResponseField name="FN.parse_key_value" type="function">
+
+  `FN.parse_key_value(text: str, separator: str = =) -> dict[str, str]`
+
+  Parse whitespace-separated `key=value` pairs into an object.
+
+</ResponseField>
+
 <ResponseField name="FN.parse_time" type="function">
 
   `FN.parse_time(x: str) -> time`
 
   Parse HH:MM:SS or HH:MM formatted string to a time object.
+
+</ResponseField>
+
+<ResponseField name="FN.parse_url" type="function">
+
+  `FN.parse_url(url: str) -> ParsedUrl`
+
+  Parse a URL into an object with its scheme, host, port, path, query, and fragment.
+
+</ResponseField>
+
+<ResponseField name="FN.pick_keys" type="function">
+
+  `FN.pick_keys(x: dict[Any, Any], keys: Sequence[Any]) -> dict[Any, Any]`
+
+  Return a copy of an object with only the given keys. Missing keys are skipped.
 
 </ResponseField>
 
@@ -845,6 +901,22 @@
   `FN.regex_extract(pattern: str, text: str) -> str | None`
 
   Extract the first captured group from text; fallback to full match if none.
+
+</ResponseField>
+
+<ResponseField name="FN.regex_extract_all" type="function">
+
+  `FN.regex_extract_all(pattern: str, text: str) -> list[str]`
+
+  Extract every match of a regex pattern from text, one item per match.
+
+</ResponseField>
+
+<ResponseField name="FN.regex_extract_fields" type="function">
+
+  `FN.regex_extract_fields(pattern: str, text: str) -> dict[str, str | None] | None`
+
+  Extract the named groups of a regex pattern from text into an object.
 
 </ResponseField>
 
@@ -1146,7 +1218,7 @@
 
 <ResponseField name="FN.url_encode" type="function">
 
-  `FN.url_encode(x: str) -> str`
+  `FN.url_encode(x: str | int, safe: str = ) -> str`
 
   Converts URL-unsafe characters into percent-encoded characters.
 

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -19,6 +19,9 @@ from tracecat.expressions.functions import (
     capitalize,
     cast,
     check_ip_version,
+    collect,
+    compact,
+    compact_object,
     contains_any_of,
     contains_none_of,
     create_days,
@@ -81,12 +84,19 @@ from tracecat.expressions.functions import (
     not_in,
     not_null,
     now,
+    omit_keys,
     or_,
     parse_datetime,
+    parse_email_addresses,
+    parse_key_value,
     parse_time,
+    parse_url,
+    pick_keys,
     pow,
     prettify_json,
     regex_extract,
+    regex_extract_all,
+    regex_extract_fields,
     regex_match,
     regex_not_match,
     seconds_between,
@@ -117,6 +127,443 @@ from tracecat.expressions.functions import (
     weeks_between,
     zip_iterables,
 )
+
+
+@pytest.mark.parametrize(
+    "mappings,expected",
+    [
+        # Example from the docs: group alternating keys
+        (
+            [
+                {"even_number": 2},
+                {"even_number": 4},
+                {"even_number": 6},
+                {"odd_number": 1},
+                {"odd_number": 3},
+                {"odd_number": 5},
+            ],
+            {"even_number": [2, 4, 6], "odd_number": [1, 3, 5]},
+        ),
+        # Multiple keys per mapping
+        (
+            [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
+            {"a": [1, 3], "b": [2, 4]},
+        ),
+        # Ragged mappings: missing keys are simply not collected
+        (
+            [{"a": 1}, {"b": 2}, {"a": 3, "c": 4}],
+            {"a": [1, 3], "b": [2], "c": [4]},
+        ),
+        # Duplicates are preserved by default
+        (
+            [{"a": 1}, {"a": 1}, {"a": 2}],
+            {"a": [1, 1, 2]},
+        ),
+        # Heterogeneous and nested values are kept as-is
+        (
+            [{"a": None}, {"a": [1, 2]}, {"a": {"b": 3}}],
+            {"a": [None, [1, 2], {"b": 3}]},
+        ),
+        # Empty inputs
+        ([], {}),
+        ([{}, {}], {}),
+        # Non-string keys
+        ([{1: "a"}, {1: "b"}, {2: "c"}], {1: ["a", "b"], 2: ["c"]}),
+    ],
+)
+def test_collect(
+    mappings: list[dict[Any, Any]], expected: dict[Any, list[Any]]
+) -> None:
+    assert collect(mappings) == expected
+
+
+def test_collect_preserves_insertion_order() -> None:
+    result = collect([{"b": 1}, {"a": 2}, {"b": 3}])
+    assert list(result.keys()) == ["b", "a"]
+    assert result["b"] == [1, 3]
+
+
+@pytest.mark.parametrize(
+    "mappings,expected",
+    [
+        # Duplicates removed, first-seen order preserved
+        (
+            [{"a": 2}, {"a": 1}, {"a": 2}, {"a": 3}, {"a": 1}],
+            {"a": [2, 1, 3]},
+        ),
+        # Deduplication is per key
+        (
+            [{"a": 1, "b": 1}, {"a": 1, "b": 2}],
+            {"a": [1], "b": [1, 2]},
+        ),
+        # Unhashable values are deduplicated without raising
+        (
+            [{"a": {"x": 1}}, {"a": {"x": 1}}, {"a": {"x": 2}}, {"a": [1]}, {"a": [1]}],
+            {"a": [{"x": 1}, {"x": 2}, [1]]},
+        ),
+        # Mixed hashable and unhashable values
+        (
+            [{"a": 1}, {"a": [1]}, {"a": 1}, {"a": [1]}],
+            {"a": [1, [1]]},
+        ),
+        # Nothing to remove
+        ([{"a": 1}, {"a": 2}], {"a": [1, 2]}),
+        ([], {}),
+    ],
+)
+def test_collect_remove_duplicates(
+    mappings: list[dict[Any, Any]], expected: dict[Any, list[Any]]
+) -> None:
+    assert collect(mappings, remove_duplicates=True) == expected
+
+
+def test_collect_dedupe_uses_equality_semantics() -> None:
+    """Dedupe follows Python equality, so `True` collapses into `1` (as `unique` does)."""
+    result = collect([{"a": 1}, {"a": True}, {"a": 1.0}], remove_duplicates=True)
+    assert result["a"] == [1]
+
+
+def test_collect_accepts_non_dict_mappings() -> None:
+    from types import MappingProxyType
+
+    result = collect([MappingProxyType({"a": 1}), MappingProxyType({"a": 2})])
+    assert result == {"a": [1, 2]}
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        (
+            "https://example.com/path/to/page?a=1&b=2#section",
+            {
+                "scheme": "https",
+                "host": "example.com",
+                "port": None,
+                "path": "/path/to/page",
+                "query": {"a": "1", "b": "2"},
+                "fragment": "section",
+            },
+        ),
+        # Explicit port
+        (
+            "https://example.com:8443/admin",
+            {
+                "scheme": "https",
+                "host": "example.com",
+                "port": 8443,
+                "path": "/admin",
+                "query": {},
+                "fragment": "",
+            },
+        ),
+        # Repeated query params are joined
+        (
+            "https://example.com/?tag=a&tag=b",
+            {
+                "scheme": "https",
+                "host": "example.com",
+                "port": None,
+                "path": "/",
+                "query": {"tag": "a,b"},
+                "fragment": "",
+            },
+        ),
+        # Percent-encoded values are decoded
+        (
+            "https://example.com/s?q=hello%20world",
+            {
+                "scheme": "https",
+                "host": "example.com",
+                "port": None,
+                "path": "/s",
+                "query": {"q": "hello world"},
+                "fragment": "",
+            },
+        ),
+        # Host is lowercased by urlsplit, credentials are not part of the host
+        (
+            "http://user:pass@EXAMPLE.com/x",
+            {
+                "scheme": "http",
+                "host": "example.com",
+                "port": None,
+                "path": "/x",
+                "query": {},
+                "fragment": "",
+            },
+        ),
+        # Non-HTTP schemes
+        (
+            "mailto:alice@example.com",
+            {
+                "scheme": "mailto",
+                "host": None,
+                "port": None,
+                "path": "alice@example.com",
+                "query": {},
+                "fragment": "",
+            },
+        ),
+        # Bare path, no scheme or host
+        (
+            "/just/a/path",
+            {
+                "scheme": "",
+                "host": None,
+                "port": None,
+                "path": "/just/a/path",
+                "query": {},
+                "fragment": "",
+            },
+        ),
+    ],
+)
+def test_parse_url(url: str, expected: dict[str, Any]) -> None:
+    assert parse_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Basic key=value log line
+        ("user=bob action=login", {"user": "bob", "action": "login"}),
+        # Quoted values may contain whitespace, and quotes are stripped
+        (
+            'user=bob msg="access denied" src=10.0.0.1',
+            {"user": "bob", "msg": "access denied", "src": "10.0.0.1"},
+        ),
+        # Single quotes work too
+        ("msg='hello world'", {"msg": "hello world"}),
+        # Tokens without the separator are ignored
+        ("noise user=bob more-noise", {"user": "bob"}),
+        # Empty values are preserved
+        ("user= action=login", {"user": "", "action": "login"}),
+        # Values containing the separator keep it
+        ("url=https://example.com/?a=1", {"url": "https://example.com/?a=1"}),
+        # Later occurrences win
+        ("user=alice user=bob", {"user": "bob"}),
+        # Empty input
+        ("", {}),
+    ],
+)
+def test_parse_key_value(text: str, expected: dict[str, str]) -> None:
+    assert parse_key_value(text) == expected
+
+
+def test_parse_key_value_custom_separator() -> None:
+    assert parse_key_value("level:info msg:'all good'", separator=":") == {
+        "level": "info",
+        "msg": "all good",
+    }
+
+
+@pytest.mark.parametrize(
+    "headers,expected",
+    [
+        # Display name and bare address in one header
+        (
+            "Alice Smith <alice@example.com>, bob@example.com",
+            [
+                {
+                    "display_name": "Alice Smith",
+                    "email": "alice@example.com",
+                    "user": "alice",
+                    "domain": "example.com",
+                },
+                {
+                    "display_name": "",
+                    "email": "bob@example.com",
+                    "user": "bob",
+                    "domain": "example.com",
+                },
+            ],
+        ),
+        # Quoted display name containing a comma is not split on
+        (
+            '"Smith, Alice" <alice@example.com>',
+            [
+                {
+                    "display_name": "Smith, Alice",
+                    "email": "alice@example.com",
+                    "user": "alice",
+                    "domain": "example.com",
+                }
+            ],
+        ),
+        # Group syntax
+        (
+            "Team: alice@example.com, bob@example.com;",
+            [
+                {
+                    "display_name": "",
+                    "email": "alice@example.com",
+                    "user": "alice",
+                    "domain": "example.com",
+                },
+                {
+                    "display_name": "",
+                    "email": "bob@example.com",
+                    "user": "bob",
+                    "domain": "example.com",
+                },
+            ],
+        ),
+        # A list of headers is de-duplicated by address, first occurrence wins
+        (
+            ["Alice <alice@example.com>", "alice@example.com, bob@example.com"],
+            [
+                {
+                    "display_name": "Alice",
+                    "email": "alice@example.com",
+                    "user": "alice",
+                    "domain": "example.com",
+                },
+                {
+                    "display_name": "",
+                    "email": "bob@example.com",
+                    "user": "bob",
+                    "domain": "example.com",
+                },
+            ],
+        ),
+        # Empty header
+        ("", []),
+        ([], []),
+    ],
+)
+def test_parse_email_addresses(
+    headers: str | list[str], expected: list[dict[str, str]]
+) -> None:
+    assert parse_email_addresses(headers) == expected
+
+
+@pytest.mark.parametrize(
+    "pattern,text,expected",
+    [
+        # No groups: full matches
+        (r"\d+", "a1 b22 c333", ["1", "22", "333"]),
+        # One group: the captured group
+        (r"user=(\w+)", "user=alice user=bob", ["alice", "bob"]),
+        # First non-null group wins, mirroring regex_extract
+        (r"(?:a(\d)|b(\d))", "a1 b2", ["1", "2"]),
+        # No matches
+        (r"\d+", "no digits here", []),
+        # Overlapping-looking patterns still scan left to right
+        (r"[aeiou]", "sequoia", ["e", "u", "o", "i", "a"]),
+    ],
+)
+def test_regex_extract_all(pattern: str, text: str, expected: list[str]) -> None:
+    assert regex_extract_all(pattern, text) == expected
+
+
+def test_regex_extract_all_matches_regex_extract_on_first_match() -> None:
+    pattern = r"user=(\w+)"
+    text = "user=alice user=bob"
+    assert regex_extract_all(pattern, text)[0] == regex_extract(pattern, text)
+
+
+@pytest.mark.parametrize(
+    "pattern,text,expected",
+    [
+        # Named groups become object keys
+        (
+            r"(?P<user>\w+)@(?P<domain>[\w.]+)",
+            "contact bob@example.com now",
+            {"user": "bob", "domain": "example.com"},
+        ),
+        # Unmatched optional groups are null
+        (
+            r"(?P<user>\w+)(?:@(?P<domain>[\w.]+))?",
+            "bob",
+            {"user": "bob", "domain": None},
+        ),
+        # Unnamed groups are not included
+        (r"(\w+)@(?P<domain>[\w.]+)", "bob@example.com", {"domain": "example.com"}),
+        # A pattern with no named groups yields an empty object
+        (r"\w+", "bob", {}),
+        # No match at all
+        (r"(?P<user>\d+)", "no digits", None),
+    ],
+)
+def test_regex_extract_fields(
+    pattern: str, text: str, expected: dict[str, str | None] | None
+) -> None:
+    assert regex_extract_fields(pattern, text) == expected
+
+
+@pytest.mark.parametrize(
+    "obj,keys,expected",
+    [
+        ({"a": 1, "b": 2, "c": 3}, ["b"], {"a": 1, "c": 3}),
+        # Keys that are not present are ignored
+        ({"a": 1}, ["b", "c"], {"a": 1}),
+        # Removing everything
+        ({"a": 1, "b": 2}, ["a", "b"], {}),
+        # Nothing to remove
+        ({"a": 1}, [], {"a": 1}),
+        ({}, ["a"], {}),
+        # Non-string keys
+        ({1: "a", 2: "b"}, [1], {2: "b"}),
+    ],
+)
+def test_omit_keys(
+    obj: dict[Any, Any], keys: list[Any], expected: dict[Any, Any]
+) -> None:
+    assert omit_keys(obj, keys) == expected
+
+
+def test_omit_keys_does_not_mutate_input() -> None:
+    original = {"a": 1, "b": 2}
+    assert omit_keys(original, ["a"]) == {"b": 2}
+    assert original == {"a": 1, "b": 2}
+
+
+@pytest.mark.parametrize(
+    "obj,keys,expected",
+    [
+        ({"a": 1, "b": 2, "c": 3}, ["a", "c"], {"a": 1, "c": 3}),
+        # Missing keys are skipped rather than raising or yielding null
+        ({"a": 1}, ["a", "zzz"], {"a": 1}),
+        # Output follows the order of `keys`, not the source object
+        ({"a": 1, "b": 2}, ["b", "a"], {"b": 2, "a": 1}),
+        # Null values are still picked
+        ({"a": None}, ["a"], {"a": None}),
+        ({"a": 1}, [], {}),
+        ({}, ["a"], {}),
+    ],
+)
+def test_pick_keys(
+    obj: dict[Any, Any], keys: list[Any], expected: dict[Any, Any]
+) -> None:
+    assert pick_keys(obj, keys) == expected
+
+
+def test_pick_keys_preserves_key_order() -> None:
+    assert list(pick_keys({"a": 1, "b": 2, "c": 3}, ["c", "a"])) == ["c", "a"]
+
+
+@pytest.mark.parametrize(
+    "obj,expected",
+    [
+        ({"a": 1, "b": None, "c": 3}, {"a": 1, "c": 3}),
+        # Only nulls go, matching `compact` for lists
+        (
+            {"a": "", "b": [], "c": {}, "d": 0, "e": False, "f": None},
+            {"a": "", "b": [], "c": {}, "d": 0, "e": False},
+        ),
+        ({"a": None}, {}),
+        ({}, {}),
+    ],
+)
+def test_compact_object(obj: dict[Any, Any], expected: dict[Any, Any]) -> None:
+    assert compact_object(obj) == expected
+
+
+def test_compact_object_matches_compact_semantics() -> None:
+    """`compact_object` drops exactly what `compact` drops, but for objects."""
+    values = [1, None, "", 0, False]
+    obj = {str(i): v for i, v in enumerate(values)}
+    assert list(compact_object(obj).values()) == compact(values)
 
 
 @pytest.mark.parametrize(

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -8,13 +8,15 @@ import itertools
 import json
 import math
 import re
+import shlex
 import urllib.parse
 import zoneinfo
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import UTC, date, datetime, time, timedelta
+from email.headerregistry import AddressHeader
 from functools import wraps
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
-from typing import Any, Literal, ParamSpec, TypeVar
+from typing import Any, Literal, ParamSpec, TypedDict, TypeVar
 from uuid import uuid4
 
 import orjson
@@ -88,6 +90,34 @@ def url_encode(x: str | int, safe: str = "") -> str:
 def url_decode(x: str) -> str:
     """Converts percent-encoded characters back into their original form."""
     return urllib.parse.unquote(x)
+
+
+class ParsedUrl(TypedDict):
+    """The component parts of a URL."""
+
+    scheme: str
+    host: str | None
+    port: int | None
+    path: str
+    query: dict[str, str]
+    fragment: str
+
+
+def parse_url(url: str) -> ParsedUrl:
+    """Parse a URL into an object with its scheme, host, port, path, query, and fragment."""
+    parsed = urllib.parse.urlsplit(url)
+    query = {
+        key: ",".join(values)
+        for key, values in urllib.parse.parse_qs(parsed.query).items()
+    }
+    return ParsedUrl(
+        scheme=parsed.scheme,
+        host=parsed.hostname,
+        port=parsed.port,
+        path=parsed.path,
+        query=query,
+        fragment=parsed.fragment,
+    )
 
 
 def add_prefix(x: str | list[str], prefix: str) -> str | list[str]:
@@ -227,6 +257,35 @@ def regex_extract(pattern: str, text: str) -> str | None:
     return match.group(0)
 
 
+def regex_extract_all(pattern: str, text: str) -> list[str]:
+    """Extract every match of a regex pattern from text, one item per match.
+
+    Each item follows `regex_extract`: the first captured group, or the full
+    match when the pattern has no groups.
+    """
+    matches: list[str] = []
+    for match in re.finditer(pattern, text):
+        if match.lastindex:
+            group = next((g for g in match.groups() if g is not None), None)
+            if group is not None:
+                matches.append(group)
+                continue
+        matches.append(match.group(0))
+    return matches
+
+
+def regex_extract_fields(pattern: str, text: str) -> dict[str, str | None] | None:
+    """Extract the named groups of a regex pattern from text into an object.
+
+    Returns null when the pattern does not match. Named groups that did not
+    participate in the match are null.
+    """
+    match = re.search(pattern, text)
+    if not match:
+        return None
+    return match.groupdict()
+
+
 def regex_match(pattern: str, text: str) -> bool:
     """Check if text matches regex pattern."""
     return bool(re.match(pattern, text))
@@ -253,6 +312,55 @@ def deserialize_ndjson(x: str) -> list[dict[str, Any]]:
 def parse_csv(x: str) -> list[dict[str, Any]]:
     """Parse CSV string into list of objects."""
     return [dict(row) for row in csv.DictReader(x.splitlines())]
+
+
+def parse_key_value(text: str, separator: str = "=") -> dict[str, str]:
+    """Parse whitespace-separated `key=value` pairs into an object.
+
+    Values may be quoted to contain whitespace, e.g. `user=bob msg="access denied"`.
+    Tokens without the separator are ignored.
+    """
+    parsed: dict[str, str] = {}
+    for token in shlex.split(text):
+        key, found, value = token.partition(separator)
+        if found:
+            parsed[key] = value
+    return parsed
+
+
+class EmailAddress(TypedDict):
+    """A single mailbox parsed out of an email address header."""
+
+    display_name: str
+    email: str
+    user: str
+    domain: str
+
+
+def parse_email_addresses(headers: str | list[str]) -> list[EmailAddress]:
+    """Parse email address headers (e.g. `To`, `From`) into a list of mailboxes.
+
+    Accepts a single header value or a list of them, and de-duplicates mailboxes
+    by address across all of them.
+    """
+    if isinstance(headers, str):
+        headers = [headers]
+
+    mailboxes: dict[str, EmailAddress] = {}
+    for header in headers:
+        parsed: dict[str, Any] = {"defects": []}
+        AddressHeader.parse(header, parsed)
+        for address in parsed["parse_tree"].addresses:
+            for mailbox in address.mailboxes:
+                if mailbox.addr_spec in mailboxes:
+                    continue
+                mailboxes[mailbox.addr_spec] = EmailAddress(
+                    display_name=mailbox.display_name or "",
+                    email=mailbox.addr_spec,
+                    user=mailbox.local_part or "",
+                    domain=mailbox.domain or "",
+                )
+    return list(mailboxes.values())
 
 
 # IP address functions
@@ -457,6 +565,37 @@ def create_range(start: int, end: int, step: int = 1) -> list[int]:
     return list(range(start, end, step))
 
 
+def _dedupe(values: Sequence[Any]) -> list[Any]:
+    """Remove duplicates while preserving order, tolerating unhashable values."""
+    seen: set[Any] = set()
+    seen_unhashable: list[Any] = []
+    deduped: list[Any] = []
+    for value in values:
+        try:
+            if value in seen:
+                continue
+            seen.add(value)
+        except TypeError:
+            if value in seen_unhashable:
+                continue
+            seen_unhashable.append(value)
+        deduped.append(value)
+    return deduped
+
+
+def collect(
+    mappings: Sequence[Mapping[Any, Any]], remove_duplicates: bool = False
+) -> dict[Any, list[Any]]:
+    """Group values from a sequence of objects by key into an object of arrays."""
+    collected: dict[Any, list[Any]] = {}
+    for mapping in mappings:
+        for key, value in mapping.items():
+            collected.setdefault(key, []).append(value)
+    if remove_duplicates:
+        return {key: _dedupe(values) for key, values in collected.items()}
+    return collected
+
+
 # Dictionary functions
 # NOTE: Use "object" in docstrings to align to Javascript / JSON terminology.
 
@@ -507,6 +646,22 @@ def dict_lookup(d: dict[Any, Any], k: Any) -> Any:
 def dict_values(x: dict[Any, Any]) -> list[Any]:
     """Extract values from an object."""
     return list(x.values())
+
+
+def omit_keys(x: dict[Any, Any], keys: Sequence[Any]) -> dict[Any, Any]:
+    """Return a copy of an object without the given keys."""
+    omitted = set(keys)
+    return {k: v for k, v in x.items() if k not in omitted}
+
+
+def pick_keys(x: dict[Any, Any], keys: Sequence[Any]) -> dict[Any, Any]:
+    """Return a copy of an object with only the given keys. Missing keys are skipped."""
+    return {k: x[k] for k in keys if k in x}
+
+
+def compact_object(x: dict[Any, Any]) -> dict[Any, Any]:
+    """Drop null values from an object. The object equivalent of `compact`."""
+    return {k: v for k, v in x.items() if v is not None}
 
 
 def zip_map(x: list[str], y: list[str]) -> dict[str, str]:
@@ -1058,6 +1213,9 @@ def deserialize_yaml(x: str) -> Any:
 _FUNCTION_MAPPING = {
     # IO
     "parse_csv": parse_csv,
+    "parse_key_value": parse_key_value,
+    "parse_email_addresses": parse_email_addresses,
+    "parse_url": parse_url,
     # String transforms
     "capitalize": capitalize,
     "concat": concat_strings,
@@ -1090,6 +1248,8 @@ _FUNCTION_MAPPING = {
     "not_null": not_null,
     # Regex
     "regex_extract": regex_extract,
+    "regex_extract_all": regex_extract_all,
+    "regex_extract_fields": regex_extract_fields,
     "regex_match": regex_match,
     "regex_not_match": regex_not_match,
     # Arrays
@@ -1114,6 +1274,7 @@ _FUNCTION_MAPPING = {
     "unique": unique,
     "zip_map": zip_map,  # Inspired by Terraform: https://developer.hashicorp.com/terraform/language/functions/zipmap
     "at": at,
+    "collect": collect,
     # Math
     "add": add,
     "sub": sub,
@@ -1137,6 +1298,9 @@ _FUNCTION_MAPPING = {
     "flatten_dict": flatten_dict,
     "to_keys": dict_keys,
     "to_values": dict_values,
+    "omit_keys": omit_keys,
+    "pick_keys": pick_keys,
+    "compact_object": compact_object,
     "tabulate": tabulate,
     # Formatters
     "to_markdown_list": to_markdown_list,


### PR DESCRIPTION
Adds nine functions to the expression function set. Each one covers a transform that cannot be expressed by chaining the existing functions, so today it requires dropping into `core.script.run_python` or a custom registry action — both of which cost a full action dispatch, where an expression costs nothing.

### Objects

- **`collect(mappings, remove_duplicates=False)`** — groups values from a list of objects by key. `[{"a": 1}, {"a": 2}, {"b": 3}]` → `{"a": [1, 2], "b": [3]}`. There is no way to reduce across a list in an expression today. Deduplication preserves first-seen order and tolerates unhashable values.
- **`omit_keys(obj, keys)`** / **`pick_keys(obj, keys)`** — return a copy of an object without, or with only, the given keys. Missing keys are skipped rather than raising.
- **`compact_object(obj)`** — drops null values from an object, the object counterpart of `compact`.

The object set previously had no way to filter entries: `map_keys` renames, `merge` combines, `to_keys`/`to_values` project, but nothing removes. Expressions cannot iterate object entries, so rebuilding a filtered object was impossible.

### Parsing

- **`parse_url(url)`** — splits a URL into `scheme`, `host`, `port`, `path`, `query`, and `fragment`. Repeated query parameters are joined with commas; values are percent-decoded.
- **`parse_key_value(text, separator="=")`** — parses whitespace-separated `key=value` pairs, quote-aware, so `msg="access denied"` survives intact. Tokens without the separator are ignored. Covers Sysmon, logfmt, and similar log payloads that `split` chains mangle at the first quoted value.
- **`parse_email_addresses(headers)`** — parses RFC 5322 address headers into mailboxes with display name, address, local part, and domain. Accepts one header or a list, de-duplicating by address. Handles quoted display names containing commas and group syntax, neither of which regex extraction gets right.

### Regex

- **`regex_extract_all(pattern, text)`** — every match, where `regex_extract` returns only the first. Each item follows the same rule as `regex_extract`: first captured group, or the full match when the pattern has no groups.
- **`regex_extract_fields(pattern, text)`** — named capture groups as an object. Returns null when the pattern does not match; named groups that did not participate are null.

### Notes

- `docs/snippets/functions-reference.mdx` is regenerated. It also picks up an unrelated pre-existing drift: `FN.url_encode`'s documented signature was stale.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nine expression functions for object filtering and grouping, log/URL/email parsing, and multi-match regex extraction, so these transforms no longer need a full action dispatch via `core.script.run_python` or a custom registry action. The regenerated function reference also corrects a pre-existing stale `FN.url_encode` signature.

**New Features**
- `collect` groups values from a list of objects by key, with optional first-seen-order deduplication.
- `omit_keys`, `pick_keys`, and `compact_object` filter object entries, which no existing function could do.
- `parse_url` splits a URL into scheme, host, port, path, query, and fragment.
- `parse_key_value` parses quote-aware `key=value` log lines and skips tokens without the separator.
- `parse_email_addresses` parses RFC 5322 address headers, handling quoted display names and group syntax.
- `regex_extract_all` returns every match instead of just the first.
- `regex_extract_fields` returns named capture groups as an object, or null on no match.

<sup>Written for commit 5e498f69cd4f7d068661725d5661b05cd570a555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

