### PR TITLE
feat(api): add aggregation query execution safeguards

### DIFF
--- a/tests/integration/test_query_execution_integration.py
+++ b/tests/integration/test_query_execution_integration.py
@@ -1,0 +1,22 @@
+"""PostgreSQL integration tests for shared query execution controls."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.query.errors import TracecatQueryTimeoutError
+from tracecat.query.execution import query_execution_context
+
+
+@pytest.mark.anyio
+async def test_postgres_statement_timeout_maps_to_query_timeout(
+    session: AsyncSession,
+) -> None:
+    with pytest.raises(TracecatQueryTimeoutError) as exc_info:
+        async with query_execution_context(session, statement_timeout_ms=1):
+            await session.execute(text("SELECT pg_sleep(0.1)"))
+
+    assert isinstance(exc_info.value.detail, dict)
+    assert exc_info.value.detail["code"] == "query_timeout"

--- a/tests/unit/test_api_exception_handlers.py
+++ b/tests/unit/test_api_exception_handlers.py
@@ -89,7 +89,7 @@ def _get(exc: Exception):
         pytest.param(
             TracecatValidationError("bad"), 500, id="other-tracecat-error-500"
         ),
-        pytest.param(TracecatQueryTimeoutError(), 408, id="query-timeout-408"),
+        pytest.param(TracecatQueryTimeoutError(), 422, id="query-timeout-422"),
         pytest.param(TracecatQueryOverflowError(), 400, id="query-overflow-400"),
     ],
 )
@@ -153,7 +153,7 @@ def test_scope_denied_keeps_its_structured_body() -> None:
     [
         pytest.param(
             TracecatQueryTimeoutError(),
-            408,
+            422,
             "query_timeout",
             id="timeout",
         ),

--- a/tests/unit/test_api_exception_handlers.py
+++ b/tests/unit/test_api_exception_handlers.py
@@ -10,13 +10,25 @@ from tracecat.api.app import (
     authorization_exception_handler,
     scope_denied_exception_handler,
 )
-from tracecat.api.common import tracecat_exception_handler
+from tracecat.api.app import (
+    create_app as create_api_app,
+)
+from tracecat.api.common import (
+    query_overflow_exception_handler,
+    query_timeout_exception_handler,
+    tracecat_exception_handler,
+)
 from tracecat.exceptions import (
     ScopeDeniedError,
     TracecatAuthorizationError,
     TracecatException,
     TracecatRLSViolationError,
     TracecatValidationError,
+)
+from tracecat.executor.action_gateway.app import create_app as create_action_gateway_app
+from tracecat.query.errors import (
+    TracecatQueryOverflowError,
+    TracecatQueryTimeoutError,
 )
 
 
@@ -29,6 +41,14 @@ def _build_app(exc: Exception) -> FastAPI:
     """
     app = FastAPI()
     app.add_exception_handler(TracecatException, tracecat_exception_handler)
+    app.add_exception_handler(
+        TracecatQueryTimeoutError,
+        query_timeout_exception_handler,
+    )
+    app.add_exception_handler(
+        TracecatQueryOverflowError,
+        query_overflow_exception_handler,
+    )
     app.add_exception_handler(
         TracecatAuthorizationError, authorization_exception_handler
     )
@@ -69,6 +89,8 @@ def _get(exc: Exception):
         pytest.param(
             TracecatValidationError("bad"), 500, id="other-tracecat-error-500"
         ),
+        pytest.param(TracecatQueryTimeoutError(), 408, id="query-timeout-408"),
+        pytest.param(TracecatQueryOverflowError(), 400, id="query-overflow-400"),
     ],
 )
 def test_exception_handler_status_codes(exc: Exception, expected_status: int) -> None:
