### PR TITLE
ci: stop the dedupe step untagging the draft release

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -178,6 +178,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           RELEASE_ID: ${{ steps.draft.outputs.id }}
+          TAG_NAME: ${{ steps.draft.outputs.tag_name }}
         run: |
           set -euo pipefail
 
@@ -197,9 +198,27 @@ jobs:
           fi
 
           echo "removed $((before - after)) duplicate entries, ${after} remain"
-          jq -Rs '{body: .}' < /tmp/deduped.md > /tmp/payload.json
+
+          # `tag_name` has to be resent. A draft release PATCHed without it is
+          # treated as untagged: GitHub replaces the tag with an
+          # `untagged-<hash>` placeholder, which silently unnames the release
+          # anyone would publish 1.0.0 from. Release Drafter resends it on its
+          # own update for the same reason.
+          if [ -z "${TAG_NAME}" ]; then
+            echo "::warning::the draft step reported no tag, skipping to avoid untagging it"
+            exit 0
+          fi
+
+          jq -Rs --arg tag "${TAG_NAME}" '{body: ., tag_name: $tag}' \
+            < /tmp/deduped.md > /tmp/payload.json
           gh api --method PATCH "repos/${REPO}/releases/${RELEASE_ID}" \
             --input /tmp/payload.json --silent
+
+          restored=$(gh api "repos/${REPO}/releases/${RELEASE_ID}" --jq .tag_name)
+          if [ "${restored}" != "${TAG_NAME}" ]; then
+            echo "::error::draft tag is '${restored}', expected '${TAG_NAME}'"
+            exit 1
+          fi
 
   # Same-repo PRs only: fork PRs get a read-only token, so the autolabeler
   # cannot write to them. Fork PRs are labelled by the backfill job once they

--- a/scripts/dedupe_release_notes.py
+++ b/scripts/dedupe_release_notes.py
@@ -21,6 +21,12 @@ it.
 Reads a release body on stdin, writes the deduplicated body on stdout, and is a
 no-op on a body that is already clean. Runs on the standard library alone: the
 job that calls it installs nothing.
+
+Normalises CRLF, then splits on "\n" alone rather than with `splitlines`, which
+also breaks on U+2028, U+0085, form feed and a bare carriage return. Any of
+those inside a title would cut one entry in two, leaving neither half carrying a
+pull request number, so both copies would survive. GitHub stores most bodies
+with CRLF, hence handling it here rather than relying on the caller.
 """
 
 from __future__ import annotations
@@ -44,7 +50,7 @@ def dedupe(body: str) -> str:
     seen: set[str] = set()
     kept: list[str] = []
 
-    for line in body.splitlines():
+    for line in body.replace("\r\n", "\n").split("\n"):
         match = CHANGE_LINE.match(line)
         if match is None:
             kept.append(line)

--- a/tests/unit/test_dedupe_release_notes.py
+++ b/tests/unit/test_dedupe_release_notes.py
@@ -151,6 +151,23 @@ def test_bodies_are_handled_whatever_the_line_endings(newline: str) -> None:
     assert out.startswith("## Security")
 
 
+@pytest.mark.parametrize(
+    "separator",
+    ["\u2028", "\u0085", "\x0c", "\r"],
+    ids=["line-sep", "next-line", "form-feed", "bare-cr"],
+)
+def test_exotic_separators_do_not_split_an_entry(separator: str) -> None:
+    """`splitlines` breaks on all of these; a split entry loses its number.
+
+    Both halves would then look like prose, so neither would be recognised as a
+    duplicate and both copies would survive.
+    """
+    title = f"- fix(ui): a{separator}b (#1)"
+    body = "\n".join(("## Fixes", "", title, "", "## Other changes", "", title, ""))
+    out = dedupe(body)
+    assert out.count("(#1)") == 1, out
+
+
 def test_the_first_section_wins_even_when_the_text_differs() -> None:
     """Identity is the pull request number; the rendered text can differ."""
     body = "\n".join(


### PR DESCRIPTION
The dedupe step added in #3369 untagged the `1.0.0` draft release the first time it ran on main. This resends the tag and asserts it survived.

## What happened

The step PATCHed only the body:

```sh
jq -Rs '{body: .}' < /tmp/deduped.md > /tmp/payload.json
```

GitHub treats a draft release updated without `tag_name` as untagged and replaces the tag with an `untagged-<hash>` placeholder. Straight after #3369 merged:

```
$ gh api repos/TracecatHQ/tracecat/releases/346484911
{"name": "Tracecat 1.0.0",
 "tag_name": "untagged-f41f7f9ea8c73ef604c6",
 "updated_at": "2026-09-02T04:06:17Z"}
```

That `updated_at` is the dedupe step's own timestamp to the second, and its PATCH was the only write at that instant. Release Drafter is ruled out: at the pinned SHA it sends `tag_name: releaseInfo.tag || draftRelease.tag_name` on its own update, precisely to avoid this.

Anyone publishing 1.0.0 from that draft would have got an empty tag. It did not self-heal in any useful way either — the next push restores the tag via Release Drafter, and the dedupe step clears it again, so the draft sits untagged between pushes.

The tag has been restored to `1.0.0` by hand already; this PR stops it recurring.

## The fix

- Send `tag_name` in the payload, from `steps.draft.outputs.tag_name`, which the action already exposes.
- Refuse to PATCH at all if that output is empty, rather than writing a body and untagging the release as a side effect.
- Read the release back afterwards and fail the job if the tag did not survive. No unit test can catch this, so the assertion belongs in the step.

## Also: split on newline alone

`dedupe` used `body.splitlines()`, which also breaks on U+2028, U+0085, form feed and a bare carriage return. Any of those inside a title cuts one entry into two lines, so neither half carries a pull request number and **both copies survive** — the function silently failing at its one job.

```
U+2028 in a title, before:  '- fix(ui): a b (#1)'  x2
                     after:  both copies kept
```

Now normalises CRLF explicitly and splits on `"\n"`. Four parametrised cases cover the separators. Unreachable today — 0 of 5,000 commit subjects and 0 of 374 release bodies contain one — but it is a one-word fix for a silent failure.

## Verification

```bash
uv run pytest tests/unit/test_dedupe_release_notes.py     # 13 passed
```

Re-checked against the live draft: 103 entries in, 103 out, 103 unique PRs, idempotent.

The rest of #3369 was reviewed against all 374 published bodies plus the draft — no `(#N)` lost, no content line lost, no heading removed that still had content, idempotent everywhere, and the `0.35.3` security advisory byte-identical.

## Not addressed here

The ranking deletes the **Tables** section from `1.0.0`. All three `tables` PRs also carry `cases`, and Case management outranks Tables, so table work ships with no Tables heading. `AGENTS.md` says `cases` and `tables` each have their own section, which now holds only when a PR is labelled `tables` and not `cases`. That is a category-ordering decision, not a defect in this step, so it wants a separate call.

## LOC

| Kind | + | - |
| --- | --- | --- |
| Logic | 4 | 2 |
| Tests | 17 | 0 |
| Infra/config | 23 | 2 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the dedupe step in the release-drafter workflow from untagging the draft release, and hardens the dedupe script against exotic line separators.

**Bug Fixes**
- The PATCH payload now includes `tag_name`; the step skips writing when no tag is reported and fails the job if the tag didn't survive.
- The script normalizes CRLF and splits on `\n` instead of `splitlines()`, which broke entries containing U+2028, U+0085, form feed, or a bare carriage return.

<sup>Written for commit 1ca9c4c28e527a3a20add0fd2d4eebe91eed0849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

