### PR TITLE
ci: stop enterprise deciding the release-notes section

### DIFF
--- a/.github/commit-conventions.toml
+++ b/.github/commit-conventions.toml
@@ -301,3 +301,9 @@ breaking = "breaking"
 extra = ["migration", "self-hosted"]
 # A PR carrying either label is left out of the release notes entirely.
 exclude = ["release", "skip changelog"]
+# Labels that describe a change without deciding where it belongs. They are
+# applied, searchable and rendered in the title, but claim no category, so the
+# rest of the title routes the change: `feat(enterprise+cases)` lands in Case
+# management and a bare `feat(enterprise)` in Features. Giving `enterprise` a
+# section would file every paid feature away from the product area it changed.
+no_section = ["enterprise"]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -108,11 +108,14 @@ categories:
       - engine
 
   # 12
+  # `enterprise` is deliberately absent. It says who can use a change, not what
+  # the change is, so it must not claim a section: `feat(enterprise+cases)`
+  # belongs under Case management, and a bare `feat(enterprise)` under Features.
+  # See `[labels] no_section` in commit-conventions.toml.
   - title: API
     labels:
       - api
       - rbac
-      - enterprise
 
   # 13
   - title: User interface

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,7 +362,7 @@ rendered release notes are normalized, by the `replacers:` block in
   | `deps` | Dependency bumps |
   | `docs` | Documentation and playbooks |
   | `engine` | The Temporal workers, executors, and scheduler that run workflows |
-  | `enterprise` | Enterprise edition and tiers |
+  | `enterprise` | Enterprise edition and tiers; pair it with the area it changes |
   | `functions` | The FN.* inline expression functions |
   | `infra` | Databases, deployments, and cloud infrastructure |
   | `integrations` | Third-party vendor connectors and registry templates |
@@ -382,6 +382,11 @@ rendered release notes are normalized, by the `replacers:` block in
   third is the machinery.
 - `cases` and `tables` are core platform features with their own scopes and
   their own sections. Neither folds into `api` or `engine`.
+- `enterprise` says who may use a change, not what the change is, so it never
+  decides the section. Pair it with the area: `feat(enterprise+cases)` lands in
+  Case management, and a bare `feat(enterprise)` falls to Features. It used to
+  sit in the API category, which filed every paid feature under API rather than
+  the area it changed.
 - `engine` is what runs; `infra` is what it runs on. If the change could ship
   by redeploying the same image, it is `infra`.
 - `audit` is the security audit log: what a workspace records about who did

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Add a scope whenever the change belongs to one product area. Leave it off only w
 | `deps` | Dependency bumps |
 | `docs` | Documentation and playbooks |
 | `engine` | The Temporal workers, executors, and scheduler that run workflows |
-| `enterprise` | Enterprise edition and tiers |
+| `enterprise` | Enterprise edition and tiers; pair it with the area it changes |
 | `functions` | The FN.* inline expression functions |
 | `infra` | Databases, deployments, and cloud infrastructure |
 | `integrations` | Third-party vendor connectors and registry templates |
@@ -160,10 +160,11 @@ Add a scope whenever the change belongs to one product area. Leave it off only w
 
 <!-- END commit-conventions:scopes -->
 
-Six distinctions cover most of the doubt:
+Seven distinctions cover most of the doubt:
 
 - `actions` is the built-in `core.*` actions a user calls in a workflow. `functions` is the `FN.*` inline expression functions. `engine` is the Temporal workers and executors that run them. The first two are catalogs of things the platform offers; the third is the machinery.
 - `cases` and `tables` are core platform features with their own scopes and their own sections. Neither folds into `api` or `engine`.
+- `enterprise` says who may use a change, not what the change is, so it never decides the section. Pair it with the area: `feat(enterprise+cases)` lands in Case management, and a bare `feat(enterprise)` falls to Features.
 - `engine` is what runs; `infra` is what it runs on. If the change could ship by redeploying the same image, it is `infra`.
 - `workflows` is not a scope, because it reads as GitHub Actions to one person and as the workflow engine to another. A GitHub Actions change is a bare `ci:` with no scope; a workflow-engine change is `engine`.
 - `audit` is the security audit log: what a workspace records about who did what, for someone reviewing it later. `logging` is application telemetry, what an operator reads to debug Tracecat itself. Audit work renders under Security, telemetry under Observability.

--- a/scripts/commit_conventions.py
+++ b/scripts/commit_conventions.py
@@ -55,6 +55,7 @@ class Conventions:
     breaking_label: str
     extra_labels: tuple[str, ...]
     exclude_labels: tuple[str, ...]
+    no_section_labels: tuple[str, ...]
 
     @property
     def canonical_scopes(self) -> tuple[str, ...]:
@@ -186,6 +187,7 @@ def load_conventions(path: Path | None = None) -> Conventions:
         breaking_label=str(raw.get("labels", {}).get("breaking", "breaking")),
         extra_labels=_require_str_list(raw, "labels", "extra"),
         exclude_labels=_require_str_list(raw, "labels", "exclude"),
+        no_section_labels=_require_str_list(raw, "labels", "no_section"),
     )
     _validate(conventions)
     return conventions
@@ -194,6 +196,12 @@ def load_conventions(path: Path | None = None) -> Conventions:
 def _validate(conventions: Conventions) -> None:
     """Fail loudly on the mistakes that would otherwise mislabel silently."""
     canonical = set(conventions.canonical_scopes)
+
+    unknown = sorted(set(conventions.no_section_labels) - conventions.all_labels())
+    if unknown:
+        raise ConventionsError(
+            f"[labels].no_section names labels that do not exist: {', '.join(unknown)}"
+        )
 
     overlap = sorted(canonical & set(conventions.scope_aliases))
     if overlap:

