### PR TITLE
ci: reject workflows as a scope, it names two different things

### DIFF
--- a/.github/commit-conventions.toml
+++ b/.github/commit-conventions.toml
@@ -228,13 +228,6 @@ playbooks = "docs"
 # as `build`. Deliberately different from `admin`, which is the org admin API.
 admin-cli = "build"
 
-# Scopes whose area depends on the type. `ci(workflows)` is GitHub Actions;
-# `feat(workflows)` is the product's workflow engine. The "*" key is the
-# fallback for every other type.
-[scopes_by_type.workflows]
-ci = "cicd"
-"*" = "engine"
-
 # Scopes that read as two different things depending on who wrote them. These
 # are never auto-mapped, in either direction: guessing here silently files
 # changes under the wrong product area, which is worse than a failed check.
@@ -242,6 +235,15 @@ ci = "cicd"
 # `app` is the reason this list exists. It has 89 historical uses and meant the
 # backend, not the frontend, in nearly all of them. Anyone reading it today
 # assumes the opposite.
+#
+# `workflows` arrives from the other direction: not a spelling that drifted,
+# but a word that names two unrelated things at once. It used to resolve by
+# type -- `ci(workflows)` was GitHub Actions, anything else was the engine --
+# through a [scopes_by_type] table that existed for this one scope. History
+# never asked for it: 1 `ci(workflows)` against 121 bare `ci:`, and the 8
+# other `(workflows)` titles split between both readings. The table is gone
+# and the scope is rejected: GitHub Actions changes are a bare `ci:`, and
+# workflow-engine changes are `engine`.
 [ambiguous_scopes]
 app = ["api", "engine", "cases"]
 dev = ["build", "infra"]
@@ -249,9 +251,11 @@ config = ["api", "infra"]
 service = ["api", "engine"]
 tracecat = ["api", "engine", "ui"]
 ai = ["agents", "actions"]
+workflows = ["engine"]
 
 [ambiguous_scope_notes]
 app = "retired: it historically meant the backend, not the frontend"
+workflows = "GitHub Actions to one reader, the product's workflow engine to another; GitHub Actions work is a bare `ci:` with no scope"
 
 # Anything that is neither canonical, alias, nor ambiguous is treated as a
 # vendor name. The autolabeler absorbs those into `integrations` so the 69

--- a/.github/commit-conventions.toml
+++ b/.github/commit-conventions.toml
@@ -253,9 +253,11 @@ tracecat = ["api", "engine", "ui"]
 ai = ["agents", "actions"]
 workflows = ["engine"]
 
+# Written as complete sentences: the checker appends them after the list of
+# candidates, so a note can name a replacement that is not itself a scope.
 [ambiguous_scope_notes]
-app = "retired: it historically meant the backend, not the frontend"
-workflows = "GitHub Actions to one reader, the product's workflow engine to another; GitHub Actions work is a bare `ci:` with no scope"
+app = "It is retired: it historically meant the backend, not the frontend."
+workflows = "It reads as GitHub Actions to another reader; if that is what you changed, drop the scope and write a bare `ci:`."
 
 # Anything that is neither canonical, alias, nor ambiguous is treated as a
 # vendor name. The autolabeler absorbs those into `integrations` so the 69

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -186,7 +186,7 @@ autolabeler:
     title:
       - '/^(\[[A-Za-z0-9._-]+\]\s+)?(?:chore)(\([^)]*\))?!?: /'
 
-  # Example: ci(workflows): pin actions to immutable SHAs
+  # Example: ci: pin actions to immutable SHAs
   - label: cicd
     title:
       - '/^(\[[A-Za-z0-9._-]+\]\s+)?(?:ci)(\([^)]*\))?!?: /'
@@ -359,17 +359,11 @@ autolabeler:
     title:
       - '/^(\[[A-Za-z0-9._-]+\]\s+)?[a-z]+\((?:[a-z0-9_-]+\+)*(?:frontend|canvas|ui|ux)(?:\+[a-z0-9_-]+)*\)!?: /'
 
