### PR TITLE
refactor(logging): emit compact structured records

### DIFF
--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -167,6 +167,28 @@ def test_json_log_format_preserves_surrogate_escaped_strings() -> None:
     assert payload["attributes"]["path"] == "bad\udcff"
 
 
+def test_json_log_format_normalizes_non_finite_floats() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings="reading=float('nan'), ceiling=float('inf')",
+        )
+    )
+
+    assert payload["attributes"] == {"ceiling": None, "reading": None}
+
+
+def test_json_log_format_preserves_unusual_mapping_keys() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings="details={('a', 'b'): 1}",
+        )
+    )
+
+    assert payload["attributes"]["details"] == {"('a', 'b')": 1}
+
+
 def test_json_log_format_preserves_correlation_fields() -> None:
     payload = json.loads(
         _emit_log(

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -253,7 +253,7 @@ def test_json_log_format_preserves_correlation_fields() -> None:
     }
 
 
-def test_json_log_format_preserves_exception_without_local_diagnostics() -> None:
+def test_json_log_format_preserves_loguru_extended_backtrace() -> None:
     payload = json.loads(
         _emit_log(
             LogFormat.JSON,
@@ -271,6 +271,23 @@ def test_json_log_format_preserves_exception_without_local_diagnostics() -> None
     assert "ValueError: invalid input" in payload["exception"]["stack"]
     assert "in outer" in payload["exception"]["stack"]
     assert "in inner" in payload["exception"]["stack"]
+
+
+def test_json_log_format_preserves_exception_for_raw_log() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            statement=(
+                "\ntry:\n    raise ValueError('invalid input')\n"
+                "except ValueError:\n"
+                "    logger.opt(raw=True).exception('Workflow failed')"
+            ),
+        )
+    )
+
+    assert payload["exception"]["type"] == "ValueError"
+    assert payload["exception"]["message"] == "invalid input"
+    assert "ValueError: invalid input" in payload["exception"]["stack"]
 
 
 def test_console_log_format_remains_human_readable() -> None:

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -40,7 +40,13 @@ def test_log_format_from_env_rejects_unknown_value(
         log_format_from_env()
 
 
-def _emit_log(log_format: LogFormat, *, spoof_process_context: bool = False) -> str:
+def _emit_log(
+    log_format: LogFormat,
+    *,
+    bindings: str = "event='workflow_terminal_failure', owner='platform'",
+    statement: str = "logger.info('Workflow failed')",
+    spoof_process_context: bool = False,
+) -> str:
     environment = os.environ.copy()
     environment.update(
         {
@@ -50,7 +56,6 @@ def _emit_log(log_format: LogFormat, *, spoof_process_context: bool = False) -> 
             "TRACECAT__SERVICE_NAME": "worker",
         }
     )
-    bindings = "event='workflow_terminal_failure', owner='platform'"
     if spoof_process_context:
         bindings += (
             ", process_service='spoofed-service', environment='spoofed-environment'"
@@ -61,7 +66,7 @@ def _emit_log(log_format: LogFormat, *, spoof_process_context: bool = False) -> 
             "-c",
             (
                 "from tracecat.logger import logger; "
-                f"logger.bind({bindings}).info('Workflow failed')"
+                f"logger = logger.bind({bindings}); {statement}"
             ),
         ],
         check=True,
@@ -75,21 +80,86 @@ def _emit_log(log_format: LogFormat, *, spoof_process_context: bool = False) -> 
 def test_json_log_format_preserves_structured_fields() -> None:
     payload = json.loads(_emit_log(LogFormat.JSON))
 
-    assert payload["record"]["level"]["name"] == "INFO"
-    assert payload["record"]["message"] == "Workflow failed"
-    assert payload["record"]["extra"] == {
+    assert payload == {
+        "schema": "tracecat.log.v1",
+        "timestamp": payload["timestamp"],
+        "level": "INFO",
+        "message": "Workflow failed",
+        "service": "worker",
         "environment": "staging",
+        "source": {
+            "module": "__main__",
+            "function": "<module>",
+            "line": 1,
+        },
         "event": "workflow_terminal_failure",
         "owner": "platform",
-        "process_service": "worker",
     }
+    assert payload["timestamp"].endswith("Z")
+    assert "text" not in payload
+    assert "record" not in payload
 
 
 def test_process_context_cannot_be_overridden_by_log_bindings() -> None:
     payload = json.loads(_emit_log(LogFormat.JSON, spoof_process_context=True))
 
-    assert payload["record"]["extra"]["environment"] == "staging"
-    assert payload["record"]["extra"]["process_service"] == "worker"
+    assert payload["environment"] == "staging"
+    assert payload["service"] == "worker"
+
+
+def test_json_log_format_preserves_only_intentional_event_attributes() -> None:
+    output = _emit_log(
+        LogFormat.JSON,
+        bindings=(
+            "event='collection_manifest_stored', count=0, num_chunks=1, "
+            "prefix='resource-path', details={'backend': 's3'}"
+        ),
+        statement="logger.info('Stored collection manifest')",
+    )
+    payload = json.loads(output)
+
+    assert payload["attributes"] == {
+        "count": 0,
+        "details": {"backend": "s3"},
+        "num_chunks": 1,
+        "prefix": "resource-path",
+    }
+    assert "event" not in payload["attributes"]
+
+
+def test_json_log_format_normalizes_correlation_fields() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings=(
+                "wf_id='wf-123', wf_exec_id='exec-456', task_ref='parse', "
+                "trace_id='0' * 32, span_id='1' * 16, trace_sampled=True"
+            ),
+        )
+    )
+
+    assert payload["workflow_id"] == "wf-123"
+    assert payload["execution_id"] == "exec-456"
+    assert payload["action_ref"] == "parse"
+    assert payload["trace_id"] == "0" * 32
+    assert payload["span_id"] == "1" * 16
+    assert payload["trace_sampled"] is True
+
+
+def test_json_log_format_preserves_exception_without_local_diagnostics() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            statement=(
+                "\ntry:\n    raise ValueError('invalid input')\n"
+                "except ValueError:\n    logger.exception('Workflow failed')"
+            ),
+        )
+    )
+
+    assert payload["exception"]["type"] == "ValueError"
+    assert payload["exception"]["message"] == "invalid input"
+    assert "ValueError: invalid input" in payload["exception"]["stack"]
 
 
 def test_console_log_format_remains_human_readable() -> None:

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -189,6 +189,21 @@ def test_json_log_format_preserves_unusual_mapping_keys() -> None:
     assert payload["attributes"]["details"] == {"('a', 'b')": 1}
 
 
