### PR TITLE
feat(api): add shared filter predicate compiler

### DIFF
--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -380,6 +380,7 @@ def test_exists_factory_receives_validated_condition() -> None:
                 expr=factory,
                 kind=FieldKind.TAG,
                 allowed_ops=KIND_OPS[FieldKind.TAG],
+                value_type=sa.String(),
             )
         }
     )
@@ -393,6 +394,66 @@ def test_exists_factory_receives_validated_condition() -> None:
     assert received == [(FilterOp.CONTAINS, "malware")]
     assert "EXISTS" in sql
     assert "tag =" in sql
+
+
+def test_exists_factory_receives_normalized_temporal_value() -> None:
+    received: list[Any] = []
+
+    def factory(_op: FilterOp, value: Any) -> ColumnElement[bool]:
+        received.append(value)
+        return sa.exists(
+            sa.select(1).where(
+                sa.column("created_at", sa.DateTime(timezone=True)) >= value
+            )
+        )
+
+    resolver = StubResolver(
+        {
+            "created_at": ResolvedField(
+                expr=factory,
+                kind=FieldKind.TEMPORAL,
+                allowed_ops=ALL_OPS,
+                value_type=sa.DateTime(timezone=True),
+            )
+        }
+    )
+
+    expression = compile_filter(
+        Condition(
+            field="created_at",
+            op=FilterOp.GTE,
+            value="2026-09-01T12:00:00Z",
+        ),
+        resolver,
+    )
+    _, params = _compile_sql(expression)
+
+    expected = datetime.fromisoformat("2026-09-01T12:00:00+00:00")
+    assert received == [expected]
+    assert list(params.values()) == [expected]
+
+
+def test_predicate_factory_requires_value_type_for_non_null_value() -> None:
+    def factory(_op: FilterOp, value: Any) -> ColumnElement[bool]:
+        return sa.exists(sa.select(1).where(sa.literal_column("tag") == value))
+
+    resolver = StubResolver(
+        {
+            "tags": ResolvedField(
+                expr=factory,
+                kind=FieldKind.TAG,
+                allowed_ops=KIND_OPS[FieldKind.TAG],
+            )
+        }
+    )
+
+    with pytest.raises(
+        TracecatValidationError, match="predicate factory requires a value type"
+    ):
+        compile_filter(
+            Condition(field="tags", op=FilterOp.CONTAINS, value="malware"),
+            resolver,
+        )
 
 
 def test_accepts_orm_instrumented_attribute() -> None:

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -566,6 +566,22 @@ def test_normalizes_large_numeric_integer_to_decimal() -> None:
     assert isinstance(expression.right.type, sa.Numeric)
 
 
