### PR TITLE
feat(integrations): add Zendesk OAuth client credentials provider

### DIFF
--- a/docs/tools/zendesk.mdx
+++ b/docs/tools/zendesk.mdx
@@ -14,8 +14,9 @@ Reference: [https://developer.zendesk.com/api-reference/ticketing/groups/groups/
 
 ### Secrets
 
-Required secrets:
+Optional secrets:
 
+- `zendesk_oauth`: OAuth token `ZENDESK_SERVICE_TOKEN`.
 - `zendesk`: required values `ZENDESK_EMAIL`, `ZENDESK_API_TOKEN`.
 
 ### Input fields
@@ -58,8 +59,9 @@ Reference: [https://developer.zendesk.com/api-reference/ticketing/groups/groups/
 
 ### Secrets
 
-Required secrets:
+Optional secrets:
 
+- `zendesk_oauth`: OAuth token `ZENDESK_SERVICE_TOKEN`.
 - `zendesk`: required values `ZENDESK_EMAIL`, `ZENDESK_API_TOKEN`.
 
 ### Input fields
@@ -96,8 +98,9 @@ Reference: [https://developer.zendesk.com/api-reference/ticketing/tickets/ticket
 
 ### Secrets
 
-Required secrets:
+Optional secrets:
 
+- `zendesk_oauth`: OAuth token `ZENDESK_SERVICE_TOKEN`.
 - `zendesk`: required values `ZENDESK_EMAIL`, `ZENDESK_API_TOKEN`.
 
 ### Input fields
@@ -124,8 +127,9 @@ Reference: [https://developer.zendesk.com/api-reference/ticketing/tickets/ticket
 
 ### Secrets
 
-Required secrets:
+Optional secrets:
 
+- `zendesk_oauth`: OAuth token `ZENDESK_SERVICE_TOKEN`.
 - `zendesk`: required values `ZENDESK_EMAIL`, `ZENDESK_API_TOKEN`.
 
 ### Input fields
@@ -152,8 +156,9 @@ Reference: [https://developer.zendesk.com/api-reference/ticketing/tickets/ticket
 
 ### Secrets
 
-Required secrets:
+Optional secrets:
 
+- `zendesk_oauth`: OAuth token `ZENDESK_SERVICE_TOKEN`.
 - `zendesk`: required values `ZENDESK_EMAIL`, `ZENDESK_API_TOKEN`.
 
 ### Input fields
@@ -196,8 +201,9 @@ Reference: [https://developer.zendesk.com/api-reference/voice/talk-api/recording
 
 ### Secrets
 
-Required secrets:
+Optional secrets:
 
+- `zendesk_oauth`: OAuth token `ZENDESK_SERVICE_TOKEN`.
 - `zendesk`: required values `ZENDESK_EMAIL`, `ZENDESK_API_TOKEN`.
 
 ### Input fields
@@ -224,8 +230,9 @@ Reference: [https://developer.zendesk.com/api-reference/ticketing/ticket-managem
 
 ### Secrets
 
-Required secrets:
+Optional secrets:
 
+- `zendesk_oauth`: OAuth token `ZENDESK_SERVICE_TOKEN`.
 - `zendesk`: required values `ZENDESK_EMAIL`, `ZENDESK_API_TOKEN`.
 
 ### Input fields

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -1010,6 +1010,11 @@ export const providerIcons: Record<
     </div>
   ),
   jamf: createCatalogIconRenderer("jamf_mcp"),
+  zendesk: ({ className, ...rest }) => (
+    <div className={className}>
+      <ZendeskIcon {...rest} />
+    </div>
+  ),
   slack: ({ className, iconClassName, flairsize: _ignored, ...rest }) => (
     <div className={cn("!rounded-sm", className)}>
       <SlackIcon {...rest} className={cn("size-full", iconClassName)} />
@@ -1227,6 +1232,11 @@ export const secretIcons: Record<
   snowflake: ({ className, ...rest }) => (
     <div className={className}>
       <SnowflakeIcon {...rest} />
+    </div>
+  ),
+  zendesk: ({ className, ...rest }) => (
+    <div className={className}>
+      <ZendeskIcon {...rest} />
     </div>
   ),
   // Default fallback using KeyRound icon

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_group_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_group_users.yml
@@ -7,8 +7,13 @@ definition:
   namespace: tools.zendesk
   name: get_group_users
   secrets:
+    - type: oauth
+      provider_id: zendesk
+      grant_type: client_credentials
+      optional: true
     - name: zendesk
       keys: ["ZENDESK_EMAIL", "ZENDESK_API_TOKEN"]
+      optional: true
   expects:
     subdomain:
       type: str
@@ -25,10 +30,10 @@ definition:
       description: Number of users per page (max 100)
       default: 100
   steps:
-    - ref: encode_auth
+    - ref: resolve_auth
       action: core.transform.reshape
       args:
-        value: ${{ FN.to_base64(SECRETS.zendesk.ZENDESK_EMAIL + "/token:" + SECRETS.zendesk.ZENDESK_API_TOKEN) }}
+        value: ${{ (SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN && FN.format("Bearer {}", SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN)) || FN.format("Basic {}", FN.to_base64(FN.format("{}/token:{}", SECRETS.zendesk.ZENDESK_EMAIL, SECRETS.zendesk.ZENDESK_API_TOKEN))) }}
     - ref: build_params
       action: core.script.run_python
       args:
@@ -47,7 +52,7 @@ definition:
         url: https://${{ inputs.subdomain }}.zendesk.com/api/v2/groups/${{ inputs.group_id }}/users.json
         method: GET
         headers:
-          Authorization: Basic ${{ steps.encode_auth.result }}
+          Authorization: ${{ steps.resolve_auth.result }}
           Accept: application/json
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.call_api.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_groups.yml
@@ -7,8 +7,13 @@ definition:
   namespace: tools.zendesk
   name: get_groups
   secrets:
+    - type: oauth
+      provider_id: zendesk
+      grant_type: client_credentials
+      optional: true
     - name: zendesk
       keys: ["ZENDESK_EMAIL", "ZENDESK_API_TOKEN"]
+      optional: true
   expects:
     subdomain:
       type: str
@@ -22,10 +27,10 @@ definition:
       description: Number of groups per page (max 100)
       default: 100
   steps:
-    - ref: encode_auth
+    - ref: resolve_auth
       action: core.transform.reshape
       args:
-        value: ${{ FN.to_base64(SECRETS.zendesk.ZENDESK_EMAIL + "/token:" + SECRETS.zendesk.ZENDESK_API_TOKEN) }}
+        value: ${{ (SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN && FN.format("Bearer {}", SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN)) || FN.format("Basic {}", FN.to_base64(FN.format("{}/token:{}", SECRETS.zendesk.ZENDESK_EMAIL, SECRETS.zendesk.ZENDESK_API_TOKEN))) }}
     - ref: build_params
       action: core.script.run_python
       args:
@@ -44,7 +49,7 @@ definition:
         url: https://${{ inputs.subdomain }}.zendesk.com/api/v2/groups.json
         method: GET
         headers:
-          Authorization: Basic ${{ steps.encode_auth.result }}
+          Authorization: ${{ steps.resolve_auth.result }}
           Accept: application/json
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.call_api.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_ticket.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_ticket.yml
@@ -7,8 +7,13 @@ definition:
   namespace: tools.zendesk
   name: get_ticket
   secrets:
+    - type: oauth
+      provider_id: zendesk
+      grant_type: client_credentials
+      optional: true
     - name: zendesk
       keys: ["ZENDESK_EMAIL", "ZENDESK_API_TOKEN"]
+      optional: true
   expects:
     subdomain:
       type: str
@@ -17,17 +22,17 @@ definition:
       type: int
       description: The ID of the ticket to retrieve
   steps:
-    - ref: encode_auth
+    - ref: resolve_auth
       action: core.transform.reshape
       args:
-        value: ${{ FN.to_base64(SECRETS.zendesk.ZENDESK_EMAIL + "/token:" + SECRETS.zendesk.ZENDESK_API_TOKEN) }}
+        value: ${{ (SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN && FN.format("Bearer {}", SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN)) || FN.format("Basic {}", FN.to_base64(FN.format("{}/token:{}", SECRETS.zendesk.ZENDESK_EMAIL, SECRETS.zendesk.ZENDESK_API_TOKEN))) }}
     - ref: call_api
       action: core.http_request
       args:
         url: https://${{ inputs.subdomain }}.zendesk.com/api/v2/tickets/${{ inputs.ticket_id }}.json
         method: GET
         headers:
-          Authorization: Basic ${{ steps.encode_auth.result }}
+          Authorization: ${{ steps.resolve_auth.result }}
           Content-Type: application/json
           Accept: application/json
   returns: ${{ steps.call_api.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_ticket_attachments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_ticket_attachments.yml
@@ -7,8 +7,13 @@ definition:
   namespace: tools.zendesk
   name: get_ticket_attachments
   secrets:
+    - type: oauth
+      provider_id: zendesk
+      grant_type: client_credentials
+      optional: true
     - name: zendesk
       keys: ["ZENDESK_EMAIL", "ZENDESK_API_TOKEN"]
+      optional: true
   expects:
     subdomain:
       type: str
@@ -17,17 +22,17 @@ definition:
       type: int
       description: The ID of the ticket
   steps:
-    - ref: encode_auth
+    - ref: resolve_auth
       action: core.transform.reshape
       args:
-        value: ${{ FN.to_base64(SECRETS.zendesk.ZENDESK_EMAIL + "/token:" + SECRETS.zendesk.ZENDESK_API_TOKEN) }}
+        value: ${{ (SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN && FN.format("Bearer {}", SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN)) || FN.format("Basic {}", FN.to_base64(FN.format("{}/token:{}", SECRETS.zendesk.ZENDESK_EMAIL, SECRETS.zendesk.ZENDESK_API_TOKEN))) }}
     - ref: get_comments
       action: core.http_request
       args:
         url: https://${{ inputs.subdomain }}.zendesk.com/api/v2/tickets/${{ inputs.ticket_id }}/comments.json
         method: GET
         headers:
-          Authorization: Basic ${{ steps.encode_auth.result }}
+          Authorization: ${{ steps.resolve_auth.result }}
           Content-Type: application/json
           Accept: application/json
     - ref: extract_attachments

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_ticket_comments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_ticket_comments.yml
@@ -7,8 +7,13 @@ definition:
   namespace: tools.zendesk
   name: get_ticket_comments
   secrets:
+    - type: oauth
+      provider_id: zendesk
+      grant_type: client_credentials
+      optional: true
     - name: zendesk
       keys: ["ZENDESK_EMAIL", "ZENDESK_API_TOKEN"]
+      optional: true
   expects:
     subdomain:
       type: str
@@ -25,10 +30,10 @@ definition:
       description: Number of comments per page (max 100)
       default: 100
   steps:
-    - ref: encode_auth
+    - ref: resolve_auth
       action: core.transform.reshape
       args:
-        value: ${{ FN.to_base64(SECRETS.zendesk.ZENDESK_EMAIL + "/token:" + SECRETS.zendesk.ZENDESK_API_TOKEN) }}
+        value: ${{ (SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN && FN.format("Bearer {}", SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN)) || FN.format("Basic {}", FN.to_base64(FN.format("{}/token:{}", SECRETS.zendesk.ZENDESK_EMAIL, SECRETS.zendesk.ZENDESK_API_TOKEN))) }}
     - ref: build_params
       action: core.transform.reshape
       args:
@@ -41,7 +46,7 @@ definition:
         url: https://${{ inputs.subdomain }}.zendesk.com/api/v2/tickets/${{ inputs.ticket_id }}/comments.json
         method: GET
         headers:
-          Authorization: Basic ${{ steps.encode_auth.result }}
+          Authorization: ${{ steps.resolve_auth.result }}
           Content-Type: application/json
           Accept: application/json
         params: ${{ steps.build_params.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_twilio_recordings.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/get_twilio_recordings.yml
@@ -7,8 +7,13 @@ definition:
   namespace: tools.zendesk
   name: get_twilio_recordings
   secrets:
+    - type: oauth
+      provider_id: zendesk
+      grant_type: client_credentials
+      optional: true
     - name: zendesk
       keys: ["ZENDESK_EMAIL", "ZENDESK_API_TOKEN"]
+      optional: true
   expects:
     subdomain:
       type: str
@@ -17,16 +22,16 @@ definition:
       type: str
       description: Call ID
   steps:
-    - ref: encode_auth
+    - ref: resolve_auth
       action: core.transform.reshape
       args:
-        value: ${{ FN.to_base64(SECRETS.zendesk.ZENDESK_EMAIL + "/token:" + SECRETS.zendesk.ZENDESK_API_TOKEN) }}
+        value: ${{ (SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN && FN.format("Bearer {}", SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN)) || FN.format("Basic {}", FN.to_base64(FN.format("{}/token:{}", SECRETS.zendesk.ZENDESK_EMAIL, SECRETS.zendesk.ZENDESK_API_TOKEN))) }}
     - ref: call_api
       action: core.http_request
       args:
         url: https://${{ inputs.subdomain }}.zendesk.com/api/v2/channels/voice/calls/${{ inputs.call_id }}/twilio/call/recording
         method: GET
         headers:
-          Authorization: Basic ${{ steps.encode_auth.result }}
+          Authorization: ${{ steps.resolve_auth.result }}
           Accept: application/json
   returns: ${{ steps.call_api.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/search_tickets.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/search_tickets.yml
@@ -7,8 +7,13 @@ definition:
   namespace: tools.zendesk
   name: search_tickets
   secrets:
+    - type: oauth
+      provider_id: zendesk
+      grant_type: client_credentials
+      optional: true
     - name: zendesk
       keys: ["ZENDESK_EMAIL", "ZENDESK_API_TOKEN"]
+      optional: true
   expects:
     subdomain:
       type: str
@@ -34,10 +39,10 @@ definition:
       description: Number of results per page (max 100)
       default: 100
   steps:
-    - ref: encode_auth
+    - ref: resolve_auth
       action: core.transform.reshape
       args:
-        value: ${{ FN.to_base64(SECRETS.zendesk.ZENDESK_EMAIL + "/token:" + SECRETS.zendesk.ZENDESK_API_TOKEN) }}
+        value: ${{ (SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN && FN.format("Bearer {}", SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN)) || FN.format("Basic {}", FN.to_base64(FN.format("{}/token:{}", SECRETS.zendesk.ZENDESK_EMAIL, SECRETS.zendesk.ZENDESK_API_TOKEN))) }}
     - ref: build_params
       action: core.script.run_python
       args:
@@ -66,7 +71,7 @@ definition:
         url: https://${{ inputs.subdomain }}.zendesk.com/api/v2/search.json
         method: GET
         headers:
-          Authorization: Basic ${{ steps.encode_auth.result }}
+          Authorization: ${{ steps.resolve_auth.result }}
           Accept: application/json
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.call_api.result.data }}

--- a/tracecat/integrations/providers/__init__.py
+++ b/tracecat/integrations/providers/__init__.py
@@ -64,6 +64,7 @@ from tracecat.integrations.providers.snowflake import (
     SnowflakeCCProvider,
 )
 from tracecat.integrations.providers.wiz.mcp import WizMCPProvider
+from tracecat.integrations.providers.zendesk import ZendeskOAuthProvider
 from tracecat.integrations.schemas import ProviderKey
 
 _PROVIDER_CLASSES: list[type[BaseOAuthProvider]] = [
@@ -122,6 +123,7 @@ _PROVIDER_CLASSES: list[type[BaseOAuthProvider]] = [
     SnowflakeACProvider,
     SnowflakeCCProvider,
     ServiceNowOAuthProvider,
+    ZendeskOAuthProvider,
 ]
 
 

--- a/tracecat/integrations/providers/zendesk/__init__.py
+++ b/tracecat/integrations/providers/zendesk/__init__.py
@@ -1,0 +1,5 @@
+"""Zendesk OAuth providers."""
+
+from .oauth import ZendeskOAuthProvider
+
+__all__ = ["ZendeskOAuthProvider"]

--- a/tracecat/integrations/providers/zendesk/oauth.py
+++ b/tracecat/integrations/providers/zendesk/oauth.py
@@ -1,0 +1,60 @@
+"""Zendesk OAuth provider using client credentials flow."""
+
+from typing import ClassVar
+
+from tracecat.integrations.providers.base import ClientCredentialsOAuthProvider
+from tracecat.integrations.schemas import ProviderMetadata, ProviderScopes
+
+ZENDESK_API_DOCS_URL = (
+    "https://developer.zendesk.com/api-reference/ticketing/introduction/"
+)
+ZENDESK_SETUP_GUIDE_URL = (
+    "https://developer.zendesk.com/documentation/ticketing/authentication/"
+    "creating-and-managing-oauth-clients/"
+)
+
+
+class ZendeskOAuthProvider(ClientCredentialsOAuthProvider):
+    """Zendesk OAuth provider using a global OAuth client with client credentials."""
+
+    id: ClassVar[str] = "zendesk"
+    scopes: ClassVar[ProviderScopes] = ProviderScopes(default=[])
+    metadata: ClassVar[ProviderMetadata] = ProviderMetadata(
+        id="zendesk",
+        name="Zendesk",
+        description=(
+            "Zendesk OAuth provider using a global OAuth client (client credentials)."
+        ),
+        requires_config=True,
+        enabled=True,
+        api_docs_url=ZENDESK_API_DOCS_URL,
+        setup_guide_url=ZENDESK_SETUP_GUIDE_URL,
+        troubleshooting_url=ZENDESK_SETUP_GUIDE_URL,
+    )
+    # Zendesk exposes both the authorization consent page and the token endpoint
+    # on the same subdomain. Only the token endpoint is used for the client
+    # credentials grant, but the base provider requires both fields to be set.
+    default_authorization_endpoint: ClassVar[str | None] = (
+        "https://{subdomain}.zendesk.com/oauth/authorizations/new"
+    )
+    default_token_endpoint: ClassVar[str | None] = (
+        "https://{subdomain}.zendesk.com/oauth/tokens"
+    )
+    authorization_endpoint_help: ClassVar[str | list[str] | None] = [
+        "Unused for the client credentials grant. Leave it pointing at the "
+        "standard Zendesk consent URL for your subdomain, for example:",
+        "https://acme.zendesk.com/oauth/authorizations/new",
+    ]
+    token_endpoint_help: ClassVar[str | list[str] | None] = [
+        "Replace {subdomain} with your Zendesk subdomain, for example:",
+        "https://acme.zendesk.com/oauth/tokens",
+        "\n",
+        "Create a global OAuth client at Admin Center > Apps and integrations "
+        "> APIs > Zendesk API > OAuth Clients. The client credentials grant is "
+        "only available for global OAuth clients; scopes such as 'read' and "
+        "'write' are configured on the client itself.",
+    ]
+
+    def _get_token_endpoint_auth_method(self) -> str | None:
+        # Zendesk expects client_id and client_secret in a form-encoded body.
+        return "client_secret_post"


### PR DESCRIPTION
## Summary

- Registers Zendesk as an OOTB OAuth provider using the `client_credentials` grant so workspaces can connect a Zendesk global OAuth client server-to-server, without going through a user consent redirect.
- Migrates the seven existing `tools.zendesk.*` action templates to prefer the new OAuth token when configured, keeping the current `ZENDESK_EMAIL` + `ZENDESK_API_TOKEN` basic auth as an optional fallback (mirrors the Jamf dual-auth precedent, adjusted for the Basic-vs-Bearer header shape mismatch).
- Wires up the existing `ZendeskIcon` in the frontend `providerIcons` / `secretIcons` maps and regenerates `docs/tools/zendesk.mdx`.

## Details

**Provider** — `tracecat/integrations/providers/zendesk/oauth.py`

`ZendeskOAuthProvider` extends `ClientCredentialsOAuthProvider`. Defaults:
- Token endpoint: `https://{subdomain}.zendesk.com/oauth/tokens`
- Authorization endpoint: `https://{subdomain}.zendesk.com/oauth/authorizations/new` (unused for CC; kept because the base class requires both fields, same pattern as Jamf)
- `requires_config=True`, no default scopes (a Zendesk global OAuth client declares its own scopes)
- Overrides `_get_token_endpoint_auth_method` to `client_secret_post` — Zendesk expects `client_id` / `client_secret` in the form body.

Registered in `tracecat/integrations/providers/__init__.py` under `ProviderKey(id="zendesk", grant_type=CLIENT_CREDENTIALS)`.

**Templates** — `packages/tracecat-registry/tracecat_registry/templates/tools/zendesk/*.yml`

Each of the seven templates now declares both secrets as optional (the OAuth grant and the basic secret) and replaces the old `encode_auth` reshape step with a `resolve_auth` reshape that emits the full `Authorization` header value:

```yaml
value: ${{ (SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN
            && FN.format("Bearer {}", SECRETS.zendesk_oauth.ZENDESK_SERVICE_TOKEN))
           || FN.format("Basic {}", FN.to_base64(FN.format("{}/token:{}",
                SECRETS.zendesk.ZENDESK_EMAIL, SECRETS.zendesk.ZENDESK_API_TOKEN))) }}
```

`FN.format` is used instead of `+` because Tracecat's `&&` / `||` operators are non-short-circuiting (both operands evaluate before `and_`/`or_` is called), so `"Bearer " + None` would raise before the fallback picks up. `FN.format` tolerates `None`, producing a string the outer `and_`/`or_` correctly discards.

Truth table verified end-to-end:

| OAuth token | Basic secret | Result |
|---|---|---|
| present | present  | `Bearer <oauth>` (OAuth wins) |
| present | missing  | `Bearer <oauth>` |
| missing | present  | `Basic <base64>` |
| missing | missing  | `Basic <garbage>` (no exception; Zendesk 401s) |

**Frontend** — `frontend/src/components/icons.tsx`

Adds `zendesk` bindings in both `providerIcons` and `secretIcons` using the already-existing `ZendeskIcon`.

**Docs** — regenerated `docs/tools/zendesk.mdx` via `scripts/generate_tool_docs.py`; now lists both `zendesk_oauth` and `zendesk` as optional secrets per action.

## LOC breakdown

| Category | + | − |
|---|---|---|
| Logic (provider + registry + frontend) | 77 | 0 |
| Integrations (7 registry templates) | 56 | 21 |
| Generated (auto-generated tool docs) | 14 | 7 |

## Test plan

- [ ] Configure the new Zendesk client-credentials integration in a workspace using a Zendesk global OAuth client (subdomain, client id, client secret) and verify token minting from `Integrations` succeeds.
- [ ] Run `tools.zendesk.get_ticket` with the OAuth integration configured (and no `zendesk` basic secret) and confirm the request succeeds.
- [ ] Delete the OAuth integration, configure the legacy `zendesk` secret with `ZENDESK_EMAIL` + `ZENDESK_API_TOKEN`, and confirm the same action still succeeds (Basic fallback).
- [ ] Configure both simultaneously and confirm the OAuth token is preferred.
- [ ] Frontend: confirm the Zendesk logo renders on both the Integrations page and the Secrets page.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Zendesk as a client-credentials OAuth provider and migrates the seven `tools.zendesk.*` templates to prefer the OAuth token when configured, keeping the existing `ZENDESK_EMAIL` + `ZENDESK_API_TOKEN` basic auth as a fallback.

**Details**
- The new `ZendeskOAuthProvider` requires a subdomain, client ID, and client secret, and uses `client_secret_post` for token requests.
- Templates now accept either `zendesk_oauth` or `zendesk` secrets; both are optional, but requests without either will send a malformed `Basic` header and get a 401 from Zendesk.
- The `resolve_auth` step uses `FN.format` instead of string concatenation because template `&&`/`||` don't short-circuit, which would otherwise error on missing values.
- Frontend provider and secret icon maps now include `zendesk` via the existing `ZendeskIcon`; `docs/tools/zendesk.mdx` is regenerated.

<sup>Written for commit 0c351223b9b3a6e7f52072ad770825d9533a75e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