+def test_json_log_format_keeps_mapping_keys_stable_on_fallback() -> None:
+    mapping_binding = "details={None: 'missing', 'None': 'literal'}"
+    normal = json.loads(_emit_log(LogFormat.JSON, bindings=mapping_binding))
+    fallback = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings=f"{mapping_binding}, path='bad' + chr(0xDCFF)",
+        )
+    )
+
+    expected = {"None": "literal", "null": "missing"}
+    assert normal["attributes"]["details"] == expected
+    assert fallback["attributes"]["details"] == expected
+
+
 def test_json_log_format_replaces_recursive_attributes() -> None:
     payload = json.loads(
         _emit_log(

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -204,6 +204,20 @@ def test_json_log_format_keeps_mapping_keys_stable_on_fallback() -> None:
     assert fallback["attributes"]["details"] == expected
 
 
+def test_json_log_format_keeps_float_keys_stable_on_fallback() -> None:
+    mapping_binding = "details={1e-5: 'reading'}"
+    normal = json.loads(_emit_log(LogFormat.JSON, bindings=mapping_binding))
+    fallback = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings=f"{mapping_binding}, path='bad' + chr(0xDCFF)",
+        )
+    )
+
+    assert normal["attributes"]["details"] == {"0.00001": "reading"}
+    assert fallback["attributes"]["details"] == {"0.00001": "reading"}
+
+
 def test_json_log_format_replaces_recursive_attributes() -> None:
     payload = json.loads(
         _emit_log(

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -228,8 +228,12 @@ def test_json_log_format_keeps_float_keys_stable_on_fallback() -> None:
         ("type('Items', (list,), {})([1, 2])", [1, 2]),
         ("type('Identifier', (int,), {})(42)", 42),
         ("type('Label', (str,), {})('ready')", "ready"),
+        (
+            "__import__('collections').namedtuple('Point', 'x')(1)",
+            "Point(x=1)",
+        ),
     ],
-    ids=["mapping", "list", "integer", "string"],
+    ids=["mapping", "list", "integer", "string", "tuple"],
 )
 def test_json_log_format_keeps_subclass_shapes_stable_on_fallback(
     value_expression: str,

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -154,6 +154,19 @@ def test_json_log_format_preserves_arbitrary_size_integers() -> None:
     assert payload["attributes"]["large_identifier"] == 1 << 128
 
 
+def test_json_log_format_preserves_surrogate_escaped_strings() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings="path='bad' + chr(0xDCFF)",
+            statement="logger.info('scan {}', 'bad' + chr(0xDCFF))",
+        )
+    )
+
+    assert payload["message"] == "scan bad\udcff"
+    assert payload["attributes"]["path"] == "bad\udcff"
+
+
 def test_json_log_format_preserves_correlation_fields() -> None:
     payload = json.loads(
         _emit_log(

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -87,13 +87,13 @@ def test_json_log_format_preserves_structured_fields() -> None:
         "message": "Workflow failed",
         "service": "worker",
         "environment": "staging",
-        "source": {
-            "module": "__main__",
-            "function": "<module>",
-            "line": 1,
+        "module": "__main__",
+        "function": "<module>",
+        "line": 1,
+        "attributes": {
+            "event": "workflow_terminal_failure",
+            "owner": "platform",
         },
-        "event": "workflow_terminal_failure",
-        "owner": "platform",
     }
     assert payload["timestamp"].endswith("Z")
     assert "text" not in payload
@@ -121,10 +121,10 @@ def test_json_log_format_preserves_only_intentional_event_attributes() -> None:
     assert payload["attributes"] == {
         "count": 0,
         "details": {"backend": "s3"},
+        "event": "collection_manifest_stored",
         "num_chunks": 1,
         "prefix": "resource-path",
     }
-    assert "event" not in payload["attributes"]
 
 
 def test_json_log_format_preserves_rejected_reserved_attributes() -> None:
@@ -143,7 +143,7 @@ def test_json_log_format_preserves_rejected_reserved_attributes() -> None:
     }
 
 
-def test_json_log_format_stringifies_integers_outside_orjson_range() -> None:
+def test_json_log_format_preserves_arbitrary_size_integers() -> None:
     payload = json.loads(
         _emit_log(
             LogFormat.JSON,
@@ -151,10 +151,10 @@ def test_json_log_format_stringifies_integers_outside_orjson_range() -> None:
         )
     )
 
-    assert payload["attributes"]["large_identifier"] == str(1 << 128)
+    assert payload["attributes"]["large_identifier"] == 1 << 128
 
 
-def test_json_log_format_normalizes_correlation_fields() -> None:
+def test_json_log_format_preserves_correlation_fields() -> None:
     payload = json.loads(
         _emit_log(
             LogFormat.JSON,
@@ -165,12 +165,14 @@ def test_json_log_format_normalizes_correlation_fields() -> None:
         )
     )
 
-    assert payload["workflow_id"] == "wf-123"
-    assert payload["execution_id"] == "exec-456"
-    assert payload["action_ref"] == "parse"
-    assert payload["trace_id"] == "0" * 32
-    assert payload["span_id"] == "1" * 16
-    assert payload["trace_sampled"] is True
+    assert payload["attributes"] == {
+        "wf_id": "wf-123",
+        "wf_exec_id": "exec-456",
+        "task_ref": "parse",
+        "trace_id": "0" * 32,
+        "span_id": "1" * 16,
+        "trace_sampled": True,
+    }
 
 
 def test_json_log_format_preserves_exception_without_local_diagnostics() -> None:

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -258,8 +258,10 @@ def test_json_log_format_preserves_exception_without_local_diagnostics() -> None
         _emit_log(
             LogFormat.JSON,
             statement=(
-                "\ntry:\n    raise ValueError('invalid input')\n"
-                "except ValueError:\n    logger.exception('Workflow failed')"
+                "\ndef outer():\n    inner()\n\n"
+                "def inner():\n    try:\n        raise ValueError('invalid input')\n"
+                "    except ValueError:\n        logger.exception('Workflow failed')\n\n"
+                "outer()"
             ),
         )
     )
