### PR TITLE
fix(tables): preserve NULL for TEXT columns in to_sql_clause

### DIFF
--- a/tests/registry/test_table_characterization.py
+++ b/tests/registry/test_table_characterization.py
@@ -566,6 +566,69 @@ class TestUpdateRow:
         # updated_at should be >= original (may be same if very fast)
         assert result["updated_at"] >= original_updated_at
 
+    async def test_update_row_preserves_null_for_text_column(
+        self, db, session: AsyncSession, table_ctx: Role, test_table_name: str
+    ):
+        """Updating a TEXT column to None stores SQL NULL, not the string "None"."""
+        columns = [{"name": "email", "type": "TEXT"}]
+        await create_table(name=test_table_name, columns=columns)
+        inserted = await insert_row(
+            table=test_table_name,
+            row_data={"email": "test@example.com"},
+        )
+
+        result = await update_row(
+            table=test_table_name,
+            row_id=str(inserted["id"]),
+            row_data={"email": None},
+        )
+
+        assert result["email"] is None
+
+
+# =============================================================================
+# insert_row / insert_rows consistency characterization tests
+# =============================================================================
+
+
+@pytest.mark.anyio
+class TestInsertRowNullTextConsistency:
+    """insert_row and insert_rows must agree on how a null TEXT value is stored."""
+
+    async def test_insert_row_preserves_null_for_text_column(
+        self, db, session: AsyncSession, table_ctx: Role, test_table_name: str
+    ):
+        """insert_row with a None TEXT value stores SQL NULL, not the string "None"."""
+        columns = [{"name": "email", "type": "TEXT"}]
+        await create_table(name=test_table_name, columns=columns)
+
+        result = await insert_row(
+            table=test_table_name,
+            row_data={"email": None},
+        )
+
+        assert result["email"] is None
+
+    async def test_insert_row_and_insert_rows_agree_on_null_text(
+        self, db, session: AsyncSession, table_ctx: Role, test_table_name: str
+    ):
+        """insert_row and insert_rows must store the same value for a None TEXT
+        column. Before the fix, insert_row stored the string "None" while
+        insert_rows (batch_insert_rows) stored real SQL NULL for the same input.
+        """
+        columns = [{"name": "email", "type": "TEXT"}]
+        await create_table(name=test_table_name, columns=columns)
+
+        single = await insert_row(table=test_table_name, row_data={"email": None})
+        await insert_rows(table=test_table_name, rows_data=[{"email": None}])
+
+        rows = await search_rows(table=test_table_name)
+        assert isinstance(rows, list)
+        batch_row = next(r for r in rows if r["id"] != single["id"])
+
+        assert single["email"] is None
+        assert batch_row["email"] is None
+
 
 # =============================================================================
 # delete_row characterization tests

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -1263,6 +1263,51 @@ class TestTableRows:
         assert "updated_at" in updated
         assert isinstance(updated["updated_at"], datetime)
 
+    async def test_insert_row_preserves_null_for_text_column(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Inserting None into a TEXT column should store SQL NULL, not "None"."""
+        inserted = await tables_service.insert_row(
+            table, TableRowInsert(data={"name": None, "age": 30})
+        )
+        assert inserted["name"] is None
+
+        retrieved = await tables_service.get_row(table, inserted["id"])
+        assert retrieved["name"] is None
+
+    async def test_update_row_preserves_null_for_text_column(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Updating a TEXT column to None should store SQL NULL, not "None"."""
+        inserted = await tables_service.insert_row(
+            table, TableRowInsert(data={"name": "Alice", "age": 25})
+        )
+        row_id: UUID = inserted["id"]
+
+        updated = await tables_service.update_row(table, row_id, {"name": None})
+        assert updated["name"] is None
+
+        retrieved = await tables_service.get_row(table, row_id)
+        assert retrieved["name"] is None
+
+    async def test_insert_row_and_batch_insert_rows_agree_on_null_text(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """insert_row and batch_insert_rows must store the same value for a
+        None TEXT column. Before the fix, insert_row stored the string "None"
+        while batch_insert_rows stored real SQL NULL for the same input.
+        """
+        single = await tables_service.insert_row(
+            table, TableRowInsert(data={"name": None, "age": 30})
+        )
+        await tables_service.batch_insert_rows(table, [{"name": None, "age": 31}])
+
+        rows = await _list_rows(tables_service, table)
+        batch_row = next(r for r in rows if r["id"] != single["id"])
+
+        assert single["name"] is None
+        assert batch_row["name"] is None
+
     async def test_delete_row(
         self, tables_service: TablesService, table: Table
     ) -> None:

--- a/tracecat/tables/common.py
+++ b/tracecat/tables/common.py
@@ -265,7 +265,8 @@ def to_sql_clause(value: Any, name: str, sql_type: SqlType) -> sa.BindParameter:
         case SqlType.JSONB:
             return sa.bindparam(key=name, value=value, type_=JSONB)
         case SqlType.TEXT:
-            return sa.bindparam(key=name, value=str(value), type_=sa.String)
+            coerced = None if value is None else str(value)
+            return sa.bindparam(key=name, value=coerced, type_=sa.String)
         case SqlType.DATE:
             coerced = coerce_optional_to_date(value)
             return sa.bindparam(key=name, value=coerced, type_=sa.Date)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `to_sql_clause` so `None` values for TEXT columns are stored as SQL NULL instead of the string `"None"`.

- `insert_row` and `update_row` now match the batch insert behavior for null TEXT values.
- Adds tests covering insert, update, and single vs. batch insert consistency.

<sup>Written for commit 66e2f76d5ac0bc88c9ba74b7be363f528d77fc2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

