### PR TITLE
fix(engine): preserve workflow failure through handler errors

### DIFF
--- a/tests/temporal/runtime_error_attribution_child_harness.py
+++ b/tests/temporal/runtime_error_attribution_child_harness.py
@@ -592,7 +592,8 @@ async def run_concurrent_sibling_cancellation_preserves_causal_owner(
     test_worker_factory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> ScenarioObservation:
-    """A fanout aggregates a causal leaf failure with a cancelled sibling."""
+    """A raw custom-action failure remains causal through sibling cancellation."""
+    action_name = "custom_actions.synthetic.fetch_data"
     leaf_wf_id = WorkflowUUID.new_uuid4()
     intermediary_wf_id = WorkflowUUID.new_uuid4()
     intermediary_dsl = fanout_dsl(
@@ -618,6 +619,7 @@ async def run_concurrent_sibling_cancellation_preserves_causal_owner(
                 return prepared_fanout(
                     child_wf_id=leaf_wf_id,
                     modes=["user", "slow"],
+                    action_name=action_name,
                 )
             case _:
                 raise AssertionError(f"Unexpected subflow task: {input.task.ref}")

--- a/tests/temporal/runtime_error_attribution_harness.py
+++ b/tests/temporal/runtime_error_attribution_harness.py
@@ -58,7 +58,9 @@ from tracecat.executor.registry_artifacts import (
 from tracecat.executor.schemas import ExecutorActionErrorInfo
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import RuntimeErrorKind
 from tracecat.storage.object import ExternalObject, InlineObject, ObjectRef
+from tracecat.temporal.errors import extract_error_classifications
 from tracecat.workflow.executions.enums import TemporalSearchAttr
 from tracecat.workflow.management.management import WorkflowsManagementService
 
@@ -192,11 +194,11 @@ class _ConcurrentChildDispatch:
             return {"ok": True}  # pragma: no cover - cancelled by Temporal
         if mode == "user":
             await self.slow_started.wait()
-            cause = ValueError(self.user_diagnostic)
+            cause = AttributeError(self.user_diagnostic)
             info = ExecutorActionErrorInfo(
                 type=type(cause).__name__,
                 message="masked child action failure",
-                action_name="core.noop",
+                action_name=input.task.action,
                 filename="<executor>",
                 function="dispatch",
             )
@@ -308,6 +310,7 @@ def child_dsl(
     title: str = "Attribution child",
     description: str = "Exercise attribution across a real child workflow",
     action_ref: str = "child_action",
+    action_name: str = "core.noop",
     start_delay: float = 0,
 ) -> DSLInput:
     """Build a one-action child definition for real-Worker topology tests."""
@@ -318,7 +321,7 @@ def child_dsl(
         actions=[
             ActionStatement(
                 ref=action_ref,
-                action="core.noop",
+                action=action_name,
                 args={},
                 start_delay=start_delay,
                 retry_policy=ActionRetryPolicy(max_attempts=1, timeout=10),
@@ -399,14 +402,22 @@ def subflow_run_args(
 
 
 def prepared_fanout(
-    *, child_wf_id: WorkflowUUID, modes: list[str]
+    *,
+    child_wf_id: WorkflowUUID,
+    modes: list[str],
+    action_name: str = "core.noop",
 ) -> PreparedSubflowResult:
+    origin = (
+        "custom_actions"
+        if action_name.startswith("custom_actions.")
+        else "tracecat_registry"
+    )
     return PreparedSubflowResult(
         wf_id=child_wf_id,
-        dsl=child_dsl(),
+        dsl=child_dsl(action_name=action_name),
         registry_lock=RegistryLock(
-            origins={"tracecat_registry": "test"},
-            actions={"core.noop": "tracecat_registry"},
+            origins={origin: "test"},
+            actions={action_name: origin},
         ),
         trigger_inputs=InlineObject(
             data=[{"mode": mode} for mode in modes],
@@ -865,6 +876,87 @@ async def run_user_action_failure_sets_user_owner(
                 await handle.result()
 
     assert diagnostic not in (await handle.fetch_history()).to_json()
+    return ScenarioObservation(
+        root=handle,
+        failure=exc_info.value,
+        attempts=fault.attempts,
+    )
+
+
+async def run_missing_error_handler_preserves_original_action_failure(
+    env: WorkflowEnvironment,
+    test_worker_factory,
+) -> ScenarioObservation:
+    """A missing handler is diagnostic and cannot replace the action failure."""
+    diagnostic = "raw custom action diagnostic must not enter history"
+    fault = _DispatchFault(
+        error_factory=lambda: AttributeError(diagnostic),
+        failures=1,
+    )
+    run_args = _inline_run_args(max_attempts=1)
+    assert run_args.dsl is not None
+    run_args.dsl.error_handler = "synthetic-missing-handler"
+    management_service = AsyncMock()
+    management_service.resolve_workflow_alias.return_value = None
+    management_context = AsyncMock()
+    management_context.__aenter__.return_value = management_service
+    dsl_queue = f"runtime-error-attribution-{uuid.uuid4()}"
+
+    with (
+        patch(
+            "tracecat.workflow.management.management."
+            "WorkflowsManagementService.with_session",
+            return_value=management_context,
+        ),
+        patch(
+            "tracecat.executor.activities.get_executor_backend",
+            return_value=object(),
+        ),
+        patch(
+            "tracecat.executor.activities.dispatch_action",
+            new=fault.dispatch,
+        ),
+    ):
+        async with (
+            test_worker_factory(
+                env.client,
+                activities=[
+                    resolve_time_anchor_activity,
+                    resolve_workflow_concurrency_limits_enabled_activity,
+                    WorkflowsManagementService.get_error_handler_workflow_id,
+                ],
+                task_queue=dsl_queue,
+            ),
+            test_worker_factory(
+                env.client,
+                activities=[ExecutorActivities.execute_action_activity],
+                task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+            ),
+        ):
+            handle = await env.client.start_workflow(
+                DSLWorkflow.run,
+                run_args,
+                id=generate_exec_id(run_args.wf_id),
+                task_queue=dsl_queue,
+            )
+            with pytest.raises(WorkflowFailureError) as exc_info:
+                await handle.result()
+
+    history = await handle.fetch_history()
+    activity_classifications = []
+    for event in history.events:
+        if event.event_type != EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED:
+            continue
+        failure = event.activity_task_failed_event_attributes.failure
+        decoded = await env.client.data_converter.decode_failure(failure)
+        activity_classifications.extend(extract_error_classifications(decoded))
+
+    assert any(
+        classification.kind is RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND
+        for classification in activity_classifications
+    )
+    assert diagnostic not in history.to_json()
+    assert management_service.resolve_workflow_alias.await_count == 1
     return ScenarioObservation(
         root=handle,
         failure=exc_info.value,

--- a/tests/temporal/test_dsl_workflow_replay.py
+++ b/tests/temporal/test_dsl_workflow_replay.py
@@ -3,36 +3,51 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Mapping
+from collections.abc import AsyncGenerator, Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Never
 
 import pytest
-from temporalio import activity
+from temporalio import activity, workflow
+from temporalio.api.enums.v1 import EventType
 from temporalio.client import Client, WorkflowFailureError
 from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Replayer, Worker
 
 from tests.shared import recorded_patch_ids
+from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.dsl import workflow as workflow_module
+from tracecat.dsl._converter import get_data_converter
 from tracecat.dsl.action import DSLActivities, PrepareSubflowActivityInput
 from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.init_activities import (
     resolve_workflow_concurrency_limits_enabled_activity,
 )
 from tracecat.dsl.interceptor import RuntimeErrorAttributionInterceptor
-from tracecat.dsl.schemas import ActionStatement
-from tracecat.dsl.types import TaskExceptionInfo
+from tracecat.dsl.schemas import ActionStatement, RunActionInput
+from tracecat.dsl.types import ActionErrorInfo, TaskExceptionInfo
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.registry.lock.types import RegistryLock
-from tracecat.runtime.errors import RuntimeErrorKind
-from tracecat.storage.object import InlineObject
-from tracecat.temporal.errors import extract_error_classification
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorClassification,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
+from tracecat.storage.object import InlineObject, StoredObject
+from tracecat.temporal.errors import (
+    build_error_transport_detail,
+    extract_error_classification,
+    raise_application_error_from_classification,
+)
 from tracecat.temporal.patches import WorkflowPatch
+from tracecat.workflow.executions.enums import TemporalSearchAttr
 from tracecat.workflow.management.management import WorkflowsManagementService
+from tracecat.workflow.management.schemas import GetErrorHandlerWorkflowIDActivityInputs
 
 pytestmark = [pytest.mark.temporal, pytest.mark.integration]
 
@@ -78,6 +93,80 @@ def _raise_legacy_workflow_application_error(
 
 def _ignore_terminal_error_owner(_error: ApplicationError) -> None:
     """Reproduce the absence of terminal owner attribution before ENG-1407."""
+
+
+@pytest.fixture
+async def replay_env() -> AsyncGenerator[WorkflowEnvironment, None]:
+    """Run replay capture against an isolated real Temporal server."""
+    async with await WorkflowEnvironment.start_local(
+        data_converter=get_data_converter(compression_enabled=False),
+        search_attributes=[TemporalSearchAttr.ERROR_OWNER.key],
+        dev_server_log_level="error",
+    ) as environment:
+        yield environment
+
+
+@activity.defn(name="execute_action_activity")
+async def _classified_action_failure_activity(
+    input: RunActionInput,
+    _role: Role,
+) -> None:
+    """Record a stable user-owned action failure in Temporal history."""
+    classification = RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The synthetic action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    raise_application_error_from_classification(
+        classification,
+        build_error_transport_detail(
+            classification,
+            ActionErrorInfo(
+                ref=input.task.ref,
+                message=classification.message,
+                type="SyntheticActionError",
+            ),
+        ),
+    )
+
+
+@activity.defn(
+    name=_activity_name(WorkflowsManagementService.get_error_handler_workflow_id)
+)
+async def _legacy_missing_error_handler(
+    _input: GetErrorHandlerWorkflowIDActivityInputs,
+) -> None:
+    """Reproduce the platform-classified handler lookup failure being replaced."""
+    raise_application_error_from_classification(
+        RuntimeErrorClassification.platform(
+            kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+            message="Tracecat could not resolve the configured error handler",
+            retry_disposition=RetryDisposition.NON_RETRYABLE,
+        )
+    )
+
+
+@workflow.defn(name="DSLWorkflow", sandboxed=False)
+class _LegacyHandlerTerminalWorkflow(DSLWorkflow):
+    """Capture the former handler-terminal behavior under the production type."""
+
+    @workflow.run
+    async def run(self, args: DSLRunArgs) -> StoredObject:
+        return await super().run(args)
+
+    async def _handle_application_error(
+        self,
+        args: DSLRunArgs,
+        error: ApplicationError,
+        *,
+        stamp_terminal_owner: bool,
+    ) -> Never:
+        del stamp_terminal_owner
+        try:
+            await self._get_error_handler_workflow_id(args)
+        except Exception as handler_error:
+            raise handler_error from None
+        raise AssertionError("The synthetic handler lookup should fail")
 
 
 @pytest.mark.anyio
@@ -199,6 +288,120 @@ async def test_dsl_workflow_replays_legacy_subflow_failure_history(
     patch_ids = await recorded_patch_ids(temporal_client, history)
     assert WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE not in patch_ids
     assert WorkflowPatch.ERROR_OWNER_AFTER_HANDLER not in patch_ids
+
+    replay_result = await Replayer(
+        workflows=[DSLWorkflow],
+        workflow_runner=new_sandbox_runner(),
+        data_converter=temporal_client.data_converter,
+        interceptors=[RuntimeErrorAttributionInterceptor()],
+    ).replay_workflow(history, raise_on_replay_failure=False)
+    assert replay_result.replay_failure is None
+
+
+@pytest.mark.anyio
+async def test_dsl_workflow_replays_handler_terminal_replacement_history(
+    replay_env: WorkflowEnvironment,
+) -> None:
+    """Preserving the causal failure keeps the terminal command topology stable."""
+    temporal_client = replay_env.client
+    task_queue = f"dsl-handler-replay-{uuid.uuid4()}"
+    wf_id = WorkflowUUID.new_uuid4()
+    run_args = DSLRunArgs(
+        role=Role(
+            type="service",
+            service_id="tracecat-runner",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+        wf_id=wf_id,
+        dsl=DSLInput(
+            title="Error handler replay probe",
+            description="Capture the former handler terminal replacement",
+            entrypoint=DSLEntrypoint(ref="run"),
+            actions=[
+                ActionStatement(
+                    ref="run",
+                    action="core.noop",
+                    args={},
+                )
+            ],
+            error_handler="synthetic-missing-handler",
+        ),
+        trigger_inputs=InlineObject(data={"source": "replay-test"}),
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test"},
+            actions={"core.noop": "tracecat_registry"},
+        ),
+        time_anchor=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    async with (
+        Worker(
+            client=temporal_client,
+            task_queue=task_queue,
+            activities=[
+                _disable_workflow_concurrency_limits,
+                _legacy_missing_error_handler,
+            ],
+            workflows=[_LegacyHandlerTerminalWorkflow],
+            workflow_runner=new_sandbox_runner(),
+            interceptors=[RuntimeErrorAttributionInterceptor()],
+        ),
+        Worker(
+            client=temporal_client,
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+            activities=[_classified_action_failure_activity],
+        ),
+    ):
+        handle = await temporal_client.start_workflow(
+            "DSLWorkflow",
+            run_args,
+            id=generate_exec_id(wf_id),
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=30),
+        )
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await handle.result()
+
+    recorded_classification = extract_error_classification(exc_info.value)
+    assert recorded_classification is not None
+    assert recorded_classification.owner is RuntimeErrorOwner.PLATFORM
+    history = await handle.fetch_history()
+    activity_failure_events = [
+        event
+        for event in history.events
+        if event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED
+    ]
+    assert len(activity_failure_events) == 2
+    handler_failure_event = activity_failure_events[-1]
+    terminal_events = [
+        event.event_type
+        for event in history.events
+        if event.event_id > handler_failure_event.event_id
+        if (
+            event.event_type == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED
+            or (
+                event.event_type
+                == EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES
+                and TemporalSearchAttr.ERROR_OWNER.value
+                in event.upsert_workflow_search_attributes_event_attributes.search_attributes.indexed_fields
+            )
+        )
+    ]
+    assert terminal_events == [
+        EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES,
+        EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED,
+    ]
+    recorded_error = await temporal_client.data_converter.decode_failure(
+        history.events[-1].workflow_execution_failed_event_attributes.failure
+    )
+    terminal_classification = extract_error_classification(recorded_error)
+    assert terminal_classification is not None
+    assert terminal_classification.owner is RuntimeErrorOwner.PLATFORM
+    assert terminal_classification.kind is RuntimeErrorKind.RUNTIME_UNCLASSIFIED
+    assert (await handle.describe()).typed_search_attributes.get(
+        TemporalSearchAttr.ERROR_OWNER.key
+    ) == RuntimeErrorOwner.PLATFORM.value
 
     replay_result = await Replayer(
         workflows=[DSLWorkflow],

--- a/tests/temporal/test_dsl_workflow_replay.py
+++ b/tests/temporal/test_dsl_workflow_replay.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import uuid
 from collections.abc import AsyncGenerator, Mapping
 from datetime import UTC, datetime, timedelta
-from typing import Never
+from typing import Any, Never
 
 import pytest
 from temporalio import activity, workflow
 from temporalio.api.enums.v1 import EventType
-from temporalio.client import Client, WorkflowFailureError
+from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Replayer, Worker
@@ -161,12 +161,81 @@ class _LegacyHandlerTerminalWorkflow(DSLWorkflow):
         *,
         stamp_terminal_owner: bool,
     ) -> Never:
-        del stamp_terminal_owner
         try:
             await self._get_error_handler_workflow_id(args)
         except Exception as handler_error:
-            raise handler_error from None
+            if stamp_terminal_owner:
+                self._upsert_terminal_error_owner(handler_error)
+            raise handler_error from error
         raise AssertionError("The synthetic handler lookup should fail")
+
+
+def _handler_failure_run_args() -> DSLRunArgs:
+    wf_id = WorkflowUUID.new_uuid4()
+    return DSLRunArgs(
+        role=Role(
+            type="service",
+            service_id="tracecat-runner",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+        wf_id=wf_id,
+        dsl=DSLInput(
+            title="Error handler replay probe",
+            description="Capture error-handler failure behavior",
+            entrypoint=DSLEntrypoint(ref="run"),
+            actions=[
+                ActionStatement(
+                    ref="run",
+                    action="core.noop",
+                    args={},
+                )
+            ],
+            error_handler="synthetic-missing-handler",
+        ),
+        trigger_inputs=InlineObject(data={"source": "replay-test"}),
+        registry_lock=RegistryLock(
+            origins={"tracecat_registry": "test"},
+            actions={"core.noop": "tracecat_registry"},
+        ),
+        time_anchor=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+async def _record_handler_failure(
+    temporal_client: Client,
+    workflow_class: type[DSLWorkflow],
+) -> tuple[WorkflowHandle[Any, Any], WorkflowFailureError]:
+    task_queue = f"dsl-handler-replay-{uuid.uuid4()}"
+    run_args = _handler_failure_run_args()
+    async with (
+        Worker(
+            client=temporal_client,
+            task_queue=task_queue,
+            activities=[
+                _disable_workflow_concurrency_limits,
+                _legacy_missing_error_handler,
+            ],
+            workflows=[workflow_class],
+            workflow_runner=new_sandbox_runner(),
+            interceptors=[RuntimeErrorAttributionInterceptor()],
+        ),
+        Worker(
+            client=temporal_client,
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+            activities=[_classified_action_failure_activity],
+        ),
+    ):
+        handle = await temporal_client.start_workflow(
+            "DSLWorkflow",
+            run_args,
+            id=generate_exec_id(run_args.wf_id),
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=30),
+        )
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await handle.result()
+    return handle, exc_info.value
 
 
 @pytest.mark.anyio
@@ -299,74 +368,23 @@ async def test_dsl_workflow_replays_legacy_subflow_failure_history(
 
 
 @pytest.mark.anyio
-async def test_dsl_workflow_replays_handler_terminal_replacement_history(
+async def test_dsl_workflow_handler_failure_preserves_original_with_one_upsert(
     replay_env: WorkflowEnvironment,
 ) -> None:
-    """Preserving the causal failure keeps the terminal command topology stable."""
+    """New histories keep the causal failure and one terminal owner upsert."""
     temporal_client = replay_env.client
-    task_queue = f"dsl-handler-replay-{uuid.uuid4()}"
-    wf_id = WorkflowUUID.new_uuid4()
-    run_args = DSLRunArgs(
-        role=Role(
-            type="service",
-            service_id="tracecat-runner",
-            workspace_id=uuid.uuid4(),
-            organization_id=uuid.uuid4(),
-        ),
-        wf_id=wf_id,
-        dsl=DSLInput(
-            title="Error handler replay probe",
-            description="Capture the former handler terminal replacement",
-            entrypoint=DSLEntrypoint(ref="run"),
-            actions=[
-                ActionStatement(
-                    ref="run",
-                    action="core.noop",
-                    args={},
-                )
-            ],
-            error_handler="synthetic-missing-handler",
-        ),
-        trigger_inputs=InlineObject(data={"source": "replay-test"}),
-        registry_lock=RegistryLock(
-            origins={"tracecat_registry": "test"},
-            actions={"core.noop": "tracecat_registry"},
-        ),
-        time_anchor=datetime(2026, 1, 1, tzinfo=UTC),
+    handle, recorded_failure = await _record_handler_failure(
+        temporal_client,
+        DSLWorkflow,
     )
 
-    async with (
-        Worker(
-            client=temporal_client,
-            task_queue=task_queue,
-            activities=[
-                _disable_workflow_concurrency_limits,
-                _legacy_missing_error_handler,
-            ],
-            workflows=[_LegacyHandlerTerminalWorkflow],
-            workflow_runner=new_sandbox_runner(),
-            interceptors=[RuntimeErrorAttributionInterceptor()],
-        ),
-        Worker(
-            client=temporal_client,
-            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
-            activities=[_classified_action_failure_activity],
-        ),
-    ):
-        handle = await temporal_client.start_workflow(
-            "DSLWorkflow",
-            run_args,
-            id=generate_exec_id(wf_id),
-            task_queue=task_queue,
-            execution_timeout=timedelta(seconds=30),
-        )
-        with pytest.raises(WorkflowFailureError) as exc_info:
-            await handle.result()
-
-    recorded_classification = extract_error_classification(exc_info.value)
+    recorded_classification = extract_error_classification(recorded_failure)
     assert recorded_classification is not None
-    assert recorded_classification.owner is RuntimeErrorOwner.PLATFORM
+    assert recorded_classification.owner is RuntimeErrorOwner.USER
+    assert recorded_classification.kind is RuntimeErrorKind.ACTION_EXECUTION_FAILED
     history = await handle.fetch_history()
+    patch_ids = await recorded_patch_ids(temporal_client, history)
+    assert WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE in patch_ids
     activity_failure_events = [
         event
         for event in history.events
@@ -397,11 +415,64 @@ async def test_dsl_workflow_replays_handler_terminal_replacement_history(
     )
     terminal_classification = extract_error_classification(recorded_error)
     assert terminal_classification is not None
+    assert terminal_classification.owner is RuntimeErrorOwner.USER
+    assert terminal_classification.kind is RuntimeErrorKind.ACTION_EXECUTION_FAILED
+    assert (await handle.describe()).typed_search_attributes.get(
+        TemporalSearchAttr.ERROR_OWNER.key
+    ) == RuntimeErrorOwner.USER.value
+
+
+@pytest.mark.anyio
+async def test_dsl_workflow_replays_handler_terminal_replacement_history(
+    replay_env: WorkflowEnvironment,
+) -> None:
+    """The preservation patch replays the exact former terminal command path."""
+    temporal_client = replay_env.client
+    handle, recorded_failure = await _record_handler_failure(
+        temporal_client,
+        _LegacyHandlerTerminalWorkflow,
+    )
+
+    recorded_classification = extract_error_classification(recorded_failure)
+    assert recorded_classification is not None
+    assert recorded_classification.owner is RuntimeErrorOwner.PLATFORM
+    history = await handle.fetch_history()
+    activity_failure_events = [
+        event
+        for event in history.events
+        if event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED
+    ]
+    assert len(activity_failure_events) == 2
+    handler_failure_event = activity_failure_events[-1]
+    terminal_events = [
+        event.event_type
+        for event in history.events
+        if event.event_id > handler_failure_event.event_id
+        if (
+            event.event_type == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED
+            or (
+                event.event_type
+                == EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES
+                and TemporalSearchAttr.ERROR_OWNER.value
+                in event.upsert_workflow_search_attributes_event_attributes.search_attributes.indexed_fields
+            )
+        )
+    ]
+    assert terminal_events == [
+        EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES,
+        EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES,
+        EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED,
+    ]
+    recorded_error = await temporal_client.data_converter.decode_failure(
+        history.events[-1].workflow_execution_failed_event_attributes.failure
+    )
+    terminal_classification = extract_error_classification(recorded_error)
+    assert terminal_classification is not None
     assert terminal_classification.owner is RuntimeErrorOwner.PLATFORM
     assert terminal_classification.kind is RuntimeErrorKind.RUNTIME_UNCLASSIFIED
     assert (await handle.describe()).typed_search_attributes.get(
         TemporalSearchAttr.ERROR_OWNER.key
-    ) == RuntimeErrorOwner.PLATFORM.value
+    ) == RuntimeErrorOwner.USER.value
 
     replay_result = await Replayer(
         workflows=[DSLWorkflow],

--- a/tests/temporal/test_runtime_error_attribution.py
+++ b/tests/temporal/test_runtime_error_attribution.py
@@ -54,6 +54,7 @@ class _FaultPoint(StrEnum):
     EXECUTOR_BACKEND = "get_executor_backend"
     EXECUTOR_DISPATCH = "dispatch_action"
     RESULT_PERSISTENCE = "object_storage.store"
+    ERROR_HANDLER_LOOKUP = "get_error_handler_workflow_id"
     DEFINITION_SERVICE = "get_definition_by_workflow_id"
     DEFINITION_DESERIALIZATION = "definition_deserialization"
     CHILD_EXECUTION = "child_dispatch"
@@ -419,7 +420,7 @@ ATTRIBUTION_SCENARIOS: tuple[_AttributionScenario, ...] = (
         id="subflows.concurrent_cancellation.preserves_causal_owner",
         topology=_Topology.FANOUT,
         fault_point=_FaultPoint.CHILD_EXECUTION,
-        fault="user leaf failure + cancelled sibling",
+        fault="raw custom-action failure + cancelled sibling",
         root=_ExecutionExpectation(_FAILED, RuntimeErrorOwner.USER),
         children=(
             _ExecutionExpectation(_FAILED, RuntimeErrorOwner.USER),
@@ -445,6 +446,20 @@ ATTRIBUTION_SCENARIOS: tuple[_AttributionScenario, ...] = (
         retry_disposition=RetryDisposition.RETRYABLE,
         runner=_monkeypatch_runner(
             child_harness.run_successful_error_handler_does_not_inherit_terminal_owner
+        ),
+    ),
+    _AttributionScenario(
+        id="error_handler.missing_alias.preserves_original_failure",
+        topology=_Topology.ERROR_HANDLER,
+        fault_point=_FaultPoint.ERROR_HANDLER_LOOKUP,
+        fault="raw custom-action failure + missing handler alias",
+        root=_ExecutionExpectation(_FAILED, RuntimeErrorOwner.USER),
+        envelope_owners=frozenset({RuntimeErrorOwner.USER}),
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        retry_disposition=RetryDisposition.RETRYABLE,
+        attempts=1,
+        runner=_basic_runner(
+            harness.run_missing_error_handler_preserves_original_action_failure
         ),
     ),
     _AttributionScenario(

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -87,6 +87,7 @@ from tracecat.pagination import CursorPaginationParams
 from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
 from tracecat.secrets.schemas import SecretCreate, SecretKeyValue
 from tracecat.secrets.service import SecretsService
 from tracecat.storage.object import (
@@ -101,7 +102,7 @@ from tracecat.storage.utils import (
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import TableColumnCreate, TableCreate, TableRowInsert
 from tracecat.tables.service import TablesService
-from tracecat.temporal.errors import ErrorTransportDetail
+from tracecat.temporal.errors import ErrorTransportDetail, extract_error_classification
 from tracecat.variables.schemas import VariableCreate
 from tracecat.variables.service import VariablesService
 from tracecat.workflow.executions.enums import (
@@ -3841,16 +3842,14 @@ async def test_workflow_error_handler_success(
 
 
 @pytest.mark.parametrize(
-    "id_or_alias,expected_err_msg",
+    "id_or_alias",
     [
         pytest.param(
             "wf-00000000000000000000000000000000",
-            "workflow.definition.not_found: Tracecat could not load a published workflow definition",
             id="id-no-match",
         ),
         pytest.param(
             "invalid_error_handler",
-            "WorkflowAliasResolutionError: Couldn't find matching workflow for alias 'invalid_error_handler'",
             id="alias-no-match",
         ),
     ],
@@ -3863,7 +3862,6 @@ async def test_workflow_error_handler_invalid_handler_fail_no_match(
     temporal_client: Client,
     failing_dsl: DSLInput,
     id_or_alias: str,
-    expected_err_msg: str,
     test_worker_factory,
     test_executor_worker_factory,
 ):
@@ -3892,15 +3890,10 @@ async def test_workflow_error_handler_invalid_handler_fail_no_match(
         executor_worker = test_executor_worker_factory(temporal_client)
         _ = await _run_workflow(wf_exec_id, run_args, worker, executor_worker)
     assert str(exc_info.value) == "Workflow execution failed"
-    cause0 = exc_info.value.cause
-    assert isinstance(cause0, ActivityError)
-    cause1 = cause0.cause
-    assert isinstance(cause1, ApplicationError)
-    assert str(cause1) == expected_err_msg
-    if id_or_alias == "invalid_error_handler":
-        err = str(cause1)
-        assert "Activity task failed" not in err
-        assert "timed out" not in err.lower()
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.ACTION_EXECUTION_FAILED
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_executor_error_policy.py
+++ b/tests/unit/test_executor_error_policy.py
@@ -56,6 +56,22 @@ def test_wrapped_entitlement_failure_is_non_retryable_user_error() -> None:
     assert result.cause_type == "EntitlementRequired"
 
 
+def test_raw_custom_action_exception_is_user_owned_action_failure() -> None:
+    """A custom action bug is owned by its author, not platform operations."""
+    cause = AttributeError("synthetic custom action failure")
+    error = _iteration_error(cause, index=0)
+
+    result = classify_execute_action_error(
+        error,
+        action_name="custom_actions.synthetic.fetch_data",
+    )
+
+    assert result.owner is RuntimeErrorOwner.USER
+    assert result.kind is RuntimeErrorKind.ACTION_EXECUTION_FAILED
+    assert result.retry_disposition is RetryDisposition.RETRYABLE
+    assert result.cause_type == "ExecutionError"
+
+
 @pytest.mark.parametrize("platform_first", [True, False])
 def test_mixed_loop_failure_is_platform_owned_but_non_retryable(
     platform_first: bool,

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -1079,6 +1079,10 @@ async def test_error_handler_failure_preserves_original_terminal_owner() -> None
             "_run_error_handler_workflow",
             new=AsyncMock(side_effect=handler_error),
         ),
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ) as patched_mock,
         patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
         patch("tracecat.dsl.workflow.workflow.info"),
         patch(
@@ -1098,6 +1102,9 @@ async def test_error_handler_failure_preserves_original_terminal_owner() -> None
 
     assert exc_info.value is original_error
     assert handler_error.__context__ is original_error
+    patched_mock.assert_called_once_with(
+        WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE
+    )
     upsert_mock.assert_not_called()
 
 
@@ -1119,6 +1126,10 @@ async def test_unclassified_handler_failure_preserves_original_owner() -> None:
             "_get_error_handler_workflow_id",
             new=AsyncMock(side_effect=handler_error),
         ),
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ) as patched_mock,
         patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
     ):
         try:
@@ -1133,6 +1144,9 @@ async def test_unclassified_handler_failure_preserves_original_owner() -> None:
 
     assert exc_info.value is original_error
     assert handler_error.__context__ is original_error
+    patched_mock.assert_called_once_with(
+        WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE
+    )
     upsert_mock.assert_not_called()
 
 
@@ -1162,6 +1176,10 @@ async def test_error_handler_lookup_failure_defers_owner_stamp_to_interceptor() 
             DSLWorkflow,
             "_upsert_terminal_error_owner",
         ) as upsert_mock,
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ),
         pytest.raises(ApplicationError) as exc_info,
     ):
         await instance._handle_application_error(
@@ -1197,6 +1215,10 @@ async def test_error_handler_detail_failure_defers_owner_stamp_to_interceptor() 
             DSLWorkflow,
             "_upsert_terminal_error_owner",
         ) as upsert_mock,
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ),
         pytest.raises(ApplicationError) as exc_info,
     ):
         await instance._handle_application_error(
@@ -1271,6 +1293,7 @@ def test_error_handler_owner_timing_has_distinct_replay_patch() -> None:
     assert WorkflowPatch.ERROR_OWNER_AFTER_HANDLER not in {
         WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE,
         WorkflowPatch.ERROR_OWNER_CONTROL_FLOW,
+        WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE,
     }
 
 

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Literal
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from botocore.exceptions import HTTPClientError
@@ -1079,10 +1079,6 @@ async def test_error_handler_failure_preserves_original_terminal_owner() -> None
             "_run_error_handler_workflow",
             new=AsyncMock(side_effect=handler_error),
         ),
-        patch(
-            "tracecat.dsl.workflow.workflow.patched",
-            return_value=True,
-        ) as patched_mock,
         patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
         patch("tracecat.dsl.workflow.workflow.info"),
         patch(
@@ -1102,15 +1098,7 @@ async def test_error_handler_failure_preserves_original_terminal_owner() -> None
 
     assert exc_info.value is original_error
     assert handler_error.__context__ is original_error
-    assert patched_mock.call_args_list == [
-        call(WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE),
-        call(WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE),
-    ]
-    upsert_mock.assert_called_once()
-    updates = upsert_mock.call_args.args[0]
-    assert len(updates) == 1
-    assert updates[0].key.name == TemporalSearchAttr.ERROR_OWNER.value
-    assert updates[0].value == RuntimeErrorOwner.USER.value
+    upsert_mock.assert_not_called()
 
 
 @pytest.mark.anyio
@@ -1131,10 +1119,6 @@ async def test_unclassified_handler_failure_preserves_original_owner() -> None:
             "_get_error_handler_workflow_id",
             new=AsyncMock(side_effect=handler_error),
         ),
-        patch(
-            "tracecat.dsl.workflow.workflow.patched",
-            return_value=True,
-        ) as patched_mock,
         patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
     ):
         try:
@@ -1149,18 +1133,11 @@ async def test_unclassified_handler_failure_preserves_original_owner() -> None:
 
     assert exc_info.value is original_error
     assert handler_error.__context__ is original_error
-    assert patched_mock.call_args_list == [
-        call(WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE),
-        call(WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE),
-    ]
-    upsert_mock.assert_called_once()
-    updates = upsert_mock.call_args.args[0]
-    assert len(updates) == 1
-    assert updates[0].value == RuntimeErrorOwner.USER.value
+    upsert_mock.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_error_handler_lookup_failure_stamps_original_error() -> None:
+async def test_error_handler_lookup_failure_defers_owner_stamp_to_interceptor() -> None:
     instance, args = _error_handler_workflow()
     original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -1185,10 +1162,6 @@ async def test_error_handler_lookup_failure_stamps_original_error() -> None:
             DSLWorkflow,
             "_upsert_terminal_error_owner",
         ) as upsert_mock,
-        patch(
-            "tracecat.dsl.workflow.workflow.patched",
-            return_value=True,
-        ),
         pytest.raises(ApplicationError) as exc_info,
     ):
         await instance._handle_application_error(
@@ -1198,11 +1171,11 @@ async def test_error_handler_lookup_failure_stamps_original_error() -> None:
         )
 
     assert exc_info.value is original_error
-    upsert_mock.assert_called_once_with(original_error)
+    upsert_mock.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -> None:
+async def test_error_handler_detail_failure_defers_owner_stamp_to_interceptor() -> None:
     instance, args = _error_handler_workflow()
     original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -1224,10 +1197,6 @@ async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -
             DSLWorkflow,
             "_upsert_terminal_error_owner",
         ) as upsert_mock,
-        patch(
-            "tracecat.dsl.workflow.workflow.patched",
-            return_value=True,
-        ),
         pytest.raises(ApplicationError) as exc_info,
     ):
         await instance._handle_application_error(
@@ -1237,53 +1206,7 @@ async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -
         )
 
     assert exc_info.value is original_error
-    upsert_mock.assert_called_once_with(original_error)
-
-
-@pytest.mark.anyio
-async def test_error_handler_failure_replays_legacy_terminal_behavior() -> None:
-    """Marker-free histories keep the handler failure as their terminal error."""
-    instance, args = _error_handler_workflow()
-    original_classification = RuntimeErrorClassification.user(
-        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
-        message="The action failed",
-        retry_disposition=RetryDisposition.NON_RETRYABLE,
-    )
-    handler_classification = RuntimeErrorClassification.platform(
-        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
-        message="Tracecat could not run the error handler",
-        retry_disposition=RetryDisposition.NON_RETRYABLE,
-    )
-    original_error = _capture_application_error(original_classification)
-    handler_error = _capture_application_error(handler_classification)
-
-    with (
-        patch.object(
-            instance,
-            "_get_error_handler_workflow_id",
-            new=AsyncMock(side_effect=handler_error),
-        ),
-        patch(
-            "tracecat.dsl.workflow.workflow.patched",
-            return_value=False,
-        ) as patched_mock,
-        patch.object(
-            DSLWorkflow,
-            "_upsert_terminal_error_owner",
-        ) as upsert_mock,
-        pytest.raises(ApplicationError) as exc_info,
-    ):
-        await instance._handle_application_error(
-            args,
-            original_error,
-            stamp_terminal_owner=True,
-        )
-
-    assert exc_info.value is handler_error
-    patched_mock.assert_called_once_with(
-        WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE
-    )
-    upsert_mock.assert_called_once_with(handler_error)
+    upsert_mock.assert_not_called()
 
 
 def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
@@ -1348,7 +1271,6 @@ def test_error_handler_owner_timing_has_distinct_replay_patch() -> None:
     assert WorkflowPatch.ERROR_OWNER_AFTER_HANDLER not in {
         WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE,
         WorkflowPatch.ERROR_OWNER_CONTROL_FLOW,
-        WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE,
     }
 
 

--- a/tests/unit/test_runtime_error_steel_thread.py
+++ b/tests/unit/test_runtime_error_steel_thread.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Literal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from botocore.exceptions import HTTPClientError
@@ -1044,8 +1044,8 @@ async def test_error_handler_runs_before_original_owner_is_stamped() -> None:
 
 
 @pytest.mark.anyio
-async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
-    """A failing handler becomes the terminal error and owns the stamped attribution."""
+async def test_error_handler_failure_preserves_original_terminal_owner() -> None:
+    """A failing handler stays secondary to the original classified failure."""
     instance, args = _error_handler_workflow()
     original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -1100,19 +1100,22 @@ async def test_error_handler_failure_replaces_original_terminal_owner() -> None:
                     stamp_terminal_owner=True,
                 )
 
-    assert exc_info.value is handler_error
+    assert exc_info.value is original_error
     assert handler_error.__context__ is original_error
-    patched_mock.assert_called_once_with(WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE)
+    assert patched_mock.call_args_list == [
+        call(WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE),
+        call(WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE),
+    ]
     upsert_mock.assert_called_once()
     updates = upsert_mock.call_args.args[0]
     assert len(updates) == 1
     assert updates[0].key.name == TemporalSearchAttr.ERROR_OWNER.value
-    assert updates[0].value == RuntimeErrorOwner.PLATFORM.value
+    assert updates[0].value == RuntimeErrorOwner.USER.value
 
 
 @pytest.mark.anyio
-async def test_unclassified_handler_failure_does_not_inherit_original_owner() -> None:
-    """Incidental exception context cannot classify an unclassified handler failure."""
+async def test_unclassified_handler_failure_preserves_original_owner() -> None:
+    """An unclassified handler failure stays secondary to the original error."""
     instance, args = _error_handler_workflow()
     original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -1128,27 +1131,36 @@ async def test_unclassified_handler_failure_does_not_inherit_original_owner() ->
             "_get_error_handler_workflow_id",
             new=AsyncMock(side_effect=handler_error),
         ),
-        patch("tracecat.dsl.workflow.workflow.patched") as patched_mock,
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ) as patched_mock,
         patch("tracecat.dsl.workflow.workflow.upsert_search_attributes") as upsert_mock,
     ):
         try:
             raise original_error
         except ApplicationError as active_error:
-            with pytest.raises(RuntimeError) as exc_info:
+            with pytest.raises(ApplicationError) as exc_info:
                 await instance._handle_application_error(
                     args,
                     active_error,
                     stamp_terminal_owner=True,
                 )
 
-    assert exc_info.value is handler_error
+    assert exc_info.value is original_error
     assert handler_error.__context__ is original_error
-    patched_mock.assert_not_called()
-    upsert_mock.assert_not_called()
+    assert patched_mock.call_args_list == [
+        call(WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE),
+        call(WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE),
+    ]
+    upsert_mock.assert_called_once()
+    updates = upsert_mock.call_args.args[0]
+    assert len(updates) == 1
+    assert updates[0].value == RuntimeErrorOwner.USER.value
 
 
 @pytest.mark.anyio
-async def test_error_handler_lookup_failure_stamps_escaping_error() -> None:
+async def test_error_handler_lookup_failure_stamps_original_error() -> None:
     instance, args = _error_handler_workflow()
     original_classification = RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
@@ -1173,6 +1185,10 @@ async def test_error_handler_lookup_failure_stamps_escaping_error() -> None:
             DSLWorkflow,
             "_upsert_terminal_error_owner",
         ) as upsert_mock,
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ),
         pytest.raises(ApplicationError) as exc_info,
     ):
         await instance._handle_application_error(
@@ -1181,8 +1197,8 @@ async def test_error_handler_lookup_failure_stamps_escaping_error() -> None:
             stamp_terminal_owner=True,
         )
 
-    assert exc_info.value is lookup_error
-    upsert_mock.assert_called_once_with(lookup_error)
+    assert exc_info.value is original_error
+    upsert_mock.assert_called_once_with(original_error)
 
 
 @pytest.mark.anyio
@@ -1208,7 +1224,11 @@ async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -
             DSLWorkflow,
             "_upsert_terminal_error_owner",
         ) as upsert_mock,
-        pytest.raises(ValidationError) as exc_info,
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=True,
+        ),
+        pytest.raises(ApplicationError) as exc_info,
     ):
         await instance._handle_application_error(
             args,
@@ -1216,7 +1236,54 @@ async def test_error_handler_detail_adaptation_failure_stamps_escaping_error() -
             stamp_terminal_owner=True,
         )
 
-    upsert_mock.assert_called_once_with(exc_info.value)
+    assert exc_info.value is original_error
+    upsert_mock.assert_called_once_with(original_error)
+
+
+@pytest.mark.anyio
+async def test_error_handler_failure_replays_legacy_terminal_behavior() -> None:
+    """Marker-free histories keep the handler failure as their terminal error."""
+    instance, args = _error_handler_workflow()
+    original_classification = RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        message="The action failed",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    handler_classification = RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="Tracecat could not run the error handler",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    original_error = _capture_application_error(original_classification)
+    handler_error = _capture_application_error(handler_classification)
+
+    with (
+        patch.object(
+            instance,
+            "_get_error_handler_workflow_id",
+            new=AsyncMock(side_effect=handler_error),
+        ),
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=False,
+        ) as patched_mock,
+        patch.object(
+            DSLWorkflow,
+            "_upsert_terminal_error_owner",
+        ) as upsert_mock,
+        pytest.raises(ApplicationError) as exc_info,
+    ):
+        await instance._handle_application_error(
+            args,
+            original_error,
+            stamp_terminal_owner=True,
+        )
+
+    assert exc_info.value is handler_error
+    patched_mock.assert_called_once_with(
+        WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE
+    )
+    upsert_mock.assert_called_once_with(handler_error)
 
 
 def test_terminal_platform_owner_wins_for_alert_attribution() -> None:
@@ -1281,6 +1348,7 @@ def test_error_handler_owner_timing_has_distinct_replay_patch() -> None:
     assert WorkflowPatch.ERROR_OWNER_AFTER_HANDLER not in {
         WorkflowPatch.ERROR_OWNER_SEARCH_ATTRIBUTE,
         WorkflowPatch.ERROR_OWNER_CONTROL_FLOW,
+        WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE,
     }
 
 

--- a/tests/unit/test_temporal_patches.py
+++ b/tests/unit/test_temporal_patches.py
@@ -7,6 +7,9 @@ def test_workflow_patch_ids_are_history_stable() -> None:
         "ERROR_OWNER_SEARCH_ATTRIBUTE": "dsl-error-owner-search-attribute-v1",
         "ERROR_OWNER_CONTROL_FLOW": "dsl-error-owner-control-flow-v1",
         "ERROR_OWNER_AFTER_HANDLER": "dsl-error-owner-after-handler-v1",
+        "PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE": (
+            "dsl-preserve-original-error-after-handler-failure-v1"
+        ),
         "PRESERVE_TEMPORAL_CANCELLATION": "dsl-preserve-temporal-cancellation-v1",
         "RUNTIME_ERROR_ATTRIBUTION_INTERCEPTOR": (
             "runtime-error-attribution-interceptor-v1"

--- a/tests/unit/test_temporal_patches.py
+++ b/tests/unit/test_temporal_patches.py
@@ -7,9 +7,6 @@ def test_workflow_patch_ids_are_history_stable() -> None:
         "ERROR_OWNER_SEARCH_ATTRIBUTE": "dsl-error-owner-search-attribute-v1",
         "ERROR_OWNER_CONTROL_FLOW": "dsl-error-owner-control-flow-v1",
         "ERROR_OWNER_AFTER_HANDLER": "dsl-error-owner-after-handler-v1",
-        "PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE": (
-            "dsl-preserve-original-error-after-handler-failure-v1"
-        ),
         "PRESERVE_TEMPORAL_CANCELLATION": "dsl-preserve-temporal-cancellation-v1",
         "RUNTIME_ERROR_ATTRIBUTION_INTERCEPTOR": (
             "runtime-error-attribution-interceptor-v1"

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -2062,23 +2062,18 @@ class DSLWorkflow:
                 "Failed to run error handler workflow",
                 error_type=type(handler_error).__name__,
             )
-            if not workflow.patched(
-                WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE
-            ):
-                if stamp_terminal_owner:
-                    self._upsert_terminal_error_owner(handler_error)
-                raise handler_error from error
             if is_cancelled_exception(handler_error):
                 raise
             handler_failure = handler_error
 
-        if stamp_terminal_owner:
-            self._upsert_terminal_error_owner(error)
         # Leave the failed handler in Temporal activity/child history and logs,
-        # but keep the classified workflow failure as the terminal cause. Raising
+        # but keep the classified workflow failure as the terminal cause. The
+        # interceptor owns the single terminal search-attribute upsert. Raising
         # outside the handler's except block avoids chaining it back onto `error`.
         if handler_failure is not None:
             raise error from None
+        if stamp_terminal_owner:
+            self._upsert_terminal_error_owner(error)
         raise error
 
     async def _get_error_handler_workflow_id(

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -2062,6 +2062,12 @@ class DSLWorkflow:
                 "Failed to run error handler workflow",
                 error_type=type(handler_error).__name__,
             )
+            if not workflow.patched(
+                WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE
+            ):
+                if stamp_terminal_owner:
+                    self._upsert_terminal_error_owner(handler_error)
+                raise handler_error from error
             if is_cancelled_exception(handler_error):
                 raise
             handler_failure = handler_error

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -2027,6 +2027,7 @@ class DSLWorkflow:
             "Error running workflow, running error handler",
             type=error.__class__.__name__,
         )
+        handler_failure: Exception | None = None
         try:
             handler_wf_id = await self._get_error_handler_workflow_id(args)
             if handler_wf_id is None:
@@ -2057,16 +2058,27 @@ class DSLWorkflow:
                 )
                 await self._run_error_handler_workflow(err_run_args)
         except Exception as handler_error:
-            if stamp_terminal_owner:
-                self._upsert_terminal_error_owner(handler_error)
             self.logger.error(
                 "Failed to run error handler workflow",
                 error_type=type(handler_error).__name__,
             )
-            raise handler_error from error
+            if not workflow.patched(
+                WorkflowPatch.PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE
+            ):
+                if stamp_terminal_owner:
+                    self._upsert_terminal_error_owner(handler_error)
+                raise handler_error from error
+            if is_cancelled_exception(handler_error):
+                raise
+            handler_failure = handler_error
 
         if stamp_terminal_owner:
             self._upsert_terminal_error_owner(error)
+        # Leave the failed handler in Temporal activity/child history and logs,
+        # but keep the classified workflow failure as the terminal cause. Raising
+        # outside the handler's except block avoids chaining it back onto `error`.
+        if handler_failure is not None:
+            raise error from None
         raise error
 
     async def _get_error_handler_workflow_id(

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -120,6 +120,10 @@ class TracecatNotFoundError(TracecatException):
     """Raised when a resource is not found in the Tracecat database."""
 
 
+class WorkflowAliasResolutionError(TracecatNotFoundError):
+    """Raised when a configured workflow alias does not resolve."""
+
+
 class TracecatServiceError(TracecatException):
     """Tracecat generic user-facing service error"""
 

--- a/tracecat/temporal/patches.py
+++ b/tracecat/temporal/patches.py
@@ -11,8 +11,5 @@ class WorkflowPatch(StrEnum):
     ERROR_OWNER_SEARCH_ATTRIBUTE = "dsl-error-owner-search-attribute-v1"
     ERROR_OWNER_CONTROL_FLOW = "dsl-error-owner-control-flow-v1"
     ERROR_OWNER_AFTER_HANDLER = "dsl-error-owner-after-handler-v1"
-    PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE = (
-        "dsl-preserve-original-error-after-handler-failure-v1"
-    )
     PRESERVE_TEMPORAL_CANCELLATION = "dsl-preserve-temporal-cancellation-v1"
     RUNTIME_ERROR_ATTRIBUTION_INTERCEPTOR = "runtime-error-attribution-interceptor-v1"

--- a/tracecat/temporal/patches.py
+++ b/tracecat/temporal/patches.py
@@ -11,5 +11,8 @@ class WorkflowPatch(StrEnum):
     ERROR_OWNER_SEARCH_ATTRIBUTE = "dsl-error-owner-search-attribute-v1"
     ERROR_OWNER_CONTROL_FLOW = "dsl-error-owner-control-flow-v1"
     ERROR_OWNER_AFTER_HANDLER = "dsl-error-owner-after-handler-v1"
+    PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE = (
+        "dsl-preserve-original-error-after-handler-failure-v1"
+    )
     PRESERVE_TEMPORAL_CANCELLATION = "dsl-preserve-temporal-cancellation-v1"
     RUNTIME_ERROR_ATTRIBUTION_INTERCEPTOR = "runtime-error-attribution-interceptor-v1"

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -13,7 +13,6 @@ from pydantic import ValidationError
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import selectinload
 from temporalio import activity
-from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.catalog.service import AgentCatalogService
 from tracecat.audit.logger import AuditEventDetails, audit_log
@@ -44,6 +43,7 @@ from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
     TracecatNotFoundError,
     TracecatValidationError,
+    WorkflowAliasResolutionError,
 )
 from tracecat.expressions.eval import eval_templated_object
 from tracecat.identifiers import WorkflowID
@@ -59,7 +59,13 @@ from tracecat.pagination import (
 )
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorClassification,
+    RuntimeErrorKind,
+)
 from tracecat.service import BaseWorkspaceService
+from tracecat.temporal.errors import raise_application_error_from_classification
 from tracecat.validation.schemas import (
     DSLValidationResult,
     ValidationDetail,
@@ -1711,9 +1717,14 @@ class WorkflowsManagementService(BaseWorkspaceService):
                     id_or_alias, use_committed=use_committed
                 )
             if not handler_wf_id:
-                raise ApplicationError(
-                    f"Couldn't find matching workflow for alias {id_or_alias!r}",
-                    non_retryable=True,
-                    type="WorkflowAliasResolutionError",
+                error = WorkflowAliasResolutionError(
+                    "The configured workflow alias does not resolve"
                 )
+                classification = RuntimeErrorClassification.user(
+                    kind=RuntimeErrorKind.WORKFLOW_DEFINITION_NOT_FOUND,
+                    message="The configured error handler workflow could not be found",
+                    retry_disposition=RetryDisposition.NON_RETRYABLE,
+                    cause=error,
+                )
+                raise_application_error_from_classification(classification)
         return handler_wf_id


### PR DESCRIPTION
## Summary

- preserve the original classified workflow failure when a configured error handler cannot be resolved or executed
- classify a missing error-handler alias as a user-owned workflow definition error
- cover raw custom-action failures propagating through concurrent sibling cancellation without changing the aggregation policy already present on `main`

## Design

The handler failure remains available as secondary Temporal activity or child-workflow history and as a sanitized log, but it no longer replaces the causal workflow failure for new executions. This keeps Sentry ownership and kind tied to the failure that caused the workflow to enter error handling.

The change is gated by `PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE`. Marker-free histories replay the exact deployed handler-terminal behavior, including the legacy inner owner upsert before the attribution interceptor's upsert. New histories record the marker, preserve the original classified failure, and rely on `RuntimeErrorAttributionInterceptor` for the single terminal owner upsert. A real Temporal replay regression records the deployed command sequence and replays it with the new implementation, while a separate new-history test proves the clean one-upsert path.

Current `main` already classifies wrapped raw custom-action exceptions as user-owned `action.execution.failed` errors and excludes native sibling cancellation from causal aggregation. This PR strengthens the exact-shape Temporal coverage instead of adding a second policy path.

## Verification

- `uv run pytest tests/unit/test_runtime_error_steel_thread.py tests/unit/test_executor_error_policy.py tests/unit/test_temporal_patches.py tests/unit/test_dsl_error_policy.py -q --confcutdir=tests/unit` — 66 passed
- `uv run pytest tests/temporal/test_dsl_workflow_replay.py -q --confcutdir=tests/temporal` — 2 passed
- `uv run pytest tests/temporal/test_runtime_error_attribution.py -q` — 29 passed
- `uv run ruff check <changed Python files>` — passed
- `uv run ruff format --check <changed Python files>` — passed
- `uv run basedpyright <changed Python files>` — 0 errors, 0 warnings, 0 notes
- repository commit hooks, including generated-client consistency and Python type checking — passed

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 40 | 9 |
| Tests | 461 | 53 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the original classified workflow failure when an error handler cannot be resolved or executed. Previously, the handler failure replaced the workflow failure as the terminal cause; now it stays secondary in history and logs, keeping Sentry ownership and kind tied to the causal failure. Handler cancellation during error handling still propagates as a workflow cancellation.

**Behavior**
- Classifies a missing error-handler alias as a user-owned workflow definition error via the new `WorkflowAliasResolutionError`.
- Covers raw custom-action failures propagating through concurrent sibling cancellation without changing the aggregation policy.
- Verifies replay of old terminal-replacement histories keeps the terminal command topology unchanged.

**Migration**
- Existing workflows replay the old terminal-replacement behavior through a Temporal patch marker; new executions deterministically use the preservation behavior.

<sup>Written for commit dd182e9ff8fb39725d68121949309288e918df96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

