### PR TITLE
feat(api): add group-by aggregation compiler

### DIFF
--- a/tests/unit/query/test_aggregations.py
+++ b/tests/unit/query/test_aggregations.py
@@ -720,7 +720,7 @@ def test_compiler_clears_base_limit_and_offset() -> None:
 
 
 @pytest.mark.parametrize("distinct_on", [False, True])
-def test_compiler_clears_base_distinct(distinct_on: bool) -> None:
+def test_compiler_rejects_base_distinct(distinct_on: bool) -> None:
     entity_id = sa.column("entity_id", sa.Integer())
     statement = _base_statement()
     if distinct_on:
@@ -728,17 +728,13 @@ def test_compiler_clears_base_distinct(distinct_on: bool) -> None:
     else:
         statement = statement.distinct()
 
-    sql = _sql(
+    with pytest.raises(TracecatValidationError, match="must not use DISTINCT"):
         compile_aggregation(
             statement,
             AggregationSpec(group_by=[]),
             {},
             limit=25,
         )
-    )
-
-    assert not sql.startswith("SELECT DISTINCT")
-    assert "ORDER BY count DESC NULLS LAST" in sql
 
 
 def test_unknown_aggregation_field_is_a_semantic_error() -> None:

--- a/tests/unit/query/test_aggregations.py
+++ b/tests/unit/query/test_aggregations.py
@@ -46,6 +46,7 @@ def _compile(
     fields: Mapping[str, ResolvedAggregationField],
     *,
     entity_id: sa.ColumnElement[Any] | None = None,
+    base_has_multi_valued_join: bool = False,
     limit: int = 100,
 ) -> str:
     return _sql(
@@ -54,6 +55,7 @@ def _compile(
             spec,
             fields,
             limit=limit,
+            base_has_multi_valued_join=base_has_multi_valued_join,
             entity_id=entity_id,
         )
     )
@@ -712,6 +714,7 @@ def test_compiler_clears_base_limit_and_offset() -> None:
             AggregationSpec(group_by=[]),
             {},
             limit=25,
+            base_has_multi_valued_join=False,
         )
     )
 
@@ -734,6 +737,7 @@ def test_compiler_rejects_base_distinct(distinct_on: bool) -> None:
             AggregationSpec(group_by=[]),
             {},
             limit=25,
+            base_has_multi_valued_join=False,
         )
 
 
@@ -754,6 +758,44 @@ def test_compiler_rejects_grouped_or_having_base(clause: str) -> None:
             AggregationSpec(group_by=[]),
             {},
             limit=25,
+            base_has_multi_valued_join=False,
+        )
+
+
+def test_base_multi_valued_join_deduplicates_counts() -> None:
+    sql = _compile(
+        AggregationSpec(group_by=[]),
+        {},
+        base_has_multi_valued_join=True,
+        entity_id=sa.column("case_id", sa.Uuid()),
+    )
+
+    assert "count(DISTINCT case_id) AS count" in sql
+
+
+def test_base_multi_valued_join_rejects_additive_aggregates() -> None:
+    spec = AggregationSpec(
+        group_by=[],
+        aggs=[AggSpec(function=AggFunction.SUM, field="amount")],
+    )
+
+    with pytest.raises(TracecatValidationError, match="multi-valued field"):
+        _compile(
+            spec,
+            {"amount": _field("amount", sa.Integer(), FieldKind.NUMBER)},
+            base_has_multi_valued_join=True,
+            entity_id=sa.column("case_id", sa.Uuid()),
+        )
+
+
+def test_compiler_rejects_row_locking_base() -> None:
+    with pytest.raises(TracecatValidationError, match="must not use row locking"):
+        compile_aggregation(
+            _base_statement().with_for_update(),
+            AggregationSpec(group_by=[]),
+            {},
+            limit=25,
+            base_has_multi_valued_join=False,
         )
 
 

--- a/tests/unit/query/test_aggregations.py
+++ b/tests/unit/query/test_aggregations.py
@@ -206,20 +206,18 @@ def test_aggregation_spec_rejects_output_key_collisions(
 
 
 @pytest.mark.parametrize(
-    ("first", "second"),
+    "alias",
     [
-        ("a" * 63 + "x", "a" * 63 + "y"),
-        ("é" * 31, "é" * 32),
+        "a" * 64,
+        "é" * 32,
     ],
 )
-def test_aggregation_spec_rejects_postgres_truncated_alias_collisions(
-    first: str,
-    second: str,
+def test_aggregation_spec_rejects_aliases_over_postgres_identifier_limit(
+    alias: str,
 ) -> None:
-    with pytest.raises(ValidationError, match="PostgreSQL identifier truncation"):
+    with pytest.raises(ValidationError, match="63-byte identifier limit"):
         AggregationSpec(
-            group_by=[GroupBySpec(field="status", alias=first)],
-            aggs=[AggSpec(function=AggFunction.COUNT, alias=second)],
+            group_by=[GroupBySpec(field="status", alias=alias)],
         )
 
 
@@ -566,6 +564,52 @@ def test_multi_valued_group_requires_entity_id() -> None:
                 )
             },
         )
+
+
+def test_multi_valued_aggregate_target_protects_other_aggregates_from_fanout() -> None:
+    spec = AggregationSpec(
+        group_by=[],
+        aggs=[
+            AggSpec(function=AggFunction.COUNT, field="tags"),
+            AggSpec(function=AggFunction.SUM, field="amount"),
+        ],
+    )
+
+    with pytest.raises(TracecatValidationError, match="multi-valued field"):
+        _compile(
+            spec,
+            {
+                "tags": _field(
+                    "tag_ref", sa.String(), FieldKind.TAG, is_multi_valued=True
+                ),
+                "amount": _field("amount", sa.Integer(), FieldKind.NUMBER),
+            },
+            entity_id=sa.column("case_id", sa.Uuid()),
+        )
+
+
+def test_multi_valued_aggregate_target_deduplicates_counts_and_having() -> None:
+    spec = AggregationSpec(
+        group_by=[],
+        aggs=[
+            AggSpec(function=AggFunction.COUNT),
+            AggSpec(function=AggFunction.COUNT, field="tags"),
+        ],
+        min_count=2,
+    )
+
+    sql = _compile(
+        spec,
+        {"tags": _field("tag_ref", sa.String(), FieldKind.TAG, is_multi_valued=True)},
+        entity_id=sa.column("case_id", sa.Uuid()),
+    )
+
+    assert "count(DISTINCT case_id) AS count" in sql
+    assert (
+        "count(DISTINCT case_id) FILTER (WHERE tag_ref IS NOT NULL) AS count_tags"
+        in sql
+    )
+    assert "HAVING count(DISTINCT case_id) >= 2" in sql
 
 
 def test_default_ordering_uses_first_bucket_even_when_not_first_group() -> None:

--- a/tests/unit/query/test_aggregations.py
+++ b/tests/unit/query/test_aggregations.py
@@ -460,6 +460,16 @@ def test_aggregate_function_type_matrix(
             sa.BigInteger(),
             "CAST(sum(value) AS DOUBLE PRECISION)",
         ),
+        (
+            AggFunction.SUM,
+            sa.REAL(),
+            "CAST(sum(CAST(value AS DOUBLE PRECISION)) AS DOUBLE PRECISION)",
+        ),
+        (
+            AggFunction.SUM,
+            sa.Float(precision=24),
+            "CAST(sum(CAST(value AS DOUBLE PRECISION)) AS DOUBLE PRECISION)",
+        ),
         (AggFunction.SUM, sa.Numeric(), "CAST(sum(value) AS DOUBLE PRECISION)"),
         (AggFunction.MEAN, sa.BigInteger(), "CAST(avg(value) AS DOUBLE PRECISION)"),
         (AggFunction.MEAN, sa.Numeric(), "CAST(avg(value) AS DOUBLE PRECISION)"),
@@ -610,6 +620,42 @@ def test_multi_valued_aggregate_target_deduplicates_counts_and_having() -> None:
         in sql
     )
     assert "HAVING count(DISTINCT case_id) >= 2" in sql
+
+
+def test_multi_valued_non_count_aggregate_does_not_require_entity_id() -> None:
+    spec = AggregationSpec(
+        group_by=[],
+        aggs=[AggSpec(function=AggFunction.COUNT_DISTINCT, field="values")],
+    )
+
+    sql = _compile(
+        spec,
+        {
+            "values": _field(
+                "value", sa.Integer(), FieldKind.NUMBER, is_multi_valued=True
+            )
+        },
+    )
+
+    assert "count(DISTINCT value) AS count_distinct_values" in sql
+
+
+def test_additive_aggregate_allows_its_own_multi_valued_target() -> None:
+    spec = AggregationSpec(
+        group_by=[],
+        aggs=[AggSpec(function=AggFunction.SUM, field="values")],
+    )
+
+    sql = _compile(
+        spec,
+        {
+            "values": _field(
+                "value", sa.Integer(), FieldKind.NUMBER, is_multi_valued=True
+            )
+        },
+    )
+
+    assert "CAST(sum(value) AS BIGINT) AS sum_values" in sql
 
 
 def test_default_ordering_uses_first_bucket_even_when_not_first_group() -> None:

