### PR TITLE
fix(audit): preserve client attribution across proxy hops

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,10 @@
+{
+	servers {
+		trusted_proxies static {$TRACECAT__TRUSTED_PROXY_CIDRS:127.0.0.1/32}
+		trusted_proxies_strict
+	}
+}
+
 {$BASE_DOMAIN} {
 	bind {$ADDRESS} # Binds to all available network interfaces if not specified
 
@@ -13,10 +20,10 @@
 
 	handle_path /api* {
 		reverse_proxy http://api:8000 {
-			header_up X-Forwarded-For {remote_host}
-			header_up X-Real-IP {remote_host}
-			header_up X-Forwarded-Proto {scheme}
+			header_up X-Forwarded-For {client_ip}
+			header_up X-Real-IP {client_ip}
 			header_up X-Forwarded-Host {host}
+			header_up X-Forwarded-Proto {scheme}
 		}
 	}
 
@@ -24,31 +31,31 @@
 	handle /mcp* {
 		reverse_proxy http://mcp:8099 {
 			flush_interval -1
+			header_up X-Forwarded-For {client_ip}
+			header_up X-Real-IP {client_ip}
 		}
 	}
 
 	# MCP OAuth and discovery routes (served at root level by FastMCP)
-	handle /.well-known/oauth-authorization-server {
-		reverse_proxy http://mcp:8099
+	@mcp_oauth_routes {
+		path /.well-known/oauth-authorization-server
+		path /.well-known/oauth-protected-resource /.well-known/oauth-protected-resource/*
+		path /authorize /authorize/*
+		path /token
+		path /register
+		path /consent /consent/*
+		path /auth/callback /auth/callback/*
 	}
-	handle /.well-known/oauth-protected-resource* {
-		reverse_proxy http://mcp:8099
-	}
-	handle /authorize* {
-		reverse_proxy http://mcp:8099
-	}
-	handle /token {
-		reverse_proxy http://mcp:8099
-	}
-	handle /register {
-		reverse_proxy http://mcp:8099
-	}
-	handle /consent* {
-		reverse_proxy http://mcp:8099
-	}
-	handle /auth/callback* {
-		reverse_proxy http://mcp:8099
+	handle @mcp_oauth_routes {
+		reverse_proxy http://mcp:8099 {
+			flush_interval -1
+			header_up X-Forwarded-For {client_ip}
+			header_up X-Real-IP {client_ip}
+		}
 	}
 
-	reverse_proxy http://ui:3000
+	reverse_proxy http://ui:3000 {
+		header_up X-Forwarded-For {client_ip}
+		header_up X-Real-IP {client_ip}
+	}
 }

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -74,6 +74,7 @@ module "ecs" {
   platform_otel_enabled                         = var.platform_otel_enabled
   otel_exporter_otlp_endpoint                   = var.otel_exporter_otlp_endpoint
   otel_exporter_otlp_headers_arn                = var.otel_exporter_otlp_headers_arn
+  audit_trusted_proxy_cidrs                     = var.audit_trusted_proxy_cidrs
   log_level                                     = var.log_level
   log_format                                    = var.log_format
   temporal_log_level                            = var.temporal_log_level

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -39,6 +39,7 @@ module "ecs" {
   # Network configuration from network module
   vpc_id                  = module.network.vpc_id
   public_subnet_ids       = module.network.public_subnet_ids
+  public_subnet_cidrs     = var.public_subnet_cidrs
   private_subnet_ids      = module.network.private_subnet_ids
   private_route_table_ids = module.network.private_route_table_ids
 

--- a/deployments/fargate/modules/ecs/ecs-caddy.tf
+++ b/deployments/fargate/modules/ecs/ecs-caddy.tf
@@ -29,6 +29,13 @@ resource "aws_ecs_task_definition" "caddy_task_definition" {
         "-c",
         <<EOT
 cat > /etc/caddy/Caddyfile <<'CONFIG'
+{
+  servers {
+    trusted_proxies static ${join(" ", var.public_subnet_cidrs)}
+    trusted_proxies_strict
+  }
+}
+
 :80 {
   handle_path /api* {
     header {
@@ -46,10 +53,10 @@ cat > /etc/caddy/Caddyfile <<'CONFIG'
       header_down Connection "keep-alive"
       header_down Keep-Alive "timeout=300"
       header_down -Content-Length
-      header_up X-Forwarded-For {remote_host}
-      header_up X-Real-IP {remote_host}
-      header_up X-Forwarded-Proto {scheme}
+      header_up X-Forwarded-For {client_ip}
+      header_up X-Real-IP {client_ip}
       header_up X-Forwarded-Host {host}
+      header_up X-Forwarded-Proto {scheme}
     }
   }
 
@@ -75,16 +82,17 @@ ${var.enable_mcp ? <<MCP
       header_up Keep-Alive "timeout=300"
       header_down Connection "keep-alive"
       header_down Keep-Alive "timeout=300"
-      header_up X-Forwarded-For {remote_host}
-      header_up X-Real-IP {remote_host}
-      header_up X-Forwarded-Proto {scheme}
-      header_up X-Forwarded-Host {host}
+      header_up X-Forwarded-For {client_ip}
+      header_up X-Real-IP {client_ip}
     }
   }
 MCP
       : ""}
 
-  reverse_proxy http://ui-service:3000
+  reverse_proxy http://ui-service:3000 {
+    header_up X-Forwarded-For {client_ip}
+    header_up X-Real-IP {client_ip}
+  }
 }
 CONFIG
 

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -66,6 +66,9 @@ locals {
     # Agent timeout ceiling: every process that parses workflow DSL or
     # enforces the clamp must agree, so it rides the common env.
     TRACECAT__AGENT_SANDBOX_TIMEOUT = var.agent_sandbox_timeout
+    # Audit client-IP attribution: both api and mcp resolve X-Forwarded-For,
+    # so it rides the common env. Empty uses the built-in private-range default.
+    TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS = var.audit_trusted_proxy_cidrs
   }
 
   tracecat_platform_otel_env = {

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -82,6 +82,11 @@ variable "public_subnet_ids" {
   description = "The IDs of the public subnets"
 }
 
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "The CIDR blocks of the public subnets"
+}
+
 variable "private_subnet_ids" {
   type        = list(string)
   description = "The IDs of the private subnets"

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -272,6 +272,12 @@ variable "otel_exporter_otlp_headers_arn" {
   default     = null
 }
 
+variable "audit_trusted_proxy_cidrs" {
+  type        = string
+  description = "Comma-separated CIDRs the API treats as its own proxy hops when resolving audit client IPs. Empty uses the built-in private-range default."
+  default     = ""
+}
+
 variable "log_level" {
   type        = string
   description = "Log level for the application"

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -236,6 +236,12 @@ variable "otel_exporter_otlp_headers_arn" {
   default     = null
 }
 
+variable "audit_trusted_proxy_cidrs" {
+  type        = string
+  description = "Comma-separated CIDRs the API treats as its own proxy hops when resolving audit client IPs. Empty uses the built-in private-range default."
+  default     = ""
+}
+
 variable "log_level" {
   type        = string
   description = "Log level for the application"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,7 @@ services:
       - ${API_PORT:-8000}:8000
     environment:
       # App
+      TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS: ${TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS:-}
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__LOG_FORMAT: ${TRACECAT__LOG_FORMAT:-console}
       TRACECAT__PLATFORM_OTEL_ENABLED: ${TRACECAT__PLATFORM_OTEL_ENABLED:-false}
@@ -504,6 +505,7 @@ services:
       target: development
     restart: on-failure:3
     environment:
+      TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS: ${TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS:-}
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__LOG_FORMAT: ${TRACECAT__LOG_FORMAT:-console}
       TRACECAT__APP_ENV: ${TRACECAT__APP_ENV}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - BASE_DOMAIN=${BASE_DOMAIN}
       - ADDRESS=${ADDRESS}
+      - TRACECAT__TRUSTED_PROXY_CIDRS=${TRACECAT__TRUSTED_PROXY_CIDRS:-127.0.0.1/32}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -29,6 +29,7 @@ services:
       - core-db
     environment:
       # App
+      TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS: ${TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS:-}
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__LOG_FORMAT: ${TRACECAT__LOG_FORMAT:-console}
       TRACECAT__PLATFORM_OTEL_ENABLED: ${TRACECAT__PLATFORM_OTEL_ENABLED:-false}
@@ -526,6 +527,7 @@ services:
       - core-db
       - temporal
     environment:
+      TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS: ${TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS:-}
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__LOG_FORMAT: ${TRACECAT__LOG_FORMAT:-console}
       TRACECAT__APP_ENV: production

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - BASE_DOMAIN=${BASE_DOMAIN}
       - ADDRESS=${ADDRESS}
+      - TRACECAT__TRUSTED_PROXY_CIDRS=${TRACECAT__TRUSTED_PROXY_CIDRS:-127.0.0.1/32}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - core-db
     environment:
       # App
+      TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS: ${TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS:-}
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__LOG_FORMAT: ${TRACECAT__LOG_FORMAT:-console}
       TRACECAT__PLATFORM_OTEL_ENABLED: ${TRACECAT__PLATFORM_OTEL_ENABLED:-false}
@@ -518,6 +519,7 @@ services:
       - core-db
       - temporal
     environment:
+      TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS: ${TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS:-}
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__LOG_FORMAT: ${TRACECAT__LOG_FORMAT:-console}
       TRACECAT__APP_ENV: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - BASE_DOMAIN=${BASE_DOMAIN}
       - ADDRESS=${ADDRESS}
+      - TRACECAT__TRUSTED_PROXY_CIDRS=${TRACECAT__TRUSTED_PROXY_CIDRS:-127.0.0.1/32}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
 

--- a/docs/self-hosting/tls.mdx
+++ b/docs/self-hosting/tls.mdx
@@ -72,7 +72,12 @@ BASE_DOMAIN=:80
 PUBLIC_APP_URL=https://tracecat.example.com
 PUBLIC_API_URL=https://tracecat.example.com/api
 TRACECAT__ALLOW_ORIGINS=https://tracecat.example.com
+TRACECAT__TRUSTED_PROXY_CIDRS="10.0.1.0/24 10.0.2.0/24"
 ```
+
+Set `TRACECAT__TRUSTED_PROXY_CIDRS` to the load balancer subnet CIDRs so Caddy can derive the client address from `X-Forwarded-For` without trusting requests from other networks. Separate multiple CIDRs with spaces.
+
+You must configure the VM firewall or security group so only the load balancer can reach Caddy's port 80. On AWS, set the instance security group's inbound source to the Application Load Balancer's security group. Do not allow the full load balancer subnets to reach port 80 because another host in a trusted subnet could forge `X-Forwarded-For`.
 
 Point the load balancer's HTTPS listener at Caddy's HTTP port (80), and redirect HTTP to HTTPS at the load balancer.
 

--- a/docs/snippets/environment-variables.mdx
+++ b/docs/snippets/environment-variables.mdx
@@ -6,6 +6,8 @@
 | `PUBLIC_APP_URL` | `http://localhost:${PUBLIC_APP_PORT}` | Public URL users visit to reach the Tracecat UI. |
 | `PUBLIC_API_URL` | `${PUBLIC_APP_URL}/api` | Public URL for the Tracecat API, used by the browser and for webhook callbacks. |
 | `INTERNAL_API_URL` | `http://api:8000` | Internal URL that other services use to reach the API container. |
+| `TRACECAT__TRUSTED_PROXY_CIDRS` | `127.0.0.1/32` | Space-separated proxy CIDRs that Caddy trusts when deriving the client address from `X-Forwarded-For`. Set this when another proxy or load balancer runs in front of Caddy. |
+| `TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS` | loopback + private ranges | Comma-separated CIDRs of proxies behind which the API runs (Caddy, the UI container, a load balancer). `X-Forwarded-For` entries from these hops are skipped when resolving the client IP for audit logs. |
 
 ### Application
 

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -16,7 +16,9 @@ global.ReadableStream = ReadableStream
 global.WritableStream = WritableStream
 
 // jsdom does not implement scrollIntoView (used by cmdk selection)
-Element.prototype.scrollIntoView = jest.fn()
+if (typeof Element !== "undefined") {
+  Element.prototype.scrollIntoView = jest.fn()
+}
 
 // jsdom does not implement ResizeObserver (used by useOverflowBadges and other
 // layout-measuring hooks). Provide a no-op stub so components that observe

--- a/frontend/src/app/auth/auth-callback-routes.test.ts
+++ b/frontend/src/app/auth/auth-callback-routes.test.ts
@@ -1,0 +1,79 @@
+/** @jest-environment node */
+
+import { NextRequest } from "next/server"
+import { GET as oauthCallback } from "@/app/auth/oauth/callback/route"
+import { POST as samlCallback } from "@/app/auth/saml/acs/route"
+
+const ORIGINAL_SERVICE_KEY = process.env.TRACECAT__SERVICE_KEY
+const ATTRIBUTION_HEADERS = {
+  "user-agent": "SyntheticBrowser/1.0",
+  "x-forwarded-for": "198.51.100.20",
+}
+
+function infoResponse(): Response {
+  return Response.json({ public_app_url: "http://localhost" })
+}
+
+function authResponse(): Response {
+  return new Response(null, {
+    headers: { "set-cookie": "session=synthetic; Path=/" },
+  })
+}
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  if (ORIGINAL_SERVICE_KEY === undefined) {
+    delete process.env.TRACECAT__SERVICE_KEY
+  } else {
+    process.env.TRACECAT__SERVICE_KEY = ORIGINAL_SERVICE_KEY
+  }
+})
+
+describe("authentication callback attribution", () => {
+  it("forwards OAuth attribution and cookies to the backend", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(authResponse())
+      .mockResolvedValueOnce(infoResponse())
+    const request = new NextRequest(
+      "http://localhost/auth/oauth/callback?code=synthetic",
+      {
+        headers: {
+          ...ATTRIBUTION_HEADERS,
+          cookie: "session=synthetic",
+        },
+      }
+    )
+
+    await oauthCallback(request)
+
+    const headers = new Headers(fetchMock.mock.calls[0][1]?.headers)
+    expect(headers.get("cookie")).toBe("session=synthetic")
+    expect(headers.get("user-agent")).toBe("SyntheticBrowser/1.0")
+    expect(headers.get("x-forwarded-for")).toBe("198.51.100.20")
+  })
+
+  it("forwards SAML attribution with service headers", async () => {
+    process.env.TRACECAT__SERVICE_KEY = "synthetic-service-key"
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(infoResponse())
+      .mockResolvedValueOnce(authResponse())
+    const formData = new FormData()
+    formData.set("SAMLResponse", "synthetic-response")
+    const request = new NextRequest("http://localhost/auth/saml/acs", {
+      method: "POST",
+      body: formData,
+      headers: ATTRIBUTION_HEADERS,
+    })
+
+    await samlCallback(request)
+
+    const headers = new Headers(fetchMock.mock.calls[1][1]?.headers)
+    expect(headers.get("user-agent")).toBe("SyntheticBrowser/1.0")
+    expect(headers.get("x-forwarded-for")).toBe("198.51.100.20")
+    expect(headers.get("x-tracecat-role-type")).toBe("service")
+    expect(headers.get("x-tracecat-role-service-id")).toBe("tracecat-ui")
+    expect(headers.get("x-tracecat-service-key")).toBe("synthetic-service-key")
+  })
+})

