### PR TITLE
fix(agents): attribute durable agent initialization failures

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -572,6 +572,11 @@ APPROVAL_STREAM_V2_PATCH = "durable-agent-approval-stream-v2"
 
 @workflow.defn
 class DurableAgentWorkflow:
+    # Instance variables initialized in run() before _run_with_agent_executor()
+    # pyright: ignore[reportUninitializedInstanceVariable]
+    workspace_id: uuid.UUID
+    organization_id: uuid.UUID
+
     @workflow.init
     def __init__(self, args: AgentWorkflowArgs):
         self.role = args.role
@@ -580,12 +585,6 @@ class DurableAgentWorkflow:
 
         self._status: Literal["running", "waiting_for_results", "done"] = "running"
         self._turn: int = 0
-        if args.role.workspace_id is None:
-            raise_application_error_from_classification(invalid_agent_configuration())
-        if args.role.organization_id is None:
-            raise_application_error_from_classification(invalid_agent_configuration())
-        self.workspace_id = args.role.workspace_id
-        self.organization_id = args.role.organization_id
         self.session_id = args.agent_args.session_id
         self.active_stream_id = args.agent_args.active_stream_id
         self.harness_type = args.harness_type or "claude_code"
@@ -595,6 +594,15 @@ class DurableAgentWorkflow:
         self._cancel_requested: bool = False
         self._cancel_reason: str | None = None
         self._executor_terminal_stream_error_emitted: bool | None = None