@@ -267,6 +269,8 @@ def test_json_log_format_preserves_exception_without_local_diagnostics() -> None
     assert payload["exception"]["type"] == "ValueError"
     assert payload["exception"]["message"] == "invalid input"
     assert "ValueError: invalid input" in payload["exception"]["stack"]
+    assert "in outer" in payload["exception"]["stack"]
+    assert "in inner" in payload["exception"]["stack"]
 
 
 def test_console_log_format_remains_human_readable() -> None:

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -127,6 +127,33 @@ def test_json_log_format_preserves_only_intentional_event_attributes() -> None:
     assert "event" not in payload["attributes"]
 
 
+def test_json_log_format_preserves_rejected_reserved_attributes() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings="event={'unexpected': 'shape'}, trace_sampled='unknown'",
+        )
+    )
+
+    assert "event" not in payload
+    assert "trace_sampled" not in payload
+    assert payload["attributes"] == {
+        "event": {"unexpected": "shape"},
+        "trace_sampled": "unknown",
+    }
+
+
+def test_json_log_format_stringifies_integers_outside_orjson_range() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings="large_identifier=1 << 128",
+        )
+    )
+
+    assert payload["attributes"]["large_identifier"] == str(1 << 128)
+
+
 def test_json_log_format_normalizes_correlation_fields() -> None:
     payload = json.loads(
         _emit_log(

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -189,6 +189,34 @@ def test_json_log_format_preserves_unusual_mapping_keys() -> None:
     assert payload["attributes"]["details"] == {"('a', 'b')": 1}
 
 
+def test_json_log_format_replaces_recursive_attributes() -> None:
+    payload = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            statement=(
+                "items = []; items.append(items); "
+                "logger.bind(items=items).info('Workflow failed')"
+            ),
+        )
+    )
+
+    assert payload["attributes"]["items"] == ["<recursive>"]
+
+
+def test_json_log_format_keeps_datetime_shape_on_fallback() -> None:
+    datetime_binding = "created_at=__import__('datetime').datetime(2024, 1, 2, 3, 4, 5)"
+    normal = json.loads(_emit_log(LogFormat.JSON, bindings=datetime_binding))
+    fallback = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings=f"{datetime_binding}, path='bad' + chr(0xDCFF)",
+        )
+    )
+
+    assert normal["attributes"]["created_at"] == "2024-01-02 03:04:05"
+    assert fallback["attributes"]["created_at"] == "2024-01-02 03:04:05"
+
+
 def test_json_log_format_preserves_correlation_fields() -> None:
     payload = json.loads(
         _emit_log(

--- a/tests/unit/test_logger_config.py
+++ b/tests/unit/test_logger_config.py
@@ -218,6 +218,36 @@ def test_json_log_format_keeps_float_keys_stable_on_fallback() -> None:
     assert fallback["attributes"]["details"] == {"0.00001": "reading"}
 
 
+@pytest.mark.parametrize(
+    ("value_expression", "expected"),
+    [
+        (
+            "__import__('collections').OrderedDict([('answer', 42)])",
+            {"answer": 42},
+        ),
+        ("type('Items', (list,), {})([1, 2])", [1, 2]),
+        ("type('Identifier', (int,), {})(42)", 42),
+        ("type('Label', (str,), {})('ready')", "ready"),
+    ],
+    ids=["mapping", "list", "integer", "string"],
+)
+def test_json_log_format_keeps_subclass_shapes_stable_on_fallback(
+    value_expression: str,
+    expected: object,
+) -> None:
+    binding = f"value={value_expression}"
+    normal = json.loads(_emit_log(LogFormat.JSON, bindings=binding))
+    fallback = json.loads(
+        _emit_log(
+            LogFormat.JSON,
+            bindings=f"{binding}, path='bad' + chr(0xDCFF)",
+        )
+    )
+
+    assert normal["attributes"]["value"] == expected
+    assert fallback["attributes"]["value"] == expected
+
+
 def test_json_log_format_replaces_recursive_attributes() -> None:
     payload = json.loads(
         _emit_log(

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -1,0 +1,222 @@
+"""Compact JSON serialization for collector-backed application logs."""
+
+import sys
+import traceback
+from collections.abc import Mapping, Sequence, Set
+from datetime import UTC, date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, NotRequired, Protocol, TypedDict
+from uuid import UUID
+
+import orjson
+
+if TYPE_CHECKING:
+    from loguru import Record
+
+
+LOG_SCHEMA = "tracecat.log.v1"
+
+
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+class LogSource(TypedDict):
+    """Source location for one application log."""
+
+    module: str
+    function: str
+    line: int
+
+
+class LogException(TypedDict):
+    """Sanitized exception details retained for warning and error diagnosis."""
+
+    type: str
+    message: str
+    stack: str
+
+
+class StructuredLog(TypedDict):
+    """Versioned, allowlisted schema emitted to collector-backed deployments."""
+
+    schema: str
+    timestamp: str
+    level: str
+    message: str
+    service: str
+    environment: str
+    source: LogSource
+    event: NotRequired[str]
+    owner: NotRequired[str]
+    kind: NotRequired[str]
+    retry_disposition: NotRequired[str]
+    workflow_type: NotRequired[str]
+    trace_id: NotRequired[str]
+    span_id: NotRequired[str]
+    trace_sampled: NotRequired[bool]
+    workflow_id: NotRequired[str]
+    execution_id: NotRequired[str]
+    action_ref: NotRequired[str]
+    error_type: NotRequired[str]
+    attributes: NotRequired[dict[str, JsonValue]]
+    exception: NotRequired[LogException]
+
+
+class LogMessage(Protocol):
+    """The portion of Loguru's runtime message contract used by the JSON sink."""
+
+    @property
+    def record(self) -> "Record": ...
+
+
+_RESERVED_EXTRA_KEYS = frozenset(
+    {
+        "action_ref",
+        "cause_type",
+        "environment",
+        "error_kind",
+        "error_owner",
+        "error_type",
+        "event",
+        "execution_id",
+        "kind",
+        "owner",
+        "process_service",
+        "retry_disposition",
+        "span_id",
+        "task_ref",
+        "trace_id",
+        "trace_sampled",
+        "wf_exec_id",
+        "wf_id",
+        "workflow_execution_id",
+        "workflow_id",
+        "workflow_type",
+    }
+)
+
+
+def _as_string(value: object) -> str | None:
+    """Normalize identifier-like scalar values without serializing arbitrary objects."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, Enum):
+        enum_value = value.value
+        if isinstance(enum_value, str):
+            return enum_value
+    return None
+
+
+def _to_json_value(value: object) -> JsonValue:
+    """Normalize intentional log attributes without exposing Loguru internals."""
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date | Path):
+        return str(value)
+    if isinstance(value, Enum):
+        return _to_json_value(value.value)
+    if isinstance(value, Mapping):
+        return {str(key): _to_json_value(item) for key, item in value.items()}
+    if isinstance(value, Sequence | Set) and not isinstance(value, bytes):
+        return [_to_json_value(item) for item in value]
+    return str(value)
+
+
+def _first_string(extra: Mapping[str, object], *keys: str) -> str | None:
+    """Return the first supported identifier from equivalent legacy field names."""
+    for key in keys:
+        if value := _as_string(extra.get(key)):
+            return value
+    return None
+
+
+def _serialize_exception(record: "Record") -> LogException | None:
+    """Render a traceback without Loguru's optional local-variable diagnostics."""
+    exception = record["exception"]
+    if exception is None or exception.type is None or exception.value is None:
+        return None
+    return {
+        "type": exception.type.__name__,
+        "message": str(exception.value),
+        "stack": "".join(
+            traceback.format_exception(
+                exception.type,
+                exception.value,
+                exception.traceback,
+            )
+        ),
+    }
+
+
+def serialize_log_record(record: "Record") -> bytes:
+    """Serialize one Loguru record into the Tracecat collector schema."""
+    extra: Mapping[str, object] = record["extra"]
+    payload: StructuredLog = {
+        "schema": LOG_SCHEMA,
+        "timestamp": record["time"].astimezone(UTC).isoformat().replace("+00:00", "Z"),
+        "level": record["level"].name,
+        "message": record["message"],
+        "service": _as_string(extra.get("process_service")) or "tracecat",
+        "environment": _as_string(extra.get("environment")) or "development",
+        "source": {
+            "module": record["name"] or "<unknown>",
+            "function": record["function"],
+            "line": record["line"],
+        },
+    }
+
+    if event := _as_string(extra.get("event")):
+        payload["event"] = event
+    if owner := _first_string(extra, "owner", "error_owner"):
+        payload["owner"] = owner
+    if kind := _first_string(extra, "kind", "error_kind"):
+        payload["kind"] = kind
+    if retry_disposition := _as_string(extra.get("retry_disposition")):
+        payload["retry_disposition"] = retry_disposition
+    if workflow_type := _as_string(extra.get("workflow_type")):
+        payload["workflow_type"] = workflow_type
+    if trace_id := _as_string(extra.get("trace_id")):
+        payload["trace_id"] = trace_id
+    if span_id := _as_string(extra.get("span_id")):
+        payload["span_id"] = span_id
+    if isinstance(trace_sampled := extra.get("trace_sampled"), bool):
+        payload["trace_sampled"] = trace_sampled
+    if workflow_id := _first_string(extra, "workflow_id", "wf_id"):
+        payload["workflow_id"] = workflow_id
+    if execution_id := _first_string(
+        extra,
+        "execution_id",
+        "wf_exec_id",
+        "workflow_execution_id",
+    ):
+        payload["execution_id"] = execution_id
+    if action_ref := _first_string(extra, "action_ref", "task_ref"):
+        payload["action_ref"] = action_ref
+    if error_type := _first_string(extra, "error_type", "cause_type"):
+        payload["error_type"] = error_type
+
+    attributes = {
+        key: _to_json_value(value)
+        for key, value in sorted(extra.items())
+        if key not in _RESERVED_EXTRA_KEYS
+    }
+    if attributes:
+        payload["attributes"] = attributes
+
+    if exception := _serialize_exception(record):
+        payload["exception"] = exception
+
+    return orjson.dumps(payload, option=orjson.OPT_APPEND_NEWLINE)
+
+
+def write_json_log(message: LogMessage) -> None:
+    """Write one structured record to the process stderr stream."""
+    sys.stderr.write(serialize_log_record(message.record).decode())

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -120,7 +120,6 @@ def _encode_payload(payload: StructuredLog) -> str:
                 | orjson.OPT_NON_STR_KEYS
                 | orjson.OPT_PASSTHROUGH_DATACLASS
                 | orjson.OPT_PASSTHROUGH_DATETIME
-                | orjson.OPT_PASSTHROUGH_SUBCLASS
             ),
         ).decode()
     except TypeError:

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -58,7 +58,9 @@ def _serialize_exception(
     if formatted_message is not None and formatted_message.startswith(
         record["message"]
     ):
-        stack = formatted_message[len(record["message"]) :].lstrip("\n")
+        formatted_stack = formatted_message[len(record["message"]) :].lstrip("\n")
+        if formatted_stack:
+            stack = formatted_stack
 
     return {
         "type": exception.type.__name__,

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -41,21 +41,29 @@ class LogMessage(Protocol):
     def record(self) -> "Record": ...
 
 
-def _serialize_exception(record: "Record") -> LogException | None:
+def _serialize_exception(
+    record: "Record", formatted_message: str | None
+) -> LogException | None:
     exception = record["exception"]
     if exception is None or exception.type is None or exception.value is None:
         return None
 
+    stack = "".join(
+        traceback.format_exception(
+            exception.type,
+            exception.value,
+            exception.traceback,
+        )
+    )
+    if formatted_message is not None and formatted_message.startswith(
+        record["message"]
+    ):
+        stack = formatted_message[len(record["message"]) :].lstrip("\n")
+
     return {
         "type": exception.type.__name__,
         "message": str(exception.value),
-        "stack": "".join(
-            traceback.format_exception(
-                exception.type,
-                exception.value,
-                exception.traceback,
-            )
-        ),
+        "stack": stack,
     }
 
 
@@ -129,7 +137,7 @@ def _encode_payload(payload: StructuredLog) -> str:
         )
 
 
-def serialize_log_record(record: "Record") -> str:
+def serialize_log_record(record: "Record", formatted_message: str | None = None) -> str:
     """Serialize one Loguru record into the collector-facing schema."""
     attributes: dict[str, object] = dict(record["extra"])
     service = attributes.pop("process_service", "tracecat")
@@ -147,7 +155,7 @@ def serialize_log_record(record: "Record") -> str:
         "line": record["line"],
         "attributes": attributes,
     }
-    if exception := _serialize_exception(record):
+    if exception := _serialize_exception(record, formatted_message):
         payload["exception"] = exception
 
     return _encode_payload(payload)
@@ -155,4 +163,4 @@ def serialize_log_record(record: "Record") -> str:
 
 def write_json_log(message: LogMessage) -> None:
     """Write one serialized Loguru message to standard error."""
-    sys.stderr.write(serialize_log_record(message.record))
+    sys.stderr.write(serialize_log_record(message.record, str(message)))

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -71,7 +71,7 @@ class LogMessage(Protocol):
     def record(self) -> "Record": ...
 
 
-_RESERVED_EXTRA_KEYS = frozenset(
+_STRING_EXTRA_KEYS = frozenset(
     {
         "action_ref",
         "cause_type",
@@ -88,7 +88,6 @@ _RESERVED_EXTRA_KEYS = frozenset(
         "span_id",
         "task_ref",
         "trace_id",
-        "trace_sampled",
         "wf_exec_id",
         "wf_id",
         "workflow_execution_id",
@@ -113,7 +112,13 @@ def _as_string(value: object) -> str | None:
 
 def _to_json_value(value: object) -> JsonValue:
     """Normalize intentional log attributes without exposing Loguru internals."""
-    if value is None or isinstance(value, str | int | float | bool):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if -(1 << 63) <= value <= (1 << 64) - 1:
+            return value
+        return str(value)
+    if value is None or isinstance(value, str | float):
         return value
     if isinstance(value, UUID):
         return str(value)
@@ -203,10 +208,16 @@ def serialize_log_record(record: "Record") -> bytes:
     if error_type := _first_string(extra, "error_type", "cause_type"):
         payload["error_type"] = error_type
 
+    promoted_extra_keys = {
+        key for key in _STRING_EXTRA_KEYS if _as_string(extra.get(key)) is not None
+    }
+    if isinstance(extra.get("trace_sampled"), bool):
+        promoted_extra_keys.add("trace_sampled")
+
     attributes = {
         key: _to_json_value(value)
         for key, value in sorted(extra.items())
-        if key not in _RESERVED_EXTRA_KEYS
+        if key not in promoted_extra_keys
     }
     if attributes:
         payload["attributes"] = attributes

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -5,6 +5,7 @@ import math
 import sys
 import traceback
 from datetime import UTC
+from enum import Enum
 from typing import TYPE_CHECKING, NotRequired, Protocol, TypedDict
 
 import orjson
@@ -58,17 +59,35 @@ def _serialize_exception(record: "Record") -> LogException | None:
     }
 
 
-def _fallback_value(value: object) -> object:
+def _fallback_value(value: object, ancestors: set[int] | None = None) -> object:
     """Make uncommon Python values safe for the standard JSON fallback."""
-    if isinstance(value, dict):
-        return {str(key): _fallback_value(item) for key, item in value.items()}
-    if isinstance(value, list | tuple | set | frozenset):
-        return [_fallback_value(item) for item in value]
     if isinstance(value, float) and not math.isfinite(value):
         return None
     if value is None or isinstance(value, str | int | float | bool):
         return value
-    return str(value)
+    if isinstance(value, Enum):
+        return _fallback_value(value.value, ancestors)
+    if isinstance(value, set | frozenset):
+        return str(value)
+    if not isinstance(value, dict | list | tuple):
+        return str(value)
+
+    if ancestors is None:
+        ancestors = set()
+    marker = id(value)
+    if marker in ancestors:
+        return "<recursive>"
+
+    ancestors.add(marker)
+    try:
+        if isinstance(value, dict):
+            return {
+                str(key): _fallback_value(item, ancestors)
+                for key, item in value.items()
+            }
+        return [_fallback_value(item, ancestors) for item in value]
+    finally:
+        ancestors.remove(marker)
 
 
 def _encode_payload(payload: StructuredLog) -> str:
@@ -77,7 +96,13 @@ def _encode_payload(payload: StructuredLog) -> str:
         return orjson.dumps(
             payload,
             default=str,
-            option=orjson.OPT_APPEND_NEWLINE | orjson.OPT_NON_STR_KEYS,
+            option=(
+                orjson.OPT_APPEND_NEWLINE
+                | orjson.OPT_NON_STR_KEYS
+                | orjson.OPT_PASSTHROUGH_DATACLASS
+                | orjson.OPT_PASSTHROUGH_DATETIME
+                | orjson.OPT_PASSTHROUGH_SUBCLASS
+            ),
         ).decode()
     except TypeError:
         return (

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -4,7 +4,7 @@ import json
 import math
 import sys
 import traceback
-from datetime import UTC
+from datetime import UTC, date, time
 from enum import Enum
 from typing import TYPE_CHECKING, NotRequired, Protocol, TypedDict
 
@@ -82,12 +82,25 @@ def _fallback_value(value: object, ancestors: set[int] | None = None) -> object:
     try:
         if isinstance(value, dict):
             return {
-                str(key): _fallback_value(item, ancestors)
+                _fallback_key(key): _fallback_value(item, ancestors)
                 for key, item in value.items()
             }
         return [_fallback_value(item, ancestors) for item in value]
     finally:
         ancestors.remove(marker)
+
+
+def _fallback_key(value: object) -> str:
+    """Match orjson's supported non-string key encoding."""
+    if value is None or (isinstance(value, float) and not math.isfinite(value)):
+        return "null"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, Enum):
+        return _fallback_key(value.value)
+    if isinstance(value, date | time):
+        return value.isoformat()
+    return str(value)
 
 
 def _encode_payload(payload: StructuredLog) -> str:

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -4,7 +4,7 @@ import json
 import math
 import sys
 import traceback
-from datetime import UTC, date, time
+from datetime import UTC
 from enum import Enum
 from typing import TYPE_CHECKING, NotRequired, Protocol, TypedDict
 
@@ -102,15 +102,11 @@ def _fallback_value(value: object, ancestors: set[int] | None = None) -> object:
 
 def _fallback_key(value: object) -> str:
     """Match orjson's supported non-string key encoding."""
-    if value is None or (isinstance(value, float) and not math.isfinite(value)):
-        return "null"
-    if isinstance(value, bool):
-        return str(value).lower()
-    if isinstance(value, Enum):
-        return _fallback_key(value.value)
-    if isinstance(value, date | time):
-        return value.isoformat()
-    return str(value)
+    try:
+        encoded = orjson.dumps({value: None}, option=orjson.OPT_NON_STR_KEYS)
+    except TypeError:
+        return str(value)
+    return next(iter(json.loads(encoded)))
 
 
 def _encode_payload(payload: StructuredLog) -> str:

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -1,153 +1,47 @@
 """Compact JSON serialization for collector-backed application logs."""
 
+import json
 import sys
 import traceback
-from collections.abc import Mapping, Sequence, Set
-from datetime import UTC, date, datetime
-from enum import Enum
-from pathlib import Path
+from datetime import UTC
 from typing import TYPE_CHECKING, NotRequired, Protocol, TypedDict
-from uuid import UUID
-
-import orjson
 
 if TYPE_CHECKING:
     from loguru import Record
 
-
 LOG_SCHEMA = "tracecat.log.v1"
 
 
-type JsonScalar = str | int | float | bool | None
-type JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
-
-
-class LogSource(TypedDict):
-    """Source location for one application log."""
-
-    module: str
-    function: str
-    line: int
-
-
 class LogException(TypedDict):
-    """Sanitized exception details retained for warning and error diagnosis."""
-
     type: str
     message: str
     stack: str
 
 
 class StructuredLog(TypedDict):
-    """Versioned, allowlisted schema emitted to collector-backed deployments."""
-
     schema: str
     timestamp: str
     level: str
     message: str
     service: str
     environment: str
-    source: LogSource
-    event: NotRequired[str]
-    owner: NotRequired[str]
-    kind: NotRequired[str]
-    retry_disposition: NotRequired[str]
-    workflow_type: NotRequired[str]
-    trace_id: NotRequired[str]
-    span_id: NotRequired[str]
-    trace_sampled: NotRequired[bool]
-    workflow_id: NotRequired[str]
-    execution_id: NotRequired[str]
-    action_ref: NotRequired[str]
-    error_type: NotRequired[str]
-    attributes: NotRequired[dict[str, JsonValue]]
+    module: str
+    function: str
+    line: int
+    attributes: dict[str, object]
     exception: NotRequired[LogException]
 
 
 class LogMessage(Protocol):
-    """The portion of Loguru's runtime message contract used by the JSON sink."""
-
     @property
     def record(self) -> "Record": ...
 
 
-_STRING_EXTRA_KEYS = frozenset(
-    {
-        "action_ref",
-        "cause_type",
-        "environment",
-        "error_kind",
-        "error_owner",
-        "error_type",
-        "event",
-        "execution_id",
-        "kind",
-        "owner",
-        "process_service",
-        "retry_disposition",
-        "span_id",
-        "task_ref",
-        "trace_id",
-        "wf_exec_id",
-        "wf_id",
-        "workflow_execution_id",
-        "workflow_id",
-        "workflow_type",
-    }
-)
-
-
-def _as_string(value: object) -> str | None:
-    """Normalize identifier-like scalar values without serializing arbitrary objects."""
-    if isinstance(value, str):
-        return value
-    if isinstance(value, UUID):
-        return str(value)
-    if isinstance(value, Enum):
-        enum_value = value.value
-        if isinstance(enum_value, str):
-            return enum_value
-    return None
-
-
-def _to_json_value(value: object) -> JsonValue:
-    """Normalize intentional log attributes without exposing Loguru internals."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, int):
-        if -(1 << 63) <= value <= (1 << 64) - 1:
-            return value
-        return str(value)
-    if value is None or isinstance(value, str | float):
-        return value
-    if isinstance(value, UUID):
-        return str(value)
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, date | Path):
-        return str(value)
-    if isinstance(value, Enum):
-        return _to_json_value(value.value)
-    if isinstance(value, Mapping):
-        return {str(key): _to_json_value(item) for key, item in value.items()}
-    if isinstance(value, Sequence | Set) and not isinstance(value, bytes):
-        return [_to_json_value(item) for item in value]
-    return str(value)
-
-
-def _first_string(extra: Mapping[str, object], *keys: str) -> str | None:
-    """Return the first supported identifier from equivalent legacy field names."""
-    for key in keys:
-        if value := _as_string(extra.get(key)):
-            return value
-    return None
-
-
 def _serialize_exception(record: "Record") -> LogException | None:
-    """Render a traceback without Loguru's optional local-variable diagnostics."""
     exception = record["exception"]
     if exception is None or exception.type is None or exception.value is None:
         return None
+
     return {
         "type": exception.type.__name__,
         "message": str(exception.value),
@@ -161,73 +55,39 @@ def _serialize_exception(record: "Record") -> LogException | None:
     }
 
 
-def serialize_log_record(record: "Record") -> bytes:
-    """Serialize one Loguru record into the Tracecat collector schema."""
-    extra: Mapping[str, object] = record["extra"]
+def serialize_log_record(record: "Record") -> str:
+    """Serialize one Loguru record into the collector-facing schema."""
+    attributes: dict[str, object] = dict(record["extra"])
+    service = attributes.pop("process_service", "tracecat")
+    environment = attributes.pop("environment", "development")
+
     payload: StructuredLog = {
         "schema": LOG_SCHEMA,
         "timestamp": record["time"].astimezone(UTC).isoformat().replace("+00:00", "Z"),
         "level": record["level"].name,
         "message": record["message"],
-        "service": _as_string(extra.get("process_service")) or "tracecat",
-        "environment": _as_string(extra.get("environment")) or "development",
-        "source": {
-            "module": record["name"] or "<unknown>",
-            "function": record["function"],
-            "line": record["line"],
-        },
+        "service": str(service),
+        "environment": str(environment),
+        "module": record["name"] or "<unknown>",
+        "function": record["function"],
+        "line": record["line"],
+        "attributes": attributes,
     }
-
-    if event := _as_string(extra.get("event")):
-        payload["event"] = event
-    if owner := _first_string(extra, "owner", "error_owner"):
-        payload["owner"] = owner
-    if kind := _first_string(extra, "kind", "error_kind"):
-        payload["kind"] = kind
-    if retry_disposition := _as_string(extra.get("retry_disposition")):
-        payload["retry_disposition"] = retry_disposition
-    if workflow_type := _as_string(extra.get("workflow_type")):
-        payload["workflow_type"] = workflow_type
-    if trace_id := _as_string(extra.get("trace_id")):
-        payload["trace_id"] = trace_id
-    if span_id := _as_string(extra.get("span_id")):
-        payload["span_id"] = span_id
-    if isinstance(trace_sampled := extra.get("trace_sampled"), bool):
-        payload["trace_sampled"] = trace_sampled
-    if workflow_id := _first_string(extra, "workflow_id", "wf_id"):
-        payload["workflow_id"] = workflow_id
-    if execution_id := _first_string(
-        extra,
-        "execution_id",
-        "wf_exec_id",
-        "workflow_execution_id",
-    ):
-        payload["execution_id"] = execution_id
-    if action_ref := _first_string(extra, "action_ref", "task_ref"):
-        payload["action_ref"] = action_ref
-    if error_type := _first_string(extra, "error_type", "cause_type"):
-        payload["error_type"] = error_type
-
-    promoted_extra_keys = {
-        key for key in _STRING_EXTRA_KEYS if _as_string(extra.get(key)) is not None
-    }
-    if isinstance(extra.get("trace_sampled"), bool):
-        promoted_extra_keys.add("trace_sampled")
-
-    attributes = {
-        key: _to_json_value(value)
-        for key, value in sorted(extra.items())
-        if key not in promoted_extra_keys
-    }
-    if attributes:
-        payload["attributes"] = attributes
-
     if exception := _serialize_exception(record):
         payload["exception"] = exception
 
-    return orjson.dumps(payload, option=orjson.OPT_APPEND_NEWLINE)
+    return (
+        json.dumps(
+            payload,
+            default=str,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            skipkeys=True,
+        )
+        + "\n"
+    )
 
 
 def write_json_log(message: LogMessage) -> None:
-    """Write one structured record to the process stderr stream."""
-    sys.stderr.write(serialize_log_record(message.record).decode())
+    """Write one serialized Loguru message to standard error."""
+    sys.stderr.write(serialize_log_record(message.record))

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -1,10 +1,13 @@
 """Compact JSON serialization for collector-backed application logs."""
 
 import json
+import math
 import sys
 import traceback
 from datetime import UTC
 from typing import TYPE_CHECKING, NotRequired, Protocol, TypedDict
+
+import orjson
 
 if TYPE_CHECKING:
     from loguru import Record
@@ -55,6 +58,39 @@ def _serialize_exception(record: "Record") -> LogException | None:
     }
 
 
+def _fallback_value(value: object) -> object:
+    """Make uncommon Python values safe for the standard JSON fallback."""
+    if isinstance(value, dict):
+        return {str(key): _fallback_value(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set | frozenset):
+        return [_fallback_value(item) for item in value]
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    return str(value)
+
+
+def _encode_payload(payload: StructuredLog) -> str:
+    """Encode the common path quickly and preserve uncommon values on fallback."""
+    try:
+        return orjson.dumps(
+            payload,
+            default=str,
+            option=orjson.OPT_APPEND_NEWLINE | orjson.OPT_NON_STR_KEYS,
+        ).decode()
+    except TypeError:
+        return (
+            json.dumps(
+                _fallback_value(payload),
+                allow_nan=False,
+                ensure_ascii=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        )
+
+
 def serialize_log_record(record: "Record") -> str:
     """Serialize one Loguru record into the collector-facing schema."""
     attributes: dict[str, object] = dict(record["extra"])
@@ -76,16 +112,7 @@ def serialize_log_record(record: "Record") -> str:
     if exception := _serialize_exception(record):
         payload["exception"] = exception
 
-    return (
-        json.dumps(
-            payload,
-            default=str,
-            ensure_ascii=False,
-            separators=(",", ":"),
-            skipkeys=True,
-        )
-        + "\n"
-    )
+    return _encode_payload(payload)
 
 
 def write_json_log(message: LogMessage) -> None:

--- a/tracecat/logger/_json.py
+++ b/tracecat/logger/_json.py
@@ -79,6 +79,8 @@ def _fallback_value(value: object, ancestors: set[int] | None = None) -> object:
         return _fallback_value(value.value, ancestors)
     if isinstance(value, set | frozenset):
         return str(value)
+    if isinstance(value, tuple) and type(value) is not tuple:
+        return str(value)
     if not isinstance(value, dict | list | tuple):
         return str(value)
 

--- a/tracecat/logger/_logger.py
+++ b/tracecat/logger/_logger.py
@@ -8,6 +8,7 @@ from loguru import logger as base_logger
 from opentelemetry import trace
 from opentelemetry.trace import TraceFlags
 
+from tracecat.logger._json import write_json_log
 from tracecat.logger.config import LogFormat, log_format_from_env
 
 if TYPE_CHECKING:
@@ -70,14 +71,23 @@ except ValueError:
     pass
 log_format = log_format_from_env()
 base_logger.configure(patcher=_add_process_context)
-base_logger.add(
-    sink=sys.stderr,
-    colorize=log_format is LogFormat.CONSOLE,
-    level=os.environ.get("LOG_LEVEL", "INFO"),
-    format=_CONSOLE_FORMAT,
-    filter=_workflow_replay_filter,
-    diagnose=False,
-    serialize=log_format is LogFormat.JSON,
-)
+if log_format is LogFormat.JSON:
+    base_logger.add(
+        sink=write_json_log,
+        colorize=False,
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="{message}",
+        filter=_workflow_replay_filter,
+        diagnose=False,
+    )
+else:
+    base_logger.add(
+        sink=sys.stderr,
+        colorize=True,
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format=_CONSOLE_FORMAT,
+        filter=_workflow_replay_filter,
+        diagnose=False,
+    )
 
 logger = base_logger


### PR DESCRIPTION
## Summary

- replace Loguru's duplicated `text` / `record` JSON envelope with the compact, versioned `tracecat.log.v1` schema
- emit only stable application fields at the top level: timestamp, severity, message, service, environment, source location, and optional exception details
- preserve callsite context unchanged in one `attributes` object; workflow/error aliases are normalized once at the collector boundary
- keep trusted service/environment values and serialize unusual attribute values without dropping the whole log record

Companion collector change: https://github.com/TracecatHQ/k8s/pull/97

## Rollout

The companion Kubernetes collector change accepts both this schema and the existing nested Loguru schema, so it should land before an application image containing this change is deployed. This PR does not deploy anything.

## Validation

- `uv run pytest --confcutdir=tests/unit tests/unit/test_logger_config.py` (22 passed)
- targeted Ruff formatting/lint and Pyright (passed)
- repository pre-commit hooks for all changed files (passed)

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 183 | 9 |
| Tests | 223 | 11 |