--- a/frontend/src/app/auth/oauth/callback/route.ts
+++ b/frontend/src/app/auth/oauth/callback/route.ts
@@ -5,6 +5,7 @@ import {
   POST_AUTH_RETURN_URL_COOKIE_NAME,
   serializeClearPostAuthReturnUrlCookie,
 } from "@/lib/auth-return-url"
+import { forwardClientAttributionHeaders } from "@/lib/forwarded-request-headers"
 import { buildUrl } from "@/lib/ss-utils"
 
 /**
@@ -19,9 +20,15 @@ export const GET = async (request: NextRequest) => {
     request.cookies.get(POST_AUTH_RETURN_URL_COOKIE_NAME)?.value
   )
 
+  const headers = new Headers()
   const incomingCookie = request.headers.get("cookie")
+  if (incomingCookie) {
+    headers.set("cookie", incomingCookie)
+  }
+  forwardClientAttributionHeaders(request.headers, headers)
+
   const response = await fetch(url.toString(), {
-    headers: incomingCookie ? { cookie: incomingCookie } : undefined,
+    headers,
     cache: "no-store",
   })
   const setCookieHeader = response.headers.get("set-cookie")

--- a/frontend/src/app/auth/saml/acs/route.ts
+++ b/frontend/src/app/auth/saml/acs/route.ts
@@ -5,6 +5,7 @@ import {
   POST_AUTH_RETURN_URL_COOKIE_NAME,
   serializeClearPostAuthReturnUrlCookie,
 } from "@/lib/auth-return-url"
+import { forwardClientAttributionHeaders } from "@/lib/forwarded-request-headers"
 import { buildUrl } from "@/lib/ss-utils"
 
 /**
@@ -43,12 +44,12 @@ export async function POST(request: NextRequest) {
   }
 
   // Forward the request to the FastAPI backend
-  const headers = {
+  const headers = new Headers({
     "x-tracecat-service-key": process.env.TRACECAT__SERVICE_KEY!,
     "x-tracecat-role-type": "service",
     "x-tracecat-role-service-id": "tracecat-ui",
-  }
-  console.log("Headers", headers)
+  })
+  forwardClientAttributionHeaders(request.headers, headers)
   const backendResponse = await fetch(backendUrl.toString(), {
     method: "POST",
     body: backendFormData,

--- a/frontend/src/lib/forwarded-request-headers.test.ts
+++ b/frontend/src/lib/forwarded-request-headers.test.ts
@@ -1,0 +1,31 @@
+import { forwardClientAttributionHeaders } from "@/lib/forwarded-request-headers"
+
+describe("forwardClientAttributionHeaders", () => {
+  it("copies client attribution headers", () => {
+    const source = new Headers({
+      authorization: "Bearer synthetic-token",
+      cookie: "session=synthetic",
+      "user-agent": "SyntheticBrowser/1.0",
+      "x-forwarded-for": "198.51.100.20",
+    })
+    const destination = new Headers({ cookie: "session=synthetic" })
+
+    forwardClientAttributionHeaders(source, destination)
+
+    expect(Object.fromEntries(destination.entries())).toEqual({
+      cookie: "session=synthetic",
+      "user-agent": "SyntheticBrowser/1.0",
+      "x-forwarded-for": "198.51.100.20",
+    })
+  })
+
+  it("leaves missing attribution headers unset", () => {
+    const destination = new Headers({ "x-tracecat-role-type": "service" })
+
+    forwardClientAttributionHeaders(new Headers(), destination)
+
+    expect(Object.fromEntries(destination.entries())).toEqual({
+      "x-tracecat-role-type": "service",
+    })
+  })
+})

--- a/frontend/src/lib/forwarded-request-headers.ts
+++ b/frontend/src/lib/forwarded-request-headers.ts
@@ -1,0 +1,16 @@
+const CLIENT_ATTRIBUTION_HEADERS = ["x-forwarded-for", "user-agent"] as const
+
+/**
+ * Copy bounded client attribution headers into a server-side backend request.
+ */
+export function forwardClientAttributionHeaders(
+  source: Headers,
+  destination: Headers
+): void {
+  for (const name of CLIENT_ATTRIBUTION_HEADERS) {
+    const value = source.get(name)
+    if (value) {
+      destination.set(name, value)
+    }
+  }
+}