+
+    def _initialize_run(self) -> None:
+        """Initialize fallible workflow runtime state inside the interceptor."""
+        if (workspace_id := self.role.workspace_id) is None:
+            raise_application_error_from_classification(invalid_agent_configuration())
+        if (organization_id := self.role.organization_id) is None:
+            raise_application_error_from_classification(invalid_agent_configuration())
+        self.workspace_id = workspace_id
+        self.organization_id = organization_id
 
     def _upsert_tracecat_search_attributes(self) -> None:
         """Ensure direct agent runs have core Tracecat search attributes.
@@ -956,6 +964,8 @@ class DurableAgentWorkflow:
     @workflow.run
     async def run(self, args: AgentWorkflowArgs) -> AgentOutput:
         """Run the agent until completion. The agent will call tools until it needs human approval."""
+        self._initialize_run()
+
         try:
             if workflow.patched(UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH):
                 self._upsert_tracecat_search_attributes()

--- a/tests/temporal/__init__.py
+++ b/tests/temporal/__init__.py
@@ -1,0 +1,1 @@
+"""Temporal integration tests."""

--- a/tests/temporal/durable_agent_failure_harness.py
+++ b/tests/temporal/durable_agent_failure_harness.py
@@ -443,7 +443,7 @@ def _activities(state: _HarnessState) -> list[Callable[..., Any]]:
         del input
         state.executor_calls += 1
         if state.injection.point is FaultPoint.EXECUTOR_TIMEOUT:
-            await asyncio.sleep(60)
+            await asyncio.sleep(2)
             raise AssertionError("executor timeout activity unexpectedly completed")
         if state.injection.point is FaultPoint.EXECUTOR_ACTIVITY:
             if state.injection.classification is not None:

--- a/tests/temporal/durable_agent_failure_harness.py
+++ b/tests/temporal/durable_agent_failure_harness.py
@@ -1,0 +1,582 @@
+"""Real-Worker runners for the durable-agent failure contract matrix."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import orjson
+import pytest
+import tracecat_ee.agent.workflows.durable as durable_workflow_module
+from temporalio import activity
+from temporalio.client import (
+    Client,
+    WorkflowFailureError,
+    WorkflowHandle,
+    WorkflowHistory,
+)
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Replayer, Worker
+from tracecat_ee.agent.activities import (
+    BuildAgentToolDefsArgs,
+    BuildAgentToolDefsResult,
+    BuildToolDefsResult,
+    EmitSessionDoneInputs,
+    EmitSessionErrorInputs,
+)
+from tracecat_ee.agent.types import AgentWorkflowID
+from tracecat_ee.agent.workflows.durable import AgentWorkflowArgs, DurableAgentWorkflow
+
+from tracecat import config
+from tracecat.agent.executor.activity import AgentExecutorInput, AgentExecutorResult
+from tracecat.agent.sandbox.llm_proxy import (
+    LLMProxyError,
+    LLMRoute,
+    LLMRoutingPlan,
+    LLMSocketProxy,
+)
+from tracecat.agent.schemas import RunAgentArgs
+from tracecat.agent.session.activities import (
+    CreateSessionInput,
+    CreateSessionResult,
+    FinalizeTurnInput,
+    FinalizeTurnResult,
+    LoadSessionInput,
+    LoadSessionResult,
+)
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.types import AgentConfig
+from tracecat.auth.types import Role
+from tracecat.dsl._converter import get_data_converter
+from tracecat.dsl.common import RETRY_POLICIES
+from tracecat.dsl.interceptor import RuntimeErrorAttributionInterceptor
+from tracecat.dsl.worker import new_sandbox_runner
+from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import RuntimeErrorClassification
+from tracecat.temporal.errors import raise_application_error_from_classification
+from tracecat.workflow.executions.enums import TemporalSearchAttr
+
+
+class FaultPoint(StrEnum):
+    """Distinct failure boundaries exercised by the acceptance matrix."""
+
+    WORKSPACE_CONTEXT_MISSING = "workspace_context.missing"
+    ORGANIZATION_CONTEXT_MISSING = "organization_context.missing"
+    TOOL_DEFINITIONS_ACTIVITY = "tool_definitions.activity"
+    TOOL_DEFINITIONS_RESULT = "tool_definitions.result"
+    SESSION_RESULT = "session.result"
+    EXECUTOR_ACTIVITY = "executor.activity"
+    EXECUTOR_TIMEOUT = "executor.timeout"
+    EXECUTOR_RESULT = "executor.result"
+    WORKFLOW_INTERNAL = "workflow.internal"
+
+
+class GatewayRoute(StrEnum):
+    """User-visible route topologies supported by agent LLM forwarding."""
+
+    DIRECT_PROVIDER = "direct_provider"
+    CUSTOM_GATEWAY = "custom_gateway"
+    MANAGED_LITELLM = "managed_litellm"
+
+
+class GatewayFailureMode(StrEnum):
+    """Representative HTTP, transport, and streaming gateway failures."""
+
+    HTTP_400 = "http_400"
+    HTTP_401 = "http_401"
+    HTTP_429 = "http_429"
+    HTTP_503 = "http_503"
+    HTTP_504 = "http_504"
+    CONNECT = "connect"
+    READ_TIMEOUT = "read_timeout"
+    STREAM_DISCONNECT = "stream_disconnect"
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayFailureInjection:
+    """One source-level failure emitted by the real LLM socket proxy."""
+
+    route: GatewayRoute
+    mode: GatewayFailureMode
+
+
+@dataclass(frozen=True, slots=True)
+class FailureInjection:
+    """One fault injected into an otherwise successful agent workflow."""
+
+    point: FaultPoint
+    classification: RuntimeErrorClassification | None = None
+    activity_non_retryable: bool = False
+    terminal_stream_error_emitted: bool | None = None
+    gateway_failure: GatewayFailureInjection | None = None
+    emit_session_error_fails: bool = False
+
+
+@dataclass(slots=True)
+class _HarnessState:
+    injection: FailureInjection
+    diagnostic: str
+    build_calls: int = 0
+    create_calls: int = 0
+    executor_calls: int = 0
+    workflow_internal_calls: int = 0
+    emit_error_failures: int = 0
+    emitted_errors: list[EmitSessionErrorInputs] = field(default_factory=list)
+    emitted_done: list[EmitSessionDoneInputs] = field(default_factory=list)
+    finalized_turns: list[FinalizeTurnInput] = field(default_factory=list)
+
+    @property
+    def fault_calls(self) -> int:
+        match self.injection.point:
+            case (
+                FaultPoint.WORKSPACE_CONTEXT_MISSING
+                | FaultPoint.ORGANIZATION_CONTEXT_MISSING
+            ):
+                return 0
+            case (
+                FaultPoint.TOOL_DEFINITIONS_ACTIVITY
+                | FaultPoint.TOOL_DEFINITIONS_RESULT
+            ):
+                return self.build_calls
+            case FaultPoint.SESSION_RESULT:
+                return self.create_calls
+            case FaultPoint.EXECUTOR_ACTIVITY | FaultPoint.EXECUTOR_TIMEOUT:
+                return self.executor_calls
+            case FaultPoint.EXECUTOR_RESULT:
+                return self.executor_calls
+            case FaultPoint.WORKFLOW_INTERNAL:
+                return self.workflow_internal_calls
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioObservation:
+    """Actual terminal state consumed by the declarative matrix assertion."""
+
+    root: WorkflowHandle[Any, Any]
+    failure: WorkflowFailureError
+    history: WorkflowHistory
+    fault_calls: int
+    emit_error_failures: int
+    emitted_errors: tuple[EmitSessionErrorInputs, ...]
+    emitted_done: tuple[EmitSessionDoneInputs, ...]
+    finalized_turns: tuple[FinalizeTurnInput, ...]
+
+
+type WorkerFactory = Callable[..., Worker]
+
+
+class _FakeWriter:
+    """Minimal StreamWriter surface consumed by the LLM socket proxy."""
+
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self._closing = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def is_closing(self) -> bool:
+        return self._closing
+
+    def close(self) -> None:
+        self._closing = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+class _FailingGatewayStream(httpx.AsyncByteStream):
+    """Response stream that disconnects after successful HTTP headers."""
+
+    def __init__(self, request: httpx.Request, diagnostic: str) -> None:
+        self._request = request
+        self._diagnostic = diagnostic
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        raise httpx.ReadError(self._diagnostic, request=self._request)
+        yield b""  # pragma: no cover - required to type this as an async iterator
+
+
+def _gateway_status_code(mode: GatewayFailureMode) -> int | None:
+    match mode:
+        case GatewayFailureMode.HTTP_400:
+            return 400
+        case GatewayFailureMode.HTTP_401:
+            return 401
+        case GatewayFailureMode.HTTP_429:
+            return 429
+        case GatewayFailureMode.HTTP_503:
+            return 503
+        case GatewayFailureMode.HTTP_504:
+            return 504
+        case _:
+            return None
+
+
+def _gateway_routing_plan(route: GatewayRoute) -> tuple[LLMRoutingPlan, str | None]:
+    managed_route = LLMRoute(
+        base_url="http://managed-litellm.invalid",
+        model_provider="openai",
+        mode="managed",
+    )
+    if route is GatewayRoute.MANAGED_LITELLM:
+        return LLMRoutingPlan(managed_route=managed_route, direct_routes={}), None
+
+    model = route.value
+    base_url = (
+        "https://direct-provider.invalid"
+        if route is GatewayRoute.DIRECT_PROVIDER
+        else "https://custom-gateway.invalid"
+    )
+    direct_route = LLMRoute(
+        base_url=base_url,
+        model_provider=(
+            "anthropic" if route is GatewayRoute.DIRECT_PROVIDER else "openai"
+        ),
+        mode="direct",
+        authorization="Bearer synthetic-test-key",
+    )
+    return (
+        LLMRoutingPlan(
+            managed_route=managed_route,
+            direct_routes={model: direct_route},
+        ),
+        model,
+    )
+
+
+async def _gateway_failure_classification(
+    injection: GatewayFailureInjection,
+    diagnostic: str,
+) -> RuntimeErrorClassification:
+    """Exercise the real proxy and return the classification it emits."""
+    errors: list[LLMProxyError] = []
+    routing_plan, request_model = _gateway_routing_plan(injection.route)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        status_code = _gateway_status_code(injection.mode)
+        if status_code is not None:
+            return httpx.Response(
+                status_code,
+                request=request,
+                json={"error": diagnostic},
+            )
+        if injection.mode is GatewayFailureMode.CONNECT:
+            raise httpx.ConnectError(diagnostic, request=request)
+        if injection.mode is GatewayFailureMode.READ_TIMEOUT:
+            raise httpx.ReadTimeout(diagnostic, request=request)
+        if injection.mode is GatewayFailureMode.STREAM_DISCONNECT:
+            return httpx.Response(
+                200,
+                request=request,
+                headers={"content-type": "text/event-stream"},
+                stream=_FailingGatewayStream(request, diagnostic),
+            )
+        raise AssertionError(f"Unhandled gateway failure mode: {injection.mode}")
+
+    proxy = LLMSocketProxy(
+        socket_path=Path(f"/tmp/tracecat-gateway-probe-{uuid.uuid4()}.sock"),
+        routing_plan=routing_plan,
+        on_error=errors.append,
+    )
+    proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+    request_body: dict[str, object] = {"messages": []}
+    if request_model is not None:
+        request_body["model"] = request_model
+
+    try:
+        await proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {"content-type": "application/json"},
+                "body": orjson.dumps(request_body),
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if proxy._client is not None:
+            await proxy._client.aclose()
+
+    if len(errors) != 1:
+        raise AssertionError(
+            f"Expected one proxy error for {injection}, observed {len(errors)}"
+        )
+    return errors[0].classification
+
+
+@pytest.fixture
+async def env() -> AsyncGenerator[WorkflowEnvironment, None]:
+    """Run each scenario against an isolated Temporal dev server."""
+    search_attributes = [
+        TemporalSearchAttr.ERROR_OWNER.key,
+        TemporalSearchAttr.TRIGGER_TYPE.key,
+        TemporalSearchAttr.EXECUTION_TYPE.key,
+        TemporalSearchAttr.TRIGGERED_BY_USER_ID.key,
+        TemporalSearchAttr.WORKSPACE_ID.key,
+        TemporalSearchAttr.CORRELATION_ID.key,
+    ]
+    async with await WorkflowEnvironment.start_local(
+        data_converter=get_data_converter(compression_enabled=False),
+        search_attributes=search_attributes,
+        dev_server_log_level="error",
+    ) as environment:
+        yield environment
+
+
+@pytest.fixture
+def worker_factory() -> Iterator[WorkerFactory]:
+    """Create Workers with the same runner and interceptor as production."""
+    with ThreadPoolExecutor(max_workers=4) as activity_executor:
+
+        def create_worker(
+            client: Client,
+            *,
+            activities: list[Callable[..., Any]],
+            workflows: list[type],
+            task_queue: str,
+        ) -> Worker:
+            return Worker(
+                client=client,
+                task_queue=task_queue,
+                activities=activities,
+                workflows=workflows,
+                workflow_runner=new_sandbox_runner(),
+                interceptors=[RuntimeErrorAttributionInterceptor()],
+                activity_executor=activity_executor,
+            )
+
+        yield create_worker
+
+
+def _workflow_args(injection: FailureInjection) -> AgentWorkflowArgs:
+    role = Role(
+        type="service",
+        service_id="tracecat-runner",
+        workspace_id=(
+            None
+            if injection.point is FaultPoint.WORKSPACE_CONTEXT_MISSING
+            else uuid.uuid4()
+        ),
+        organization_id=(
+            None
+            if injection.point is FaultPoint.ORGANIZATION_CONTEXT_MISSING
+            else uuid.uuid4()
+        ),
+    )
+    agent_config = AgentConfig(
+        model_name="test-model",
+        model_provider="test-provider",
+        actions=[],
+    )
+    return AgentWorkflowArgs(
+        role=role,
+        agent_args=RunAgentArgs(
+            session_id=uuid.uuid4(),
+            user_prompt="synthetic prompt",
+            config=agent_config,
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+    )
+
+
+def _activities(state: _HarnessState) -> list[Callable[..., Any]]:
+    @activity.defn(name="load_session_activity")
+    async def load_session(input: LoadSessionInput) -> LoadSessionResult:
+        del input
+        return LoadSessionResult(found=False)
+
+    @activity.defn(name="create_session_activity")
+    async def create_session(input: CreateSessionInput) -> CreateSessionResult:
+        state.create_calls += 1
+        if state.injection.point is FaultPoint.SESSION_RESULT:
+            return CreateSessionResult(
+                session_id=input.session_id,
+                success=False,
+                error=state.diagnostic,
+            )
+        return CreateSessionResult(session_id=input.session_id, success=True)
+
+    @activity.defn(name="build_agent_tool_definitions")
+    async def build_agent_tool_definitions(
+        args: BuildAgentToolDefsArgs,
+    ) -> BuildAgentToolDefsResult:
+        state.build_calls += 1
+        if state.injection.point is FaultPoint.TOOL_DEFINITIONS_ACTIVITY:
+            if state.injection.classification is not None:
+                raise_application_error_from_classification(
+                    state.injection.classification
+                )
+            if state.injection.activity_non_retryable:
+                raise ApplicationError(state.diagnostic, non_retryable=True)
+            raise RuntimeError(state.diagnostic)
+
+        if state.injection.point is FaultPoint.TOOL_DEFINITIONS_RESULT:
+            return BuildAgentToolDefsResult(scopes={})
+
+        registry_lock = RegistryLock(origins={}, actions={})
+        return BuildAgentToolDefsResult(
+            scopes={
+                scope.scope: BuildToolDefsResult(
+                    tool_definitions={},
+                    registry_lock=registry_lock,
+                )
+                for scope in args.scopes
+            }
+        )
+
+    @activity.defn(name="run_agent_activity")
+    async def run_agent(input: AgentExecutorInput) -> AgentExecutorResult:
+        del input
+        state.executor_calls += 1
+        if state.injection.point is FaultPoint.EXECUTOR_TIMEOUT:
+            await asyncio.sleep(60)
+            raise AssertionError("executor timeout activity unexpectedly completed")
+        if state.injection.point is FaultPoint.EXECUTOR_ACTIVITY:
+            if state.injection.classification is not None:
+                raise_application_error_from_classification(
+                    state.injection.classification
+                )
+            raise RuntimeError(state.diagnostic)
+        if state.injection.point is FaultPoint.EXECUTOR_RESULT:
+            return AgentExecutorResult(
+                success=False,
+                error=state.diagnostic,
+                classification=state.injection.classification,
+                terminal_stream_error_emitted=(
+                    state.injection.terminal_stream_error_emitted
+                ),
+            )
+        return AgentExecutorResult(success=True, output="ok")
+
+    @activity.defn(name="emit_session_error")
+    async def emit_session_error(input: EmitSessionErrorInputs) -> None:
+        state.emitted_errors.append(input)
+        if state.injection.emit_session_error_fails:
+            state.emit_error_failures += 1
+            raise RuntimeError(state.diagnostic)
+
+    @activity.defn(name="finalize_turn_activity")
+    async def finalize_turn(input: FinalizeTurnInput) -> FinalizeTurnResult:
+        state.finalized_turns.append(input)
+        return FinalizeTurnResult(terminal_done_emitted=True)
+
+    @activity.defn(name="emit_session_done")
+    async def emit_session_done(input: EmitSessionDoneInputs) -> None:
+        state.emitted_done.append(input)
+
+    return [
+        load_session,
+        create_session,
+        build_agent_tool_definitions,
+        run_agent,
+        emit_session_error,
+        finalize_turn,
+        emit_session_done,
+    ]
+
+
+async def run_failure_scenario(
+    env: WorkflowEnvironment,
+    worker_factory: WorkerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    injection: FailureInjection,
+    diagnostic: str,
+) -> ScenarioObservation:
+    """Execute one matrix row through the production workflow configuration."""
+    if injection.gateway_failure is not None:
+        injection = replace(
+            injection,
+            classification=await _gateway_failure_classification(
+                injection.gateway_failure,
+                diagnostic,
+            ),
+        )
+    state = _HarnessState(injection=injection, diagnostic=diagnostic)
+    args = _workflow_args(injection)
+    task_queue = f"durable-agent-failure-{uuid.uuid4()}"
+
+    monkeypatch.setattr(config, "TRACECAT__AGENT_EXECUTOR_QUEUE", task_queue)
+    monkeypatch.setattr(durable_workflow_module, "mint_mcp_token", lambda **_: "mcp")
+    monkeypatch.setattr(
+        durable_workflow_module, "mint_agent_otel_token", lambda **_: "otel"
+    )
+
+    if injection.point is FaultPoint.WORKFLOW_INTERNAL:
+
+        def fail_llm_token(**_: object) -> str:
+            state.workflow_internal_calls += 1
+            raise RuntimeError(diagnostic)
+
+        monkeypatch.setattr(durable_workflow_module, "mint_llm_token", fail_llm_token)
+    else:
+        monkeypatch.setattr(
+            durable_workflow_module, "mint_llm_token", lambda **_: "llm"
+        )
+
+    if injection.point is FaultPoint.EXECUTOR_TIMEOUT:
+        monkeypatch.setattr(
+            durable_workflow_module,
+            "clamp_agent_timeout_seconds",
+            lambda _: 0.05,
+        )
+        monkeypatch.setattr(
+            durable_workflow_module,
+            "AGENT_TIMEOUT_CLEANUP_BUFFER_SECONDS",
+            0,
+        )
+
+    async with worker_factory(
+        env.client,
+        activities=_activities(state),
+        workflows=[DurableAgentWorkflow],
+        task_queue=task_queue,
+    ):
+        handle = await env.client.start_workflow(
+            DurableAgentWorkflow.run,
+            args,
+            id=AgentWorkflowID(args.agent_args.session_id),
+            task_queue=task_queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await handle.result()
+
+    return ScenarioObservation(
+        root=handle,
+        failure=exc_info.value,
+        history=await handle.fetch_history(),
+        fault_calls=state.fault_calls,
+        emit_error_failures=state.emit_error_failures,
+        emitted_errors=tuple(state.emitted_errors),
+        emitted_done=tuple(state.emitted_done),
+        finalized_turns=tuple(state.finalized_turns),
+    )
+
+
+async def replay_scenario_history(
+    env: WorkflowEnvironment,
+    history: WorkflowHistory,
+) -> None:
+    """Verify that the current production worker can replay a failed history."""
+    result = await Replayer(
+        workflows=[DurableAgentWorkflow],
+        workflow_runner=new_sandbox_runner(),
+        data_converter=env.client.data_converter,
+        interceptors=[RuntimeErrorAttributionInterceptor()],
+    ).replay_workflow(history, raise_on_replay_failure=False)
+    assert result.replay_failure is None

--- a/tests/temporal/test_durable_agent_runtime_error_attribution.py
+++ b/tests/temporal/test_durable_agent_runtime_error_attribution.py
@@ -1,0 +1,539 @@
+"""Declarative acceptance matrix for durable-agent failure attribution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+
+from tests.temporal import durable_agent_failure_harness as harness
+from tracecat.agent.error_policy import (
+    agent_executor_protocol_failed,
+    tenant_entitlement_denied,
+    user_agent_execution_failed,
+)
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
+from tracecat.temporal.errors import extract_error_classifications
+from tracecat.workflow.executions.enums import TemporalSearchAttr
+
+pytestmark = [pytest.mark.temporal]
+
+# Re-export the harness fixture under the name collected by this test module.
+temporal_env = harness.env
+agent_worker_factory = harness.worker_factory
+
+_FAILED = WorkflowExecutionStatus.FAILED
+_DIAGNOSTIC = "synthetic sensitive diagnostic must not reach the terminal envelope"
+
+
+@dataclass(frozen=True, slots=True)
+class _FailureScenario:
+    """One row in the complete durable-agent failure acceptance matrix."""
+
+    id: str
+    fault: str
+    injection: harness.FailureInjection
+    status: WorkflowExecutionStatus
+    owner: RuntimeErrorOwner
+    kind: RuntimeErrorKind
+    retry_disposition: RetryDisposition
+    should_stream: bool
+    fault_calls: int = 1
+    emitted_error_count: int = 1
+    emitted_error_failure_count: int = 0
+    finalized_turn_count: int = 1
+    diagnostic_absent_from_history: bool = False
+
+
+_WORKFLOW_FAILURE_SCENARIOS: tuple[_FailureScenario, ...] = (
+    _FailureScenario(
+        id="initialization.workspace_context_missing",
+        fault="workflow role has no workspace context",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.WORKSPACE_CONTEXT_MISSING
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.USER,
+        kind=RuntimeErrorKind.AGENT_CONFIGURATION_INVALID,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=False,
+        fault_calls=0,
+        emitted_error_count=0,
+        finalized_turn_count=0,
+    ),
+    _FailureScenario(
+        id="initialization.organization_context_missing",
+        fault="workflow role has no organization context",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.ORGANIZATION_CONTEXT_MISSING
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.USER,
+        kind=RuntimeErrorKind.AGENT_CONFIGURATION_INVALID,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=False,
+        fault_calls=0,
+        emitted_error_count=0,
+        finalized_turn_count=0,
+    ),
+    _FailureScenario(
+        id="tool_definitions.classified_entitlement",
+        fault="tool-definition activity raises a typed entitlement denial",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.TOOL_DEFINITIONS_ACTIVITY,
+            classification=tenant_entitlement_denied(ValueError(_DIAGNOSTIC)),
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.USER,
+        kind=RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=True,
+        diagnostic_absent_from_history=True,
+    ),
+    _FailureScenario(
+        id="preparation.activity_crash",
+        fault="tool-definition activity raises an unclassified exception",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.TOOL_DEFINITIONS_ACTIVITY
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_PREPARATION_FAILED,
+        retry_disposition=RetryDisposition.RETRYABLE,
+        should_stream=True,
+    ),
+    _FailureScenario(
+        id="preparation.activity_non_retryable",
+        fault="tool-definition activity raises an unclassified non-retryable error",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.TOOL_DEFINITIONS_ACTIVITY,
+            activity_non_retryable=True,
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_PREPARATION_FAILED,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=True,
+    ),
+    _FailureScenario(
+        id="preparation.tool_definitions_missing_root",
+        fault="tool-definition activity omits the required root scope",
+        injection=harness.FailureInjection(harness.FaultPoint.TOOL_DEFINITIONS_RESULT),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_PREPARATION_FAILED,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=True,
+    ),
+    _FailureScenario(
+        id="session.initialization_result",
+        fault="session creation returns an unsuccessful result",
+        injection=harness.FailureInjection(harness.FaultPoint.SESSION_RESULT),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_SESSION_INITIALIZATION_FAILED,
+        retry_disposition=RetryDisposition.RETRYABLE,
+        should_stream=True,
+    ),
+    _FailureScenario(
+        id="executor.activity_crash",
+        fault="executor activity raises an unclassified exception",
+        injection=harness.FailureInjection(harness.FaultPoint.EXECUTOR_ACTIVITY),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE,
+        retry_disposition=RetryDisposition.RETRYABLE,
+        should_stream=True,
+    ),
+    _FailureScenario(
+        id="executor.activity_classified",
+        fault="executor activity raises an explicitly classified failure",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.EXECUTOR_ACTIVITY,
+            classification=user_agent_execution_failed(
+                ValueError(_DIAGNOSTIC), retryable=True
+            ),
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.USER,
+        kind=RuntimeErrorKind.AGENT_EXECUTION_FAILED,
+        retry_disposition=RetryDisposition.RETRYABLE,
+        should_stream=True,
+        diagnostic_absent_from_history=True,
+    ),
+    _FailureScenario(
+        id="executor.activity_timeout",
+        fault="executor activity exceeds its start-to-close timeout",
+        injection=harness.FailureInjection(harness.FaultPoint.EXECUTOR_TIMEOUT),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT,
+        retry_disposition=RetryDisposition.RETRYABLE,
+        should_stream=True,
+    ),
+    _FailureScenario(
+        id="executor.result_user_retryable",
+        fault="executor returns a typed retryable caller/provider failure",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.EXECUTOR_RESULT,
+            classification=user_agent_execution_failed(
+                ValueError(_DIAGNOSTIC), retryable=True
+            ),
+            terminal_stream_error_emitted=True,
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.USER,
+        kind=RuntimeErrorKind.AGENT_EXECUTION_FAILED,
+        retry_disposition=RetryDisposition.RETRYABLE,
+        should_stream=False,
+    ),
+    _FailureScenario(
+        id="executor.result_protocol",
+        fault="executor returns a typed non-retryable protocol failure",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.EXECUTOR_RESULT,
+            classification=agent_executor_protocol_failed(ValueError(_DIAGNOSTIC)),
+            terminal_stream_error_emitted=False,
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=True,
+    ),
+    _FailureScenario(
+        id="streaming.error_persistence_activity_crash",
+        fault="error persistence/streaming fails without masking the root failure",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.EXECUTOR_RESULT,
+            classification=agent_executor_protocol_failed(ValueError(_DIAGNOSTIC)),
+            terminal_stream_error_emitted=False,
+            emit_session_error_fails=True,
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_EXECUTOR_PROTOCOL_FAILED,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=True,
+        emitted_error_failure_count=1,
+    ),
+    _FailureScenario(
+        id="executor.result_missing_classification",
+        fault="executor violates its contract by omitting a failure classification",
+        injection=harness.FailureInjection(
+            harness.FaultPoint.EXECUTOR_RESULT,
+            terminal_stream_error_emitted=False,
+        ),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_WORKFLOW_INTERNAL_ERROR,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=True,
+    ),
+    _FailureScenario(
+        id="workflow.internal_exception",
+        fault="workflow-owned token preparation raises an unexpected exception",
+        injection=harness.FailureInjection(harness.FaultPoint.WORKFLOW_INTERNAL),
+        status=_FAILED,
+        owner=RuntimeErrorOwner.PLATFORM,
+        kind=RuntimeErrorKind.AGENT_WORKFLOW_INTERNAL_ERROR,
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        should_stream=True,
+        diagnostic_absent_from_history=True,
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _GatewayExpectation:
+    """One source-level gateway failure and its expected durable attribution."""
+
+    route: harness.GatewayRoute
+    mode: harness.GatewayFailureMode
+    owner: RuntimeErrorOwner
+    kind: RuntimeErrorKind
+    retry_disposition: RetryDisposition
+
+
+def _gateway_scenario(expectation: _GatewayExpectation) -> _FailureScenario:
+    return _FailureScenario(
+        id=f"gateway.{expectation.route.value}.{expectation.mode.value}",
+        fault=(
+            f"{expectation.route.value} produces "
+            f"{expectation.mode.value.replace('_', ' ')}"
+        ),
+        injection=harness.FailureInjection(
+            harness.FaultPoint.EXECUTOR_RESULT,
+            gateway_failure=harness.GatewayFailureInjection(
+                route=expectation.route,
+                mode=expectation.mode,
+            ),
+            # Proxy failures are terminal-streamed by AgentExecutor before its
+            # typed result crosses the Temporal activity boundary.
+            terminal_stream_error_emitted=True,
+        ),
+        status=_FAILED,
+        owner=expectation.owner,
+        kind=expectation.kind,
+        retry_disposition=expectation.retry_disposition,
+        should_stream=False,
+    )
+
+
+_USER = RuntimeErrorOwner.USER
+_PLATFORM = RuntimeErrorOwner.PLATFORM
+_EXECUTION_FAILED = RuntimeErrorKind.AGENT_EXECUTION_FAILED
+_UNAVAILABLE = RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+_TIMED_OUT = RuntimeErrorKind.AGENT_EXECUTOR_TIMED_OUT
+_RETRYABLE = RetryDisposition.RETRYABLE
+_NON_RETRYABLE = RetryDisposition.NON_RETRYABLE
+
+# A custom gateway is currently a customer-controlled direct route with a custom
+# base URL, so it intentionally shares ownership semantics with direct providers.
+_GATEWAY_EXPECTATIONS: tuple[_GatewayExpectation, ...] = (
+    # Direct provider (no gateway).
+    _GatewayExpectation(
+        harness.GatewayRoute.DIRECT_PROVIDER,
+        harness.GatewayFailureMode.HTTP_400,
+        _USER,
+        _EXECUTION_FAILED,
+        _NON_RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.DIRECT_PROVIDER,
+        harness.GatewayFailureMode.HTTP_401,
+        _USER,
+        _EXECUTION_FAILED,
+        _NON_RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.DIRECT_PROVIDER,
+        harness.GatewayFailureMode.HTTP_429,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.DIRECT_PROVIDER,
+        harness.GatewayFailureMode.HTTP_503,
+        _USER,
+        _EXECUTION_FAILED,
+        _NON_RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.DIRECT_PROVIDER,
+        harness.GatewayFailureMode.HTTP_504,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.DIRECT_PROVIDER,
+        harness.GatewayFailureMode.CONNECT,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.DIRECT_PROVIDER,
+        harness.GatewayFailureMode.READ_TIMEOUT,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.DIRECT_PROVIDER,
+        harness.GatewayFailureMode.STREAM_DISCONNECT,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    # Customer-configured gateway (implemented as a direct custom base URL).
+    _GatewayExpectation(
+        harness.GatewayRoute.CUSTOM_GATEWAY,
+        harness.GatewayFailureMode.HTTP_400,
+        _USER,
+        _EXECUTION_FAILED,
+        _NON_RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.CUSTOM_GATEWAY,
+        harness.GatewayFailureMode.HTTP_401,
+        _USER,
+        _EXECUTION_FAILED,
+        _NON_RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.CUSTOM_GATEWAY,
+        harness.GatewayFailureMode.HTTP_429,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.CUSTOM_GATEWAY,
+        harness.GatewayFailureMode.HTTP_503,
+        _USER,
+        _EXECUTION_FAILED,
+        _NON_RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.CUSTOM_GATEWAY,
+        harness.GatewayFailureMode.HTTP_504,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.CUSTOM_GATEWAY,
+        harness.GatewayFailureMode.CONNECT,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.CUSTOM_GATEWAY,
+        harness.GatewayFailureMode.READ_TIMEOUT,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.CUSTOM_GATEWAY,
+        harness.GatewayFailureMode.STREAM_DISCONNECT,
+        _USER,
+        _EXECUTION_FAILED,
+        _RETRYABLE,
+    ),
+    # Tracecat-managed LiteLLM.
+    _GatewayExpectation(
+        harness.GatewayRoute.MANAGED_LITELLM,
+        harness.GatewayFailureMode.HTTP_400,
+        _USER,
+        _EXECUTION_FAILED,
+        _NON_RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.MANAGED_LITELLM,
+        harness.GatewayFailureMode.HTTP_401,
+        _PLATFORM,
+        _UNAVAILABLE,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.MANAGED_LITELLM,
+        harness.GatewayFailureMode.HTTP_429,
+        _PLATFORM,
+        _UNAVAILABLE,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.MANAGED_LITELLM,
+        harness.GatewayFailureMode.HTTP_503,
+        _PLATFORM,
+        _UNAVAILABLE,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.MANAGED_LITELLM,
+        harness.GatewayFailureMode.HTTP_504,
+        _PLATFORM,
+        _TIMED_OUT,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.MANAGED_LITELLM,
+        harness.GatewayFailureMode.CONNECT,
+        _PLATFORM,
+        _UNAVAILABLE,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.MANAGED_LITELLM,
+        harness.GatewayFailureMode.READ_TIMEOUT,
+        _PLATFORM,
+        _TIMED_OUT,
+        _RETRYABLE,
+    ),
+    _GatewayExpectation(
+        harness.GatewayRoute.MANAGED_LITELLM,
+        harness.GatewayFailureMode.STREAM_DISCONNECT,
+        _PLATFORM,
+        _UNAVAILABLE,
+        _RETRYABLE,
+    ),
+)
+
+
+FAILURE_SCENARIOS: tuple[_FailureScenario, ...] = (
+    *_WORKFLOW_FAILURE_SCENARIOS,
+    *(_gateway_scenario(expectation) for expectation in _GATEWAY_EXPECTATIONS),
+)
+
+
+def _scenario_id(scenario: _FailureScenario) -> str:
+    return scenario.id
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("scenario", FAILURE_SCENARIOS, ids=_scenario_id)
+async def test_durable_agent_failure_attribution(
+    scenario: _FailureScenario,
+    temporal_env: WorkflowEnvironment,
+    agent_worker_factory: harness.WorkerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run every durable-agent failure contract row through a real Worker."""
+    observation = await harness.run_failure_scenario(
+        temporal_env,
+        agent_worker_factory,
+        monkeypatch,
+        injection=scenario.injection,
+        diagnostic=_DIAGNOSTIC,
+    )
+
+    description = await observation.root.describe()
+    assert description.status is scenario.status
+    assert (
+        description.typed_search_attributes.get(TemporalSearchAttr.ERROR_OWNER.key)
+        == scenario.owner.value
+    )
+
+    classifications = extract_error_classifications(observation.failure)
+    assert len(classifications) == 1
+    classification = classifications[0]
+    assert classification.owner is scenario.owner
+    assert classification.kind is scenario.kind
+    assert classification.retry_disposition is scenario.retry_disposition
+    assert _DIAGNOSTIC not in classification.message
+
+    assert isinstance(observation.failure.cause, ApplicationError)
+    assert observation.failure.cause.non_retryable is (
+        scenario.retry_disposition is RetryDisposition.NON_RETRYABLE
+    )
+    assert _DIAGNOSTIC not in str(observation.failure.cause)
+    assert observation.fault_calls == scenario.fault_calls
+
+    assert len(observation.emitted_errors) == scenario.emitted_error_count
+    assert observation.emit_error_failures == scenario.emitted_error_failure_count
+    for emitted_error in observation.emitted_errors:
+        assert emitted_error.message == classification.message
+        assert emitted_error.should_stream is scenario.should_stream
+        assert _DIAGNOSTIC not in emitted_error.message
+
+    assert len(observation.finalized_turns) == scenario.finalized_turn_count
+    for finalized_turn in observation.finalized_turns:
+        assert finalized_turn.emit_terminal_done is True
+    assert observation.emitted_done == ()
+
+    if scenario.diagnostic_absent_from_history:
+        assert _DIAGNOSTIC not in observation.history.to_json()
+
+    await harness.replay_scenario_history(temporal_env, observation.history)

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -27,11 +27,9 @@ from temporalio import workflow as temporal_workflow
 from temporalio.api.enums.v1 import EventType
 from temporalio.client import (
     Client,
-    WorkflowFailureError,
     WorkflowHandle,
     WorkflowHistory,
 )
-from temporalio.exceptions import ApplicationError
 from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
 from tracecat_ee.agent.activities import (
     AgentActivities,
@@ -64,11 +62,6 @@ from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.common.stream_types import ToolCallContent
 from tracecat.agent.common.types import MCPToolDefinition
-from tracecat.agent.error_policy import (
-    agent_executor_unavailable,
-    invalid_agent_configuration,
-    user_agent_execution_failed,
-)
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
@@ -116,12 +109,7 @@ from tracecat.db.models import AgentSessionHistory, User
 from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.dsl.schemas import RunActionInput
 from tracecat.registry.lock.types import RegistryLock
-from tracecat.runtime.errors import RuntimeErrorKind, RuntimeErrorOwner
 from tracecat.storage.object import InlineObject
-from tracecat.temporal.errors import (
-    extract_error_classification,
-    raise_application_error_from_classification,
-)
 from tracecat.tiers import defaults as tier_defaults
 
 
@@ -588,204 +576,6 @@ async def agent_worker_factory(threadpool, monkeypatch: pytest.MonkeyPatch):
 # =============================================================================
 # Tests: Basic Workflow Execution
 # =============================================================================
-
-
-@pytest.mark.anyio
-@pytest.mark.integration
-async def test_agent_workflow_streams_tool_definition_error(
-    temporal_client: Client,
-    agent_worker_factory,
-    agent_workflow_args: AgentWorkflowArgs,
-    mock_session_id: uuid.UUID,
-) -> None:
-    queue = f"test-agent-queue-{mock_session_id}"
-    emitted_errors: list[EmitSessionErrorInputs] = []
-
-    @activity.defn(name="build_agent_tool_definitions")
-    async def mock_build_tool_definitions(
-        args: BuildAgentToolDefsArgs,
-    ) -> BuildAgentToolDefsResult:
-        del args
-        raise_application_error_from_classification(
-            invalid_agent_configuration(
-                ValueError("Cannot request more than 100 tools")
-            )
-        )
-
-    @activity.defn(name="emit_session_error")
-    async def mock_emit_session_error(args: EmitSessionErrorInputs) -> None:
-        emitted_errors.append(args)
-
-    activities = [
-        create_mock_create_session_activity(),
-        create_mock_load_session_activity(),
-        mock_build_tool_definitions,
-        mock_emit_session_error,
-        create_mock_finalize_turn_activity(),
-        create_mock_emit_session_done_activity(),
-    ]
-
-    async with agent_worker_factory(
-        temporal_client, task_queue=queue, custom_activities=activities
-    ):
-        handle = await temporal_client.start_workflow(
-            DurableAgentWorkflow.run,
-            agent_workflow_args,
-            id=AgentWorkflowID(mock_session_id),
-            task_queue=queue,
-            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-            execution_timeout=timedelta(seconds=30),
-        )
-        with pytest.raises(WorkflowFailureError) as exc_info:
-            await handle.result()
-
-    assert isinstance(exc_info.value.cause, ApplicationError)
-    classification = extract_error_classification(exc_info.value.cause)
-    assert classification is not None
-    assert classification.owner is RuntimeErrorOwner.USER
-    assert classification.kind is RuntimeErrorKind.AGENT_CONFIGURATION_INVALID
-    assert "Cannot request more than 100 tools" not in str(exc_info.value.cause)
-    assert len(emitted_errors) == 1
-    assert emitted_errors[0].session_id == mock_session_id
-    assert emitted_errors[0].message == "Agent configuration is invalid"
-
-
-@pytest.mark.anyio
-@pytest.mark.integration
-async def test_agent_workflow_persists_runtime_terminal_error_without_streaming(
-    temporal_client: Client,
-    agent_worker_factory,
-    agent_workflow_args: AgentWorkflowArgs,
-    mock_session_id: uuid.UUID,
-) -> None:
-    """A runtime failure that already streamed its error persists last_error only.
-
-    ``terminal_stream_error_emitted=True`` means the loopback already pushed the
-    error event onto the SSE stream, so ``emit_session_error`` runs with
-    ``should_stream=False`` to record the durable last_error signal. The workflow
-    emits END separately after finalization.
-    """
-    queue = f"test-agent-queue-{mock_session_id}"
-    emitted_errors: list[EmitSessionErrorInputs] = []
-    emitted_done: list[EmitSessionDoneInputs] = []
-    call_order: list[str] = []
-
-    def runtime_failure(
-        call_count: int, input: AgentExecutorInput
-    ) -> AgentExecutorResult:
-        del call_count
-        return AgentExecutorResult(
-            success=False,
-            error="runtime exploded",
-            classification=user_agent_execution_failed(),
-            terminal_stream_error_emitted=True,
-        )
-
-    @activity.defn(name="emit_session_error")
-    async def mock_emit_session_error(args: EmitSessionErrorInputs) -> None:
-        emitted_errors.append(args)
-        call_order.append("persist_error")
-
-    activities = [
-        *create_activities_with_mock_executor(
-            runtime_failure,
-            done_inputs=emitted_done,
-            done_call_order=call_order,
-        ),
-        mock_emit_session_error,
-    ]
-
-    async with agent_worker_factory(
-        temporal_client, task_queue=queue, custom_activities=activities
-    ):
-        handle = await temporal_client.start_workflow(
-            DurableAgentWorkflow.run,
-            agent_workflow_args,
-            id=AgentWorkflowID(mock_session_id),
-            task_queue=queue,
-            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-            execution_timeout=timedelta(seconds=30),
-        )
-        with pytest.raises(WorkflowFailureError) as exc_info:
-            await handle.result()
-        failed_history = await handle.fetch_history()
-
-    assert isinstance(exc_info.value.cause, ApplicationError)
-    classification = extract_error_classification(exc_info.value.cause)
-    assert classification is not None
-    assert classification.owner is RuntimeErrorOwner.USER
-    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTION_FAILED
-    assert "runtime exploded" not in str(exc_info.value.cause)
-    # Persist-only: exactly one emit, carrying last_error, with error streaming
-    # off so the already-emitted inline error is not duplicated.
-    assert len(emitted_errors) == 1
-    assert emitted_errors[0].session_id == mock_session_id
-    assert emitted_errors[0].message == "Agent execution failed"
-    assert emitted_errors[0].should_stream is False
-    assert len(emitted_done) == 1
-    assert call_order == ["persist_error", "emit_session_done"]
-    await replay_durable_agent_workflow_history(temporal_client, failed_history)
-
-
-@pytest.mark.anyio
-@pytest.mark.integration
-async def test_agent_workflow_streams_executor_pre_stream_failure(
-    temporal_client: Client,
-    agent_worker_factory,
-    agent_workflow_args: AgentWorkflowArgs,
-    mock_session_id: uuid.UUID,
-) -> None:
-    queue = f"test-agent-queue-{mock_session_id}"
-    emitted_errors: list[EmitSessionErrorInputs] = []
-    emitted_done: list[EmitSessionDoneInputs] = []
-
-    def setup_failure(
-        call_count: int, input: AgentExecutorInput
-    ) -> AgentExecutorResult:
-        del call_count
-        return AgentExecutorResult(
-            success=False,
-            error="executor setup failed",
-            classification=agent_executor_unavailable(),
-            terminal_stream_error_emitted=False,
-        )
-
-    @activity.defn(name="emit_session_error")
-    async def mock_emit_session_error(args: EmitSessionErrorInputs) -> None:
-        emitted_errors.append(args)
-
-    activities = [
-        *create_activities_with_mock_executor(
-            setup_failure,
-            done_inputs=emitted_done,
-        ),
-        mock_emit_session_error,
-    ]
-
-    async with agent_worker_factory(
-        temporal_client, task_queue=queue, custom_activities=activities
-    ):
-        with pytest.raises(WorkflowFailureError) as exc_info:
-            await temporal_client.execute_workflow(
-                DurableAgentWorkflow.run,
-                agent_workflow_args,
-                id=AgentWorkflowID(mock_session_id),
-                task_queue=queue,
-                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-                execution_timeout=timedelta(seconds=30),
-            )
-
-    assert isinstance(exc_info.value.cause, ApplicationError)
-    classification = extract_error_classification(exc_info.value.cause)
-    assert classification is not None
-    assert classification.owner is RuntimeErrorOwner.PLATFORM
-    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
-    assert "executor setup failed" not in str(exc_info.value.cause)
-    assert len(emitted_errors) == 1
-    assert emitted_errors[0].session_id == mock_session_id
-    assert emitted_errors[0].message == "Tracecat agent executor is unavailable"
-    assert emitted_errors[0].should_stream is True
-    assert len(emitted_done) == 1
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -715,6 +715,7 @@ async def test_approval_pause_done_failure_does_not_abort_workflow() -> None:
         scopes=frozenset({"agent:execute", "secret:read"}),
     )
     workflow_instance = DurableAgentWorkflow(_build_workflow_args(role))
+    workflow_instance._initialize_run()
     activity_error = ActivityError(
         "stream close failed",
         scheduled_event_id=1,
@@ -814,6 +815,7 @@ async def test_sequential_approved_remote_tools_receive_fresh_mcp_tokens() -> No
         scopes=frozenset({"agent:execute", "secret:read"}),
     )
     workflow_instance = DurableAgentWorkflow(_build_workflow_args(role))
+    workflow_instance._initialize_run()
     build_result = BuildToolDefsResult(
         tool_definitions={},
         registry_lock=RegistryLock(origins={}, actions={}),


### PR DESCRIPTION
## Summary

- add a centralized, declarative DurableAgentWorkflow failure matrix modeled after the DSLWorkflow attribution harness
- exercise 15 workflow and streaming boundaries plus 24 gateway permutations across direct providers, customer-configured gateways, and Tracecat-managed LiteLLM
- run gateway failures through the real LLM socket proxy and then through a real Temporal worker with the production sandbox runner and attribution interceptor
- initialize required workflow state through an intercepted `_initialize_run()` helper, matching DSLWorkflow's class-attribute pattern, so initialization failures receive `TracecatErrorOwner`
- consolidate three scattered failure tests into the shared matrix
- make the Temporal harness importable in isolated runs and bound its synthetic timeout fixture
- initialize direct-construction unit tests through the same run-state helper as production

Customer-configured gateways currently use the same customer-controlled direct-route semantics as direct providers, while the managed fallback route represents Tracecat LiteLLM.

## Test plan

- `uv run pytest --confcutdir=tests/temporal tests/temporal/test_durable_agent_runtime_error_attribution.py -q` — 39 passed
- `uv run pytest --confcutdir=tests/unit tests/unit/test_agent_llm_proxy.py tests/unit/test_agent_activities.py::TestSandboxedAgentExecutorHelpers::test_fatal_proxy_classification_reaches_executor_result -q` — 44 passed
- `uv run pytest --confcutdir=tests/unit tests/unit/test_agent_error_policy.py tests/unit/test_durable_agent_workflow_search_attributes.py tests/unit/test_temporal_errors.py -q` — 88 passed
- `uv run ruff check` and `uv run ruff format --check` on all changed files
- `uv run basedpyright` on all changed files — 0 errors, 0 warnings
- pre-commit hooks, including OpenAPI client generation and Python type checking

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 16 | 6 |
| Tests | 1124 | 210 |
| **Total** | **1140** | **216** |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves durable-agent workspace and organization validation from `@workflow.init` into the intercepted `run()` boundary, so missing context failures now receive `TracecatErrorOwner` instead of bypassing terminal error attribution.

**Tests**
- Adds a declarative real-worker failure matrix covering 15 workflow and streaming boundaries plus 24 gateway failures across direct providers, customer-configured gateways, and Tracecat-managed LiteLLM.
- Runs failures through the real LLM socket proxy, production sandbox runner, and attribution interceptor, verifying error classification, search attributes, streaming behavior, diagnostic redaction, and history replay.
- Replaces three scattered tests and updates existing unit tests to initialize workflow state via `_initialize_run()`.

<sup>Written for commit bc082db22ed4e867e038f9e22f5dd98dbab8b1ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

