### PR TITLE
feat(agents): classify durable runtime failures

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -472,6 +472,11 @@ class AgentActivities:
                 e.detail,
                 type=e.__class__.__name__,
             ) from e
+        except EntitlementRequired as e:
+            raise_application_error_from_classification(
+                tenant_entitlement_denied(e),
+                e.detail,
+            )
 
         return BuildToolDefsResult(
             tool_definitions=defs,

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -22,6 +22,7 @@ from tracecat.agent.common.types import (
 from tracecat.agent.error_policy import (
     agent_preparation_failed,
     invalid_agent_configuration,
+    tenant_entitlement_denied,
 )
 from tracecat.agent.mcp.internal_tools import (
     BUILDER_BUNDLED_ACTIONS,
@@ -39,12 +40,13 @@ from tracecat.agent.tools import build_agent_tools
 from tracecat.auth.types import Role
 from tracecat.common import all_activities
 from tracecat.contexts import ctx_role
-from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError, EntitlementRequired
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.temporal.errors import raise_application_error_from_classification
-from tracecat.tiers.entitlements import Entitlement, EntitlementService
+from tracecat.tiers.entitlements import EntitlementService
+from tracecat.tiers.enums import Entitlement
 from tracecat.tiers.service import TierService
 
 if TYPE_CHECKING:
@@ -221,10 +223,16 @@ class AgentActivities:
     async def _check_tool_approval_entitlement(role: Role) -> None:
         if role.organization_id is None:
             raise ValueError("Role must have organization_id to validate entitlements")
-        async with TierService.with_session() as tier_service:
-            entitlement_service = EntitlementService(tier_service)
-            await entitlement_service.check_entitlement(
-                role.organization_id, Entitlement.AGENT_ADDONS
+        try:
+            async with TierService.with_session() as tier_service:
+                entitlement_service = EntitlementService(tier_service)
+                await entitlement_service.check_entitlement(
+                    role.organization_id, Entitlement.AGENT_ADDONS
+                )
+        except EntitlementRequired as exc:
+            raise_application_error_from_classification(
+                tenant_entitlement_denied(exc),
+                exc.detail,
             )
 
     async def _build_scope_tool_definitions(

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -19,6 +19,10 @@ from tracecat.agent.common.types import (
     MCPToolDefinition,
     is_http_mcp_server,
 )
+from tracecat.agent.error_policy import (
+    agent_preparation_failed,
+    invalid_agent_configuration,
+)
 from tracecat.agent.mcp.internal_tools import (
     BUILDER_BUNDLED_ACTIONS,
     BUILDER_INTERNAL_TOOL_NAMES,
@@ -39,6 +43,7 @@ from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.temporal.errors import raise_application_error_from_classification
 from tracecat.tiers.entitlements import Entitlement, EntitlementService
 from tracecat.tiers.service import TierService
 
@@ -251,11 +256,7 @@ class AgentActivities:
                 tool_approvals=args.tool_approvals,
             )
         except ValueError as e:
-            raise ApplicationError(
-                str(e),
-                type="AgentToolDefinitionError",
-                non_retryable=True,
-            ) from e
+            raise_application_error_from_classification(invalid_agent_configuration(e))
         # Convert to dict[str, MCPToolDefinition] keyed by canonical action name
         # Tools already have canonical names (with dots, e.g., "core.cases.list_cases")
         defs: dict[str, MCPToolDefinition] = {}
@@ -431,12 +432,9 @@ class AgentActivities:
                     server_count=len(hydrated_servers),
                 )
                 if args.fail_on_mcp_discovery_error:
-                    raise ApplicationError(
-                        "Failed to discover configured MCP tools for agent scope",
-                        str(e),
-                        type="AgentToolDefinitionError",
-                        non_retryable=True,
-                    ) from e
+                    raise_application_error_from_classification(
+                        invalid_agent_configuration(e)
+                    )
                 # Continue without user MCP tools - don't fail the whole operation
             finally:
                 # Defensive: ensure hydrated configs (with headers) drop out
@@ -514,9 +512,8 @@ class AgentActivities:
         results: dict[str, BuildToolDefsResult] = {}
         for scope in args.scopes:
             if scope.scope in results:
-                raise ApplicationError(
-                    f"Duplicate agent compile scope '{scope.scope}'",
-                    non_retryable=True,
+                raise_application_error_from_classification(
+                    agent_preparation_failed(retryable=False)
                 )
             results[scope.scope] = await self._build_scope_tool_definitions(
                 scope,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -11,10 +11,12 @@ from temporalio.common import TypedSearchAttributes
 from temporalio.exceptions import (
     ActivityError,
     ApplicationError,
+    is_cancelled_exception,
 )
 from temporalio.exceptions import (
     CancelledError as TemporalCancelledError,
 )
+from temporalio.exceptions import TimeoutError as TemporalTimeoutError
 
 with workflow.unsafe.imports_passed_through():
     from pydantic_ai.messages import ToolCallPart
@@ -28,6 +30,14 @@ with workflow.unsafe.imports_passed_through():
         SandboxSubagentConfig,
     )
     from tracecat.agent.constants import AGENT_TIMEOUT_CLEANUP_BUFFER_SECONDS
+    from tracecat.agent.error_policy import (
+        agent_executor_timed_out,
+        agent_executor_unavailable,
+        agent_preparation_failed,
+        agent_session_initialization_failed,
+        agent_workflow_internal_error,
+        invalid_agent_configuration,
+    )
     from tracecat.agent.executor.activity import (
         AgentExecutorInput,
         AgentExecutorResult,
@@ -99,6 +109,13 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.executor.activities import ExecutorActivities
     from tracecat.logger import logger
     from tracecat.registry.lock.types import RegistryLock
+    from tracecat.runtime.errors import RuntimeErrorClassification
+    from tracecat.temporal.errors import (
+        extract_error_classifications,
+        iter_error_chain,
+        raise_application_error_from_classification,
+        raise_wrapped_application_error,
+    )
     from tracecat.workflow.executions.correlation import (
         build_agent_session_correlation_id,
     )
@@ -125,7 +142,6 @@ with workflow.unsafe.imports_passed_through():
 
 ROOT_AGENT_SCOPE = "root"
 AGENT_TOOL_DEFINITION_ERROR = "AgentToolDefinitionError"
-AGENT_EXECUTOR_PRE_STREAM_ERROR = "AgentExecutorPreStreamError"
 AGENT_RUNTIME_EXECUTION_ERROR = "AgentRuntimeExecutionError"
 BUILD_AGENT_TOOL_DEFINITIONS_PATCH = (
     "tracecat_ee.agent.workflows.durable.build_agent_tool_definitions"
@@ -155,6 +171,40 @@ def _activity_error_message(error: ActivityError) -> str:
     if cause is not None:
         return str(cause)
     return str(error)
+
+
+def _agent_activity_classification(
+    error: ActivityError,
+) -> RuntimeErrorClassification:
+    """Classify an untyped pre-executor activity failure at its workflow boundary."""
+    if classifications := extract_error_classifications(
+        error,
+        include_implicit_context=False,
+    ):
+        classification = classifications[0]
+        return classification
+    cause = error.cause or error
+    retryable = not (isinstance(cause, ApplicationError) and cause.non_retryable)
+    return agent_preparation_failed(cause, retryable=retryable)
+
+
+def _executor_activity_classification(
+    error: ActivityError,
+) -> RuntimeErrorClassification:
+    """Classify activity transport failures that return no executor result."""
+    if classifications := extract_error_classifications(
+        error,
+        include_implicit_context=False,
+    ):
+        classification = classifications[0]
+        return classification
+    cause = error.cause or error
+    if any(
+        isinstance(current, TemporalTimeoutError)
+        for current in iter_error_chain(error, include_implicit_context=False)
+    ):
+        return agent_executor_timed_out(cause)
+    return agent_executor_unavailable(cause)
 
 
 def _agent_token_ttl_seconds(activity_timeout_seconds: int) -> int:
@@ -531,11 +581,9 @@ class DurableAgentWorkflow:
         self._status: Literal["running", "waiting_for_results", "done"] = "running"
         self._turn: int = 0
         if args.role.workspace_id is None:
-            raise ApplicationError("Role must have a workspace ID", non_retryable=True)
+            raise_application_error_from_classification(invalid_agent_configuration())
         if args.role.organization_id is None:
-            raise ApplicationError(
-                "Role must have an organization ID", non_retryable=True
-            )
+            raise_application_error_from_classification(invalid_agent_configuration())
         self.workspace_id = args.role.workspace_id
         self.organization_id = args.role.organization_id
         self.session_id = args.agent_args.session_id
@@ -546,6 +594,7 @@ class DurableAgentWorkflow:
         self.max_tool_calls = args.agent_args.max_tool_calls
         self._cancel_requested: bool = False
         self._cancel_reason: str | None = None
+        self._executor_terminal_stream_error_emitted: bool | None = None
 
     def _upsert_tracecat_search_attributes(self) -> None:
         """Ensure direct agent runs have core Tracecat search attributes.
@@ -661,9 +710,8 @@ class DurableAgentWorkflow:
             cfg = preset_config
         else:
             if args.agent_args.config is None:
-                raise ApplicationError(
-                    "Config must be provided if preset_slug is not set",
-                    non_retryable=True,
+                raise_application_error_from_classification(
+                    invalid_agent_configuration()
                 )
             cfg = args.agent_args.config
 
@@ -809,10 +857,8 @@ class DurableAgentWorkflow:
         for resolved_subagent in subagents:
             child_cfg = agent_config_from_payload(resolved_subagent.config)
             if has_manual_tool_approvals(child_cfg.tool_approvals):
-                raise ApplicationError(
-                    f"Subagent preset '{resolved_subagent.binding.preset}' uses manual approvals, "
-                    "which are not supported for subagents yet.",
-                    non_retryable=True,
+                raise_application_error_from_classification(
+                    invalid_agent_configuration()
                 )
             await self._apply_custom_model_provider_config(child_cfg)
             scope_spec = AgentScopeSpec(
@@ -847,9 +893,8 @@ class DurableAgentWorkflow:
 
         root_build_result = build_result.scopes.get(ROOT_AGENT_SCOPE)
         if root_build_result is None:
-            raise ApplicationError(
-                "Batched agent tool compilation did not return the root scope",
-                non_retryable=True,
+            raise_application_error_from_classification(
+                agent_preparation_failed(retryable=False)
             )
 
         _apply_tool_approvals(root_spec, root_build_result)
@@ -869,15 +914,12 @@ class DurableAgentWorkflow:
             scope_spec = subagent_spec.scope
             child_build_result = build_result.scopes.get(scope_spec.name)
             if child_build_result is None:
-                raise ApplicationError(
-                    f"Batched agent tool compilation did not return scope '{scope_spec.name}'",
-                    non_retryable=True,
+                raise_application_error_from_classification(
+                    agent_preparation_failed(retryable=False)
                 )
             if has_manual_tool_approvals(child_build_result.tool_approvals):
-                raise ApplicationError(
-                    f"Subagent preset '{subagent_spec.resolved.binding.preset}' uses manual approvals, "
-                    "which are not supported for subagents yet.",
-                    non_retryable=True,
+                raise_application_error_from_classification(
+                    invalid_agent_configuration()
                 )
             _apply_tool_approvals(scope_spec, child_build_result)
             route_resolution = _llm_route_for_config(
@@ -914,39 +956,78 @@ class DurableAgentWorkflow:
     @workflow.run
     async def run(self, args: AgentWorkflowArgs) -> AgentOutput:
         """Run the agent until completion. The agent will call tools until it needs human approval."""
-        if workflow.patched(UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH):
-            self._upsert_tracecat_search_attributes()
-        logger.debug(
-            "DurableAgentWorkflow run", args=args, harness_type=self.harness_type
-        )
-        logger.debug("AGENT CONTEXT", agent_context=AgentContext.get())
-        if workflow.unsafe.is_replaying():
-            logger.debug("Workflow is replaying")
-        else:
-            logger.debug("Starting agent", prompt=args.agent_args.user_prompt)
-
         try:
+            if workflow.patched(UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH):
+                self._upsert_tracecat_search_attributes()
+            logger.debug(
+                "DurableAgentWorkflow run", args=args, harness_type=self.harness_type
+            )
+            logger.debug("AGENT CONTEXT", agent_context=AgentContext.get())
+            if workflow.unsafe.is_replaying():
+                logger.debug("Workflow is replaying")
+            else:
+                logger.debug("Starting agent", prompt=args.agent_args.user_prompt)
+
             cfg = await self._build_config(args)
             # Success needs no write: last_error was already cleared at turn
             # start, and last_error is the only persisted run-outcome signal.
             return await self._run_with_agent_executor(args, cfg)
         except ActivityError as e:
+            if is_cancelled_exception(e):
+                raise
+            classification = _agent_activity_classification(e)
             # Pre-stream failure: persist last_error and stream it (the loopback
             # was not yet wired up to surface it inline).
             await self._finalize_session_error(
-                _activity_error_message(e),
+                classification.message,
                 should_stream=workflow.patched(EMIT_PRE_STREAM_SESSION_ERRORS_PATCH),
             )
-            raise
+            raise_wrapped_application_error(
+                e,
+                fallback_classification=classification,
+                include_implicit_context=False,
+            )
         except ApplicationError as e:
+            classifications = extract_error_classifications(
+                e,
+                include_implicit_context=False,
+            )
+            classification = (
+                classifications[0]
+                if classifications
+                else agent_preparation_failed(e, retryable=not e.non_retryable)
+            )
             # Runtime errors stream inline via the loopback, so persist-only.
             # Pre-stream errors (tool-definition / pre-runtime) stream too.
-            should_stream = e.type == AGENT_TOOL_DEFINITION_ERROR or (
-                e.type != AGENT_RUNTIME_EXECUTION_ERROR
-                and workflow.patched(EMIT_PRE_STREAM_SESSION_ERRORS_PATCH)
+            should_stream = (
+                not self._executor_terminal_stream_error_emitted
+                if self._executor_terminal_stream_error_emitted is not None
+                else e.type == AGENT_TOOL_DEFINITION_ERROR
+                or (
+                    e.type != AGENT_RUNTIME_EXECUTION_ERROR
+                    and workflow.patched(EMIT_PRE_STREAM_SESSION_ERRORS_PATCH)
+                )
             )
-            await self._finalize_session_error(e.message, should_stream=should_stream)
-            raise
+            await self._finalize_session_error(
+                classification.message,
+                should_stream=should_stream,
+            )
+            raise_wrapped_application_error(
+                e,
+                fallback_classification=classification,
+                include_implicit_context=False,
+            )
+        except Exception as e:
+            if is_cancelled_exception(e):
+                raise
+            # This is an intentional invariant fallback for workflow-owned code.
+            # Executor and activity failures are classified at narrower boundaries.
+            classification = agent_workflow_internal_error(e)
+            await self._finalize_session_error(
+                classification.message,
+                should_stream=workflow.patched(EMIT_PRE_STREAM_SESSION_ERRORS_PATCH),
+            )
+            raise_application_error_from_classification(classification)
         finally:
             # Terminal boundary only: approval-pause awaits inside the executor
             # loop and never reaches here. Clear the active-turn pointers so the
@@ -1273,9 +1354,8 @@ class DurableAgentWorkflow:
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
         )
         if not create_result.success:
-            raise ApplicationError(
-                f"Failed to create agent session: {create_result.error}",
-                non_retryable=True,
+            raise_application_error_from_classification(
+                agent_session_initialization_failed(retryable=True)
             )
 
         # Build internal tool context for builder assistant sessions
@@ -1377,56 +1457,70 @@ class DurableAgentWorkflow:
             logger.info("Executing agent turn", turn=self._turn)
 
             # Run one executor activity turn with update-driven cancellation.
-            if not workflow.patched(AGENT_REQUEST_CANCEL_PATCH):
-                result = await workflow.execute_activity(
-                    run_agent_activity,
-                    executor_input,
-                    task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
-                    start_to_close_timeout=timedelta(seconds=activity_timeout_seconds),
-                    heartbeat_timeout=timedelta(seconds=60),
-                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
-                )
-            else:
-                activity_handle = workflow.start_activity(
-                    run_agent_activity,
-                    executor_input,
-                    cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
-                    task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
-                    start_to_close_timeout=timedelta(seconds=activity_timeout_seconds),
-                    heartbeat_timeout=timedelta(seconds=60),
-                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
-                )
-                # ActivityHandle is an asyncio.Task subclass, so .done() is
-                # valid. Neither wait_condition nor the handle poll emits
-                # history commands, so this race stays replay-safe.
-                await workflow.wait_condition(
-                    lambda handle=activity_handle: (
-                        handle.done() or self._cancel_requested
+            try:
+                if not workflow.patched(AGENT_REQUEST_CANCEL_PATCH):
+                    result = await workflow.execute_activity(
+                        run_agent_activity,
+                        executor_input,
+                        task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
+                        start_to_close_timeout=timedelta(
+                            seconds=activity_timeout_seconds
+                        ),
+                        heartbeat_timeout=timedelta(seconds=60),
+                        retry_policy=RETRY_POLICIES["activity:fail_fast"],
                     )
-                )
-                if not activity_handle.done():
-                    activity_handle.cancel()
-                try:
-                    result = await activity_handle
-                except ActivityError as e:
-                    if self._cancel_requested and isinstance(
-                        e.cause, TemporalCancelledError
-                    ):
-                        # The activity was cancelled without returning a
-                        # loopback result (never picked up, still in setup, or
-                        # hard-cancelled), so no executor wrote the cancelled/
-                        # done frames to the per-turn stream. Emit them here or
-                        # the client's SSE reader blocks until disconnect.
-                        return await self._cancelled_turn_output(
-                            AgentExecutorResult(
-                                success=True,
-                                cancelled=True,
-                                cancelled_reason=self._cancel_reason or "user_cancel",
-                            ),
-                            info,
-                            emit_cancelled=True,
+                else:
+                    activity_handle = workflow.start_activity(
+                        run_agent_activity,
+                        executor_input,
+                        cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+                        task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
+                        start_to_close_timeout=timedelta(
+                            seconds=activity_timeout_seconds
+                        ),
+                        heartbeat_timeout=timedelta(seconds=60),
+                        retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                    )
+                    # ActivityHandle is an asyncio.Task subclass, so .done() is
+                    # valid. Neither wait_condition nor the handle poll emits
+                    # history commands, so this race stays replay-safe.
+                    await workflow.wait_condition(
+                        lambda handle=activity_handle: (
+                            handle.done() or self._cancel_requested
                         )
+                    )
+                    if not activity_handle.done():
+                        activity_handle.cancel()
+                    try:
+                        result = await activity_handle
+                    except ActivityError as e:
+                        if self._cancel_requested and isinstance(
+                            e.cause, TemporalCancelledError
+                        ):
+                            # The activity was cancelled without returning a
+                            # loopback result (never picked up, still in setup, or
+                            # hard-cancelled), so no executor wrote the cancelled/
+                            # done frames to the per-turn stream. Emit them here or
+                            # the client's SSE reader blocks until disconnect.
+                            return await self._cancelled_turn_output(
+                                AgentExecutorResult(
+                                    success=True,
+                                    cancelled=True,
+                                    cancelled_reason=self._cancel_reason
+                                    or "user_cancel",
+                                ),
+                                info,
+                                emit_cancelled=True,
+                            )
+                        raise
+            except ActivityError as e:
+                if is_cancelled_exception(e):
                     raise
+                raise_wrapped_application_error(
+                    e,
+                    fallback_classification=_executor_activity_classification(e),
+                    include_implicit_context=False,
+                )
 
             if result.cancelled:
                 logger.info(
@@ -1445,12 +1539,14 @@ class DurableAgentWorkflow:
                 terminal_stream_error_emitted = (
                     result.terminal_stream_error_emitted is not False
                 )
-                raise ApplicationError(
-                    f"Agent execution failed: {result.error}",
-                    type=AGENT_RUNTIME_EXECUTION_ERROR
-                    if terminal_stream_error_emitted
-                    else AGENT_EXECUTOR_PRE_STREAM_ERROR,
-                    non_retryable=True,
+                self._executor_terminal_stream_error_emitted = (
+                    terminal_stream_error_emitted
+                )
+                # A missing classification can only come from a legacy history or
+                # a broken executor contract. Treat it as a platform invariant,
+                # never infer ownership from the free-form error string.
+                raise_application_error_from_classification(
+                    result.classification or agent_workflow_internal_error()
                 )
 
             if result.approval_requested:

--- a/tests/integration/test_agent_worker.py
+++ b/tests/integration/test_agent_worker.py
@@ -37,6 +37,7 @@ from tracecat_ee.agent.workflows.durable import (
 from tests.conftest import AGENT_TASK_QUEUE
 from tracecat import config
 from tracecat.agent.common.stream_types import ToolCallContent
+from tracecat.agent.error_policy import user_agent_execution_failed
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
@@ -61,6 +62,7 @@ from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.redis.client import get_redis_client
 from tracecat.storage.object import InlineObject
+from tracecat.temporal.errors import extract_error_classification
 
 # Use worker-specific queue from conftest for pytest-xdist isolation
 TEST_AGENT_QUEUE = AGENT_TASK_QUEUE
@@ -377,6 +379,7 @@ class TestAgentWorkerSingleTenant:
             return AgentExecutorResult(
                 success=False,
                 error="Simulated agent error",
+                classification=user_agent_execution_failed(),
             )
 
         activities = create_activities_with_mock_executor(mock_executor)
@@ -412,8 +415,9 @@ class TestAgentWorkerSingleTenant:
             with pytest.raises(WorkflowFailureError) as exc_info:
                 await wf_handle.result()
 
-            # The error message is in the cause chain
-            assert "Simulated agent error" in str(exc_info.value.cause)
+            classification = extract_error_classification(exc_info.value.cause)
+            assert classification == user_agent_execution_failed()
+            assert "Simulated agent error" not in str(exc_info.value.cause)
 
     @pytest.mark.anyio
     @pytest.mark.integration

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -64,6 +64,11 @@ from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.common.stream_types import ToolCallContent
 from tracecat.agent.common.types import MCPToolDefinition
+from tracecat.agent.error_policy import (
+    agent_executor_unavailable,
+    invalid_agent_configuration,
+    user_agent_execution_failed,
+)
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
@@ -111,7 +116,12 @@ from tracecat.db.models import AgentSessionHistory, User
 from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.dsl.schemas import RunActionInput
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
 from tracecat.storage.object import InlineObject
+from tracecat.temporal.errors import (
+    extract_error_classification,
+    raise_application_error_from_classification,
+)
 from tracecat.tiers import defaults as tier_defaults
 
 
@@ -596,10 +606,10 @@ async def test_agent_workflow_streams_tool_definition_error(
         args: BuildAgentToolDefsArgs,
     ) -> BuildAgentToolDefsResult:
         del args
-        raise ApplicationError(
-            "Cannot request more than 100 tools",
-            type="AgentToolDefinitionError",
-            non_retryable=True,
+        raise_application_error_from_classification(
+            invalid_agent_configuration(
+                ValueError("Cannot request more than 100 tools")
+            )
         )
 
     @activity.defn(name="emit_session_error")
@@ -618,21 +628,26 @@ async def test_agent_workflow_streams_tool_definition_error(
     async with agent_worker_factory(
         temporal_client, task_queue=queue, custom_activities=activities
     ):
+        handle = await temporal_client.start_workflow(
+            DurableAgentWorkflow.run,
+            agent_workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
         with pytest.raises(WorkflowFailureError) as exc_info:
-            await temporal_client.execute_workflow(
-                DurableAgentWorkflow.run,
-                agent_workflow_args,
-                id=AgentWorkflowID(mock_session_id),
-                task_queue=queue,
-                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-                execution_timeout=timedelta(seconds=30),
-            )
+            await handle.result()
 
     assert isinstance(exc_info.value.cause, ApplicationError)
-    assert "Cannot request more than 100 tools" in str(exc_info.value.cause)
+    classification = extract_error_classification(exc_info.value.cause)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert "Cannot request more than 100 tools" not in str(exc_info.value.cause)
     assert len(emitted_errors) == 1
     assert emitted_errors[0].session_id == mock_session_id
-    assert emitted_errors[0].message == "Cannot request more than 100 tools"
+    assert emitted_errors[0].message == "Agent configuration is invalid"
 
 
 @pytest.mark.anyio
@@ -662,6 +677,7 @@ async def test_agent_workflow_persists_runtime_terminal_error_without_streaming(
         return AgentExecutorResult(
             success=False,
             error="runtime exploded",
+            classification=user_agent_execution_failed(),
             terminal_stream_error_emitted=True,
         )
 
@@ -682,26 +698,33 @@ async def test_agent_workflow_persists_runtime_terminal_error_without_streaming(
     async with agent_worker_factory(
         temporal_client, task_queue=queue, custom_activities=activities
     ):
+        handle = await temporal_client.start_workflow(
+            DurableAgentWorkflow.run,
+            agent_workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
         with pytest.raises(WorkflowFailureError) as exc_info:
-            await temporal_client.execute_workflow(
-                DurableAgentWorkflow.run,
-                agent_workflow_args,
-                id=AgentWorkflowID(mock_session_id),
-                task_queue=queue,
-                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-                execution_timeout=timedelta(seconds=30),
-            )
+            await handle.result()
+        failed_history = await handle.fetch_history()
 
     assert isinstance(exc_info.value.cause, ApplicationError)
-    assert "Agent execution failed: runtime exploded" in str(exc_info.value.cause)
+    classification = extract_error_classification(exc_info.value.cause)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+    assert "runtime exploded" not in str(exc_info.value.cause)
     # Persist-only: exactly one emit, carrying last_error, with error streaming
     # off so the already-emitted inline error is not duplicated.
     assert len(emitted_errors) == 1
     assert emitted_errors[0].session_id == mock_session_id
-    assert emitted_errors[0].message == "Agent execution failed: runtime exploded"
+    assert emitted_errors[0].message == "Agent execution failed"
     assert emitted_errors[0].should_stream is False
     assert len(emitted_done) == 1
     assert call_order == ["persist_error", "emit_session_done"]
+    await replay_durable_agent_workflow_history(temporal_client, failed_history)
 
 
 @pytest.mark.anyio
@@ -723,6 +746,7 @@ async def test_agent_workflow_streams_executor_pre_stream_failure(
         return AgentExecutorResult(
             success=False,
             error="executor setup failed",
+            classification=agent_executor_unavailable(),
             terminal_stream_error_emitted=False,
         )
 
@@ -752,10 +776,14 @@ async def test_agent_workflow_streams_executor_pre_stream_failure(
             )
 
     assert isinstance(exc_info.value.cause, ApplicationError)
-    assert "Agent execution failed: executor setup failed" in str(exc_info.value.cause)
+    classification = extract_error_classification(exc_info.value.cause)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+    assert "executor setup failed" not in str(exc_info.value.cause)
     assert len(emitted_errors) == 1
     assert emitted_errors[0].session_id == mock_session_id
-    assert emitted_errors[0].message == "Agent execution failed: executor setup failed"
+    assert emitted_errors[0].message == "Tracecat agent executor is unavailable"
     assert emitted_errors[0].should_stream is True
     assert len(emitted_done) == 1
 

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -75,7 +75,7 @@ from tracecat.agent.types import AgentConfig, Tool, clamp_agent_timeout_seconds
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.chat.schemas import ChatMessage
-from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError, EntitlementRequired
 from tracecat.integrations.schemas import MCPToolSummary
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
@@ -168,6 +168,42 @@ class TestSessionActivities:
 
 
 class TestBuildToolDefinitionsActivity:
+    @pytest.mark.anyio
+    async def test_classifies_tool_approval_entitlement_denial(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_role: Role,
+    ) -> None:
+        class _TierContext:
+            async def __aenter__(self) -> object:
+                return object()
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        monkeypatch.setattr(
+            agent_activities.TierService,
+            "with_session",
+            lambda: _TierContext(),
+        )
+        monkeypatch.setattr(
+            agent_activities.EntitlementService,
+            "check_entitlement",
+            AsyncMock(side_effect=EntitlementRequired("agent_addons")),
+        )
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await AgentActivities._check_tool_approval_entitlement(mock_role)
+
+        classification = extract_error_classification(exc_info.value)
+        assert classification is not None
+        assert classification.owner is RuntimeErrorOwner.USER
+        assert classification.kind is RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED
+        assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+        assert exc_info.value.non_retryable is True
+
     @pytest.mark.anyio
     async def test_maps_tool_definition_errors_to_application_error(
         self,

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -24,6 +24,7 @@ from tracecat_ee.agent.activities import (
     BuildAgentScopeToolDefsArgs,
     BuildAgentToolDefsArgs,
     BuildToolDefsArgs,
+    BuildToolDefsResult,
     EmitSessionDoneInputs,
     EmitSessionErrorInputs,
 )
@@ -33,6 +34,10 @@ from tracecat.agent.common.fs import force_rmtree
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.common.types import MCPToolDefinition
+from tracecat.agent.error_policy import (
+    agent_executor_timed_out,
+    user_agent_execution_failed,
+)
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
@@ -41,8 +46,14 @@ from tracecat.agent.executor.activity import (
     _hydrate_sdk_session_history,
     run_agent_activity,
 )
-from tracecat.agent.executor.loopback import LoopbackResult
+from tracecat.agent.executor.loopback import (
+    LoopbackHandler,
+    LoopbackInput,
+    LoopbackResult,
+)
+from tracecat.agent.runtime.claude_code.broker import ConcurrentSessionTurnError
 from tracecat.agent.runtime.session_paths import job_uv_state_dir
+from tracecat.agent.sandbox.llm_proxy import LLMProxyError, LLMSocketProxy
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.session.activities import (
     CreateSessionInput,
@@ -68,6 +79,12 @@ from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.integrations.schemas import MCPToolSummary
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
+from tracecat.temporal.errors import extract_error_classification
 
 
 @pytest.fixture
@@ -172,9 +189,13 @@ class TestBuildToolDefinitionsActivity:
             await AgentActivities().build_tool_definitions(args)
 
         app_error = exc_info.value
-        assert app_error.type == "AgentToolDefinitionError"
+        classification = extract_error_classification(app_error)
+        assert classification is not None
+        assert classification.owner is RuntimeErrorOwner.USER
+        assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
         assert app_error.non_retryable is True
-        assert app_error.message == "Cannot request more than 100 tools"
+        assert app_error.message == "Agent configuration is invalid"
+        assert "Cannot request more than 100 tools" not in str(app_error)
 
     @pytest.mark.anyio
     async def test_maps_builtin_sync_pending_to_application_error(
@@ -289,10 +310,11 @@ class TestBuildToolDefinitionsActivity:
             await AgentActivities().build_tool_definitions(args)
 
         assert discover_fail_flags == [True]
-        assert exc_info.value.message == (
-            "Failed to discover configured MCP tools for agent scope"
-        )
-        assert exc_info.value.type == "AgentToolDefinitionError"
+        classification = extract_error_classification(exc_info.value)
+        assert classification is not None
+        assert classification.owner is RuntimeErrorOwner.USER
+        assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+        assert exc_info.value.message == "Agent configuration is invalid"
         assert exc_info.value.non_retryable is True
 
     @pytest.mark.anyio
@@ -633,6 +655,42 @@ class TestBuildToolDefinitionsActivity:
         assert set(result.scopes["analyst"].tool_definitions) == {"core.child"}
         assert build_calls == [["core.root"], ["core.child"]]
 
+    @pytest.mark.anyio
+    async def test_duplicate_compile_scope_is_platform_invariant(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_role: Role,
+    ) -> None:
+        activities = AgentActivities()
+        monkeypatch.setattr(
+            activities,
+            "_build_scope_tool_definitions",
+            AsyncMock(
+                return_value=BuildToolDefsResult(
+                    tool_definitions={},
+                    registry_lock=RegistryLock(origins={}, actions={}),
+                )
+            ),
+        )
+        duplicate_scope = BuildAgentScopeToolDefsArgs(
+            scope="root",
+            tool_filters=ToolFilters(),
+        )
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await activities.build_agent_tool_definitions(
+                BuildAgentToolDefsArgs(
+                    role=mock_role,
+                    scopes=[duplicate_scope, duplicate_scope],
+                )
+            )
+
+        classification = extract_error_classification(exc_info.value)
+        assert classification is not None
+        assert classification.owner is RuntimeErrorOwner.PLATFORM
+        assert classification.kind is RuntimeErrorKind.AGENT_PREPARATION_FAILED
+        assert exc_info.value.non_retryable is True
+
 
 class TestCreateSessionActivity:
     """Tests for create_session_activity."""
@@ -850,9 +908,11 @@ class TestCreateSessionActivity:
         else:
             with pytest.raises(ApplicationError) as exc_info:
                 await create_session_activity(input)
-            assert exc_info.value.message == (
-                "Agent session was created with a different agents binding"
-            )
+            classification = extract_error_classification(exc_info.value)
+            assert classification is not None
+            assert classification.owner is RuntimeErrorOwner.USER
+            assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+            assert exc_info.value.message == "Agent configuration is invalid"
             assert exc_info.value.non_retryable is True
 
         if expected_backfill:
@@ -922,7 +982,12 @@ class TestCreateSessionActivity:
         with pytest.raises(ApplicationError) as exc_info:
             await create_session_activity(input)
 
-        assert str(mock_session_id) in exc_info.value.message
+        classification = extract_error_classification(exc_info.value)
+        assert classification is not None
+        assert classification.owner is RuntimeErrorOwner.USER
+        assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+        assert exc_info.value.message == "Agent configuration is invalid"
+        assert str(mock_session_id) not in str(exc_info.value)
         assert exc_info.value.non_retryable is True
         mock_service.get_session.assert_awaited_once_with(mock_session_id)
         mock_service.get_or_create_session.assert_not_called()
@@ -1381,6 +1446,7 @@ class TestRunAgentActivity:
         expected_result = AgentExecutorResult(
             success=False,
             error="Agent execution failed: timeout",
+            classification=user_agent_execution_failed(),
         )
 
         with (
@@ -1397,6 +1463,7 @@ class TestRunAgentActivity:
             result = await run_agent_activity(mock_executor_input)
 
             assert result.success is False
+            assert result.classification == user_agent_execution_failed()
 
     @pytest.mark.anyio
     async def test_sends_heartbeats(self, mock_executor_input: AgentExecutorInput):
@@ -1507,6 +1574,140 @@ class TestSandboxedAgentExecutorHelpers:
 
         assert result.success is False
         assert result.error == "runtime failed"
+        assert result.terminal_stream_error_emitted is True
+
+    async def _run_broker_leaf(
+        self,
+        *,
+        executor: SandboxedAgentExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        concurrent: bool = False,
+    ) -> AgentExecutorResult:
+        executor._job_dir = tmp_path
+        executor._llm_proxy = cast(
+            LLMSocketProxy,
+            SimpleNamespace(start=AsyncMock()),
+        )
+        handler = LoopbackHandler(
+            input=LoopbackInput(
+                session_id=executor.input.session_id,
+                workspace_id=executor.input.workspace_id,
+            )
+        )
+        monkeypatch.setattr(
+            handler,
+            "emit_terminal_error",
+            AsyncMock(return_value=True),
+        )
+
+        class FakeBroker:
+            @asynccontextmanager
+            async def session_turn_lease(self, _session_id: str):
+                if concurrent:
+                    raise ConcurrentSessionTurnError("active turn")
+                yield
+
+            async def run_turn_in_session_lease(
+                self, _request: Any, _handler: Any
+            ) -> None:
+                await asyncio.Event().wait()
+
+            async def cancel_turn(self, _session_id: str) -> None:
+                return None
+
+        async def wait_for_cancel_signal(**_kwargs: Any) -> None:
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(
+            "tracecat.agent.executor.activity.get_claude_runtime_broker",
+            lambda: FakeBroker(),
+        )
+        monkeypatch.setattr(executor, "_watch_cancel_signal", wait_for_cancel_signal)
+
+        result = AgentExecutorResult(
+            success=False,
+            terminal_stream_error_emitted=False,
+        )
+        await executor._run_with_broker(
+            result=result,
+            handler=handler,
+            init_payload=executor._build_runtime_init_payload(),
+            socket_dir=tmp_path / "sockets",
+            llm_socket_path=tmp_path / "sockets" / "llm.sock",
+            artifact_working_set=None,
+            otel_socket_path=None,
+        )
+        return result
+
+    @pytest.mark.anyio
+    async def test_fatal_proxy_classification_reaches_executor_result(
+        self,
+        executor_input: AgentExecutorInput,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        executor = SandboxedAgentExecutor(input=executor_input)
+        executor._fatal_error = LLMProxyError(
+            message="raw gateway timeout",
+            classification=agent_executor_timed_out(TimeoutError("secret")),
+        )
+        executor._fatal_error_event.set()
+
+        result = await self._run_broker_leaf(
+            executor=executor,
+            monkeypatch=monkeypatch,
+            tmp_path=tmp_path,
+        )
+
+        assert result.classification is not None
+        assert result.classification.owner is RuntimeErrorOwner.PLATFORM
+        assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT
+        assert result.classification.retry_disposition is RetryDisposition.RETRYABLE
+        assert "secret" not in result.classification.message
+        assert result.terminal_stream_error_emitted is True
+
+    @pytest.mark.anyio
+    async def test_elapsed_deadline_is_platform_timeout(
+        self,
+        executor_input: AgentExecutorInput,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        executor = SandboxedAgentExecutor(input=executor_input, timeout_seconds=0)
+
+        result = await self._run_broker_leaf(
+            executor=executor,
+            monkeypatch=monkeypatch,
+            tmp_path=tmp_path,
+        )
+
+        assert result.classification is not None
+        assert result.classification.owner is RuntimeErrorOwner.PLATFORM
+        assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT
+        assert result.classification.retry_disposition is RetryDisposition.RETRYABLE
+        assert result.terminal_stream_error_emitted is True
+
+    @pytest.mark.anyio
+    async def test_concurrent_turn_is_platform_unavailable(
+        self,
+        executor_input: AgentExecutorInput,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        executor = SandboxedAgentExecutor(input=executor_input)
+
+        result = await self._run_broker_leaf(
+            executor=executor,
+            monkeypatch=monkeypatch,
+            tmp_path=tmp_path,
+            concurrent=True,
+        )
+
+        assert result.classification is not None
+        assert result.classification.owner is RuntimeErrorOwner.PLATFORM
+        assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+        assert result.classification.retry_disposition is RetryDisposition.RETRYABLE
         assert result.terminal_stream_error_emitted is True
 
     @pytest.mark.anyio
@@ -1689,12 +1890,17 @@ class TestSandboxedAgentExecutorCancellation:
             executor,
             monkeypatch=monkeypatch,
             tmp_path=tmp_path,
-            loopback_result=LoopbackResult(success=False, error="runtime crashed"),
+            loopback_result=LoopbackResult(
+                success=False,
+                error="runtime crashed",
+                classification=user_agent_execution_failed(),
+            ),
         )
 
         assert result.cancelled is True
         assert result.cancelled_reason == "user_cancel"
         assert result.error == "runtime crashed"
+        assert result.classification == user_agent_execution_failed()
         assert result.success is False
 
     @pytest.mark.anyio

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -280,6 +280,51 @@ class TestBuildToolDefinitionsActivity:
         assert app_error.details[0] == {"origin": "tracecat_registry"}
 
     @pytest.mark.anyio
+    async def test_classifies_custom_registry_entitlement_denial(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def mock_build_agent_tools(**_kwargs: Any) -> BuildToolsResult:
+            return BuildToolsResult(tools=[], collected_secrets=set())
+
+        class _LockService:
+            async def resolve_lock_with_bindings(self, _actions: set[str]) -> None:
+                raise EntitlementRequired("custom_registry")
+
+        class _AsyncContext:
+            async def __aenter__(self) -> _LockService:
+                return _LockService()
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        monkeypatch.setattr(
+            agent_activities, "build_agent_tools", mock_build_agent_tools
+        )
+        monkeypatch.setattr(
+            RegistryLockService,
+            "with_session",
+            lambda: _AsyncContext(),
+        )
+
+        args = BuildToolDefsArgs(
+            role=Role(type="service", service_id="tracecat-api"),
+            tool_filters=ToolFilters(actions=[]),
+        )
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await AgentActivities().build_tool_definitions(args)
+
+        classification = extract_error_classification(exc_info.value)
+        assert classification is not None
+        assert classification.owner is RuntimeErrorOwner.USER
+        assert classification.kind is RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED
+        assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+        assert exc_info.value.non_retryable is True
+
+    @pytest.mark.anyio
     async def test_strict_mcp_discovery_failure_fails_scope_compilation(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_agent_error_policy.py
+++ b/tests/unit/test_agent_error_policy.py
@@ -211,7 +211,7 @@ class _StreamSink:
 
 
 @pytest.mark.anyio
-async def test_runtime_reported_error_is_user_classified() -> None:
+async def test_untyped_runtime_error_is_platform_classified() -> None:
     handler = LoopbackHandler(
         input=LoopbackInput(
             session_id=uuid.uuid4(),
@@ -225,8 +225,9 @@ async def test_runtime_reported_error_is_user_classified() -> None:
     result = handler.build_result()
 
     assert result.classification is not None
-    assert result.classification.owner is RuntimeErrorOwner.USER
-    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+    assert result.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+    assert result.classification.retry_disposition is RetryDisposition.RETRYABLE
     assert "raw provider response" not in result.classification.message
 
 

--- a/tests/unit/test_agent_error_policy.py
+++ b/tests/unit/test_agent_error_policy.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+    RetryState,
+    TimeoutError,
+    TimeoutType,
+)
+from tracecat_ee.agent.workflows.durable import (
+    _agent_activity_classification,
+    _executor_activity_classification,
+)
+
+from tracecat.agent.error_policy import (
+    agent_executor_protocol_failed,
+    agent_executor_timed_out,
+    agent_executor_unavailable,
+    agent_preparation_failed,
+    agent_session_initialization_failed,
+    agent_workflow_internal_error,
+    invalid_agent_configuration,
+    user_agent_execution_failed,
+)
+from tracecat.agent.executor.activity import AgentExecutorResult, SandboxedAgentExecutor
+from tracecat.agent.executor.loopback import (
+    LoopbackEventSink,
+    LoopbackHandler,
+    LoopbackInput,
+    LoopbackResult,
+)
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorClassification,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
+from tracecat.temporal.errors import application_error_from_classification
+
+
+def _activity_error(cause: BaseException) -> ActivityError:
+    error = ActivityError(
+        "activity failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="test-worker",
+        activity_type="test_activity",
+        activity_id="activity-id",
+        retry_state=RetryState.NON_RETRYABLE_FAILURE,
+    )
+    error.__cause__ = cause
+    return error
+
+
+@pytest.mark.parametrize(
+    ("factory", "owner", "kind", "retry_disposition"),
+    [
+        (
+            invalid_agent_configuration,
+            RuntimeErrorOwner.USER,
+            RuntimeErrorKind.AGENT_CONFIGURATION_INVALID,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            lambda error: agent_preparation_failed(error, retryable=True),
+            RuntimeErrorOwner.PLATFORM,
+            RuntimeErrorKind.AGENT_PREPARATION_FAILED,
+            RetryDisposition.RETRYABLE,
+        ),
+        (
+            lambda error: agent_session_initialization_failed(error, retryable=False),
+            RuntimeErrorOwner.PLATFORM,
+            RuntimeErrorKind.AGENT_SESSION_INITIALIZATION_FAILED,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            user_agent_execution_failed,
+            RuntimeErrorOwner.USER,
+            RuntimeErrorKind.AGENT_EXECUTION_FAILED,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            agent_executor_unavailable,
+            RuntimeErrorOwner.PLATFORM,
+            RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE,
+            RetryDisposition.RETRYABLE,
+        ),
+        (
+            agent_executor_timed_out,
+            RuntimeErrorOwner.PLATFORM,
+            RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT,
+            RetryDisposition.RETRYABLE,
+        ),
+        (
+            agent_executor_protocol_failed,
+            RuntimeErrorOwner.PLATFORM,
+            RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            agent_workflow_internal_error,
+            RuntimeErrorOwner.PLATFORM,
+            RuntimeErrorKind.AGENT_WORKFLOW_INTERNAL_ERROR,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+    ],
+)
+def test_agent_classification_factories_are_static_and_sanitized(
+    factory: Callable[[BaseException | None], RuntimeErrorClassification],
+    owner: RuntimeErrorOwner,
+    kind: RuntimeErrorKind,
+    retry_disposition: RetryDisposition,
+) -> None:
+    secret = "raw prompt and token"
+    classification = factory(ValueError(secret))
+
+    assert classification.owner is owner
+    assert classification.kind is kind
+    assert classification.retry_disposition is retry_disposition
+    assert classification.cause_type == "ValueError"
+    assert secret not in classification.message
+
+
+def test_agent_executor_result_round_trips_typed_classification() -> None:
+    classification = user_agent_execution_failed()
+
+    result = AgentExecutorResult(success=False, classification=classification)
+    restored = AgentExecutorResult.model_validate(result.model_dump(mode="json"))
+
+    assert restored.classification == classification
+
+
+def test_agent_executor_result_accepts_legacy_payload_without_classification() -> None:
+    result = AgentExecutorResult.model_validate(
+        {"success": False, "error": "legacy free-form failure"}
+    )
+
+    assert result.classification is None
+
+
+def test_agent_activity_does_not_infer_user_owner_from_non_retryable() -> None:
+    error = _activity_error(ApplicationError("invalid", non_retryable=True))
+
+    classification = _agent_activity_classification(error)
+
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.kind is RuntimeErrorKind.AGENT_PREPARATION_FAILED
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+
+
+def test_agent_activity_classifies_untyped_crash_as_platform_preparation() -> None:
+    classification = _agent_activity_classification(_activity_error(RuntimeError()))
+
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.kind is RuntimeErrorKind.AGENT_PREPARATION_FAILED
+    assert classification.retry_disposition is RetryDisposition.RETRYABLE
+
+
+def test_agent_activity_preserves_existing_classification() -> None:
+    expected = invalid_agent_configuration()
+    error = _activity_error(application_error_from_classification(expected))
+
+    assert _agent_activity_classification(error) == expected
+
+
+def test_agent_activity_ignores_incidental_classified_context() -> None:
+    error = _activity_error(RuntimeError("current platform failure"))
+    error.__context__ = application_error_from_classification(
+        invalid_agent_configuration()
+    )
+
+    classification = _agent_activity_classification(error)
+
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.kind is RuntimeErrorKind.AGENT_PREPARATION_FAILED
+
+
+def test_executor_activity_classifies_timeout_without_message_inspection() -> None:
+    timeout = TimeoutError(
+        "opaque timeout",
+        type=TimeoutType.START_TO_CLOSE,
+        last_heartbeat_details=[],
+    )
+
+    classification = _executor_activity_classification(_activity_error(timeout))
+
+    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT
+    assert classification.retry_disposition is RetryDisposition.RETRYABLE
+
+
+def test_executor_activity_classifies_crash_as_unavailable() -> None:
+    classification = _executor_activity_classification(
+        _activity_error(RuntimeError("opaque crash"))
+    )
+
+    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+    assert classification.retry_disposition is RetryDisposition.RETRYABLE
+
+
+class _StreamSink:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+
+    async def error(self, error: str) -> None:
+        self.errors.append(error)
+
+
+@pytest.mark.anyio
+async def test_runtime_reported_error_is_user_classified() -> None:
+    handler = LoopbackHandler(
+        input=LoopbackInput(
+            session_id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+        )
+    )
+    sink = _StreamSink()
+    handler._stream_sink = cast(LoopbackEventSink, sink)
+
+    await handler.send_error("raw provider response")
+    result = handler.build_result()
+
+    assert result.classification is not None
+    assert result.classification.owner is RuntimeErrorOwner.USER
+    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+    assert "raw provider response" not in result.classification.message
+
+
+def test_loopback_classification_is_copied_to_executor_result() -> None:
+    classification = agent_executor_protocol_failed()
+    result = AgentExecutorResult(success=False)
+
+    SandboxedAgentExecutor._apply_loopback_result(
+        result,
+        LoopbackResult(success=False, classification=classification),
+    )
+
+    assert result.classification == classification

--- a/tests/unit/test_agent_error_policy.py
+++ b/tests/unit/test_agent_error_policy.py
@@ -25,6 +25,7 @@ from tracecat.agent.error_policy import (
     agent_session_initialization_failed,
     agent_workflow_internal_error,
     invalid_agent_configuration,
+    tenant_entitlement_denied,
     user_agent_execution_failed,
 )
 from tracecat.agent.executor.activity import AgentExecutorResult, SandboxedAgentExecutor
@@ -64,6 +65,12 @@ def _activity_error(cause: BaseException) -> ActivityError:
             invalid_agent_configuration,
             RuntimeErrorOwner.USER,
             RuntimeErrorKind.AGENT_CONFIGURATION_INVALID,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            tenant_entitlement_denied,
+            RuntimeErrorOwner.USER,
+            RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED,
             RetryDisposition.NON_RETRYABLE,
         ),
         (

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -1041,6 +1041,14 @@ async def test_handle_connection_deadline_cancels_slack_terminal_cleanup(
     [
         {
             "type": "stream_event",
+            "event": {"type": "approval_request"},
+        },
+        {
+            "type": "stream_event",
+            "event": {"type": "approval_request", "approval_items": []},
+        },
+        {
+            "type": "stream_event",
             "event": {
                 "type": "approval_request",
                 "approval_items": [{"id": [], "name": "tool"}],

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -31,6 +31,7 @@ from tracecat.artifacts.schemas import CaseArtifact
 from tracecat.auth.types import Role
 from tracecat.cases.enums import CaseSeverity, CaseStatus
 from tracecat.db.models import AgentSessionHistory
+from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
 
 
 class _FakeStream:
@@ -643,6 +644,12 @@ async def test_process_runtime_events_emits_failed_compaction_on_runtime_error()
     ]
     stream.error.assert_awaited_once_with("request_timeout: LLM gateway timed out")
     stream.done.assert_not_awaited()
+    assert handler._result.classification is not None
+    assert handler._result.classification.owner is RuntimeErrorOwner.USER
+    assert (
+        handler._result.classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+    )
+    assert handler._result.terminal_stream_error_emitted is True
 
 
 @pytest.mark.anyio
@@ -688,7 +695,13 @@ async def test_process_runtime_events_fails_when_done_arrives_without_result() -
     await handler._process_runtime_events(reader)
 
     assert handler._result.error == "Runtime completed without final result"
+    assert handler._result.classification is not None
+    assert (
+        handler._result.classification.kind
+        is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
+    )
     stream.error.assert_awaited_once_with("Runtime completed without final result")
+    assert handler._result.terminal_stream_error_emitted is True
     stream.done.assert_not_awaited()
 
 
@@ -716,9 +729,35 @@ async def test_process_runtime_events_fails_zero_work_completion() -> None:
         handler._result.error
         == "Runtime completed without assistant output or model usage"
     )
+    assert handler._result.classification is not None
+    assert (
+        handler._result.classification.kind
+        is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
+    )
     stream.error.assert_awaited_once_with(
         "Runtime completed without assistant output or model usage"
     )
+    assert handler._result.terminal_stream_error_emitted is True
+
+
+@pytest.mark.anyio
+async def test_process_runtime_events_classifies_disconnect_and_marks_streamed() -> (
+    None
+):
+    handler = _make_handler()
+    stream = _FakeStream()
+    handler._stream_sink = stream
+
+    await handler._process_runtime_events(_reader_for_envelopes())
+
+    assert handler._result.classification is not None
+    assert handler._result.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert (
+        handler._result.classification.kind
+        is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+    )
+    assert handler._result.terminal_stream_error_emitted is True
+    stream.error.assert_awaited_once_with("Runtime disconnected during execution")
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -911,6 +911,36 @@ async def test_handle_connection_bounds_protocol_error_stream_emission(
 
 
 @pytest.mark.anyio
+async def test_handle_connection_preserves_protocol_error_when_stream_sink_fails() -> (
+    None
+):
+    handler = _make_handler()
+    stream = _FakeStream()
+    stream.error.side_effect = ConnectionError("stream unavailable")
+    handler._stream_sink = stream
+    reader = asyncio.StreamReader()
+    reader.feed_data(build_message(MessageType.EVENT, b"{"))
+    reader.feed_eof()
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    result = await handler.handle_connection(
+        reader,
+        cast(asyncio.StreamWriter, writer),
+    )
+
+    assert result.error == "Runtime sent an invalid event envelope"
+    assert result.classification is not None
+    assert result.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
+    assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert result.terminal_stream_error_emitted is False
+    stream.error.assert_awaited_once_with("Runtime sent an invalid event envelope")
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_handle_connection_deadline_cancels_slack_terminal_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -573,6 +573,15 @@ async def test_terminal_error_streams_error_and_closes_only_external_sink() -> N
     redis_stream.done.assert_not_awaited()
     external_stream.done.assert_awaited_once()
     assert handler._external_stream_done_emitted is True
+    assert handler._result.classification is not None
+    assert handler._result.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert (
+        handler._result.classification.kind
+        is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+    )
+    assert (
+        handler._result.classification.retry_disposition is RetryDisposition.RETRYABLE
+    )
 
 
 @pytest.mark.anyio
@@ -649,9 +658,13 @@ async def test_process_runtime_events_emits_failed_compaction_on_runtime_error()
     stream.error.assert_awaited_once_with("request_timeout: LLM gateway timed out")
     stream.done.assert_not_awaited()
     assert handler._result.classification is not None
-    assert handler._result.classification.owner is RuntimeErrorOwner.USER
+    assert handler._result.classification.owner is RuntimeErrorOwner.PLATFORM
     assert (
-        handler._result.classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+        handler._result.classification.kind
+        is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+    )
+    assert (
+        handler._result.classification.retry_disposition is RetryDisposition.RETRYABLE
     )
     assert handler._result.terminal_stream_error_emitted is True
 

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -219,6 +219,53 @@ async def test_emit_terminal_error_emits_failed_compaction_when_pending(
 
 
 @pytest.mark.anyio
+async def test_emit_terminal_error_bounds_stalled_stream_sink(
+    monkeypatch: pytest.MonkeyPatch, loopback_input: LoopbackInput
+) -> None:
+    async def stalled_error(_error: str) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        loopback_module,
+        "TERMINAL_STREAM_ERROR_TIMEOUT_SECONDS",
+        0.01,
+    )
+    handler = LoopbackHandler(input=loopback_input)
+    fake_stream = _FakeStream()
+    fake_stream.error.side_effect = stalled_error
+    handler._stream_sink = fake_stream
+
+    emitted = await handler.emit_terminal_error("provider request failed")
+
+    assert emitted is False
+    assert handler.build_result().terminal_stream_error_emitted is False
+    fake_stream.error.assert_awaited_once_with("provider request failed")
+
+
+@pytest.mark.anyio
+async def test_emit_terminal_error_bounds_stalled_stream_sink_initialization(
+    monkeypatch: pytest.MonkeyPatch, loopback_input: LoopbackInput
+) -> None:
+    async def stalled_initialization() -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        loopback_module,
+        "TERMINAL_STREAM_ERROR_TIMEOUT_SECONDS",
+        0.01,
+    )
+    handler = LoopbackHandler(input=loopback_input)
+    initialize_stream_sink = AsyncMock(side_effect=stalled_initialization)
+    monkeypatch.setattr(handler, "_initialize_stream_sink", initialize_stream_sink)
+
+    emitted = await handler.emit_terminal_error("provider request failed")
+
+    assert emitted is False
+    assert handler.build_result().terminal_stream_error_emitted is False
+    initialize_stream_sink.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_prepare_initializes_stream_sink_once(
     monkeypatch: pytest.MonkeyPatch, loopback_input: LoopbackInput
 ) -> None:

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -13,6 +13,7 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
 import tracecat.agent.executor.loopback as loopback_module
+from tracecat.agent.channels.sinks.slack import SlackStreamSink
 from tracecat.agent.common.protocol import RuntimeEventEnvelope
 from tracecat.agent.common.socket_io import MAX_PAYLOAD_SIZE, MessageType, build_message
 from tracecat.agent.common.stream_types import (
@@ -907,6 +908,55 @@ async def test_handle_connection_bounds_protocol_error_stream_emission(
     stream.error.assert_awaited_once_with("Runtime sent an invalid event envelope")
     writer.close.assert_called_once()
     writer.wait_closed.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_handle_connection_deadline_cancels_slack_terminal_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def stalled_operation(*_args: object, **_kwargs: object) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        loopback_module,
+        "TERMINAL_STREAM_ERROR_TIMEOUT_SECONDS",
+        0.01,
+    )
+    slack_sink = SlackStreamSink(
+        slack_bot_token="xoxb-test",
+        channel_id="C123",
+        thread_ts="1700000000.000001",
+        reaction_ts="1700000000.000001",
+        session_id="session-1",
+        workspace_id="workspace-1",
+    )
+    append_stream_text = AsyncMock(side_effect=stalled_operation)
+    terminal_reaction = AsyncMock(side_effect=stalled_operation)
+    monkeypatch.setattr(slack_sink, "_append_stream_text", append_stream_text)
+    monkeypatch.setattr(slack_sink, "_set_terminal_reaction", terminal_reaction)
+
+    handler = _make_handler()
+    handler._stream_sink = slack_sink
+    reader = asyncio.StreamReader()
+    reader.feed_data(build_message(MessageType.EVENT, b"{"))
+    reader.feed_eof()
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    result = await asyncio.wait_for(
+        handler.handle_connection(
+            reader,
+            cast(asyncio.StreamWriter, writer),
+        ),
+        timeout=0.2,
+    )
+
+    assert result.classification is not None
+    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
+    assert result.terminal_stream_error_emitted is False
+    append_stream_text.assert_awaited_once()
+    terminal_reaction.assert_not_awaited()
+    assert slack_sink._is_closed is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -24,6 +24,8 @@ from tracecat.agent.executor.loopback import (
     FanoutStreamSink,
     LoopbackHandler,
     LoopbackInput,
+    RuntimeEnvelopeProtocolError,
+    _runtime_envelope_from_json,
 )
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.artifacts.bindings import ArtifactSideEffect
@@ -831,6 +833,124 @@ async def test_handle_connection_classifies_invalid_runtime_envelope_as_protocol
     assert result.terminal_stream_error_emitted is True
     writer.close.assert_called_once()
     writer.wait_closed.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "approval_request",
+                "approval_items": [{"id": [], "name": "tool"}],
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "approval_request",
+                "approval_items": [{"id": "call", "name": "tool", "input": []}],
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "approval_request",
+                "approval_items": [{"id": "call", "name": "tool", "metadata": []}],
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "approval_request",
+                "approval_items": [{"id": "call", "name": "tool", "status": "waiting"}],
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "approval_request",
+                "approval_items": [{"id": "call", "name": "tool", "decision": []}],
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "approval_request",
+                "approval_items": [
+                    {
+                        "id": "call",
+                        "name": "tool",
+                        "decision": {"value": "yes", "metadata": {}},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "artifact",
+                "artifact_data": {"op": "replace", "artifact": {}},
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "artifact",
+                "artifact_data": {"op": "upsert", "artifact": []},
+            },
+        },
+        {"type": "stream_event", "event": {"type": "text_delta", "part_id": True}},
+        {"type": "stream_event", "event": {"type": "text_delta", "text": []}},
+        {
+            "type": "stream_event",
+            "event": {"type": "tool_call_start", "tool_call_id": []},
+        },
+        {
+            "type": "stream_event",
+            "event": {"type": "tool_call_start", "tool_input": []},
+        },
+        {
+            "type": "stream_event",
+            "event": {"type": "tool_result", "is_error": "false"},
+        },
+        {
+            "type": "stream_event",
+            "event": {"type": "compaction", "metadata": []},
+        },
+        {"type": "stream_event", "event": {"type": "text_delta", "timestamp": 1}},
+        {"type": "message", "message": []},
+        {"type": "message"},
+        {"type": "session_line", "session_line": 1, "sdk_session_id": "sdk"},
+        {"type": "session_line", "session_line": "{", "sdk_session_id": "sdk"},
+        {"type": "session_line", "session_line": "[]", "sdk_session_id": "sdk"},
+        {"type": "session_line", "session_line": "{}", "internal": 1},
+        {"type": "session_update", "sdk_session_id": "sdk"},
+        {"type": "error"},
+        {"type": "result", "result_usage": []},
+        {"type": "result", "result_num_turns": True},
+        {"type": "result", "result_duration_ms": "1"},
+        {"type": "log", "log_level": "fatal", "log_message": "message"},
+        {"type": "log", "log_level": "info", "log_message": []},
+        {
+            "type": "log",
+            "log_level": "info",
+            "log_message": "message",
+            "log_extra": [],
+        },
+        {
+            "type": "log",
+            "log_level": "info",
+            "log_message": "message",
+            "log_extra": {"session_id": "spoofed"},
+        },
+    ],
+)
+def test_runtime_envelope_parser_rejects_malformed_typed_fields(
+    envelope: dict[str, object],
+) -> None:
+    with pytest.raises(RuntimeEnvelopeProtocolError):
+        _runtime_envelope_from_json(orjson.dumps(envelope))
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -13,7 +13,7 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
 from tracecat.agent.common.protocol import RuntimeEventEnvelope
-from tracecat.agent.common.socket_io import MessageType, build_message
+from tracecat.agent.common.socket_io import MAX_PAYLOAD_SIZE, MessageType, build_message
 from tracecat.agent.common.stream_types import (
     StreamEventType,
     ToolCallContent,
@@ -815,6 +815,43 @@ async def test_handle_connection_classifies_invalid_runtime_envelope_as_protocol
     handler._stream_sink = stream
     reader = asyncio.StreamReader()
     reader.feed_data(build_message(MessageType.EVENT, payload))
+    reader.feed_eof()
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    result = await handler.handle_connection(
+        reader,
+        cast(asyncio.StreamWriter, writer),
+    )
+
+    assert result.error == "Runtime sent an invalid event envelope"
+    assert result.classification is not None
+    assert result.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
+    assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    stream.error.assert_awaited_once_with("Runtime sent an invalid event envelope")
+    assert result.terminal_stream_error_emitted is True
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "frame",
+    [
+        build_message(MessageType.INIT, b"{}"),
+        bytes([0xFF]) + (0).to_bytes(4, "big"),
+        bytes([MessageType.EVENT]) + (MAX_PAYLOAD_SIZE + 1).to_bytes(4, "big"),
+    ],
+)
+async def test_handle_connection_classifies_invalid_runtime_frame_as_protocol_failure(
+    frame: bytes,
+) -> None:
+    handler = _make_handler()
+    stream = _FakeStream()
+    handler._stream_sink = stream
+    reader = asyncio.StreamReader()
+    reader.feed_data(frame)
     reader.feed_eof()
     writer = MagicMock()
     writer.wait_closed = AsyncMock()

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -12,6 +12,7 @@ import orjson
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
+import tracecat.agent.executor.loopback as loopback_module
 from tracecat.agent.common.protocol import RuntimeEventEnvelope
 from tracecat.agent.common.socket_io import MAX_PAYLOAD_SIZE, MessageType, build_message
 from tracecat.agent.common.stream_types import (
@@ -868,6 +869,42 @@ async def test_handle_connection_classifies_invalid_runtime_frame_as_protocol_fa
     assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
     stream.error.assert_awaited_once_with("Runtime sent an invalid event envelope")
     assert result.terminal_stream_error_emitted is True
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_handle_connection_bounds_protocol_error_stream_emission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def stalled_error(_error: str) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        loopback_module,
+        "TERMINAL_STREAM_ERROR_TIMEOUT_SECONDS",
+        0.01,
+    )
+    handler = _make_handler()
+    stream = _FakeStream()
+    stream.error.side_effect = stalled_error
+    handler._stream_sink = stream
+    reader = asyncio.StreamReader()
+    reader.feed_data(build_message(MessageType.EVENT, b"{"))
+    reader.feed_eof()
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    result = await handler.handle_connection(
+        reader,
+        cast(asyncio.StreamWriter, writer),
+    )
+
+    assert result.error == "Runtime sent an invalid event envelope"
+    assert result.classification is not None
+    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
+    assert result.terminal_stream_error_emitted is False
+    stream.error.assert_awaited_once_with("Runtime sent an invalid event envelope")
     writer.close.assert_called_once()
     writer.wait_closed.assert_awaited_once()
 

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -785,6 +785,24 @@ async def test_process_runtime_events_classifies_disconnect_and_marks_streamed()
         orjson.dumps({"event": {"type": StreamEventType.TEXT_DELTA.value}}),
         orjson.dumps({"type": "unknown"}),
         orjson.dumps({"type": "stream_event", "event": []}),
+        orjson.dumps(
+            {
+                "type": "stream_event",
+                "event": {
+                    "type": StreamEventType.APPROVAL_REQUEST.value,
+                    "approval_items": [1],
+                },
+            }
+        ),
+        orjson.dumps(
+            {
+                "type": "stream_event",
+                "event": {
+                    "type": StreamEventType.ARTIFACT.value,
+                    "artifact_data": [],
+                },
+            }
+        ),
     ],
 )
 async def test_handle_connection_classifies_invalid_runtime_envelope_as_protocol_failure(

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -922,7 +922,9 @@ async def test_handle_connection_classifies_invalid_runtime_envelope_as_protocol
         {"type": "message", "message": []},
         {"type": "message"},
         {"type": "session_line", "session_line": 1, "sdk_session_id": "sdk"},
+        {"type": "session_line", "session_line": "{}", "sdk_session_id": ""},
         {"type": "session_line", "session_line": "{}", "internal": 1},
+        {"type": "session_update", "sdk_session_id": "", "sdk_session_data": "{}"},
         {"type": "session_update", "sdk_session_id": "sdk"},
         {"type": "error"},
         {"type": "result", "result_usage": []},
@@ -997,6 +999,9 @@ async def test_handle_connection_classifies_malformed_session_line_as_protocol_f
     assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
     assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
     stream.error.assert_awaited_once_with("Runtime sent an invalid event envelope")
+    assert result.terminal_stream_error_emitted is True
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -922,8 +922,6 @@ async def test_handle_connection_classifies_invalid_runtime_envelope_as_protocol
         {"type": "message", "message": []},
         {"type": "message"},
         {"type": "session_line", "session_line": 1, "sdk_session_id": "sdk"},
-        {"type": "session_line", "session_line": "{", "sdk_session_id": "sdk"},
-        {"type": "session_line", "session_line": "[]", "sdk_session_id": "sdk"},
         {"type": "session_line", "session_line": "{}", "internal": 1},
         {"type": "session_update", "sdk_session_id": "sdk"},
         {"type": "error"},
@@ -944,6 +942,24 @@ async def test_handle_connection_classifies_invalid_runtime_envelope_as_protocol
             "log_message": "message",
             "log_extra": {"session_id": "spoofed"},
         },
+        {
+            "type": "log",
+            "log_level": "info",
+            "log_message": "message",
+            "log_extra": {"self": "spoofed"},
+        },
+        {
+            "type": "log",
+            "log_level": "info",
+            "log_message": "message",
+            "log_extra": {"level": "spoofed"},
+        },
+        {
+            "type": "log",
+            "log_level": "info",
+            "log_message": "message",
+            "log_extra": {"message": "spoofed"},
+        },
     ],
 )
 def test_runtime_envelope_parser_rejects_malformed_typed_fields(
@@ -951,6 +967,36 @@ def test_runtime_envelope_parser_rejects_malformed_typed_fields(
 ) -> None:
     with pytest.raises(RuntimeEnvelopeProtocolError):
         _runtime_envelope_from_json(orjson.dumps(envelope))
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("session_line", ["", "{", "[]"])
+async def test_handle_connection_classifies_malformed_session_line_as_protocol_failure(
+    session_line: str,
+) -> None:
+    handler = _make_handler()
+    stream = _FakeStream()
+    handler._stream_sink = stream
+    reader = _reader_for_envelopes(
+        RuntimeEventEnvelope.from_session_line(
+            "sdk-session",
+            session_line,
+        )
+    )
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    result = await handler.handle_connection(
+        reader,
+        cast(asyncio.StreamWriter, writer),
+    )
+
+    assert result.error == "Runtime sent an invalid event envelope"
+    assert result.classification is not None
+    assert result.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
+    assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    stream.error.assert_awaited_once_with("Runtime sent an invalid event envelope")
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -5,7 +5,7 @@ import uuid
 from pathlib import Path
 from types import TracebackType
 from typing import cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import orjson
@@ -31,7 +31,11 @@ from tracecat.artifacts.schemas import CaseArtifact
 from tracecat.auth.types import Role
 from tracecat.cases.enums import CaseSeverity, CaseStatus
 from tracecat.db.models import AgentSessionHistory
-from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
 
 
 class _FakeStream:
@@ -758,6 +762,42 @@ async def test_process_runtime_events_classifies_disconnect_and_marks_streamed()
     )
     assert handler._result.terminal_stream_error_emitted is True
     stream.error.assert_awaited_once_with("Runtime disconnected during execution")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"{",
+        orjson.dumps({"event": {"type": StreamEventType.TEXT_DELTA.value}}),
+    ],
+)
+async def test_handle_connection_classifies_invalid_runtime_envelope_as_protocol_failure(
+    payload: bytes,
+) -> None:
+    handler = _make_handler()
+    stream = _FakeStream()
+    handler._stream_sink = stream
+    reader = asyncio.StreamReader()
+    reader.feed_data(build_message(MessageType.EVENT, payload))
+    reader.feed_eof()
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    result = await handler.handle_connection(
+        reader,
+        cast(asyncio.StreamWriter, writer),
+    )
+
+    assert result.error == "Runtime sent an invalid event envelope"
+    assert result.classification is not None
+    assert result.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert result.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED
+    assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    stream.error.assert_awaited_once_with("Runtime sent an invalid event envelope")
+    assert result.terminal_stream_error_emitted is True
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -783,6 +783,8 @@ async def test_process_runtime_events_classifies_disconnect_and_marks_streamed()
     [
         b"{",
         orjson.dumps({"event": {"type": StreamEventType.TEXT_DELTA.value}}),
+        orjson.dumps({"type": "unknown"}),
+        orjson.dumps({"type": "stream_event", "event": []}),
     ],
 )
 async def test_handle_connection_classifies_invalid_runtime_envelope_as_protocol_failure(

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -45,6 +45,15 @@ class _FakeWriter:
         return None
 
 
+class _FailingResponseStream(httpx.AsyncByteStream):
+    def __init__(self, request: httpx.Request) -> None:
+        self._request = request
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        raise httpx.ReadError("provider disconnected", request=self._request)
+        yield b""  # pragma: no cover
+
+
 def _routing_plan(
     *,
     managed_url: str = "http://litellm:4000",
@@ -383,6 +392,73 @@ async def test_forward_request_classifies_connect_failure_as_platform(
     assert len(errors) == 1
     assert errors[0].classification.owner is RuntimeErrorOwner.PLATFORM
     assert errors[0].classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("direct", "expected_owner", "expected_kind"),
+    [
+        (
+            False,
+            RuntimeErrorOwner.PLATFORM,
+            RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE,
+        ),
+        (True, RuntimeErrorOwner.USER, RuntimeErrorKind.AGENT_EXECUTION_FAILED),
+    ],
+)
+async def test_forward_request_classifies_error_body_read_failure_by_route(
+    tmp_path: Path,
+    direct: bool,
+    expected_owner: RuntimeErrorOwner,
+    expected_kind: RuntimeErrorKind,
+) -> None:
+    errors: list[LLMProxyError] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            request=request,
+            stream=_FailingResponseStream(request),
+        )
+
+    direct_routes = (
+        {
+            "customer-alias": LLMRoute(
+                base_url="https://customer-provider.example",
+                model_provider="custom-model-provider",
+            )
+        }
+        if direct
+        else None
+    )
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=_routing_plan(direct_routes=direct_routes),
+        on_error=errors.append,
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+    body = b'{"model":"customer-alias","messages":[]}' if direct else b'{"messages":[]}'
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {"Content-Type": "application/json"},
+                "body": body,
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    assert writer.buffer.decode("utf-8").startswith("HTTP/1.1 502 ")
+    assert len(errors) == 1
+    assert errors[0].classification.owner is expected_owner
+    assert errors[0].classification.kind is expected_kind
+    assert errors[0].classification.retry_disposition is RetryDisposition.RETRYABLE
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -386,6 +386,55 @@ async def test_forward_request_classifies_connect_failure_as_platform(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("failure", ["connect", "timeout"])
+async def test_forward_request_classifies_direct_transport_failure_as_user_owned(
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    errors: list[LLMProxyError] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://customer-provider.example/v1/messages"
+        if failure == "connect":
+            raise httpx.ConnectError("provider unavailable", request=request)
+        raise httpx.ReadTimeout("provider timed out", request=request)
+
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=_routing_plan(
+            direct_routes={
+                "customer-alias": LLMRoute(
+                    base_url="https://customer-provider.example",
+                    model_provider="custom-model-provider",
+                )
+            }
+        ),
+        on_error=errors.append,
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {"Content-Type": "application/json"},
+                "body": b'{"model":"customer-alias","messages":[]}',
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    assert len(errors) == 1
+    assert errors[0].classification.owner is RuntimeErrorOwner.USER
+    assert errors[0].classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+    assert errors[0].classification.retry_disposition is RetryDisposition.RETRYABLE
+
+
+@pytest.mark.anyio
 async def test_write_stream_response_emits_error_after_headers_sent(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -259,6 +259,7 @@ async def test_forward_request_emits_error_for_critical_upstream_http_error(
 @pytest.mark.parametrize(
     ("status_code", "expected_kind"),
     [
+        (401, RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE),
         (500, RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE),
         (504, RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT),
     ],

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -12,10 +12,12 @@ import pytest
 
 from tracecat.agent.observability import LLMGatewayLoadTracker
 from tracecat.agent.sandbox.llm_proxy import (
+    LLMProxyError,
     LLMRoute,
     LLMRoutingPlan,
     LLMSocketProxy,
 )
+from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
 
 
 class _FakeWriter:
@@ -144,7 +146,7 @@ async def test_forward_request_streams_litellm_response(
 async def test_forward_request_returns_upstream_error_response(
     tmp_path: Path,
 ) -> None:
-    errors: list[str] = []
+    errors: list[LLMProxyError] = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
         assert str(request.url) == "http://litellm:4000/v1/messages/count_tokens"
@@ -190,7 +192,7 @@ async def test_forward_request_returns_upstream_error_response(
 async def test_forward_request_emits_error_for_critical_upstream_http_error(
     tmp_path: Path,
 ) -> None:
-    errors: list[str] = []
+    errors: list[LLMProxyError] = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
         assert str(request.url) == "http://litellm:4000/v1/messages"
@@ -230,17 +232,101 @@ async def test_forward_request_emits_error_for_critical_upstream_http_error(
     assert response_text.startswith("HTTP/1.1 429 Too Many Requests")
     assert "provider quota exhausted" in response_text
     assert len(errors) == 1
-    assert "LiteLLM request failed (429 Too Many Requests)" in errors[0]
-    assert "Rate limit exceeded" in errors[0]
-    assert "provider quota exhausted" in errors[0]
-    assert "request_id=trace-test-123" in errors[0]
+    error = errors[0]
+    assert "LiteLLM request failed (429 Too Many Requests)" in error.message
+    assert "Rate limit exceeded" in error.message
+    assert "provider quota exhausted" in error.message
+    assert "request_id=trace-test-123" in error.message
+    assert error.classification.owner is RuntimeErrorOwner.USER
+    assert error.classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("status_code", "expected_kind"),
+    [
+        (500, RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE),
+        (504, RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT),
+    ],
+)
+async def test_forward_request_classifies_platform_http_failures_at_source(
+    tmp_path: Path,
+    status_code: int,
+    expected_kind: RuntimeErrorKind,
+) -> None:
+    errors: list[LLMProxyError] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, request=request, json={"error": "failure"})
+
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=_routing_plan(),
+        on_error=errors.append,
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {"Content-Type": "application/json"},
+                "body": b'{"messages":[]}',
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    assert len(errors) == 1
+    assert errors[0].classification.owner is RuntimeErrorOwner.PLATFORM
+    assert errors[0].classification.kind is expected_kind
+
+
+@pytest.mark.anyio
+async def test_forward_request_classifies_connect_failure_as_platform(
+    tmp_path: Path,
+) -> None:
+    errors: list[LLMProxyError] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("gateway unavailable", request=request)
+
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=_routing_plan(),
+        on_error=errors.append,
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {"Content-Type": "application/json"},
+                "body": b'{"messages":[]}',
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    assert len(errors) == 1
+    assert errors[0].classification.owner is RuntimeErrorOwner.PLATFORM
+    assert errors[0].classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
 
 
 @pytest.mark.anyio
 async def test_write_stream_response_emits_error_after_headers_sent(
     tmp_path: Path,
 ) -> None:
-    errors: list[str] = []
+    errors: list[LLMProxyError] = []
     socket_proxy = LLMSocketProxy(
         socket_path=tmp_path / "llm.sock",
         routing_plan=_routing_plan(),
@@ -266,7 +352,11 @@ async def test_write_stream_response_emits_error_after_headers_sent(
     assert response_text.startswith("HTTP/1.1 200 OK")
     assert "event: error" in response_text
     assert "provider stream disconnected" in response_text
-    assert errors == ["LiteLLM stream failed: provider stream disconnected"]
+    assert [error.message for error in errors] == [
+        "LiteLLM stream failed: provider stream disconnected"
+    ]
+    assert errors[0].classification.owner is RuntimeErrorOwner.PLATFORM
+    assert errors[0].classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
 
 
 @pytest.mark.anyio
@@ -278,7 +368,7 @@ async def test_write_stream_response_surfaces_friendly_read_timeout(
         "tracecat.agent.sandbox.llm_proxy.app_config.TRACECAT__LLM_PROXY_READ_TIMEOUT",
         600.0,
     )
-    errors: list[str] = []
+    errors: list[LLMProxyError] = []
     socket_proxy = LLMSocketProxy(
         socket_path=tmp_path / "llm.sock",
         routing_plan=_routing_plan(),
@@ -308,7 +398,9 @@ async def test_write_stream_response_surfaces_friendly_read_timeout(
     assert response_text.startswith("HTTP/1.1 200 OK")
     assert "event: error" in response_text
     assert expected_message in response_text
-    assert errors == [expected_message]
+    assert [error.message for error in errors] == [expected_message]
+    assert errors[0].classification.owner is RuntimeErrorOwner.PLATFORM
+    assert errors[0].classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -17,7 +17,11 @@ from tracecat.agent.sandbox.llm_proxy import (
     LLMRoutingPlan,
     LLMSocketProxy,
 )
-from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
 
 
 class _FakeWriter:
@@ -237,8 +241,9 @@ async def test_forward_request_emits_error_for_critical_upstream_http_error(
     assert "Rate limit exceeded" in error.message
     assert "provider quota exhausted" in error.message
     assert "request_id=trace-test-123" in error.message
-    assert error.classification.owner is RuntimeErrorOwner.USER
-    assert error.classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+    assert error.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert error.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+    assert error.classification.retry_disposition is RetryDisposition.RETRYABLE
 
 
 @pytest.mark.anyio
@@ -287,14 +292,27 @@ async def test_forward_request_classifies_platform_http_failures_at_source(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("status_code", "expected_retry_disposition"),
+    [
+        (503, RetryDisposition.NON_RETRYABLE),
+        (429, RetryDisposition.RETRYABLE),
+    ],
+)
 async def test_forward_request_classifies_direct_provider_http_failure_as_user_owned(
     tmp_path: Path,
+    status_code: int,
+    expected_retry_disposition: RetryDisposition,
 ) -> None:
     errors: list[LLMProxyError] = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
         assert str(request.url) == "https://customer-provider.example/v1/messages"
-        return httpx.Response(503, request=request, json={"error": "unavailable"})
+        return httpx.Response(
+            status_code,
+            request=request,
+            json={"error": "unavailable"},
+        )
 
     socket_proxy = LLMSocketProxy(
         socket_path=tmp_path / "llm.sock",
@@ -328,6 +346,7 @@ async def test_forward_request_classifies_direct_provider_http_failure_as_user_o
     assert len(errors) == 1
     assert errors[0].classification.owner is RuntimeErrorOwner.USER
     assert errors[0].classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+    assert errors[0].classification.retry_disposition is expected_retry_disposition
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -307,6 +307,8 @@ async def test_forward_request_classifies_platform_http_failures_at_source(
     [
         (503, RetryDisposition.NON_RETRYABLE),
         (429, RetryDisposition.RETRYABLE),
+        (408, RetryDisposition.RETRYABLE),
+        (504, RetryDisposition.RETRYABLE),
     ],
 )
 async def test_forward_request_classifies_direct_provider_http_failure_as_user_owned(

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -700,6 +700,40 @@ async def test_write_stream_response_keeps_direct_transport_failure_retryable(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("content_type", ["application/json", "text/event-stream"])
+async def test_write_response_ignores_transport_failure_after_client_disconnect(
+    tmp_path: Path,
+    content_type: str,
+) -> None:
+    errors: list[LLMProxyError] = []
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=_routing_plan(),
+        on_error=errors.append,
+    )
+    writer = _FakeWriter()
+
+    async def disconnected_stream() -> AsyncIterator[bytes]:
+        writer.close()
+        request = httpx.Request("POST", "http://litellm:4000/v1/messages")
+        raise httpx.ReadError("provider disconnected", request=request)
+        yield b""  # pragma: no cover
+
+    await socket_proxy._write_response(
+        cast(asyncio.StreamWriter, writer),
+        status_code=200,
+        reason_phrase="OK",
+        headers={"Content-Type": content_type},
+        body_chunks=disconnected_stream(),
+        trace_request_id="trace-test-client-disconnect",
+        path="/v1/messages",
+    )
+
+    assert writer.buffer.count(b"HTTP/1.1") == 1
+    assert errors == []
+
+
+@pytest.mark.anyio
 async def test_forward_request_strips_authorization_for_passthrough_upstream(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -287,6 +287,50 @@ async def test_forward_request_classifies_platform_http_failures_at_source(
 
 
 @pytest.mark.anyio
+async def test_forward_request_classifies_direct_provider_http_failure_as_user_owned(
+    tmp_path: Path,
+) -> None:
+    errors: list[LLMProxyError] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://customer-provider.example/v1/messages"
+        return httpx.Response(503, request=request, json={"error": "unavailable"})
+
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=_routing_plan(
+            direct_routes={
+                "customer-alias": LLMRoute(
+                    base_url="https://customer-provider.example",
+                    model_provider="custom-model-provider",
+                )
+            }
+        ),
+        on_error=errors.append,
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {"Content-Type": "application/json"},
+                "body": b'{"model":"customer-alias","messages":[]}',
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    assert len(errors) == 1
+    assert errors[0].classification.owner is RuntimeErrorOwner.USER
+    assert errors[0].classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+
+
+@pytest.mark.anyio
 async def test_forward_request_classifies_connect_failure_as_platform(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -516,6 +516,44 @@ async def test_write_stream_response_surfaces_friendly_read_timeout(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("failure", ["disconnect", "timeout"])
+async def test_write_stream_response_keeps_direct_transport_failure_retryable(
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    errors: list[LLMProxyError] = []
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=_routing_plan(),
+        on_error=errors.append,
+    )
+    writer = _FakeWriter()
+
+    async def broken_stream() -> AsyncIterator[bytes]:
+        yield b'event: message_start\ndata: {"type":"message_start"}\n\n'
+        request = httpx.Request("POST", "https://customer-provider.example")
+        if failure == "timeout":
+            raise httpx.ReadTimeout("provider timed out", request=request)
+        raise httpx.ReadError("provider disconnected", request=request)
+
+    await socket_proxy._write_response(
+        cast(asyncio.StreamWriter, writer),
+        status_code=200,
+        reason_phrase="OK",
+        headers={"Content-Type": "text/event-stream"},
+        body_chunks=broken_stream(),
+        trace_request_id="trace-test-direct-transport",
+        path="/v1/messages",
+        route_is_direct=True,
+    )
+
+    assert len(errors) == 1
+    assert errors[0].classification.owner is RuntimeErrorOwner.USER
+    assert errors[0].classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
+    assert errors[0].classification.retry_disposition is RetryDisposition.RETRYABLE
+
+
+@pytest.mark.anyio
 async def test_forward_request_strips_authorization_for_passthrough_upstream(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -260,6 +260,7 @@ async def test_forward_request_emits_error_for_critical_upstream_http_error(
     ("status_code", "expected_kind"),
     [
         (401, RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE),
+        (403, RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE),
         (500, RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE),
         (504, RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT),
     ],
@@ -305,6 +306,7 @@ async def test_forward_request_classifies_platform_http_failures_at_source(
 @pytest.mark.parametrize(
     ("status_code", "expected_retry_disposition"),
     [
+        (403, RetryDisposition.NON_RETRYABLE),
         (503, RetryDisposition.NON_RETRYABLE),
         (429, RetryDisposition.RETRYABLE),
         (408, RetryDisposition.RETRYABLE),

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -462,6 +462,76 @@ async def test_forward_request_classifies_error_body_read_failure_by_route(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("direct", "expected_owner", "expected_kind"),
+    [
+        (
+            False,
+            RuntimeErrorOwner.PLATFORM,
+            RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE,
+        ),
+        (True, RuntimeErrorOwner.USER, RuntimeErrorKind.AGENT_EXECUTION_FAILED),
+    ],
+)
+async def test_forward_request_does_not_write_second_response_after_body_failure(
+    tmp_path: Path,
+    direct: bool,
+    expected_owner: RuntimeErrorOwner,
+    expected_kind: RuntimeErrorKind,
+) -> None:
+    errors: list[LLMProxyError] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "application/json", "Content-Length": "100"},
+            request=request,
+            stream=_FailingResponseStream(request),
+        )
+
+    direct_routes = (
+        {
+            "customer-alias": LLMRoute(
+                base_url="https://customer-provider.example",
+                model_provider="custom-model-provider",
+            )
+        }
+        if direct
+        else None
+    )
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=_routing_plan(direct_routes=direct_routes),
+        on_error=errors.append,
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+    body = b'{"model":"customer-alias","messages":[]}' if direct else b'{"messages":[]}'
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {"Content-Type": "application/json"},
+                "body": body,
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    response_text = writer.buffer.decode("utf-8")
+    assert response_text.startswith("HTTP/1.1 200 OK")
+    assert response_text.count("HTTP/1.1") == 1
+    assert len(errors) == 1
+    assert errors[0].classification.owner is expected_owner
+    assert errors[0].classification.kind is expected_kind
+    assert errors[0].classification.retry_disposition is RetryDisposition.RETRYABLE
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("failure", ["connect", "timeout"])
 async def test_forward_request_classifies_direct_transport_failure_as_user_owned(
     tmp_path: Path,

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -350,6 +350,47 @@ async def test_resolve_agents_config_explicitly_disables_latest_resolution(
 
 
 @pytest.mark.anyio
+async def test_resolve_agents_config_classifies_missing_subagent_preset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = SimpleNamespace(
+        resolve_agent_preset_version=AsyncMock(
+            side_effect=TracecatNotFoundError("Agent preset 'missing-child' not found")
+        ),
+        use_latest_resource_versions=AsyncMock(return_value=False),
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    with pytest.raises(ApplicationError) as exc_info:
+        await resolve_agents_config_activity(
+            ResolveAgentsConfigActivityInput(
+                role=role,
+                agents=AgentSubagentsConfig.model_validate(
+                    {
+                        "enabled": True,
+                        "subagents": [{"preset": "missing-child"}],
+                    }
+                ),
+            )
+        )
+
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert exc_info.value.non_retryable is True
+
+
+@pytest.mark.anyio
 async def test_resolve_agents_config_rejects_subagent_with_tool_approvals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -376,13 +417,7 @@ async def test_resolve_agents_config_rejects_subagent_with_tool_approvals(
         lambda **_: _AsyncContext(service),
     )
 
-    with pytest.raises(
-        TracecatValidationError,
-        match=(
-            "Subagent preset 'approval-child' uses manual approvals, "
-            "which are not supported for subagents yet."
-        ),
-    ):
+    with pytest.raises(ApplicationError) as exc_info:
         await resolve_agents_config_activity(
             ResolveAgentsConfigActivityInput(
                 role=role,
@@ -394,6 +429,12 @@ async def test_resolve_agents_config_rejects_subagent_with_tool_approvals(
                 ),
             )
         )
+
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert exc_info.value.non_retryable is True
 
 
 @pytest.mark.anyio
@@ -414,10 +455,7 @@ async def test_resolve_agents_config_rejects_invalid_fallback_alias(
         ),
     )
 
-    with pytest.raises(
-        TracecatValidationError,
-        match="Invalid subagent alias 'Bad Alias'",
-    ):
+    with pytest.raises(ApplicationError) as exc_info:
         await resolve_agents_config_activity(
             ResolveAgentsConfigActivityInput(
                 role=role,
@@ -429,6 +467,12 @@ async def test_resolve_agents_config_rejects_invalid_fallback_alias(
                 ),
             )
         )
+
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert exc_info.value.non_retryable is True
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
+from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.preset.activities import (
     ResolveAgentPresetVersionRefActivityInput,
@@ -25,6 +26,8 @@ from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatValidationError
+from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
+from tracecat.temporal.errors import extract_error_classification
 
 
 class _AsyncContext:
@@ -407,3 +410,37 @@ async def test_resolve_custom_model_provider_config_activity_returns_base_url(
     assert result.base_url == "https://customer.example"
     assert result.model_name == "provider/custom-model"
     assert result.passthrough is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "credentials",
+    [None, {"CUSTOM_MODEL_PROVIDER_API_KEY": "opaque-secret"}],
+)
+async def test_resolve_custom_model_provider_config_classifies_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+    credentials: dict[str, str] | None,
+) -> None:
+    service = SimpleNamespace(
+        get_workspace_provider_credentials=AsyncMock(return_value=credentials)
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentManagementService.with_session",
+        lambda *_args, **_kwargs: _AsyncContext(service),
+    )
+
+    with pytest.raises(ApplicationError) as exc_info:
+        await resolve_custom_model_provider_config_activity(role)
+
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert exc_info.value.message == "Agent configuration is invalid"
+    assert "opaque-secret" not in str(exc_info.value)

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -27,7 +27,11 @@ from tracecat.agent.subagents import AgentSubagentsConfig, ResolvedAttachedSubag
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
-from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
 from tracecat.temporal.errors import extract_error_classification
 
@@ -438,6 +442,52 @@ async def test_resolve_agents_config_rejects_subagent_with_tool_approvals(
 
 
 @pytest.mark.anyio
+async def test_resolve_agents_config_classifies_malformed_persisted_agents_as_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    version = SimpleNamespace(
+        id=uuid.uuid4(),
+        preset_id=uuid.uuid4(),
+        version=1,
+        agents={"enabled": True, "subagents": {}},
+        tool_approvals={},
+    )
+    service = SimpleNamespace(
+        resolve_agent_preset_version=AsyncMock(return_value=version),
+        use_latest_resource_versions=AsyncMock(return_value=False),
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    with pytest.raises(ApplicationError) as exc_info:
+        await resolve_agents_config_activity(
+            ResolveAgentsConfigActivityInput(
+                role=role,
+                agents=AgentSubagentsConfig.model_validate(
+                    {
+                        "enabled": True,
+                        "subagents": [{"preset": "malformed-child"}],
+                    }
+                ),
+            )
+        )
+
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.kind is RuntimeErrorKind.AGENT_PREPARATION_FAILED
+    assert exc_info.value.non_retryable is True
+
+
+@pytest.mark.anyio
 async def test_resolve_agents_config_rejects_invalid_fallback_alias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -542,3 +592,45 @@ async def test_resolve_custom_model_provider_config_classifies_invalid_config(
     assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
     assert exc_info.value.message == "Agent configuration is invalid"
     assert "opaque-secret" not in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_resolve_custom_model_provider_config_classifies_revoked_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_id = uuid.uuid4()
+    service = SimpleNamespace(
+        session=SimpleNamespace(
+            execute=AsyncMock(
+                return_value=SimpleNamespace(
+                    scalar_one_or_none=lambda: SimpleNamespace(
+                        custom_provider_id=uuid.uuid4()
+                    )
+                )
+            )
+        ),
+        organization_id=uuid.uuid4(),
+        get_catalog_credentials=AsyncMock(
+            side_effect=TracecatAuthorizationError("catalog access revoked")
+        ),
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentManagementService.with_session",
+        lambda *_args, **_kwargs: _AsyncContext(service),
+    )
+
+    with pytest.raises(ApplicationError) as exc_info:
+        await resolve_custom_model_provider_config_activity(role, catalog_id)
+
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert exc_info.value.non_retryable is True
+    assert "catalog access revoked" not in str(exc_info.value)

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -10,8 +10,10 @@ import pytest
 from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.preset.activities import (
+    ResolveAgentPresetConfigActivityInput,
     ResolveAgentPresetVersionRefActivityInput,
     ResolveAgentsConfigActivityInput,
+    resolve_agent_preset_config_activity,
     resolve_agent_preset_version_ref_activity,
     resolve_agents_config_activity,
     resolve_custom_model_provider_config_activity,
@@ -25,7 +27,7 @@ from tracecat.agent.subagents import AgentSubagentsConfig, ResolvedAttachedSubag
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
 from tracecat.temporal.errors import extract_error_classification
 
@@ -36,6 +38,17 @@ class _AsyncContext:
 
     async def __aenter__(self) -> object:
         return self._value
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class _FailingAsyncContext:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    async def __aenter__(self) -> None:
+        raise self._error
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         return None
@@ -85,6 +98,47 @@ async def test_resolve_agent_preset_version_ref_activity_returns_ids(
     )
     assert result.preset_id == version.preset_id
     assert result.preset_version_id == version.id
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "error",
+    [
+        TracecatNotFoundError("Agent preset not found"),
+        TracecatValidationError("Preset version does not belong to preset"),
+    ],
+)
+async def test_resolve_agent_preset_config_classifies_user_input_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    service = SimpleNamespace(
+        with_preset_config=lambda **_: _FailingAsyncContext(error)
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentManagementService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    with pytest.raises(ApplicationError) as exc_info:
+        await resolve_agent_preset_config_activity(
+            ResolveAgentPresetConfigActivityInput(
+                role=role,
+                preset_slug="missing-preset",
+            )
+        )
+
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert exc_info.value.non_retryable is True
 
 
 def test_resolve_agents_config_result_derives_session_binding() -> None:

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -271,6 +271,31 @@ def _make_executor_input(*, enable_internet_access: bool) -> AgentExecutorInput:
     )
 
 
+@pytest.mark.anyio
+async def test_run_agent_activity_classifies_missing_stdio_source_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor_input = _make_executor_input(enable_internet_access=False)
+    executor_input.config.mcp_servers = [
+        {
+            "type": "stdio",
+            "name": "local-tools",
+            "command": "uvx",
+        }
+    ]
+    monkeypatch.setattr(executor_activity, "activity", _fake_temporal_activity())
+
+    result = await run_agent_activity(executor_input)
+
+    assert result.success is False
+    assert result.error == "Agent configuration is invalid"
+    assert result.classification is not None
+    assert result.classification.owner is RuntimeErrorOwner.USER
+    assert result.classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert result.terminal_stream_error_emitted is False
+
+
 def _make_passthrough_executor_input(
     *, enable_internet_access: bool, base_url: str = "https://customer-litellm.example"
 ) -> AgentExecutorInput:

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -617,7 +617,7 @@ class _FakeLLMSocketProxy:
         *,
         socket_path: Path,
         routing_plan: LLMRoutingPlan,
-        on_error: Callable[[str], None] | None = None,
+        on_error: Callable[[llm_proxy_module.LLMProxyError], None] | None = None,
     ) -> None:
         del on_error
         self.socket_path = socket_path

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -71,6 +71,7 @@ from tracecat.agent.skill.service import SkillService
 from tracecat.agent.skill.types import ResolvedSkillRef
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.runtime.errors import (
     RetryDisposition,
     RuntimeErrorKind,
@@ -2855,16 +2856,12 @@ async def test_executor_starts_llm_socket_proxy_for_passthrough_provider_with_in
     assert fake_broker.requests[0].enable_internet_access is True
 
 
-@pytest.mark.anyio
-async def test_executor_classifies_passthrough_without_base_url_as_invalid_config(
+async def _run_executor_through_route_materialization(
+    *,
+    executor_input: AgentExecutorInput,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-) -> None:
-    valid_input = _make_passthrough_executor_input(enable_internet_access=False)
-    executor_input = valid_input.model_copy(
-        update={"config": replace(valid_input.config, base_url=None)}
-    )
-
+) -> AgentExecutorResult:
     async def fake_create_job_directory(self: SandboxedAgentExecutor) -> Path:
         del self
         (tmp_path / "sockets").mkdir()
@@ -2894,13 +2891,74 @@ async def test_executor_classifies_passthrough_without_base_url_as_invalid_confi
         "_cleanup",
         fake_cleanup,
     )
-    result = await SandboxedAgentExecutor(input=executor_input).run()
+    return await SandboxedAgentExecutor(input=executor_input).run()
+
+
+@pytest.mark.anyio
+async def test_executor_classifies_passthrough_without_base_url_as_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    valid_input = _make_passthrough_executor_input(enable_internet_access=False)
+    executor_input = valid_input.model_copy(
+        update={"config": replace(valid_input.config, base_url=None)}
+    )
+
+    result = await _run_executor_through_route_materialization(
+        executor_input=executor_input,
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
 
     assert result.success is False
     assert result.classification is not None
     assert result.classification.owner is RuntimeErrorOwner.USER
     assert result.classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
     assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+
+
+@pytest.mark.anyio
+async def test_executor_classifies_revoked_passthrough_catalog_as_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    catalog_id = uuid.uuid4()
+    valid_input = _make_passthrough_executor_input(enable_internet_access=False)
+    executor_input = valid_input.model_copy(
+        update={"config": replace(valid_input.config, catalog_id=catalog_id)}
+    )
+
+    class _RevokedCatalogService(_FakeAgentManagementService):
+        async def get_catalog_credentials(
+            self, requested_catalog_id: uuid.UUID
+        ) -> dict[str, str]:
+            assert requested_catalog_id == catalog_id
+            raise TracecatAuthorizationError("catalog access revoked")
+
+    @contextlib.asynccontextmanager
+    async def fake_agent_management_context(
+        _role: Role,
+    ) -> AsyncIterator[_RevokedCatalogService]:
+        yield _RevokedCatalogService()
+
+    monkeypatch.setattr(
+        llm_proxy_module.AgentManagementService,
+        "with_session",
+        fake_agent_management_context,
+    )
+
+    result = await _run_executor_through_route_materialization(
+        executor_input=executor_input,
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+
+    assert result.success is False
+    assert result.classification is not None
+    assert result.classification.owner is RuntimeErrorOwner.USER
+    assert result.classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert "catalog access revoked" not in result.classification.message
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -71,6 +71,11 @@ from tracecat.agent.skill.service import SkillService
 from tracecat.agent.skill.types import ResolvedSkillRef
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
 from tracecat.sandbox.types import (
     SandboxEgressRule,
     SandboxNetworkPolicy,
@@ -2848,6 +2853,54 @@ async def test_executor_starts_llm_socket_proxy_for_passthrough_provider_with_in
         tmp_path / "sockets" / LLM_SOCKET_NAME
     )
     assert fake_broker.requests[0].enable_internet_access is True
+
+
+@pytest.mark.anyio
+async def test_executor_classifies_passthrough_without_base_url_as_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    valid_input = _make_passthrough_executor_input(enable_internet_access=False)
+    executor_input = valid_input.model_copy(
+        update={"config": replace(valid_input.config, base_url=None)}
+    )
+
+    async def fake_create_job_directory(self: SandboxedAgentExecutor) -> Path:
+        del self
+        (tmp_path / "sockets").mkdir()
+        return tmp_path
+
+    async def fake_resolve_agent_otel_config(
+        self: SandboxedAgentExecutor,
+    ) -> SimpleNamespace:
+        del self
+        return SimpleNamespace(enabled=False)
+
+    async def fake_cleanup(self: SandboxedAgentExecutor) -> None:
+        del self
+
+    monkeypatch.setattr(
+        SandboxedAgentExecutor,
+        "_create_job_directory",
+        fake_create_job_directory,
+    )
+    monkeypatch.setattr(
+        SandboxedAgentExecutor,
+        "_resolve_agent_otel_config",
+        fake_resolve_agent_otel_config,
+    )
+    monkeypatch.setattr(
+        SandboxedAgentExecutor,
+        "_cleanup",
+        fake_cleanup,
+    )
+    result = await SandboxedAgentExecutor(input=executor_input).run()
+
+    assert result.success is False
+    assert result.classification is not None
+    assert result.classification.owner is RuntimeErrorOwner.USER
+    assert result.classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
+    assert result.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from temporalio.common import TypedSearchAttributes
-from temporalio.exceptions import ActivityError
+from temporalio.exceptions import ActivityError, ApplicationError
 from tracecat_ee.agent.activities import BuildToolDefsArgs, BuildToolDefsResult
 from tracecat_ee.agent.workflows.durable import (
     BUILD_AGENT_TOOL_DEFINITIONS_PATCH,
@@ -587,7 +587,7 @@ async def test_run_skips_activity_error_emission_without_patch_marker() -> None:
             AsyncMock(),
         ) as emit_terminal_done_mock,
     ):
-        with pytest.raises(ActivityError):
+        with pytest.raises(ApplicationError):
             await workflow_instance.run(workflow_args)
 
     # Legacy replay (all patches off) on the pre-stream error path: should_stream

--- a/tests/unit/test_sentry_interceptor.py
+++ b/tests/unit/test_sentry_interceptor.py
@@ -21,6 +21,11 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
 )
 
+from tracecat.agent.error_policy import (
+    agent_executor_unavailable,
+    invalid_agent_configuration,
+    user_agent_execution_failed,
+)
 from tracecat.dsl import interceptor as interceptor_module
 from tracecat.dsl.interceptor import (
     RuntimeErrorAttributionInterceptor,
@@ -305,6 +310,64 @@ async def test_user_failure_is_logged_without_a_sentry_event(
     sentry_sdk.flush()
 
     assert sentry_events == []
+
+
+@pytest.mark.anyio
+async def test_user_agent_executor_failure_does_not_emit_sentry(
+    sentry_events: list[Event],
+    workflow_runtime: _WorkflowInfo,
+) -> None:
+    del workflow_runtime
+    error = application_error_from_classification(user_agent_execution_failed())
+    attribution = _RuntimeErrorAttributionWorkflowInterceptor(_RaisingInbound(error))
+
+    with pytest.raises(ApplicationError):
+        await attribution.execute_workflow(_workflow_input())
+    sentry_sdk.flush()
+
+    assert sentry_events == []
+
+
+@pytest.mark.anyio
+async def test_invalid_agent_configuration_does_not_emit_sentry(
+    sentry_events: list[Event],
+    workflow_runtime: _WorkflowInfo,
+) -> None:
+    del workflow_runtime
+    error = application_error_from_classification(invalid_agent_configuration())
+    attribution = _RuntimeErrorAttributionWorkflowInterceptor(_RaisingInbound(error))
+
+    with pytest.raises(ApplicationError):
+        await attribution.execute_workflow(_workflow_input())
+    sentry_sdk.flush()
+
+    assert sentry_events == []
+
+
+@pytest.mark.anyio
+async def test_platform_agent_executor_failure_emits_one_sanitized_sentry_event(
+    sentry_events: list[Event],
+    workflow_runtime: _WorkflowInfo,
+) -> None:
+    del workflow_runtime
+    error = application_error_from_classification(
+        agent_executor_unavailable(RuntimeError(_SENSITIVE_VALUE))
+    )
+    attribution = _RuntimeErrorAttributionWorkflowInterceptor(_RaisingInbound(error))
+
+    with pytest.raises(ApplicationError):
+        await attribution.execute_workflow(_workflow_input())
+    sentry_sdk.flush()
+
+    assert len(sentry_events) == 1
+    event = sentry_events[0]
+    assert "tags" in event
+    tags = event["tags"]
+    assert tags[SentryTag.ERROR_KIND.value] == (
+        RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE.value
+    )
+    assert tags[SentryTag.ERROR_OWNER.value] == "platform"
+    assert _SENSITIVE_VALUE not in json.dumps(event)
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/channels/sinks/slack.py
+++ b/tracecat/agent/channels/sinks/slack.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from time import monotonic
@@ -426,6 +427,7 @@ class SlackStreamSink:
             return
 
         is_error = final_error_text is not None
+        was_cancelled = False
         try:
             await self._flush_delta_buffer(force=True)
             if final_error_text:
@@ -482,9 +484,13 @@ class SlackStreamSink:
                     workspace_id=self._workspace_id,
                     error=str(exc),
                 )
+        except asyncio.CancelledError:
+            was_cancelled = True
+            raise
         finally:
-            await self._set_terminal_reaction(is_error=is_error)
             self._is_closed = True
+            if not was_cancelled:
+                await self._set_terminal_reaction(is_error=is_error)
 
     async def append(self, event: UnifiedStreamEvent) -> None:
         if self._is_closed:

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -144,6 +144,7 @@ type RuntimeEventType = Literal[
 
 _RUNTIME_EVENT_TYPES: frozenset[str] = frozenset(get_args(RuntimeEventType.__value__))
 _RUNTIME_LOG_LEVELS = frozenset({"debug", "info", "warning", "error"})
+_RUNTIME_LOG_EXTRA_RESERVED_KEYS = frozenset({"self", "level", "message", "session_id"})
 
 
 def _is_runtime_event_type(value: object) -> TypeGuard[RuntimeEventType]:
@@ -233,8 +234,11 @@ class RuntimeEventEnvelope:
         internal = boolean(data, "internal", path="runtime_event")
         if log_level is not None and log_level not in _RUNTIME_LOG_LEVELS:
             raise ValueError("Runtime event log_level has an unknown log level")
-        if log_extra is not None and "session_id" in log_extra:
-            raise ValueError("Runtime event log_extra cannot override session_id")
+        if (
+            log_extra is not None
+            and _RUNTIME_LOG_EXTRA_RESERVED_KEYS & log_extra.keys()
+        ):
+            raise ValueError("Runtime event log_extra contains a reserved key")
 
         match raw_type:
             case "stream_event" if event is None:

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from tracecat.agent.common.stream_types import UnifiedStreamEvent
 from tracecat.agent.common.types import (
@@ -125,6 +125,31 @@ class RuntimeInitPayload:
         return result
 
 
+type RuntimeEventType = Literal[
+    "stream_event",
+    "message",
+    "session_line",
+    "session_update",
+    "result",
+    "error",
+    "done",
+    "log",
+]
+
+_RUNTIME_EVENT_TYPES = frozenset(
+    {
+        "stream_event",
+        "message",
+        "session_line",
+        "session_update",
+        "result",
+        "error",
+        "done",
+        "log",
+    }
+)
+
+
 @dataclass(kw_only=True, slots=True)
 class RuntimeEventEnvelope:
     """Envelope for events sent from runtime to orchestrator.
@@ -143,16 +168,7 @@ class RuntimeEventEnvelope:
     when persisting messages to ensure proper authorization.
     """
 
-    type: Literal[
-        "stream_event",
-        "message",
-        "session_line",
-        "session_update",
-        "result",
-        "error",
-        "done",
-        "log",
-    ]
+    type: RuntimeEventType
     event: UnifiedStreamEvent | None = None  # For type="stream_event"
     message: dict[str, Any] | None = None  # For type="message" (serialized Message)
     session_line: str | None = None  # For type="session_line" (raw JSONL line)
@@ -175,12 +191,22 @@ class RuntimeEventEnvelope:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RuntimeEventEnvelope:
         """Construct from dict (orjson parsed)."""
+        raw_type = data.get("type")
+        if not isinstance(raw_type, str) or raw_type not in _RUNTIME_EVENT_TYPES:
+            raise ValueError("Unknown runtime event envelope type")
+
+        raw_event = data.get("event")
+        if raw_type == "stream_event" and not isinstance(raw_event, dict):
+            raise ValueError("Runtime stream event payload must be a JSON object")
+        if raw_event is not None and not isinstance(raw_event, dict):
+            raise ValueError("Runtime event payload must be a JSON object")
+
         event = None
-        if data.get("event"):
-            event = UnifiedStreamEvent.from_dict(data["event"])
+        if raw_event is not None:
+            event = UnifiedStreamEvent.from_dict(raw_event)
 
         return cls(
-            type=data["type"],
+            type=cast(RuntimeEventType, raw_type),
             event=event,
             message=data.get("message"),
             session_line=data.get("session_line"),

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -18,6 +18,12 @@ from tracecat.agent.common.types import (
     SandboxAgentConfig,
     SandboxSubagentConfig,
 )
+from tracecat.agent.common.wire import (
+    boolean,
+    optional_integer,
+    optional_object,
+    optional_string,
+)
 
 
 @dataclass(kw_only=True, slots=True)
@@ -137,6 +143,7 @@ type RuntimeEventType = Literal[
 ]
 
 _RUNTIME_EVENT_TYPES: frozenset[str] = frozenset(get_args(RuntimeEventType.__value__))
+_RUNTIME_LOG_LEVELS = frozenset({"debug", "info", "warning", "error"})
 
 
 def _is_runtime_event_type(value: object) -> TypeGuard[RuntimeEventType]:
@@ -199,25 +206,75 @@ class RuntimeEventEnvelope:
         if raw_event is not None:
             event = UnifiedStreamEvent.from_dict(raw_event)
 
+        message = optional_object(data, "message", path="runtime_event")
+        session_line = optional_string(data, "session_line", path="runtime_event")
+        sdk_session_id = optional_string(data, "sdk_session_id", path="runtime_event")
+        sdk_session_data = optional_string(
+            data,
+            "sdk_session_data",
+            path="runtime_event",
+        )
+        error = optional_string(data, "error", path="runtime_event")
+        result_usage = optional_object(data, "result_usage", path="runtime_event")
+        result_num_turns = optional_integer(
+            data,
+            "result_num_turns",
+            path="runtime_event",
+        )
+        result_duration_ms = optional_integer(
+            data,
+            "result_duration_ms",
+            path="runtime_event",
+        )
+        log_level = optional_string(data, "log_level", path="runtime_event")
+        log_message = optional_string(data, "log_message", path="runtime_event")
+        log_extra = optional_object(data, "log_extra", path="runtime_event")
+
+        internal = boolean(data, "internal", path="runtime_event")
+        if log_level is not None and log_level not in _RUNTIME_LOG_LEVELS:
+            raise ValueError("Runtime event log_level has an unknown log level")
+        if log_extra is not None and "session_id" in log_extra:
+            raise ValueError("Runtime event log_extra cannot override session_id")
+
+        match raw_type:
+            case "stream_event" if event is None:
+                raise ValueError("Runtime stream event must include event")
+            case "message" if message is None:
+                raise ValueError("Runtime message event must include message")
+            case "session_line" if session_line is None or sdk_session_id is None:
+                raise ValueError(
+                    "Runtime session_line event must include session_line and sdk_session_id"
+                )
+            case "session_update" if sdk_session_id is None or sdk_session_data is None:
+                raise ValueError(
+                    "Runtime session_update event must include sdk_session_id and sdk_session_data"
+                )
+            case "error" if error is None:
+                raise ValueError("Runtime error event must include error")
+            case "log" if log_level is None or log_message is None:
+                raise ValueError(
+                    "Runtime log event must include log_level and log_message"
+                )
+
         return cls(
             type=raw_type,
             event=event,
-            message=data.get("message"),
-            session_line=data.get("session_line"),
-            internal=data.get("internal", False),
-            sdk_session_id=data.get("sdk_session_id"),
-            sdk_session_data=data.get("sdk_session_data"),
-            error=data.get("error"),
-            result_usage=data.get("result_usage"),
-            result_num_turns=data.get("result_num_turns"),
-            result_duration_ms=data.get("result_duration_ms"),
+            message=message,
+            session_line=session_line,
+            internal=internal,
+            sdk_session_id=sdk_session_id,
+            sdk_session_data=sdk_session_data,
+            error=error,
+            result_usage=result_usage,
+            result_num_turns=result_num_turns,
+            result_duration_ms=result_duration_ms,
             result_output=data.get(
                 "result_output",
                 data.get("result_structured_output", data.get("result_result")),
             ),
-            log_level=data.get("log_level"),
-            log_message=data.get("log_message"),
-            log_extra=data.get("log_extra"),
+            log_level=log_level,
+            log_message=log_message,
+            log_extra=log_extra,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -245,13 +245,13 @@ class RuntimeEventEnvelope:
                 raise ValueError("Runtime stream event must include event")
             case "message" if message is None:
                 raise ValueError("Runtime message event must include message")
-            case "session_line" if session_line is None or sdk_session_id is None:
+            case "session_line" if session_line is None or not sdk_session_id:
                 raise ValueError(
-                    "Runtime session_line event must include session_line and sdk_session_id"
+                    "Runtime session_line event must include session_line and a non-empty sdk_session_id"
                 )
-            case "session_update" if sdk_session_id is None or sdk_session_data is None:
+            case "session_update" if not sdk_session_id or sdk_session_data is None:
                 raise ValueError(
-                    "Runtime session_update event must include sdk_session_id and sdk_session_data"
+                    "Runtime session_update event must include a non-empty sdk_session_id and sdk_session_data"
                 )
             case "error" if error is None:
                 raise ValueError("Runtime error event must include error")

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Literal, cast
+from typing import Any, Literal, TypeGuard, get_args
 
 from tracecat.agent.common.stream_types import UnifiedStreamEvent
 from tracecat.agent.common.types import (
@@ -136,18 +136,12 @@ type RuntimeEventType = Literal[
     "log",
 ]
 
-_RUNTIME_EVENT_TYPES = frozenset(
-    {
-        "stream_event",
-        "message",
-        "session_line",
-        "session_update",
-        "result",
-        "error",
-        "done",
-        "log",
-    }
-)
+_RUNTIME_EVENT_TYPES: frozenset[str] = frozenset(get_args(RuntimeEventType.__value__))
+
+
+def _is_runtime_event_type(value: object) -> TypeGuard[RuntimeEventType]:
+    """Narrow a wire value using the canonical runtime event type definition."""
+    return isinstance(value, str) and value in _RUNTIME_EVENT_TYPES
 
 
 @dataclass(kw_only=True, slots=True)
@@ -192,7 +186,7 @@ class RuntimeEventEnvelope:
     def from_dict(cls, data: dict[str, Any]) -> RuntimeEventEnvelope:
         """Construct from dict (orjson parsed)."""
         raw_type = data.get("type")
-        if not isinstance(raw_type, str) or raw_type not in _RUNTIME_EVENT_TYPES:
+        if not _is_runtime_event_type(raw_type):
             raise ValueError("Unknown runtime event envelope type")
 
         raw_event = data.get("event")
@@ -206,7 +200,7 @@ class RuntimeEventEnvelope:
             event = UnifiedStreamEvent.from_dict(raw_event)
 
         return cls(
-            type=cast(RuntimeEventType, raw_type),
+            type=raw_type,
             event=event,
             message=data.get("message"),
             session_line=data.get("session_line"),

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -8,12 +8,57 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, get_args
 
 from tracecat.agent.approvals.types import PersistedApprovalDecision
+from tracecat.agent.common.wire import (
+    boolean,
+    optional_integer,
+    optional_object,
+    optional_string,
+    required_object,
+    required_string,
+)
 
 type ArtifactEventOp = Literal["upsert", "remove"]
 type ApprovalStreamStatus = Literal["pending", "approved", "rejected"]
+
+_ARTIFACT_EVENT_OPS: frozenset[str] = frozenset(get_args(ArtifactEventOp.__value__))
+_APPROVAL_STREAM_STATUSES: frozenset[str] = frozenset(
+    get_args(ApprovalStreamStatus.__value__)
+)
+
+
+def _parse_approval_decision(
+    value: object,
+    *,
+    path: str,
+) -> PersistedApprovalDecision | None:
+    if value is None or isinstance(value, bool):
+        return value
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must be a JSON boolean or object")
+
+    decision = cast(dict[str, Any], value)
+    if "kind" in decision:
+        kind = required_string(decision, "kind", path=path)
+        if kind == "tool-approved":
+            optional_object(decision, "metadata", path=path)
+        elif kind == "tool-denied":
+            optional_string(decision, "message", path=path)
+            optional_object(decision, "metadata", path=path)
+        else:
+            raise ValueError(f"{path}.kind has an unknown approval decision type")
+    elif "value" in decision:
+        if not isinstance(decision["value"], bool):
+            raise ValueError(f"{path}.value must be a JSON boolean")
+        metadata = decision.get("metadata")
+        if not isinstance(metadata, dict):
+            raise ValueError(f"{path}.metadata must be a JSON object")
+    else:
+        raise ValueError(f"{path} has an unknown approval decision shape")
+
+    return cast(PersistedApprovalDecision, decision)
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,15 +148,53 @@ class ToolCallContent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ToolCallContent:
         """Construct from dict (orjson parsed)."""
+        raw_type = data.get("type", "tool_call")
+        if raw_type != "tool_call":
+            raise ValueError("stream_event.approval_items[].type must be 'tool_call'")
+
+        status = optional_string(
+            data,
+            "status",
+            path="stream_event.approval_items[]",
+        )
+        if status is not None and status not in _APPROVAL_STREAM_STATUSES:
+            raise ValueError(
+                "stream_event.approval_items[].status has an unknown approval status"
+            )
+
         return cls(
-            type=data.get("type", "tool_call"),
-            id=data["id"],
-            name=data["name"],
-            input=data.get("input", {}),
-            metadata=data.get("metadata"),
-            status=data.get("status"),
-            decision=data.get("decision"),
-            reason=data.get("reason"),
+            type="tool_call",
+            id=required_string(
+                data,
+                "id",
+                path="stream_event.approval_items[]",
+            ),
+            name=required_string(
+                data,
+                "name",
+                path="stream_event.approval_items[]",
+            ),
+            input=optional_object(
+                data,
+                "input",
+                path="stream_event.approval_items[]",
+            )
+            or {},
+            metadata=optional_object(
+                data,
+                "metadata",
+                path="stream_event.approval_items[]",
+            ),
+            status=cast(ApprovalStreamStatus | None, status),
+            decision=_parse_approval_decision(
+                data.get("decision"),
+                path="stream_event.approval_items[].decision",
+            ),
+            reason=optional_string(
+                data,
+                "reason",
+                path="stream_event.approval_items[]",
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -143,7 +226,11 @@ class ArtifactEventContent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ArtifactEventContent:
         """Construct from dict (orjson parsed)."""
-        return cls(op=data["op"], artifact=data["artifact"])
+        raw_op = required_string(data, "op", path="stream_event.artifact_data")
+        if raw_op not in _ARTIFACT_EVENT_OPS:
+            raise ValueError("stream_event.artifact_data.op has an unknown operation")
+        artifact = required_object(data, "artifact", path="stream_event.artifact_data")
+        return cls(op=cast(ArtifactEventOp, raw_op), artifact=artifact)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict for orjson serialization."""
@@ -187,14 +274,20 @@ class UnifiedStreamEvent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> UnifiedStreamEvent:
         """Construct from dict (orjson parsed)."""
+        raw_type = required_string(data, "type", path="stream_event")
+        try:
+            event_type = StreamEventType(raw_type)
+        except ValueError as exc:
+            raise ValueError("stream_event.type has an unknown event type") from exc
+
         approval_items = None
         raw_approval_items = data.get("approval_items")
         if raw_approval_items is not None and not isinstance(raw_approval_items, list):
-            raise ValueError("Stream event approval_items must be a JSON array")
+            raise ValueError("stream_event.approval_items must be a JSON array")
         if raw_approval_items:
             if not all(isinstance(item, dict) for item in raw_approval_items):
                 raise ValueError(
-                    "Stream event approval_items entries must be JSON objects"
+                    "stream_event.approval_items entries must be JSON objects"
                 )
             approval_items = [
                 ToolCallContent.from_dict(cast(dict[str, Any], item))
@@ -205,7 +298,7 @@ class UnifiedStreamEvent:
         raw_artifact_data = data.get("artifact_data")
         if raw_artifact_data is not None:
             if not isinstance(raw_artifact_data, dict):
-                raise ValueError("Stream event artifact_data must be a JSON object")
+                raise ValueError("stream_event.artifact_data must be a JSON object")
             artifact_data = ArtifactEventContent.from_dict(
                 cast(dict[str, Any], raw_artifact_data)
             )
@@ -215,19 +308,27 @@ class UnifiedStreamEvent:
             timestamp = datetime.fromisoformat(timestamp)
         elif timestamp is None:
             timestamp = datetime.now(UTC)
+        elif not isinstance(timestamp, datetime):
+            raise ValueError("stream_event.timestamp must be an ISO 8601 string")
+
+        is_error = boolean(data, "is_error", path="stream_event")
 
         return cls(
-            type=StreamEventType(data["type"]),
-            part_id=data.get("part_id"),
-            text=data.get("text"),
-            thinking=data.get("thinking"),
-            tool_call_id=data.get("tool_call_id"),
-            tool_name=data.get("tool_name"),
-            tool_input=data.get("tool_input"),
+            type=event_type,
+            part_id=optional_integer(data, "part_id", path="stream_event"),
+            text=optional_string(data, "text", path="stream_event"),
+            thinking=optional_string(data, "thinking", path="stream_event"),
+            tool_call_id=optional_string(
+                data,
+                "tool_call_id",
+                path="stream_event",
+            ),
+            tool_name=optional_string(data, "tool_name", path="stream_event"),
+            tool_input=optional_object(data, "tool_input", path="stream_event"),
             tool_output=data.get("tool_output"),
-            is_error=data.get("is_error", False),
-            error=data.get("error"),
-            metadata=data.get("metadata"),
+            is_error=is_error,
+            error=optional_string(data, "error", path="stream_event"),
+            metadata=optional_object(data, "metadata", path="stream_event"),
             approval_items=approval_items,
             artifact_data=artifact_data,
             timestamp=timestamp,

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -293,6 +293,10 @@ class UnifiedStreamEvent:
                 ToolCallContent.from_dict(cast(dict[str, Any], item))
                 for item in raw_approval_items
             ]
+        if event_type is StreamEventType.APPROVAL_REQUEST and not approval_items:
+            raise ValueError(
+                "stream_event.approval_request must include at least one approval item"
+            )
 
         artifact_data = None
         raw_artifact_data = data.get("artifact_data")

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from tracecat.agent.approvals.types import PersistedApprovalDecision
 
@@ -188,13 +188,27 @@ class UnifiedStreamEvent:
     def from_dict(cls, data: dict[str, Any]) -> UnifiedStreamEvent:
         """Construct from dict (orjson parsed)."""
         approval_items = None
-        if data.get("approval_items"):
+        raw_approval_items = data.get("approval_items")
+        if raw_approval_items is not None and not isinstance(raw_approval_items, list):
+            raise ValueError("Stream event approval_items must be a JSON array")
+        if raw_approval_items:
+            if not all(isinstance(item, dict) for item in raw_approval_items):
+                raise ValueError(
+                    "Stream event approval_items entries must be JSON objects"
+                )
             approval_items = [
-                ToolCallContent.from_dict(item) for item in data["approval_items"]
+                ToolCallContent.from_dict(cast(dict[str, Any], item))
+                for item in raw_approval_items
             ]
+
         artifact_data = None
-        if data.get("artifact_data"):
-            artifact_data = ArtifactEventContent.from_dict(data["artifact_data"])
+        raw_artifact_data = data.get("artifact_data")
+        if raw_artifact_data is not None:
+            if not isinstance(raw_artifact_data, dict):
+                raise ValueError("Stream event artifact_data must be a JSON object")
+            artifact_data = ArtifactEventContent.from_dict(
+                cast(dict[str, Any], raw_artifact_data)
+            )
 
         timestamp = data.get("timestamp")
         if isinstance(timestamp, str):

--- a/tracecat/agent/common/wire.py
+++ b/tracecat/agent/common/wire.py
@@ -1,0 +1,65 @@
+"""Strict helpers for decoding typed values from agent wire payloads."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+def required_string(data: dict[str, Any], field_name: str, *, path: str) -> str:
+    """Return a required string field or reject the wire payload."""
+    value = data.get(field_name)
+    if not isinstance(value, str):
+        raise ValueError(f"{path}.{field_name} must be a JSON string")
+    return value
+
+
+def optional_string(data: dict[str, Any], field_name: str, *, path: str) -> str | None:
+    """Return an optional string field or reject the wire payload."""
+    value = data.get(field_name)
+    if value is not None and not isinstance(value, str):
+        raise ValueError(f"{path}.{field_name} must be a JSON string")
+    return value
+
+
+def optional_object(
+    data: dict[str, Any], field_name: str, *, path: str
+) -> dict[str, Any] | None:
+    """Return an optional object field or reject the wire payload."""
+    value = data.get(field_name)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}.{field_name} must be a JSON object")
+    return cast(dict[str, Any], value)
+
+
+def required_object(
+    data: dict[str, Any], field_name: str, *, path: str
+) -> dict[str, Any]:
+    """Return a required object field or reject the wire payload."""
+    value = optional_object(data, field_name, path=path)
+    if value is None:
+        raise ValueError(f"{path}.{field_name} must be a JSON object")
+    return value
+
+
+def optional_integer(data: dict[str, Any], field_name: str, *, path: str) -> int | None:
+    """Return an optional non-boolean integer or reject the wire payload."""
+    value = data.get(field_name)
+    if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+        raise ValueError(f"{path}.{field_name} must be a JSON integer")
+    return value
+
+
+def boolean(
+    data: dict[str, Any],
+    field_name: str,
+    *,
+    path: str,
+    default: bool = False,
+) -> bool:
+    """Return a boolean field or reject the wire payload."""
+    value = data.get(field_name, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"{path}.{field_name} must be a JSON boolean")
+    return value

--- a/tracecat/agent/error_policy.py
+++ b/tracecat/agent/error_policy.py
@@ -1,0 +1,113 @@
+"""Privacy-safe runtime classifications for durable agent failures."""
+
+from __future__ import annotations
+
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorClassification,
+    RuntimeErrorKind,
+)
+
+
+def invalid_agent_configuration(
+    error: BaseException | None = None,
+) -> RuntimeErrorClassification:
+    """Classify deterministic caller-owned agent configuration failures."""
+    return RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.AGENT_CONFIGURATION_INVALID,
+        message="Agent configuration is invalid",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=error,
+    )
+
+
+def agent_preparation_failed(
+    error: BaseException | None = None,
+    *,
+    retryable: bool,
+) -> RuntimeErrorClassification:
+    """Classify trusted workflow failures while preparing an agent run."""
+    return RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.AGENT_PREPARATION_FAILED,
+        message="Tracecat could not prepare the agent run",
+        retry_disposition=(
+            RetryDisposition.RETRYABLE if retryable else RetryDisposition.NON_RETRYABLE
+        ),
+        cause=error,
+    )
+
+
+def agent_session_initialization_failed(
+    error: BaseException | None = None,
+    *,
+    retryable: bool,
+) -> RuntimeErrorClassification:
+    """Classify failures establishing trusted durable session state."""
+    return RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.AGENT_SESSION_INITIALIZATION_FAILED,
+        message="Tracecat could not initialize the agent session",
+        retry_disposition=(
+            RetryDisposition.RETRYABLE if retryable else RetryDisposition.NON_RETRYABLE
+        ),
+        cause=error,
+    )
+
+
+def user_agent_execution_failed(
+    error: BaseException | None = None,
+) -> RuntimeErrorClassification:
+    """Classify a terminal error explicitly returned by the agent runtime."""
+    return RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.AGENT_EXECUTION_FAILED,
+        message="Agent execution failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=error,
+    )
+
+
+def agent_executor_unavailable(
+    error: BaseException | None = None,
+) -> RuntimeErrorClassification:
+    """Classify trusted executor infrastructure or transport failures."""
+    return RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE,
+        message="Tracecat agent executor is unavailable",
+        retry_disposition=RetryDisposition.RETRYABLE,
+        cause=error,
+    )
+
+
+def agent_executor_timed_out(
+    error: BaseException | None = None,
+) -> RuntimeErrorClassification:
+    """Classify executor activity or runtime deadline exhaustion."""
+    return RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT,
+        message="Tracecat agent execution timed out",
+        retry_disposition=RetryDisposition.RETRYABLE,
+        cause=error,
+    )
+
+
+def agent_executor_protocol_failed(
+    error: BaseException | None = None,
+) -> RuntimeErrorClassification:
+    """Classify invalid or incomplete executor protocol outcomes."""
+    return RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED,
+        message="Tracecat agent executor returned an invalid result",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=error,
+    )
+
+
+def agent_workflow_internal_error(
+    error: BaseException | None = None,
+) -> RuntimeErrorClassification:
+    """Classify the workflow's final invariant fallback."""
+    return RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.AGENT_WORKFLOW_INTERNAL_ERROR,
+        message="Tracecat agent workflow encountered an internal error",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=error,
+    )

--- a/tracecat/agent/error_policy.py
+++ b/tracecat/agent/error_policy.py
@@ -55,12 +55,16 @@ def agent_session_initialization_failed(
 
 def user_agent_execution_failed(
     error: BaseException | None = None,
+    *,
+    retryable: bool = False,
 ) -> RuntimeErrorClassification:
-    """Classify a terminal error explicitly returned by the agent runtime."""
+    """Classify an error owned by the agent caller or its direct provider."""
     return RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.AGENT_EXECUTION_FAILED,
         message="Agent execution failed",
-        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        retry_disposition=(
+            RetryDisposition.RETRYABLE if retryable else RetryDisposition.NON_RETRYABLE
+        ),
         cause=error,
     )
 

--- a/tracecat/agent/error_policy.py
+++ b/tracecat/agent/error_policy.py
@@ -21,6 +21,18 @@ def invalid_agent_configuration(
     )
 
 
+def tenant_entitlement_denied(
+    error: BaseException | None = None,
+) -> RuntimeErrorClassification:
+    """Classify a deterministic tenant feature-entitlement denial."""
+    return RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED,
+        message="This feature requires an upgraded plan",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=error,
+    )
+
+
 def agent_preparation_failed(
     error: BaseException | None = None,
     *,

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -29,7 +29,10 @@ from tracecat.agent.common.config import (
     TRACECAT__AGENT_SANDBOX_MEMORY_MB,
     TRACECAT__DISABLE_NSJAIL,
 )
-from tracecat.agent.common.exceptions import AgentSandboxExecutionError
+from tracecat.agent.common.exceptions import (
+    AgentSandboxExecutionError,
+    AgentSandboxValidationError,
+)
 from tracecat.agent.common.fs import force_rmtree
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import ToolCallContent
@@ -45,6 +48,7 @@ from tracecat.agent.error_policy import (
     agent_executor_protocol_failed,
     agent_executor_timed_out,
     agent_executor_unavailable,
+    invalid_agent_configuration,
 )
 from tracecat.agent.executor.loopback import (
     LoopbackHandler,
@@ -439,11 +443,11 @@ class SandboxedAgentExecutor:
             Direct route for the model config.
 
         Raises:
-            AgentSandboxExecutionError: If passthrough is enabled without a
+            AgentSandboxValidationError: If passthrough is enabled without a
                 resolved base URL.
         """
         if base_url is None:
-            raise AgentSandboxExecutionError(
+            raise AgentSandboxValidationError(
                 "Custom model provider passthrough requires a resolved base_url."
             )
         return LLMRoute(
@@ -595,6 +599,10 @@ class SandboxedAgentExecutor:
                 otel_socket_path=otel_socket_path,
             )
 
+        except AgentSandboxValidationError as e:
+            logger.error("Agent configuration is invalid", error=str(e))
+            result.error = str(e)
+            result.classification = invalid_agent_configuration(e)
         except AgentSandboxExecutionError as e:
             logger.error("Agent sandbox execution failed", error=str(e))
             result.error = str(e)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -1231,17 +1231,19 @@ async def _hydrate_stdio_env(
     if not mcp_servers:
         return mcp_servers
 
+    for cfg in mcp_servers:
+        if is_stdio_mcp_server(cfg) and not cfg.get("id"):
+            raise AgentSandboxValidationError(
+                "Stdio MCP server configuration is missing a source integration id"
+            )
+
     result: list[MCPServerConfig] = []
     async with AgentPresetService.with_session(role=role) as svc:
         for cfg in mcp_servers:
             if not is_stdio_mcp_server(cfg):
                 result.append(cfg)
             else:
-                cfg_id = cfg.get("id")
-                if not cfg_id:
-                    raise ValueError(
-                        f"Stdio MCP server {cfg.get('name')!r} is missing a source integration id"
-                    )
+                cfg_id = cast(str, cfg.get("id"))
                 try:
                     env = await svc.resolve_mcp_integration_secrets(uuid.UUID(cfg_id))
                 except (ValueError, MCPSecretResolutionError):
@@ -1380,10 +1382,21 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
     # ``config.mcp_servers`` arrive in refs-only shape (no ``env``) — hydrate
     # from the DB here so the spawned processes get their credentials.
     config = cast(Any, input.config)
-    config.mcp_servers = await _hydrate_stdio_env(config.mcp_servers, role=input.role)
-    for subagent in input.subagents:
-        subagent.config.mcp_servers = await _hydrate_stdio_env(
-            subagent.config.mcp_servers, role=input.role
+    try:
+        config.mcp_servers = await _hydrate_stdio_env(
+            config.mcp_servers, role=input.role
+        )
+        for subagent in input.subagents:
+            subagent.config.mcp_servers = await _hydrate_stdio_env(
+                subagent.config.mcp_servers, role=input.role
+            )
+    except AgentSandboxValidationError as e:
+        classification = invalid_agent_configuration(e)
+        return AgentExecutorResult(
+            success=False,
+            error=classification.message,
+            classification=classification,
+            terminal_stream_error_emitted=False,
         )
 
     timeout_seconds = clamp_agent_timeout_seconds(input.timeout_seconds)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -41,6 +41,11 @@ from tracecat.agent.common.types import (
     is_stdio_mcp_server,
     requires_sandbox_internet_access,
 )
+from tracecat.agent.error_policy import (
+    agent_executor_protocol_failed,
+    agent_executor_timed_out,
+    agent_executor_unavailable,
+)
 from tracecat.agent.executor.loopback import (
     LoopbackHandler,
     LoopbackInput,
@@ -72,6 +77,7 @@ from tracecat.agent.runtime.session_paths import build_agent_sandbox_path_mappin
 from tracecat.agent.runtime_services import get_claude_runtime_broker
 from tracecat.agent.sandbox.llm_proxy import (
     LLM_SOCKET_NAME,
+    LLMProxyError,
     LLMRoute,
     LLMRoutingPlan,
     LLMSocketProxy,
@@ -94,6 +100,7 @@ from tracecat.integrations.mcp_validation import MCPSecretResolutionError
 from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import RuntimeErrorClassification
 from tracecat.settings.service import SettingsService
 from tracecat.storage import blob
 
@@ -191,6 +198,9 @@ class AgentExecutorResult(BaseModel):
 
     success: bool
     error: str | None = None
+    # Typed terminal attribution produced by the trusted executor boundary.
+    # None keeps activity results recorded before this field replayable.
+    classification: RuntimeErrorClassification | None = None
     # None means a legacy activity result did not carry this field. The
     # workflow treats unknown failed results as already terminal-emitted so old
     # histories keep their original command shape.
@@ -296,7 +306,7 @@ class SandboxedAgentExecutor:
     _otel_receiver: OtelSocketReceiver | None = field(
         default=None, init=False, repr=False
     )
-    _fatal_error: str | None = field(default=None, init=False, repr=False)
+    _fatal_error: LLMProxyError | None = field(default=None, init=False, repr=False)
     _fatal_error_event: asyncio.Event = field(
         default_factory=asyncio.Event, init=False, repr=False
     )
@@ -319,8 +329,8 @@ class SandboxedAgentExecutor:
     async def _create_llm_socket_proxy(self, socket_path: Path) -> LLMSocketProxy:
         """Create the host-side LiteLLM transport proxy for this execution."""
 
-        def on_error(error_msg: str) -> None:
-            self._fatal_error = error_msg
+        def on_error(error: LLMProxyError) -> None:
+            self._fatal_error = error
             self._fatal_error_event.set()
 
         routing_plan = self._llm_routing_plan()
@@ -588,9 +598,11 @@ class SandboxedAgentExecutor:
         except AgentSandboxExecutionError as e:
             logger.error("Agent sandbox execution failed", error=str(e))
             result.error = str(e)
+            result.classification = agent_executor_unavailable(e)
         except Exception as e:
             logger.exception("Unexpected error in agent executor", error=str(e))
             result.error = f"Unexpected error: {e}"
+            result.classification = agent_executor_unavailable(e)
         finally:
             await self._cleanup()
 
@@ -658,6 +670,7 @@ class SandboxedAgentExecutor:
         """Copy loopback result fields into the activity result."""
         result.success = loopback_result.success
         result.error = loopback_result.error
+        result.classification = loopback_result.classification
         result.approval_requested = loopback_result.approval_requested
         result.approval_items = loopback_result.approval_items or None
         result.terminal_stream_error_emitted = (
@@ -730,12 +743,15 @@ class SandboxedAgentExecutor:
             otel_socket_path=otel_socket_path,
         )
 
-        async def wait_fatal_error() -> str:
+        async def wait_fatal_error() -> LLMProxyError:
             await self._fatal_error_event.wait()
-            return self._fatal_error or "Unknown LLM error"
+            return self._fatal_error or LLMProxyError(
+                message="Unknown LLM error",
+                classification=agent_executor_protocol_failed(),
+            )
 
         broker_task: asyncio.Task[None] | None = None
-        fatal_error_task: asyncio.Task[str] | None = None
+        fatal_error_task: asyncio.Task[LLMProxyError] | None = None
         cancel_signal_task: asyncio.Task[None] | None = None
         try:
             async with broker.session_turn_lease(str(self.input.session_id)):
@@ -774,10 +790,11 @@ class SandboxedAgentExecutor:
                         continue
 
                     if fatal_error_task in done:
-                        error_msg = fatal_error_task.result()
-                        result.error = error_msg
+                        proxy_error = fatal_error_task.result()
+                        result.error = proxy_error.message
+                        result.classification = proxy_error.classification
                         result.terminal_stream_error_emitted = (
-                            await handler.emit_terminal_error(error_msg)
+                            await handler.emit_terminal_error(proxy_error.message)
                         )
                         await broker.cancel_turn(str(self.input.session_id))
                         await _cancel_task_with_timeout(
@@ -814,6 +831,7 @@ class SandboxedAgentExecutor:
                     result.error = (
                         f"Agent execution timed out after {self.timeout_seconds}s"
                     )
+                    result.classification = agent_executor_timed_out()
                     result.terminal_stream_error_emitted = (
                         await handler.emit_terminal_error(result.error)
                     )
@@ -825,6 +843,7 @@ class SandboxedAgentExecutor:
                     broker_task = None
         except Exception as e:
             result.error = str(e)
+            result.classification = agent_executor_unavailable(e)
             result.terminal_stream_error_emitted = await handler.emit_terminal_error(
                 result.error
             )

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -99,6 +99,8 @@ class ClaudeSessionLine(TypedDict):
 
 type SinkOperation = Callable[[LoopbackEventSink], Awaitable[None]]
 
+TERMINAL_STREAM_ERROR_TIMEOUT_SECONDS = 5.0
+
 
 @dataclass(kw_only=True, slots=True)
 class LoopbackInput:
@@ -404,6 +406,23 @@ class LoopbackHandler:
         await self._close_external_stream()
         self._result.terminal_stream_error_emitted = True
 
+    async def _emit_terminal_stream_error_best_effort(
+        self,
+        stream_sink: LoopbackEventSink,
+        error: str,
+    ) -> None:
+        """Bound terminal stream delivery on failure paths."""
+        try:
+            await asyncio.wait_for(
+                self._emit_terminal_stream_error(stream_sink, error),
+                timeout=TERMINAL_STREAM_ERROR_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Timeout emitting stream error",
+                session_id=self.input.session_id,
+            )
+
     def mark_cancelled(self, reason: str) -> None:
         """Record that the active runtime turn is expected to stop early.
 
@@ -545,7 +564,7 @@ class LoopbackHandler:
             self._result.error = "Runtime sent an invalid event envelope"
             self._result.classification = agent_executor_protocol_failed(e)
             if self._stream_sink:
-                await self._emit_terminal_stream_error(
+                await self._emit_terminal_stream_error_best_effort(
                     self._stream_sink,
                     self._result.error,
                 )
@@ -554,16 +573,10 @@ class LoopbackHandler:
             self._result.error = f"Connection error: {e}"
             self._result.classification = agent_executor_unavailable(e)
             if self._stream_sink:
-                try:
-                    await asyncio.wait_for(
-                        self._emit_terminal_stream_error(
-                            self._stream_sink,
-                            self._result.error,
-                        ),
-                        timeout=5.0,
-                    )
-                except TimeoutError:
-                    logger.warning("Timeout emitting stream error")
+                await self._emit_terminal_stream_error_best_effort(
+                    self._stream_sink,
+                    self._result.error,
+                )
         finally:
             # External channels finish with the runtime. The durable workflow
             # owns Redis completion after approval persistence or finalization.

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -481,16 +481,26 @@ class LoopbackHandler:
         """Emit a terminal error through the resolved stream sink.
 
         This is used by executor-level crash/timeout paths that happen outside
-        normal loopback event processing.
+        normal loopback event processing. Bound the entire best-effort operation,
+        including sink initialization, so a stalled stream cannot replace the
+        executor's authoritative failure with an activity timeout.
         """
         try:
-            if self._stream_sink is None:
-                self._stream_sink = await self._initialize_stream_sink()
-            await self._emit_terminal_stream_error(self._stream_sink, error)
-            return self._result.terminal_stream_error_emitted
-        except Exception:
+            async with asyncio.timeout(TERMINAL_STREAM_ERROR_TIMEOUT_SECONDS):
+                if self._stream_sink is None:
+                    self._stream_sink = await self._initialize_stream_sink()
+                await self._emit_terminal_stream_error(self._stream_sink, error)
+                return self._result.terminal_stream_error_emitted
+        except TimeoutError:
+            logger.warning(
+                "Timeout emitting terminal stream error",
+                session_id=self.input.session_id,
+            )
+            return False
+        except Exception as e:
             logger.warning(
                 "Failed to emit terminal stream error",
+                error_type=type(e).__name__,
                 session_id=self.input.session_id,
             )
             return False

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -37,6 +37,11 @@ from tracecat.agent.common.stream_types import (
     ToolCallContent,
     UnifiedStreamEvent,
 )
+from tracecat.agent.error_policy import (
+    agent_executor_protocol_failed,
+    agent_executor_unavailable,
+    user_agent_execution_failed,
+)
 from tracecat.agent.session.history import prepare_session_history
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
@@ -60,6 +65,7 @@ from tracecat.db.models import (
 )
 from tracecat.exceptions import TracecatValidationError
 from tracecat.logger import logger
+from tracecat.runtime.errors import RuntimeErrorClassification
 
 type JsonScalar = str | int | float | bool | None
 type JsonValue = JsonScalar | list[JsonValue] | dict[str, JsonValue]
@@ -107,6 +113,7 @@ class LoopbackResult:
 
     success: bool
     error: str | None = None
+    classification: RuntimeErrorClassification | None = None
     terminal_stream_error_emitted: bool = False
     approval_requested: bool = False
     approval_items: list[ToolCallContent] = field(default_factory=list)
@@ -518,16 +525,25 @@ class LoopbackHandler:
         except asyncio.IncompleteReadError:
             logger.warning("Runtime disconnected unexpectedly during execution")
             self._result.error = "Runtime disconnected unexpectedly"
+            self._result.classification = agent_executor_unavailable()
             if self._stream_sink:
-                await self._emit_failed_compaction_if_pending()
-                await self._stream_sink.error(self._result.error)
+                await self._emit_terminal_stream_error(
+                    self._stream_sink,
+                    self._result.error,
+                )
         except Exception as e:
             logger.exception("Error handling runtime connection", error=str(e))
             self._result.error = f"Connection error: {e}"
+            self._result.classification = agent_executor_unavailable(e)
             if self._stream_sink:
                 try:
-                    await self._emit_failed_compaction_if_pending()
-                    await asyncio.wait_for(self._stream_sink.error(str(e)), timeout=5.0)
+                    await asyncio.wait_for(
+                        self._emit_terminal_stream_error(
+                            self._stream_sink,
+                            self._result.error,
+                        ),
+                        timeout=5.0,
+                    )
                 except TimeoutError:
                     logger.warning("Timeout emitting stream error")
         finally:
@@ -551,9 +567,12 @@ class LoopbackHandler:
                     "Runtime connection closed unexpectedly during execution"
                 )
                 self._result.error = "Runtime disconnected during execution"
+                self._result.classification = agent_executor_unavailable()
                 if self._stream_sink is not None:
-                    await self._emit_failed_compaction_if_pending()
-                    await self._stream_sink.error(self._result.error)
+                    await self._emit_terminal_stream_error(
+                        self._stream_sink,
+                        self._result.error,
+                    )
                 break
 
             envelope = _runtime_envelope_from_json(payload_bytes)
@@ -703,6 +722,9 @@ class LoopbackHandler:
         )
         await self._emit_terminal_stream_error(stream_sink, error_msg)
         self._result.error = error_msg
+        # Runtime-originated free-form errors are caller-owned by contract.
+        # Trusted host proxy and transport faults are classified before this boundary.
+        self._result.classification = user_agent_execution_failed()
         return True
 
     def _track_tool_event(self, event: UnifiedStreamEvent) -> None:
@@ -841,6 +863,8 @@ class LoopbackHandler:
         logger.error("Runtime error", error=error)
         await self._emit_terminal_stream_error(stream_sink, error)
         self._result.error = error
+        # See the stream-envelope branch above for this trust-boundary invariant.
+        self._result.classification = user_agent_execution_failed()
         return True
 
     async def send_error(self, error: str) -> None:
@@ -862,6 +886,7 @@ class LoopbackHandler:
         if validation_error := self._validate_runtime_completion():
             await self._emit_terminal_stream_error(stream_sink, validation_error)
             self._result.error = validation_error
+            self._result.classification = agent_executor_protocol_failed()
             return True
         self._result.success = True
         await self._emit_interrupt_notice_if_cancelled(stream_sink)

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -259,20 +259,20 @@ def _runtime_envelope_from_json(payload: bytes) -> RuntimeEventEnvelope:
         decoded = orjson.loads(payload)
         if not isinstance(decoded, dict):
             raise ValueError("Runtime event payload must be a JSON object")
-        envelope = RuntimeEventEnvelope.from_dict(cast(dict[str, Any], decoded))
-        if envelope.type == "session_line" and envelope.session_line is not None:
-            _session_line_from_json(envelope.session_line)
-        return envelope
+        return RuntimeEventEnvelope.from_dict(cast(dict[str, Any], decoded))
     except (orjson.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
         raise RuntimeEnvelopeProtocolError from exc
 
 
 def _session_line_from_json(session_line: str) -> ClaudeSessionLine:
     """Decode and validate the outer shape of a Claude Code JSONL line."""
-    decoded = orjson.loads(session_line)
-    if not isinstance(decoded, dict):
-        raise ValueError("Claude session line must be a JSON object")
-    return cast(ClaudeSessionLine, decoded)
+    try:
+        decoded = orjson.loads(session_line)
+        if not isinstance(decoded, dict):
+            raise ValueError("Claude session line must be a JSON object")
+        return cast(ClaudeSessionLine, decoded)
+    except (orjson.JSONDecodeError, ValueError) as exc:
+        raise RuntimeEnvelopeProtocolError from exc
 
 
 class LoopbackHandler:
@@ -613,7 +613,10 @@ class LoopbackHandler:
                 pass
 
             case "session_line":
-                if envelope.session_line and envelope.sdk_session_id:
+                if (
+                    envelope.session_line is not None
+                    and envelope.sdk_session_id is not None
+                ):
                     await self.send_session_line(
                         envelope.sdk_session_id,
                         envelope.session_line,

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -592,6 +592,8 @@ class LoopbackHandler:
                         self._result.error,
                     )
                 break
+            except (RuntimeError, ValueError) as e:
+                raise RuntimeEnvelopeProtocolError from e
 
             envelope = _runtime_envelope_from_json(payload_bytes)
             if await self.process_envelope(envelope):

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -76,6 +76,10 @@ type SessionLineKind = Literal["chat-message", "internal", "compaction"]
 type CompactionPhase = Literal["started", "completed", "failed"]
 
 
+class RuntimeEnvelopeProtocolError(ValueError):
+    """The sandbox runtime sent an event that violates the socket protocol."""
+
+
 class ClaudeSessionMessage(TypedDict):
     """Message payload embedded in a Claude Code JSONL session line."""
 
@@ -252,10 +256,13 @@ class FanoutStreamSink:
 
 def _runtime_envelope_from_json(payload: bytes) -> RuntimeEventEnvelope:
     """Decode a socket payload into a typed runtime event envelope."""
-    decoded = orjson.loads(payload)
-    if not isinstance(decoded, dict):
-        raise ValueError("Runtime event payload must be a JSON object")
-    return RuntimeEventEnvelope.from_dict(cast(dict[str, Any], decoded))
+    try:
+        decoded = orjson.loads(payload)
+        if not isinstance(decoded, dict):
+            raise ValueError("Runtime event payload must be a JSON object")
+        return RuntimeEventEnvelope.from_dict(cast(dict[str, Any], decoded))
+    except (orjson.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise RuntimeEnvelopeProtocolError from exc
 
 
 def _session_line_from_json(session_line: str) -> ClaudeSessionLine:
@@ -526,6 +533,15 @@ class LoopbackHandler:
             logger.warning("Runtime disconnected unexpectedly during execution")
             self._result.error = "Runtime disconnected unexpectedly"
             self._result.classification = agent_executor_unavailable()
+            if self._stream_sink:
+                await self._emit_terminal_stream_error(
+                    self._stream_sink,
+                    self._result.error,
+                )
+        except RuntimeEnvelopeProtocolError as e:
+            logger.warning("Runtime sent an invalid event envelope")
+            self._result.error = "Runtime sent an invalid event envelope"
+            self._result.classification = agent_executor_protocol_failed(e)
             if self._stream_sink:
                 await self._emit_terminal_stream_error(
                     self._stream_sink,

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -259,7 +259,10 @@ def _runtime_envelope_from_json(payload: bytes) -> RuntimeEventEnvelope:
         decoded = orjson.loads(payload)
         if not isinstance(decoded, dict):
             raise ValueError("Runtime event payload must be a JSON object")
-        return RuntimeEventEnvelope.from_dict(cast(dict[str, Any], decoded))
+        envelope = RuntimeEventEnvelope.from_dict(cast(dict[str, Any], decoded))
+        if envelope.type == "session_line" and envelope.session_line is not None:
+            _session_line_from_json(envelope.session_line)
+        return envelope
     except (orjson.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
         raise RuntimeEnvelopeProtocolError from exc
 

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -422,6 +422,12 @@ class LoopbackHandler:
                 "Timeout emitting stream error",
                 session_id=self.input.session_id,
             )
+        except Exception as e:
+            logger.warning(
+                "Failed to emit stream error",
+                error_type=type(e).__name__,
+                session_id=self.input.session_id,
+            )
 
     def mark_cancelled(self, reason: str) -> None:
         """Record that the active runtime turn is expected to stop early.

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -40,7 +40,6 @@ from tracecat.agent.common.stream_types import (
 from tracecat.agent.error_policy import (
     agent_executor_protocol_failed,
     agent_executor_unavailable,
-    user_agent_execution_failed,
 )
 from tracecat.agent.session.history import prepare_session_history
 from tracecat.agent.session.service import AgentSessionService
@@ -738,9 +737,11 @@ class LoopbackHandler:
         )
         await self._emit_terminal_stream_error(stream_sink, error_msg)
         self._result.error = error_msg
-        # Runtime-originated free-form errors are caller-owned by contract.
-        # Trusted host proxy and transport faults are classified before this boundary.
-        self._result.classification = user_agent_execution_failed()
+        # The runtime error event carries no trusted ownership metadata. Known
+        # route/status failures are classified by the host-side LLM proxy before
+        # they reach this fallback, so do not blame the caller for an untyped
+        # runtime or provider failure.
+        self._result.classification = agent_executor_unavailable()
         return True
 
     def _track_tool_event(self, event: UnifiedStreamEvent) -> None:
@@ -879,8 +880,9 @@ class LoopbackHandler:
         logger.error("Runtime error", error=error)
         await self._emit_terminal_stream_error(stream_sink, error)
         self._result.error = error
-        # See the stream-envelope branch above for this trust-boundary invariant.
-        self._result.classification = user_agent_execution_failed()
+        # Top-level runtime errors are emitted by the runtime's unexpected-error
+        # boundary and carry no trusted ownership metadata.
+        self._result.classification = agent_executor_unavailable()
         return True
 
     async def send_error(self, error: str) -> None:

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -19,6 +19,7 @@ from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentCatalog
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.temporal.errors import raise_application_error_from_classification
 
 
@@ -65,14 +66,17 @@ class ResolveAgentsConfigActivityInput(BaseModel):
 async def resolve_agent_preset_config_activity(
     args: ResolveAgentPresetConfigActivityInput,
 ) -> AgentConfigPayload:
-    async with AgentManagementService.with_session(role=args.role) as service:
-        async with service.with_preset_config(
-            preset_id=args.preset_id,
-            slug=args.preset_slug,
-            preset_version_id=args.preset_version_id,
-            preset_version=args.preset_version,
-        ) as config:
-            return agent_config_to_payload(config)
+    try:
+        async with AgentManagementService.with_session(role=args.role) as service:
+            async with service.with_preset_config(
+                preset_id=args.preset_id,
+                slug=args.preset_slug,
+                preset_version_id=args.preset_version_id,
+                preset_version=args.preset_version,
+            ) as config:
+                return agent_config_to_payload(config)
+    except (TracecatNotFoundError, TracecatValidationError) as exc:
+        raise_application_error_from_classification(invalid_agent_configuration(exc))
 
 
 @activity.defn

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -6,8 +6,8 @@ import sqlalchemy as sa
 from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import select
 from temporalio import activity
-from temporalio.exceptions import ApplicationError
 
+from tracecat.agent.error_policy import invalid_agent_configuration
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
     resolve_agents_config,
@@ -19,6 +19,7 @@ from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentCatalog
+from tracecat.temporal.errors import raise_application_error_from_classification
 
 
 class ResolveAgentPresetConfigActivityInput(BaseModel):
@@ -149,7 +150,7 @@ async def resolve_custom_model_provider_config_activity(
 
     if creds is None:
         activity.logger.error("Custom model provider credentials not found")
-        raise ApplicationError("Invalid custom model provider credentials")
+        raise_application_error_from_classification(invalid_agent_configuration())
     if not (base_url := creds.get("CUSTOM_MODEL_PROVIDER_BASE_URL")):
         activity.logger.error(
             "Custom model provider base URL missing",
@@ -160,7 +161,7 @@ async def resolve_custom_model_provider_config_activity(
                 "has_api_key": bool(creds.get("CUSTOM_MODEL_PROVIDER_API_KEY")),
             },
         )
-        raise ApplicationError("Custom model provider base URL is required")
+        raise_application_error_from_classification(invalid_agent_configuration())
     passthrough = creds.get("CUSTOM_MODEL_PROVIDER_PASSTHROUGH", "").lower() in {
         "1",
         "true",

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 from sqlalchemy import select
 from temporalio import activity
 
-from tracecat.agent.error_policy import invalid_agent_configuration
+from tracecat.agent.error_policy import (
+    agent_preparation_failed,
+    invalid_agent_configuration,
+)
 from tracecat.agent.preset.resolver import (
     ResolvedAgentsRuntimeConfig,
     resolve_agents_config,
@@ -19,7 +22,11 @@ from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentCatalog
-from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.temporal.errors import raise_application_error_from_classification
 
 
@@ -112,6 +119,10 @@ async def resolve_agents_config_activity(
                 follow_latest_versions=follow_latest_versions,
             )
             return resolved.to_runtime_config()
+    except ValidationError as exc:
+        raise_application_error_from_classification(
+            agent_preparation_failed(exc, retryable=False)
+        )
     except (TracecatNotFoundError, TracecatValidationError) as exc:
         raise_application_error_from_classification(invalid_agent_configuration(exc))
 
@@ -150,10 +161,15 @@ async def resolve_custom_model_provider_config_activity(
 
     role = role if isinstance(role, Role) else Role.model_validate(role)
     async with AgentManagementService.with_session(role) as svc:
-        creds = await _load_custom_model_provider_creds(
-            svc,
-            catalog_id=catalog_id,
-        )
+        try:
+            creds = await _load_custom_model_provider_creds(
+                svc,
+                catalog_id=catalog_id,
+            )
+        except TracecatAuthorizationError as exc:
+            raise_application_error_from_classification(
+                invalid_agent_configuration(exc)
+            )
 
     if creds is None:
         activity.logger.error("Custom model provider credentials not found")

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -98,19 +98,22 @@ async def resolve_agent_preset_version_ref_activity(
 async def resolve_agents_config_activity(
     args: ResolveAgentsConfigActivityInput,
 ) -> ResolvedAgentsRuntimeConfig:
-    async with AgentPresetService.with_session(role=args.role) as service:
-        follow_latest_versions = args.follow_latest_versions
-        if follow_latest_versions is None:
-            follow_latest_versions = await service.use_latest_resource_versions()
-        resolved = await resolve_agents_config(
-            service,
-            agents=args.agents,
-            parent_preset_id=args.parent_preset_id,
-            parent_slug=args.parent_slug,
-            include_runtime_config=True,
-            follow_latest_versions=follow_latest_versions,
-        )
-        return resolved.to_runtime_config()
+    try:
+        async with AgentPresetService.with_session(role=args.role) as service:
+            follow_latest_versions = args.follow_latest_versions
+            if follow_latest_versions is None:
+                follow_latest_versions = await service.use_latest_resource_versions()
+            resolved = await resolve_agents_config(
+                service,
+                agents=args.agents,
+                parent_preset_id=args.parent_preset_id,
+                parent_slug=args.parent_slug,
+                include_runtime_config=True,
+                follow_latest_versions=follow_latest_versions,
+            )
+            return resolved.to_runtime_config()
+    except (TracecatNotFoundError, TracecatValidationError) as exc:
+        raise_application_error_from_classification(invalid_agent_configuration(exc))
 
 
 class CustomModelProviderConfigResult(BaseModel):

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -126,6 +126,10 @@ def _http_error_classification(
     *,
     route_is_direct: bool,
 ) -> RuntimeErrorClassification:
+    if status_code == 429:
+        if route_is_direct:
+            return user_agent_execution_failed(retryable=True)
+        return agent_executor_unavailable()
     if route_is_direct:
         return user_agent_execution_failed()
     if status_code in {408, 504}:

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -24,10 +24,17 @@ import orjson
 from fastapi import HTTPException
 
 from tracecat import config as app_config
+from tracecat.agent.error_policy import (
+    agent_executor_protocol_failed,
+    agent_executor_timed_out,
+    agent_executor_unavailable,
+    user_agent_execution_failed,
+)
 from tracecat.agent.observability import get_load_tracker
 from tracecat.agent.service import AgentManagementService
 from tracecat.auth.types import Role
 from tracecat.logger import logger
+from tracecat.runtime.errors import RuntimeErrorClassification
 
 # Strip a trailing "/vN" segment (with optional trailing slash) from a
 # passthrough upstream URL. The contract for stored ``base_url`` is the
@@ -104,6 +111,22 @@ class ParsedRequest(TypedDict):
     path: str
     headers: dict[str, str]
     body: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class LLMProxyError:
+    """One terminal proxy error with source-owned runtime attribution."""
+
+    message: str
+    classification: RuntimeErrorClassification
+
+
+def _http_error_classification(status_code: int) -> RuntimeErrorClassification:
+    if status_code in {408, 504}:
+        return agent_executor_timed_out()
+    if status_code >= 500:
+        return agent_executor_unavailable()
+    return user_agent_execution_failed()
 
 
 @dataclass(frozen=True, slots=True)
@@ -544,7 +567,7 @@ class LLMSocketProxy:
         self,
         socket_path: Path,
         routing_plan: LLMRoutingPlan,
-        on_error: Callable[[str], None] | None = None,
+        on_error: Callable[[LLMProxyError], None] | None = None,
     ):
         """Initialize the LLM socket proxy.
 
@@ -629,13 +652,22 @@ class LLMSocketProxy:
         async for chunk in chunks:
             yield chunk
 
-    def _emit_error(self, message: str) -> None:
+    def _emit_error(
+        self,
+        message: str,
+        classification: RuntimeErrorClassification,
+    ) -> None:
         """Emit error via callback (only once)."""
         if not self._error_emitted:
             self._error_emitted = True
             logger.error("LLM proxy error", error=message, **_load_fields())
             if self._on_error:
-                self._on_error(message)
+                self._on_error(
+                    LLMProxyError(
+                        message=message,
+                        classification=classification,
+                    )
+                )
 
     @staticmethod
     def _is_client_disconnect_error(exc: Exception) -> bool:
@@ -682,7 +714,10 @@ class LLMSocketProxy:
                 logger.debug("Proxy error during shutdown (ignored)", error=str(e))
             else:
                 logger.exception("LLM proxy error", error=str(e))
-                self._emit_error(f"Proxy error: {e}")
+                self._emit_error(
+                    f"Proxy error: {e}",
+                    agent_executor_protocol_failed(e),
+                )
         finally:
             _proxy_load_tracker.end_connection()
             try:
@@ -709,12 +744,18 @@ class LLMSocketProxy:
             request_line_str = request_line.decode("utf-8").strip()
             parts = request_line_str.split(" ", 2)
             if len(parts) < 2:
-                self._emit_error("Malformed request line")
+                self._emit_error(
+                    "Malformed request line",
+                    agent_executor_protocol_failed(),
+                )
                 return None
             method = parts[0]
             path = parts[1]
         except (UnicodeDecodeError, ValueError):
-            self._emit_error("Invalid request encoding")
+            self._emit_error(
+                "Invalid request encoding",
+                agent_executor_protocol_failed(),
+            )
             return None
 
         # Read headers
@@ -743,7 +784,7 @@ class LLMSocketProxy:
                 content_length=content_length,
                 max_size=MAX_BODY_SIZE,
             )
-            self._emit_error("Request body too large")
+            self._emit_error("Request body too large", user_agent_execution_failed())
             return None
 
         # Read body if present
@@ -824,7 +865,10 @@ class LLMSocketProxy:
                 request_counter=request_counter,
                 trace_request_id=trace_request_id,
             )
-            self._emit_error("LiteLLM proxy not initialized")
+            self._emit_error(
+                "LiteLLM proxy not initialized",
+                agent_executor_unavailable(),
+            )
             return
 
         path = request["path"]
@@ -867,7 +911,8 @@ class LLMSocketProxy:
                             reason_phrase=response.reason_phrase,
                             body=error_body,
                             trace_request_id=trace_request_id,
-                        )
+                        ),
+                        _http_error_classification(response.status_code),
                     )
                     body_chunks = [error_body]
                 else:
@@ -894,7 +939,10 @@ class LLMSocketProxy:
                 trace_request_id=trace_request_id,
             )
             if not _is_non_critical_path(path):
-                self._emit_error(f"LiteLLM unavailable: {exc}")
+                self._emit_error(
+                    f"LiteLLM unavailable: {exc}",
+                    agent_executor_unavailable(exc),
+                )
         except httpx.TimeoutException as exc:
             await self._write_error_response(
                 writer,
@@ -904,7 +952,10 @@ class LLMSocketProxy:
                 trace_request_id=trace_request_id,
             )
             if not _is_non_critical_path(path):
-                self._emit_error(f"Gateway timeout ({type(exc).__name__}): {exc}")
+                self._emit_error(
+                    f"Gateway timeout ({type(exc).__name__}): {exc}",
+                    agent_executor_timed_out(exc),
+                )
 
     async def _write_response(
         self,
@@ -1007,7 +1058,10 @@ class LLMSocketProxy:
                     trace_request_id=trace_request_id,
                 )
                 if path is not None and not _is_non_critical_path(path):
-                    self._emit_error(surfaced_error)
+                    self._emit_error(
+                        surfaced_error,
+                        _http_error_classification(status_code),
+                    )
                 error_payload = orjson.dumps(
                     {
                         "type": "error",

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -24,6 +24,7 @@ import orjson
 from fastapi import HTTPException
 
 from tracecat import config as app_config
+from tracecat.agent.common.exceptions import AgentSandboxValidationError
 from tracecat.agent.error_policy import (
     agent_executor_protocol_failed,
     agent_executor_timed_out,
@@ -33,6 +34,7 @@ from tracecat.agent.error_policy import (
 from tracecat.agent.observability import get_load_tracker
 from tracecat.agent.service import AgentManagementService
 from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.logger import logger
 from tracecat.runtime.errors import RuntimeErrorClassification
 
@@ -228,7 +230,12 @@ class LLMRoute:
         if not self.is_direct:
             return None
         if self.catalog_id is not None:
-            creds = await svc.get_catalog_credentials(self.catalog_id)
+            try:
+                creds = await svc.get_catalog_credentials(self.catalog_id)
+            except TracecatAuthorizationError as exc:
+                raise AgentSandboxValidationError(
+                    "Custom model provider is not available for this workspace."
+                ) from exc
         else:
             creds = await svc.get_runtime_provider_credentials(
                 "custom-model-provider",

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -139,6 +139,19 @@ def _http_error_classification(
     return user_agent_execution_failed()
 
 
+def _transport_error_classification(
+    error: httpx.TransportError,
+    *,
+    route_is_direct: bool,
+    timed_out: bool,
+) -> RuntimeErrorClassification:
+    if route_is_direct:
+        return user_agent_execution_failed(error, retryable=True)
+    if timed_out:
+        return agent_executor_timed_out(error)
+    return agent_executor_unavailable(error)
+
+
 @dataclass(frozen=True, slots=True)
 class LLMForwardRequest:
     """Prepared upstream request after route-specific handling.
@@ -955,7 +968,11 @@ class LLMSocketProxy:
             if not _is_non_critical_path(path):
                 self._emit_error(
                     f"LiteLLM unavailable: {exc}",
-                    agent_executor_unavailable(exc),
+                    _transport_error_classification(
+                        exc,
+                        route_is_direct=route.is_direct,
+                        timed_out=False,
+                    ),
                 )
         except httpx.TimeoutException as exc:
             await self._write_error_response(
@@ -968,7 +985,11 @@ class LLMSocketProxy:
             if not _is_non_critical_path(path):
                 self._emit_error(
                     f"Gateway timeout ({type(exc).__name__}): {exc}",
-                    agent_executor_timed_out(exc),
+                    _transport_error_classification(
+                        exc,
+                        route_is_direct=route.is_direct,
+                        timed_out=True,
+                    ),
                 )
 
     async def _write_response(

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -132,6 +132,8 @@ def _http_error_classification(
         if route_is_direct:
             return user_agent_execution_failed(retryable=True)
         return agent_executor_unavailable()
+    if status_code == 401 and not route_is_direct:
+        return agent_executor_unavailable()
     if route_is_direct:
         return user_agent_execution_failed()
     if status_code in {408, 504}:

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -1094,12 +1094,21 @@ class LLMSocketProxy:
                     trace_request_id=trace_request_id,
                 )
                 if path is not None and not _is_non_critical_path(path):
-                    self._emit_error(
-                        surfaced_error,
-                        _http_error_classification(
+                    classification = (
+                        _transport_error_classification(
+                            exc,
+                            route_is_direct=route_is_direct,
+                            timed_out=isinstance(exc, httpx.TimeoutException),
+                        )
+                        if isinstance(exc, httpx.TransportError)
+                        else _http_error_classification(
                             status_code,
                             route_is_direct=route_is_direct,
-                        ),
+                        )
+                    )
+                    self._emit_error(
+                        surfaced_error,
+                        classification,
                     )
                 error_payload = orjson.dumps(
                     {

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -1115,6 +1115,23 @@ class LLMSocketProxy:
                     logger.debug(
                         "Failed to send SSE error event, client likely disconnected"
                     )
+            elif isinstance(exc, httpx.TransportError):
+                status_code = 504 if isinstance(exc, httpx.TimeoutException) else 502
+                logger.warning(
+                    "Response body transport error after headers sent",
+                    status_code=status_code,
+                    error_type=type(exc).__name__,
+                    trace_request_id=trace_request_id,
+                )
+                if path is not None and not _is_non_critical_path(path):
+                    self._emit_error(
+                        f"LiteLLM response failed: {str(exc)[:512]}",
+                        _transport_error_classification(
+                            exc,
+                            route_is_direct=route_is_direct,
+                            timed_out=isinstance(exc, httpx.TimeoutException),
+                        ),
+                    )
             else:
                 raise
 

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -121,7 +121,13 @@ class LLMProxyError:
     classification: RuntimeErrorClassification
 
 
-def _http_error_classification(status_code: int) -> RuntimeErrorClassification:
+def _http_error_classification(
+    status_code: int,
+    *,
+    route_is_direct: bool,
+) -> RuntimeErrorClassification:
+    if route_is_direct:
+        return user_agent_execution_failed()
     if status_code in {408, 504}:
         return agent_executor_timed_out()
     if status_code >= 500:
@@ -912,7 +918,10 @@ class LLMSocketProxy:
                             body=error_body,
                             trace_request_id=trace_request_id,
                         ),
-                        _http_error_classification(response.status_code),
+                        _http_error_classification(
+                            response.status_code,
+                            route_is_direct=route.is_direct,
+                        ),
                     )
                     body_chunks = [error_body]
                 else:
@@ -929,6 +938,7 @@ class LLMSocketProxy:
                     request_counter=request_counter,
                     method=method,
                     path=path,
+                    route_is_direct=route.is_direct,
                 )
         except httpx.ConnectError as exc:
             await self._write_error_response(
@@ -970,6 +980,7 @@ class LLMSocketProxy:
         request_counter: int | None = None,
         method: str | None = None,
         path: str | None = None,
+        route_is_direct: bool = False,
     ) -> None:
         """Write an HTTP response head and stream the response body."""
         content_type = next(
@@ -1060,7 +1071,10 @@ class LLMSocketProxy:
                 if path is not None and not _is_non_critical_path(path):
                     self._emit_error(
                         surfaced_error,
-                        _http_error_classification(status_code),
+                        _http_error_classification(
+                            status_code,
+                            route_is_direct=route_is_direct,
+                        ),
                     )
                 error_payload = orjson.dumps(
                     {

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -135,7 +135,7 @@ def _http_error_classification(
     if status_code == 401 and not route_is_direct:
         return agent_executor_unavailable()
     if route_is_direct:
-        return user_agent_execution_failed()
+        return user_agent_execution_failed(retryable=status_code in {408, 504})
     if status_code in {408, 504}:
         return agent_executor_timed_out()
     if status_code >= 500:

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -957,38 +957,27 @@ class LLMSocketProxy:
                     path=path,
                     route_is_direct=route.is_direct,
                 )
-        except httpx.ConnectError as exc:
+        except httpx.TransportError as exc:
+            timed_out = isinstance(exc, httpx.TimeoutException)
             await self._write_error_response(
                 writer,
-                status_code=502,
-                detail="LiteLLM unavailable",
+                status_code=504 if timed_out else 502,
+                detail="Gateway timeout" if timed_out else "LiteLLM unavailable",
                 request_counter=request_counter,
                 trace_request_id=trace_request_id,
             )
             if not _is_non_critical_path(path):
-                self._emit_error(
-                    f"LiteLLM unavailable: {exc}",
-                    _transport_error_classification(
-                        exc,
-                        route_is_direct=route.is_direct,
-                        timed_out=False,
-                    ),
+                message = (
+                    f"Gateway timeout ({type(exc).__name__}): {exc}"
+                    if timed_out
+                    else f"LiteLLM unavailable: {exc}"
                 )
-        except httpx.TimeoutException as exc:
-            await self._write_error_response(
-                writer,
-                status_code=504,
-                detail="Gateway timeout",
-                request_counter=request_counter,
-                trace_request_id=trace_request_id,
-            )
-            if not _is_non_critical_path(path):
                 self._emit_error(
-                    f"Gateway timeout ({type(exc).__name__}): {exc}",
+                    message,
                     _transport_error_classification(
                         exc,
                         route_is_direct=route.is_direct,
-                        timed_out=True,
+                        timed_out=timed_out,
                     ),
                 )
 

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -1056,7 +1056,10 @@ class LLMSocketProxy:
             # so the client can surface it.  This covers HTTPException from
             # the proxy layer and RuntimeError from upstream provider errors
             # (e.g. _raise_stream_http_error on 4xx/5xx).
-            if is_streaming_response and not writer.is_closing():
+            if writer.is_closing():
+                logger.debug("Client disconnected while reading response body")
+                return
+            if is_streaming_response:
                 if isinstance(exc, httpx.ReadTimeout):
                     status_code = 504
                     timeout_duration = _format_timeout_duration(

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -132,7 +132,7 @@ def _http_error_classification(
         if route_is_direct:
             return user_agent_execution_failed(retryable=True)
         return agent_executor_unavailable()
-    if status_code == 401 and not route_is_direct:
+    if status_code in {401, 403} and not route_is_direct:
         return agent_executor_unavailable()
     if route_is_direct:
         return user_agent_execution_failed(retryable=status_code in {408, 504})

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -15,6 +15,7 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.common.stream_types import HarnessType, UnifiedStreamEvent
+from tracecat.agent.error_policy import invalid_agent_configuration
 from tracecat.agent.executor.schemas import ToolExecutionResult
 from tracecat.agent.session.schemas import AgentSessionCreate
 from tracecat.agent.session.service import AgentSessionService
@@ -29,6 +30,7 @@ from tracecat.chat.schemas import ChatMessage
 from tracecat.contexts import ctx_role
 from tracecat.logger import logger
 from tracecat.storage.object import StoredObject, retrieve_stored_object
+from tracecat.temporal.errors import raise_application_error_from_classification
 
 
 class CreateSessionInput(BaseModel):
@@ -142,9 +144,8 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
             if input.require_existing:
                 agent_session = await service.get_session(input.session_id)
                 if agent_session is None:
-                    raise ApplicationError(
-                        f"Session {input.session_id} does not exist",
-                        non_retryable=True,
+                    raise_application_error_from_classification(
+                        invalid_agent_configuration()
                     )
                 created = False
             else:
@@ -196,9 +197,8 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                 if stored_agents_binding != requested_agents_binding:
                     # Non-retryable: retrying with the same mismatched input
                     # will deterministically fail; surface to the caller.
-                    raise ApplicationError(
-                        "Agent session was created with a different agents binding",
-                        non_retryable=True,
+                    raise_application_error_from_classification(
+                        invalid_agent_configuration()
                     )
                 if should_backfill_agents_binding:
                     agent_session.agents_binding = stored_agents_binding.model_dump(

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -77,6 +77,14 @@ class RuntimeErrorKind(StrEnum):
     WORKFLOW_RUNTIME_INVARIANT_VIOLATION = "workflow.runtime.invariant_violation"
     WORKFLOW_AGENT_INPUT_INVALID = "workflow.agent.input_invalid"
     WORKFLOW_AGENT_PREPARATION_FAILED = "workflow.agent.preparation_failed"
+    AGENT_CONFIGURATION_INVALID = "agent.configuration.invalid"
+    AGENT_PREPARATION_FAILED = "agent.preparation.failed"
+    AGENT_SESSION_INITIALIZATION_FAILED = "agent.session.initialization_failed"
+    AGENT_EXECUTION_FAILED = "agent.execution.failed"
+    AGENT_EXECUTOR_UNAVAILABLE = "agent.executor.unavailable"
+    AGENT_EXECUTOR_TIMED_OUT = "agent.executor.timed_out"
+    AGENT_EXECUTOR_PROTOCOL_FAILED = "agent.executor.protocol_failed"
+    AGENT_WORKFLOW_INTERNAL_ERROR = "agent.workflow.internal_error"
 
 
 class RuntimeErrorClassification(BaseModel):


### PR DESCRIPTION
## Summary

- add privacy-safe, source-owned classifications for durable agent configuration, preparation, executor, timeout, protocol, and workflow failures
- carry typed classifications through the LLM proxy, loopback, executor activity result, and `DurableAgentWorkflow` terminal boundary
- preserve cancellation, approval, handled-tool, finalization, and replay behavior while enforcing exactly-once sanitized platform reporting
- add focused leaf-error, in-memory Sentry capture, integration, and Temporal replay coverage

Implements [ENG-1755](https://linear.app/tracecat/issue/ENG-1755).

## Testing

- expanded focused unit suite: 149 passed, 1 skipped
- targeted Temporal/replay suite: 3 passed
- `tests/integration/test_agent_worker.py::TestAgentWorkerSingleTenant::test_handles_agent_error`: passed against the isolated worktree cluster
- `uv run ruff check` and `uv run ruff format --check` on all changed files
- targeted `uv run basedpyright` on all changed files: 0 errors, 0 warnings
- independent leaf-error audits found no remaining PR-blocking classification or false-Sentry gap

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 1050 | 272 |
| Tests | 1982 | 68 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Durable agent failures now use typed, privacy-safe classifications instead of forwarding raw terminal error strings to Sentry or session error reporting. Executor terminal reporting is bounded, stream-sink failures no longer replace the original failure, cancelled Slack cleanup skips terminal reactions, and empty approval requests are rejected.

- Carries source-owned classifications through the LLM proxy, loopback, executor activity, and workflow boundaries.
- Preserves user ownership for invalid configuration, managed authorization, entitlement denials, revoked routes, preset resolution, session initialization, and tool preparation failures.
- Validates runtime envelopes and nested wire events, classifying malformed frames, invalid stdio setup, and untyped failures.
- Retries rate-limited provider calls and direct provider or stream transport timeouts.
- Emits protocol errors only when a source-owned classification is available.
- Preserves handled-tool, finalization, exactly-once reporting, and legacy replay behavior for valid approval requests.

Implements [ENG-1755](https://linear.app/tracecat/issue/ENG-1755).

<sup>Written for commit a79985f313b341c7dc86f03859a05c3058b54096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