--- a/tests/unit/test_caddy_config.py
+++ b/tests/unit/test_caddy_config.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_compose_caddy_canonicalizes_mcp_oauth_client_ip() -> None:
+    caddyfile = (REPO_ROOT / "Caddyfile").read_text()
+    oauth_routes = caddyfile.split("@mcp_oauth_routes", maxsplit=1)[1].split(
+        "reverse_proxy http://ui:3000", maxsplit=1
+    )[0]
+
+    for path in (
+        "/.well-known/oauth-authorization-server",
+        "/.well-known/oauth-protected-resource",
+        "/authorize",
+        "/token",
+        "/register",
+        "/consent",
+        "/auth/callback",
+    ):
+        assert path in oauth_routes
+    assert "trusted_proxies_strict" in caddyfile
+    assert "header_up X-Forwarded-For {client_ip}" in oauth_routes
+    assert "header_up X-Real-IP {client_ip}" in oauth_routes
+
+
+def _upstream_block(config: str, upstream: str) -> str:
+    """Return the header_up lines of a Caddyfile reverse_proxy block."""
+    after = config.split(upstream, maxsplit=1)[1]
+    lines = []
+    for line in after.splitlines()[1:]:
+        if line.strip() == "}":
+            break
+        lines.append(line.strip())
+    return "\n".join(lines)
+
+
+def test_api_upstream_forwards_host_and_proto_for_oidc_discovery() -> None:
+    """The MCP OIDC discovery endpoint builds advertised endpoint URLs from
+    X-Forwarded-Host/Proto, so the api upstream must forward both."""
+    caddyfile = (REPO_ROOT / "Caddyfile").read_text()
+    api_upstream = _upstream_block(caddyfile, "reverse_proxy http://api:8000")
+    assert "header_up X-Forwarded-Host {host}" in api_upstream
+    assert "header_up X-Forwarded-Proto {scheme}" in api_upstream
+
+    fargate_config = (
+        REPO_ROOT / "deployments/fargate/modules/ecs/ecs-caddy.tf"
+    ).read_text()
+    fargate_api_upstream = _upstream_block(
+        fargate_config, "reverse_proxy http://api-service:8000"
+    )
+    assert "header_up X-Forwarded-Host {host}" in fargate_api_upstream
+    assert "header_up X-Forwarded-Proto {scheme}" in fargate_api_upstream
+
+
+def test_fargate_caddy_trusts_only_alb_subnets() -> None:
+    caddy_config = (
+        REPO_ROOT / "deployments/fargate/modules/ecs/ecs-caddy.tf"
+    ).read_text()
+
+    assert (
+        'trusted_proxies static ${join(" ", var.public_subnet_cidrs)}' in caddy_config
+    )
+    assert "trusted_proxies_strict" in caddy_config
+    assert "trusted_proxies static private_ranges" not in caddy_config

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -187,6 +187,40 @@ def test_env_ports_uses_default_when_unset_or_blank(
     assert env_ports("TEST_PORTS_ENV", default=(80, 443)) == (80, 443)
 
 
+@pytest.mark.parametrize("raw_value", [None, "", "  "])
+def test_env_networks_uses_default_when_unset_or_blank(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_value: str | None,
+) -> None:
+    if raw_value is None:
+        monkeypatch.delenv("TEST_NETWORKS_ENV", raising=False)
+    else:
+        monkeypatch.setenv("TEST_NETWORKS_ENV", raw_value)
+    default = env_networks(
+        "TEST_NETWORKS_ENV", default=tracecat_config.TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS
+    )
+
+    assert default == tracecat_config.TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS
+
+
+def test_audit_trusted_proxy_env_is_wired_to_deployments() -> None:
+    """Both audit consumers (api, mcp) must receive the override in every target."""
+    name = "TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS"
+    for path in SANDBOX_POLICY_COMPOSE_ENV_FILES:
+        source = path.read_text()
+        for service in ("api", "mcp"):
+            match = re.search(
+                rf"(?ms)^  {service}:\n(?P<body>.*?)(?=^  [a-z][a-z0-9_-]*:\n|\Z)",
+                source,
+            )
+            assert match is not None, f"{path.name}: no {service} service block"
+            assert name in match.group("body"), f"{path.name}: {service}"
+    fargate = REPO_ROOT / "deployments/fargate"
+    assert name in (fargate / "modules/ecs/locals.tf").read_text()
+    for tf in ("variables.tf", "main.tf", "modules/ecs/variables.tf"):
+        assert "audit_trusted_proxy_cidrs" in (fargate / tf).read_text(), tf
+
+
 def test_sandbox_policy_env_vars_are_wired_to_compose_files() -> None:
     missing_by_file = {
         str(path.relative_to(REPO_ROOT)): sorted(

--- a/tests/unit/test_request_middleware.py
+++ b/tests/unit/test_request_middleware.py
@@ -1,7 +1,10 @@
+from ipaddress import ip_network
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tracecat import config
 from tracecat.contexts import ctx_request_audit
 from tracecat.middleware.request import RequestLoggingMiddleware
 
@@ -124,6 +127,32 @@ def test_request_context_reduces_unknown_user_agent() -> None:
         )
 
     assert response.json() == {"user_agent": "other"}
+
+
+def test_client_ip_resolution_honors_custom_trusted_networks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A narrowed trust list stops private-range peers from speaking for clients."""
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS",
+        (ip_network("198.51.100.0/24"),),
+    )
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    async def read_client_ip() -> dict[str, str | None]:
+        return {"client_ip": _read_audit_context()["client_ip"]}
+
+    app.add_api_route("/", read_client_ip)
+    app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
+    with TestClient(app, client=("198.51.100.7", 50000)) as client:
+        trusted = client.get("/", headers={"X-Forwarded-For": "203.0.113.9"})
+    with TestClient(app, client=("10.0.0.5", 50000)) as client:
+        untrusted = client.get("/", headers={"X-Forwarded-For": "203.0.113.9"})
+
+    assert trusted.json() == {"client_ip": "203.0.113.9"}
+    assert untrusted.json() == {"client_ip": "10.0.0.5"}
 
 
 def test_invalid_forwarded_ip_falls_back_to_socket_peer() -> None:

--- a/tests/unit/test_request_middleware.py
+++ b/tests/unit/test_request_middleware.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -22,7 +23,7 @@ def test_request_context_values_are_normalized() -> None:
 
     app.add_api_route("/", read_context)
     app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
-    with TestClient(app, client=("203.0.113.10", 50000)) as client:
+    with TestClient(app, client=("10.0.0.5", 50000)) as client:
         response = client.get(
             "/",
             headers={
@@ -38,6 +39,73 @@ def test_request_context_values_are_normalized() -> None:
         "client_ip": "198.51.100.20",
         "user_agent": "tracecat/1.0",
     }
+
+
+@pytest.mark.parametrize(
+    ("peer", "forwarded_for", "expected"),
+    [
+        # Trusted peer: rightmost untrusted hop wins; the client-sent
+        # leftmost entry is ignored.
+        ("10.0.0.5", "6.6.6.6, 203.0.113.7", "203.0.113.7"),
+        # Untrusted peer talking directly: its spoofed header is ignored.
+        ("203.0.113.10", "6.6.6.6", "203.0.113.10"),
+        # Fully trusted chain (internal traffic): leftmost hop attributed.
+        ("10.0.0.5", "10.0.8.4", "10.0.8.4"),
+    ],
+)
+def test_client_ip_resolution_walks_trusted_proxies(
+    peer: str, forwarded_for: str, expected: str
+) -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    async def read_client_ip() -> dict[str, str | None]:
+        return {"client_ip": _read_audit_context()["client_ip"]}
+
+    app.add_api_route("/", read_client_ip)
+    app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
+    with TestClient(app, client=(peer, 50000)) as client:
+        response = client.get("/", headers={"X-Forwarded-For": forwarded_for})
+
+    assert response.json() == {"client_ip": expected}
+
+
+@pytest.mark.parametrize(
+    ("user_agent", "expected"),
+    [
+        (
+            "Mozilla/5.0 Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
+            "edge/131.0.0.0",
+        ),
+        (
+            "Mozilla/5.0 AppleWebKit/537.36 Chrome/131.0.0.0 Safari/537.36",
+            "chrome/131.0.0.0",
+        ),
+        ("Mozilla/5.0 Firefox/133.0", "firefox/133.0"),
+        (
+            "Mozilla/5.0 Version/18.0 Safari/605.1.15",
+            "safari/18.0",
+        ),
+        (
+            "mozilla/5.0 version/18.0 safari/605.1.15",
+            "safari/18.0",
+        ),
+        ("Mozilla/5.0 SyntheticBrowser/1.0", "browser/other"),
+    ],
+)
+def test_request_context_identifies_browser(user_agent: str, expected: str) -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    async def read_user_agent() -> dict[str, str | None]:
+        return {"user_agent": _read_audit_context()["user_agent"]}
+
+    app.add_api_route("/", read_user_agent)
+    app.state.logger = type("Logger", (), {"debug": lambda *_args, **_kwargs: None})()
+    with TestClient(app) as client:
+        response = client.get("/", headers={"User-Agent": user_agent})
+
+    assert response.json() == {"user_agent": expected}
 
 
 def test_request_context_reduces_unknown_user_agent() -> None:

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -408,6 +408,17 @@ SAML_VERIFY_SSL_ENTITY = env_bool("SAML_VERIFY_SSL_ENTITY", default=True)
 SAML_VERIFY_SSL_METADATA = env_bool("SAML_VERIFY_SSL_METADATA", default=True)
 """Whether to verify SSL certificates for SAML metadata operations."""
 
+# === Audit config === #
+TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS = os.environ.get(
+    "TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS"
+) or (
+    "127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,"
+    "169.254.0.0/16,fc00::/7"
+)
+"""Comma-separated CIDRs of proxies behind which the API runs (Caddy, the UI
+container, a load balancer). X-Forwarded-For entries from these hops are
+skipped when resolving the client IP for audit attribution."""
+
 # === CORS config === #
 # NOTE: If you are using Tracecat self-hosted, please replace with your
 # own domain by setting the comma separated TRACECAT__ALLOW_ORIGINS env var.

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -408,17 +408,6 @@ SAML_VERIFY_SSL_ENTITY = env_bool("SAML_VERIFY_SSL_ENTITY", default=True)
 SAML_VERIFY_SSL_METADATA = env_bool("SAML_VERIFY_SSL_METADATA", default=True)
 """Whether to verify SSL certificates for SAML metadata operations."""
 
-# === Audit config === #
-TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS = os.environ.get(
-    "TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS"
-) or (
-    "127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,"
-    "169.254.0.0/16,fc00::/7"
-)
-"""Comma-separated CIDRs of proxies behind which the API runs (Caddy, the UI
-container, a load balancer). X-Forwarded-For entries from these hops are
-skipped when resolving the client IP for audit attribution."""
-
 # === CORS config === #
 # NOTE: If you are using Tracecat self-hosted, please replace with your
 # own domain by setting the comma separated TRACECAT__ALLOW_ORIGINS env var.
@@ -679,11 +668,14 @@ TRACECAT__SANDBOX_PYPI_EXTRA_INDEX_URLS = [
 """Additional PyPI index URLs (comma-separated). Used as fallback sources for package installation."""
 
 
-def env_networks(name: str) -> tuple[IPv4Network | IPv6Network, ...]:
+def env_networks(
+    name: str, *, default: tuple[IPv4Network | IPv6Network, ...] = ()
+) -> tuple[IPv4Network | IPv6Network, ...]:
     """Parse a comma-separated environment variable into validated IP networks.
 
     Args:
         name: Environment variable name.
+        default: Networks returned when the variable is unset or blank.
 
     Returns:
         Parsed IPv4 and IPv6 networks in configured order.
@@ -692,6 +684,8 @@ def env_networks(name: str) -> tuple[IPv4Network | IPv6Network, ...]:
         ValueError: If any configured value is not a valid CIDR or IP address.
     """
     raw_value = os.environ.get(name, "")
+    if not raw_value.strip():
+        return default
     networks: list[IPv4Network | IPv6Network] = []
     for value in raw_value.split(","):
         stripped = value.strip()
@@ -725,6 +719,22 @@ def env_ports(name: str, *, default: tuple[int, ...]) -> tuple[int, ...]:
             ports.append(port)
     return tuple(ports)
 
+
+TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS = env_networks(
+    "TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS",
+    default=(
+        ip_network("127.0.0.0/8"),
+        ip_network("::1/128"),
+        ip_network("10.0.0.0/8"),
+        ip_network("172.16.0.0/12"),
+        ip_network("192.168.0.0/16"),
+        ip_network("169.254.0.0/16"),
+        ip_network("fc00::/7"),
+    ),
+)
+"""CIDRs of proxies behind which the API runs (Caddy, the UI container, a load
+balancer). X-Forwarded-For entries from these hops are skipped when resolving
+the client IP for audit attribution."""
 
 TRACECAT__SANDBOX_INSTALL_ALLOWED_EGRESS_CIDRS = env_networks(
     "TRACECAT__SANDBOX_INSTALL_ALLOWED_EGRESS_CIDRS"

--- a/tracecat/middleware/request.py
+++ b/tracecat/middleware/request.py
@@ -1,26 +1,21 @@
 from __future__ import annotations
 
 import re
-from ipaddress import ip_address
+from ipaddress import ip_address, ip_network
 
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from tracecat import config
 from tracecat.contexts import RequestAuditContext, ctx_request_audit
 
-_AUDIT_USER_AGENT_PATTERN = re.compile(
-    r"^(?P<product>Mozilla|TracecatClient|curl|python-httpx|Claude-Code|Codex)"
-    r"/(?P<version>\d{1,4}(?:\.\d{1,4}){0,3})\b",
-    re.IGNORECASE,
-)
-_AUDIT_USER_AGENT_FAMILIES = {
-    "claude-code": "claude-code",
-    "codex": "codex",
-    "curl": "curl",
-    "mozilla": "browser",
-    "python-httpx": "httpx",
-    "tracecatclient": "tracecat",
-}
+# === Client IP resolution === #
+
+_TRUSTED_PROXY_NETWORKS = [
+    ip_network(cidr.strip())
+    for cidr in config.TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS.split(",")
+    if cidr.strip()
+]
 
 
 def _normalize_client_ip(value: str | None) -> str | None:
@@ -32,29 +27,109 @@ def _normalize_client_ip(value: str | None) -> str | None:
         return None
 
 
+def _is_trusted_proxy(value: str) -> bool:
+    addr = ip_address(value)
+    return any(addr in network for network in _TRUSTED_PROXY_NETWORKS)
+
+
+def _resolve_client_ip(request: Request) -> str | None:
+    """Rightmost untrusted hop of X-Forwarded-For plus the socket peer.
+
+    Each proxy appends its peer, so the chain is trustworthy only from the
+    right; the leftmost entries are client-controlled. Walk right to left,
+    skipping TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS hops; the first address not
+    on that list is the client. A fully trusted chain (internal service
+    traffic) attributes to its leftmost hop.
+    """
+    candidates: list[str] = []
+    if forwarded_for := request.headers.get("X-Forwarded-For"):
+        for entry in forwarded_for.split(","):
+            if normalized := _normalize_client_ip(entry.strip()):
+                candidates.append(normalized)
+    if peer := _normalize_client_ip(
+        request.client.host if request.client is not None else None
+    ):
+        candidates.append(peer)
+    for candidate in reversed(candidates):
+        if not _is_trusted_proxy(candidate):
+            return candidate
+    return candidates[0] if candidates else None
+
+
+# === User-agent normalization === #
+
+_AUDIT_CLIENT_USER_AGENT_PATTERN = re.compile(
+    r"^(?P<product>TracecatClient|curl|python-httpx|Claude-Code|Codex)"
+    r"/(?P<version>\d{1,4}(?:\.\d{1,4}){0,3})\b",
+    re.IGNORECASE,
+)
+_AUDIT_CLIENT_USER_AGENT_FAMILIES = {
+    "claude-code": "claude-code",
+    "codex": "codex",
+    "curl": "curl",
+    "python-httpx": "httpx",
+    "tracecatclient": "tracecat",
+}
+# Browser UAs hide their identity mid-string; most-specific token first
+# (Edge UAs contain Chrome/, Chrome UAs contain Safari/).
+_AUDIT_BROWSER_USER_AGENT_PATTERNS = (
+    (
+        "edge",
+        re.compile(
+            r"\bEdg(?:A|iOS)?/(?P<version>\d{1,4}(?:\.\d{1,4}){0,3})\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "chrome",
+        re.compile(
+            r"\b(?:Chrome|CriOS)/(?P<version>\d{1,4}(?:\.\d{1,4}){0,3})\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "firefox",
+        re.compile(
+            r"\b(?:Firefox|FxiOS)/(?P<version>\d{1,4}(?:\.\d{1,4}){0,3})\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+_AUDIT_SAFARI_PRODUCT_PATTERN = re.compile(r"\bSafari/", re.IGNORECASE)
+_AUDIT_SAFARI_VERSION_PATTERN = re.compile(
+    r"\bVersion/(?P<version>\d{1,4}(?:\.\d{1,4}){0,3})\b",
+    re.IGNORECASE,
+)
+
+
 def _normalize_audit_user_agent(value: str | None) -> str | None:
     """Return a bounded client family/version without forwarding raw metadata."""
     if not value:
         return None
-    if match := _AUDIT_USER_AGENT_PATTERN.match(value):
-        family = _AUDIT_USER_AGENT_FAMILIES[match.group("product").lower()]
+    if match := _AUDIT_CLIENT_USER_AGENT_PATTERN.match(value):
+        family = _AUDIT_CLIENT_USER_AGENT_FAMILIES[match.group("product").lower()]
         return f"{family}/{match.group('version')}"
+    for family, pattern in _AUDIT_BROWSER_USER_AGENT_PATTERNS:
+        if match := pattern.search(value):
+            return f"{family}/{match.group('version')}"
+    if _AUDIT_SAFARI_PRODUCT_PATTERN.search(value) and (
+        match := _AUDIT_SAFARI_VERSION_PATTERN.search(value)
+    ):
+        return f"safari/{match.group('version')}"
+    if value.lower().startswith("mozilla/"):
+        return "browser/other"
     return "other"
+
+
+# === Audit context === #
 
 
 def build_request_audit_context(request: Request) -> RequestAuditContext:
     """Derive audit attribution from an HTTP request.
 
-    Leftmost X-Forwarded-For hop, falling back to the socket peer.
-    Client-controlled: informational attribution, not a security control.
+    Informational attribution, not a security control.
     """
-    client_ip = None
-    if forwarded_for := request.headers.get("X-Forwarded-For"):
-        client_ip = _normalize_client_ip(forwarded_for.split(",", 1)[0].strip())
-    if client_ip is None:
-        client_ip = _normalize_client_ip(
-            request.client.host if request.client is not None else None
-        )
+    client_ip = _resolve_client_ip(request)
     user_agent = _normalize_audit_user_agent(request.headers.get("User-Agent"))
     return RequestAuditContext(client_ip=client_ip, user_agent=user_agent)
 

--- a/tracecat/middleware/request.py
+++ b/tracecat/middleware/request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_address
 
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -10,12 +10,6 @@ from tracecat import config
 from tracecat.contexts import RequestAuditContext, ctx_request_audit
 
 # === Client IP resolution === #
-
-_TRUSTED_PROXY_NETWORKS = [
-    ip_network(cidr.strip())
-    for cidr in config.TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS.split(",")
-    if cidr.strip()
-]
 
 
 def _normalize_client_ip(value: str | None) -> str | None:
@@ -29,7 +23,9 @@ def _normalize_client_ip(value: str | None) -> str | None:
 
 def _is_trusted_proxy(value: str) -> bool:
     addr = ip_address(value)
-    return any(addr in network for network in _TRUSTED_PROXY_NETWORKS)
+    return any(
+        addr in network for network in config.TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS
+    )
 
 
 def _resolve_client_ip(request: Request) -> str | None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes audit attribution across proxy hops. Previously, the API used the leftmost `X-Forwarded-For` entry and Caddy reported the immediate proxy; now Caddy canonicalizes forwarding headers and the API and MCP select the rightmost untrusted hop.

- Caddy enables strict proxy trust, using `TRACECAT__TRUSTED_PROXY_CIDRS` with a loopback default; Fargate trusts only the public subnet CIDRs.
- `TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS` configures the proxy networks skipped during audit IP resolution, with loopback and private ranges as the default, and is wired through Compose and Terraform.
- OAuth and SAML callbacks forward `x-forwarded-for` and `user-agent`; browser user agents now normalize to their detected family and version.
- Self-hosted deployments behind a load balancer must set `TRACECAT__TRUSTED_PROXY_CIDRS` to the load balancer CIDRs and restrict Caddy's port 80 to the load balancer.

<sup>Written for commit 474764ad8ba46f38fa6c25677a13ca396eeade8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