-  # `workflows` is the one scope whose area depends on the type:
-  # ci(workflows) is GitHub Actions, feat(workflows) is the product engine.
-  # Example: ci(workflows): pin actions to immutable SHAs
-  - label: cicd
-    title:
-      - '/^(\[[A-Za-z0-9._-]+\]\s+)?ci\((?:[a-z0-9_-]+\+)*workflows(?:\+[a-z0-9_-]+)*\)!?: /'
-
-  # Example: feat(workflows): add a workflow alias resolver
-  - label: engine
-    title:
-      - '/^(\[[A-Za-z0-9._-]+\]\s+)?(?!ci\()[a-z]+\((?:[a-z0-9_-]+\+)*workflows(?:\+[a-z0-9_-]+)*\)!?: /'
+  # `workflows` has no rule of its own. It named GitHub Actions under `ci` and
+  # the product engine under every other type, which is what put it in
+  # [ambiguous_scopes]; like `app`, it now gets the type label and no area. It
+  # stays in the vendor-absorption lookahead below because it is still a known
+  # word: dropping it there would file `feat(workflows)` under Integrations.
 
   # Vendor absorption. Any scope that is neither canonical, an alias, nor on
   # the ambiguous list is read as a vendor name and filed under Integrations,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,14 @@ Removing something takes three PRs, usually across three releases:
   express.
 - Before hand-labeling, list existing repo labels with `gh label list` and
   pick from that set. See "Never invent vocabulary" below.
+- The autolabeler only ever adds. Retitle a pull request and the labels its
+  old title earned stay put, so `fix(workflows): ...` retitled to `ci: ...`
+  keeps `engine` alongside the new `cicd` and lands in two sections. Remove the
+  stale ones yourself:
+  `gh api --method DELETE repos/TracecatHQ/tracecat/issues/<pr>/labels/<label>`.
+  This is deliberate rather than a gap: the backfill and the autolabeler both
+  add only, so a label applied by hand for nuance the title cannot express is
+  never silently removed.
 - `gh pr edit` subcommands fail on this repo because of the Projects-classic
   deprecation. Apply labels with
   `gh api repos/TracecatHQ/tracecat/issues/<pr-number>/labels -f "labels[]=<label>"`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,7 +372,6 @@ rendered release notes are normalized, by the `replacers:` block in
   | `skills` | Agent skills |
   | `tables` | Workspace tables |
   | `ui` | The Next.js app and React UI |
-  | `workflows` | GitHub Actions when the type is ci, the workflow engine otherwise |
 
   <!-- END commit-conventions:scopes -->
 
