### PR TITLE
ci: keep each pull request in one release-notes section

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,8 +12,14 @@
 #   held render at the top of the notes with no heading.
 # - The autolabeler guarantees each PR receives at least one category label
 #   derived from its conventional-commit type, so nothing renders headerless.
-# - Categories are matched in order: each PR lands in the first category that
-#   matches one of its labels.
+# - Categories are ranked, not merely listed. Release Drafter itself puts a PR
+#   under EVERY category its labels match -- its source calls that intentional
+#   -- and offers no first-match option and no per-category exclude. The
+#   `Keep each pull request in one section` step in the release-drafter
+#   workflow applies the ranking afterwards, keeping the first occurrence,
+#   which is the highest-ranked one because sections are emitted in the order
+#   declared here. Reordering this list therefore changes which section a
+#   change lands in.
 #
 # The autolabeler is deliberately more forgiving than
 # scripts/check_pr_title.py. The checker only accepts canonical types and

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -111,6 +111,19 @@ jobs:
           done
 
   draft:
+    # One draft job at a time. This job now reads the drafted body, rewrites it
+    # and PATCHes it back, so two pushes racing could have an older run
+    # overwrite a newer body and drop whatever the newer push added, until some
+    # later push happened to repair it. `cancel-in-progress: false` queues
+    # rather than cancels, and GitHub keeps only the newest pending run per
+    # group, so the last PATCH is always the newest one.
+    #
+    # Only this job. The backfill just adds labels and is idempotent, so racing
+    # it is harmless, and cancelling it would silently skip labelling a push.
+    concurrency:
+      group: release-draft-${{ github.ref }}
+      cancel-in-progress: false
+
     # Ordered after the backfill so the notes reflect labels applied this push,
     # but not gated on it. The backfill is best-effort label hygiene; the draft
     # is the release path. A transient `gh api` failure in the backfill must not

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -123,12 +123,57 @@ jobs:
       contents: write
       pull-requests: read
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
+        with:
+          python-version: "3.12"
+
       - name: Draft release
