### PR TITLE
feat(tables): add TableFieldResolver for the shared query model

### DIFF
--- a/tests/unit/test_tables_query.py
+++ b/tests/unit/test_tables_query.py
@@ -1,0 +1,281 @@
+from collections.abc import Mapping
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.elements import ColumnClause
+
+from tracecat.db.models import TableColumn
+from tracecat.exceptions import TracecatValidationError
+from tracecat.query.compiler import compile_filter
+from tracecat.query.filters import Condition, FilterOp
+from tracecat.query.resolver import FieldKind, FieldResolver
+from tracecat.tables.common import sanitize_identifier
+from tracecat.tables.enums import SqlType
+from tracecat.tables.query import TableFieldResolver
+
+TEXT_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.CONTAINS,
+        FilterOp.STARTS_WITH,
+        FilterOp.IS_NULL,
+    }
+)
+NUMBER_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.GT,
+        FilterOp.GTE,
+        FilterOp.LT,
+        FilterOp.LTE,
+        FilterOp.IS_NULL,
+    }
+)
+BOOLEAN_OPS = frozenset({FilterOp.EQ, FilterOp.NE, FilterOp.IS_NULL})
+TEMPORAL_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.GT,
+        FilterOp.GTE,
+        FilterOp.LT,
+        FilterOp.LTE,
+        FilterOp.IS_NULL,
+    }
+)
+ENUM_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.IS_NULL,
+    }
+)
+
+
+def _column(name: str, sql_type: str) -> TableColumn:
+    return TableColumn(name=name, type=sql_type, nullable=True, default=None)
+
+
+def _compile(
+    condition: Condition, resolver: TableFieldResolver
+) -> tuple[str, Mapping[str, Any]]:
+    compiled = compile_filter(condition, resolver).compile(dialect=postgresql.dialect())
+    return str(compiled), compiled.params
+
+
+@pytest.mark.parametrize(
+    ("sql_type", "expected_kind", "expected_ops", "expected_sa_type"),
+    [
+        (SqlType.TEXT, FieldKind.TEXT, TEXT_OPS, sa.String),
+        (SqlType.INTEGER, FieldKind.NUMBER, NUMBER_OPS, sa.BigInteger),
+        (SqlType.NUMERIC, FieldKind.NUMBER, NUMBER_OPS, sa.Numeric),
+        (SqlType.DATE, FieldKind.TEMPORAL, TEMPORAL_OPS, sa.Date),
+        (SqlType.BOOLEAN, FieldKind.BOOLEAN, BOOLEAN_OPS, sa.Boolean),
+        (SqlType.TIMESTAMPTZ, FieldKind.TEMPORAL, TEMPORAL_OPS, sa.TIMESTAMP),
+        (SqlType.SELECT, FieldKind.ENUM, ENUM_OPS, sa.String),
+    ],
+)
+def test_resolves_supported_column_types(
+    sql_type: SqlType,
+    expected_kind: FieldKind,
+    expected_ops: frozenset[FilterOp],
+    expected_sa_type: type[sa.types.TypeEngine[Any]],
+) -> None:
+    name = "Display_Name"
+    resolver = TableFieldResolver([_column(name, sql_type.value)])
+
+    resolved = resolver.resolve(name)
+
+    assert resolved is not None
+    assert isinstance(resolved.expr, ColumnClause)
+    assert resolved.expr.name == sanitize_identifier(name)
+    assert resolved.kind is expected_kind
+    assert resolved.allowed_ops == expected_ops
+    assert isinstance(resolved.expr.type, expected_sa_type)
+    if sql_type is SqlType.TIMESTAMPTZ:
+        assert isinstance(resolved.expr.type, sa.TIMESTAMP)
+        assert resolved.expr.type.timezone is True
+
+
+@pytest.mark.parametrize("sql_type", [SqlType.JSONB, SqlType.MULTI_SELECT])
+def test_rejects_unsupported_column_types(sql_type: SqlType) -> None:
+    resolver = TableFieldResolver([_column("tags", sql_type.value)])
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        resolver.resolve("tags")
+
+    assert "tags" in str(exc_info.value)
+    assert sql_type.value in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "field", ["__tc_workspace_id", "__TC_workspace_id", "__tc_shadow"]
+)
+def test_internal_columns_are_never_resolvable(field: str) -> None:
+    resolver = TableFieldResolver([_column(field, SqlType.TEXT.value)])
+
+    assert resolver.resolve(field) is None
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        '"; drop table"',
+        "'; SELECT pg_sleep(1); --",
+        '"quoted"',
+        "naïve",
+        "名前",
+        "123field",
+        "",
+        "a.b",
+    ],
+)
+def test_hostile_column_names_are_not_resolvable(field: str) -> None:
+    resolver = TableFieldResolver([_column("status", SqlType.TEXT.value)])
+
+    assert resolver.resolve(field) is None
+
+
+def test_resolves_case_insensitive_fallback() -> None:
+    resolver = TableFieldResolver([_column("status", SqlType.TEXT.value)])
+
+    resolved = resolver.resolve("Status")
+
+    assert resolved is not None
+    assert resolved.kind is FieldKind.TEXT
+
+
+def test_exact_column_name_wins_over_normalized_fallback() -> None:
+    resolver = TableFieldResolver(
+        [
+            _column("status", SqlType.TEXT.value),
+            _column("Status", SqlType.INTEGER.value),
+        ]
+    )
+
+    resolved = resolver.resolve("Status")
+
+    assert resolved is not None
+    assert resolved.kind is FieldKind.NUMBER
+
+
+@pytest.mark.parametrize("field", ["created_at", "updated_at", "Created_At"])
+def test_resolves_system_temporal_columns(field: str) -> None:
+    resolver = TableFieldResolver([])
+
+    resolved = resolver.resolve(field)
+
+    assert resolved is not None
+    assert isinstance(resolved.expr, ColumnClause)
+    assert resolved.kind is FieldKind.TEMPORAL
+    assert resolved.allowed_ops == TEMPORAL_OPS
+    assert isinstance(resolved.expr.type, sa.TIMESTAMP)
+    assert resolved.expr.type.timezone is True
+
+
+@pytest.mark.parametrize("field", ["id", "ID"])
+def test_id_is_not_resolvable(field: str) -> None:
+    resolver = TableFieldResolver([_column(field, SqlType.TEXT.value)])
+
+    assert resolver.resolve(field) is None
+
+
+def test_system_columns_take_precedence_over_user_metadata() -> None:
+    resolver = TableFieldResolver([_column("created_at", SqlType.TEXT.value)])
+
+    resolved = resolver.resolve("created_at")
+
+    assert resolved is not None
+    assert resolved.kind is FieldKind.TEMPORAL
+
+
+def test_compiler_rejects_unknown_column_with_field_name() -> None:
+    resolver = TableFieldResolver([])
+
+    with pytest.raises(TracecatValidationError, match="missing"):
+        compile_filter(Condition(field="missing", op=FilterOp.EQ, value="x"), resolver)
+
+
+def test_rejects_invalid_stored_column_type() -> None:
+    resolver = TableFieldResolver([_column("payload", "BLOB")])
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        resolver.resolve("payload")
+
+    assert "payload" in str(exc_info.value)
+    assert "BLOB" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("name", "sql_type", "value", "expected"),
+    [
+        ("count", SqlType.INTEGER, "42", 42),
+        ("amount", SqlType.NUMERIC, "1.50", Decimal("1.50")),
+        (
+            "observed_at",
+            SqlType.TIMESTAMPTZ,
+            "2026-09-01T12:00:00Z",
+            datetime.fromisoformat("2026-09-01T12:00:00+00:00"),
+        ),
+        ("observed_on", SqlType.DATE, "2026-09-01", date(2026, 9, 1)),
+    ],
+)
+def test_compiler_normalizes_bind_values_for_physical_type(
+    name: str, sql_type: SqlType, value: str, expected: object
+) -> None:
+    resolver = TableFieldResolver([_column(name, sql_type.value)])
+
+    _, params = _compile(Condition(field=name, op=FilterOp.EQ, value=value), resolver)
+
+    assert list(params.values()) == [expected]
+
+
+def test_text_contains_compiles_to_escaped_ilike() -> None:
+    resolver = TableFieldResolver([_column("summary", SqlType.TEXT.value)])
+
+    sql, params = _compile(
+        Condition(field="summary", op=FilterOp.CONTAINS, value="a%_"), resolver
+    )
+
+    assert "summary ILIKE" in sql
+    assert "ESCAPE '\\\\'" in sql
+    assert list(params.values()) == [r"%a\%\_%"]
+
+
+def test_select_values_are_not_validated_against_column_options() -> None:
+    column = _column("status", SqlType.SELECT.value)
+    column.options = ["open"]
+    resolver = TableFieldResolver([column])
+
+    _, params = _compile(
+        Condition(field="status", op=FilterOp.EQ, value="closed"), resolver
+    )
+
+    assert list(params.values()) == ["closed"]
+
+
+def test_compiler_rejects_disallowed_operation() -> None:
+    resolver = TableFieldResolver([_column("count", SqlType.INTEGER.value)])
+
+    with pytest.raises(TracecatValidationError, match="count"):
+        compile_filter(
+            Condition(field="count", op=FilterOp.CONTAINS, value="4"), resolver
+        )
+
+
+def test_satisfies_field_resolver_protocol() -> None:
+    resolver: FieldResolver = TableFieldResolver([])
+
+    assert resolver.resolve("missing") is None