+@pytest.mark.parametrize("value", [10**309, Decimal("1e10000")])
+def test_rejects_values_that_overflow_float(value: int | Decimal) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.Float()),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    with pytest.raises(TracecatValidationError, match="field 'value'"):
+        compile_filter(Condition(field="value", op=FilterOp.EQ, value=value), resolver)
+
+
 def test_normalizes_native_enum_values() -> None:
     expression = sa.column("status", sa.Enum(_NativeStatus))
     resolver = StubResolver(

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -682,12 +682,83 @@ def test_rejects_invalid_numeric_string(value: str) -> None:
         compile_filter(Condition(field="value", op=FilterOp.EQ, value=value), resolver)
 
 
+@pytest.mark.parametrize(
+    ("value", "should_pass"),
+    [
+        ("1e131071", True),
+        ("1e131072", False),
+        ("1e-16383", True),
+        ("1e-16384", False),
+    ],
+)
+def test_validates_postgresql_numeric_extent(value: str, should_pass: bool) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.Numeric()),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+    condition = Condition(field="value", op=FilterOp.EQ, value=value)
+
+    if should_pass:
+        _, params = _compile_sql(compile_filter(condition, resolver))
+        assert list(params.values()) == [Decimal(value)]
+    else:
+        with pytest.raises(TracecatValidationError, match="field 'value'"):
+            compile_filter(condition, resolver)
+
+
+def test_rejects_extreme_exponent_before_integer_conversion() -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.BigInteger()),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    with pytest.raises(TracecatValidationError, match="field 'value'"):
+        compile_filter(
+            Condition(field="value", op=FilterOp.EQ, value="1e1000000"), resolver
+        )
+
+
 @pytest.mark.parametrize("value", [10**309, Decimal("1e10000")])
 def test_rejects_values_that_overflow_float(value: int | Decimal) -> None:
     resolver = StubResolver(
         {
             "value": ResolvedField(
                 expr=sa.column("value", sa.Float()),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    with pytest.raises(TracecatValidationError, match="field 'value'"):
+        compile_filter(Condition(field="value", op=FilterOp.EQ, value=value), resolver)
+
+
+@pytest.mark.parametrize(
+    ("sql_type", "value"),
+    [
+        (sa.Float(), "1e-400"),
+        (sa.REAL(), "1e100"),
+        (sa.Float(precision=24), "1e100"),
+    ],
+)
+def test_rejects_float_underflow_and_type_overflow(
+    sql_type: sa.Float, value: str
+) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sql_type),
                 kind=FieldKind.NUMBER,
                 allowed_ops=ALL_OPS,
             )

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -646,6 +646,42 @@ def test_normalizes_large_numeric_integer_to_decimal() -> None:
     assert isinstance(expression.right.type, sa.Numeric)
 
 
+def test_normalizes_lossless_numeric_string_to_decimal() -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.Numeric()),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+    value = "0.1234567890123456789"
+
+    expression = compile_filter(
+        Condition(field="value", op=FilterOp.EQ, value=value), resolver
+    )
+    _, params = _compile_sql(expression)
+
+    assert list(params.values()) == [Decimal(value)]
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "NaN", "Infinity"])
+def test_rejects_invalid_numeric_string(value: str) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.Numeric()),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    with pytest.raises(TracecatValidationError, match="field 'value'"):
+        compile_filter(Condition(field="value", op=FilterOp.EQ, value=value), resolver)
+
+
 @pytest.mark.parametrize("value", [10**309, Decimal("1e10000")])
 def test_rejects_values_that_overflow_float(value: int | Decimal) -> None:
     resolver = StubResolver(

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -467,6 +467,25 @@ def test_rejects_wrong_kind_value(kind: FieldKind, value: Any) -> None:
         compile_filter(Condition(field="value", op=FilterOp.EQ, value=value), resolver)
 
 
+@pytest.mark.parametrize("kind", [FieldKind.TEXT, FieldKind.ENUM, FieldKind.TAG])
+def test_rejects_nul_in_string_values(kind: FieldKind) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=_expression(kind),
+                kind=kind,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    with pytest.raises(TracecatValidationError, match="field 'value'"):
+        compile_filter(
+            Condition(field="value", op=FilterOp.IN, value=["before\x00after"]),
+            resolver,
+        )
+
+
 def test_normalizes_direct_expression_values() -> None:
     field_id = "00000000-0000-0000-0000-000000000001"
     scenarios: list[tuple[FieldKind, ColumnElement[Any], Any, object]] = [

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.sql.elements import ColumnElement
+
+from tracecat.exceptions import TracecatValidationError
+from tracecat.query.compiler import compile_filter
+from tracecat.query.filters import (
+    AndClause,
+    Condition,
+    FilterOp,
+    FilterScalar,
+    NotClause,
+    OrClause,
+)
+from tracecat.query.resolver import FieldKind, ResolvedField
+
+ALL_OPS = frozenset(FilterOp)
+KIND_OPS: Mapping[FieldKind, frozenset[FilterOp]] = {
+    FieldKind.TEXT: frozenset(
+        {
+            FilterOp.EQ,
+            FilterOp.NE,
+            FilterOp.IN,
+            FilterOp.NOT_IN,
+            FilterOp.CONTAINS,
+            FilterOp.STARTS_WITH,
+            FilterOp.IS_NULL,
+        }
+    ),
+    FieldKind.NUMBER: frozenset(
+        {
+            FilterOp.EQ,
+            FilterOp.NE,
+            FilterOp.IN,
+            FilterOp.NOT_IN,
+            FilterOp.GT,
+            FilterOp.GTE,
+            FilterOp.LT,
+            FilterOp.LTE,
+            FilterOp.IS_NULL,
+        }
+    ),
+    FieldKind.BOOLEAN: frozenset({FilterOp.EQ, FilterOp.NE, FilterOp.IS_NULL}),
+    FieldKind.TEMPORAL: frozenset(
+        {
+            FilterOp.EQ,
+            FilterOp.NE,
+            FilterOp.GT,
+            FilterOp.GTE,
+            FilterOp.LT,
+            FilterOp.LTE,
+            FilterOp.IS_NULL,
+        }
+    ),
+    FieldKind.ENUM: frozenset(
+        {
+            FilterOp.EQ,
+            FilterOp.NE,
+            FilterOp.IN,
+            FilterOp.NOT_IN,
+            FilterOp.IS_NULL,
+        }
+    ),
+    FieldKind.UUID: frozenset(
+        {
+            FilterOp.EQ,
+            FilterOp.NE,
+            FilterOp.IN,
+            FilterOp.NOT_IN,
+            FilterOp.IS_NULL,
+        }
+    ),
+    FieldKind.TAG: frozenset({FilterOp.CONTAINS, FilterOp.IN, FilterOp.IS_NULL}),
+}
+
+
+class StubResolver:
+    def __init__(self, fields: Mapping[str, ResolvedField]) -> None:
+        self._fields = fields
+
+    def resolve(self, field: str) -> ResolvedField | None:
+        return self._fields.get(field)
+
+
+class _Base(DeclarativeBase):
+    pass
+
+
+class _Row(_Base):
+    __tablename__ = "query_compiler_test_row"
+
+    value: Mapped[str] = mapped_column(primary_key=True)
+
+
+def _expression(kind: FieldKind) -> ColumnElement[Any]:
+    match kind:
+        case FieldKind.NUMBER:
+            return sa.column("value", sa.Numeric())
+        case FieldKind.BOOLEAN:
+            return sa.column("value", sa.Boolean())
+        case FieldKind.TEMPORAL:
+            return sa.column("value", sa.DateTime(timezone=True))
+        case FieldKind.UUID:
+            return sa.column("value", sa.Uuid())
+        case _:
+            return sa.column("value", sa.String())
+
+
+def _scalar(kind: FieldKind) -> FilterScalar:
+    match kind:
+        case FieldKind.NUMBER:
+            return 42
+        case FieldKind.BOOLEAN:
+            return True
+        case FieldKind.TEMPORAL:
+            return "2026-09-01T12:00:00Z"
+        case FieldKind.UUID:
+            return "00000000-0000-0000-0000-000000000001"
+        case _:
+            return "value"
+
+
+def _value(kind: FieldKind, op: FilterOp) -> Any:
+    if op is FilterOp.IS_NULL:
+        return None
+    scalar = _scalar(kind)
+    if op in {FilterOp.IN, FilterOp.NOT_IN}:
+        return [scalar]
+    return scalar
+
+
+def _compile_sql(expression: ColumnElement[bool]) -> tuple[str, Mapping[str, Any]]:
+    compiled = expression.compile(dialect=postgresql.dialect())
+    return str(compiled), compiled.params
+
+
+@pytest.mark.parametrize(
+    ("kind", "op"),
+    [(kind, op) for kind in FieldKind for op in FilterOp],
+)
+def test_operation_kind_matrix(kind: FieldKind, op: FilterOp) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=_expression(kind),
+                kind=kind,
+                allowed_ops=KIND_OPS[kind],
+            )
+        }
+    )
+    condition = Condition(field="value", op=op, value=_value(kind, op))
+
+    if op not in KIND_OPS[kind]:
+        with pytest.raises(TracecatValidationError, match="field 'value'"):
+            compile_filter(condition, resolver)
+        return
+
+    assert isinstance(compile_filter(condition, resolver), ColumnElement)
+
+
+@pytest.mark.parametrize(
+    ("op", "sql_fragment"),
+    [
+        (FilterOp.EQ, "value ="),
+        (FilterOp.NE, "value !="),
+        (FilterOp.IN, "value IN"),
+        (FilterOp.NOT_IN, "value NOT IN"),
+        (FilterOp.GT, "value >"),
+        (FilterOp.GTE, "value >="),
+        (FilterOp.LT, "value <"),
+        (FilterOp.LTE, "value <="),
+        (FilterOp.CONTAINS, "value ILIKE"),
+        (FilterOp.STARTS_WITH, "value ILIKE"),
+        (FilterOp.IS_NULL, "value IS NULL"),
+    ],
+)
+def test_compiles_each_operation(op: FilterOp, sql_fragment: str) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.String()),
+                kind=FieldKind.TEXT,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+    value: Any
+    if op is FilterOp.IS_NULL:
+        value = None
+    elif op in {FilterOp.IN, FilterOp.NOT_IN}:
+        value = ["expected"]
+    else:
+        value = "expected"
+
+    sql, _ = _compile_sql(
+        compile_filter(Condition(field="value", op=op, value=value), resolver)
+    )
+
+    assert sql_fragment in sql
+
+
+def test_ne_and_not_in_keep_sql_three_valued_logic() -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.String()),
+                kind=FieldKind.TEXT,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    ne_sql, _ = _compile_sql(
+        compile_filter(
+            Condition(field="value", op=FilterOp.NE, value="expected"), resolver
+        )
+    )
+    not_in_sql, _ = _compile_sql(
+        compile_filter(
+            Condition(field="value", op=FilterOp.NOT_IN, value=["expected"]),
+            resolver,
+        )
+    )
+
+    assert "IS NULL" not in ne_sql
+    assert "IS DISTINCT FROM" not in ne_sql
+    assert "IS NULL" not in not_in_sql
+    assert "IS DISTINCT FROM" not in not_in_sql
+
+
+@pytest.mark.parametrize(
+    ("op", "expected_sql"),
+    [(FilterOp.IN, "false"), (FilterOp.NOT_IN, "true")],
+)
+def test_empty_membership_short_circuits_direct_expression(
+    op: FilterOp, expected_sql: str
+) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.String()),
+                kind=FieldKind.TEXT,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    sql, _ = _compile_sql(
+        compile_filter(Condition(field="value", op=op, value=[]), resolver)
+    )
+
+    assert sql == expected_sql
+
+
+@pytest.mark.parametrize(
+    ("op", "expected_sql"),
+    [(FilterOp.IN, "false"), (FilterOp.NOT_IN, "true")],
+)
+def test_empty_membership_short_circuits_exists_factory(
+    op: FilterOp, expected_sql: str
+) -> None:
+    calls = 0
+
+    def factory(_op: FilterOp, _value: Any) -> ColumnElement[bool]:
+        nonlocal calls
+        calls += 1
+        return sa.exists(sa.select(1))
+
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=factory,
+                kind=FieldKind.TEXT,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    sql, _ = _compile_sql(
+        compile_filter(Condition(field="value", op=op, value=[]), resolver)
+    )
+
+    assert sql == expected_sql
+    assert calls == 0
+
+
+def test_ilike_escapes_wildcards_and_escape_character() -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.String()),
+                kind=FieldKind.TEXT,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    contains, contains_params = _compile_sql(
+        compile_filter(
+            Condition(field="value", op=FilterOp.CONTAINS, value=r"a%_\b"),
+            resolver,
+        )
+    )
+    starts_sql, starts_params = _compile_sql(
+        compile_filter(
+            Condition(field="value", op=FilterOp.STARTS_WITH, value=r"a%_\b"),
+            resolver,
+        )
+    )
+
+    assert "ESCAPE '\\\\'" in contains
+    assert "ESCAPE '\\\\'" in starts_sql
+    assert list(contains_params.values()) == [r"%a\%\_\\b%"]
+    assert list(starts_params.values()) == [r"a\%\_\\b%"]
+
+
+def test_compiles_boolean_tree() -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.String()),
+                kind=FieldKind.TEXT,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+    negated = NotClause.model_validate(
+        {"not_": Condition(field="value", op=FilterOp.EQ, value="third")}
+    )
+    disjunction = OrClause.model_validate(
+        {
+            "or_": [
+                Condition(field="value", op=FilterOp.EQ, value="second"),
+                negated,
+            ]
+        }
+    )
+    tree = AndClause.model_validate(
+        {
+            "and_": [
+                Condition(field="value", op=FilterOp.EQ, value="first"),
+                disjunction,
+            ]
+        }
+    )
+
+    sql, _ = _compile_sql(compile_filter(tree, resolver))
+
+    assert " AND " in sql
+    assert " OR " in sql
+    assert "value !=" in sql
+
+
+def test_exists_factory_receives_validated_condition() -> None:
+    received: list[tuple[FilterOp, Any]] = []
+
+    def factory(op: FilterOp, value: Any) -> ColumnElement[bool]:
+        received.append((op, value))
+        return sa.exists(sa.select(1).where(sa.literal_column("tag") == value))
+
+    resolver = StubResolver(
+        {
+            "tags": ResolvedField(
+                expr=factory,
+                kind=FieldKind.TAG,
+                allowed_ops=KIND_OPS[FieldKind.TAG],
+            )
+        }
+    )
+
+    expression = compile_filter(
+        Condition(field="tags", op=FilterOp.CONTAINS, value="malware"), resolver
+    )
+
+    assert isinstance(expression, ColumnElement)
+    assert received == [(FilterOp.CONTAINS, "malware")]
+
+
+def test_accepts_orm_instrumented_attribute() -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=_Row.value,
+                kind=FieldKind.TEXT,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    sql, _ = _compile_sql(
+        compile_filter(
+            Condition(field="value", op=FilterOp.EQ, value="expected"), resolver
+        )
+    )
+
+    assert "query_compiler_test_row.value =" in sql
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        Condition(field="value", op=FilterOp.EQ, value=["one"]),
+        Condition(field="value", op=FilterOp.IN, value="one"),
+        Condition(field="value", op=FilterOp.IS_NULL, value="one"),
+        Condition(field="value", op=FilterOp.EQ, value=None),
+    ],
+)
+def test_rejects_wrong_operator_value_shape(condition: Condition) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.String()),
+                kind=FieldKind.TEXT,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    with pytest.raises(TracecatValidationError, match="field 'value'"):
+        compile_filter(condition, resolver)
+
+
+@pytest.mark.parametrize(
+    ("kind", "value"),
+    [
+        (FieldKind.TEXT, 1),
+        (FieldKind.NUMBER, True),
+        (FieldKind.NUMBER, float("inf")),
+        (FieldKind.BOOLEAN, "true"),
+        (FieldKind.TEMPORAL, "not-a-date"),
+        (FieldKind.ENUM, 1),
+        (FieldKind.UUID, "not-a-uuid"),
+        (FieldKind.TAG, 1),
+    ],
+)
+def test_rejects_wrong_kind_value(kind: FieldKind, value: Any) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=_expression(kind),
+                kind=kind,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    with pytest.raises(TracecatValidationError, match="field 'value'"):
+        compile_filter(Condition(field="value", op=FilterOp.EQ, value=value), resolver)
+
+
+def test_normalizes_direct_expression_values() -> None:
+    field_id = "00000000-0000-0000-0000-000000000001"
+    scenarios: list[tuple[FieldKind, ColumnElement[Any], Any, object]] = [
+        (
+            FieldKind.NUMBER,
+            sa.column("value", sa.Numeric()),
+            Decimal("1.5"),
+            Decimal("1.5"),
+        ),
+        (
+            FieldKind.TEMPORAL,
+            sa.column("value", sa.Date()),
+            "2026-09-01",
+            date(2026, 9, 1),
+        ),
+        (
+            FieldKind.TEMPORAL,
+            sa.column("value", sa.DateTime(timezone=True)),
+            "2026-09-01T12:00:00Z",
+            datetime.fromisoformat("2026-09-01T12:00:00+00:00"),
+        ),
+        (FieldKind.UUID, sa.column("value", sa.Uuid()), field_id, UUID(field_id)),
+    ]
+
+    for kind, expression, value, expected in scenarios:
+        resolver = StubResolver(
+            {
+                "value": ResolvedField(
+                    expr=expression,
+                    kind=kind,
+                    allowed_ops=ALL_OPS,
+                )
+            }
+        )
+        _, params = _compile_sql(
+            compile_filter(
+                Condition(field="value", op=FilterOp.EQ, value=value), resolver
+            )
+        )
+        assert list(params.values()) == [expected]
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["unknown", '"; drop table case; --', "workspace_id", "internal_secret"],
+)
+def test_rejects_unknown_and_hostile_field_names(field: str) -> None:
+    resolver = StubResolver({})
+
+    with pytest.raises(TracecatValidationError, match=field.replace("?", "\\?")):
+        compile_filter(Condition(field=field, op=FilterOp.EQ, value="value"), resolver)

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -509,6 +509,63 @@ def test_normalizes_direct_expression_values() -> None:
         assert list(params.values()) == [expected]
 
 