+        id: draft
         uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         with:
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Release Drafter lists a pull request under every category its labels
+      # match; its own source calls that intentional. This repo wants each
+      # change once, in the highest-ranked section that claimed it, which is
+      # what the `categories:` order in release-drafter.yml means. The action
+      # has no per-category `exclude-labels` and no first-match option, so the
+      # ranking is applied here, to the body it just wrote. Sections come out
+      # in config order, so first occurrence is highest rank.
+      - name: Keep each pull request in one section
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RELEASE_ID: ${{ steps.draft.outputs.id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_ID}" ]; then
+            echo "::warning::the draft step reported no release id, skipping"
+            exit 0
+          fi
+
+          gh api "repos/${REPO}/releases/${RELEASE_ID}" --jq .body > /tmp/body.md
+          python scripts/dedupe_release_notes.py < /tmp/body.md > /tmp/deduped.md
+
+          before=$(grep -c '^- ' /tmp/body.md || true)
+          after=$(grep -c '^- ' /tmp/deduped.md || true)
+          if [ "${before}" = "${after}" ]; then
+            echo "no duplicates across ${before} entries"
+            exit 0
+          fi
+
+          echo "removed $((before - after)) duplicate entries, ${after} remain"
+          jq -Rs '{body: .}' < /tmp/deduped.md > /tmp/payload.json
+          gh api --method PATCH "repos/${REPO}/releases/${RELEASE_ID}" \
+            --input /tmp/payload.json --silent
 
   # Same-repo PRs only: fork PRs get a read-only token, so the autolabeler
   # cannot write to them. Fork PRs are labelled by the backfill job once they

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -111,15 +111,28 @@ jobs:
           done
 
   draft:
-    # One draft job at a time. This job now reads the drafted body, rewrites it
-    # and PATCHes it back, so two pushes racing could have an older run
-    # overwrite a newer body and drop whatever the newer push added, until some
-    # later push happened to repair it. `cancel-in-progress: false` queues
-    # rather than cancels, and GitHub keeps only the newest pending run per
-    # group, so the last PATCH is always the newest one.
+    # One draft job at a time. This job reads the drafted body, rewrites it and
+    # PATCHes it back, so without a group two pushes could interleave that
+    # read/modify/write and lose whatever the other added.
     #
-    # Only this job. The backfill just adds labels and is idempotent, so racing
-    # it is harmless, and cancelling it would silently skip labelling a push.
+    # What the group guarantees is that no two PATCHes overlap. It does NOT
+    # guarantee the newest push writes last: the group is acquired after each
+    # run's own `backfill`, those run unserialized, and an older run whose
+    # backfill finishes late can therefore reach the group after a newer run
+    # has already written.
+    #
+    # That is survivable because Release Drafter regenerates the body from the
+    # merged pull requests each time it runs, so a late writer still produces
+    # current CONTENT. The one thing that can lag is the version of
+    # dedupe_release_notes.py in that run's checkout, and only until the next
+    # push to main runs the newer one. Rejecting superseded runs outright would
+    # trade that for a worse failure: if the newest run then failed, no run
+    # would update the draft at all.
+    #
+    # `cancel-in-progress: false` so pushes queue rather than cancel, since
+    # cancelling would take that run's backfill with it and silently skip
+    # labelling a push. The guard is on this job alone: the backfill only adds
+    # labels and is idempotent, so racing it is harmless.
     concurrency:
       group: release-draft-${{ github.ref }}
       cancel-in-progress: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,7 +394,9 @@ rendered release notes are normalized, by the `replacers:` block in
   absorbs vendor scopes into `integrations` so merged PRs categorize, but the
   checker rejects them.
 - At most two scopes, joined with `+`, e.g. `feat(cases+actions): add a case
-  linking action`. A change lands in the first section its labels match, so
+  linking action`. A change lands in the highest-ranked section its labels
+  match -- Release Drafter would list it in every one, and a workflow step
+  reduces that to the first -- so
   that example appears under Case management, not Core actions. Needing three
   scopes usually means the PR should be split.
 - Scopes that used to mean two different things are rejected outright: `app`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ Five distinctions cover most of the doubt:
 - `audit` is the security audit log: what a workspace records about who did what, for someone reviewing it later. `logging` is application telemetry, what an operator reads to debug Tracecat itself. Audit work renders under Security, telemetry under Observability.
 - Vendor names are not scopes. Write `feat(integrations): add Jira issue search` and name the vendor in the description, where it is readable and searchable.
 
-At most two scopes, joined with `+`, as in `feat(cases+actions): add a case linking action`. A change lands in the first section its labels match, so that example appears under Case management, not Core actions: the reader cares that case management gained something, not which package it was built from. Needing three scopes usually means the pull request should be split.
+At most two scopes, joined with `+`, as in `feat(cases+actions): add a case linking action`. A change lands in the highest-ranked section its labels match, so that example appears under Case management, not Core actions: the reader cares that case management gained something, not which package it was built from. Needing three scopes usually means the pull request should be split.
 
 ### Breaking changes and deprecations
 

--- a/scripts/dedupe_release_notes.py
+++ b/scripts/dedupe_release_notes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Keep each pull request in one release-notes section, the highest-ranked one.
+
+Release Drafter lists a pull request under *every* category whose labels it
+matches. Its own source says so:
+
+    // note that having the same label in multiple categories
+    // then it is intended to "duplicate" the pull request into each category
+
+That is not what this repo wants. A reader should meet each change once, in the
+section that best describes it, and `.github/release-drafter.yml` orders its
+categories by exactly that ranking: act-on-this first, then product areas, then
+by kind. There is no per-category `exclude-labels` in the action's schema and no
+first-match option, so the ranking has to be applied after the draft is written.
+
+Release Drafter emits sections in the order the config declares them, so the
+first occurrence of a pull request is the highest-ranked one. This keeps that
+occurrence and drops the rest, then removes any heading left with nothing under
+it.
+
+Reads a release body on stdin, writes the deduplicated body on stdout, and is a
+no-op on a body that is already clean. Runs on the standard library alone: the
+job that calls it installs nothing.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from typing import Final
+
+# A rendered change line always ends in its pull request number; that number is
+# the identity we deduplicate on, not the text, which differs between sections
+# only by accident.
+CHANGE_LINE: Final = re.compile(r"^- .*\(#(?P<number>\d+)\)\s*$")
+HEADING: Final = re.compile(r"^#{2,6} \S")
+# The changelog link ends the sections; everything from it on is a document
+# trailer rather than the content of whichever section happens to precede it.
+TRAILER: Final = re.compile(r"^\*\*Full [Cc]hangelog\*\*")
+
+
+def dedupe(body: str) -> str:
+    """Return `body` with every repeated pull request dropped after its first."""
+    seen: set[str] = set()
+    kept: list[str] = []
+
+    for line in body.splitlines():
+        match = CHANGE_LINE.match(line)
+        if match is None:
+            kept.append(line)
+            continue
+        number = match.group("number")
+        if number in seen:
+            continue
+        seen.add(number)
+        kept.append(line)
+
+    return _drop_empty_sections(kept)
+
+
+def _drop_empty_sections(lines: list[str]) -> str:
+    """Remove a heading whose entries were all taken by a higher-ranked section.
+
+    The changelog link is a document trailer, not the content of whichever
+    section happens to precede it, so it is held back before the scan. Without
+    that, the last section always looks occupied and never gets removed.
+    """
+    end = next((i for i, line in enumerate(lines) if TRAILER.match(line)), len(lines))
+    body, trailer = lines[:end], lines[end:]
+
+    keep = [True] * len(body)
+    for i, line in enumerate(body):
+        if not HEADING.match(line):
+            continue
+        following = next(
+            (body[j] for j in range(i + 1, len(body)) if body[j].strip()), None
+        )
+        if following is None or HEADING.match(following):
+            keep[i] = False
+
+    out = [line for i, line in enumerate(body) if keep[i]] + trailer
+    return re.sub(r"\n{3,}", "\n\n", "\n".join(out)).strip() + "\n"
+
+
+def main() -> int:
+    sys.stdout.write(dedupe(sys.stdin.read().replace("\r\n", "\n")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_dedupe_release_notes.py
+++ b/tests/unit/test_dedupe_release_notes.py
@@ -1,0 +1,167 @@
+"""Each pull request appears once, in the highest-ranked section that claimed it.
+
+Release Drafter duplicates a pull request into every category its labels match.
+`.github/release-drafter.yml` orders categories by rank and the action emits
+them in that order, so keeping the first occurrence is the ranking.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dedupe_release_notes import dedupe
+
+FOOTER = "**Full changelog**: https://github.com/TracecatHQ/tracecat/compare/a...b"
+
+
+def test_a_pull_request_is_kept_in_the_first_section_that_claimed_it() -> None:
+    body = "\n".join(
+        (
+            "## Security",
+            "",
+            "- fix(audit): Preserve client attribution (#3362)",
+            "",
+            "## API",
+            "",
+            "- fix(audit): Preserve client attribution (#3362)",
+            "- fix(api): Return adjacent reverse pages (#3258)",
+            "",
+            FOOTER,
+            "",
+        )
+    )
+    assert dedupe(body) == "\n".join(
+        (
+            "## Security",
+            "",
+            "- fix(audit): Preserve client attribution (#3362)",
+            "",
+            "## API",
+            "",
+            "- fix(api): Return adjacent reverse pages (#3258)",
+            "",
+            FOOTER,
+            "",
+        )
+    )
+
+
+def test_a_section_left_with_nothing_is_removed() -> None:
+    body = "\n".join(
+        (
+            "## Case management",
+            "",
+            "- feat(cases): Add duplication (#1)",
+            "",
+            "## User interface",
+            "",
+            "- feat(cases): Add duplication (#1)",
+            "",
+            "## Fixes",
+            "",
+            "- fix(ui): Correct a label (#2)",
+            "",
+            FOOTER,
+            "",
+        )
+    )
+    out = dedupe(body)
+    assert "## User interface" not in out
+    assert "## Case management" in out and "## Fixes" in out
+    assert out.count("(#1)") == 1
+
+
+def test_a_clean_body_is_unchanged() -> None:
+    body = "\n".join(
+        ("## Fixes", "", "- fix(ui): Correct a label (#2)", "", FOOTER, "")
+    )
+    assert dedupe(body) == body
+
+
+def test_it_is_idempotent() -> None:
+    body = "\n".join(
+        (
+            "## Security",
+            "",
+            "- fix(audit): x (#1)",
+            "",
+            "## Fixes",
+            "",
+            "- fix(audit): x (#1)",
+            "",
+            FOOTER,
+            "",
+        )
+    )
+    once = dedupe(body)
+    assert dedupe(once) == once
+
+
+def test_trailing_prose_after_the_last_section_survives() -> None:
+    """The contributors block is not a heading and must not be treated as one."""
+    body = "\n".join(
+        (
+            "## Fixes",
+            "",
+            "- fix(ui): x (#1)",
+            "",
+            "## Contributors",
+            "",
+            "@someone and @someone-else",
+            "",
+            FOOTER,
+            "",
+        )
+    )
+    out = dedupe(body)
+    assert "## Contributors" in out
+    assert "@someone and @someone-else" in out
+    assert FOOTER in out
+
+
+def test_lines_without_a_pull_request_number_are_never_dropped() -> None:
+    """Hand-written bullets have no number and are not duplicates of each other."""
+    body = "\n".join(
+        (
+            "## Notes",
+            "",
+            "- Upgrade to Node 18 before installing",
+            "- Upgrade to Node 18 before installing",
+            "",
+            FOOTER,
+            "",
+        )
+    )
+    assert dedupe(body).count("Upgrade to Node 18") == 2
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
+def test_crlf_bodies_are_handled(newline: str) -> None:
+    """GitHub stores release bodies with CRLF, which breaks `$`-anchored matching."""
+    body = newline.join(
+        ("## Security", "", "- fix: x (#1)", "", "## Fixes", "", "- fix: x (#1)", "")
+    )
+    out = dedupe(body.replace("\r\n", "\n"))
+    assert out.count("(#1)") == 1
+    assert "\r" not in out
+
+
+def test_the_first_section_wins_even_when_the_text_differs() -> None:
+    """Identity is the pull request number; the rendered text can differ."""
+    body = "\n".join(
+        (
+            "## Breaking changes",
+            "",
+            "- feat(api)!: Drop the v1 payload (#9)",
+            "",
+            "## Features",
+            "",
+            "- feat(api): Drop the v1 payload (#9)",
+            "",
+            FOOTER,
+            "",
+        )
+    )
+    out = dedupe(body)
+    assert "## Breaking changes" in out
+    assert "## Features" not in out
+    assert out.count("(#9)") == 1

--- a/tests/unit/test_dedupe_release_notes.py
+++ b/tests/unit/test_dedupe_release_notes.py
@@ -135,14 +135,20 @@ def test_lines_without_a_pull_request_number_are_never_dropped() -> None:
 
 
 @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
-def test_crlf_bodies_are_handled(newline: str) -> None:
-    """GitHub stores release bodies with CRLF, which breaks `$`-anchored matching."""
+def test_bodies_are_handled_whatever_the_line_endings(newline: str) -> None:
+    """GitHub stores most release bodies with CRLF, so the raw body must work.
+
+    Passed straight to `dedupe`, not normalised first: normalising here would
+    make the CRLF case byte-identical to the LF one and test nothing.
+    `splitlines` is what actually absorbs the `\r`.
+    """
     body = newline.join(
         ("## Security", "", "- fix: x (#1)", "", "## Fixes", "", "- fix: x (#1)", "")
     )
-    out = dedupe(body.replace("\r\n", "\n"))
+    out = dedupe(body)
     assert out.count("(#1)") == 1
     assert "\r" not in out
+    assert out.startswith("## Security")
 
 
 def test_the_first_section_wins_even_when_the_text_differs() -> None:


### PR DESCRIPTION
Each pull request now appears once in the release notes, in the highest-ranked section that claimed it.

## The problem

The `1.0.0` draft that #3361 produced has **280 entries for 102 changes**. 93 pull requests are listed more than once. #3362 appears five times:

```
## Security         - fix(audit): Preserve client attribution across proxy hops (#3362)
## API              - fix(audit): Preserve client attribution across proxy hops (#3362)
## User interface   - fix(audit): Preserve client attribution across proxy hops (#3362)
## Infrastructure   - fix(audit): Preserve client attribution across proxy hops (#3362)
## Fixes            - fix(audit): Preserve client attribution across proxy hops (#3362)
```

`.github/release-drafter.yml`, `AGENTS.md` and `CONTRIBUTING.md` all stated that a change lands in the *first* category matching its labels. That was never true. From the action's own source at the pinned SHA:

```js
// note that having the same label in multiple categories
// then it is intended to "duplicate" the pull request into each category
```

Its category schema accepts only `title`, `collapse-after`, `label` and `labels` — there is no per-category `exclude-labels`, and the categorizer has no first-match branch.

Two things made it visible now. The old config had far fewer categories, so a pull request rarely matched more than one; and the label backfill in #3361 gave 418 merged pull requests the labels their titles imply, which multiplies the matches.

## The fix

Release Drafter emits sections in the order the categories are declared, so **the first occurrence of a pull request is the highest-ranked one**. A step after the draft keeps that occurrence, drops the rest, and removes any heading left with nothing under it.

That makes the documented behaviour true rather than restating it. Ranking stays where a reader expects it — the order of `categories:` — and reordering that list now genuinely changes where a change lands.

Measured on the live draft:

| | entries | unique PRs | sections |
| --- | --- | --- | --- |
| before | 280 | 102 | 20 |
| after | 102 | 102 | 16 |

No pull request is lost, and a second run changes nothing.

## Why not the alternatives

**Per-category `exclude-labels`** was my first instinct. It is not in the schema at this version; I checked before writing anything.

**Dropping the by-kind categories** so only areas categorize still leaves 39 pull requests matching two or more area categories, and it cannot express the ranking that puts a breaking change above its product area.

**A dedicated single section label** would work, but it means ~21 new labels, and the type and area labels would still exist for triage — two vocabularies describing the same thing.

## Notes

- The step is skipped, with a warning rather than a failure, if the draft step reports no release id.
- `scripts/dedupe_release_notes.py` is standard library only; the job installs nothing.
- Identity is the pull request number, not the rendered text, which can differ between sections after the replacers run.
- Lines with no pull request number — hand-written bullets, the `0.35.3` advisory — are never treated as duplicates of each other.
- The contributors block and changelog link are held back before the empty-section scan, so the last real section can still be removed.

## Verification

```bash
uv run pytest tests/unit/test_dedupe_release_notes.py
gh api repos/TracecatHQ/tracecat/releases --jq 'first(.[]|select(.draft==true))|.body' \
  | uv run python scripts/dedupe_release_notes.py
```

9 new tests cover first-section-wins, empty-section removal, idempotency, CRLF bodies, trailing prose, and lines without a number. Full suite 439 passing.

## LOC

| Kind | + | - |
| --- | --- | --- |
| Logic | 91 | 0 |
| Tests | 167 | 0 |
| Infra/config | 53 | 2 |
| Docs | 4 | 2 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps each pull request in one release-notes section, the highest-ranked one its labels match, instead of listing it under every matching category (the 1.0.0 draft had 280 entries for 102 changes).

**Bug Fixes**
- Adds a workflow step that keeps the first occurrence of each PR, since Release Drafter emits sections in config order and has no first-match option.
- Removes section headings left empty after deduplication.
- Serializes the draft job so two pushes cannot interleave their read/modify/write of the draft body.
- Updates `AGENTS.md`, `CONTRIBUTING.md`, and the config comment to describe ranking rather than first-match behavior.

<sup>Written for commit c1e756d26b3eae22620841b47755f51b76383971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