--- a/tests/unit/test_commit_conventions.py
+++ b/tests/unit/test_commit_conventions.py
@@ -287,11 +287,55 @@ def test_exclude_labels_match_the_toml(conventions: Conventions) -> None:
 
 
 def test_every_vocabulary_label_has_a_home(conventions: Conventions) -> None:
-    """A label with no category renders its PRs with no heading."""
+    """A label with no category renders its PRs with no heading.
+
+    `no_section` is the deliberate exception, declared in the TOML so that a
+    label which claims no category reads differently from one dropped by
+    accident.
+    """
     homeless = (
-        conventions.all_labels() - category_labels() - set(conventions.exclude_labels)
+        conventions.all_labels()
+        - category_labels()
+        - set(conventions.exclude_labels)
+        - set(conventions.no_section_labels)
     )
     assert not homeless, sorted(homeless)
+
+
+@pytest.mark.parametrize("label", sorted(CONVENTIONS.no_section_labels))
+def test_a_no_section_label_claims_no_category(
+    label: str, conventions: Conventions
+) -> None:
+    """Giving one a category would defeat the point of declaring it."""
+    assert label not in category_labels()
+    assert label not in conventions.exclude_labels
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        # The other scope decides, not `enterprise`.
+        ("feat(enterprise+cases): add case tasks", "Case management"),
+        ("feat(cases+enterprise): add case tasks", "Case management"),
+        ("fix(enterprise+ui): correct the tier badge", "User interface"),
+        # Alone, the type decides.
+        ("feat(enterprise): add a paid-tier gate", "Features"),
+        ("fix(enterprise): correct a tier check", "Fixes"),
+        ("refactor(enterprise): split the tier module", "Other changes"),
+    ],
+)
+def test_enterprise_never_claims_the_section(title: str, expected: str) -> None:
+    """`enterprise` says who may use a change, not what the change is.
+
+    It used to sit in the API category, so every paid feature was filed under
+    API rather than the product area it actually changed.
+    """
+    labels = autolabel(title)
+    assert "enterprise" in labels, labels
+    section = next(
+        c["title"] for c in DRAFTER["categories"] if labels & set(c["labels"])
+    )
+    assert section == expected, f"{title} -> {section}"
 
 
 def test_audit_script_has_no_top_level_yaml_import() -> None:


### PR DESCRIPTION
`enterprise` no longer decides which release-notes section a change lands in.

## The problem

The `enterprise` label sat inside the API category:

```yaml
- title: API
  labels: [api, rbac, enterprise]
```

So every paid feature was filed under API regardless of what it changed. `feat(enterprise+cases): Add case tasks` is case-management work that happens to be tier-gated, not API work — and `0.47.5` rendered it under a hand-written `## 🔒 Enterprise only` heading precisely because the vocabulary had nowhere sensible to put it.

## The change

`enterprise` claims no category at all. The rest of the title routes the change:

| title | lands in |
| --- | --- |
| `feat(enterprise+cases): add case tasks` | Case management |
| `feat(enterprise+ui): tier badge` | User interface |
| `feat(enterprise): add a paid-tier gate` | Features |
| `fix(enterprise): correct a tier check` | Fixes |
| `refactor(enterprise): split the tier module` | Other changes |

The label is still applied by the autolabeler and still searchable on GitHub. It says *who may use* a change, not *what the change is*, so it should not claim a heading.

`api` and `rbac` keep the API category. Only `enterprise` moves.

## Declared, not silently dropped

A label with no category is normally a bug — its pull requests render with no heading, which is the failure `test_every_vocabulary_label_has_a_home` exists to catch. So the omission is declared:

```toml
[labels]
# Labels that describe a change without deciding where it belongs.
no_section = ["enterprise"]
```

The drift guard subtracts that list rather than being deleted, so a category dropped by accident still fails. The loader rejects a `no_section` entry naming a label that does not exist, so the declaration cannot rot into a silent exemption.

## Verification

```bash
uv run pytest tests/unit/test_commit_conventions.py tests/unit/test_check_pr_title.py   # 441 passed
```

Six new routing cases assert the table above against the compiled autolabeler rules and the real category order, plus one asserting no `no_section` label appears in any category or in `exclude`.

Checked against the live config end to end:

```
feat(enterprise+cases)  ['cases', 'enterprise', 'feat']  ->  Case management
feat(enterprise)        ['enterprise', 'feat']           ->  Features
fix(enterprise)         ['enterprise', 'fix']            ->  Fixes
feat(api)               ['api', 'feat']                  ->  API
feat(rbac)              ['feat', 'rbac']                 ->  API
```

## Follow-up

17 lines across published releases carry an enterprise-ish scope. Most already sit under Features, which is where this change puts them anyway; a handful move, mostly `feat(ui+enterprise)` from Features to User interface. Backfilling those separately once this lands, so history and future drafts agree.

## LOC

| Kind | + | - |
| --- | --- | --- |
| Logic | 11 | 1 |
| Tests | 47 | 4 |
| Infra/config | 11 | 1 |
| Docs | 12 | 2 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the `enterprise` label from deciding which release-notes section a change lands in. It used to sit in the API category, so every paid feature was filed under API regardless of the area it changed; now the rest of the title routes the change.

- `feat(enterprise+cases)` lands in Case management; a bare `feat(enterprise)` falls to Features, `fix(enterprise)` to Fixes.
- Declares the omission as `no_section`, so the drift guard still fails on a category dropped by accident and the loader rejects a `no_section` entry naming a nonexistent label.
- `enterprise` stays applied and searchable; `api` and `rbac` keep the API category.
- Historical releases get backfilled separately once this lands.

<sup>Written for commit c7017be4a6b6b1456bb0f6082bdf92776411d17a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