--- a/tests/unit/test_tables_query.py
+++ b/tests/unit/test_tables_query.py
@@ -148,6 +148,16 @@ def test_hostile_column_names_are_not_resolvable(field: str) -> None:
     assert resolver.resolve(field) is None
 
 
+@pytest.mark.parametrize("field", ["st;atus", '"status"', "status;--", "sta tus"])
+def test_invalid_names_never_alias_to_existing_columns(field: str) -> None:
+    # Guard against resolving through sanitize_identifier, which would strip the
+    # offending characters and silently alias the input onto a real column.
+    assert sanitize_identifier(field) == "status"
+    resolver = TableFieldResolver([_column("status", SqlType.TEXT.value)])
+
+    assert resolver.resolve(field) is None
+
+
 def test_resolves_case_insensitive_fallback() -> None:
     resolver = TableFieldResolver([_column("status", SqlType.TEXT.value)])
 

--- a/tracecat/tables/common.py
+++ b/tracecat/tables/common.py
@@ -11,8 +11,69 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from tracecat.tables.enums import SqlType
 
+INTERNAL_COLUMN_PREFIX = "__tc_"
 POSTGRES_BIGINT_MIN = -(2**63)
 POSTGRES_BIGINT_MAX = 2**63 - 1
+
+
+def sanitize_identifier(identifier: str) -> str:
+    """Normalize a stored identifier to its physical SQL name."""
+    sanitized = "".join(c for c in identifier if c.isalnum() or c == "_")
+    if not sanitized:
+        raise ValueError("Identifier must contain at least one letter")
+    if not (sanitized[0].isalpha() or sanitized[0] == "_"):
+        raise ValueError("Identifier must start with a letter or underscore")
+    return sanitized.lower()
+
+
+def quote_identifier(identifier: str) -> str:
+    """Double-quote a SQL identifier for safe use in DDL statements.
+
+    Prevents syntax errors when identifier names collide with SQL reserved
+    keywords (e.g. ``select``, ``order``, ``group``).  Safe to use because
+    all callers pass values already restricted to ``[a-zA-Z0-9_]`` by
+    ``validate_identifier`` / ``sanitize_identifier``.
+    """
+    return f'"{identifier}"'
+
+
+def is_internal_column_name(column_name: str) -> bool:
+    """Check whether a column is internal/system-managed for dynamic schemas."""
+    return column_name.lower().startswith(INTERNAL_COLUMN_PREFIX)
+
+
+def validate_identifier(identifier: str) -> str:
+    """Validate an external identifier before using it in DDL operations."""
+    if not identifier:
+        raise ValueError("Identifier must contain at least one letter")
+    if not all(c.isalnum() or c == "_" for c in identifier):
+        raise ValueError(
+            "Identifier must contain only letters, numbers, and underscores"
+        )
+    if not (identifier[0].isalpha() or identifier[0] == "_"):
+        raise ValueError("Identifier must start with a letter or underscore")
+    return identifier.lower()
+
+
+def sa_type_for_column(sql_type: SqlType) -> sa.types.TypeEngine[Any]:
+    """Map SqlType to the SQLAlchemy type of the physical column."""
+    match sql_type:
+        case SqlType.TEXT | SqlType.SELECT:
+            return sa.String()
+        case SqlType.INTEGER:
+            return sa.BigInteger()
+        case SqlType.NUMERIC:
+            return sa.Numeric()
+        case SqlType.DATE:
+            return sa.Date()
+        case SqlType.BOOLEAN:
+            return sa.Boolean()
+        case SqlType.TIMESTAMPTZ:
+            return sa.TIMESTAMP(timezone=True)
+        case SqlType.JSONB | SqlType.MULTI_SELECT:
+            return JSONB()
+        case _:
+            return sa.String()
 
 
 def is_valid_sql_type(type: str | SqlType) -> bool:

