### PR TITLE
test(engine): wait for supervisor monitor exit

### DIFF
--- a/tests/unit/executor/test_process_supervisor.py
+++ b/tests/unit/executor/test_process_supervisor.py
@@ -41,6 +41,14 @@ async def _wait_for_file(path: Path) -> None:
     raise AssertionError(f"Timed out waiting for {path}")
 
 
+async def _wait_for_process_exit(pid: int) -> None:
+    for _ in range(500):
+        if not _process_is_running(pid):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"Timed out waiting for process {pid} to exit")
+
+
 def _write_action_script(path: Path) -> None:
     path.write_text(
         """
@@ -269,7 +277,10 @@ async def test_parent_death_resumes_monitor_and_reaps_action_tree(
 
         assert process.returncode == -signal.SIGKILL, stderr.decode()
         assert stdout == b""
-        assert not _process_is_running(monitor_pid)
+        # The stopped monitor cleans up asynchronously after the supervisor
+        # dies: PDEATHSIG's SIGCONT resumes it, then it reaps the action tree
+        # before exiting. Wait for that instead of sampling instantly.
+        await _wait_for_process_exit(monitor_pid)
         assert not _process_is_running(action_pid)
         assert not _process_is_running(detached_pid)
     finally:


### PR DESCRIPTION
## Summary

- wait for the stopped supervisor monitor to exit before asserting its state
- preserve immediate assertions for the action tree, which the monitor reaps before exiting
- remove a timing race seen on loaded GitHub Actions runners

## Why

After the outer supervisor is killed, the kernel delivers `SIGCONT` to the stopped monitor through `PDEATHSIG`. The monitor then resumes, reaps the action tree, and exits asynchronously. Sampling its PID immediately can race that cleanup even when the implementation is behaving correctly.

## Verification

- `uv run pytest tests/unit/executor/test_process_supervisor.py -x --confcutdir=tests/unit` (8 collected and skipped because these supervisor tests require Linux)
- `uv run ruff check tests/unit/executor/test_process_supervisor.py`
- `uv run ruff format --check tests/unit/executor/test_process_supervisor.py`
- `uv run basedpyright tests/unit/executor/test_process_supervisor.py`
- `just check-pr-title "test(engine): wait for supervisor monitor exit"`

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Tests | 12 | 1 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky `test_parent_death_resumes_monitor_and_reaps_action_tree` test by polling for the stopped supervisor monitor to exit instead of sampling its PID immediately after the outer supervisor dies. The monitor resumes via `PDEATHSIG`'s `SIGCONT`, reaps the action tree, then exits asynchronously, so the instant assertion raced that cleanup on loaded CI runners. Action-tree assertions stay instant because the monitor reaps them before exiting.

<sup>Written for commit c1a1432878fb3be86eb8e10eff29e8348dedcc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