@@ -124,3 +146,49 @@ def test_scope_denied_keeps_its_structured_body() -> None:
     error = response.json()["error"]
     assert error["code"] == "insufficient_scope"
     assert error["missing_scopes"] == ["org:rbac:update"]
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_status", "expected_code"),
+    [
+        pytest.param(
+            TracecatQueryTimeoutError(),
+            408,
+            "query_timeout",
+            id="timeout",
+        ),
+        pytest.param(
+            TracecatQueryOverflowError(),
+            400,
+            "query_numeric_overflow",
+            id="overflow",
+        ),
+    ],
+)
+def test_query_error_response_contract(
+    exc: Exception,
+    expected_status: int,
+    expected_code: str,
+) -> None:
+    response = _get(exc)
+
+    assert response.status_code == expected_status
+    body = response.json()
+    assert body["type"] == type(exc).__name__
+    assert body["message"] == str(exc)
+    assert body["detail"] == {
+        "code": expected_code,
+        "message": str(exc),
+    }
+
+
+def test_query_error_handlers_are_registered_in_both_api_apps() -> None:
+    for app in (create_api_app(), create_action_gateway_app()):
+        assert (
+            app.exception_handlers[TracecatQueryTimeoutError]
+            is query_timeout_exception_handler
+        )
+        assert (
+            app.exception_handlers[TracecatQueryOverflowError]
+            is query_overflow_exception_handler
+        )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -451,6 +451,53 @@ def test_agent_executor_drain_default_covers_all_supported_timeouts(
         importlib.reload(tracecat_config)
 
 
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        pytest.param(
+            {},
+            (100, 1000, 30_000),
+            id="defaults",
+        ),
+        pytest.param(
+            {
+                "TRACECAT__LIMIT_AGG_GROUPS_DEFAULT": "250",
+                "TRACECAT__LIMIT_AGG_GROUPS_MAX": "2000",
+                "TRACECAT__AGG_STATEMENT_TIMEOUT_MS": "15000",
+            },
+            (250, 2000, 15_000),
+            id="operator-overrides",
+        ),
+    ],
+)
+def test_aggregation_query_config(
+    monkeypatch: pytest.MonkeyPatch,
+    values: dict[str, str],
+    expected: tuple[int, int, int],
+) -> None:
+    names = (
+        "TRACECAT__LIMIT_AGG_GROUPS_DEFAULT",
+        "TRACECAT__LIMIT_AGG_GROUPS_MAX",
+        "TRACECAT__AGG_STATEMENT_TIMEOUT_MS",
+    )
+    try:
+        with monkeypatch.context() as env:
+            for name in names:
+                env.delenv(name, raising=False)
+            for name, value in values.items():
+                env.setenv(name, value)
+
+            reloaded_config = importlib.reload(tracecat_config)
+
+            assert (
+                reloaded_config.TRACECAT__LIMIT_AGG_GROUPS_DEFAULT,
+                reloaded_config.TRACECAT__LIMIT_AGG_GROUPS_MAX,
+                reloaded_config.TRACECAT__AGG_STATEMENT_TIMEOUT_MS,
+            ) == expected
+    finally:
+        importlib.reload(tracecat_config)
+
+
 def test_executor_concurrency_uses_bounded_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -468,6 +468,13 @@ def test_agent_executor_drain_default_covers_all_supported_timeouts(
             (250, 2000, 15_000),
             id="operator-overrides",
         ),