--- a/tracecat/tables/query.py
+++ b/tracecat/tables/query.py
@@ -1,0 +1,148 @@
+from collections.abc import Sequence
+from typing import assert_never
+
+import sqlalchemy as sa
+
+from tracecat.db.models import TableColumn
+from tracecat.exceptions import TracecatValidationError
+from tracecat.query.filters import FilterOp
+from tracecat.query.resolver import FieldKind, ResolvedField
+from tracecat.tables.common import (
+    is_internal_column_name,
+    sa_type_for_column,
+    sanitize_identifier,
+    validate_identifier,
+)
+from tracecat.tables.enums import SqlType
+
+TEXT_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.CONTAINS,
+        FilterOp.STARTS_WITH,
+        FilterOp.IS_NULL,
+    }
+)
+NUMBER_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.GT,
+        FilterOp.GTE,
+        FilterOp.LT,
+        FilterOp.LTE,
+        FilterOp.IS_NULL,
+    }
+)
+BOOLEAN_OPS = frozenset({FilterOp.EQ, FilterOp.NE, FilterOp.IS_NULL})
+TEMPORAL_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.GT,
+        FilterOp.GTE,
+        FilterOp.LT,
+        FilterOp.LTE,
+        FilterOp.IS_NULL,
+    }
+)
+ENUM_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.IS_NULL,
+    }
+)
+
+_SYSTEM_TEMPORAL_COLUMNS = frozenset({"created_at", "updated_at"})
+_UNRESOLVABLE_SYSTEM_COLUMNS = frozenset({"id"})
+
+
+class TableFieldResolver:
+    """Resolve user-facing table column names to trusted SQL expressions."""
+
+    def __init__(self, columns: Sequence[TableColumn]) -> None:
+        self._columns_by_name = {column.name: column for column in columns}
+
+    def resolve(self, field: str) -> ResolvedField | None:
+        """Return the resolved table field, or ``None`` when it is unknown."""
+        if is_internal_column_name(field):
+            return None
+
+        exact_column = self._columns_by_name.get(field)
+        if field in _SYSTEM_TEMPORAL_COLUMNS:
+            return self._resolve_system_column(field)
+        if field in _UNRESOLVABLE_SYSTEM_COLUMNS:
+            return None
+
+        try:
+            normalized_name = validate_identifier(field)
+        except ValueError:
+            if exact_column is None:
+                return None
+            return self._resolve_user_column(exact_column)
+
+        if normalized_name in _SYSTEM_TEMPORAL_COLUMNS:
+            return self._resolve_system_column(normalized_name)
+        if normalized_name in _UNRESOLVABLE_SYSTEM_COLUMNS:
+            return None
+
+        column = exact_column or self._columns_by_name.get(normalized_name)
+        if column is None:
+            return None
+        return self._resolve_user_column(column)
+
+    @staticmethod
+    def _resolve_system_column(name: str) -> ResolvedField:
+        return ResolvedField(
+            expr=sa.column(name, sa.TIMESTAMP(timezone=True)),
+            kind=FieldKind.TEMPORAL,
+            allowed_ops=TEMPORAL_OPS,
+        )
+
+    @staticmethod
+    def _resolve_user_column(column: TableColumn) -> ResolvedField:
+        try:
+            sql_type = SqlType(column.type)
+        except ValueError as exc:
+            raise TracecatValidationError(
+                f"Column {column.name!r} has invalid stored type {column.type!r}"
+            ) from exc
+
+        match sql_type:
+            case SqlType.TEXT:
+                kind = FieldKind.TEXT
+                allowed_ops = TEXT_OPS
+            case SqlType.INTEGER | SqlType.NUMERIC:
+                kind = FieldKind.NUMBER
+                allowed_ops = NUMBER_OPS
+            case SqlType.BOOLEAN:
+                kind = FieldKind.BOOLEAN
+                allowed_ops = BOOLEAN_OPS
+            case SqlType.DATE | SqlType.TIMESTAMPTZ:
+                kind = FieldKind.TEMPORAL
+                allowed_ops = TEMPORAL_OPS
+            case SqlType.SELECT:
+                kind = FieldKind.ENUM
+                allowed_ops = ENUM_OPS
+            case SqlType.JSONB | SqlType.MULTI_SELECT:
+                raise TracecatValidationError(
+                    f"Column {column.name!r} of type {sql_type.value} "
+                    "cannot be used in filters"
+                )
+            case _ as unreachable:
+                assert_never(unreachable)
+
+        physical_name = sanitize_identifier(column.name)
+        return ResolvedField(
+            expr=sa.column(physical_name, sa_type_for_column(sql_type)),
+            kind=kind,
+            allowed_ops=allowed_ops,
+        )

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -14,7 +14,7 @@ from asyncpg.exceptions import (
     UndefinedTableError,
 )
 from sqlalchemy import select