--- a/tests/unit/query/test_aggregations.py
+++ b/tests/unit/query/test_aggregations.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from pydantic import BaseModel, ValidationError
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import Select
+
+from tracecat.exceptions import TracecatValidationError
+from tracecat.query.aggregations import (
+    MAX_AGGREGATIONS,
+    MAX_GROUP_BY_FIELDS,
+    AggFunction,
+    AggregationSpec,
+    AggSpec,
+    GroupBySpec,
+    SortDirection,
+    TimeBucket,
+)
+from tracecat.query.compiler import compile_aggregation
+from tracecat.query.resolver import FieldKind, ResolvedAggregationField
+
+
+def _sql(statement: Select[Any]) -> str:
+    return str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def _base_statement() -> Select[Any]:
+    return (
+        sa.select(sa.literal_column("seed"))
+        .select_from(sa.table("events", sa.column("tenant_id", sa.String())))
+        .where(sa.column("tenant_id", sa.String()) == "workspace-1")
+    )
+
+
+def _compile(
+    spec: AggregationSpec,
+    fields: Mapping[str, ResolvedAggregationField],
+    *,
+    entity_id: sa.ColumnElement[Any] | None = None,
+    limit: int = 100,
+) -> str:
+    return _sql(
+        compile_aggregation(
+            _base_statement(),
+            spec,
+            fields,
+            limit=limit,
+            entity_id=entity_id,
+        )
+    )
+
+
+def _field(
+    name: str,
+    type_: sa.types.TypeEngine[Any],
+    kind: FieldKind,
+    *,
+    is_multi_valued: bool = False,
+) -> ResolvedAggregationField:
+    return ResolvedAggregationField(
+        expr=sa.column(name, type_),
+        kind=kind,
+        is_multi_valued=is_multi_valued,
+    )
+
+
+def test_agg_function_values_are_stable() -> None:
+    assert [function.value for function in AggFunction] == [
+        "count",
+        "count_distinct",
+        "sum",
+        "mean",
+        "median",
+        "min",
+        "max",
+    ]
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        AggFunction.COUNT_DISTINCT,
+        AggFunction.SUM,
+        AggFunction.MEAN,
+        AggFunction.MEDIAN,
+        AggFunction.MIN,
+        AggFunction.MAX,
+    ],
+)
+def test_only_count_allows_an_omitted_field(function: AggFunction) -> None:
+    with pytest.raises(ValidationError, match="requires a field"):
+        AggSpec(function=function)
+
+
+def test_aggregate_default_aliases() -> None:
+    assert AggSpec(function=AggFunction.COUNT).output_key == "count"
+    assert (
+        AggSpec(function=AggFunction.COUNT, field="fields.region").output_key
+        == "count_region"
+    )
+    assert (
+        AggSpec(function=AggFunction.SUM, field="fields.bytes").output_key
+        == "sum_bytes"
+    )
+
+
+def test_group_by_defaults_alias_to_full_field_address() -> None:
+    group = GroupBySpec(field="fields.region")
+
+    assert group.output_key == "fields.region"
+
+
+def test_group_by_validates_timezone_and_bucket_relationship() -> None:
+    assert (
+        GroupBySpec(
+            field="created_at", bucket="day", timezone="America/New_York"
+        ).timezone
+        == "America/New_York"
+    )
+
+    with pytest.raises(ValidationError, match="unknown IANA timezone"):
+        GroupBySpec(field="created_at", bucket="day", timezone="Mars/Olympus")
+    with pytest.raises(ValidationError, match="timezone requires a bucket"):
+        GroupBySpec(field="created_at", timezone="UTC")
+
+
+def test_group_by_rejects_unknown_bucket() -> None:
+    with pytest.raises(ValidationError):
+        GroupBySpec.model_validate({"field": "created_at", "bucket": "minute"})
+
+
+def test_aggregation_spec_expands_bare_group_by_strings() -> None:
+    spec = AggregationSpec.model_validate(
+        {
+            "group_by": ["status", {"field": "created_at", "bucket": "day"}],
+        }
+    )
+
+    assert spec.group_by == [
+        GroupBySpec(field="status"),
+        GroupBySpec(field="created_at", bucket="day"),
+    ]
+    assert spec.aggs == [AggSpec(function=AggFunction.COUNT)]
+
+
+def test_aggregation_spec_treats_null_aggs_as_default_count() -> None:
+    spec = AggregationSpec.model_validate({"group_by": [], "aggs": None})
+
+    assert spec.aggs == [AggSpec(function=AggFunction.COUNT)]
+
+
+def test_aggregation_spec_enforces_structural_limits() -> None:
+    with pytest.raises(ValidationError):
+        AggregationSpec(
+            group_by=[GroupBySpec(field=f"field_{index}") for index in range(4)]
+        )
+    with pytest.raises(ValidationError):
+        AggregationSpec(
+            group_by=[],
+            aggs=[
+                AggSpec(function=AggFunction.COUNT, alias=f"count_{index}")
+                for index in range(9)
+            ],
+        )
+
+    assert MAX_GROUP_BY_FIELDS == 3
+    assert MAX_AGGREGATIONS == 8
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {
+            "group_by": [
+                {"field": "status", "alias": "dimension"},
+                {"field": "priority", "alias": "dimension"},
+            ]
+        },
+        {
+            "group_by": [{"field": "status", "alias": "count"}],
+            "aggs": [{"function": "count"}],
+        },
+        {
+            "group_by": [],
+            "aggs": [
+                {"function": "count", "alias": "total"},
+                {"function": "count", "field": "status", "alias": "total"},
+            ],
+        },
+    ],
+)
+def test_aggregation_spec_rejects_output_key_collisions(
+    data: Mapping[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="output keys must be unique"):
+        AggregationSpec.model_validate(data)
+
+
+def test_aggregation_spec_rejects_unknown_order_key() -> None:
+    with pytest.raises(ValidationError, match="does not match"):
+        AggregationSpec(group_by=[GroupBySpec(field="status")], order_by="missing")
+
+
+@pytest.mark.parametrize(
+    ("model", "data"),
+    [
+        (AggSpec, {"function": "count", "alias": "bad\x00alias"}),
+        (GroupBySpec, {"field": "bad\x00field"}),
+        (AggregationSpec, {"group_by": [], "order_by": "bad\x00key"}),
+    ],
+)
+def test_models_reject_nul_in_sql_labels_or_addresses(
+    model: type[BaseModel],
+    data: Mapping[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="NUL"):
+        model.model_validate(data)
+
+
+def test_compiles_plain_group_and_count() -> None:
+    spec = AggregationSpec(group_by=[GroupBySpec(field="priority")])
+    sql = _compile(
+        spec,
+        {"priority": _field("priority", sa.String(), FieldKind.TEXT)},
+        limit=25,
+    )
+
+    assert "SELECT left(priority, 256) AS priority, count(*) AS count" in sql
+    assert "FROM events" in sql
+    assert "WHERE tenant_id = 'workspace-1'" in sql
+    assert "GROUP BY left(priority, 256)" in sql
+    assert "ORDER BY count DESC NULLS LAST, priority DESC NULLS LAST" in sql
+    assert "LIMIT 26" in sql
+
+
+@pytest.mark.parametrize("bucket", ["hour", "day", "week", "month"])
+def test_compiles_timestamptz_buckets_with_timezone(bucket: TimeBucket) -> None:
+    spec = AggregationSpec(
+        group_by=[
+            GroupBySpec(
+                field="created_at",
+                bucket=bucket,
+                timezone="America/New_York",
+            )
+        ]
+    )
+    sql = _compile(
+        spec,
+        {
+            "created_at": _field(
+                "created_at", sa.DateTime(timezone=True), FieldKind.TEMPORAL
+            )
+        },
+    )
+
+    assert (
+        f"date_trunc('{bucket}', created_at, 'America/New_York') AS created_at" in sql
+    )
+    assert "ORDER BY created_at ASC NULLS LAST" in sql
+
+
+def test_timestamptz_bucket_defaults_to_utc() -> None:
+    spec = AggregationSpec(group_by=[GroupBySpec(field="created_at", bucket="day")])
+    sql = _compile(
+        spec,
+        {
+            "created_at": _field(
+                "created_at", sa.DateTime(timezone=True), FieldKind.TEMPORAL
+            )
+        },
+    )
+
+    assert "date_trunc('day', created_at, 'UTC')" in sql
+
+
+def test_compiles_date_bucket_without_session_timezone_dependency() -> None:
+    spec = AggregationSpec(group_by=[GroupBySpec(field="event_date", bucket="month")])
+    sql = _compile(
+        spec,
+        {"event_date": _field("event_date", sa.Date(), FieldKind.TEMPORAL)},
+    )
+
+    assert (
+        "CAST(date_trunc('month', CAST(event_date AS TIMESTAMP WITHOUT TIME ZONE)) "
+        "AS DATE) AS event_date" in sql
+    )
+
+
+def test_rejects_timezone_on_date_bucket() -> None:
+    spec = AggregationSpec(
+        group_by=[GroupBySpec(field="event_date", bucket="day", timezone="UTC")]
+    )
+
+    with pytest.raises(TracecatValidationError, match="timezone.*DATE"):
+        _compile(
+            spec,
+            {"event_date": _field("event_date", sa.Date(), FieldKind.TEMPORAL)},
+        )
+
+
+@pytest.mark.parametrize(
+    ("spec", "field", "message"),
+    [
+        (
+            AggregationSpec(group_by=[GroupBySpec(field="created_at")]),
+            _field("created_at", sa.DateTime(timezone=True), FieldKind.TEMPORAL),
+            "require a bucket",
+        ),
+        (
+            AggregationSpec(group_by=[GroupBySpec(field="status", bucket="day")]),
+            _field("status", sa.String(), FieldKind.TEXT),
+            "bucket is not allowed",
+        ),
+        (
+            AggregationSpec(group_by=[GroupBySpec(field="created_at", bucket="day")]),
+            _field("created_at", sa.DateTime(timezone=False), FieldKind.TEMPORAL),
+            "DATE or TIMESTAMPTZ",
+        ),
+    ],
+)
+def test_rejects_invalid_group_bucket_combinations(
+    spec: AggregationSpec,
+    field: ResolvedAggregationField,
+    message: str,
+) -> None:
+    with pytest.raises(TracecatValidationError, match=message):
+        _compile(spec, {spec.group_by[0].field: field})
+
+
+def test_text_and_select_groups_are_bounded_but_native_enums_are_not() -> None:
+    native_status = sa.Enum("OPEN", "CLOSED", name="status")
+    spec = AggregationSpec(
+        group_by=[
+            GroupBySpec(field="message"),
+            GroupBySpec(field="category"),
+            GroupBySpec(field="status"),
+        ]
+    )
+    sql = _compile(
+        spec,
+        {
+            "message": _field("message", sa.Text(), FieldKind.TEXT),
+            "category": _field("category", sa.String(), FieldKind.ENUM),
+            "status": _field("status", native_status, FieldKind.ENUM),
+        },
+    )
+
+    assert "left(message, 256) AS message" in sql
+    assert "left(category, 256) AS category" in sql
+    assert "left(status" not in sql
+    assert "status AS status" in sql
+
+
+@pytest.mark.parametrize(
+    ("function", "column_type", "kind", "allowed"),
+    [
+        (function, column_type, kind, function in allowed_functions)
+        for column_type, kind, allowed_functions in [
+            (
+                sa.Text(),
+                FieldKind.TEXT,
+                {
+                    AggFunction.COUNT,
+                    AggFunction.COUNT_DISTINCT,
+                    AggFunction.MIN,
+                    AggFunction.MAX,
+                },
+            ),
+            (sa.BigInteger(), FieldKind.NUMBER, set(AggFunction)),
+            (sa.Numeric(), FieldKind.NUMBER, set(AggFunction)),
+            (
+                sa.Boolean(),
+                FieldKind.BOOLEAN,
+                {AggFunction.COUNT, AggFunction.COUNT_DISTINCT},
+            ),
+            (
+                sa.Date(),
+                FieldKind.TEMPORAL,
+                {
+                    AggFunction.COUNT,
+                    AggFunction.COUNT_DISTINCT,
+                    AggFunction.MIN,
+                    AggFunction.MAX,
+                },
+            ),
+            (
+                sa.DateTime(timezone=True),
+                FieldKind.TEMPORAL,
+                {
+                    AggFunction.COUNT,
+                    AggFunction.COUNT_DISTINCT,
+                    AggFunction.MIN,
+                    AggFunction.MAX,
+                },
+            ),
+            (
+                sa.String(),
+                FieldKind.ENUM,
+                {AggFunction.COUNT, AggFunction.COUNT_DISTINCT},
+            ),
+            (
+                sa.Uuid(),
+                FieldKind.UUID,
+                {AggFunction.COUNT, AggFunction.COUNT_DISTINCT},
+            ),
+            (sa.String(), FieldKind.TAG, {AggFunction.COUNT}),
+        ]
+        for function in AggFunction
+    ],
+)
+def test_aggregate_function_type_matrix(
+    function: AggFunction,
+    column_type: sa.types.TypeEngine[Any],
+    kind: FieldKind,
+    allowed: bool,
+) -> None:
+    spec = AggregationSpec(
+        group_by=[],
+        aggs=[AggSpec(function=function, field="value")],
+    )
+    if not allowed:
+        with pytest.raises(TracecatValidationError, match="not allowed"):
+            _compile(spec, {"value": _field("value", column_type, kind)})
+        return
+
+    assert " AS " in _compile(spec, {"value": _field("value", column_type, kind)})
+
+
+@pytest.mark.parametrize(
+    ("function", "column_type", "sql_fragment"),
+    [
+        (AggFunction.SUM, sa.BigInteger(), "CAST(sum(value) AS BIGINT)"),
+        (AggFunction.SUM, sa.Numeric(), "CAST(sum(value) AS DOUBLE PRECISION)"),
+        (AggFunction.MEAN, sa.BigInteger(), "CAST(avg(value) AS DOUBLE PRECISION)"),
+        (AggFunction.MEAN, sa.Numeric(), "CAST(avg(value) AS DOUBLE PRECISION)"),
+        (
+            AggFunction.MEDIAN,
+            sa.BigInteger(),
+            "CAST(percentile_cont(0.5) WITHIN GROUP (ORDER BY value) AS DOUBLE PRECISION)",
+        ),
+        (
+            AggFunction.MEDIAN,
+            sa.Numeric(),
+            "CAST(percentile_cont(0.5) WITHIN GROUP (ORDER BY value) AS DOUBLE PRECISION)",
+        ),
+        (AggFunction.MIN, sa.Numeric(), "CAST(min(value) AS DOUBLE PRECISION)"),
+        (AggFunction.MAX, sa.Numeric(), "CAST(max(value) AS DOUBLE PRECISION)"),
+    ],
+)
+def test_numeric_aggregate_output_casts(
+    function: AggFunction,
+    column_type: sa.types.TypeEngine[Any],
+    sql_fragment: str,
+) -> None:
+    spec = AggregationSpec(
+        group_by=[],
+        aggs=[AggSpec(function=function, field="value")],
+    )
+
+    assert sql_fragment in _compile(
+        spec, {"value": _field("value", column_type, FieldKind.NUMBER)}
+    )
+
+
+def test_count_field_counts_non_null_values() -> None:
+    spec = AggregationSpec(
+        group_by=[],
+        aggs=[AggSpec(function=AggFunction.COUNT, field="value")],
+    )
+    sql = _compile(spec, {"value": _field("value", sa.String(), FieldKind.TEXT)})
+
+    assert "count(value) AS count_value" in sql
+
+
+def test_multi_valued_group_rewrites_all_row_counts_and_having() -> None:
+    spec = AggregationSpec(
+        group_by=[GroupBySpec(field="tags")],
+        aggs=[
+            AggSpec(function=AggFunction.COUNT),
+            AggSpec(function=AggFunction.COUNT, field="summary"),
+        ],
+        min_count=3,
+    )
+    sql = _compile(
+        spec,
+        {
+            "tags": _field("tag_ref", sa.String(), FieldKind.TAG, is_multi_valued=True),
+            "summary": _field("summary", sa.String(), FieldKind.TEXT),
+        },
+        entity_id=sa.column("case_id", sa.Uuid()),
+    )
+
+    assert "count(DISTINCT case_id) AS count" in sql
+    assert (
+        "count(DISTINCT case_id) FILTER (WHERE summary IS NOT NULL) AS count_summary"
+        in sql
+    )
+    assert "HAVING count(DISTINCT case_id) >= 3" in sql
+
+
+@pytest.mark.parametrize(
+    "function", [AggFunction.SUM, AggFunction.MEAN, AggFunction.MEDIAN]
+)
+def test_multi_valued_group_rejects_additive_aggregates(
+    function: AggFunction,
+) -> None:
+    spec = AggregationSpec(
+        group_by=[GroupBySpec(field="tags")],
+        aggs=[AggSpec(function=function, field="value")],
+    )
+
+    with pytest.raises(TracecatValidationError, match="multi-valued"):
+        _compile(
+            spec,
+            {
+                "tags": _field(
+                    "tag_ref", sa.String(), FieldKind.TAG, is_multi_valued=True
+                ),
+                "value": _field("value", sa.BigInteger(), FieldKind.NUMBER),
+            },
+            entity_id=sa.column("case_id", sa.Uuid()),
+        )
+
+
+def test_multi_valued_group_requires_entity_id() -> None:
+    spec = AggregationSpec(group_by=[GroupBySpec(field="tags")])
+
+    with pytest.raises(TracecatValidationError, match="requires an entity id"):
+        _compile(
+            spec,
+            {
+                "tags": _field(
+                    "tag_ref", sa.String(), FieldKind.TAG, is_multi_valued=True
+                )
+            },
+        )
+
+
+def test_default_ordering_uses_first_bucket_even_when_not_first_group() -> None:
+    spec = AggregationSpec(
+        group_by=[
+            GroupBySpec(field="status"),
+            GroupBySpec(field="created_at", bucket="day", alias="day"),
+        ]
+    )
+    sql = _compile(
+        spec,
+        {
+            "status": _field("status", sa.String(), FieldKind.TEXT),
+            "created_at": _field(
+                "created_at", sa.DateTime(timezone=True), FieldKind.TEMPORAL
+            ),
+        },
+    )
+
+    assert "ORDER BY day ASC NULLS LAST, status ASC NULLS LAST" in sql
+
+
+def test_explicit_order_and_sort_use_labels_with_group_tiebreakers() -> None:
+    spec = AggregationSpec(
+        group_by=[GroupBySpec(field="status")],
+        aggs=[AggSpec(function=AggFunction.COUNT, alias="total")],
+        order_by="status",
+        sort=SortDirection.DESC,
+    )
+    sql = _compile(
+        spec,
+        {"status": _field("status", sa.String(), FieldKind.TEXT)},
+    )
+
+    assert "ORDER BY status DESC NULLS LAST" in sql
+    assert "ORDER BY left(" not in sql
+
+
+def test_empty_group_by_compiles_grand_total() -> None:
+    spec = AggregationSpec(group_by=[])
+    sql = _compile(spec, {})
+
+    assert "SELECT count(*) AS count" in sql
+    assert "GROUP BY" not in sql
+    assert "ORDER BY count DESC NULLS LAST" in sql
+
+
+def test_unknown_aggregation_field_is_a_semantic_error() -> None:
+    spec = AggregationSpec(group_by=[GroupBySpec(field="missing")])
+
+    with pytest.raises(TracecatValidationError, match="Unknown.*'missing'"):
+        _compile(spec, {})
+
+
+def test_limit_must_be_positive() -> None:
+    with pytest.raises(TracecatValidationError, match="at least 1"):
+        _compile(AggregationSpec(group_by=[]), {}, limit=0)

--- a/tests/unit/query/test_aggregations.py
+++ b/tests/unit/query/test_aggregations.py
@@ -737,6 +737,26 @@ def test_compiler_rejects_base_distinct(distinct_on: bool) -> None:
         )
 
 
+@pytest.mark.parametrize("clause", ["group_by", "having"])
+def test_compiler_rejects_grouped_or_having_base(clause: str) -> None:
+    entity_id = sa.column("entity_id", sa.Integer())
+    statement = _base_statement()
+    if clause == "group_by":
+        statement = statement.group_by(entity_id)
+    else:
+        statement = statement.having(sa.func.count() > 1)
+
+    with pytest.raises(
+        TracecatValidationError, match="must not use GROUP BY or HAVING"
+    ):
+        compile_aggregation(
+            statement,
+            AggregationSpec(group_by=[]),
+            {},
+            limit=25,
+        )
+
+
 def test_unknown_aggregation_field_is_a_semantic_error() -> None:
     spec = AggregationSpec(group_by=[GroupBySpec(field="missing")])
 

--- a/tests/unit/query/test_aggregations.py
+++ b/tests/unit/query/test_aggregations.py
@@ -205,6 +205,24 @@ def test_aggregation_spec_rejects_output_key_collisions(
         AggregationSpec.model_validate(data)
 
 
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        ("a" * 63 + "x", "a" * 63 + "y"),
+        ("é" * 31, "é" * 32),
+    ],
+)
+def test_aggregation_spec_rejects_postgres_truncated_alias_collisions(
+    first: str,
+    second: str,
+) -> None:
+    with pytest.raises(ValidationError, match="PostgreSQL identifier truncation"):
+        AggregationSpec(
+            group_by=[GroupBySpec(field="status", alias=first)],
+            aggs=[AggSpec(function=AggFunction.COUNT, alias=second)],
+        )
+
+
 def test_aggregation_spec_rejects_unknown_order_key() -> None:
     with pytest.raises(ValidationError, match="does not match"):
         AggregationSpec(group_by=[GroupBySpec(field="status")], order_by="missing")