+        pytest.param(
+            {
+                "TRACECAT__AGG_STATEMENT_TIMEOUT_MS": "2147483648",
+            },
+            (100, 1000, 2_147_483_647),
+            id="timeout-clamped-to-postgres-maximum",
+        ),
     ],
 )
 def test_aggregation_query_config(

--- a/tests/unit/test_query_execution.py
+++ b/tests/unit/test_query_execution.py
@@ -1,0 +1,143 @@
+"""Unit tests for shared query execution controls."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from asyncpg import NumericValueOutOfRangeError, QueryCanceledError
+from sqlalchemy.exc import DataError, OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.query.errors import (
+    QueryErrorCode,
+    TracecatQueryOverflowError,
+    TracecatQueryTimeoutError,
+)
+from tracecat.query.execution import query_execution_context
+
+
+def _wrapped_driver_error(driver_error: BaseException) -> RuntimeError:
+    adapter_error = RuntimeError("asyncpg adapter error")
+    adapter_error.__cause__ = driver_error
+    return adapter_error
+
+
+@pytest.mark.anyio
+async def test_query_execution_sets_transaction_local_timeout() -> None:
+    session = AsyncMock(spec=AsyncSession)
+
+    async with query_execution_context(session, statement_timeout_ms=1234):
+        pass
+
+    statement = session.execute.await_args.args[0]
+    assert str(statement) == "SET LOCAL statement_timeout = 1234"
+
+
+@pytest.mark.anyio
+async def test_query_execution_reads_configured_default_at_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.query.execution.config.TRACECAT__AGG_STATEMENT_TIMEOUT_MS",
+        4321,
+    )
+    session = AsyncMock(spec=AsyncSession)
+
+    async with query_execution_context(session):
+        pass
+
+    statement = session.execute.await_args.args[0]
+    assert str(statement) == "SET LOCAL statement_timeout = 4321"
+
+
+@pytest.mark.parametrize(
+    "statement_timeout_ms",
+    [0, -1, True, 1.5, "1", 2_147_483_648],
+)
+@pytest.mark.anyio
+async def test_query_execution_rejects_unsafe_timeout_values(
+    statement_timeout_ms: object,
+) -> None:
+    session = AsyncMock(spec=AsyncSession)
+
+    with pytest.raises((TypeError, ValueError)):
+        async with query_execution_context(
+            session,
+            statement_timeout_ms=cast(int, statement_timeout_ms),
+        ):
+            pass
+
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.parametrize("wrapped", [False, True], ids=["direct", "adapter-wrapped"])
+@pytest.mark.anyio
+async def test_query_execution_maps_query_cancellation_by_type(
+    wrapped: bool,
+) -> None:
+    driver_error = QueryCanceledError("cancelled")
+    orig = _wrapped_driver_error(driver_error) if wrapped else driver_error
+    sqlalchemy_error = OperationalError("SELECT pg_sleep(1)", {}, orig)
+    session = AsyncMock(spec=AsyncSession)
+
+    with pytest.raises(TracecatQueryTimeoutError) as exc_info:
+        async with query_execution_context(session):
+            raise sqlalchemy_error
+
+    assert exc_info.value.code is QueryErrorCode.TIMEOUT
+    assert exc_info.value.detail == {
+        "code": "query_timeout",
+        "message": (
+            "Aggregation timed out. Narrow filters or reduce group cardinality."
+        ),
+    }
+    assert exc_info.value.__cause__ is sqlalchemy_error
+
+
+@pytest.mark.parametrize("wrapped", [False, True], ids=["direct", "adapter-wrapped"])
+@pytest.mark.anyio
+async def test_query_execution_maps_numeric_overflow_by_type(
+    wrapped: bool,
+) -> None:
+    driver_error = NumericValueOutOfRangeError("overflow")
+    orig = _wrapped_driver_error(driver_error) if wrapped else driver_error
+    sqlalchemy_error = DataError("SELECT value::bigint", {}, orig)
+    session = AsyncMock(spec=AsyncSession)
+
+    with pytest.raises(TracecatQueryOverflowError) as exc_info:
+        async with query_execution_context(session):
+            raise sqlalchemy_error
+
+    assert exc_info.value.code is QueryErrorCode.NUMERIC_OVERFLOW
+    assert exc_info.value.detail == {
+        "code": "query_numeric_overflow",
+        "message": "Aggregation result exceeds the supported numeric range.",
+    }
+    assert exc_info.value.__cause__ is sqlalchemy_error
+
+
+@pytest.mark.parametrize(
+    "sqlalchemy_error",
+    [
+        OperationalError(
+            "SELECT 1",
+            {},
+            RuntimeError("canceling statement due to statement timeout"),
+        ),
+        DataError("SELECT 1", {}, OverflowError("numeric value out of range")),
+    ],
+    ids=["timeout-like-message", "overflow-like-message"],
+)
+@pytest.mark.anyio
+async def test_query_execution_does_not_match_error_messages(
+    sqlalchemy_error: OperationalError | DataError,
+) -> None:
+    session = AsyncMock(spec=AsyncSession)
+
+    with pytest.raises(type(sqlalchemy_error)) as exc_info:
+        async with query_execution_context(session):
+            raise sqlalchemy_error
+
+    assert exc_info.value is sqlalchemy_error

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -51,6 +51,8 @@ from tracecat.api.common import (
     custom_generate_unique_id,
     generic_exception_handler,
     http_exception_handler,
+    query_overflow_exception_handler,
+    query_timeout_exception_handler,
     tracecat_exception_handler,
 )
 from tracecat.api.lifespan import LifespanTaskSupervisor
@@ -140,6 +142,10 @@ from tracecat.organization.management import (
     get_default_organization_id,
 )
 from tracecat.organization.router import router as org_router
+from tracecat.query.errors import (
+    TracecatQueryOverflowError,
+    TracecatQueryTimeoutError,
+)
 from tracecat.registry.actions.router import router as registry_actions_router
 from tracecat.registry.repositories.router import router as registry_repos_router
 from tracecat.registry.sync.jobs import sync_platform_registry_on_startup
@@ -633,6 +639,14 @@ def create_app(**kwargs) -> FastAPI:
         auth_pool_exhausted_exception_handler,
     )
     app.add_exception_handler(TracecatException, tracecat_exception_handler)
+    app.add_exception_handler(
+        TracecatQueryTimeoutError,
+        query_timeout_exception_handler,
+    )
+    app.add_exception_handler(
+        TracecatQueryOverflowError,
+        query_overflow_exception_handler,
+    )
     app.add_exception_handler(RequestValidationError, validation_exception_handler)
     app.add_exception_handler(
         FastAPIUsersException,

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -196,7 +196,7 @@ def _query_exception_response(
 
 
 def query_timeout_exception_handler(request: Request, exc: Exception) -> Response:
-    """Return the stable 408 contract for timed-out shared queries."""
+    """Return the stable 422 contract for timed-out shared queries."""
     query_exc = (
         exc
         if isinstance(exc, TracecatQueryTimeoutError)
@@ -205,7 +205,7 @@ def query_timeout_exception_handler(request: Request, exc: Exception) -> Respons
     return _query_exception_response(
         request,
         query_exc,
-        status_code=status.HTTP_408_REQUEST_TIMEOUT,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
     )
 
 

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -25,6 +25,10 @@ from tracecat.dsl.client import get_temporal_client
 from tracecat.exceptions import TracecatException
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
+from tracecat.query.errors import (
+    TracecatQueryOverflowError,
+    TracecatQueryTimeoutError,
+)
 from tracecat.workflow.executions.enums import TemporalSearchAttr
 
 # All Tracecat search attributes are Keyword-typed.
@@ -164,6 +168,58 @@ def tracecat_exception_handler(request: Request, exc: Exception) -> Response:
             "message": msg,
             "detail": tracecat_exc.detail,
         },
+    )
+
+
+def _query_exception_response(
+    request: Request,
+    exc: TracecatQueryTimeoutError | TracecatQueryOverflowError,
+    *,
+    status_code: int,
+) -> Response:
+    logger.warning(
+        "Query execution rejected",
+        status_code=status_code,
+        exception_type=type(exc).__name__,
+        path=request.url.path,
+        role=ctx_role.get(),
+        detail=exc.detail,
+    )
+    return ORJSONResponse(
+        status_code=status_code,
+        content={
+            "type": type(exc).__name__,
+            "message": str(exc),
+            "detail": exc.detail,
+        },
+    )
+
+
+def query_timeout_exception_handler(request: Request, exc: Exception) -> Response:
+    """Return the stable 408 contract for timed-out shared queries."""
+    query_exc = (
+        exc
+        if isinstance(exc, TracecatQueryTimeoutError)
+        else TracecatQueryTimeoutError(str(exc))
+    )
+    return _query_exception_response(
+        request,
+        query_exc,
+        status_code=status.HTTP_408_REQUEST_TIMEOUT,
+    )
+
+
+def query_overflow_exception_handler(request: Request, exc: Exception) -> Response:
+    """Return the stable 400 contract for shared-query numeric overflow."""
+    query_exc = (
+        exc
+        if isinstance(exc, TracecatQueryOverflowError)
+        else TracecatQueryOverflowError(str(exc))
+    )
+    return _query_exception_response(
+        request,
+        query_exc,
+        status_code=status.HTTP_400_BAD_REQUEST,
     )
 
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1091,10 +1091,14 @@ TRACECAT__LIMIT_AGG_GROUPS_DEFAULT = bound_env(
 )
 """Default number of groups returned by an aggregation query."""
 
+POSTGRES_STATEMENT_TIMEOUT_MAX_MS = 2_147_483_647
+"""Largest PostgreSQL statement timeout accepted in milliseconds."""
+
 TRACECAT__AGG_STATEMENT_TIMEOUT_MS = bound_env(
     "TRACECAT__AGG_STATEMENT_TIMEOUT_MS",
     30_000,
     lower=1,
+    upper=POSTGRES_STATEMENT_TIMEOUT_MAX_MS,
 )
 """PostgreSQL statement timeout for aggregation queries, in milliseconds."""
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1076,6 +1076,28 @@ TRACECAT__S3_CONCURRENCY_LIMIT = int(
 TRACECAT__LIMIT_MIN = 1
 """Minimum list/search page size."""
 
+TRACECAT__LIMIT_AGG_GROUPS_MAX = bound_env(
+    "TRACECAT__LIMIT_AGG_GROUPS_MAX",
+    1000,
+    lower=1,
+)
+"""Maximum number of groups returned by an aggregation query."""
+
+TRACECAT__LIMIT_AGG_GROUPS_DEFAULT = bound_env(
+    "TRACECAT__LIMIT_AGG_GROUPS_DEFAULT",
+    100,
+    lower=1,
+    upper=TRACECAT__LIMIT_AGG_GROUPS_MAX,
+)
+"""Default number of groups returned by an aggregation query."""
+
+TRACECAT__AGG_STATEMENT_TIMEOUT_MS = bound_env(
+    "TRACECAT__AGG_STATEMENT_TIMEOUT_MS",
+    30_000,
+    lower=1,
+)
+"""PostgreSQL statement timeout for aggregation queries, in milliseconds."""
+
 TRACECAT__LIMIT_DEFAULT = 20
 """Default list/search page size."""
 

--- a/tracecat/executor/action_gateway/app.py
+++ b/tracecat/executor/action_gateway/app.py
@@ -17,11 +17,19 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import ORJSONResponse
 from pydantic_core import to_jsonable_python
 
+from tracecat.api.common import (
+    query_overflow_exception_handler,
+    query_timeout_exception_handler,
+)
 from tracecat.contexts import ctx_role
 from tracecat.executor.action_gateway.policy import (
     enforce_agent_script_gateway_access,
 )
 from tracecat.logger import logger
+from tracecat.query.errors import (
+    TracecatQueryOverflowError,
+    TracecatQueryTimeoutError,
+)
 
 router = APIRouter(
     prefix="/internal",
@@ -170,8 +178,6 @@ def _add_exception_handlers(app: FastAPI) -> None:
         auth_pool_exhausted_exception_handler,
         generic_exception_handler,
         http_exception_handler,
-        query_overflow_exception_handler,
-        query_timeout_exception_handler,
         tracecat_exception_handler,
     )
     from tracecat.db.exceptions import AuthPoolExhaustedError
@@ -179,10 +185,6 @@ def _add_exception_handlers(app: FastAPI) -> None:
         EntitlementRequired,
         ScopeDeniedError,
         TracecatException,
-    )
-    from tracecat.query.errors import (
-        TracecatQueryOverflowError,
-        TracecatQueryTimeoutError,
     )
 
     app.add_exception_handler(Exception, generic_exception_handler)

--- a/tracecat/executor/action_gateway/app.py
+++ b/tracecat/executor/action_gateway/app.py
@@ -170,6 +170,8 @@ def _add_exception_handlers(app: FastAPI) -> None:
         auth_pool_exhausted_exception_handler,
         generic_exception_handler,
         http_exception_handler,
+        query_overflow_exception_handler,
+        query_timeout_exception_handler,
         tracecat_exception_handler,
     )
     from tracecat.db.exceptions import AuthPoolExhaustedError
@@ -178,6 +180,10 @@ def _add_exception_handlers(app: FastAPI) -> None:
         ScopeDeniedError,
         TracecatException,
     )
+    from tracecat.query.errors import (
+        TracecatQueryOverflowError,
+        TracecatQueryTimeoutError,
+    )
 
     app.add_exception_handler(Exception, generic_exception_handler)
     app.add_exception_handler(
@@ -185,6 +191,14 @@ def _add_exception_handlers(app: FastAPI) -> None:
         auth_pool_exhausted_exception_handler,
     )
     app.add_exception_handler(TracecatException, tracecat_exception_handler)
+    app.add_exception_handler(
+        TracecatQueryTimeoutError,
+        query_timeout_exception_handler,
+    )
+    app.add_exception_handler(
+        TracecatQueryOverflowError,
+        query_overflow_exception_handler,
+    )
     app.add_exception_handler(RequestValidationError, validation_exception_handler)
     app.add_exception_handler(EntitlementRequired, entitlement_exception_handler)
     app.add_exception_handler(ScopeDeniedError, scope_denied_exception_handler)

--- a/tracecat/query/__init__.py
+++ b/tracecat/query/__init__.py
@@ -1,0 +1,1 @@
+"""Shared query compilation and execution primitives."""

--- a/tracecat/query/errors.py
+++ b/tracecat/query/errors.py
@@ -1,0 +1,46 @@
+"""Typed, user-facing errors raised by shared query execution."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from tracecat.exceptions import TracecatException, TracecatValidationError
+
+
+class QueryErrorCode(StrEnum):
+    """Stable machine-readable query error codes."""
+
+    TIMEOUT = "query_timeout"
+    NUMERIC_OVERFLOW = "query_numeric_overflow"
+
+
+class TracecatQueryTimeoutError(TracecatException):
+    """Raised when PostgreSQL cancels a query at its statement timeout."""
+
+    code = QueryErrorCode.TIMEOUT
+
+    def __init__(
+        self,
+        message: str = (
+            "Aggregation timed out. Narrow filters or reduce group cardinality."
+        ),
+    ) -> None:
+        super().__init__(
+            message,
+            detail={"code": self.code.value, "message": message},
+        )
+
+
+class TracecatQueryOverflowError(TracecatValidationError):
+    """Raised when a query result exceeds its supported numeric range."""
+
+    code = QueryErrorCode.NUMERIC_OVERFLOW
+
+    def __init__(
+        self,
+        message: str = "Aggregation result exceeds the supported numeric range.",
+    ) -> None:
+        super().__init__(
+            message,
+            detail={"code": self.code.value, "message": message},
+        )

--- a/tracecat/query/execution.py
+++ b/tracecat/query/execution.py
@@ -1,0 +1,85 @@
+"""Transaction-local execution controls for shared queries."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from asyncpg import NumericValueOutOfRangeError, QueryCanceledError
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat import config
+from tracecat.query.errors import (
+    TracecatQueryOverflowError,
+    TracecatQueryTimeoutError,
+)
+
+_POSTGRES_STATEMENT_TIMEOUT_MAX_MS = 2_147_483_647
+
+
+def _validate_statement_timeout_ms(statement_timeout_ms: int) -> None:
+    if isinstance(statement_timeout_ms, bool) or not isinstance(
+        statement_timeout_ms, int
+    ):
+        raise TypeError("statement_timeout_ms must be an integer")
+    if not 1 <= statement_timeout_ms <= _POSTGRES_STATEMENT_TIMEOUT_MAX_MS:
+        raise ValueError(
+            "statement_timeout_ms must be between 1 and 2147483647 milliseconds"
+        )
+
+
+def _has_driver_error(
+    error: BaseException | None,
+    driver_error_type: type[BaseException],
+) -> bool:
+    """Return whether a SQLAlchemy DBAPI error wraps a typed driver error."""
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        if isinstance(current, driver_error_type):
+            return True
+        seen.add(id(current))
+        current = current.__cause__
+    return False
+
+
+@asynccontextmanager
+async def query_execution_context(
+    session: AsyncSession,
+    *,
+    statement_timeout_ms: int | None = None,
+) -> AsyncIterator[None]:
+    """Apply a transaction-local timeout and map known PostgreSQL query errors.
+
+    The timeout is interpolated because PostgreSQL does not support bind parameters
+    in ``SET LOCAL``. Validation guarantees that only a positive integer is placed
+    in the statement. The caller owns the surrounding transaction.
+
+    Args:
+        session: Session whose current transaction will execute the query.
+        statement_timeout_ms: PostgreSQL statement timeout in milliseconds.
+
+    Raises:
+        TracecatQueryTimeoutError: If PostgreSQL cancels the query at its timeout.
+        TracecatQueryOverflowError: If PostgreSQL reports numeric overflow.
+    """
+    resolved_timeout_ms = (
+        config.TRACECAT__AGG_STATEMENT_TIMEOUT_MS
+        if statement_timeout_ms is None
+        else statement_timeout_ms
+    )
+    _validate_statement_timeout_ms(resolved_timeout_ms)
+
+    try:
+        await session.execute(
+            text(f"SET LOCAL statement_timeout = {resolved_timeout_ms}")
+        )
+        yield
+    except DBAPIError as exc:
+        if _has_driver_error(exc.orig, QueryCanceledError):
+            raise TracecatQueryTimeoutError from exc
+        if _has_driver_error(exc.orig, NumericValueOutOfRangeError):
+            raise TracecatQueryOverflowError from exc
+        raise

--- a/tracecat/query/execution.py
+++ b/tracecat/query/execution.py
@@ -16,15 +16,13 @@ from tracecat.query.errors import (
     TracecatQueryTimeoutError,
 )
 
-_POSTGRES_STATEMENT_TIMEOUT_MAX_MS = 2_147_483_647
-
 
 def _validate_statement_timeout_ms(statement_timeout_ms: int) -> None:
     if isinstance(statement_timeout_ms, bool) or not isinstance(
         statement_timeout_ms, int
     ):
         raise TypeError("statement_timeout_ms must be an integer")
-    if not 1 <= statement_timeout_ms <= _POSTGRES_STATEMENT_TIMEOUT_MAX_MS:
+    if not 1 <= statement_timeout_ms <= config.POSTGRES_STATEMENT_TIMEOUT_MAX_MS:
         raise ValueError(
             "statement_timeout_ms must be between 1 and 2147483647 milliseconds"
         )


### PR DESCRIPTION
## Summary

- add operator-overridable aggregation group limits (100 default, 1,000 maximum) and a 30-second PostgreSQL statement timeout without exposing advanced knobs in `.env.example`
- add a transaction-local query execution context that validates the interpolated timeout and maps typed asyncpg cancellation and numeric-overflow errors through SQLAlchemy's adapter chain
- register stable `query_timeout` (HTTP 408) and `query_numeric_overflow` (HTTP 400) response contracts in both the main API and action-gateway apps

## Testing

- `uv run pytest tests/unit/test_query_execution.py tests/unit/test_api_exception_handlers.py tests/unit/test_action_gateway_app.py tests/unit/test_config.py tests/integration/test_query_execution_integration.py -q` — 108 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- commit-time pre-commit hooks, including Ruff, Gitleaks, client generation checks, and Python type checking

The PostgreSQL integration test forces a 1 ms transaction-local timeout around `pg_sleep` and verifies the real SQLAlchemy/asyncpg path raises `TracecatQueryTimeoutError`.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 238 | 0 |
| Tests | 281 | 1 |

## Linear

- Closes [ENG-1746](https://linear.app/tracecat/issue/ENG-1746/query-aggregation-config-constants-statement-timeout-error-contract)
- Implements the shared execution/error-contract portion of [ENG-1692](https://linear.app/tracecat/issue/ENG-1692/groupby-agg-on-cases-and-tables)