@@ -397,9 +396,13 @@ rendered release notes are normalized, by the `replacers:` block in
   linking action`. A change lands in the first section its labels match, so
   that example appears under Case management, not Core actions. Needing three
   scopes usually means the PR should be split.
-- Scopes that used to mean two different things are rejected outright: `app`,
-  `dev`, `config`, `service`, `tracecat`, `ai`. `app` is the reason the list
-  exists; it historically meant the backend, not the frontend.
+- Scopes that name two different things are rejected outright: `app`, `dev`,
+  `config`, `service`, `tracecat`, `ai`, `workflows`. `app` is the reason the
+  list exists; it historically meant the backend, not the frontend.
+- `workflows` is the one that is ambiguous by construction rather than by
+  history: it reads as GitHub Actions to one person and as the workflow engine
+  to another. GitHub Actions work is a bare `ci:` with no scope, and
+  workflow-engine work is `engine`.
 - Everything else the checker rejects is an old spelling with a canonical
   replacement it will name for you, e.g. `registry` to `integrations`, `agent`
   to `agents`, `ee` to `enterprise`, `udfs` and `core` to `actions`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,15 +157,15 @@ Add a scope whenever the change belongs to one product area. Leave it off only w
 | `skills` | Agent skills |
 | `tables` | Workspace tables |
 | `ui` | The Next.js app and React UI |
-| `workflows` | GitHub Actions when the type is ci, the workflow engine otherwise |
 
 <!-- END commit-conventions:scopes -->
 
-Five distinctions cover most of the doubt:
+Six distinctions cover most of the doubt:
 
 - `actions` is the built-in `core.*` actions a user calls in a workflow. `functions` is the `FN.*` inline expression functions. `engine` is the Temporal workers and executors that run them. The first two are catalogs of things the platform offers; the third is the machinery.
 - `cases` and `tables` are core platform features with their own scopes and their own sections. Neither folds into `api` or `engine`.
 - `engine` is what runs; `infra` is what it runs on. If the change could ship by redeploying the same image, it is `infra`.
+- `workflows` is not a scope, because it reads as GitHub Actions to one person and as the workflow engine to another. A GitHub Actions change is a bare `ci:` with no scope; a workflow-engine change is `engine`.
 - `audit` is the security audit log: what a workspace records about who did what, for someone reviewing it later. `logging` is application telemetry, what an operator reads to debug Tracecat itself. Audit work renders under Security, telemetry under Observability.
 - Vendor names are not scopes. Write `feat(integrations): add Jira issue search` and name the vendor in the description, where it is readable and searchable.
 

--- a/scripts/audit_commit_conventions.py
+++ b/scripts/audit_commit_conventions.py
@@ -219,11 +219,11 @@ def resolve_labels(parsed: ParsedTitle, conventions: Conventions) -> frozenset[s
 
     vendor_label = conventions.scopes["integrations"]
     for part in parsed.scope_parts:
-        label = conventions.scope_label(part, type_=parsed.type)
+        label = conventions.scope_label(part)
         if label is None:
             canonical = conventions.scope_aliases.get(part)
             if canonical is not None:
-                label = conventions.scope_label(canonical, type_=parsed.type)
+                label = conventions.scope_label(canonical)
         if label is None:
             legacy = conventions.legacy_scopes.get(part)
             if legacy is not None:

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -118,7 +118,7 @@ def _check_type(type_: str, conventions: Conventions) -> tuple[Violation | None,
 
 def _check_scope_part(part: str, conventions: Conventions) -> Violation | None:
     """Validate one canonical scope component."""
-    if part in conventions.scopes or part in conventions.scopes_by_type:
+    if part in conventions.scopes:
         return None
 
     canonical = conventions.scope_aliases.get(part)
@@ -386,9 +386,6 @@ def render_taxonomy(conventions: Conventions) -> str:
     lines += [
         f"  {name:<14} {label}" for name, label in sorted(conventions.scopes.items())
     ]
-    for name, by_type in sorted(conventions.scopes_by_type.items()):
-        rendered = ", ".join(f"{k}={v}" for k, v in sorted(by_type.items()))
-        lines.append(f"  {name:<14} {rendered}")
 
     lines.append("")
     lines.append("Old spellings (rewrite these):")

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -137,12 +137,17 @@ def _check_scope_part(part: str, conventions: Conventions) -> Violation | None:
 
     candidates = conventions.ambiguous_scopes.get(part)
     if candidates is not None:
+        # The note trails the candidates rather than interrupting them. A
+        # scope whose other reading takes no scope at all -- `workflows`, where
+        # the GitHub Actions answer is a bare `ci:` -- cannot be expressed as a
+        # candidate, and reading that before "pick one of these" made the two
+        # halves contradict each other.
         note = conventions.ambiguous_scope_notes.get(part)
-        detail = f" ({note})" if note else ""
+        detail = f" {note}" if note else ""
         return Violation(
             "ambiguous-scope",
-            f"`{part}` is ambiguous{detail}. "
-            f"Pick the area you actually changed: {_quote(candidates)}.",
+            f"`{part}` is ambiguous. "
+            f"Pick the area you actually changed: {_quote(candidates)}.{detail}",
         )
 
     # Two very different mistakes land here, so the message names both. Calling

--- a/scripts/commit_conventions.py
+++ b/scripts/commit_conventions.py
@@ -16,9 +16,6 @@ CONVENTIONS_PATH: Final = (
     Path(__file__).resolve().parents[1] / ".github" / "commit-conventions.toml"
 )
 
-# Key used in [scopes_by_type.<scope>] for "any other type".
-TYPE_FALLBACK: Final = "*"
-
 
 class ConventionsError(Exception):
     """The conventions file is missing, unparseable, or internally inconsistent."""
@@ -50,7 +47,6 @@ class Conventions:
     legacy_scopes: Mapping[str, LegacyType]
     scopes: Mapping[str, str]
     scope_aliases: Mapping[str, str]
-    scopes_by_type: Mapping[str, Mapping[str, str]]
     ambiguous_scopes: Mapping[str, tuple[str, ...]]
     ambiguous_scope_notes: Mapping[str, str]
     deprecation_type: str
@@ -62,30 +58,21 @@ class Conventions:
 
     @property
     def canonical_scopes(self) -> tuple[str, ...]:
-        """Scopes an author may write, including the type-disambiguated ones."""
-        return tuple(sorted({*self.scopes, *self.scopes_by_type}))
+        """Scopes an author may write."""
+        return tuple(sorted(self.scopes))
 
-    def scope_label(self, scope: str, *, type_: str) -> str | None:
-        """Area label for a canonical scope under `type_`, or None if unknown."""
-        if scope in self.scopes:
-            return self.scopes[scope]
-        by_type = self.scopes_by_type.get(scope)
-        if by_type is None:
-            return None
-        return by_type.get(type_, by_type.get(TYPE_FALLBACK))
+    def scope_label(self, scope: str) -> str | None:
+        """Area label for a canonical scope, or None if it is not one."""
+        return self.scopes.get(scope)
 
     def all_labels(self) -> frozenset[str]:
         """Every label the system can put on a pull request."""
-        by_type: set[str] = set()
-        for mapping in self.scopes_by_type.values():
-            by_type.update(mapping.values())
         return frozenset(
             {
                 *self.types.values(),
                 *(legacy.label for legacy in self.legacy_types.values()),
                 *(legacy.label for legacy in self.legacy_scopes.values()),
                 *self.scopes.values(),
-                *by_type,
                 self.breaking_label,
                 *self.extra_labels,
                 *self.exclude_labels,
@@ -165,23 +152,6 @@ def load_conventions(path: Path | None = None) -> Conventions:
             )
         legacy_scopes[name] = LegacyType(label=label, suggest=suggest)
 
-    by_type_raw = raw.get("scopes_by_type", {})
-    if not isinstance(by_type_raw, dict):
-        raise ConventionsError("[scopes_by_type] must be a table")
-    scopes_by_type: dict[str, dict[str, str]] = {}
-    for name, entry in by_type_raw.items():
-        if not isinstance(entry, dict) or not all(
-            isinstance(value, str) for value in entry.values()
-        ):
-            raise ConventionsError(
-                f"[scopes_by_type.{name}] must map type names to label strings"
-            )
-        if TYPE_FALLBACK not in entry:
-            raise ConventionsError(
-                f'[scopes_by_type.{name}] needs a "{TYPE_FALLBACK}" fallback'
-            )
-        scopes_by_type[name] = dict(entry)  # pyright: ignore[reportUnknownArgumentType]
-
     ambiguous_raw = raw.get("ambiguous_scopes", {})
     if not isinstance(ambiguous_raw, dict):
         raise ConventionsError("[ambiguous_scopes] must be a table")
@@ -206,7 +176,6 @@ def load_conventions(path: Path | None = None) -> Conventions:
         legacy_scopes=legacy_scopes,
         scopes=_require_str_map(raw, "scopes"),
         scope_aliases=_require_str_map(raw, "scope_aliases"),
-        scopes_by_type=scopes_by_type,
         ambiguous_scopes=ambiguous,
         ambiguous_scope_notes=_require_str_map(raw, "ambiguous_scope_notes"),
         deprecation_type=str(raw.get("deprecation", {}).get("type", "deprecation")),
@@ -230,12 +199,6 @@ def _validate(conventions: Conventions) -> None:
     if overlap:
         raise ConventionsError(
             f"scopes are both canonical and aliases: {', '.join(overlap)}"
-        )
-
-    shadowed = sorted(set(conventions.scopes) & set(conventions.scopes_by_type))
-    if shadowed:
-        raise ConventionsError(
-            f"scopes appear in both [scopes] and [scopes_by_type]: {', '.join(shadowed)}"
         )
 
     ambiguous_conflict = sorted(

--- a/tests/unit/test_check_pr_title.py
+++ b/tests/unit/test_check_pr_title.py
@@ -27,6 +27,8 @@ ACCEPT = [
     "fix(functions): regex_extract corner case",
     "feat(cases+actions): add a case linking action",
     "feat(audit): stream audit logs via webhook",
+    "ci: pin actions to immutable SHAs",
+    "fix(engine): retry backoff",
 ]
 
 REJECT: list[tuple[str, str]] = [
@@ -36,6 +38,7 @@ REJECT: list[tuple[str, str]] = [
     ("feat(integration): add Okta event hooks", "unknown-scope"),
     ("feat(jira): add issue search", "unknown-scope"),
     ("refactor(app): update case filtering", "ambiguous-scope"),
+    ("ci(workflows): pin actions to immutable SHAs", "ambiguous-scope"),
     ("deps: bump orjson", "unknown-type"),
     ("deprecation(registry): remove old thing", "depr-no-replacement"),
     ("feat(ui+api+ee): x", "too-many-scopes"),
@@ -94,6 +97,22 @@ def test_retired_app_scope_explains_itself() -> None:
         assert f"`{candidate}`" in messages
 
 
+def test_rejected_workflows_scope_names_both_readings() -> None:
+    """The message is the whole user-facing value of rejecting this scope.
+
+    Neither reading is a rewrite of the other: GitHub Actions work drops the
+    scope entirely, engine work replaces it. A message naming only one of the
+    two sends half the authors to the wrong place.
+    """
+    messages = " ".join(
+        v.message
+        for v in check_title("ci(workflows): pin actions", CONVENTIONS).violations
+    )
+    assert "GitHub Actions" in messages
+    assert "`ci:`" in messages
+    assert "`engine`" in messages
+
+
 def test_all_violations_are_reported_not_just_the_first() -> None:
     report = check_title("style(app): x.", CONVENTIONS)
     assert set(report.codes) == {"unknown-type", "ambiguous-scope", "trailing-period"}
@@ -103,9 +122,9 @@ def test_compound_scope_resolves_to_both_area_labels() -> None:
     """`feat(cases+actions)` is the worked example in CONTRIBUTING.md."""
     title = "feat(cases+actions): add a case linking action"
     assert check_title(title, CONVENTIONS).ok
-    assert CONVENTIONS.scope_label("cases", type_="feat") == "cases"
-    assert CONVENTIONS.scope_label("actions", type_="feat") == "actions"
-    assert CONVENTIONS.scope_label("functions", type_="fix") == "functions"
+    assert CONVENTIONS.scope_label("cases") == "cases"
+    assert CONVENTIONS.scope_label("actions") == "actions"
+    assert CONVENTIONS.scope_label("functions") == "functions"
 
 
 def test_audit_is_canonical_not_an_alias_for_api() -> None:
@@ -117,9 +136,9 @@ def test_audit_is_canonical_not_an_alias_for_api() -> None:
     result = check_title("fix(audit): preserve client attribution", CONVENTIONS)
     assert result.ok, [v.message for v in result.violations]
     assert "audit" not in CONVENTIONS.scope_aliases
-    assert CONVENTIONS.scope_label("audit", type_="fix") == "audit"
+    assert CONVENTIONS.scope_label("audit") == "audit"
     # The distinction the scope exists to draw.
-    assert CONVENTIONS.scope_label("logging", type_="fix") == "logging"
+    assert CONVENTIONS.scope_label("logging") == "logging"
 
 
 def _suggestion_cases() -> list[tuple[str, str]]:

--- a/tests/unit/test_check_pr_title.py
+++ b/tests/unit/test_check_pr_title.py
@@ -111,6 +111,21 @@ def test_rejected_workflows_scope_names_both_readings() -> None:
     assert "GitHub Actions" in messages
     assert "`ci:`" in messages
     assert "`engine`" in messages
+    # The bare-`ci:` guidance has to trail the candidate list. Read before it,
+    # "pick the area you changed: `engine`" contradicts "write no scope at all".
+    assert messages.index("`engine`") < messages.index("`ci:`")
+
+
+@pytest.mark.parametrize("scope", sorted(CONVENTIONS.ambiguous_scope_notes))
+def test_an_ambiguous_note_is_a_sentence_after_the_candidates(scope: str) -> None:
+    """Notes are appended, so a fragment reads as a run-on against the list."""
+    note = CONVENTIONS.ambiguous_scope_notes[scope]
+    assert note[:1].isupper(), note
+    assert note.endswith("."), note
+    messages = " ".join(
+        v.message for v in check_title(f"fix({scope}): x", CONVENTIONS).violations
+    )
+    assert messages.endswith(note)
 
 
 def test_all_violations_are_reported_not_just_the_first() -> None:

--- a/tests/unit/test_commit_conventions.py
+++ b/tests/unit/test_commit_conventions.py
@@ -186,26 +186,31 @@ def test_scope_alias_produces_the_canonical_area_label(
 
 
 @pytest.mark.parametrize(
-    ("title", "expected"),
+    ("title", "type_"),
     [
-        ("ci(workflows): pin actions to immutable SHAs", "cicd"),
-        ("feat(workflows): add a workflow alias resolver", "engine"),
-        ("fix(workflows): resolve alias collisions", "engine"),
+        ("ci(workflows): pin actions to immutable SHAs", "ci"),
+        ("feat(workflows): add a workflow alias resolver", "feat"),
+        ("fix(workflows): resolve alias collisions", "fix"),
     ],
 )
-def test_workflows_is_disambiguated_by_type(title: str, expected: str) -> None:
-    assert expected in autolabel(title)
+def test_workflows_gets_no_area_label_whatever_the_type(
+    title: str, type_: str, conventions: Conventions
+) -> None:
+    """`workflows` used to resolve to `cicd` under `ci` and `engine` otherwise.
 
-
-def test_ci_workflows_is_not_labelled_as_engine() -> None:
-    assert "engine" not in autolabel("ci(workflows): pin actions")
+    It is ambiguous now, so it labels like `app`: the type label and nothing
+    else. The equality also pins the other half of the change -- `workflows`
+    stays in the vendor-absorption lookahead, so no `integrations` label leaks
+    in from there.
+    """
+    assert autolabel(title) == {conventions.types[type_]}
 
 
 @pytest.mark.parametrize("scope", sorted(set(CONVENTIONS.canonical_scopes) - {"ui"}))
 def test_compound_scopes_label_like_their_components(
     scope: str, conventions: Conventions
 ) -> None:
-    expected = conventions.scope_label(scope, type_="feat")
+    expected = conventions.scope_label(scope)
     assert expected is not None
     for compound in (f"{scope}+ui", f"ui+{scope}"):
         labels = autolabel(f"feat({compound}): example change")


### PR DESCRIPTION
`workflows` is now rejected as a scope, and the type-dependent mechanism that existed solely to support it is deleted.

## The problem

`ci(workflows)` meant GitHub Actions. `feat(workflows)` meant the product's Temporal workflow engine. One word, two unrelated readings, resolved by a `[scopes_by_type]` table:

```toml
[scopes_by_type.workflows]
ci  = "cicd"
"*" = "engine"
```

That is the exact property that already gets a scope rejected here — `app`, `dev`, `config`, `service`, `tracecat` and `ai` are in `[ambiguous_scopes]` for it. `workflows` only escaped the rule because #3361 gave it a bespoke mechanism instead of applying the rule.

It bit immediately: I opened #3369 as `fix(workflows): …` for a GitHub Actions change. The checker passed it, and it resolved to `engine, fix` — filing an Actions change under the Temporal engine section.

## The special case was not earning its keep

Across all of `origin/main`:

| | uses |
| --- | --- |
| `ci(workflows)` | 1 |
| bare `ci:` | 121 |
| `fix`/`feat`/`refactor(workflows)` | 8 |

And those 8 split across **both** readings — three Helm publish-workflow fixes and a release-workflow refactor are GitHub Actions work; the rest are engine. The ambiguity demonstrating itself in the data the rule was built from.

## The change

`workflows` moves into `[ambiguous_scopes]`, and `[scopes_by_type]` is deleted — it had exactly one entry.

```
$ just check-pr-title "ci(workflows): pin actions"
[ambiguous-scope] `workflows` is ambiguous (GitHub Actions to one reader, the
  product's workflow engine to another; GitHub Actions work is a bare `ci:`
  with no scope). Pick the area you actually changed: `engine`.