+@pytest.mark.parametrize(
+    ("sql_type", "minimum", "maximum"),
+    [
+        (sa.SmallInteger(), -(2**15), 2**15 - 1),
+        (sa.Integer(), -(2**31), 2**31 - 1),
+        (sa.BigInteger(), -(2**63), 2**63 - 1),
+    ],
+)
+def test_validates_integer_bounds(
+    sql_type: sa.Integer, minimum: int, maximum: int
+) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sql_type),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    for value in (minimum, maximum):
+        _, params = _compile_sql(
+            compile_filter(
+                Condition(field="value", op=FilterOp.EQ, value=value), resolver
+            )
+        )
+        assert list(params.values()) == [value]
+
+    for value in (minimum - 1, maximum + 1):
+        with pytest.raises(TracecatValidationError, match="field 'value'"):
+            compile_filter(
+                Condition(field="value", op=FilterOp.EQ, value=value), resolver
+            )
+
+
+def test_normalizes_large_numeric_integer_to_decimal() -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.Numeric()),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+    value = 10**100
+
+    expression = compile_filter(
+        Condition(field="value", op=FilterOp.EQ, value=value), resolver
+    )
+    _, params = _compile_sql(expression)
+
+    assert list(params.values()) == [Decimal(str(value))]
+    assert isinstance(expression.right.type, sa.Numeric)
+
+
 def test_normalizes_native_enum_values() -> None:
     expression = sa.column("status", sa.Enum(_NativeStatus))
     resolver = StubResolver(

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -690,7 +690,7 @@ def test_rejects_invalid_numeric_string(value: str) -> None:
         ("1e-16383", True),
         ("1e-16384", False),
         ("0e-16383", True),
-        ("0e-16384", False),
+        ("0e-16384", True),
         ("1.2300e-16382", False),
     ],
 )
@@ -712,6 +712,27 @@ def test_validates_postgresql_numeric_extent(value: str, should_pass: bool) -> N
     else:
         with pytest.raises(TracecatValidationError, match="field 'value'"):
             compile_filter(condition, resolver)
+
+
+@pytest.mark.parametrize("value", ["0e-1000000", "0e1000000", "-0e1000000"])
+def test_canonicalizes_extreme_numeric_zero(value: str) -> None:
+    resolver = StubResolver(
+        {
+            "value": ResolvedField(
+                expr=sa.column("value", sa.Numeric()),
+                kind=FieldKind.NUMBER,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    _, params = _compile_sql(
+        compile_filter(Condition(field="value", op=FilterOp.EQ, value=value), resolver)
+    )
+
+    normalized = next(iter(params.values()))
+    assert normalized == Decimal(0)
+    assert normalized.as_tuple().exponent == 0
 
 
 def test_rejects_extreme_exponent_before_integer_conversion() -> None:

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -689,6 +689,9 @@ def test_rejects_invalid_numeric_string(value: str) -> None:
         ("1e131072", False),
         ("1e-16383", True),
         ("1e-16384", False),
+        ("0e-16383", True),
+        ("0e-16384", False),
+        ("1.2300e-16382", False),
     ],
 )
 def test_validates_postgresql_numeric_extent(value: str, should_pass: bool) -> None:

--- a/tests/unit/query/test_compiler.py
+++ b/tests/unit/query/test_compiler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
+from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
@@ -100,6 +101,11 @@ class _Row(_Base):
     __tablename__ = "query_compiler_test_row"
 
     value: Mapped[str] = mapped_column(primary_key=True)
+
+
+class _NativeStatus(StrEnum):
+    OPEN = "open"
+    CLOSED = "closed"
 
 
 def _expression(kind: FieldKind) -> ColumnElement[Any]:
@@ -381,9 +387,12 @@ def test_exists_factory_receives_validated_condition() -> None:
     expression = compile_filter(
         Condition(field="tags", op=FilterOp.CONTAINS, value="malware"), resolver
     )
+    sql, _ = _compile_sql(expression)
 
     assert isinstance(expression, ColumnElement)
     assert received == [(FilterOp.CONTAINS, "malware")]
+    assert "EXISTS" in sql
+    assert "tag =" in sql
 
 
 def test_accepts_orm_instrumented_attribute() -> None:
@@ -498,6 +507,75 @@ def test_normalizes_direct_expression_values() -> None:
             )
         )
         assert list(params.values()) == [expected]