@@ -438,7 +456,12 @@ def test_aggregate_function_type_matrix(
 @pytest.mark.parametrize(
     ("function", "column_type", "sql_fragment"),
     [
-        (AggFunction.SUM, sa.BigInteger(), "CAST(sum(value) AS BIGINT)"),
+        (AggFunction.SUM, sa.Integer(), "CAST(sum(value) AS BIGINT)"),
+        (
+            AggFunction.SUM,
+            sa.BigInteger(),
+            "CAST(sum(value) AS DOUBLE PRECISION)",
+        ),
         (AggFunction.SUM, sa.Numeric(), "CAST(sum(value) AS DOUBLE PRECISION)"),
         (AggFunction.MEAN, sa.BigInteger(), "CAST(avg(value) AS DOUBLE PRECISION)"),
         (AggFunction.MEAN, sa.Numeric(), "CAST(avg(value) AS DOUBLE PRECISION)"),
@@ -588,6 +611,22 @@ def test_empty_group_by_compiles_grand_total() -> None:
     assert "SELECT count(*) AS count" in sql
     assert "GROUP BY" not in sql
     assert "ORDER BY count DESC NULLS LAST" in sql
+
+
+def test_compiler_clears_base_limit_and_offset() -> None:
+    statement = _base_statement().limit(10).offset(5)
+
+    sql = _sql(
+        compile_aggregation(
+            statement,
+            AggregationSpec(group_by=[]),
+            {},
+            limit=25,
+        )
+    )
+
+    assert " LIMIT 26" in sql
+    assert " OFFSET " not in sql
 
 
 def test_unknown_aggregation_field_is_a_semantic_error() -> None:

--- a/tests/unit/query/test_aggregations.py
+++ b/tests/unit/query/test_aggregations.py
@@ -719,6 +719,28 @@ def test_compiler_clears_base_limit_and_offset() -> None:
     assert " OFFSET " not in sql
 
 
+@pytest.mark.parametrize("distinct_on", [False, True])
+def test_compiler_clears_base_distinct(distinct_on: bool) -> None:
+    entity_id = sa.column("entity_id", sa.Integer())
+    statement = _base_statement()
+    if distinct_on:
+        statement = statement.distinct(entity_id).order_by(entity_id)
+    else:
+        statement = statement.distinct()
+
+    sql = _sql(
+        compile_aggregation(
+            statement,
+            AggregationSpec(group_by=[]),
+            {},
+            limit=25,
+        )
+    )
+
+    assert not sql.startswith("SELECT DISTINCT")
+    assert "ORDER BY count DESC NULLS LAST" in sql
+
+
 def test_unknown_aggregation_field_is_a_semantic_error() -> None:
     spec = AggregationSpec(group_by=[GroupBySpec(field="missing")])
 

--- a/tracecat/query/aggregations.py
+++ b/tracecat/query/aggregations.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal, Self
+from zoneinfo import available_timezones
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+MAX_GROUP_BY_FIELDS = 3
+MAX_AGGREGATIONS = 8
+IANA_TIMEZONES = frozenset(available_timezones())
+type TimeBucket = Literal["hour", "day", "week", "month"]
+
+
+class AggFunction(StrEnum):
+    """Aggregate functions supported by the shared query compiler."""
+
+    COUNT = "count"
+    COUNT_DISTINCT = "count_distinct"
+    SUM = "sum"
+    MEAN = "mean"
+    MEDIAN = "median"
+    MIN = "min"
+    MAX = "max"
+
+
+class SortDirection(StrEnum):
+    """Sort directions supported by aggregation queries."""
+
+    ASC = "asc"
+    DESC = "desc"
+
+
+class _AggregationModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class AggSpec(_AggregationModel):
+    """One aggregate output requested by a query."""
+
+    function: AggFunction
+    field: str | None = Field(default=None, min_length=1)
+    alias: str | None = Field(default=None, min_length=1)
+
+    @field_validator("field", "alias")
+    @classmethod
+    def reject_nul(cls, value: str | None) -> str | None:
+        if value is not None and "\x00" in value:
+            raise ValueError("must not contain a NUL character")
+        return value
+
+    @model_validator(mode="after")
+    def validate_field_and_alias(self) -> Self:
+        if self.function is not AggFunction.COUNT and self.field is None:
+            raise ValueError(f"{self.function.value} requires a field")
+        if self.alias is None:
+            if self.field is None:
+                self.alias = self.function.value
+            else:
+                leaf = self.field.rsplit(".", maxsplit=1)[-1]
+                self.alias = f"{self.function.value}_{leaf}"
+        return self
+
+    @property
+    def output_key(self) -> str:
+        """Return the validated output key for this aggregate."""
+        assert self.alias is not None
+        return self.alias
+
+
+class GroupBySpec(_AggregationModel):
+    """One grouping dimension requested by a query."""
+
+    field: str = Field(min_length=1)
+    bucket: TimeBucket | None = Field(default=None)
+    timezone: str | None = Field(default=None, min_length=1)
+    alias: str | None = Field(default=None, min_length=1)
+
+    @field_validator("field", "alias")
+    @classmethod
+    def reject_nul(cls, value: str | None) -> str | None:
+        if value is not None and "\x00" in value:
+            raise ValueError("must not contain a NUL character")
+        return value
+
+    @field_validator("timezone")
+    @classmethod
+    def validate_timezone(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if "\x00" in value or value not in IANA_TIMEZONES:
+            raise ValueError(f"unknown IANA timezone {value!r}")
+        return value
+
+    @model_validator(mode="after")
+    def validate_bucket_and_alias(self) -> Self:
+        if self.timezone is not None and self.bucket is None:
+            raise ValueError("timezone requires a bucket")
+        if self.alias is None:
+            self.alias = self.field
+        return self
+
+    @property
+    def output_key(self) -> str:
+        """Return the validated output key for this grouping dimension."""
+        assert self.alias is not None
+        return self.alias
+
+
+class AggregationSpec(_AggregationModel):
+    """Shared group-by, aggregate, having, and ordering query shape."""
+
+    group_by: list[GroupBySpec] = Field(max_length=MAX_GROUP_BY_FIELDS)
+    aggs: list[AggSpec] = Field(
+        default_factory=lambda: [AggSpec(function=AggFunction.COUNT)],
+        min_length=1,
+        max_length=MAX_AGGREGATIONS,
+    )
+    min_count: int | None = Field(default=None, ge=1)
+    order_by: str | None = Field(default=None, min_length=1)
+    sort: SortDirection | None = Field(default=None)
+
+    @field_validator("group_by", mode="before")
+    @classmethod
+    def expand_group_by_shorthand(cls, value: Any) -> Any:
+        if not isinstance(value, list):
+            return value
+        return [
+            GroupBySpec(field=item) if isinstance(item, str) else item for item in value
+        ]
+
+    @field_validator("aggs", mode="before")
+    @classmethod
+    def default_null_aggs_to_count(cls, value: Any) -> Any:
+        if value is None:
+            return [AggSpec(function=AggFunction.COUNT)]
+        return value
+
+    @field_validator("order_by")
+    @classmethod
+    def reject_order_by_nul(cls, value: str | None) -> str | None:
+        if value is not None and "\x00" in value:
+            raise ValueError("must not contain a NUL character")
+        return value
+
+    @model_validator(mode="after")
+    def validate_output_keys(self) -> Self:
+        output_keys = [group.output_key for group in self.group_by]
+        output_keys.extend(agg.output_key for agg in self.aggs)
+        duplicates = sorted(
+            key for key in set(output_keys) if output_keys.count(key) > 1
+        )
+        if duplicates:
+            raise ValueError(
+                "Aggregation output keys must be unique; duplicate keys: "
+                + ", ".join(repr(key) for key in duplicates)
+            )
+        if self.order_by is not None and self.order_by not in output_keys:
+            raise ValueError(
+                f"order_by {self.order_by!r} does not match an aggregation output key"
+            )
+        return self

--- a/tracecat/query/aggregations.py
+++ b/tracecat/query/aggregations.py
@@ -13,12 +13,6 @@ IANA_TIMEZONES = frozenset(available_timezones())
 type TimeBucket = Literal["hour", "day", "week", "month"]
 
 
-def _postgres_identifier(value: str) -> str:
-    """Return an identifier as PostgreSQL stores it after byte truncation."""
-    encoded = value.encode("utf-8")[:POSTGRES_IDENTIFIER_MAX_BYTES]
-    return encoded.decode("utf-8", errors="ignore")
-
-
 class AggFunction(StrEnum):
     """Aggregate functions supported by the shared query compiler."""
 
@@ -154,16 +148,23 @@ class AggregationSpec(_AggregationModel):
     def validate_output_keys(self) -> Self:
         output_keys = [group.output_key for group in self.group_by]
         output_keys.extend(agg.output_key for agg in self.aggs)
-        normalized_output_keys = [_postgres_identifier(key) for key in output_keys]
-        duplicates = sorted(
+        overlong_keys = sorted(
             key
-            for key in set(normalized_output_keys)
-            if normalized_output_keys.count(key) > 1
+            for key in output_keys
+            if len(key.encode("utf-8")) > POSTGRES_IDENTIFIER_MAX_BYTES
+        )
+        if overlong_keys:
+            raise ValueError(
+                "Aggregation output keys must not exceed PostgreSQL's 63-byte "
+                "identifier limit; overlong keys: "
+                + ", ".join(repr(key) for key in overlong_keys)
+            )
+        duplicates = sorted(
+            key for key in set(output_keys) if output_keys.count(key) > 1
         )
         if duplicates:
             raise ValueError(
-                "Aggregation output keys must be unique after PostgreSQL identifier "
-                "truncation; duplicate keys: "
+                "Aggregation output keys must be unique; duplicate keys: "
                 + ", ".join(repr(key) for key in duplicates)
             )
         if self.order_by is not None and self.order_by not in output_keys:

--- a/tracecat/query/aggregations.py
+++ b/tracecat/query/aggregations.py
@@ -8,8 +8,15 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 MAX_GROUP_BY_FIELDS = 3
 MAX_AGGREGATIONS = 8
+POSTGRES_IDENTIFIER_MAX_BYTES = 63
 IANA_TIMEZONES = frozenset(available_timezones())
 type TimeBucket = Literal["hour", "day", "week", "month"]
+
+
+def _postgres_identifier(value: str) -> str:
+    """Return an identifier as PostgreSQL stores it after byte truncation."""
+    encoded = value.encode("utf-8")[:POSTGRES_IDENTIFIER_MAX_BYTES]
+    return encoded.decode("utf-8", errors="ignore")
 
 
 class AggFunction(StrEnum):
@@ -147,12 +154,16 @@ class AggregationSpec(_AggregationModel):
     def validate_output_keys(self) -> Self:
         output_keys = [group.output_key for group in self.group_by]
         output_keys.extend(agg.output_key for agg in self.aggs)
+        normalized_output_keys = [_postgres_identifier(key) for key in output_keys]
         duplicates = sorted(
-            key for key in set(output_keys) if output_keys.count(key) > 1
+            key
+            for key in set(normalized_output_keys)
+            if normalized_output_keys.count(key) > 1
         )
         if duplicates:
             raise ValueError(
-                "Aggregation output keys must be unique; duplicate keys: "
+                "Aggregation output keys must be unique after PostgreSQL identifier "
+                "truncation; duplicate keys: "
                 + ", ".join(repr(key) for key in duplicates)
             )
         if self.order_by is not None and self.order_by not in output_keys:

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -121,7 +121,7 @@ def compile_aggregation(
         *agg_expressions,
         maintain_column_froms=True,
     )
-    compiled = compiled.group_by(None).order_by(None).limit(None)
+    compiled = compiled.group_by(None).order_by(None).limit(None).offset(None)
     if group_expressions:
         compiled = compiled.group_by(*group_expressions)
 
@@ -257,7 +257,9 @@ def _compile_aggregate(
             expression = sa.func.count(sa.distinct(field_expression))
         case AggFunction.SUM:
             expression = sa.func.sum(field_expression)
-            if isinstance(field_expression.type, sa.Integer):
+            if isinstance(field_expression.type, sa.BigInteger):
+                expression = sa.cast(expression, postgresql.DOUBLE_PRECISION())
+            elif isinstance(field_expression.type, sa.Integer):
                 expression = sa.cast(expression, sa.BigInteger())
             else:
                 expression = sa.cast(expression, postgresql.DOUBLE_PRECISION())

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -2,17 +2,27 @@ from __future__ import annotations
 
 import math
 import struct
+from collections.abc import Mapping
 from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
 from uuid import UUID
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.sql import Select
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.type_api import TypeEngine
 
 from tracecat.exceptions import TracecatValidationError
+from tracecat.query.aggregations import (
+    AggFunction,
+    AggregationSpec,
+    AggSpec,
+    GroupBySpec,
+    SortDirection,
+)
 from tracecat.query.filters import (
     AndClause,
     Condition,
@@ -28,6 +38,7 @@ from tracecat.query.resolver import (
     FieldResolver,
     NormalizedFilterScalar,
     NormalizedFilterValue,
+    ResolvedAggregationField,
 )
 
 POSTGRES_SMALLINT_MIN = -(2**15)
@@ -38,6 +49,315 @@ POSTGRES_BIGINT_MIN = -(2**63)
 POSTGRES_BIGINT_MAX = 2**63 - 1
 POSTGRES_NUMERIC_MAX_WHOLE_DIGITS = 131_072
 POSTGRES_NUMERIC_MAX_FRACTIONAL_DIGITS = 16_383
+
+
+def compile_aggregation(
+    statement: Select[Any],
+    spec: AggregationSpec,
+    resolved_fields: Mapping[str, ResolvedAggregationField],
+    *,
+    limit: int,
+    entity_id: ColumnElement[Any] | InstrumentedAttribute[Any] | None = None,
+) -> Select[Any]:
+    """Compile aggregation clauses onto an entity-scoped base statement.
+
+    The caller owns field resolution, joins, and row-level predicates. This
+    function replaces the base statement's projection, then adds GROUP BY,
+    aggregates, HAVING, deterministic ordering, and ``LIMIT limit + 1``.
+
+    Args:
+        statement: A base select with its FROM clauses, joins, and filters.
+        spec: Validated shared aggregation query shape.
+        resolved_fields: Trusted aggregation expressions keyed by field address.
+        limit: Maximum number of groups the caller will return.
+        entity_id: Stable row identity used to de-duplicate counts when a
+            multi-valued grouping dimension explodes one entity into many rows.
+
+    Returns:
+        The compiled SQLAlchemy select.
+
+    Raises:
+        TracecatValidationError: If resolved fields or requested operations are
+            semantically incompatible.
+    """
+    if limit < 1:
+        raise TracecatValidationError("Aggregation limit must be at least 1")
+
+    resolved_groups = [
+        (group, _resolve_aggregation_field(group.field, resolved_fields))
+        for group in spec.group_by
+    ]
+    resolved_aggs = [
+        (
+            agg,
+            None
+            if agg.field is None
+            else _resolve_aggregation_field(agg.field, resolved_fields),
+        )
+        for agg in spec.aggs
+    ]
+    has_multi_valued_group = any(field.is_multi_valued for _, field in resolved_groups)
+    entity_id_expression = None if entity_id is None else _column_expression(entity_id)
+    if has_multi_valued_group and entity_id_expression is None:
+        raise TracecatValidationError(
+            "Aggregation with a multi-valued group requires an entity id expression"
+        )
+
+    group_expressions = [
+        _compile_group_by(group, field) for group, field in resolved_groups
+    ]
+    agg_expressions = [
+        _compile_aggregate(
+            agg,
+            field,
+            has_multi_valued_group=has_multi_valued_group,
+            entity_id=entity_id_expression,
+        )
+        for agg, field in resolved_aggs
+    ]
+
+    compiled = statement.with_only_columns(
+        *group_expressions,
+        *agg_expressions,
+        maintain_column_froms=True,
+    )
+    compiled = compiled.group_by(None).order_by(None).limit(None)
+    if group_expressions:
+        compiled = compiled.group_by(*group_expressions)
+
+    if spec.min_count is not None:
+        row_count = _compile_row_count(
+            has_multi_valued_group=has_multi_valued_group,
+            entity_id=entity_id_expression,
+        )
+        compiled = compiled.having(row_count >= spec.min_count)
+
+    output_expressions = {
+        expression.name: expression
+        for expression in [*group_expressions, *agg_expressions]
+    }
+    order_key, direction = _resolve_ordering(spec)
+    primary = output_expressions[order_key]
+    order_expressions = [_ordered(primary, direction)]
+    order_expressions.extend(
+        _ordered(group, direction)
+        for group in group_expressions
+        if group.name != order_key
+    )
+    return compiled.order_by(*order_expressions).limit(limit + 1)
+
+
+def _resolve_aggregation_field(
+    field: str,
+    resolved_fields: Mapping[str, ResolvedAggregationField],
+) -> ResolvedAggregationField:
+    resolved = resolved_fields.get(field)
+    if resolved is None:
+        raise TracecatValidationError(f"Unknown aggregation field {field!r}")
+    return resolved
+
+
+def _column_expression(
+    expression: ColumnElement[Any] | InstrumentedAttribute[Any],
+) -> ColumnElement[Any]:
+    if isinstance(expression, InstrumentedAttribute):
+        return expression.expression
+    return expression
+
+
+def _compile_group_by(
+    spec: GroupBySpec, resolved: ResolvedAggregationField
+) -> sa.Label[Any]:
+    expression = _column_expression(resolved.expr)
+    if resolved.kind is FieldKind.TEMPORAL:
+        if spec.bucket is None:
+            raise _aggregation_error(spec.field, "temporal group keys require a bucket")
+        expression = _compile_bucket(spec, expression)
+    elif spec.bucket is not None:
+        raise _aggregation_error(
+            spec.field,
+            f"bucket is not allowed for {resolved.kind.value} fields",
+        )
+
+    if _uses_bounded_text_group(resolved.kind, expression.type):
+        expression = sa.func.left(expression, 256, type_=sa.String())
+    return expression.label(spec.output_key)
+
+
+def _compile_bucket(
+    spec: GroupBySpec, expression: ColumnElement[Any]
+) -> ColumnElement[Any]:
+    type_ = expression.type
+    if isinstance(type_, sa.Date) and not isinstance(type_, sa.DateTime):
+        if spec.timezone is not None:
+            raise _aggregation_error(spec.field, "timezone is not allowed for DATE")
+        timestamp = sa.cast(expression, sa.DateTime(timezone=False))
+        return sa.cast(
+            sa.func.date_trunc(spec.bucket, timestamp),
+            sa.Date(),
+        )
+    if isinstance(type_, sa.DateTime) and type_.timezone:
+        return sa.func.date_trunc(
+            spec.bucket,
+            expression,
+            spec.timezone or "UTC",
+            type_=sa.DateTime(timezone=True),
+        )
+    raise _aggregation_error(spec.field, "temporal buckets require DATE or TIMESTAMPTZ")
+
+
+def _uses_bounded_text_group(kind: FieldKind, type_: TypeEngine[Any]) -> bool:
+    if kind is FieldKind.TEXT:
+        return True
+    return (
+        kind is FieldKind.ENUM
+        and isinstance(type_, sa.String)
+        and not isinstance(type_, sa.Enum)
+    )
+
+
+def _compile_aggregate(
+    spec: AggSpec,
+    resolved: ResolvedAggregationField | None,
+    *,
+    has_multi_valued_group: bool,
+    entity_id: ColumnElement[Any] | None,
+) -> sa.Label[Any]:
+    if resolved is None:
+        assert spec.function is AggFunction.COUNT
+        expression = _compile_row_count(
+            has_multi_valued_group=has_multi_valued_group,
+            entity_id=entity_id,
+        )
+        return expression.label(spec.output_key)
+
+    field_expression = _column_expression(resolved.expr)
+    _validate_aggregate_target(spec, resolved.kind, field_expression.type)
+
+    if has_multi_valued_group and spec.function in {
+        AggFunction.SUM,
+        AggFunction.MEAN,
+        AggFunction.MEDIAN,
+    }:
+        raise _aggregation_error(
+            spec.field,
+            f"{spec.function.value} is not allowed with a multi-valued group",
+        )
+
+    match spec.function:
+        case AggFunction.COUNT:
+            if has_multi_valued_group:
+                assert entity_id is not None
+                expression = sa.func.count(sa.distinct(entity_id)).filter(
+                    field_expression.is_not(None)
+                )
+            else:
+                expression = sa.func.count(field_expression)
+        case AggFunction.COUNT_DISTINCT:
+            expression = sa.func.count(sa.distinct(field_expression))
+        case AggFunction.SUM:
+            expression = sa.func.sum(field_expression)
+            if isinstance(field_expression.type, sa.Integer):
+                expression = sa.cast(expression, sa.BigInteger())
+            else:
+                expression = sa.cast(expression, postgresql.DOUBLE_PRECISION())
+        case AggFunction.MEAN:
+            expression = sa.cast(
+                sa.func.avg(field_expression), postgresql.DOUBLE_PRECISION()
+            )
+        case AggFunction.MEDIAN:
+            expression = sa.cast(
+                sa.func.percentile_cont(0.5).within_group(field_expression),
+                postgresql.DOUBLE_PRECISION(),
+            )
+        case AggFunction.MIN:
+            expression = sa.func.min(field_expression)
+            if isinstance(field_expression.type, sa.Numeric) and not isinstance(
+                field_expression.type, sa.Integer
+            ):
+                expression = sa.cast(expression, postgresql.DOUBLE_PRECISION())
+        case AggFunction.MAX:
+            expression = sa.func.max(field_expression)
+            if isinstance(field_expression.type, sa.Numeric) and not isinstance(
+                field_expression.type, sa.Integer
+            ):
+                expression = sa.cast(expression, postgresql.DOUBLE_PRECISION())
+    return expression.label(spec.output_key)
+
+
+def _validate_aggregate_target(
+    spec: AggSpec, kind: FieldKind, type_: TypeEngine[Any]
+) -> None:
+    function = spec.function
+    if function is AggFunction.COUNT:
+        return
+    if function is AggFunction.COUNT_DISTINCT and kind in {
+        FieldKind.TEXT,
+        FieldKind.NUMBER,
+        FieldKind.BOOLEAN,
+        FieldKind.TEMPORAL,
+        FieldKind.ENUM,
+        FieldKind.UUID,
+    }:
+        return
+    if function in {AggFunction.SUM, AggFunction.MEAN, AggFunction.MEDIAN}:
+        if kind is FieldKind.NUMBER and isinstance(
+            type_, sa.Integer | sa.Numeric | sa.Float
+        ):
+            return
+    if function in {AggFunction.MIN, AggFunction.MAX} and kind in {
+        FieldKind.TEXT,
+        FieldKind.NUMBER,
+        FieldKind.TEMPORAL,
+    }:
+        return
+    raise _aggregation_error(
+        spec.field,
+        f"{function.value} is not allowed for {kind.value} fields",
+    )
+
+
+def _compile_row_count(
+    *,
+    has_multi_valued_group: bool,
+    entity_id: ColumnElement[Any] | None,
+) -> ColumnElement[int]:
+    if has_multi_valued_group:
+        assert entity_id is not None
+        return sa.func.count(sa.distinct(entity_id))
+    return sa.func.count()
+
+
+def _resolve_ordering(spec: AggregationSpec) -> tuple[str, SortDirection]:
+    if spec.order_by is not None:
+        default_direction = SortDirection.DESC
+        key = spec.order_by
+    else:
+        bucket_group = next(
+            (group for group in spec.group_by if group.bucket is not None), None
+        )
+        if bucket_group is not None:
+            default_direction = SortDirection.ASC
+            key = bucket_group.output_key
+        else:
+            default_direction = SortDirection.DESC
+            key = spec.aggs[0].output_key
+    return key, spec.sort or default_direction
+
+
+def _ordered(
+    expression: ColumnElement[Any], direction: SortDirection
+) -> ColumnElement[Any]:
+    ordered = expression.asc() if direction is SortDirection.ASC else expression.desc()
+    return ordered.nulls_last()
+
+
+def _aggregation_error(field: str | None, message: str) -> TracecatValidationError:
+    if field is None:
+        return TracecatValidationError(f"Invalid aggregation: {message}")
+    return TracecatValidationError(
+        f"Invalid aggregation for field {field!r}: {message}"
+    )
 
 
 def compile_filter(node: Filter, resolver: FieldResolver) -> ColumnElement[bool]:

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -82,6 +82,13 @@ def compile_aggregation(
     """
     if limit < 1:
         raise TracecatValidationError("Aggregation limit must be at least 1")
+    # SQLAlchemy has no public Select API for inspecting or removing DISTINCT.
+    # Dropping it would silently change the entity set for join-backed queries,
+    # while retaining DISTINCT ON can conflict with aggregation ordering.
+    if statement._distinct:
+        raise TracecatValidationError(
+            "Aggregation base statement must not use DISTINCT or DISTINCT ON"
+        )
 
     resolved_groups = [
         (group, _resolve_aggregation_field(group.field, resolved_fields))
@@ -135,12 +142,6 @@ def compile_aggregation(
         *agg_expressions,
         maintain_column_froms=True,
     )
-    # SQLAlchemy has no public generative API for removing DISTINCT. Since
-    # ``with_only_columns`` returned a clone, clear its inherited state without
-    # mutating the caller's base statement. In particular, leaving DISTINCT ON
-    # here can make PostgreSQL reject our aggregate-first ORDER BY.
-    compiled._distinct = False
-    compiled._distinct_on = ()
     compiled = compiled.group_by(None).order_by(None).limit(None).offset(None)
     if group_expressions:
         compiled = compiled.group_by(*group_expressions)

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -71,7 +71,7 @@ def compile_aggregation(
         resolved_fields: Trusted aggregation expressions keyed by field address.
         limit: Maximum number of groups the caller will return.
         entity_id: Stable row identity used to de-duplicate counts when a
-            multi-valued grouping dimension explodes one entity into many rows.
+            multi-valued field explodes one entity into many rows.
 
     Returns:
         The compiled SQLAlchemy select.
@@ -96,11 +96,13 @@ def compile_aggregation(
         )
         for agg in spec.aggs
     ]
-    has_multi_valued_group = any(field.is_multi_valued for _, field in resolved_groups)
+    has_multi_valued_join = any(
+        field.is_multi_valued for _, field in resolved_groups
+    ) or any(field is not None and field.is_multi_valued for _, field in resolved_aggs)
     entity_id_expression = None if entity_id is None else _column_expression(entity_id)
-    if has_multi_valued_group and entity_id_expression is None:
+    if has_multi_valued_join and entity_id_expression is None:
         raise TracecatValidationError(
-            "Aggregation with a multi-valued group requires an entity id expression"
+            "Aggregation with a multi-valued field requires an entity id expression"
         )
 
     group_expressions = [
@@ -110,7 +112,7 @@ def compile_aggregation(
         _compile_aggregate(
             agg,
             field,
-            has_multi_valued_group=has_multi_valued_group,
+            has_multi_valued_join=has_multi_valued_join,
             entity_id=entity_id_expression,
         )
         for agg, field in resolved_aggs
@@ -127,7 +129,7 @@ def compile_aggregation(
 
     if spec.min_count is not None:
         row_count = _compile_row_count(
-            has_multi_valued_group=has_multi_valued_group,
+            has_multi_valued_join=has_multi_valued_join,
             entity_id=entity_id_expression,
         )
         compiled = compiled.having(row_count >= spec.min_count)
@@ -220,13 +222,13 @@ def _compile_aggregate(
     spec: AggSpec,
     resolved: ResolvedAggregationField | None,
     *,
-    has_multi_valued_group: bool,
+    has_multi_valued_join: bool,
     entity_id: ColumnElement[Any] | None,
 ) -> sa.Label[Any]:
     if resolved is None:
         assert spec.function is AggFunction.COUNT
         expression = _compile_row_count(
-            has_multi_valued_group=has_multi_valued_group,
+            has_multi_valued_join=has_multi_valued_join,
             entity_id=entity_id,
         )
         return expression.label(spec.output_key)
@@ -234,19 +236,19 @@ def _compile_aggregate(
     field_expression = _column_expression(resolved.expr)
     _validate_aggregate_target(spec, resolved.kind, field_expression.type)
 
-    if has_multi_valued_group and spec.function in {
+    if has_multi_valued_join and spec.function in {
         AggFunction.SUM,
         AggFunction.MEAN,
         AggFunction.MEDIAN,
     }:
         raise _aggregation_error(
             spec.field,
-            f"{spec.function.value} is not allowed with a multi-valued group",
+            f"{spec.function.value} is not allowed with a multi-valued field",
         )
 
     match spec.function:
         case AggFunction.COUNT:
-            if has_multi_valued_group:
+            if has_multi_valued_join:
                 assert entity_id is not None
                 expression = sa.func.count(sa.distinct(entity_id)).filter(
                     field_expression.is_not(None)
@@ -321,10 +323,10 @@ def _validate_aggregate_target(
 
 def _compile_row_count(
     *,
-    has_multi_valued_group: bool,
+    has_multi_valued_join: bool,
     entity_id: ColumnElement[Any] | None,
 ) -> ColumnElement[int]:
-    if has_multi_valued_group:
+    if has_multi_valued_join:
         assert entity_id is not None
         return sa.func.count(sa.distinct(entity_id))
     return sa.func.count()

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -96,11 +96,18 @@ def compile_aggregation(
         )
         for agg in spec.aggs
     ]
-    has_multi_valued_join = any(
-        field.is_multi_valued for _, field in resolved_groups
-    ) or any(field is not None and field.is_multi_valued for _, field in resolved_aggs)
+    has_multi_valued_group = any(field.is_multi_valued for _, field in resolved_groups)
+    multi_valued_agg_fields = {
+        agg.field
+        for agg, field in resolved_aggs
+        if field is not None and field.is_multi_valued
+    }
+    has_multi_valued_join = has_multi_valued_group or bool(multi_valued_agg_fields)
+    needs_entity_id = spec.min_count is not None or any(
+        agg.function is AggFunction.COUNT for agg in spec.aggs
+    )
     entity_id_expression = None if entity_id is None else _column_expression(entity_id)
-    if has_multi_valued_join and entity_id_expression is None:
+    if has_multi_valued_join and needs_entity_id and entity_id_expression is None:
         raise TracecatValidationError(
             "Aggregation with a multi-valued field requires an entity id expression"
         )
@@ -113,6 +120,11 @@ def compile_aggregation(
             agg,
             field,
             has_multi_valued_join=has_multi_valued_join,
+            has_other_multi_valued_source=has_multi_valued_group
+            or any(
+                multi_valued_field != agg.field
+                for multi_valued_field in multi_valued_agg_fields
+            ),
             entity_id=entity_id_expression,
         )
         for agg, field in resolved_aggs
@@ -223,6 +235,7 @@ def _compile_aggregate(
     resolved: ResolvedAggregationField | None,
     *,
     has_multi_valued_join: bool,
+    has_other_multi_valued_source: bool,
     entity_id: ColumnElement[Any] | None,
 ) -> sa.Label[Any]:
     if resolved is None:
@@ -236,14 +249,14 @@ def _compile_aggregate(
     field_expression = _column_expression(resolved.expr)
     _validate_aggregate_target(spec, resolved.kind, field_expression.type)
 
-    if has_multi_valued_join and spec.function in {
+    if has_other_multi_valued_source and spec.function in {
         AggFunction.SUM,
         AggFunction.MEAN,
         AggFunction.MEDIAN,
     }:
         raise _aggregation_error(
             spec.field,
-            f"{spec.function.value} is not allowed with a multi-valued field",
+            f"{spec.function.value} is not allowed with another multi-valued field",
         )
 
     match spec.function:
@@ -258,7 +271,12 @@ def _compile_aggregate(
         case AggFunction.COUNT_DISTINCT:
             expression = sa.func.count(sa.distinct(field_expression))
         case AggFunction.SUM:
-            expression = sa.func.sum(field_expression)
+            aggregate_input = (
+                sa.cast(field_expression, postgresql.DOUBLE_PRECISION())
+                if _is_narrow_float(field_expression.type)
+                else field_expression
+            )
+            expression = sa.func.sum(aggregate_input)
             if isinstance(field_expression.type, sa.BigInteger):
                 expression = sa.cast(expression, postgresql.DOUBLE_PRECISION())
             elif isinstance(field_expression.type, sa.Integer):
@@ -287,6 +305,14 @@ def _compile_aggregate(
             ):
                 expression = sa.cast(expression, postgresql.DOUBLE_PRECISION())
     return expression.label(spec.output_key)
+
+
+def _is_narrow_float(type_: TypeEngine[Any]) -> bool:
+    return isinstance(type_, sa.REAL) or (
+        isinstance(type_, sa.Float)
+        and type_.precision is not None
+        and type_.precision <= 24
+    )
 
 
 def _validate_aggregate_target(

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -57,6 +57,7 @@ def compile_aggregation(
     resolved_fields: Mapping[str, ResolvedAggregationField],
     *,
     limit: int,
+    base_has_multi_valued_join: bool,
     entity_id: ColumnElement[Any] | InstrumentedAttribute[Any] | None = None,
 ) -> Select[Any]:
     """Compile aggregation clauses onto an entity-scoped base statement.
@@ -70,6 +71,8 @@ def compile_aggregation(
         spec: Validated shared aggregation query shape.
         resolved_fields: Trusted aggregation expressions keyed by field address.
         limit: Maximum number of groups the caller will return.
+        base_has_multi_valued_join: Whether joins already present in the base
+            statement can fan one entity out to multiple rows.
         entity_id: Stable row identity used to de-duplicate counts when a
             multi-valued field explodes one entity into many rows.
 
@@ -93,6 +96,10 @@ def compile_aggregation(
         raise TracecatValidationError(
             "Aggregation base statement must not use GROUP BY or HAVING"
         )
+    if statement._for_update_arg is not None:
+        raise TracecatValidationError(
+            "Aggregation base statement must not use row locking"
+        )
 
     resolved_groups = [
         (group, _resolve_aggregation_field(group.field, resolved_fields))
@@ -113,7 +120,11 @@ def compile_aggregation(
         for agg, field in resolved_aggs
         if field is not None and field.is_multi_valued
     }
-    has_multi_valued_join = has_multi_valued_group or bool(multi_valued_agg_fields)
+    has_multi_valued_join = (
+        base_has_multi_valued_join
+        or has_multi_valued_group
+        or bool(multi_valued_agg_fields)
+    )
     needs_entity_id = spec.min_count is not None or any(
         agg.function is AggFunction.COUNT for agg in spec.aggs
     )
@@ -131,7 +142,8 @@ def compile_aggregation(
             agg,
             field,
             has_multi_valued_join=has_multi_valued_join,
-            has_other_multi_valued_source=has_multi_valued_group
+            has_other_multi_valued_source=base_has_multi_valued_join
+            or has_multi_valued_group
             or any(
                 multi_valued_field != agg.field
                 for multi_valued_field in multi_valued_agg_fields

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -89,6 +89,10 @@ def compile_aggregation(
         raise TracecatValidationError(
             "Aggregation base statement must not use DISTINCT or DISTINCT ON"
         )
+    if statement._group_by_clauses or statement._having_criteria:
+        raise TracecatValidationError(
+            "Aggregation base statement must not use GROUP BY or HAVING"
+        )
 
     resolved_groups = [
         (group, _resolve_aggregation_field(group.field, resolved_fields))

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -135,6 +135,12 @@ def compile_aggregation(
         *agg_expressions,
         maintain_column_froms=True,
     )
+    # SQLAlchemy has no public generative API for removing DISTINCT. Since
+    # ``with_only_columns`` returned a clone, clear its inherited state without
+    # mutating the caller's base statement. In particular, leaving DISTINCT ON
+    # here can make PostgreSQL reject our aggregate-first ORDER BY.
+    compiled._distinct = False
+    compiled._distinct_on = ()
     compiled = compiled.group_by(None).order_by(None).limit(None).offset(None)
     if group_expressions:
         compiled = compiled.group_by(*group_expressions)

--- a/tracecat/query/resolver.py
+++ b/tracecat/query/resolver.py
@@ -32,6 +32,7 @@ type PredicateFactory = Callable[
 type FilterExpression = (
     ColumnElement[Any] | InstrumentedAttribute[Any] | PredicateFactory
 )
+type AggregationExpression = ColumnElement[Any] | InstrumentedAttribute[Any]
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,6 +49,21 @@ class ResolvedField:
     kind: FieldKind
     allowed_ops: frozenset[FilterOp]
     value_type: TypeEngine[Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedAggregationField:
+    """A trusted expression available to the aggregation compiler.
+
+    Entity-specific resolvers validate whether a field is groupable or can be
+    used as an aggregate target before constructing this value. The shared
+    compiler uses ``kind`` and the SQL expression type for the generic type
+    matrix, bucketing, and output casts.
+    """
+
+    expr: AggregationExpression
+    kind: FieldKind
+    is_multi_valued: bool = False
 
 
 class FieldResolver(Protocol):


### PR DESCRIPTION
## Summary

- add validated models for aggregate functions, grouping, time bucketing, ordering, aliases, and result limits
- compile PostgreSQL `GROUP BY`, aggregate expressions, `HAVING`, deterministic ordering, and `LIMIT + 1` onto an entity-scoped base query
- support timezone-aware `TIMESTAMPTZ` buckets, session-independent `DATE` buckets, bounded text dimensions, and pinned numeric output casts
- protect entity counts and `min_count` from one-to-many join fan-out, and reject additive aggregates whose inputs would be duplicated
- require callers to declare fan-out already present in the base query rather than inferring it incompletely
- fail closed on base statements whose `DISTINCT`, `DISTINCT ON`, `GROUP BY`, `HAVING`, or row-locking semantics cannot be safely preserved
- validate the aggregate function/type matrix, PostgreSQL-safe aliases, unique output keys, and field cardinality constraints

## Scope

This implements the ENG-1745 query aggregation compiler from the ENG-1692 v3 design. It is based directly on `main`; the ENG-1744 filter foundation has already merged.

This PR intentionally contains the reusable specification models and compiler only. Entity-specific resolvers, services, API endpoints, and query timeout/configuration work remain outside this ticket.

- Implementation ticket: [ENG-1745](https://linear.app/tracecat/issue/ENG-1745/query-aggregation-spec-models-group-by-compiler)
- Design ticket: [ENG-1692](https://linear.app/tracecat/issue/ENG-1692/groupby-agg-on-cases-and-tables)

## Safety and semantics

- counts use distinct entity IDs whenever the requested fields or base query can fan out rows
- `sum`, `mean`, and `median` are rejected when unrelated multi-valued joins could duplicate their inputs
- narrow floating-point operands are widened before summation, and integer output casts follow the specified PostgreSQL result contract
- inherited pagination and ordering are removed before aggregation; the compiler applies its own deterministic ordering and sentinel row limit
- unsupported pre-shaped or locking base queries raise validation errors instead of silently changing their entity-set semantics or failing at execution

## Testing

- `uv run pytest tests/unit/query -q` — 294 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- commit-time pre-commit hooks
- GitHub CI, CodeQL, security scanning, and automated review are green on `4c30b82ce`

## LOC breakdown

| Category | + | - |
|---|---:|---:|
| Logic | 563 | 0 |
| Tests | 811 | 0 |
| **Total** | **1374** | **0** |