-from sqlalchemy.dialects.postgresql import JSONB, insert
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import DBAPIError, IntegrityError, NoResultFound, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 from sqlalchemy.orm import selectinload
@@ -47,6 +47,9 @@ from tracecat.pagination import (
 )
 from tracecat.service import BaseWorkspaceService
 from tracecat.tables.common import (
+    INTERNAL_COLUMN_PREFIX as INTERNAL_COLUMN_PREFIX,
+)
+from tracecat.tables.common import (
     ColumnHasDuplicateValuesError,
     coerce_integer_value,
     coerce_multi_select_value,
@@ -58,7 +61,20 @@ from tracecat.tables.common import (
     is_valid_sql_type,
     normalize_column_options,
     prepare_default_value,
+    sa_type_for_column,
     to_sql_clause,
+)
+from tracecat.tables.common import (
+    is_internal_column_name as is_internal_column_name,
+)
+from tracecat.tables.common import (
+    quote_identifier as quote_identifier,
+)
+from tracecat.tables.common import (
+    sanitize_identifier as sanitize_identifier,
+)
+from tracecat.tables.common import (
+    validate_identifier as validate_identifier,
 )
 from tracecat.tables.enums import SqlType
 from tracecat.tables.importer import (
@@ -86,7 +102,6 @@ DYNAMIC_WORKSPACE_RLS_POLICY = "rls_policy_dynamic_workspace"
 RLS_WORKSPACE_VAR = "app.current_workspace_id"
 RLS_BYPASS_VAR = "app.rls_bypass"
 RLS_BYPASS_ON = "on"
-INTERNAL_COLUMN_PREFIX = "__tc_"
 SYSTEM_VISIBLE_COLUMN_NAMES: tuple[str, ...] = ("id", "created_at", "updated_at")
 
 
@@ -279,25 +294,9 @@ class BaseTablesService(BaseWorkspaceService):
 
         return normalised
 
-    def _sa_type_for_column(self, sql_type: SqlType) -> sa.types.TypeEngine:
+    def _sa_type_for_column(self, sql_type: SqlType) -> sa.types.TypeEngine[Any]:
         """Map SqlType to SQLAlchemy column types for safe binding."""
-        match sql_type:
-            case SqlType.TEXT | SqlType.SELECT:
-                return sa.String()
-            case SqlType.INTEGER:
-                return sa.BigInteger()
-            case SqlType.NUMERIC:
-                return sa.Numeric()
-            case SqlType.DATE:
-                return sa.Date()
-            case SqlType.BOOLEAN:
-                return sa.Boolean()
-            case SqlType.TIMESTAMPTZ:
-                return sa.TIMESTAMP(timezone=True)
-            case SqlType.JSONB | SqlType.MULTI_SELECT:
-                return JSONB()
-            case _:
-                return sa.String()
+        return sa_type_for_column(sql_type)
 
     async def list_tables(self) -> Sequence[Table]:
         """List all lookup tables for a workspace.
@@ -2328,42 +2327,3 @@ class TableEditorService(BaseWorkspaceService):
         stmt = sa.delete(table_clause).where(sa.column("id") == row_id)
         await conn.execute(stmt)
         await self.session.flush()
-
-
-def sanitize_identifier(identifier: str) -> str:
-    """Normalize a stored identifier to its physical SQL name."""
-    sanitized = "".join(c for c in identifier if c.isalnum() or c == "_")
-    if not sanitized:
-        raise ValueError("Identifier must contain at least one letter")
-    if not (sanitized[0].isalpha() or sanitized[0] == "_"):
-        raise ValueError("Identifier must start with a letter or underscore")
-    return sanitized.lower()
-
-
-def quote_identifier(identifier: str) -> str:
-    """Double-quote a SQL identifier for safe use in DDL statements.
-
-    Prevents syntax errors when identifier names collide with SQL reserved
-    keywords (e.g. ``select``, ``order``, ``group``).  Safe to use because
-    all callers pass values already restricted to ``[a-zA-Z0-9_]`` by
-    ``validate_identifier`` / ``sanitize_identifier``.
-    """
-    return f'"{identifier}"'
-
-
-def is_internal_column_name(column_name: str) -> bool:
-    """Check whether a column is internal/system-managed for dynamic schemas."""
-    return column_name.lower().startswith(INTERNAL_COLUMN_PREFIX)
-
-
-def validate_identifier(identifier: str) -> str:
-    """Validate an external identifier before using it in DDL operations."""
-    if not identifier:
-        raise ValueError("Identifier must contain at least one letter")
-    if not all(c.isalnum() or c == "_" for c in identifier):
-        raise ValueError(
-            "Identifier must contain only letters, numbers, and underscores"
-        )
-    if not (identifier[0].isalpha() or identifier[0] == "_"):
-        raise ValueError("Identifier must start with a letter or underscore")
-    return identifier.lower()


### PR DESCRIPTION
## Summary

Adds `TableFieldResolver`, the tables-side `FieldResolver` for the shared query model in `tracecat/query` (ENG-1747, part of ENG-1692 design v3 §3.2 / §4.3). Filter side only; aggregation-side resolution lands with the service in ENG-1748.

- **Helper relocation.** `sanitize_identifier`, `validate_identifier`, `quote_identifier`, `is_internal_column_name`, `INTERNAL_COLUMN_PREFIX` and a new module-level `sa_type_for_column(SqlType)` now live in `tracecat/tables/common.py`. `service.py` re-exports them so existing importers are untouched, and `TablesService._sa_type_for_column` delegates. This lets the service import the resolver later without an import cycle.
- **`tracecat/tables/query.py`.** `TableFieldResolver(columns: Sequence[TableColumn])`:
  - `__tc_*` names (any case) are never resolvable. `created_at` / `updated_at` always resolve as `TIMESTAMPTZ` and take precedence over metadata. `id` is deliberately not exposed.
  - User columns match exactly, then via the `validate_identifier`-normalized name, mirroring `_resolve_external_column_name`. Hostile strings fail validation and are unresolvable.
  - Expressions are typed `sa.column(physical_name, sa_type_for_column(type))` so the compiler coerces bound values through the physical type (`INTEGER` is `BIGINT`, `SELECT` is `TEXT`).
  - `SqlType` → `FieldKind` / allowed ops per the design matrix. `SELECT` is `ENUM` over `sa.String`, so values bind as text (not validated against `options`) and the aggregation compiler in #3380 applies its `left(col, 256)` bound.
  - `JSONB` / `MULTI_SELECT` columns raise a `TracecatValidationError` naming the column and type, distinct from the compiler's unknown-field error.

## Testing

`tests/unit/test_tables_query.py`, no database: every `SqlType` → kind / ops / SQLAlchemy type, internal-column rejection incl. mixed case, hostile names (`"; drop table"`, quotes, unicode, leading digit, empty, dotted), case-insensitive fallback, system columns and `id`, unknown column through `compile_filter`, invalid stored type, JSONB / MULTI_SELECT rejection, end-to-end bind typing (`"42"` → `int`, `"1.50"` → `Decimal`, ISO strings → aware `datetime` / `date`), escaped `ILIKE`, disallowed op, and structural `FieldResolver` conformance.

Also ran `tests/unit/query`, `tests/unit/test_tables_service.py`, `tests/unit/test_tables_router.py`, `tests/unit/test_case_table_rows_service.py`, `ruff`, and `basedpyright --warnings`: all green.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 228 | 59 |
| Tests | 281 | 0 |

## Linear

https://linear.app/tracecat/issue/ENG-1747/tables-tablefieldresolver-for-the-shared-query-model