+
+
+def test_normalizes_native_enum_values() -> None:
+    expression = sa.column("status", sa.Enum(_NativeStatus))
+    resolver = StubResolver(
+        {
+            "status": ResolvedField(
+                expr=expression,
+                kind=FieldKind.ENUM,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    _, params = _compile_sql(
+        compile_filter(
+            Condition(field="status", op=FilterOp.IN, value=["open", "closed"]),
+            resolver,
+        )
+    )
+
+    assert list(params.values()) == [[_NativeStatus.OPEN, _NativeStatus.CLOSED]]
+
+
+def test_rejects_unknown_native_enum_value() -> None:
+    resolver = StubResolver(
+        {
+            "status": ResolvedField(
+                expr=sa.column("status", sa.Enum(_NativeStatus)),
+                kind=FieldKind.ENUM,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    with pytest.raises(TracecatValidationError, match="field 'status'"):
+        compile_filter(
+            Condition(field="status", op=FilterOp.EQ, value="invalid"), resolver
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2026-09-01T12:00:00", datetime(2026, 9, 1, 12)),
+        ("2026-09-01T12:00:00-04:00", datetime(2026, 9, 1, 12)),
+        (date(2026, 9, 1), datetime(2026, 9, 1)),
+    ],
+)
+def test_normalizes_timezone_free_datetime_without_tzinfo(
+    value: str | date, expected: datetime
+) -> None:
+    resolver = StubResolver(
+        {
+            "created_at": ResolvedField(
+                expr=sa.column("created_at", sa.DateTime(timezone=False)),
+                kind=FieldKind.TEMPORAL,
+                allowed_ops=ALL_OPS,
+            )
+        }
+    )
+
+    _, params = _compile_sql(
+        compile_filter(
+            Condition(field="created_at", op=FilterOp.EQ, value=value), resolver
+        )
+    )
+
+    assert list(params.values()) == [expected]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/query/test_filters.py
+++ b/tests/unit/query/test_filters.py
@@ -5,6 +5,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from tracecat.query.filters import (
     MAX_FILTER_CONDITIONS,
+    MAX_FILTER_VALUES,
     AndClause,
     Condition,
     Filter,
@@ -105,4 +106,35 @@ def test_filter_rejects_tree_over_maximum_condition_count() -> None:
     with pytest.raises(ValidationError, match="maximum condition count 50"):
         FILTER_ADAPTER.validate_python(
             {"and": [_condition(index) for index in range(MAX_FILTER_CONDITIONS + 1)]}
+        )
+
+
+def test_filter_accepts_maximum_value_count() -> None:
+    parsed = FILTER_ADAPTER.validate_python(
+        {"field": "status", "op": "in", "value": list(range(MAX_FILTER_VALUES))}
+    )
+
+    assert isinstance(parsed, Condition)
+
+
+def test_filter_rejects_single_condition_over_maximum_value_count() -> None:
+    with pytest.raises(ValidationError, match="maximum value count 1000"):
+        FILTER_ADAPTER.validate_python(
+            {
+                "field": "status",
+                "op": "in",
+                "value": list(range(MAX_FILTER_VALUES + 1)),
+            }
+        )
+
+
+def test_filter_rejects_combined_tree_over_maximum_value_count() -> None:
+    with pytest.raises(ValidationError, match="maximum value count 1000"):
+        FILTER_ADAPTER.validate_python(
+            {
+                "and": [
+                    {"field": "first", "op": "in", "value": list(range(501))},
+                    {"field": "second", "op": "in", "value": list(range(500))},
+                ]
+            }
         )

--- a/tests/unit/query/test_filters.py
+++ b/tests/unit/query/test_filters.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from tracecat.query.filters import (
+    MAX_FILTER_CONDITIONS,
+    AndClause,
+    Condition,
+    Filter,
+    FilterOp,
+)
+
+FILTER_ADAPTER = TypeAdapter(Filter)
+
+
+def _condition(index: int = 0) -> dict[str, Any]:
+    return {"field": f"field_{index}", "op": "eq", "value": "value"}
+
+
+def _nested_not(depth: int) -> dict[str, Any]:
+    node = _condition()
+    for _ in range(depth - 1):
+        node = {"not": node}
+    return node
+
+
+def test_filter_aliases_round_trip() -> None:
+    payload = {
+        "and": [
+            {"field": "status", "op": "eq", "value": "open"},
+            {
+                "or": [
+                    {"field": "priority", "op": "in", "value": ["high"]},
+                    {
+                        "not": {
+                            "field": "summary",
+                            "op": "contains",
+                            "value": "test",
+                        }
+                    },
+                ]
+            },
+        ]
+    }
+
+    parsed = FILTER_ADAPTER.validate_python(payload)
+
+    assert isinstance(parsed, AndClause)
+    assert parsed.model_dump(mode="json") == payload
+    assert FILTER_ADAPTER.validate_python(parsed.model_dump()) == parsed
+
+
+def test_filter_alias_accepts_python_field_name() -> None:
+    parsed = AndClause.model_validate(
+        {"and_": [Condition(field="status", op=FilterOp.EQ, value="open")]}
+    )
+
+    assert parsed.model_dump(mode="json") == {
+        "and": [{"field": "status", "op": "eq", "value": "open"}]
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "field": "status",
+            "op": "eq",
+            "value": "open",
+            "and": [_condition()],
+        },
+        {"and": []},
+        {"not": [_condition()]},
+        {"field": "status", "op": "eq", "value": "open", "unexpected": True},
+        {},
+    ],
+)
+def test_filter_rejects_discriminator_edge_shapes(payload: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        FILTER_ADAPTER.validate_python(payload)
+
+
+def test_filter_accepts_maximum_depth() -> None:
+    parsed = FILTER_ADAPTER.validate_python(_nested_not(4))
+
+    assert parsed.model_dump(mode="json") == _nested_not(4)
+
+
+def test_filter_rejects_tree_over_maximum_depth() -> None:
+    with pytest.raises(ValidationError, match="maximum depth 4"):
+        FILTER_ADAPTER.validate_python(_nested_not(5))
+
+
+def test_filter_accepts_maximum_condition_count() -> None:
+    parsed = FILTER_ADAPTER.validate_python(
+        {"and": [_condition(index) for index in range(MAX_FILTER_CONDITIONS)]}
+    )
+
+    assert isinstance(parsed, AndClause)
+    assert len(parsed.and_) == MAX_FILTER_CONDITIONS
+
+
+def test_filter_rejects_tree_over_maximum_condition_count() -> None:
+    with pytest.raises(ValidationError, match="maximum condition count 50"):
+        FILTER_ADAPTER.validate_python(
+            {"and": [_condition(index) for index in range(MAX_FILTER_CONDITIONS + 1)]}
+        )

--- a/tracecat/query/__init__.py
+++ b/tracecat/query/__init__.py
@@ -1,0 +1,1 @@
+"""Shared query models and SQLAlchemy compilers."""

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -141,7 +141,7 @@ def _normalize_value(
     resolved: ResolvedField,
     expression: ColumnElement[Any],
     value: FilterValue | None,
-) -> FilterValue | None:
+) -> object | list[object] | None:
     if value is None:
         return None
     if isinstance(value, list):
@@ -157,13 +157,15 @@ def _normalize_scalar(
     kind: FieldKind,
     expression: ColumnElement[Any],
     value: FilterScalar,
-) -> FilterScalar:
+) -> object:
     try:
         match kind:
             case FieldKind.NUMBER:
                 return _normalize_number(expression, value)
             case FieldKind.TEMPORAL:
                 return _normalize_temporal(expression, value)
+            case FieldKind.ENUM:
+                return _normalize_enum(expression, value)
             case FieldKind.UUID:
                 if isinstance(value, UUID):
                     return value
@@ -218,7 +220,22 @@ def _normalize_temporal(
         parsed = datetime(value.year, value.month, value.day, tzinfo=UTC)
     else:
         parsed = _parse_iso_datetime(value)
+    if isinstance(expression.type, sa.DateTime) and not expression.type.timezone:
+        return parsed.replace(tzinfo=None)
     return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+
+
+def _normalize_enum(expression: ColumnElement[Any], value: FilterScalar) -> object:
+    if not isinstance(value, str):
+        raise TypeError
+    if not isinstance(expression.type, sa.Enum):
+        return value
+
+    if enum_class := expression.type.enum_class:
+        return enum_class(value)
+    if value not in expression.type.enums:
+        raise ValueError
+    return value
 
 
 def _parse_iso_datetime(value: str) -> datetime:
@@ -229,7 +246,7 @@ def _parse_iso_datetime(value: str) -> datetime:
 def _compile_expression(
     condition: Condition,
     expression: ColumnElement[Any],
-    value: FilterValue | None,
+    value: object | list[object] | None,
 ) -> ColumnElement[bool]:
     match condition.op:
         case FilterOp.EQ:

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -222,6 +222,8 @@ def _normalize_number(
         raise ValueError from exc
     if not decimal_value.is_finite():
         raise ValueError
+    if decimal_value.is_zero():
+        decimal_value = Decimal(0)
     if isinstance(value_type, sa.Integer):
         lower_bound, upper_bound = _integer_bounds(value_type)
         if not Decimal(lower_bound) <= decimal_value <= Decimal(upper_bound):

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -110,7 +110,7 @@ def _validate_scalar(
 def _matches_kind_value(kind: FieldKind, value: FilterScalar) -> bool:
     match kind:
         case FieldKind.TEXT | FieldKind.ENUM | FieldKind.TAG:
-            return isinstance(value, str)
+            return isinstance(value, str) and "\x00" not in value
         case FieldKind.NUMBER:
             if isinstance(value, bool) or not isinstance(value, int | float | Decimal):
                 return False

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import struct
 from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -35,6 +36,8 @@ POSTGRES_INTEGER_MIN = -(2**31)
 POSTGRES_INTEGER_MAX = 2**31 - 1
 POSTGRES_BIGINT_MIN = -(2**63)
 POSTGRES_BIGINT_MAX = 2**63 - 1
+POSTGRES_NUMERIC_MAX_WHOLE_DIGITS = 131_072
+POSTGRES_NUMERIC_MAX_FRACTIONAL_DIGITS = 16_383
 
 
 def compile_filter(node: Filter, resolver: FieldResolver) -> ColumnElement[bool]:
@@ -220,22 +223,16 @@ def _normalize_number(
     if not decimal_value.is_finite():
         raise ValueError
     if isinstance(value_type, sa.Integer):
+        lower_bound, upper_bound = _integer_bounds(value_type)
+        if not Decimal(lower_bound) <= decimal_value <= Decimal(upper_bound):
+            raise ValueError
         if decimal_value != decimal_value.to_integral_value():
             raise ValueError
-        integer_value = int(decimal_value)
-        lower_bound, upper_bound = _integer_bounds(value_type)
-        if not lower_bound <= integer_value <= upper_bound:
-            raise ValueError
-        return integer_value
+        return int(decimal_value)
     if isinstance(value_type, sa.Float):
-        try:
-            float_value = float(value)
-        except OverflowError as exc:
-            raise ValueError from exc
-        if not math.isfinite(float_value):
-            raise ValueError
-        return float_value
+        return _normalize_float(value_type, decimal_value)
     if isinstance(value_type, sa.Numeric):
+        _validate_numeric_extent(decimal_value)
         # SQLAlchemy otherwise infers an integer literal as BIGINT, even when the
         # compared expression is NUMERIC. Decimal forces the correct bind type.
         return decimal_value
@@ -248,6 +245,51 @@ def _integer_bounds(type_: sa.Integer) -> tuple[int, int]:
     if isinstance(type_, sa.BigInteger):
         return POSTGRES_BIGINT_MIN, POSTGRES_BIGINT_MAX
     return POSTGRES_INTEGER_MIN, POSTGRES_INTEGER_MAX
+
+
+def _normalize_float(type_: sa.Float, value: Decimal) -> float:
+    try:
+        float_value = float(value)
+    except OverflowError as exc:
+        raise ValueError from exc
+    if not math.isfinite(float_value) or (float_value == 0 and not value.is_zero()):
+        raise ValueError
+
+    if isinstance(type_, sa.REAL) or (
+        type_.precision is not None and type_.precision <= 24
+    ):
+        try:
+            packed = struct.pack("!f", float_value)
+        except OverflowError as exc:
+            raise ValueError from exc
+        float32_value = struct.unpack("!f", packed)[0]
+        if not math.isfinite(float32_value) or (
+            float32_value == 0 and not value.is_zero()
+        ):
+            raise ValueError
+    return float_value
+
+
+def _validate_numeric_extent(value: Decimal) -> None:
+    if value.is_zero():
+        return
+
+    decimal_tuple = value.as_tuple()
+    exponent = decimal_tuple.exponent
+    assert isinstance(exponent, int)
+    trailing_zeros = 0
+    for digit in reversed(decimal_tuple.digits):
+        if digit != 0:
+            break
+        trailing_zeros += 1
+    effective_exponent = exponent + trailing_zeros
+    whole_digits = max(value.adjusted() + 1, 0)
+    fractional_digits = max(-effective_exponent, 0)
+    if (
+        whole_digits > POSTGRES_NUMERIC_MAX_WHOLE_DIGITS
+        or fractional_digits > POSTGRES_NUMERIC_MAX_FRACTIONAL_DIGITS
+    ):
+        raise ValueError
 
 
 def _normalize_temporal(

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -23,6 +23,13 @@ from tracecat.query.filters import (
 )
 from tracecat.query.resolver import FieldKind, FieldResolver, ResolvedField
 
+POSTGRES_SMALLINT_MIN = -(2**15)
+POSTGRES_SMALLINT_MAX = 2**15 - 1
+POSTGRES_INTEGER_MIN = -(2**31)
+POSTGRES_INTEGER_MAX = 2**31 - 1
+POSTGRES_BIGINT_MIN = -(2**63)
+POSTGRES_BIGINT_MAX = 2**63 - 1
+
 
 def compile_filter(node: Filter, resolver: FieldResolver) -> ColumnElement[bool]:
     """Compile a validated filter tree into a SQLAlchemy predicate."""
@@ -191,10 +198,29 @@ def _normalize_number(
     if isinstance(value, Decimal) and not value.is_finite():
         raise ValueError
     if isinstance(expression.type, sa.Integer):
-        if Decimal(str(value)) != Decimal(str(value)).to_integral_value():
+        decimal_value = Decimal(str(value))
+        if decimal_value != decimal_value.to_integral_value():
             raise ValueError
-        return int(value)
+        integer_value = int(decimal_value)
+        lower_bound, upper_bound = _integer_bounds(expression.type)
+        if not lower_bound <= integer_value <= upper_bound:
+            raise ValueError
+        return integer_value
+    if isinstance(expression.type, sa.Float):
+        return float(value)
+    if isinstance(expression.type, sa.Numeric):
+        # SQLAlchemy otherwise infers an integer literal as BIGINT, even when the
+        # compared expression is NUMERIC. Decimal forces the correct bind type.
+        return Decimal(str(value))
     return value
+
+
+def _integer_bounds(type_: sa.Integer) -> tuple[int, int]:
+    if isinstance(type_, sa.SmallInteger):
+        return POSTGRES_SMALLINT_MIN, POSTGRES_SMALLINT_MAX
+    if isinstance(type_, sa.BigInteger):
+        return POSTGRES_BIGINT_MIN, POSTGRES_BIGINT_MAX
+    return POSTGRES_INTEGER_MIN, POSTGRES_INTEGER_MAX
 
 
 def _normalize_temporal(

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -271,20 +271,11 @@ def _normalize_float(type_: sa.Float, value: Decimal) -> float:
 
 
 def _validate_numeric_extent(value: Decimal) -> None:
-    if value.is_zero():
-        return
-
     decimal_tuple = value.as_tuple()
     exponent = decimal_tuple.exponent
     assert isinstance(exponent, int)
-    trailing_zeros = 0
-    for digit in reversed(decimal_tuple.digits):
-        if digit != 0:
-            break
-        trailing_zeros += 1
-    effective_exponent = exponent + trailing_zeros
-    whole_digits = max(value.adjusted() + 1, 0)
-    fractional_digits = max(-effective_exponent, 0)
+    whole_digits = 0 if value.is_zero() else max(value.adjusted() + 1, 0)
+    fractional_digits = max(-exponent, 0)
     if (
         whole_digits > POSTGRES_NUMERIC_MAX_WHOLE_DIGITS
         or fractional_digits > POSTGRES_NUMERIC_MAX_FRACTIONAL_DIGITS

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -207,7 +207,13 @@ def _normalize_number(
             raise ValueError
         return integer_value
     if isinstance(expression.type, sa.Float):
-        return float(value)
+        try:
+            float_value = float(value)
+        except OverflowError as exc:
+            raise ValueError from exc
+        if not math.isfinite(float_value):
+            raise ValueError
+        return float_value
     if isinstance(expression.type, sa.Numeric):
         # SQLAlchemy otherwise infers an integer literal as BIGINT, even when the
         # compared expression is NUMERIC. Decimal forces the correct bind type.

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -9,6 +9,7 @@ from uuid import UUID
 import sqlalchemy as sa
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy.sql.type_api import TypeEngine
 
 from tracecat.exceptions import TracecatValidationError
 from tracecat.query.filters import (
@@ -21,7 +22,12 @@ from tracecat.query.filters import (
     NotClause,
     OrClause,
 )
-from tracecat.query.resolver import FieldKind, FieldResolver, ResolvedField
+from tracecat.query.resolver import (
+    FieldKind,
+    FieldResolver,
+    NormalizedFilterScalar,
+    NormalizedFilterValue,
+)
 
 POSTGRES_SMALLINT_MIN = -(2**15)
 POSTGRES_SMALLINT_MAX = 2**15 - 1
@@ -68,9 +74,22 @@ def _compile_condition(
     elif isinstance(expression, ColumnElement):
         column_expression = expression
     else:
-        return expression(condition.op, value)
+        if value is None:
+            normalized = None
+        elif resolved.value_type is None:
+            raise _condition_error(
+                condition,
+                "predicate factory requires a value type",
+            )
+        else:
+            normalized = _normalize_value(
+                condition, resolved.kind, resolved.value_type, value
+            )
+        return expression(condition.op, normalized)
 
-    normalized = _normalize_value(condition, resolved, column_expression, value)
+    normalized = _normalize_value(
+        condition, resolved.kind, column_expression.type, value
+    )
     return _compile_expression(condition, column_expression, normalized)
 
 
@@ -145,34 +164,31 @@ def _matches_kind_value(kind: FieldKind, value: FilterScalar) -> bool:
 
 def _normalize_value(
     condition: Condition,
-    resolved: ResolvedField,
-    expression: ColumnElement[Any],
+    kind: FieldKind,
+    value_type: TypeEngine[Any],
     value: FilterValue | None,
-) -> object | list[object] | None:
+) -> NormalizedFilterValue | None:
     if value is None:
         return None
     if isinstance(value, list):
-        return [
-            _normalize_scalar(condition, resolved.kind, expression, item)
-            for item in value
-        ]
-    return _normalize_scalar(condition, resolved.kind, expression, value)
+        return [_normalize_scalar(condition, kind, value_type, item) for item in value]
+    return _normalize_scalar(condition, kind, value_type, value)
 
 
 def _normalize_scalar(
     condition: Condition,
     kind: FieldKind,
-    expression: ColumnElement[Any],
+    value_type: TypeEngine[Any],
     value: FilterScalar,
-) -> object:
+) -> NormalizedFilterScalar:
     try:
         match kind:
             case FieldKind.NUMBER:
-                return _normalize_number(expression, value)
+                return _normalize_number(value_type, value)
             case FieldKind.TEMPORAL:
-                return _normalize_temporal(expression, value)
+                return _normalize_temporal(value_type, value)
             case FieldKind.ENUM:
-                return _normalize_enum(expression, value)
+                return _normalize_enum(value_type, value)
             case FieldKind.UUID:
                 if isinstance(value, UUID):
                     return value
@@ -189,7 +205,7 @@ def _normalize_scalar(
 
 
 def _normalize_number(
-    expression: ColumnElement[Any], value: FilterScalar
+    value_type: TypeEngine[Any], value: FilterScalar
 ) -> int | float | Decimal:
     if isinstance(value, bool) or not isinstance(value, int | float | Decimal):
         raise TypeError
@@ -197,16 +213,16 @@ def _normalize_number(
         raise ValueError
     if isinstance(value, Decimal) and not value.is_finite():
         raise ValueError
-    if isinstance(expression.type, sa.Integer):
+    if isinstance(value_type, sa.Integer):
         decimal_value = Decimal(str(value))
         if decimal_value != decimal_value.to_integral_value():
             raise ValueError
         integer_value = int(decimal_value)
-        lower_bound, upper_bound = _integer_bounds(expression.type)
+        lower_bound, upper_bound = _integer_bounds(value_type)
         if not lower_bound <= integer_value <= upper_bound:
             raise ValueError
         return integer_value
-    if isinstance(expression.type, sa.Float):
+    if isinstance(value_type, sa.Float):
         try:
             float_value = float(value)
         except OverflowError as exc:
@@ -214,7 +230,7 @@ def _normalize_number(
         if not math.isfinite(float_value):
             raise ValueError
         return float_value
-    if isinstance(expression.type, sa.Numeric):
+    if isinstance(value_type, sa.Numeric):
         # SQLAlchemy otherwise infers an integer literal as BIGINT, even when the
         # compared expression is NUMERIC. Decimal forces the correct bind type.
         return Decimal(str(value))
@@ -230,13 +246,11 @@ def _integer_bounds(type_: sa.Integer) -> tuple[int, int]:
 
 
 def _normalize_temporal(
-    expression: ColumnElement[Any], value: FilterScalar
+    value_type: TypeEngine[Any], value: FilterScalar
 ) -> date | datetime:
     if not isinstance(value, str | date | datetime):
         raise TypeError
-    if isinstance(expression.type, sa.Date) and not isinstance(
-        expression.type, sa.DateTime
-    ):
+    if isinstance(value_type, sa.Date) and not isinstance(value_type, sa.DateTime):
         if isinstance(value, datetime):
             return value.date()
         if isinstance(value, date):
@@ -252,20 +266,22 @@ def _normalize_temporal(
         parsed = datetime(value.year, value.month, value.day, tzinfo=UTC)
     else:
         parsed = _parse_iso_datetime(value)
-    if isinstance(expression.type, sa.DateTime) and not expression.type.timezone:
+    if isinstance(value_type, sa.DateTime) and not value_type.timezone:
         return parsed.replace(tzinfo=None)
     return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
 
 
-def _normalize_enum(expression: ColumnElement[Any], value: FilterScalar) -> object:
+def _normalize_enum(
+    value_type: TypeEngine[Any], value: FilterScalar
+) -> NormalizedFilterScalar:
     if not isinstance(value, str):
         raise TypeError
-    if not isinstance(expression.type, sa.Enum):
+    if not isinstance(value_type, sa.Enum):
         return value
 
-    if enum_class := expression.type.enum_class:
+    if enum_class := value_type.enum_class:
         return enum_class(value)
-    if value not in expression.type.enums:
+    if value not in value_type.enums:
         raise ValueError
     return value
 

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -65,7 +65,7 @@ def _compile_condition(
             f"operation {condition.op.value!r} is not allowed for {resolved.kind.value}",
         )
 
-    value = _validate_value_shape(condition, resolved.kind)
+    value = _validate_value_shape(condition)
     if condition.op is FilterOp.IN and value == []:
         return sa.false()
     if condition.op is FilterOp.NOT_IN and value == []:
@@ -96,7 +96,7 @@ def _compile_condition(
     return _compile_expression(condition, column_expression, normalized)
 
 
-def _validate_value_shape(condition: Condition, kind: FieldKind) -> FilterValue | None:
+def _validate_value_shape(condition: Condition) -> FilterValue | None:
     value = condition.value
     if condition.op is FilterOp.IS_NULL:
         if value is not None:
@@ -108,65 +108,11 @@ def _validate_value_shape(condition: Condition, kind: FieldKind) -> FilterValue 
     if condition.op in {FilterOp.IN, FilterOp.NOT_IN}:
         if not isinstance(value, list):
             raise _condition_error(condition, "operation requires a list value")
-        for item in value:
-            _validate_scalar(condition, kind, item)
         return value
 
     if isinstance(value, list):
         raise _condition_error(condition, "operation requires a scalar value")
-    _validate_scalar(condition, kind, value)
     return value
-
-
-def _validate_scalar(
-    condition: Condition, kind: FieldKind, value: FilterScalar
-) -> None:
-    valid = _matches_kind_value(kind, value)
-    if not valid:
-        raise _condition_error(
-            condition,
-            f"value has the wrong shape for {kind.value}",
-        )
-
-
-def _matches_kind_value(kind: FieldKind, value: FilterScalar) -> bool:
-    match kind:
-        case FieldKind.TEXT | FieldKind.ENUM | FieldKind.TAG:
-            return isinstance(value, str) and "\x00" not in value
-        case FieldKind.NUMBER:
-            if isinstance(value, bool) or not isinstance(
-                value, int | float | Decimal | str
-            ):
-                return False
-            try:
-                decimal_value = Decimal(
-                    value.strip() if isinstance(value, str) else str(value)
-                )
-            except (InvalidOperation, ValueError):
-                return False
-            return decimal_value.is_finite()
-        case FieldKind.BOOLEAN:
-            return isinstance(value, bool)
-        case FieldKind.TEMPORAL:
-            if isinstance(value, date | datetime):
-                return True
-            if not isinstance(value, str):
-                return False
-            try:
-                _parse_iso_datetime(value)
-            except ValueError:
-                return False
-            return True
-        case FieldKind.UUID:
-            if isinstance(value, UUID):
-                return True
-            if not isinstance(value, str):
-                return False
-            try:
-                UUID(value)
-            except ValueError:
-                return False
-            return True
 
 
 def _normalize_value(
@@ -202,7 +148,13 @@ def _normalize_scalar(
                 if isinstance(value, str):
                     return UUID(value)
                 raise TypeError
-            case _:
+            case FieldKind.BOOLEAN:
+                if not isinstance(value, bool):
+                    raise TypeError
+                return value
+            case FieldKind.TEXT | FieldKind.TAG:
+                if not isinstance(value, str) or "\x00" in value:
+                    raise TypeError
                 return value
     except (TypeError, ValueError) as exc:
         raise _condition_error(
@@ -250,10 +202,7 @@ def _integer_bounds(type_: sa.Integer) -> tuple[int, int]:
 
 
 def _normalize_float(type_: sa.Float, value: Decimal) -> float:
-    try:
-        float_value = float(value)
-    except OverflowError as exc:
-        raise ValueError from exc
+    float_value = float(value)
     if not math.isfinite(float_value) or (float_value == 0 and not value.is_zero()):
         raise ValueError
 
@@ -316,6 +265,8 @@ def _normalize_enum(
 ) -> NormalizedFilterScalar:
     if not isinstance(value, str):
         raise TypeError
+    if "\x00" in value:
+        raise ValueError
     if not isinstance(value_type, sa.Enum):
         return value
 
@@ -343,10 +294,10 @@ def _compile_expression(
             return expression != value
         case FilterOp.IN:
             assert isinstance(value, list)
-            return sa.false() if not value else expression.in_(value)
+            return expression.in_(value)
         case FilterOp.NOT_IN:
             assert isinstance(value, list)
-            return sa.true() if not value else expression.not_in(value)
+            return expression.not_in(value)
         case FilterOp.GT:
             return expression > value
         case FilterOp.GTE:

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import math
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.sql.elements import ColumnElement
+
+from tracecat.exceptions import TracecatValidationError
+from tracecat.query.filters import (
+    AndClause,
+    Condition,
+    Filter,
+    FilterOp,
+    FilterScalar,
+    FilterValue,
+    NotClause,
+    OrClause,
+)
+from tracecat.query.resolver import FieldKind, FieldResolver, ResolvedField
+
+
+def compile_filter(node: Filter, resolver: FieldResolver) -> ColumnElement[bool]:
+    """Compile a validated filter tree into a SQLAlchemy predicate."""
+    match node:
+        case Condition():
+            return _compile_condition(node, resolver)
+        case AndClause(and_=children):
+            return sa.and_(*(compile_filter(child, resolver) for child in children))
+        case OrClause(or_=children):
+            return sa.or_(*(compile_filter(child, resolver) for child in children))
+        case NotClause(not_=child):
+            return sa.not_(compile_filter(child, resolver))
+
+
+def _compile_condition(
+    condition: Condition, resolver: FieldResolver
+) -> ColumnElement[bool]:
+    resolved = resolver.resolve(condition.field)
+    if resolved is None:
+        raise _condition_error(condition, f"unknown field {condition.field!r}")
+    if condition.op not in resolved.allowed_ops:
+        raise _condition_error(
+            condition,
+            f"operation {condition.op.value!r} is not allowed for {resolved.kind.value}",
+        )
+
+    value = _validate_value_shape(condition, resolved.kind)
+    if condition.op is FilterOp.IN and value == []:
+        return sa.false()
+    if condition.op is FilterOp.NOT_IN and value == []:
+        return sa.true()
+
+    expression = resolved.expr
+    if isinstance(expression, InstrumentedAttribute):
+        column_expression = expression.expression
+    elif isinstance(expression, ColumnElement):
+        column_expression = expression
+    else:
+        return expression(condition.op, value)
+
+    normalized = _normalize_value(condition, resolved, column_expression, value)
+    return _compile_expression(condition, column_expression, normalized)
+
+
+def _validate_value_shape(condition: Condition, kind: FieldKind) -> FilterValue | None:
+    value = condition.value
+    if condition.op is FilterOp.IS_NULL:
+        if value is not None:
+            raise _condition_error(condition, "is_null does not accept a value")
+        return None
+    if value is None:
+        raise _condition_error(condition, "operation requires a value")
+
+    if condition.op in {FilterOp.IN, FilterOp.NOT_IN}:
+        if not isinstance(value, list):
+            raise _condition_error(condition, "operation requires a list value")
+        for item in value:
+            _validate_scalar(condition, kind, item)
+        return value
+
+    if isinstance(value, list):
+        raise _condition_error(condition, "operation requires a scalar value")
+    _validate_scalar(condition, kind, value)
+    return value
+
+
+def _validate_scalar(
+    condition: Condition, kind: FieldKind, value: FilterScalar
+) -> None:
+    valid = _matches_kind_value(kind, value)
+    if not valid:
+        raise _condition_error(
+            condition,
+            f"value has the wrong shape for {kind.value}",
+        )
+
+
+def _matches_kind_value(kind: FieldKind, value: FilterScalar) -> bool:
+    match kind:
+        case FieldKind.TEXT | FieldKind.ENUM | FieldKind.TAG:
+            return isinstance(value, str)
+        case FieldKind.NUMBER:
+            if isinstance(value, bool) or not isinstance(value, int | float | Decimal):
+                return False
+            if isinstance(value, float):
+                return math.isfinite(value)
+            if isinstance(value, Decimal):
+                return value.is_finite()
+            return True
+        case FieldKind.BOOLEAN:
+            return isinstance(value, bool)
+        case FieldKind.TEMPORAL:
+            if isinstance(value, date | datetime):
+                return True
+            if not isinstance(value, str):
+                return False
+            try:
+                _parse_iso_datetime(value)
+            except ValueError:
+                return False
+            return True
+        case FieldKind.UUID:
+            if isinstance(value, UUID):
+                return True
+            if not isinstance(value, str):
+                return False
+            try:
+                UUID(value)
+            except ValueError:
+                return False
+            return True
+
+
+def _normalize_value(
+    condition: Condition,
+    resolved: ResolvedField,
+    expression: ColumnElement[Any],
+    value: FilterValue | None,
+) -> FilterValue | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [
+            _normalize_scalar(condition, resolved.kind, expression, item)
+            for item in value
+        ]
+    return _normalize_scalar(condition, resolved.kind, expression, value)
+
+
+def _normalize_scalar(
+    condition: Condition,
+    kind: FieldKind,
+    expression: ColumnElement[Any],
+    value: FilterScalar,
+) -> FilterScalar:
+    try:
+        match kind:
+            case FieldKind.NUMBER:
+                return _normalize_number(expression, value)
+            case FieldKind.TEMPORAL:
+                return _normalize_temporal(expression, value)
+            case FieldKind.UUID:
+                if isinstance(value, UUID):
+                    return value
+                if isinstance(value, str):
+                    return UUID(value)
+                raise TypeError
+            case _:
+                return value
+    except (TypeError, ValueError) as exc:
+        raise _condition_error(
+            condition,
+            f"value is invalid for {kind.value}",
+        ) from exc
+
+
+def _normalize_number(
+    expression: ColumnElement[Any], value: FilterScalar
+) -> int | float | Decimal:
+    if isinstance(value, bool) or not isinstance(value, int | float | Decimal):
+        raise TypeError
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError
+    if isinstance(value, Decimal) and not value.is_finite():
+        raise ValueError
+    if isinstance(expression.type, sa.Integer):
+        if Decimal(str(value)) != Decimal(str(value)).to_integral_value():
+            raise ValueError
+        return int(value)
+    return value
+
+
+def _normalize_temporal(
+    expression: ColumnElement[Any], value: FilterScalar
+) -> date | datetime:
+    if not isinstance(value, str | date | datetime):
+        raise TypeError
+    if isinstance(expression.type, sa.Date) and not isinstance(
+        expression.type, sa.DateTime
+    ):
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return _parse_iso_datetime(value).date()
+
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, date):
+        parsed = datetime(value.year, value.month, value.day, tzinfo=UTC)
+    else:
+        parsed = _parse_iso_datetime(value)
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    text = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
+    return datetime.fromisoformat(text)
+
+
+def _compile_expression(
+    condition: Condition,
+    expression: ColumnElement[Any],
+    value: FilterValue | None,
+) -> ColumnElement[bool]:
+    match condition.op:
+        case FilterOp.EQ:
+            return expression == value
+        case FilterOp.NE:
+            return expression != value
+        case FilterOp.IN:
+            assert isinstance(value, list)
+            return sa.false() if not value else expression.in_(value)
+        case FilterOp.NOT_IN:
+            assert isinstance(value, list)
+            return sa.true() if not value else expression.not_in(value)
+        case FilterOp.GT:
+            return expression > value
+        case FilterOp.GTE:
+            return expression >= value
+        case FilterOp.LT:
+            return expression < value
+        case FilterOp.LTE:
+            return expression <= value
+        case FilterOp.CONTAINS:
+            assert isinstance(value, str)
+            return expression.ilike(f"%{_escape_like(value)}%", escape="\\")
+        case FilterOp.STARTS_WITH:
+            assert isinstance(value, str)
+            return expression.ilike(f"{_escape_like(value)}%", escape="\\")
+        case FilterOp.IS_NULL:
+            return expression.is_(None)
+
+
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _condition_error(condition: Condition, message: str) -> TracecatValidationError:
+    return TracecatValidationError(
+        f"Invalid filter condition for field {condition.field!r} "
+        f"with operation {condition.op.value!r}: {message}"
+    )

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from datetime import UTC, date, datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any
 from uuid import UUID
 
@@ -131,13 +131,17 @@ def _matches_kind_value(kind: FieldKind, value: FilterScalar) -> bool:
         case FieldKind.TEXT | FieldKind.ENUM | FieldKind.TAG:
             return isinstance(value, str) and "\x00" not in value
         case FieldKind.NUMBER:
-            if isinstance(value, bool) or not isinstance(value, int | float | Decimal):
+            if isinstance(value, bool) or not isinstance(
+                value, int | float | Decimal | str
+            ):
                 return False
-            if isinstance(value, float):
-                return math.isfinite(value)
-            if isinstance(value, Decimal):
-                return value.is_finite()
-            return True
+            try:
+                decimal_value = Decimal(
+                    value.strip() if isinstance(value, str) else str(value)
+                )
+            except (InvalidOperation, ValueError):
+                return False
+            return decimal_value.is_finite()
         case FieldKind.BOOLEAN:
             return isinstance(value, bool)
         case FieldKind.TEMPORAL:
@@ -207,14 +211,15 @@ def _normalize_scalar(
 def _normalize_number(
     value_type: TypeEngine[Any], value: FilterScalar
 ) -> int | float | Decimal:
-    if isinstance(value, bool) or not isinstance(value, int | float | Decimal):
+    if isinstance(value, bool) or not isinstance(value, int | float | Decimal | str):
         raise TypeError
-    if isinstance(value, float) and not math.isfinite(value):
-        raise ValueError
-    if isinstance(value, Decimal) and not value.is_finite():
+    try:
+        decimal_value = Decimal(value.strip() if isinstance(value, str) else str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError from exc
+    if not decimal_value.is_finite():
         raise ValueError
     if isinstance(value_type, sa.Integer):
-        decimal_value = Decimal(str(value))
         if decimal_value != decimal_value.to_integral_value():
             raise ValueError
         integer_value = int(decimal_value)
@@ -233,8 +238,8 @@ def _normalize_number(
     if isinstance(value_type, sa.Numeric):
         # SQLAlchemy otherwise infers an integer literal as BIGINT, even when the
         # compared expression is NUMERIC. Decimal forces the correct bind type.
-        return Decimal(str(value))
-    return value
+        return decimal_value
+    return decimal_value if isinstance(value, str) else value
 
 
 def _integer_bounds(type_: sa.Integer) -> tuple[int, int]:

--- a/tracecat/query/filters.py
+++ b/tracecat/query/filters.py
@@ -48,6 +48,12 @@ class _FilterModel(BaseModel):
         serialize_by_alias=True,
     )
 
+    @model_validator(mode="after")
+    def validate_tree_limits(self) -> Self:
+        if isinstance(self, Condition | AndClause | OrClause | NotClause):
+            _validate_tree_limits(self)
+        return self
+
 
 class Condition(_FilterModel):
     """A predicate over one resolver-defined field."""
@@ -55,11 +61,6 @@ class Condition(_FilterModel):
     field: str = Field(min_length=1)
     op: FilterOp
     value: FilterValue | None = Field(default=None)
-
-    @model_validator(mode="after")
-    def validate_tree_limits(self) -> Self:
-        _validate_tree_limits(self)
-        return self
 
 
 class AndClause(_FilterModel):
@@ -71,11 +72,6 @@ class AndClause(_FilterModel):
         min_length=1,
     )
 
-    @model_validator(mode="after")
-    def validate_tree_limits(self) -> Self:
-        _validate_tree_limits(self)
-        return self
-
 
 class OrClause(_FilterModel):
     """A disjunction of one or more filters."""
@@ -86,21 +82,11 @@ class OrClause(_FilterModel):
         min_length=1,
     )
 
-    @model_validator(mode="after")
-    def validate_tree_limits(self) -> Self:
-        _validate_tree_limits(self)
-        return self
-
 
 class NotClause(_FilterModel):
     """The negation of one filter."""
 
     not_: Filter = Field(alias="not", serialization_alias="not")
-
-    @model_validator(mode="after")
-    def validate_tree_limits(self) -> Self:
-        _validate_tree_limits(self)
-        return self
 
 
 def _filter_discriminator(value: object) -> str:

--- a/tracecat/query/filters.py
+++ b/tracecat/query/filters.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated, Self
+from uuid import UUID
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    Tag,
+    model_validator,
+)
+
+MAX_FILTER_DEPTH = 4
+MAX_FILTER_CONDITIONS = 50
+
+
+class FilterOp(StrEnum):
+    """Operations supported by the shared filter language."""
+
+    EQ = "eq"
+    NE = "ne"
+    IN = "in"
+    NOT_IN = "not_in"
+    GT = "gt"
+    GTE = "gte"
+    LT = "lt"
+    LTE = "lte"
+    CONTAINS = "contains"
+    STARTS_WITH = "starts_with"
+    IS_NULL = "is_null"
+
+
+type FilterScalar = str | int | float | bool | Decimal | datetime | date | UUID
+type FilterValue = FilterScalar | list[FilterScalar]
+
+
+class _FilterModel(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )
+
+
+class Condition(_FilterModel):
+    """A predicate over one resolver-defined field."""
+
+    field: str = Field(min_length=1)
+    op: FilterOp
+    value: FilterValue | None = Field(default=None)
+
+
+class AndClause(_FilterModel):
+    """A conjunction of one or more filters."""
+
+    and_: list[Filter] = Field(
+        alias="and",
+        serialization_alias="and",
+        min_length=1,
+    )
+
+    @model_validator(mode="after")
+    def validate_tree_limits(self) -> Self:
+        _validate_tree_limits(self)
+        return self
+
+
+class OrClause(_FilterModel):
+    """A disjunction of one or more filters."""
+
+    or_: list[Filter] = Field(
+        alias="or",
+        serialization_alias="or",
+        min_length=1,
+    )
+
+    @model_validator(mode="after")
+    def validate_tree_limits(self) -> Self:
+        _validate_tree_limits(self)
+        return self
+
+
+class NotClause(_FilterModel):
+    """The negation of one filter."""
+
+    not_: Filter = Field(alias="not", serialization_alias="not")
+
+    @model_validator(mode="after")
+    def validate_tree_limits(self) -> Self:
+        _validate_tree_limits(self)
+        return self
+
+
+def _filter_discriminator(value: object) -> str:
+    if isinstance(value, Condition):
+        return "condition"
+    if isinstance(value, AndClause):
+        return "and"
+    if isinstance(value, OrClause):
+        return "or"
+    if isinstance(value, NotClause):
+        return "not"
+    if not isinstance(value, Mapping):
+        return "invalid"
+
+    node_types: list[str] = []
+    if "field" in value:
+        node_types.append("condition")
+    if "and" in value or "and_" in value:
+        node_types.append("and")
+    if "or" in value or "or_" in value:
+        node_types.append("or")
+    if "not" in value or "not_" in value:
+        node_types.append("not")
+    return node_types[0] if len(node_types) == 1 else "invalid"
+
+
+type Filter = Annotated[
+    Annotated[Condition, Tag("condition")]
+    | Annotated[AndClause, Tag("and")]
+    | Annotated[OrClause, Tag("or")]
+    | Annotated[NotClause, Tag("not")],
+    Discriminator(_filter_discriminator),
+]
+
+
+def _tree_stats(node: Filter, *, depth: int = 1) -> tuple[int, int]:
+    match node:
+        case Condition():
+            return depth, 1
+        case AndClause(and_=children) | OrClause(or_=children):
+            stats = [_tree_stats(child, depth=depth + 1) for child in children]
+        case NotClause(not_=child):
+            stats = [_tree_stats(child, depth=depth + 1)]
+
+    return max(node_depth for node_depth, _ in stats), sum(
+        condition_count for _, condition_count in stats
+    )
+
+
+def _validate_tree_limits(node: Filter) -> None:
+    depth, condition_count = _tree_stats(node)
+    if depth > MAX_FILTER_DEPTH:
+        raise ValueError(f"Filter tree exceeds maximum depth {MAX_FILTER_DEPTH}")
+    if condition_count > MAX_FILTER_CONDITIONS:
+        raise ValueError(
+            f"Filter tree exceeds maximum condition count {MAX_FILTER_CONDITIONS}"
+        )
+
+
+AndClause.model_rebuild(_types_namespace={"Filter": Filter})
+OrClause.model_rebuild(_types_namespace={"Filter": Filter})
+NotClause.model_rebuild(_types_namespace={"Filter": Filter})

--- a/tracecat/query/filters.py
+++ b/tracecat/query/filters.py
@@ -18,6 +18,7 @@ from pydantic import (
 
 MAX_FILTER_DEPTH = 4
 MAX_FILTER_CONDITIONS = 50
+MAX_FILTER_VALUES = 1_000
 
 
 class FilterOp(StrEnum):
@@ -54,6 +55,11 @@ class Condition(_FilterModel):
     field: str = Field(min_length=1)
     op: FilterOp
     value: FilterValue | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def validate_tree_limits(self) -> Self:
+        _validate_tree_limits(self)
+        return self
 
 
 class AndClause(_FilterModel):
@@ -130,28 +136,33 @@ type Filter = Annotated[
 ]
 
 
-def _tree_stats(node: Filter, *, depth: int = 1) -> tuple[int, int]:
+def _tree_stats(node: Filter, *, depth: int = 1) -> tuple[int, int, int]:
     match node:
-        case Condition():
-            return depth, 1
+        case Condition(value=value):
+            value_count = len(value) if isinstance(value, list) else value is not None
+            return depth, 1, int(value_count)
         case AndClause(and_=children) | OrClause(or_=children):
             stats = [_tree_stats(child, depth=depth + 1) for child in children]
         case NotClause(not_=child):
             stats = [_tree_stats(child, depth=depth + 1)]
 
-    return max(node_depth for node_depth, _ in stats), sum(
-        condition_count for _, condition_count in stats
+    return (
+        max(node_depth for node_depth, _, _ in stats),
+        sum(condition_count for _, condition_count, _ in stats),
+        sum(value_count for _, _, value_count in stats),
     )
 
 
 def _validate_tree_limits(node: Filter) -> None:
-    depth, condition_count = _tree_stats(node)
+    depth, condition_count, value_count = _tree_stats(node)
     if depth > MAX_FILTER_DEPTH:
         raise ValueError(f"Filter tree exceeds maximum depth {MAX_FILTER_DEPTH}")
     if condition_count > MAX_FILTER_CONDITIONS:
         raise ValueError(
             f"Filter tree exceeds maximum condition count {MAX_FILTER_CONDITIONS}"
         )
+    if value_count > MAX_FILTER_VALUES:
+        raise ValueError(f"Filter tree exceeds maximum value count {MAX_FILTER_VALUES}")
 
 
 AndClause.model_rebuild(_types_namespace={"Filter": Filter})

--- a/tracecat/query/resolver.py
+++ b/tracecat/query/resolver.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum, StrEnum
 from typing import Any, Protocol
 
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy.sql.type_api import TypeEngine
 
-from tracecat.query.filters import FilterOp, FilterValue
+from tracecat.query.filters import FilterOp, FilterScalar
 
 
 class FieldKind(StrEnum):
@@ -23,7 +24,11 @@ class FieldKind(StrEnum):
     TAG = "tag"
 
 
-type PredicateFactory = Callable[[FilterOp, FilterValue | None], ColumnElement[bool]]
+type NormalizedFilterScalar = FilterScalar | Enum
+type NormalizedFilterValue = NormalizedFilterScalar | list[NormalizedFilterScalar]
+type PredicateFactory = Callable[
+    [FilterOp, NormalizedFilterValue | None], ColumnElement[bool]
+]
 type FilterExpression = (
     ColumnElement[Any] | InstrumentedAttribute[Any] | PredicateFactory
 )
@@ -34,12 +39,15 @@ class ResolvedField:
     """A safe field expression and the operations it supports.
 
     ``expr`` may be a direct SQL expression or a factory for fields whose
-    predicate needs a correlated EXISTS query.
+    predicate needs a correlated EXISTS query. Factories that accept non-null
+    values must provide ``value_type`` so the compiler can normalize those
+    values exactly as it does for direct expressions.
     """
 
     expr: FilterExpression
     kind: FieldKind
     allowed_ops: frozenset[FilterOp]
+    value_type: TypeEngine[Any] | None = None
 
 
 class FieldResolver(Protocol):

--- a/tracecat/query/resolver.py
+++ b/tracecat/query/resolver.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.sql.elements import ColumnElement
+
+from tracecat.query.filters import FilterOp, FilterValue
+
+
+class FieldKind(StrEnum):
+    """Value families understood by the shared filter compiler."""
+
+    TEXT = "text"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    TEMPORAL = "temporal"
+    ENUM = "enum"
+    UUID = "uuid"
+    TAG = "tag"
+
+
+type PredicateFactory = Callable[[FilterOp, FilterValue | None], ColumnElement[bool]]
+type FilterExpression = (
+    ColumnElement[Any] | InstrumentedAttribute[Any] | PredicateFactory
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedField:
+    """A safe field expression and the operations it supports.
+
+    ``expr`` may be a direct SQL expression or a factory for fields whose
+    predicate needs a correlated EXISTS query.
+    """
+
+    expr: FilterExpression
+    kind: FieldKind
+    allowed_ops: frozenset[FilterOp]
+
+
+class FieldResolver(Protocol):
+    """Resolve user-facing field addresses to trusted SQL expressions."""
+
+    def resolve(self, field: str) -> ResolvedField | None:
+        """Return the resolved field, or ``None`` when it is unknown."""
+        ...


### PR DESCRIPTION
## Summary

- add a recursive shared filter model with callable discrimination for condition, `and`, `or`, and `not` nodes
- add the typed field resolver contract for trusted SQLAlchemy expressions and correlated `EXISTS` predicate factories, including explicit SQL type metadata for factory value normalization
- compile validated filter trees into SQLAlchemy predicates with SQL three-valued inequality semantics, empty-list short-circuiting, typed value normalization, lossless decimal-string support, asyncpg/PostgreSQL-aware numeric bounds, canonicalized numeric zero values, database-safe text validation, native enum validation, and escaped `ILIKE`
- enforce a maximum depth of 4, maximum of 50 conditions, and maximum of 1,000 total filter values
- cover the complete field-kind/operator matrix and malformed or hostile inputs

## Scope

This is the foundational ENG-1744 change described by the ENG-1692 v3 design. It intentionally does not include aggregation specs, entity-specific case/table resolvers, services, database changes, or endpoints.

Linear: https://linear.app/tracecat/issue/ENG-1744/query-shared-filter-predicate-tree-compiler-tracecatquery

## Testing

- `uv run pytest tests/unit/query -q` — 162 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- commit-time pre-commit hooks
- read-only asyncpg checks against local PostgreSQL for extreme NUMERIC scale and exponent handling

## LOC breakdown

| Category | + | - |
|---|---:|---:|
| Logic | 542 | 0 |
| Tests | 1013 | 0 |
| **Total** | **1555** | **0** |