$ just check-pr-title "ci: pin actions"          OK
$ just check-pr-title "fix(engine): retry"       OK
```

`workflows` stays in the autolabeler's vendor-absorption lookahead. It is still a known word; it just gets no area label. Removing it would make `feat(workflows)` absorb into `integrations`, which is worse than no label.

`scope_label` loses its `type_` parameter. It existed only to consult that table, and a parameter that can no longer change the result would be a lie in the signature.

## Where the 8 historical titles move

From the Workflow engine section to their type's section. Nothing is lost from GitHub — the backfill only ever adds labels, so an already-applied `engine` survives; it simply stops being proposed.

| Title | Before | After |
| --- | --- | --- |
| `feat(workflows): support target-branch publish and branch picker` (#2164) | engine, feat | feat |
| `fix(workflows): coerce empty alias to null on clear` (#2543) | engine, fix | fix |
| `fix(workflows): preserve imported runtime metadata` (#2382) | engine, fix | fix |
| `fix(workflows): serialize restore expects` (#2799) | engine, fix | fix |
| three Helm publish-workflow fixes | engine, fix | fix |
| `refactor(workflows): Simplify release and publish workflows` | engine, refactor | refactor |

`ci(workflows): Add publish-release workflow` (#2173) is unchanged at `cicd` — the Tier A type rule already gave it that, so deleting the Tier B rule costs it nothing.

Published release bodies are frozen and unaffected. As with `app`, the replacers do not rewrite an ambiguous scope, so those lines keep reading `fix(workflows):`.

## Verification

```bash
uv run pytest tests/unit/test_commit_conventions.py tests/unit/test_check_pr_title.py
uv run python scripts/check_pr_title.py --list      # workflows appears only under Ambiguous
```

433 passing. Two tests encoding the removed behaviour are gone, replaced by one asserting `workflows` yields no area label whatever the type, plus a test that the rejection message names both readings and the replacement for each — that message is the whole user-facing value here.

Also fixed: the Tier A `ci` rule's example comment was `ci(workflows): pin actions to immutable SHAs`, a title this PR makes invalid.

## LOC

| Kind | + | - |
| --- | --- | --- |
| Logic | 9 | 51 |
| Tests | 42 | 16 |
| Infra/config | 14 | 17 |
| Docs | 9 | 5 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects `workflows` as a commit scope because it named GitHub Actions under `ci` and the product's Temporal workflow engine under every other type. The type-based disambiguation table is removed; GitHub Actions changes use bare `ci:` and workflow-engine changes use `engine`.

**Details**
- `workflows` now sits in `[ambiguous_scopes]`, and the rejection message names both readings and the replacement for each.
- The ambiguous-scope note now trails the candidate list as a complete sentence, so the bare-`ci:` guidance no longer contradicts "pick a candidate."
- `workflows` stays in the vendor-absorption lookahead so `feat(workflows)` doesn't get mislabeled as `integrations`.
- The autolabeler only adds labels, so retitling an old `fix(workflows)` to `ci:` keeps the stale `engine` label; AGENTS.md documents removing it.
- `scope_label` drops its `type_` parameter, which only existed for the removed table.

<sup>Written for commit 6103a41e20c448e3d2697cfb2bc00f48e5433351. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

