### PR TITLE
feat(rbac): derive membership from role assignments

### DIFF
--- a/alembic/versions/2bf069003a77_membership_derived_from_rbac_assignments.py
+++ b/alembic/versions/2bf069003a77_membership_derived_from_rbac_assignments.py
@@ -15,9 +15,11 @@ from sqlalchemy.dialects import postgresql
 
 from alembic import op
 from tracecat.db.tenant_rls import (
+    disable_assignment_split_table_rls,
     disable_org_optional_workspace_table_rls,
     disable_org_table_rls,
     disable_workspace_table_rls,
+    enable_assignment_split_table_rls,
     enable_org_optional_workspace_table_rls,
     enable_org_table_rls,
     enable_workspace_table_rls,
@@ -31,7 +33,7 @@ depends_on: str | Sequence[str] | None = None
 
 logger = logging.getLogger("alembic.runtime.migration")
 
-RECLASSIFIED_TABLES = ("user_role_assignment", "group_role_assignment")
+SPLIT_POLICY_TABLES = ("user_role_assignment", "group_role_assignment")
 
 # Backfill a workspace-editor assignment for every workspace membership that no
 # assignment path already covers. Rows whose org lacks the system role are
@@ -201,11 +203,11 @@ def upgrade() -> None:
     backfill_assignments(connection)
     assert_no_membership_dropped(connection)
 
-    # 2. Assignments become plain org-scoped: the optional-workspace clause hid
-    # other-workspace rows from the view's org-presence reads.
-    for table in RECLASSIFIED_TABLES:
+    # 2. Assignments gain an org-wide read policy so org-presence queries see
+    # other-workspace rows; writes stay pinned to the session's workspace.
+    for table in SPLIT_POLICY_TABLES:
         op.execute(disable_org_optional_workspace_table_rls(table))
-        op.execute(enable_org_table_rls(table))
+        op.execute(enable_assignment_split_table_rls(table))
 
     # 3. Drop the legacy membership tables.
     op.execute(disable_workspace_table_rls("membership"))
@@ -290,6 +292,6 @@ def downgrade() -> None:
     op.execute(enable_workspace_table_rls("membership"))
     op.execute(enable_org_table_rls("organization_membership"))
 
-    for table in RECLASSIFIED_TABLES:
-        op.execute(disable_org_table_rls(table))
+    for table in SPLIT_POLICY_TABLES:
+        op.execute(disable_assignment_split_table_rls(table))
         op.execute(enable_org_optional_workspace_table_rls(table))

--- a/alembic/versions/2bf069003a77_membership_derived_from_rbac_assignments.py
+++ b/alembic/versions/2bf069003a77_membership_derived_from_rbac_assignments.py
@@ -1,0 +1,227 @@
+"""membership derived from rbac assignments
+
+Revision ID: 2bf069003a77
+Revises: 44d7e75b6f4c
+Create Date: 2026-09-02 13:35:40.252876
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_org_optional_workspace_table_rls,
+    disable_org_table_rls,
+    disable_workspace_table_rls,
+    enable_org_optional_workspace_table_rls,
+    enable_org_table_rls,
+    enable_workspace_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "2bf069003a77"
+down_revision: str | None = "44d7e75b6f4c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+RECLASSIFIED_TABLES = ("user_role_assignment", "group_role_assignment")
+
+# Backfill a workspace-editor assignment for every workspace membership that no
+# assignment path already covers. Rows whose org lacks the system role are
+# skipped rather than failing the migration.
+BACKFILL_WORKSPACE_ASSIGNMENTS = """
+WITH inserted AS (
+    INSERT INTO user_role_assignment (
+        id, organization_id, user_id, workspace_id, role_id
+    )
+    SELECT gen_random_uuid(), w.organization_id, m.user_id, m.workspace_id, r.id
+    FROM   membership m
+    JOIN   workspace w ON w.id = m.workspace_id
+    JOIN   role r
+      ON   r.organization_id = w.organization_id
+     AND   r.slug = 'workspace-editor'
+    WHERE  NOT EXISTS (
+        SELECT 1 FROM user_role_assignment ura
+        WHERE  ura.user_id = m.user_id
+          AND  ura.workspace_id = m.workspace_id
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM   group_role_assignment gra
+        JOIN   group_member gm ON gm.group_id = gra.group_id
+        WHERE  gm.user_id = m.user_id
+          AND  gra.workspace_id = m.workspace_id
+    )
+    RETURNING 1
+)
+SELECT count(*) FROM inserted
+"""
+
+# Backfill an organization-member assignment for every org membership with no
+# assignment at all in that organization.
+BACKFILL_ORG_ASSIGNMENTS = """
+WITH inserted AS (
+    INSERT INTO user_role_assignment (
+        id, organization_id, user_id, workspace_id, role_id
+    )
+    SELECT gen_random_uuid(), om.organization_id, om.user_id, NULL, r.id
+    FROM   organization_membership om
+    JOIN   role r
+      ON   r.organization_id = om.organization_id
+     AND   r.slug = 'organization-member'
+    WHERE  NOT EXISTS (
+        SELECT 1 FROM user_role_assignment ura
+        WHERE  ura.user_id = om.user_id
+          AND  ura.organization_id = om.organization_id
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM   group_role_assignment gra
+        JOIN   group_member gm ON gm.group_id = gra.group_id
+        WHERE  gm.user_id = om.user_id
+          AND  gra.organization_id = om.organization_id
+    )
+    RETURNING 1
+)
+SELECT count(*) FROM inserted
+"""
+
+# Repopulate the dropped tables from the assignment graph on downgrade.
+REPOPULATE_ORG_MEMBERSHIP = """
+INSERT INTO organization_membership (user_id, organization_id)
+SELECT DISTINCT user_id, organization_id
+FROM (
+  SELECT user_id, organization_id FROM user_role_assignment
+  UNION ALL
+  SELECT gm.user_id, gra.organization_id
+  FROM   group_role_assignment gra JOIN group_member gm ON gm.group_id = gra.group_id
+) o
+ON CONFLICT DO NOTHING
+"""
+
+REPOPULATE_WORKSPACE_MEMBERSHIP = """
+INSERT INTO membership (user_id, workspace_id)
+SELECT DISTINCT user_id, workspace_id
+FROM (
+  SELECT user_id, workspace_id
+  FROM   user_role_assignment WHERE workspace_id IS NOT NULL
+  UNION ALL
+  SELECT gm.user_id, gra.workspace_id
+  FROM   group_role_assignment gra JOIN group_member gm ON gm.group_id = gra.group_id
+  WHERE  gra.workspace_id IS NOT NULL
+) w
+ON CONFLICT DO NOTHING
+"""
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    # 1. Backfill assignments so no existing member loses access.
+    workspace_backfilled = connection.execute(
+        sa.text(BACKFILL_WORKSPACE_ASSIGNMENTS)
+    ).scalar_one()
+    org_backfilled = connection.execute(sa.text(BACKFILL_ORG_ASSIGNMENTS)).scalar_one()
+    connection.execute(
+        sa.text(
+            "DO $$ BEGIN RAISE NOTICE "
+            "'membership backfill: % workspace, % org assignments', "
+            f"{workspace_backfilled}, {org_backfilled}; END $$"
+        )
+    )
+
+    # 2. Assignments become plain org-scoped: the optional-workspace clause hid
+    # other-workspace rows from the view's org-presence reads.
+    for table in RECLASSIFIED_TABLES:
+        op.execute(disable_org_optional_workspace_table_rls(table))
+        op.execute(enable_org_table_rls(table))
+
+    # 3. Drop the legacy membership tables.
+    op.execute(disable_workspace_table_rls("membership"))
+    op.execute(disable_org_table_rls("organization_membership"))
+    op.drop_index("ix_membership_workspace_id", table_name="membership")
+    op.drop_index("ix_membership_workspace_user", table_name="membership")
+    op.drop_table("membership")
+    op.drop_index("ix_org_membership_org_id", table_name="organization_membership")
+    op.drop_table("organization_membership")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "membership",
+        sa.Column("user_id", sa.UUID(), autoincrement=False, nullable=False),
+        sa.Column("workspace_id", sa.UUID(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["user.id"], name="fk_membership_user_id_user"
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name="fk_membership_workspace_id_workspace",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("user_id", "workspace_id", name="pk_membership"),
+    )
+    op.create_index(
+        "ix_membership_workspace_id", "membership", ["workspace_id"], unique=False
+    )
+    op.create_index(
+        "ix_membership_workspace_user",
+        "membership",
+        ["workspace_id", "user_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "organization_membership",
+        sa.Column("user_id", sa.UUID(), autoincrement=False, nullable=False),
+        sa.Column("organization_id", sa.UUID(), autoincrement=False, nullable=False),
+        sa.Column(
+            "created_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name="fk_organization_membership_organization_id_organization",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            name="fk_organization_membership_user_id_user",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "user_id", "organization_id", name="pk_organization_membership"
+        ),
+    )
+    op.create_index(
+        "ix_org_membership_org_id",
+        "organization_membership",
+        ["organization_id"],
+        unique=False,
+    )
+
+    op.execute(REPOPULATE_ORG_MEMBERSHIP)
+    op.execute(REPOPULATE_WORKSPACE_MEMBERSHIP)
+
+    op.execute(enable_workspace_table_rls("membership"))
+    op.execute(enable_org_table_rls("organization_membership"))
+
+    for table in RECLASSIFIED_TABLES:
+        op.execute(disable_org_table_rls(table))
+        op.execute(enable_org_optional_workspace_table_rls(table))

--- a/alembic/versions/2bf069003a77_membership_derived_from_rbac_assignments.py
+++ b/alembic/versions/2bf069003a77_membership_derived_from_rbac_assignments.py
@@ -6,9 +6,11 @@ Create Date: 2026-09-02 13:35:40.252876
 
 """
 
+import logging
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy import Connection
 from sqlalchemy.dialects import postgresql
 
 from alembic import op
@@ -26,6 +28,8 @@ revision: str = "2bf069003a77"
 down_revision: str | None = "44d7e75b6f4c"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
+
+logger = logging.getLogger("alembic.runtime.migration")
 
 RECLASSIFIED_TABLES = ("user_role_assignment", "group_role_assignment")
 
@@ -89,6 +93,46 @@ WITH inserted AS (
 SELECT count(*) FROM inserted
 """
 
+# Workspace memberships still uncovered by any assignment path after backfill.
+# The backfill inner-joins `role`, so an org missing the system role silently
+# skips its members; dropping the table would lose their access permanently.
+UNCOVERED_WORKSPACE_MEMBERSHIPS = """
+SELECT count(*) AS uncovered,
+       coalesce(array_agg(DISTINCT w.organization_id), '{}') AS organization_ids
+FROM   membership m
+JOIN   workspace w ON w.id = m.workspace_id
+WHERE  NOT EXISTS (
+    SELECT 1 FROM user_role_assignment ura
+    WHERE  ura.user_id = m.user_id
+      AND  ura.workspace_id = m.workspace_id
+)
+AND NOT EXISTS (
+    SELECT 1
+    FROM   group_role_assignment gra
+    JOIN   group_member gm ON gm.group_id = gra.group_id
+    WHERE  gm.user_id = m.user_id
+      AND  gra.workspace_id = m.workspace_id
+)
+"""
+
+UNCOVERED_ORG_MEMBERSHIPS = """
+SELECT count(*) AS uncovered,
+       coalesce(array_agg(DISTINCT om.organization_id), '{}') AS organization_ids
+FROM   organization_membership om
+WHERE  NOT EXISTS (
+    SELECT 1 FROM user_role_assignment ura
+    WHERE  ura.user_id = om.user_id
+      AND  ura.organization_id = om.organization_id
+)
+AND NOT EXISTS (
+    SELECT 1
+    FROM   group_role_assignment gra
+    JOIN   group_member gm ON gm.group_id = gra.group_id
+    WHERE  gm.user_id = om.user_id
+      AND  gra.organization_id = om.organization_id
+)
+"""
+
 # Repopulate the dropped tables from the assignment graph on downgrade.
 REPOPULATE_ORG_MEMBERSHIP = """
 INSERT INTO organization_membership (user_id, organization_id)
@@ -117,21 +161,45 @@ ON CONFLICT DO NOTHING
 """
 
 
-def upgrade() -> None:
-    connection = op.get_bind()
-
-    # 1. Backfill assignments so no existing member loses access.
+def backfill_assignments(connection: Connection) -> tuple[int, int]:
+    """Backfill assignments for every legacy membership, returning the counts."""
     workspace_backfilled = connection.execute(
         sa.text(BACKFILL_WORKSPACE_ASSIGNMENTS)
     ).scalar_one()
     org_backfilled = connection.execute(sa.text(BACKFILL_ORG_ASSIGNMENTS)).scalar_one()
-    connection.execute(
-        sa.text(
-            "DO $$ BEGIN RAISE NOTICE "
-            "'membership backfill: % workspace, % org assignments', "
-            f"{workspace_backfilled}, {org_backfilled}; END $$"
-        )
+    logger.info(
+        "membership backfill: %s workspace, %s org assignments",
+        workspace_backfilled,
+        org_backfilled,
     )
+    return workspace_backfilled, org_backfilled
+
+
+def assert_no_membership_dropped(connection: Connection) -> None:
+    """Fail the migration if any legacy membership row lacks an assignment path."""
+    workspace_row = connection.execute(sa.text(UNCOVERED_WORKSPACE_MEMBERSHIPS)).one()
+    org_row = connection.execute(sa.text(UNCOVERED_ORG_MEMBERSHIPS)).one()
+    if workspace_row.uncovered or org_row.uncovered:
+        affected = sorted(
+            {str(org_id) for org_id in workspace_row.organization_ids}
+            | {str(org_id) for org_id in org_row.organization_ids}
+        )
+        raise RuntimeError(
+            "Refusing to drop membership tables: "
+            f"{workspace_row.uncovered} workspace membership(s) and "
+            f"{org_row.uncovered} organization membership(s) are not covered by "
+            "any role assignment. Affected organization_ids: "
+            f"{', '.join(affected)}. Seed the 'workspace-editor' and "
+            "'organization-member' system roles in these organizations, then retry."
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    # 1. Backfill assignments so no existing member loses access, then verify.
+    backfill_assignments(connection)
+    assert_no_membership_dropped(connection)
 
     # 2. Assignments become plain org-scoped: the optional-workspace clause hid
     # other-workspace rows from the view's org-presence reads.

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -33791,10 +33791,45 @@ export const $WorkspaceMember = {
       type: "string",
       title: "Role Name",
     },
+    source: {
+      $ref: "#/components/schemas/WorkspaceMemberSource",
+    },
   },
   type: "object",
-  required: ["user_id", "first_name", "last_name", "email", "role_name"],
+  required: [
+    "user_id",
+    "first_name",
+    "last_name",
+    "email",
+    "role_name",
+    "source",
+  ],
   title: "WorkspaceMember",
+} as const
+
+export const $WorkspaceMemberSource = {
+  properties: {
+    kind: {
+      type: "string",
+      enum: ["direct", "group"],
+      title: "Kind",
+    },
+    group_names: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Group Names",
+    },
+  },
+  type: "object",
+  required: ["kind"],
+  title: "WorkspaceMemberSource",
+  description: `Where a member's workspace access comes from.
+
+\`\`kind\`\` is \`\`"direct"\`\` for a direct role assignment, or \`\`"group"\`\` when
+access is derived only from group membership, in which case \`\`group_names\`\`
+lists the granting groups.`,
 } as const
 
 export const $WorkspaceMembershipCreate = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -10125,7 +10125,22 @@ export type WorkspaceMember = {
   last_name: string | null
   email: string
   role_name: string
+  source: WorkspaceMemberSource
 }
+
+/**
+ * Where a member's workspace access comes from.
+ *
+ * ``kind`` is ``"direct"`` for a direct role assignment, or ``"group"`` when
+ * access is derived only from group membership, in which case ``group_names``
+ * lists the granting groups.
+ */
+export type WorkspaceMemberSource = {
+  kind: "direct" | "group"
+  group_names?: Array<string>
+}
+
+export type kind3 = "direct" | "group"
 
 export type WorkspaceMembershipCreate = {
   user_id: string

--- a/frontend/src/components/workspaces/workspace-members-table.tsx
+++ b/frontend/src/components/workspaces/workspace-members-table.tsx
@@ -43,6 +43,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import {
   useWorkspaceMembers,
@@ -50,6 +55,21 @@ import {
 } from "@/hooks/use-workspace"
 import { useRbacRoles, useRbacUserAssignments } from "@/lib/hooks"
 import { useQueryClient } from "@/lib/query"
+
+/**
+ * Describes where a member's workspace access comes from, for display.
+ * Group-derived members cannot be removed here; their group must change.
+ */
+function describeMemberSource(source: WorkspaceMember["source"]): string {
+  if (source.kind === "direct") {
+    return "Direct"
+  }
+  const groupNames = source.group_names ?? []
+  if (groupNames.length === 0) {
+    return "Group"
+  }
+  return groupNames.join(", ")
+}
 
 export function WorkspaceMembersTable({
   workspace,
@@ -227,9 +247,28 @@ export function WorkspaceMembersTable({
             },
 
             {
+              accessorKey: "source",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Source"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {describeMemberSource(row.original.source)}
+                </div>
+              ),
+              enableSorting: false,
+              enableHiding: false,
+            },
+
+            {
               id: "actions",
               enableHiding: false,
               cell: ({ row }) => {
+                const isGroupDerived = row.original.source.kind === "group"
                 return (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
@@ -260,19 +299,39 @@ export function WorkspaceMembersTable({
                         </DialogTrigger>
                       )}
 
-                      {canRemoveMembers && (
-                        <AlertDialogTrigger asChild>
-                          <DropdownMenuItem
-                            className="text-rose-500 focus:text-rose-600"
-                            onClick={() => {
-                              setSelectedUser(row.original)
-                              console.debug("Selected user", row.original)
-                            }}
-                          >
-                            Remove from workspace
-                          </DropdownMenuItem>
-                        </AlertDialogTrigger>
-                      )}
+                      {canRemoveMembers &&
+                        (isGroupDerived ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              {/* A span keeps the tooltip reachable: a disabled
+                                  menu item emits no pointer events itself. */}
+                              <span className="block">
+                                <DropdownMenuItem
+                                  disabled
+                                  onSelect={(event) => event.preventDefault()}
+                                >
+                                  Remove from workspace
+                                </DropdownMenuItem>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              Access comes from{" "}
+                              {describeMemberSource(row.original.source)}.
+                              Remove this user from the group instead.
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem
+                              className="text-rose-500 focus:text-rose-600"
+                              onClick={() => {
+                                setSelectedUser(row.original)
+                              }}
+                            >
+                              Remove from workspace
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                        ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )

--- a/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
+++ b/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
@@ -27,8 +27,6 @@ from tracecat.db.engine import (
     get_async_session_context_manager,
 )
 from tracecat.db.models import (
-    Membership,
-    OrganizationMembership,
     OrganizationTier,
     Tier,
     User,
@@ -349,48 +347,6 @@ async def _get_or_create_local_user(
     return user, True
 
 
-async def _ensure_org_membership(
-    *,
-    session: AsyncSession,
-    user_id: UUID,
-    organization_id: UUID,
-) -> None:
-    result = await session.execute(
-        select(OrganizationMembership).where(
-            OrganizationMembership.user_id == user_id,
-            OrganizationMembership.organization_id == organization_id,
-        )
-    )
-    if result.scalar_one_or_none() is None:
-        session.add(
-            OrganizationMembership(
-                user_id=user_id,
-                organization_id=organization_id,
-            )
-        )
-
-
-async def _ensure_workspace_membership(
-    *,
-    session: AsyncSession,
-    user_id: UUID,
-    workspace_id: UUID,
-) -> None:
-    result = await session.execute(
-        select(Membership).where(
-            Membership.user_id == user_id,
-            Membership.workspace_id == workspace_id,
-        )
-    )
-    if result.scalar_one_or_none() is None:
-        session.add(
-            Membership(
-                user_id=user_id,
-                workspace_id=workspace_id,
-            )
-        )
-
-
 async def _ensure_role_assignment(
     *,
     session: AsyncSession,
@@ -488,16 +444,7 @@ async def create_dev_user(
             slug=workspace_role,
         )
 
-        await _ensure_org_membership(
-            session=session,
-            user_id=user.id,
-            organization_id=organization_id,
-        )
-        await _ensure_workspace_membership(
-            session=session,
-            user_id=user.id,
-            workspace_id=workspace.id,
-        )
+        # Membership is derived from these assignments.
         await _ensure_role_assignment(
             session=session,
             user_id=user.id,

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
@@ -18,6 +18,7 @@ from tracecat.audit.logger import audit_log
 from tracecat.audit.service import AuditService
 from tracecat.audit.types import AuditAction
 from tracecat.auth.types import Role
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import (
     Membership,
@@ -172,8 +173,7 @@ class AdminOrgService(BasePlatformService):
             select(Membership)
             .join(User, Membership.user_id == User.id)
             .where(
-                Membership.organization_id == org_id,
-                Membership.workspace_id.is_(None),
+                org_membership_predicate(None, org_id),
                 func.lower(User.email) == params.email.lower(),
             )
         )

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
@@ -20,10 +20,10 @@ from tracecat.audit.types import AuditAction
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import (
+    Membership,
     Organization,
     OrganizationDomain,
     OrganizationInvitation,
-    OrganizationMembership,
     RegistryRepository,
     RegistryVersion,
     User,
@@ -169,10 +169,11 @@ class AdminOrgService(BasePlatformService):
         role_obj = await self._get_org_invitation_role(org_id, params.role_slug)
 
         existing_member_stmt = (
-            select(OrganizationMembership)
-            .join(User, OrganizationMembership.user_id == User.id)
+            select(Membership)
+            .join(User, Membership.user_id == User.id)
             .where(
-                OrganizationMembership.organization_id == org_id,
+                Membership.organization_id == org_id,
+                Membership.workspace_id.is_(None),
                 func.lower(User.email) == params.email.lower(),
             )
         )

--- a/packages/tracecat-ee/tracecat_ee/admin/users/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/users/service.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped
 from tracecat.audit.logger import audit_log
 from tracecat.auth.schemas import UserCreate, UserRole
 from tracecat.auth.users import get_user_db_context, get_user_manager_context
-from tracecat.db.models import AccessToken, Approval, Membership, User
+from tracecat.db.models import AccessToken, Approval, User, UserRoleAssignment
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.organization.management import (
     ensure_single_tenant_user_defaults_for_session,
@@ -170,8 +170,10 @@ class AdminUserService(BasePlatformService):
                 cast(Mapped[uuid.UUID], AccessToken.user_id) == user_id
             )
         )
+        # Deleting the user cascades its role assignments, which is what
+        # removes the derived membership rows.
         await self.session.execute(
-            delete(Membership).where(Membership.user_id == user_id)
+            delete(UserRoleAssignment).where(UserRoleAssignment.user_id == user_id)
         )
         await self.session.execute(
             update(Approval)

--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -22,7 +22,7 @@ from tracecat.db.models import (
     Group,
     GroupMember,
     GroupRoleAssignment,
-    OrganizationMembership,
+    Membership,
     RoleScope,
     Scope,
     User,
@@ -439,9 +439,10 @@ class RBACService(BaseOrgService):
         await self._ensure_group_membership_assignable(group_id)
 
         # Verify user belongs to this organization
-        stmt = select(OrganizationMembership).where(
-            OrganizationMembership.user_id == user_id,
-            OrganizationMembership.organization_id == self.organization_id,
+        stmt = select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.organization_id == self.organization_id,
+            Membership.workspace_id.is_(None),
         )
         result = await self.session.execute(stmt)
         if result.scalar_one_or_none() is None:
@@ -700,9 +701,10 @@ class RBACService(BaseOrgService):
             Created UserRoleAssignment
         """
         # Verify user belongs to this organization
-        stmt = select(OrganizationMembership).where(
-            OrganizationMembership.user_id == user_id,
-            OrganizationMembership.organization_id == self.organization_id,
+        stmt = select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.organization_id == self.organization_id,
+            Membership.workspace_id.is_(None),
         )
         result = await self.session.execute(stmt)
         if result.scalar_one_or_none() is None:

--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -16,6 +16,7 @@ from tracecat.authz.controls import (
     validate_scope_string,
 )
 from tracecat.authz.enums import ScopeSource
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.authz.scopes import PRESET_ROLE_SCOPES
 from tracecat.authz.service import resolve_grantable_role, resolve_granter_scopes
 from tracecat.db.models import (
@@ -440,9 +441,7 @@ class RBACService(BaseOrgService):
 
         # Verify user belongs to this organization
         stmt = select(Membership).where(
-            Membership.user_id == user_id,
-            Membership.organization_id == self.organization_id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user_id, self.organization_id),
         )
         result = await self.session.execute(stmt)
         if result.scalar_one_or_none() is None:
@@ -702,9 +701,7 @@ class RBACService(BaseOrgService):
         """
         # Verify user belongs to this organization
         stmt = select(Membership).where(
-            Membership.user_id == user_id,
-            Membership.organization_id == self.organization_id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user_id, self.organization_id),
         )
         result = await self.session.execute(stmt)
         if result.scalar_one_or_none() is None:

--- a/packages/tracecat-ee/tracecat_ee/watchtower/service.py
+++ b/packages/tracecat-ee/tracecat_ee/watchtower/service.py
@@ -16,7 +16,7 @@ from tracecat import config
 from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import (
-    OrganizationMembership,
+    Membership,
     User,
     WatchtowerAgent,
     WatchtowerAgentSession,
@@ -605,8 +605,9 @@ async def _resolve_unambiguous_org(
         return workspace_org_id
 
     memberships_result = await session.execute(
-        select(OrganizationMembership.organization_id).where(
-            OrganizationMembership.user_id == user_id
+        select(Membership.organization_id).where(
+            Membership.user_id == user_id,
+            Membership.workspace_id.is_(None),
         )
     )
     organization_ids = set(memberships_result.scalars().all())

--- a/packages/tracecat-ee/tracecat_ee/watchtower/service.py
+++ b/packages/tracecat-ee/tracecat_ee/watchtower/service.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
 from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import (
     Membership,
@@ -606,8 +607,7 @@ async def _resolve_unambiguous_org(
 
     memberships_result = await session.execute(
         select(Membership.organization_id).where(
-            Membership.user_id == user_id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user_id),
         )
     )
     organization_ids = set(memberships_result.scalars().all())

--- a/tests/integration/test_install_and_run_custom_remote_registry_flow.py
+++ b/tests/integration/test_install_and_run_custom_remote_registry_flow.py
@@ -32,7 +32,6 @@ from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import (
     Organization,
-    OrganizationMembership,
     User,
     UserRoleAssignment,
 )
@@ -90,20 +89,6 @@ async def _ensure_test_user_access(
         user.is_active = True
         user.is_verified = True
         user.is_superuser = True
-
-        membership = await db_session.scalar(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == user.id,
-                OrganizationMembership.organization_id == organization_id,
-            )
-        )
-        if membership is None:
-            db_session.add(
-                OrganizationMembership(
-                    user_id=user.id,
-                    organization_id=organization_id,
-                )
-            )
 
         owner_role = await db_session.scalar(
             select(DBRole).where(

--- a/tests/membership.py
+++ b/tests/membership.py
@@ -1,0 +1,101 @@
+"""Helpers for granting membership in tests.
+
+Membership is derived from role assignments, so tests grant a role rather than
+insert a membership row.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.authz.seeding import seed_system_roles_for_org
+from tracecat.db.models import Role as DBRole
+from tracecat.db.models import UserRoleAssignment
+from tracecat.identifiers import OrganizationID, UserID, WorkspaceID
+
+
+async def _role_id(
+    session: AsyncSession, organization_id: OrganizationID, slug: str
+) -> uuid.UUID:
+    stmt = select(DBRole.id).where(
+        DBRole.organization_id == organization_id,
+        DBRole.slug == slug,
+    )
+    role_id = (await session.execute(stmt)).scalar_one_or_none()
+    if role_id is not None:
+        return role_id
+
+    # Seeding is idempotent but can collide with a fixture seeding in parallel.
+    try:
+        await seed_system_roles_for_org(session, organization_id)
+    except IntegrityError:
+        await session.rollback()
+    return (await session.execute(stmt)).scalar_one()
+
+
+async def grant_org_membership(
+    session: AsyncSession,
+    *,
+    user_id: UserID,
+    organization_id: OrganizationID,
+    slug: str = "organization-member",
+) -> None:
+    """Make a user an organization member by assigning an org-wide role.
+
+    Idempotent: a user may hold at most one org-wide assignment per org, so an
+    existing assignment is left in place.
+    """
+    role_id = await _role_id(session, organization_id, slug)
+    await session.execute(
+        pg_insert(UserRoleAssignment)
+        .values(
+            organization_id=organization_id,
+            user_id=user_id,
+            workspace_id=None,
+            role_id=role_id,
+        )
+        .on_conflict_do_nothing(
+            index_elements=[
+                UserRoleAssignment.organization_id,
+                UserRoleAssignment.user_id,
+            ],
+            index_where=UserRoleAssignment.workspace_id.is_(None),
+        )
+    )
+    await session.flush()
+
+
+async def grant_workspace_membership(
+    session: AsyncSession,
+    *,
+    user_id: UserID,
+    organization_id: OrganizationID,
+    workspace_id: WorkspaceID,
+    slug: str = "workspace-editor",
+) -> None:
+    """Make a user a workspace member by assigning a workspace-scoped role.
+
+    Idempotent: a user may hold at most one assignment per workspace.
+    """
+    role_id = await _role_id(session, organization_id, slug)
+    await session.execute(
+        pg_insert(UserRoleAssignment)
+        .values(
+            organization_id=organization_id,
+            user_id=user_id,
+            workspace_id=workspace_id,
+            role_id=role_id,
+        )
+        .on_conflict_do_nothing(
+            index_elements=[
+                UserRoleAssignment.user_id,
+                UserRoleAssignment.workspace_id,
+            ],
+        )
+    )
+    await session.flush()

--- a/tests/migration/test_membership_backfill_guard.py
+++ b/tests/migration/test_membership_backfill_guard.py
@@ -1,0 +1,203 @@
+"""Tests for the membership backfill guard in the RBAC-derived membership migration.
+
+The migration exposes ``backfill_assignments`` and ``assert_no_membership_dropped``
+as plain functions over a SQLAlchemy ``Connection`` so the guard can be exercised
+without running alembic end-to-end. The legacy ``membership`` and
+``organization_membership`` tables no longer exist in the model metadata, so each
+test recreates them for the duration of its own transaction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.authz.seeding import seed_system_roles_for_org
+from tracecat.db.models import Organization, User, Workspace
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "2bf069003a77_membership_derived_from_rbac_assignments.py"
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+CREATE_LEGACY_TABLES = (
+    """
+    CREATE TABLE IF NOT EXISTS membership (
+        user_id uuid NOT NULL,
+        workspace_id uuid NOT NULL,
+        PRIMARY KEY (user_id, workspace_id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS organization_membership (
+        user_id uuid NOT NULL,
+        organization_id uuid NOT NULL,
+        PRIMARY KEY (user_id, organization_id)
+    )
+    """,
+)
+
+DROP_LEGACY_TABLES = (
+    "DROP TABLE IF EXISTS membership",
+    "DROP TABLE IF EXISTS organization_membership",
+)
+
+
+@pytest.fixture
+def migration() -> Any:
+    """Import the migration module by file path; alembic versions aren't a package."""
+    module_name = "_membership_derived_migration_under_test"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(module_name, MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+async def legacy_tables(session: AsyncSession):
+    for statement in CREATE_LEGACY_TABLES:
+        await session.execute(sa.text(statement))
+    await session.commit()
+    yield
+    for statement in DROP_LEGACY_TABLES:
+        await session.execute(sa.text(statement))
+    await session.commit()
+
+
+@pytest.fixture
+async def org(session: AsyncSession) -> Organization:
+    organization = Organization(
+        id=uuid.uuid4(),
+        name="Membership Guard Org",
+        slug=f"guard-org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(organization)
+    await session.commit()
+    return organization
+
+
+@pytest.fixture
+async def workspace(session: AsyncSession, org: Organization) -> Workspace:
+    ws = Workspace(id=uuid.uuid4(), name="guard-workspace", organization_id=org.id)
+    session.add(ws)
+    await session.commit()
+    return ws
+
+
+@pytest.fixture
+async def user(session: AsyncSession) -> User:
+    account = User(
+        id=uuid.uuid4(),
+        email=f"guard-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(account)
+    await session.commit()
+    return account
+
+
+async def _run_sync(session: AsyncSession, fn, *args):
+    """Run a sync Connection-taking migration helper on the async session's bind."""
+    connection = await session.connection()
+    return await connection.run_sync(lambda conn: fn(conn, *args))
+
+
+@pytest.mark.anyio
+async def test_guard_passes_when_backfill_covers_every_membership(
+    session: AsyncSession,
+    migration: Any,
+    legacy_tables: None,
+    org: Organization,
+    workspace: Workspace,
+    user: User,
+) -> None:
+    """With system roles seeded, the backfill covers both memberships."""
+    await seed_system_roles_for_org(session, org.id)
+    await session.execute(
+        sa.text(
+            "INSERT INTO membership (user_id, workspace_id) VALUES (:u, :w)"
+        ).bindparams(u=user.id, w=workspace.id)
+    )
+    await session.execute(
+        sa.text(
+            "INSERT INTO organization_membership (user_id, organization_id) "
+            "VALUES (:u, :o)"
+        ).bindparams(u=user.id, o=org.id)
+    )
+    await session.commit()
+
+    workspace_count, org_count = await _run_sync(
+        session, migration.backfill_assignments
+    )
+    assert workspace_count >= 1
+    assert org_count >= 0
+
+    await _run_sync(session, migration.assert_no_membership_dropped)
+
+
+@pytest.mark.anyio
+async def test_guard_raises_when_org_lacks_system_roles(
+    session: AsyncSession,
+    migration: Any,
+    legacy_tables: None,
+    org: Organization,
+    workspace: Workspace,
+    user: User,
+) -> None:
+    """Without seeded system roles the backfill skips the rows and the guard fails."""
+    await session.execute(
+        sa.text(
+            "INSERT INTO membership (user_id, workspace_id) VALUES (:u, :w)"
+        ).bindparams(u=user.id, w=workspace.id)
+    )
+    await session.execute(
+        sa.text(
+            "INSERT INTO organization_membership (user_id, organization_id) "
+            "VALUES (:u, :o)"
+        ).bindparams(u=user.id, o=org.id)
+    )
+    await session.commit()
+
+    await _run_sync(session, migration.backfill_assignments)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await _run_sync(session, migration.assert_no_membership_dropped)
+
+    message = str(excinfo.value)
+    assert "1 workspace membership(s)" in message
+    assert "1 organization membership(s)" in message
+    assert str(org.id) in message
+
+
+@pytest.mark.anyio
+async def test_guard_sql_is_valid_against_the_legacy_schema(
+    session: AsyncSession, migration: Any, legacy_tables: None
+) -> None:
+    """The guard statements execute and return zero on an empty legacy schema."""
+    for statement in (
+        migration.UNCOVERED_WORKSPACE_MEMBERSHIPS,
+        migration.UNCOVERED_ORG_MEMBERSHIPS,
+    ):
+        row = (await session.execute(sa.text(statement))).one()
+        assert row.uncovered == 0
+        assert list(row.organization_ids) == []

--- a/tests/unit/api/test_api_organization_members.py
+++ b/tests/unit/api/test_api_organization_members.py
@@ -93,7 +93,9 @@ async def test_list_current_user_organization_memberships(
     compiled = stmt.compile()
     sql = str(compiled)
 
-    assert "organization_membership.user_id = " in sql
+    assert "membership.user_id = " in sql
+    # Org presence is the NULL-workspace row of derived membership.
+    assert "membership.workspace_id IS NULL" in sql
     assert "organization.is_active" in sql
     assert test_admin_role.user_id in compiled.params.values()
 

--- a/tests/unit/api/test_api_workspace_memberships.py
+++ b/tests/unit/api/test_api_workspace_memberships.py
@@ -1,0 +1,57 @@
+"""HTTP-level tests for the workspace membership removal route."""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.db.models import Workspace
+from tracecat.exceptions import GroupDerivedMembershipError
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.usefixtures("db", "test_admin_role"),
+]
+
+
+async def test_delete_membership_returns_409_for_group_derived_member(
+    client: TestClient, test_workspace: Workspace
+) -> None:
+    """A group-derived member's removal is refused with the machine-readable code."""
+    user_id = uuid.uuid4()
+    service = AsyncMock()
+    service.delete_membership.side_effect = GroupDerivedMembershipError(
+        "group derived", group_names=["engineering", "platform"]
+    )
+
+    with patch("tracecat.workspaces.router.MembershipService", return_value=service):
+        response = client.delete(
+            f"/workspaces/{test_workspace.id}/memberships/{user_id}"
+        )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["detail"] == {
+        "code": "group_derived_membership",
+        "group_names": ["engineering", "platform"],
+    }
+
+
+async def test_delete_membership_returns_204_for_direct_member(
+    client: TestClient, test_workspace: Workspace
+) -> None:
+    """A directly assigned member is removed and the route returns 204."""
+    user_id = uuid.uuid4()
+    service = AsyncMock()
+    service.delete_membership.return_value = None
+
+    with patch("tracecat.workspaces.router.MembershipService", return_value=service):
+        response = client.delete(
+            f"/workspaces/{test_workspace.id}/memberships/{user_id}"
+        )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    service.delete_membership.assert_awaited_once_with(
+        test_workspace.id, user_id=user_id
+    )

--- a/tests/unit/test_active_org_cookie.py
+++ b/tests/unit/test_active_org_cookie.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.membership import grant_org_membership
 from tracecat.auth.credentials import (
     ACTIVE_ORG_COOKIE,
     _resolve_org_for_regular_user,
@@ -15,7 +16,6 @@ from tracecat.auth.credentials import (
 from tracecat.auth.schemas import UserRole
 from tracecat.db.models import (
     Organization,
-    OrganizationMembership,
     User,
 )
 
@@ -64,10 +64,9 @@ async def _seed_org(
 async def _add_membership(
     session: AsyncSession, *, user_id: uuid.UUID, organization_id: uuid.UUID
 ) -> None:
-    session.add(
-        OrganizationMembership(user_id=user_id, organization_id=organization_id)
+    await grant_org_membership(
+        session, user_id=user_id, organization_id=organization_id
     )
-    await session.flush()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_admin_org_invitations_service.py
+++ b/tests/unit/test_admin_org_invitations_service.py
@@ -13,12 +13,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_ee.admin.organizations.schemas import AdminOrgInvitationCreate
 from tracecat_ee.admin.organizations.service import AdminOrgService
 
+from tests.membership import grant_org_membership
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import PlatformRole
 from tracecat.db.models import (
     Organization,
     OrganizationInvitation,
-    OrganizationMembership,
     User,
 )
 from tracecat.db.models import Role as DBRole
@@ -163,7 +163,7 @@ async def test_create_organization_invitation_rejects_existing_member(
     )
     session.add(member)
     await session.flush()
-    session.add(OrganizationMembership(user_id=member.id, organization_id=org.id))
+    await grant_org_membership(session, user_id=member.id, organization_id=org.id)
     await session.commit()
 
     service = AdminOrgService(session, platform_role)

--- a/tests/unit/test_admin_users_service.py
+++ b/tests/unit/test_admin_users_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Mapped
 from tracecat_ee.admin.users.schemas import AdminUserCreate
 from tracecat_ee.admin.users.service import AdminUserService
 
+from tests.membership import grant_org_membership, grant_workspace_membership
 from tracecat import config
 from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.service import AuditService
@@ -22,7 +23,6 @@ from tracecat.db.models import (
     AccessToken,
     Membership,
     Organization,
-    OrganizationMembership,
     User,
     UserRoleAssignment,
     Workspace,
@@ -74,8 +74,8 @@ async def test_create_user_creates_platform_user_without_memberships(
 
     org_membership_result = await session.execute(
         select(func.count())
-        .select_from(OrganizationMembership)
-        .where(OrganizationMembership.user_id == created.id)
+        .select_from(Membership)
+        .where(Membership.user_id == created.id, Membership.workspace_id.is_(None))
     )
     org_membership_count = org_membership_result.scalar_one()
     assert org_membership_count == 0
@@ -83,7 +83,10 @@ async def test_create_user_creates_platform_user_without_memberships(
     workspace_membership_result = await session.execute(
         select(func.count())
         .select_from(Membership)
-        .where(Membership.user_id == created.id)
+        .where(
+            Membership.user_id == created.id,
+            Membership.workspace_id.is_not(None),
+        )
     )
     workspace_membership_count = workspace_membership_result.scalar_one()
     assert workspace_membership_count == 0
@@ -181,8 +184,8 @@ async def test_create_user_provisions_default_org_in_single_tenant(
 
     membership_count = await session.scalar(
         select(func.count())
-        .select_from(OrganizationMembership)
-        .where(OrganizationMembership.user_id == created.id)
+        .select_from(Membership)
+        .where(Membership.user_id == created.id, Membership.workspace_id.is_(None))
     )
     role_slug = await session.scalar(
         select(DBRole.slug)
@@ -195,7 +198,10 @@ async def test_create_user_provisions_default_org_in_single_tenant(
     workspace_membership_count = await session.scalar(
         select(func.count())
         .select_from(Membership)
-        .where(Membership.user_id == created.id)
+        .where(
+            Membership.user_id == created.id,
+            Membership.workspace_id.is_not(None),
+        )
     )
 
     assert membership_count == 1
@@ -280,12 +286,13 @@ async def test_delete_user_clears_sessions_and_memberships(
     session.add(workspace)
     await session.flush()
     token = AccessToken(token=f"token-{uuid.uuid4().hex}", user_id=user.id)
-    session.add_all(
-        [
-            token,
-            OrganizationMembership(user_id=user.id, organization_id=org.id),
-            Membership(user_id=user.id, workspace_id=workspace.id),
-        ]
+    session.add(token)
+    await grant_org_membership(session, user_id=user.id, organization_id=org.id)
+    await grant_workspace_membership(
+        session,
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
     )
     await session.commit()
 
@@ -310,8 +317,9 @@ async def test_delete_user_clears_sessions_and_memberships(
     )
     assert (
         await session.scalar(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == user_id
+            select(Membership).where(
+                Membership.user_id == user_id,
+                Membership.workspace_id.is_(None),
             )
         )
         is None

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.membership import grant_org_membership, grant_workspace_membership
 from tracecat import config
 from tracecat.auth.credentials import (
     RoleACL,
@@ -28,7 +29,6 @@ from tracecat.contexts import ctx_agent_session_id, ctx_role
 from tracecat.db.models import (
     Membership,
     Organization,
-    OrganizationMembership,
     User,
     Workspace,
 )
@@ -936,7 +936,7 @@ async def test_cache_size_limit(monkeypatch: pytest.MonkeyPatch):
 async def test_organization_id_populated_when_require_workspace_no(
     mocker, monkeypatch: pytest.MonkeyPatch
 ):
-    """Test that organization_id is inferred from OrganizationMembership when require_workspace="no"."""
+    """Test that organization_id is inferred from membership when require_workspace="no"."""
 
     monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
 
@@ -953,11 +953,11 @@ async def test_organization_id_populated_when_require_workspace_no(
     # The code does: org_ids = org_membership_result.scalars().all()
     mock_session = AsyncMock()
 
-    # First call: OrganizationMembership query returns the org_id
+    # First call: membership query returns the org_id
     org_result = MagicMock()
     org_result.scalars.return_value.all.return_value = [test_org_id]
 
-    # Second call: OrganizationMembership lookup for org_role returns None
+    # Second call: membership lookup for org_role returns None
     org_role_result = MagicMock()
     org_role_result.scalar_one_or_none.return_value = None
 
@@ -979,7 +979,7 @@ async def test_organization_id_populated_when_require_workspace_no(
     request.state = MagicMock()
     request.state.auth_cache = None
 
-    # Test with require_workspace="no" - organization_id should be inferred from OrganizationMembership
+    # Test with require_workspace="no" - organization_id should be inferred from membership
     role = await _role_dependency(
         request=request,
         session=mock_session,
@@ -991,7 +991,7 @@ async def test_organization_id_populated_when_require_workspace_no(
         require_workspace="no",
     )
 
-    # Verify organization_id was inferred from the user's OrganizationMembership
+    # Verify organization_id was inferred from the user's membership
     assert role.organization_id == test_org_id
     assert role.workspace_id is None
     assert role.user_id == mock_user.id
@@ -1029,16 +1029,14 @@ async def test_role_dependency_infers_org_from_single_membership(
     session.add_all([org, user, workspace])
     await session.commit()
 
-    membership = Membership(
-        user_id=user.id,
-        workspace_id=workspace.id,
-    )
-    # Also create organization membership - required for org context resolution
-    org_membership = OrganizationMembership(
+    # Org membership is required for org context resolution.
+    await grant_org_membership(session, user_id=user.id, organization_id=org.id)
+    await grant_workspace_membership(
+        session,
         user_id=user.id,
         organization_id=org.id,
+        workspace_id=workspace.id,
     )
-    session.add_all([membership, org_membership])
     await session.commit()
 
     request = MagicMock(spec=Request)
@@ -1111,22 +1109,14 @@ async def test_role_dependency_uses_stable_org_for_multi_org_without_workspace(
     session.add_all([org_a, org_b, user, workspace_a, workspace_b])
     await session.commit()
 
-    memberships = [
-        Membership(
+    for org, workspace in ((org_a, workspace_a), (org_b, workspace_b)):
+        await grant_org_membership(session, user_id=user.id, organization_id=org.id)
+        await grant_workspace_membership(
+            session,
             user_id=user.id,
-            workspace_id=workspace_a.id,
-        ),
-        Membership(
-            user_id=user.id,
-            workspace_id=workspace_b.id,
-        ),
-    ]
-    # Also create organization memberships for both orgs
-    org_memberships = [
-        OrganizationMembership(user_id=user.id, organization_id=org_a.id),
-        OrganizationMembership(user_id=user.id, organization_id=org_b.id),
-    ]
-    session.add_all(memberships + org_memberships)
+            organization_id=org.id,
+            workspace_id=workspace.id,
+        )
     await session.commit()
 
     request = MagicMock(spec=Request)

--- a/tests/unit/test_authz_grant_resolver.py
+++ b/tests/unit/test_authz_grant_resolver.py
@@ -14,6 +14,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.membership import grant_org_membership
 from tracecat.auth.types import Role
 from tracecat.authz.seeding import seed_system_scopes
 from tracecat.authz.service import resolve_grantable_role
@@ -22,7 +23,6 @@ from tracecat.db.models import (
     GroupMember,
     GroupRoleAssignment,
     Organization,
-    OrganizationMembership,
     RoleScope,
     Scope,
     User,
@@ -60,7 +60,7 @@ async def granter_user(session: AsyncSession, org: Organization) -> User:
     )
     session.add(user)
     await session.flush()
-    session.add(OrganizationMembership(user_id=user.id, organization_id=org.id))
+    await grant_org_membership(session, user_id=user.id, organization_id=org.id)
     await session.commit()
     return user
 
@@ -107,14 +107,31 @@ async def _assign(
     role: DBRole,
     workspace_id: uuid.UUID | None = None,
 ) -> None:
-    session.add(
-        UserRoleAssignment(
-            organization_id=org.id,
-            user_id=user.id,
-            workspace_id=workspace_id,
-            role_id=role.id,
+    # A user holds at most one assignment per scope, and the membership
+    # fixture already granted an org-wide one, so replace the role in place.
+    existing = (
+        await session.execute(
+            select(UserRoleAssignment).where(
+                UserRoleAssignment.organization_id == org.id,
+                UserRoleAssignment.user_id == user.id,
+                UserRoleAssignment.workspace_id == workspace_id
+                if workspace_id is not None
+                else UserRoleAssignment.workspace_id.is_(None),
+            )
         )
-    )
+    ).scalar_one_or_none()
+
+    if existing is not None:
+        existing.role_id = role.id
+    else:
+        session.add(
+            UserRoleAssignment(
+                organization_id=org.id,
+                user_id=user.id,
+                workspace_id=workspace_id,
+                role_id=role.id,
+            )
+        )
     await session.commit()
 
 

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -12,6 +12,9 @@ from tracecat.authz.scopes import ADMIN_SCOPES, EDITOR_SCOPES
 from tracecat.authz.seeding import seed_system_scopes
 from tracecat.authz.service import MembershipService
 from tracecat.db.models import (
+    Group,
+    GroupMember,
+    GroupRoleAssignment,
     Membership,
     Organization,
     RoleScope,
@@ -21,7 +24,10 @@ from tracecat.db.models import (
     Workspace,
 )
 from tracecat.db.models import Role as DBRole
-from tracecat.exceptions import TracecatAuthorizationError
+from tracecat.exceptions import (
+    GroupDerivedMembershipError,
+    TracecatAuthorizationError,
+)
 from tracecat.workspaces.schemas import WorkspaceMembershipCreate
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("db")]
@@ -426,3 +432,141 @@ async def test_create_membership_allows_admin_inviter(
         )
     ).scalar_one_or_none()
     assert membership is not None
+
+
+@pytest.fixture
+async def granting_group(
+    session: AsyncSession,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    workspace_editor_role: DBRole,
+) -> Group:
+    """A group that grants member_user access to the workspace."""
+    group = Group(
+        id=uuid.uuid4(),
+        name=f"engineering-{uuid.uuid4().hex[:8]}",
+        organization_id=organization.id,
+    )
+    session.add(group)
+    await session.flush()
+    session.add(GroupMember(group_id=group.id, user_id=member_user.id))
+    session.add(
+        GroupRoleAssignment(
+            organization_id=organization.id,
+            group_id=group.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    await session.commit()
+    await session.refresh(group)
+    return group
+
+
+async def test_delete_membership_rejects_group_derived_member(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    workspace: Workspace,
+    member_user: User,
+    granting_group: Group,
+) -> None:
+    """A member whose access is only group-derived cannot be removed directly."""
+    with pytest.raises(GroupDerivedMembershipError) as excinfo:
+        await membership_service.delete_membership(
+            workspace_id=workspace.id,
+            user_id=member_user.id,
+        )
+
+    assert excinfo.value.group_names == [granting_group.name]
+    assert excinfo.value.detail == {
+        "code": "group_derived_membership",
+        "group_names": [granting_group.name],
+    }
+
+    # The preflight must not have mutated anything: the member is still there.
+    membership = await session.scalar(
+        select(Membership).where(
+            Membership.workspace_id == workspace.id,
+            Membership.user_id == member_user.id,
+        )
+    )
+    assert membership is not None
+
+
+async def test_delete_membership_removes_direct_assignment_despite_group(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+    granting_group: Group,
+) -> None:
+    """A direct assignment is deleted even when a group also grants access."""
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+            assigned_by=actor_user.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.delete_membership(
+        workspace_id=workspace.id,
+        user_id=member_user.id,
+    )
+
+    assignment = await session.scalar(
+        select(UserRoleAssignment).where(
+            UserRoleAssignment.workspace_id == workspace.id,
+            UserRoleAssignment.user_id == member_user.id,
+        )
+    )
+    assert assignment is None
+
+
+async def test_list_workspace_members_reports_direct_source(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """A directly assigned member reports source kind 'direct'."""
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+            assigned_by=actor_user.id,
+        )
+    )
+    await session.commit()
+
+    members = await membership_service.list_workspace_members(workspace.id)
+
+    member = next(m for m in members if m.user_id == member_user.id)
+    assert member.source.kind == "direct"
+    assert member.source.group_names == []
+
+
+async def test_list_workspace_members_reports_group_source(
+    membership_service: MembershipService,
+    workspace: Workspace,
+    member_user: User,
+    granting_group: Group,
+) -> None:
+    """A group-derived member reports the granting group names."""
+    members = await membership_service.list_workspace_members(workspace.id)
+
+    member = next(m for m in members if m.user_id == member_user.id)
+    assert member.source.kind == "group"
+    assert member.source.group_names == [granting_group.name]

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -4,7 +4,6 @@ import uuid
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.schemas import UserRole
@@ -143,12 +142,6 @@ async def test_delete_membership_removes_membership_and_assignment(
 ) -> None:
     """Deleting membership should also delete workspace direct role assignment."""
     session.add(
-        Membership(
-            user_id=member_user.id,
-            workspace_id=workspace.id,
-        )
-    )
-    session.add(
         UserRoleAssignment(
             organization_id=organization.id,
             user_id=member_user.id,
@@ -266,28 +259,40 @@ async def test_create_membership_heals_stale_workspace_assignment(
     assert assignment_list[0].assigned_by == actor_user.id
 
 
-async def test_create_membership_duplicate_raises_integrity_error(
+async def test_create_membership_is_idempotent(
     session: AsyncSession,
     membership_service: MembershipService,
+    organization: Organization,
     workspace: Workspace,
     member_user: User,
     workspace_editor_role: DBRole,
 ) -> None:
-    """Creating an existing membership should raise an integrity conflict."""
+    """Re-adding an existing member replaces the assignment rather than failing."""
     assert workspace_editor_role.slug == "workspace-editor"
     session.add(
-        Membership(
+        UserRoleAssignment(
+            organization_id=organization.id,
             user_id=member_user.id,
             workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
         )
     )
     await session.commit()
 
-    with pytest.raises(IntegrityError):
-        await membership_service.create_membership(
-            workspace_id=workspace.id,
-            params=WorkspaceMembershipCreate(user_id=member_user.id),
+    await membership_service.create_membership(
+        workspace_id=workspace.id,
+        params=WorkspaceMembershipCreate(user_id=member_user.id),
+    )
+
+    assignments = (
+        await session.execute(
+            select(UserRoleAssignment).where(
+                UserRoleAssignment.workspace_id == workspace.id,
+                UserRoleAssignment.user_id == member_user.id,
+            )
         )
+    ).scalars()
+    assert len(list(assignments)) == 1
 
 
 @pytest.fixture

--- a/tests/unit/test_mcp_personal_access_tokens_service.py
+++ b/tests/unit/test_mcp_personal_access_tokens_service.py
@@ -10,15 +10,14 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import tracecat.mcp.personal_access_tokens.service as mcp_pat_service
+from tests.membership import grant_org_membership, grant_workspace_membership
 from tracecat.auth.api_keys import generate_managed_api_key
 from tracecat.auth.credentials import _authenticate_api_key
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
 from tracecat.db.models import (
     MCPPersonalAccessToken,
-    Membership,
     Organization,
-    OrganizationMembership,
     User,
     Workspace,
 )
@@ -63,14 +62,16 @@ async def _create_user_org_workspace(
     await session.flush()
 
     if org_membership:
-        session.add(
-            OrganizationMembership(
-                user_id=user.id,
-                organization_id=organization.id,
-            )
+        await grant_org_membership(
+            session, user_id=user.id, organization_id=organization.id
         )
     if workspace_membership:
-        session.add(Membership(user_id=user.id, workspace_id=workspace.id))
+        await grant_workspace_membership(
+            session,
+            user_id=user.id,
+            organization_id=organization.id,
+            workspace_id=workspace.id,
+        )
     await session.commit()
     return user, organization, workspace
 

--- a/tests/unit/test_membership.py
+++ b/tests/unit/test_membership.py
@@ -1,0 +1,333 @@
+"""Tests for membership derived from RBAC role assignments.
+
+Membership is a SQLAlchemy subquery over user and group role assignments. A
+NULL workspace_id is organization presence; a non-NULL value is workspace
+presence. Org-wide roles never produce workspace rows.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.membership import grant_org_membership, grant_workspace_membership
+from tracecat.auth.schemas import UserRole
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import ORG_ADMIN_SCOPES
+from tracecat.authz.seeding import seed_system_roles_for_org
+from tracecat.db.models import (
+    Group,
+    GroupMember,
+    GroupRoleAssignment,
+    Membership,
+    Organization,
+    User,
+    UserRoleAssignment,
+    Workspace,
+)
+from tracecat.db.models import Role as DBRole
+from tracecat.organization.service import OrgService
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+async def org(session: AsyncSession) -> Organization:
+    org_id = uuid.uuid4()
+    org = Organization(
+        id=org_id,
+        name="Membership Org",
+        slug=f"membership-{org_id.hex[:8]}",
+    )
+    session.add(org)
+    await session.flush()
+    await seed_system_roles_for_org(session, org.id)
+    await session.commit()
+    return org
+
+
+@pytest.fixture
+async def workspace(session: AsyncSession, org: Organization) -> Workspace:
+    workspace = Workspace(id=uuid.uuid4(), name="Workspace One", organization_id=org.id)
+    session.add(workspace)
+    await session.commit()
+    return workspace
+
+
+@pytest.fixture
+async def other_workspace(session: AsyncSession, org: Organization) -> Workspace:
+    workspace = Workspace(id=uuid.uuid4(), name="Workspace Two", organization_id=org.id)
+    session.add(workspace)
+    await session.commit()
+    return workspace
+
+
+async def _make_user(session: AsyncSession) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"member-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.BASIC,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _membership_rows(
+    session: AsyncSession, user_id: uuid.UUID
+) -> list[Membership]:
+    result = await session.execute(
+        select(Membership).where(Membership.user_id == user_id)
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.anyio
+async def test_org_wide_role_grants_org_membership_only(
+    session: AsyncSession, org: Organization, workspace: Workspace
+) -> None:
+    """An org-wide role makes the user an org member but not a workspace member."""
+    user = await _make_user(session)
+    await grant_org_membership(session, user_id=user.id, organization_id=org.id)
+    await session.commit()
+
+    rows = await _membership_rows(session, user.id)
+
+    assert len(rows) == 1
+    assert rows[0].organization_id == org.id
+    assert rows[0].workspace_id is None
+
+
+@pytest.mark.anyio
+async def test_workspace_scoped_role_grants_workspace_and_org_membership(
+    session: AsyncSession, org: Organization, workspace: Workspace
+) -> None:
+    """A workspace-scoped role yields both an org row and a workspace row."""
+    user = await _make_user(session)
+    await grant_workspace_membership(
+        session,
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+    )
+    await session.commit()
+
+    rows = await _membership_rows(session, user.id)
+
+    assert {row.workspace_id for row in rows} == {None, workspace.id}
+    assert {row.organization_id for row in rows} == {org.id}
+
+
+@pytest.mark.anyio
+async def test_group_workspace_assignment_grants_membership_to_group_members(
+    session: AsyncSession, org: Organization, workspace: Workspace
+) -> None:
+    """Group members inherit workspace membership, and lose it when it is revoked."""
+    user = await _make_user(session)
+    group = Group(id=uuid.uuid4(), name="Engineering", organization_id=org.id)
+    session.add(group)
+    await session.flush()
+    session.add(GroupMember(user_id=user.id, group_id=group.id))
+
+    editor_role_id = (
+        await session.execute(
+            select(DBRole.id).where(
+                DBRole.organization_id == org.id,
+                DBRole.slug == "workspace-editor",
+            )
+        )
+    ).scalar_one()
+    assignment = GroupRoleAssignment(
+        organization_id=org.id,
+        group_id=group.id,
+        workspace_id=workspace.id,
+        role_id=editor_role_id,
+    )
+    session.add(assignment)
+    await session.commit()
+
+    rows = await _membership_rows(session, user.id)
+    assert {row.workspace_id for row in rows} == {None, workspace.id}
+
+    # Revoking the group's assignment delists every group member.
+    await session.execute(
+        delete(GroupRoleAssignment).where(GroupRoleAssignment.id == assignment.id)
+    )
+    await session.commit()
+
+    assert await _membership_rows(session, user.id) == []
+
+
+@pytest.mark.anyio
+async def test_deleting_last_assignment_removes_org_membership(
+    session: AsyncSession, org: Organization, workspace: Workspace
+) -> None:
+    """Membership disappears once the user's last assignment is gone."""
+    user = await _make_user(session)
+    await grant_workspace_membership(
+        session,
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+    )
+    await session.commit()
+    assert await _membership_rows(session, user.id)
+
+    await session.execute(
+        delete(UserRoleAssignment).where(UserRoleAssignment.user_id == user.id)
+    )
+    await session.commit()
+
+    assert await _membership_rows(session, user.id) == []
+
+
+@pytest.mark.anyio
+async def test_org_and_workspace_assignments_do_not_duplicate_org_row(
+    session: AsyncSession, org: Organization, workspace: Workspace
+) -> None:
+    """A user holding both assignment kinds still has exactly one org row."""
+    user = await _make_user(session)
+    await grant_org_membership(session, user_id=user.id, organization_id=org.id)
+    await grant_workspace_membership(
+        session,
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+    )
+    await session.commit()
+
+    rows = await _membership_rows(session, user.id)
+
+    assert len([row for row in rows if row.workspace_id is None]) == 1
+    assert len(rows) == 2
+
+
+@pytest.mark.anyio
+async def test_user_in_two_workspaces_has_single_org_row(
+    session: AsyncSession,
+    org: Organization,
+    workspace: Workspace,
+    other_workspace: Workspace,
+) -> None:
+    """Membership in two workspaces still collapses to one org-presence row."""
+    user = await _make_user(session)
+    for ws in (workspace, other_workspace):
+        await grant_workspace_membership(
+            session,
+            user_id=user.id,
+            organization_id=org.id,
+            workspace_id=ws.id,
+        )
+    await session.commit()
+
+    rows = await _membership_rows(session, user.id)
+
+    assert len(rows) == 3
+    assert [row.workspace_id for row in rows].count(None) == 1
+    assert {row.workspace_id for row in rows if row.workspace_id is not None} == {
+        workspace.id,
+        other_workspace.id,
+    }
+
+
+@pytest.mark.anyio
+async def test_org_members_list_returns_user_once_for_two_workspace_roles(
+    session: AsyncSession,
+    org: Organization,
+    workspace: Workspace,
+    other_workspace: Workspace,
+) -> None:
+    user = await _make_user(session)
+    for ws in (workspace, other_workspace):
+        await grant_workspace_membership(
+            session,
+            user_id=user.id,
+            organization_id=org.id,
+            workspace_id=ws.id,
+        )
+    await session.commit()
+
+    service = OrgService(
+        session,
+        role=Role(
+            type="user",
+            user_id=user.id,
+            organization_id=org.id,
+            service_id="tracecat-api",
+            scopes=ORG_ADMIN_SCOPES,
+        ),
+    )
+
+    members = await service.list_members()
+
+    assert [member.id for member in members] == [user.id]
+
+
+@pytest.mark.anyio
+async def test_membership_rows_are_scoped_to_their_own_organization(
+    session: AsyncSession, org: Organization, workspace: Workspace
+) -> None:
+    """An assignment in one org never produces membership rows for another."""
+    other_org = Organization(
+        id=uuid.uuid4(),
+        name="Other Org",
+        slug=f"other-org-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(other_org)
+    await session.flush()
+    await seed_system_roles_for_org(session, other_org.id)
+
+    user = await _make_user(session)
+    await grant_workspace_membership(
+        session,
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+    )
+    await session.commit()
+
+    rows = await _membership_rows(session, user.id)
+
+    assert {row.organization_id for row in rows} == {org.id}
+
+
+@pytest.mark.anyio
+async def test_group_org_wide_assignment_grants_org_membership_only(
+    session: AsyncSession, org: Organization, workspace: Workspace
+) -> None:
+    """An org-wide group role gives members org presence but no workspace row."""
+    user = await _make_user(session)
+    group = Group(id=uuid.uuid4(), name="Org Wide", organization_id=org.id)
+    session.add(group)
+    await session.flush()
+    session.add(GroupMember(user_id=user.id, group_id=group.id))
+
+    role_id = (
+        await session.execute(
+            select(DBRole.id).where(
+                DBRole.organization_id == org.id,
+                DBRole.slug == "organization-member",
+            )
+        )
+    ).scalar_one()
+    session.add(
+        GroupRoleAssignment(
+            organization_id=org.id,
+            group_id=group.id,
+            workspace_id=None,
+            role_id=role_id,
+        )
+    )
+    await session.commit()
+
+    rows = await _membership_rows(session, user.id)
+
+    assert len(rows) == 1
+    assert rows[0].workspace_id is None

--- a/tests/unit/test_org_enrollment_policy.py
+++ b/tests/unit/test_org_enrollment_policy.py
@@ -13,12 +13,13 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.membership import grant_org_membership
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.users import UserManager
 from tracecat.authz.seeding import seed_system_roles_for_org
 from tracecat.db.models import (
+    Membership,
     Organization,
-    OrganizationMembership,
     User,
     UserRoleAssignment,
 )
@@ -79,10 +80,15 @@ async def _assert_not_enrolled(
     user_id: uuid.UUID,
     organization_id: uuid.UUID,
 ) -> None:
-    membership = await session.get(
-        OrganizationMembership,
-        {"user_id": user_id, "organization_id": organization_id},
-    )
+    membership = (
+        await session.execute(
+            select(Membership).where(
+                Membership.user_id == user_id,
+                Membership.organization_id == organization_id,
+                Membership.workspace_id.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
     assert membership is None, "account was enrolled into the organization"
     assert (
         await _org_role_assignment_count(
@@ -175,8 +181,7 @@ async def test_existing_member_is_still_repaired(
     org = await _create_org_with_roles(session)
     user = await _create_user(session)
 
-    session.add(OrganizationMembership(user_id=user.id, organization_id=org.id))
-    await session.flush()
+    await grant_org_membership(session, user_id=user.id, organization_id=org.id)
 
     result = await ensure_single_tenant_user_defaults_for_session(
         session=session,
@@ -214,8 +219,13 @@ async def test_superuser_bootstrap_still_enrolls(
     await session.flush()
 
     assert result.organization_id == org.id
-    membership = await session.get(
-        OrganizationMembership,
-        {"user_id": user.id, "organization_id": org.id},
-    )
+    membership = (
+        await session.execute(
+            select(Membership).where(
+                Membership.user_id == user.id,
+                Membership.organization_id == org.id,
+                Membership.workspace_id.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
     assert membership is not None

--- a/tests/unit/test_organization_membership.py
+++ b/tests/unit/test_organization_membership.py
@@ -1,4 +1,4 @@
-"""Tests for OrganizationMembership model and related functionality."""
+"""Tests for derived membership and related functionality."""
 
 import uuid
 
@@ -6,22 +6,23 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.membership import grant_org_membership
 from tracecat.auth.credentials import get_role_from_user
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
 from tracecat.db.models import (
+    Membership,
     Organization,
-    OrganizationMembership,
     User,
 )
 
 
 class TestOrganizationMembershipModel:
-    """Tests for the OrganizationMembership model."""
+    """Tests for organization membership derived from role assignments."""
 
     @pytest.mark.anyio
     async def test_create_organization_membership(self, session: AsyncSession):
-        """Test creating an OrganizationMembership record."""
+        """An org-wide role assignment makes the user an organization member."""
         # Create organization
         org = Organization(
             id=uuid.uuid4(),
@@ -45,25 +46,21 @@ class TestOrganizationMembershipModel:
         await session.flush()
 
         # Create organization membership
-        membership = OrganizationMembership(
-            user_id=user.id,
-            organization_id=org.id,
-        )
-        session.add(membership)
+        await grant_org_membership(session, user_id=user.id, organization_id=org.id)
         await session.commit()
 
         # Verify membership was created
         result = await session.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == user.id,
-                OrganizationMembership.organization_id == org.id,
+            select(Membership).where(
+                Membership.user_id == user.id,
+                Membership.organization_id == org.id,
+                Membership.workspace_id.is_(None),
             )
         )
         fetched = result.scalar_one()
         assert fetched.user_id == user.id
         assert fetched.organization_id == org.id
-        assert fetched.created_at is not None
-        assert fetched.updated_at is not None
+        assert fetched.workspace_id is None
 
     @pytest.mark.anyio
     async def test_organization_membership_with_admin_user(self, session: AsyncSession):
@@ -88,16 +85,13 @@ class TestOrganizationMembershipModel:
         session.add(user)
         await session.flush()
 
-        membership = OrganizationMembership(
-            user_id=user.id,
-            organization_id=org.id,
-        )
-        session.add(membership)
+        await grant_org_membership(session, user_id=user.id, organization_id=org.id)
         await session.commit()
 
         result = await session.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == user.id,
+            select(Membership).where(
+                Membership.user_id == user.id,
+                Membership.workspace_id.is_(None),
             )
         )
         fetched = result.scalar_one()
@@ -130,11 +124,7 @@ class TestOrganizationMembershipModel:
         await session.flush()
         user_id = user.id
 
-        membership = OrganizationMembership(
-            user_id=user.id,
-            organization_id=org.id,
-        )
-        session.add(membership)
+        await grant_org_membership(session, user_id=user.id, organization_id=org.id)
         await session.commit()
 
         # Delete user
@@ -143,8 +133,8 @@ class TestOrganizationMembershipModel:
 
         # Verify membership was also deleted
         result = await session.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == user_id,
+            select(Membership).where(
+                Membership.user_id == user_id,
             )
         )
         assert result.scalar_one_or_none() is None
@@ -175,11 +165,7 @@ class TestOrganizationMembershipModel:
         session.add(user)
         await session.flush()
 
-        membership = OrganizationMembership(
-            user_id=user.id,
-            organization_id=org.id,
-        )
-        session.add(membership)
+        await grant_org_membership(session, user_id=user.id, organization_id=org.id)
         await session.commit()
 
         # Delete organization
@@ -188,8 +174,8 @@ class TestOrganizationMembershipModel:
 
         # Verify membership was also deleted
         result = await session.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.organization_id == org_id,
+            select(Membership).where(
+                Membership.organization_id == org_id,
             )
         )
         assert result.scalar_one_or_none() is None
@@ -223,21 +209,15 @@ class TestOrganizationMembershipModel:
         session.add(user)
         await session.flush()
 
-        membership1 = OrganizationMembership(
-            user_id=user.id,
-            organization_id=org1.id,
-        )
-        membership2 = OrganizationMembership(
-            user_id=user.id,
-            organization_id=org2.id,
-        )
-        session.add_all([membership1, membership2])
+        await grant_org_membership(session, user_id=user.id, organization_id=org1.id)
+        await grant_org_membership(session, user_id=user.id, organization_id=org2.id)
         await session.commit()
 
         # Verify both memberships exist
         result = await session.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == user.id,
+            select(Membership).where(
+                Membership.user_id == user.id,
+                Membership.workspace_id.is_(None),
             )
         )
         memberships = result.scalars().all()
@@ -342,106 +322,3 @@ class TestGetRoleFromUser:
         )
 
         assert role.is_platform_superuser is False
-
-
-class TestOrganizationMembershipRelationships:
-    """Tests for User and Organization relationships via OrganizationMembership."""
-
-    @pytest.mark.anyio
-    async def test_user_organizations_relationship(self, session: AsyncSession):
-        """Test User.organizations relationship returns correct organizations."""
-        org1 = Organization(
-            id=uuid.uuid4(),
-            name="Rel Org 1",
-            slug=f"rel-org1-{uuid.uuid4().hex[:8]}",
-            is_active=True,
-        )
-        org2 = Organization(
-            id=uuid.uuid4(),
-            name="Rel Org 2",
-            slug=f"rel-org2-{uuid.uuid4().hex[:8]}",
-            is_active=True,
-        )
-        session.add_all([org1, org2])
-
-        user = User(
-            id=uuid.uuid4(),
-            email=f"rel-user-{uuid.uuid4().hex[:8]}@example.com",
-            hashed_password="hashed",
-            role=UserRole.BASIC,
-            is_active=True,
-            is_superuser=False,
-            is_verified=True,
-        )
-        session.add(user)
-        await session.flush()
-
-        membership1 = OrganizationMembership(
-            user_id=user.id,
-            organization_id=org1.id,
-        )
-        membership2 = OrganizationMembership(
-            user_id=user.id,
-            organization_id=org2.id,
-        )
-        session.add_all([membership1, membership2])
-        await session.commit()
-
-        # Refresh user to load relationship
-        await session.refresh(user, ["organizations"])
-
-        # Verify relationship
-        assert len(user.organizations) == 2
-        org_ids = {org.id for org in user.organizations}
-        assert org_ids == {org1.id, org2.id}
-
-    @pytest.mark.anyio
-    async def test_organization_members_relationship(self, session: AsyncSession):
-        """Test Organization.members relationship returns correct users."""
-        org = Organization(
-            id=uuid.uuid4(),
-            name="Members Org",
-            slug=f"members-org-{uuid.uuid4().hex[:8]}",
-            is_active=True,
-        )
-        session.add(org)
-
-        user1 = User(
-            id=uuid.uuid4(),
-            email=f"member1-{uuid.uuid4().hex[:8]}@example.com",
-            hashed_password="hashed",
-            role=UserRole.BASIC,
-            is_active=True,
-            is_superuser=False,
-            is_verified=True,
-        )
-        user2 = User(
-            id=uuid.uuid4(),
-            email=f"member2-{uuid.uuid4().hex[:8]}@example.com",
-            hashed_password="hashed",
-            role=UserRole.ADMIN,
-            is_active=True,
-            is_superuser=False,
-            is_verified=True,
-        )
-        session.add_all([user1, user2])
-        await session.flush()
-
-        membership1 = OrganizationMembership(
-            user_id=user1.id,
-            organization_id=org.id,
-        )
-        membership2 = OrganizationMembership(
-            user_id=user2.id,
-            organization_id=org.id,
-        )
-        session.add_all([membership1, membership2])
-        await session.commit()
-
-        # Refresh org to load relationship
-        await session.refresh(org, ["members"])
-
-        # Verify relationship
-        assert len(org.members) == 2
-        user_ids = {u.id for u in org.members}
-        assert user_ids == {user1.id, user2.id}

--- a/tests/unit/test_organization_service.py
+++ b/tests/unit/test_organization_service.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.membership import grant_org_membership
 from tracecat import config
 from tracecat.auth.api_keys import ORG_API_KEY_PREFIX, generate_managed_api_key
 from tracecat.auth.schemas import UserRole
@@ -25,7 +26,6 @@ from tracecat.db.models import (
     Membership,
     Organization,
     OrganizationInvitation,
-    OrganizationMembership,
     RoleScope,
     Scope,
     ServiceAccount,
@@ -92,11 +92,7 @@ async def user_in_org1(session: AsyncSession, org1: Organization) -> User:
     session.add(user)
     await session.flush()
 
-    membership = OrganizationMembership(
-        user_id=user.id,
-        organization_id=org1.id,
-    )
-    session.add(membership)
+    await grant_org_membership(session, user_id=user.id, organization_id=org1.id)
     await session.commit()
     return user
 
@@ -121,12 +117,7 @@ async def admin_in_org1(session: AsyncSession, org1: Organization) -> User:
     session.add(user)
     await session.flush()
 
-    membership = OrganizationMembership(
-        user_id=user.id,
-        organization_id=org1.id,
-    )
-    session.add(membership)
-
+    # The org-wide admin assignment below is what makes this user a member.
     await seed_system_scopes(session)
     admin_db_role = DBRole(
         id=uuid.uuid4(),
@@ -168,11 +159,7 @@ async def user_in_org2(session: AsyncSession, org2: Organization) -> User:
     session.add(user)
     await session.flush()
 
-    membership = OrganizationMembership(
-        user_id=user.id,
-        organization_id=org2.id,
-    )
-    session.add(membership)
+    await grant_org_membership(session, user_id=user.id, organization_id=org2.id)
     await session.commit()
     return user
 
@@ -204,6 +191,16 @@ def create_superuser_role(organization_id: uuid.UUID, user_id: uuid.UUID) -> Rol
 @pytest.fixture
 async def org1_member_role(session: AsyncSession, org1: Organization) -> DBRole:
     """Create an RBAC 'organization-member' role for org1."""
+    existing = (
+        await session.execute(
+            select(DBRole).where(
+                DBRole.organization_id == org1.id,
+                DBRole.slug == "organization-member",
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
     role = DBRole(
         id=uuid.uuid4(),
         name="Organization Member",
@@ -219,6 +216,16 @@ async def org1_member_role(session: AsyncSession, org1: Organization) -> DBRole:
 @pytest.fixture
 async def org1_admin_role(session: AsyncSession, org1: Organization) -> DBRole:
     """Create an RBAC 'organization-admin' role for org1."""
+    existing = (
+        await session.execute(
+            select(DBRole).where(
+                DBRole.organization_id == org1.id,
+                DBRole.slug == "organization-admin",
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
     role = DBRole(
         id=uuid.uuid4(),
         name="Organization Admin",
@@ -400,9 +407,10 @@ class TestOrganizationServiceDeleteMember:
         )
         assert (
             await session.scalar(
-                select(OrganizationMembership).where(
-                    OrganizationMembership.user_id == user_id,
-                    OrganizationMembership.organization_id == org1.id,
+                select(Membership).where(
+                    Membership.user_id == user_id,
+                    Membership.organization_id == org1.id,
+                    Membership.workspace_id.is_(None),
                 )
             )
             is None
@@ -424,10 +432,6 @@ class TestOrganizationServiceDeleteMember:
             name="Organization Member",
             slug="organization-member",
             description="Default member role",
-            organization_id=org2.id,
-        )
-        org2_membership = OrganizationMembership(
-            user_id=user_in_org1.id,
             organization_id=org2.id,
         )
         workspace_org1 = Workspace(
@@ -453,7 +457,6 @@ class TestOrganizationServiceDeleteMember:
         session.add_all(
             [
                 org2_member_role,
-                org2_membership,
                 workspace_org1,
                 workspace_org2,
                 group_org1,
@@ -461,18 +464,20 @@ class TestOrganizationServiceDeleteMember:
             ]
         )
         await session.flush()
+        # Use the org2 member role created above rather than seeding a new one.
+        session.add(
+            UserRoleAssignment(
+                organization_id=org2.id,
+                user_id=user_in_org1.id,
+                workspace_id=None,
+                role_id=org2_member_role.id,
+            )
+        )
+        await session.flush()
 
         token = AccessToken(
             token=f"token-{uuid.uuid4().hex}",
             user_id=user_in_org1.id,
-        )
-        org1_workspace_membership = Membership(
-            user_id=user_in_org1.id,
-            workspace_id=workspace_org1.id,
-        )
-        org2_workspace_membership = Membership(
-            user_id=user_in_org1.id,
-            workspace_id=workspace_org2.id,
         )
         org1_role_assignment = UserRoleAssignment(
             organization_id=org1.id,
@@ -499,8 +504,6 @@ class TestOrganizationServiceDeleteMember:
         session.add_all(
             [
                 token,
-                org1_workspace_membership,
-                org2_workspace_membership,
                 org1_role_assignment,
                 org2_role_assignment,
                 org1_group_member,
@@ -529,18 +532,20 @@ class TestOrganizationServiceDeleteMember:
         )
         assert (
             await session.scalar(
-                select(OrganizationMembership).where(
-                    OrganizationMembership.user_id == user_id,
-                    OrganizationMembership.organization_id == org1.id,
+                select(Membership).where(
+                    Membership.user_id == user_id,
+                    Membership.organization_id == org1.id,
+                    Membership.workspace_id.is_(None),
                 )
             )
             is None
         )
         assert (
             await session.scalar(
-                select(OrganizationMembership).where(
-                    OrganizationMembership.user_id == user_id,
-                    OrganizationMembership.organization_id == org2.id,
+                select(Membership).where(
+                    Membership.user_id == user_id,
+                    Membership.organization_id == org2.id,
+                    Membership.workspace_id.is_(None),
                 )
             )
             is not None
@@ -637,11 +642,9 @@ class TestOrganizationServiceDeleteMember:
         session.add(superuser)
         await session.flush()
 
-        membership = OrganizationMembership(
-            user_id=superuser.id,
-            organization_id=org1.id,
+        await grant_org_membership(
+            session, user_id=superuser.id, organization_id=org1.id
         )
-        session.add(membership)
         role = create_admin_role(org1.id, admin_in_org1.id)
         service = OrgService(session, role=role)
 
@@ -702,8 +705,9 @@ class TestOrganizationServiceDeleteOrganization:
             select(Organization).where(Organization.id == org1.id)
         )
         membership_result = await session.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.organization_id == org1.id
+            select(Membership).where(
+                Membership.organization_id == org1.id,
+                Membership.workspace_id.is_(None),
             )
         )
         assert org_result.scalar_one_or_none() is None
@@ -988,7 +992,7 @@ class TestOrganizationServiceAddMember:
         org1: Organization,
         admin_in_org1: User,
     ):
-        """Test add_member creates an OrganizationMembership record."""
+        """Test add_member makes the user an organization member."""
         # Create a new user not yet in the org
         new_user = User(
             id=uuid.uuid4(),

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_ee.rbac.service import RBACService
 
+from tests.membership import grant_workspace_membership
 from tracecat.auth.types import Role
 from tracecat.authz.enums import ScopeSource
 from tracecat.authz.scopes import ORG_ADMIN_SCOPES
@@ -18,7 +19,6 @@ from tracecat.db.models import (
     GroupMember,
     GroupRoleAssignment,
     Organization,
-    OrganizationMembership,
     RoleScope,
     Scope,
     User,
@@ -55,12 +55,21 @@ async def user(session: AsyncSession, org: Organization) -> User:
     session.add(user)
     await session.flush()
 
-    # Add org membership
-    membership = OrganizationMembership(
-        user_id=user.id,
+    # Grant membership through a workspace-scoped role so the single org-wide
+    # assignment slot stays free for tests that create one.
+    membership_workspace = Workspace(
+        id=uuid.uuid4(),
+        name="Membership Workspace",
         organization_id=org.id,
     )
-    session.add(membership)
+    session.add(membership_workspace)
+    await session.flush()
+    await grant_workspace_membership(
+        session,
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=membership_workspace.id,
+    )
     await session.commit()
     await session.refresh(user)
     return user
@@ -142,8 +151,8 @@ async def role(
     )
     session.add(admin_user)
     await session.flush()
-    session.add(OrganizationMembership(user_id=admin_user.id, organization_id=org.id))
 
+    # The org-wide assignment below is what makes this user an org member.
     admin_role = DBRole(
         name="Test Org Admin",
         slug=None,
@@ -743,11 +752,19 @@ class TestRBACServiceUserAssignments:
         )
         session.add(other_org)
         await session.flush()
-        session.add(
-            OrganizationMembership(
-                user_id=user.id,
-                organization_id=other_org.id,
-            )
+        # Workspace-scoped grant keeps the org-wide slot free for the assertion.
+        other_workspace = Workspace(
+            id=uuid.uuid4(),
+            name="Other Org Workspace",
+            organization_id=other_org.id,
+        )
+        session.add(other_workspace)
+        await session.flush()
+        await grant_workspace_membership(
+            session,
+            user_id=user.id,
+            organization_id=other_org.id,
+            workspace_id=other_workspace.id,
         )
         await session.commit()
 

--- a/tests/unit/test_single_tenant_user_defaults.py
+++ b/tests/unit/test_single_tenant_user_defaults.py
@@ -14,8 +14,8 @@ from tracecat.auth.schemas import UserRole
 from tracecat.authz.seeding import seed_system_roles_for_org
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import (
+    Membership,
     Organization,
-    OrganizationMembership,
     User,
     UserRoleAssignment,
 )
@@ -128,10 +128,15 @@ async def test_single_tenant_defaults_for_session_resolves_default_org(
 
     assert result.organization_id is not None
     assert result.changed is True
-    membership = await session.get(
-        OrganizationMembership,
-        {"user_id": user.id, "organization_id": result.organization_id},
-    )
+    membership = (
+        await session.execute(
+            select(Membership).where(
+                Membership.user_id == user.id,
+                Membership.organization_id == result.organization_id,
+                Membership.workspace_id.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
     assert membership is not None
 
 
@@ -151,10 +156,15 @@ async def test_single_tenant_defaults_assign_member_role(
     )
     await session.flush()
 
-    membership = await session.get(
-        OrganizationMembership,
-        {"user_id": user.id, "organization_id": org.id},
-    )
+    membership = (
+        await session.execute(
+            select(Membership).where(
+                Membership.user_id == user.id,
+                Membership.organization_id == org.id,
+                Membership.workspace_id.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
     assert membership is not None
     assert (
         await _get_org_role_assignment_slug(
@@ -206,9 +216,10 @@ async def test_single_tenant_defaults_are_idempotent(
     await session.flush()
 
     membership_count = await session.scalar(
-        select(OrganizationMembership).where(
-            OrganizationMembership.user_id == user.id,
-            OrganizationMembership.organization_id == org.id,
+        select(Membership).where(
+            Membership.user_id == user.id,
+            Membership.organization_id == org.id,
+            Membership.workspace_id.is_(None),
         )
     )
     assignment_result = await session.execute(
@@ -269,10 +280,11 @@ async def test_single_tenant_defaults_handle_concurrent_repairs() -> None:
         async with get_async_session_bypass_rls_context_manager() as verify_session:
             membership_count = await verify_session.scalar(
                 select(func.count())
-                .select_from(OrganizationMembership)
+                .select_from(Membership)
                 .where(
-                    OrganizationMembership.user_id == user_id,
-                    OrganizationMembership.organization_id == org_id,
+                    Membership.user_id == user_id,
+                    Membership.organization_id == org_id,
+                    Membership.workspace_id.is_(None),
                 )
             )
             assignment_count = await verify_session.scalar(
@@ -293,11 +305,6 @@ async def test_single_tenant_defaults_handle_concurrent_repairs() -> None:
                 delete(UserRoleAssignment).where(UserRoleAssignment.user_id == user_id)
             )
             await cleanup_session.execute(
-                delete(OrganizationMembership).where(
-                    OrganizationMembership.user_id == user_id
-                )
-            )
-            await cleanup_session.execute(
                 delete(User).where(cast(Mapped[uuid.UUID], User.id) == user_id)
             )
             await cleanup_session.execute(
@@ -314,7 +321,6 @@ async def test_single_tenant_defaults_keep_existing_role_after_repair(
 ) -> None:
     org = await _create_org_with_roles(session)
     user = await _create_user(session)
-    session.add(OrganizationMembership(user_id=user.id, organization_id=org.id))
     owner_role = (
         await session.execute(
             select(DBRole).where(
@@ -352,9 +358,14 @@ async def test_single_tenant_defaults_keep_existing_role_after_repair(
 
 
 @pytest.mark.anyio
-async def test_single_tenant_defaults_normalize_existing_role_during_repair(
+async def test_single_tenant_defaults_keep_owner_role_for_regular_user(
     session: AsyncSession,
 ) -> None:
+    """An org-wide assignment is self-sufficient, so no repair demotes it.
+
+    Membership is derived from the assignment, so the pre-view state this used
+    to normalize (owner assignment with no membership row) cannot occur.
+    """
     org = await _create_org_with_roles(session)
     user = await _create_user(session)
     owner_role = (
@@ -384,18 +395,23 @@ async def test_single_tenant_defaults_normalize_existing_role_during_repair(
     )
     await session.flush()
 
-    membership = await session.get(
-        OrganizationMembership,
-        {"user_id": user.id, "organization_id": org.id},
-    )
+    membership = (
+        await session.execute(
+            select(Membership).where(
+                Membership.user_id == user.id,
+                Membership.organization_id == org.id,
+                Membership.workspace_id.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
     assert membership is not None
     assert (
         await _get_org_role_assignment_slug(
             session, user_id=user.id, organization_id=org.id
         )
-        == "organization-member"
+        == "organization-owner"
     )
-    assert changed is True
+    assert changed is False
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_tenant_rls_registry.py
+++ b/tests/unit/test_tenant_rls_registry.py
@@ -12,14 +12,15 @@ from tracecat.cases.service import CaseFieldsService
 from tracecat.db.models import Base, Membership
 from tracecat.db.tenant_rls import (
     ALL_TENANT_RLS_TABLES,
+    ASSIGNMENT_SPLIT_POLICY_TABLES,
     ORG_OPTIONAL_WORKSPACE_POLICY_TABLES,
     ORG_POLICY_TABLES,
-    RECLASSIFIED_TO_ORG_SCOPED_TABLES,
     SPECIAL_ORG_POLICY_TABLES,
     SPECIAL_TENANT_POLICY_TABLES,
     SPECIAL_WORKSPACE_POLICY_TABLES,
     WORKSPACE_POLICY_TABLES,
     enable_agent_tag_link_table_rls,
+    enable_assignment_split_table_rls,
 )
 from tracecat.tables.service import TablesService
 
@@ -60,9 +61,9 @@ def test_all_workspace_keyed_models_are_registered_for_tenant_rls() -> None:
         WORKSPACE_POLICY_TABLES
         | ORG_OPTIONAL_WORKSPACE_POLICY_TABLES
         | SPECIAL_WORKSPACE_POLICY_TABLES
-        # Assignments are org-owned; the org clause alone isolates tenants and
-        # keeps other-workspace rows visible to org-presence reads.
-        | frozenset(RECLASSIFIED_TO_ORG_SCOPED_TABLES)
+        # Assignments carry a split policy: workspace-scoped writes plus an
+        # additive org-wide read for org-presence queries.
+        | frozenset(ASSIGNMENT_SPLIT_POLICY_TABLES)
     )
 
     missing_workspace_coverage = workspace_keyed_tables - covered_workspace_tables
@@ -79,6 +80,7 @@ def test_all_org_keyed_models_are_registered_for_tenant_rls() -> None:
         ORG_POLICY_TABLES
         | ORG_OPTIONAL_WORKSPACE_POLICY_TABLES
         | SPECIAL_ORG_POLICY_TABLES
+        | frozenset(ASSIGNMENT_SPLIT_POLICY_TABLES)
     )
 
     missing_org_coverage = org_keyed_tables - covered_org_tables
@@ -104,10 +106,30 @@ def test_membership_selectable_is_not_registered_for_tenant_rls() -> None:
     assert not isinstance(Membership.__table__, Table)
 
 
-def test_assignment_tables_use_plain_org_policy() -> None:
-    for table in RECLASSIFIED_TO_ORG_SCOPED_TABLES:
-        assert table in ORG_POLICY_TABLES
+def test_assignment_tables_use_split_policy() -> None:
+    for table in ASSIGNMENT_SPLIT_POLICY_TABLES:
+        assert table in SPECIAL_TENANT_POLICY_TABLES
+        assert table not in ORG_POLICY_TABLES
         assert table not in ORG_OPTIONAL_WORKSPACE_POLICY_TABLES
+
+
+def test_assignment_split_policy_keeps_writes_workspace_scoped() -> None:
+    for table in ASSIGNMENT_SPLIT_POLICY_TABLES:
+        policy_sql = enable_assignment_split_table_rls(table)
+
+        assert f'ALTER TABLE "{table}" ENABLE ROW LEVEL SECURITY' in policy_sql
+        assert f"CREATE POLICY rls_policy_{table} ON" in policy_sql
+        assert f"CREATE POLICY rls_policy_{table}_org_read ON" in policy_sql
+        assert "FOR SELECT" in policy_sql
+        # The FOR ALL policy must still pin writes to the session workspace.
+        for_all_policy = policy_sql.split("FOR SELECT")[0]
+        assert for_all_policy.count("WITH CHECK") == 1
+        assert for_all_policy.count("app.current_workspace_id") == 4
+        # The additive read policy is org-only, with the bypass clause.
+        org_read_policy = policy_sql.split("_org_read")[1]
+        assert "app.current_workspace_id" not in org_read_policy
+        assert "app.rls_bypass" in org_read_policy
+        assert "WITH CHECK" not in org_read_policy
 
 
 def test_agent_tag_link_is_registered_for_tenant_rls() -> None:

--- a/tests/unit/test_tenant_rls_registry.py
+++ b/tests/unit/test_tenant_rls_registry.py
@@ -5,14 +5,16 @@ from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy import Table
 
 from tracecat.auth.types import Role
 from tracecat.cases.service import CaseFieldsService
-from tracecat.db.models import Base
+from tracecat.db.models import Base, Membership
 from tracecat.db.tenant_rls import (
     ALL_TENANT_RLS_TABLES,
     ORG_OPTIONAL_WORKSPACE_POLICY_TABLES,
     ORG_POLICY_TABLES,
+    RECLASSIFIED_TO_ORG_SCOPED_TABLES,
     SPECIAL_ORG_POLICY_TABLES,
     SPECIAL_TENANT_POLICY_TABLES,
     SPECIAL_WORKSPACE_POLICY_TABLES,
@@ -31,7 +33,10 @@ def workflow_bucket() -> Iterator[None]:
 def _mapped_table_names() -> set[str]:
     table_names: set[str] = set()
     for mapper in Base.registry.mappers:
-        table_name = getattr(mapper.local_table, "name", None)
+        local_table = mapper.local_table
+        if not isinstance(local_table, Table):
+            continue
+        table_name = local_table.name
         if isinstance(table_name, str):
             table_names.add(table_name)
     return table_names
@@ -41,6 +46,8 @@ def _mapped_table_names_with_column(column_name: str) -> set[str]:
     table_names: set[str] = set()
     for mapper in Base.registry.mappers:
         local_table = mapper.local_table
+        if not isinstance(local_table, Table):
+            continue
         table_name = getattr(local_table, "name", None)
         if isinstance(table_name, str) and column_name in local_table.columns:
             table_names.add(table_name)
@@ -53,6 +60,9 @@ def test_all_workspace_keyed_models_are_registered_for_tenant_rls() -> None:
         WORKSPACE_POLICY_TABLES
         | ORG_OPTIONAL_WORKSPACE_POLICY_TABLES
         | SPECIAL_WORKSPACE_POLICY_TABLES
+        # Assignments are org-owned; the org clause alone isolates tenants and
+        # keeps other-workspace rows visible to org-presence reads.
+        | frozenset(RECLASSIFIED_TO_ORG_SCOPED_TABLES)
     )
 
     missing_workspace_coverage = workspace_keyed_tables - covered_workspace_tables
@@ -87,6 +97,17 @@ def test_tenant_rls_registry_contains_only_mapped_tables() -> None:
         "Tenant RLS registry contains tables that are not mapped in SQLAlchemy: "
         f"{sorted(stale_registry_entries)}"
     )
+
+
+def test_membership_selectable_is_not_registered_for_tenant_rls() -> None:
+    assert "membership" not in ALL_TENANT_RLS_TABLES
+    assert not isinstance(Membership.__table__, Table)
+
+
+def test_assignment_tables_use_plain_org_policy() -> None:
+    for table in RECLASSIFIED_TO_ORG_SCOPED_TABLES:
+        assert table in ORG_POLICY_TABLES
+        assert table not in ORG_OPTIONAL_WORKSPACE_POLICY_TABLES
 
 
 def test_agent_tag_link_is_registered_for_tenant_rls() -> None:

--- a/tests/unit/test_user_manager_auth_policy.py
+++ b/tests/unit/test_user_manager_auth_policy.py
@@ -12,6 +12,7 @@ from fastapi_users.db import SQLAlchemyUserDatabase
 from fastapi_users.password import PasswordHelper
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.membership import grant_org_membership
 from tracecat import config
 from tracecat.api.common import bootstrap_role
 from tracecat.auth.enums import AuthType
@@ -20,7 +21,6 @@ from tracecat.db.models import (
     OAuthAccount,
     Organization,
     OrganizationDomain,
-    OrganizationMembership,
     User,
 )
 from tracecat.organization.domains import normalize_domain
@@ -84,11 +84,8 @@ async def _create_user_with_org_membership(
     session.add(user)
     await session.flush()
 
-    session.add(
-        OrganizationMembership(
-            user_id=user.id,
-            organization_id=organization.id,
-        )
+    await grant_org_membership(
+        session, user_id=user.id, organization_id=organization.id
     )
 
     normalized_domain = normalize_domain(email.rpartition("@")[2])
@@ -133,11 +130,8 @@ async def _add_org_membership(
     session.add(organization)
     await session.flush()
 
-    session.add(
-        OrganizationMembership(
-            user_id=user.id,
-            organization_id=organization.id,
-        )
+    await grant_org_membership(
+        session, user_id=user.id, organization_id=organization.id
     )
 
     normalized_domain = normalize_domain(domain)

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -8,6 +8,7 @@ from pydantic import TypeAdapter
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.membership import grant_org_membership, grant_workspace_membership
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import ADMIN_SCOPES
@@ -15,7 +16,6 @@ from tracecat.authz.seeding import seed_system_scopes
 from tracecat.db.models import (
     Membership,
     Organization,
-    OrganizationMembership,
     RoleScope,
     Scope,
     User,
@@ -130,11 +130,11 @@ class TestWorkspaceService:
         session.add_all([workspace, other_workspace, member])
         await session.flush()
 
-        session.add(
-            Membership(
-                user_id=member.id,
-                workspace_id=workspace.id,
-            )
+        await grant_workspace_membership(
+            session,
+            user_id=member.id,
+            organization_id=svc_organization.id,
+            workspace_id=workspace.id,
         )
         await session.commit()
 
@@ -565,6 +565,17 @@ async def rbac_roles(session: AsyncSession, inv_org: Organization) -> dict[str, 
         ("workspace-admin", "Workspace Admin"),
         ("workspace-viewer", "Workspace Viewer"),
     ]:
+        existing = (
+            await session.execute(
+                select(DBRole).where(
+                    DBRole.organization_id == inv_org.id,
+                    DBRole.slug == slug,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            roles[slug] = str(existing.id)
+            continue
         role = DBRole(
             id=uuid.uuid4(),
             name=name,
@@ -606,11 +617,7 @@ async def admin_user(session: AsyncSession, inv_org: Organization) -> User:
     session.add(user)
     await session.flush()
 
-    membership = OrganizationMembership(
-        user_id=user.id,
-        organization_id=inv_org.id,
-    )
-    session.add(membership)
+    await grant_org_membership(session, user_id=user.id, organization_id=inv_org.id)
     await session.commit()
     return user
 
@@ -630,11 +637,7 @@ async def basic_user(session: AsyncSession, inv_org: Organization) -> User:
     session.add(user)
     await session.flush()
 
-    membership = OrganizationMembership(
-        user_id=user.id,
-        organization_id=inv_org.id,
-    )
-    session.add(membership)
+    await grant_org_membership(session, user_id=user.id, organization_id=inv_org.id)
     await session.commit()
     return user
 
@@ -1015,9 +1018,10 @@ class TestAcceptInvitation:
 
         # Verify org membership was created
         result = await session.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == external_user.id,
-                OrganizationMembership.organization_id == inv_org.id,
+            select(Membership).where(
+                Membership.user_id == external_user.id,
+                Membership.organization_id == inv_org.id,
+                Membership.workspace_id.is_(None),
             )
         )
         org_membership = result.scalar_one()
@@ -1112,11 +1116,12 @@ class TestAcceptInvitation:
     ):
         """Test accepting invitation when user is already a workspace member fails."""
         # Add basic_user to workspace
-        ws_membership = Membership(
+        await grant_workspace_membership(
+            session,
             user_id=basic_user.id,
+            organization_id=inv_org.id,
             workspace_id=inv_workspace.id,
         )
-        session.add(ws_membership)
         await session.commit()
 
         role = create_workspace_admin_role(inv_org.id, inv_workspace.id, admin_user.id)

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -50,8 +50,8 @@ from tracecat.contexts import ctx_agent_session_id, ctx_role
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.engine import AuthSession, get_async_session_auth_context_manager
 from tracecat.db.models import (
+    Membership,
     Organization,
-    OrganizationMembership,
     ServiceAccount,
     ServiceAccountApiKey,
     User,
@@ -609,14 +609,15 @@ async def _resolve_org_for_regular_user(
             cookie_org_id = None
         if cookie_org_id is not None:
             membership_stmt = (
-                select(OrganizationMembership.organization_id)
+                select(Membership.organization_id)
                 .join(
                     Organization,
-                    Organization.id == OrganizationMembership.organization_id,
+                    Organization.id == Membership.organization_id,
                 )
                 .where(
-                    OrganizationMembership.user_id == user.id,
-                    OrganizationMembership.organization_id == cookie_org_id,
+                    Membership.user_id == user.id,
+                    Membership.organization_id == cookie_org_id,
+                    Membership.workspace_id.is_(None),
                     Organization.is_active.is_(True),
                 )
             )
@@ -627,10 +628,11 @@ async def _resolve_org_for_regular_user(
                 return cookie_org_id
 
     org_mem_stmt = (
-        select(OrganizationMembership.organization_id)
-        .join(Organization, Organization.id == OrganizationMembership.organization_id)
+        select(Membership.organization_id)
+        .join(Organization, Organization.id == Membership.organization_id)
         .where(
-            OrganizationMembership.user_id == user.id,
+            Membership.user_id == user.id,
+            Membership.workspace_id.is_(None),
             Organization.is_active.is_(True),
         )
         .order_by(Organization.created_at.asc(), Organization.id.asc())

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -44,6 +44,7 @@ from tracecat.auth.users import (
     optional_current_active_user,
 )
 from tracecat.authz.controls import has_scope
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.authz.service import MembershipService, MembershipWithOrg
 from tracecat.contexts import ctx_agent_session_id, ctx_role
@@ -615,9 +616,7 @@ async def _resolve_org_for_regular_user(
                     Organization.id == Membership.organization_id,
                 )
                 .where(
-                    Membership.user_id == user.id,
-                    Membership.organization_id == cookie_org_id,
-                    Membership.workspace_id.is_(None),
+                    org_membership_predicate(user.id, cookie_org_id),
                     Organization.is_active.is_(True),
                 )
             )
@@ -631,8 +630,7 @@ async def _resolve_org_for_regular_user(
         select(Membership.organization_id)
         .join(Organization, Organization.id == Membership.organization_id)
         .where(
-            Membership.user_id == user.id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user.id),
             Organization.is_active.is_(True),
         )
         .order_by(Organization.created_at.asc(), Organization.id.asc())

--- a/tracecat/auth/saml.py
+++ b/tracecat/auth/saml.py
@@ -83,9 +83,9 @@ from tracecat.config import (
 )
 from tracecat.db.dependencies import AsyncDBSession, AsyncDBSessionBypass
 from tracecat.db.models import (
+    Membership,
     OrganizationDomain,
     OrganizationInvitation,
-    OrganizationMembership,
     SAMLRequestData,
     User,
 )
@@ -954,9 +954,10 @@ async def sso_acs(
             )
 
     # Ensure user can access this organization.
-    membership_stmt = select(OrganizationMembership).where(
-        OrganizationMembership.user_id == user.id,  # pyright: ignore[reportArgumentType]
-        OrganizationMembership.organization_id == organization_id,
+    membership_stmt = select(Membership).where(
+        Membership.user_id == user.id,  # pyright: ignore[reportArgumentType]
+        Membership.organization_id == organization_id,
+        Membership.workspace_id.is_(None),
     )
     existing_membership = (
         await db_session.execute(membership_stmt)

--- a/tracecat/auth/saml.py
+++ b/tracecat/auth/saml.py
@@ -66,6 +66,7 @@ from tracecat.auth.users import (
     UserManagerDep,
     auth_backend,
 )
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.config import (
     SAML_ACCEPTED_TIME_DIFF,
     SAML_ALLOW_UNSOLICITED,
@@ -955,9 +956,7 @@ async def sso_acs(
 
     # Ensure user can access this organization.
     membership_stmt = select(Membership).where(
-        Membership.user_id == user.id,  # pyright: ignore[reportArgumentType]
-        Membership.organization_id == organization_id,
-        Membership.workspace_id.is_(None),
+        org_membership_predicate(user.id, organization_id),
     )
     existing_membership = (
         await db_session.execute(membership_stmt)

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -52,9 +52,9 @@ from tracecat.db.engine import (
 )
 from tracecat.db.models import (
     AccessToken,
+    Membership,
     OAuthAccount,
     OrganizationDomain,
-    OrganizationMembership,
     User,
 )
 from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
@@ -191,8 +191,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         return not await self._any_org_saml_enforced(org_ids)
 
     async def _list_user_org_ids(self, user_id: uuid.UUID) -> set[OrganizationID]:
-        statement = select(OrganizationMembership.organization_id).where(
-            OrganizationMembership.user_id == user_id
+        statement = select(Membership.organization_id).where(
+            Membership.user_id == user_id,
+            Membership.workspace_id.is_(None),
         )
         async with get_async_session_auth_context_manager() as session:
             result = await session.execute(statement)

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -43,6 +43,7 @@ from tracecat.auth.enums import AuthType
 from tracecat.auth.schemas import UserCreate, UserUpdate
 from tracecat.auth.secrets import get_user_auth_secret
 from tracecat.auth.types import PlatformRole, Role
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import (
     SupportsExecute,
@@ -192,8 +193,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
     async def _list_user_org_ids(self, user_id: uuid.UUID) -> set[OrganizationID]:
         statement = select(Membership.organization_id).where(
-            Membership.user_id == user_id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user_id),
         )
         async with get_async_session_auth_context_manager() as session:
             result = await session.execute(statement)

--- a/tracecat/authz/membership.py
+++ b/tracecat/authz/membership.py
@@ -1,0 +1,34 @@
+"""Shared predicates over the derived ``Membership`` selectable.
+
+``Membership`` is a read-only union over RBAC role assignments, so a row with a
+NULL ``workspace_id`` means org-wide presence rather than workspace access.
+That distinction is easy to drop, so the predicate lives here instead of being
+rewritten at each call site.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import and_
+from sqlalchemy.sql.elements import ColumnElement
+
+from tracecat.db.models import Membership
+
+
+def org_membership_predicate(
+    user_id: ColumnElement[object] | object | None = None,
+    organization_id: ColumnElement[object] | object | None = None,
+) -> ColumnElement[bool]:
+    """Predicate matching a user's org-wide presence rows.
+
+    Both operands accept a literal value or a column expression, so the same
+    helper serves ``WHERE`` clauses and outer-join ``ON`` clauses that correlate
+    with ``User.id``. Omit either argument to leave that side unconstrained: no
+    ``user_id`` lists an organization's members, and no ``organization_id``
+    lists a user's organizations.
+    """
+    clauses: list[ColumnElement[bool]] = [Membership.workspace_id.is_(None)]
+    if user_id is not None:
+        clauses.insert(0, Membership.user_id == user_id)
+    if organization_id is not None:
+        clauses.insert(-1, Membership.organization_id == organization_id)
+    return and_(*clauses)

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -263,7 +263,10 @@ class MembershipService(BaseService):
 
         This is used by the authorization middleware to cache user permissions.
         """
-        statement = select(Membership).where(Membership.user_id == user_id)
+        statement = select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.workspace_id.is_not(None),
+        )
         result = await self.session.execute(statement)
         return result.scalars().all()
 
@@ -320,11 +323,6 @@ class MembershipService(BaseService):
             )
         )
 
-        membership = Membership(
-            user_id=params.user_id,
-            workspace_id=workspace_id,
-        )
-        self.session.add(membership)
         self.session.add(
             UserRoleAssignment(
                 organization_id=organization_id,
@@ -345,12 +343,8 @@ class MembershipService(BaseService):
         Note: The authorization cache is request-scoped, so changes will be
         reflected in subsequent requests automatically.
         """
-        await self.session.execute(
-            delete(Membership).where(
-                Membership.workspace_id == workspace_id,
-                Membership.user_id == user_id,
-            )
-        )
+        # Membership is derived, so deleting the workspace-scoped assignments
+        # delists the user. Group-derived access needs a group change instead.
         await self.session.execute(
             delete(UserRoleAssignment).where(
                 UserRoleAssignment.workspace_id == workspace_id,

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -14,6 +14,7 @@ from tracecat.authz.controls import ensure_can_grant_scopes, require_scope
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import SupportsExecute
 from tracecat.db.models import (
+    Group,
     GroupMember,
     GroupRoleAssignment,
     Membership,
@@ -25,6 +26,7 @@ from tracecat.db.models import (
 )
 from tracecat.db.models import Role as DBRole
 from tracecat.exceptions import (
+    GroupDerivedMembershipError,
     TracecatAuthorizationError,
     TracecatNotFoundError,
     TracecatValidationError,
@@ -34,6 +36,7 @@ from tracecat.service import BaseService
 from tracecat.workspaces.schemas import (
     WorkspaceMember,
     WorkspaceMembershipCreate,
+    WorkspaceMemberSource,
 )
 
 
@@ -212,6 +215,7 @@ class MembershipService(BaseService):
                 func.coalesce(DBRole.name, literal("Workspace Editor")).label(
                     "role_name"
                 ),
+                UserRoleAssignment.id.is_not(None).label("is_direct"),
             )
             .select_from(Membership)
             .join(User, Membership.user_id == User.id)  # pyright: ignore[reportArgumentType]
@@ -228,6 +232,22 @@ class MembershipService(BaseService):
             .where(Membership.workspace_id == workspace_id)
         )
         rows = (await self.session.execute(statement)).all()
+
+        # One extra query for group provenance rather than an N+1 per member.
+        group_statement = (
+            select(GroupMember.user_id, Group.name)
+            .join(Group, Group.id == GroupMember.group_id)
+            .join(GroupRoleAssignment, GroupRoleAssignment.group_id == Group.id)
+            .where(GroupRoleAssignment.workspace_id == workspace_id)
+            .distinct()
+            .order_by(GroupMember.user_id, Group.name)
+        )
+        groups_by_user: dict[UUID, list[str]] = {}
+        for member_user_id, group_name in (
+            await self.session.execute(group_statement)
+        ).all():
+            groups_by_user.setdefault(member_user_id, []).append(group_name)
+
         return [
             WorkspaceMember(
                 user_id=user.id,
@@ -235,8 +255,13 @@ class MembershipService(BaseService):
                 last_name=user.last_name,
                 email=user.email,
                 role_name=role_name,
+                source=WorkspaceMemberSource(kind="direct")
+                if is_direct
+                else WorkspaceMemberSource(
+                    kind="group", group_names=groups_by_user.get(user.id, [])
+                ),
             )
-            for user, role_name in rows
+            for user, role_name, is_direct in rows
         ]
 
     async def get_membership(
@@ -344,7 +369,27 @@ class MembershipService(BaseService):
         reflected in subsequent requests automatically.
         """
         # Membership is derived, so deleting the workspace-scoped assignments
-        # delists the user. Group-derived access needs a group change instead.
+        # delists the user. Group-derived access survives the delete, so refuse
+        # rather than return success without removing the member.
+        has_direct = (
+            await self.session.execute(
+                select(literal(1)).where(
+                    UserRoleAssignment.workspace_id == workspace_id,
+                    UserRoleAssignment.user_id == user_id,
+                )
+            )
+        ).first() is not None
+        if not has_direct:
+            group_names = await self.list_membership_group_names(
+                workspace_id, user_id=user_id
+            )
+            if group_names:
+                raise GroupDerivedMembershipError(
+                    "This member's workspace access comes from group membership. "
+                    "Remove them from the granting group instead.",
+                    group_names=group_names,
+                )
+
         await self.session.execute(
             delete(UserRoleAssignment).where(
                 UserRoleAssignment.workspace_id == workspace_id,
@@ -352,3 +397,20 @@ class MembershipService(BaseService):
             )
         )
         await self.session.commit()
+
+    async def list_membership_group_names(
+        self, workspace_id: WorkspaceID, user_id: UserID
+    ) -> list[str]:
+        """Names of the groups granting a user access to a workspace."""
+        statement = (
+            select(Group.name)
+            .join(GroupRoleAssignment, GroupRoleAssignment.group_id == Group.id)
+            .join(GroupMember, GroupMember.group_id == Group.id)
+            .where(
+                GroupMember.user_id == user_id,
+                GroupRoleAssignment.workspace_id == workspace_id,
+            )
+            .distinct()
+            .order_by(Group.name)
+        )
+        return list((await self.session.execute(statement)).scalars().all())

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -31,10 +31,15 @@ from sqlalchemy import (
     MetaData,
     PrimaryKeyConstraint,
     String,
+    Subquery,
     Text,
     UniqueConstraint,
     func,
+    null,
+    select,
     text,
+    union,
+    union_all,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -234,12 +239,6 @@ class Organization(Base, TimestampMixin):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
 
     # Relationships
-    members: Mapped[list[User]] = relationship(
-        "User",
-        secondary="organization_membership",
-        back_populates="organizations",
-        lazy="select",
-    )
     organization_tier: Mapped[OrganizationTier | None] = relationship(
         "OrganizationTier",
         back_populates="organization",
@@ -360,49 +359,6 @@ class OAuthAccount(SQLAlchemyBaseOAuthAccountTableUUID, Base):
     user: Mapped[User] = relationship(back_populates="oauth_accounts")
 
 
-class Membership(Base):
-    """Link table for users and workspaces (many to many)."""
-
-    __tablename__ = "membership"
-    __table_args__ = (
-        Index("ix_membership_workspace_id", "workspace_id"),
-        Index("ix_membership_workspace_user", "workspace_id", "user_id"),
-    )
-
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        ForeignKey("user.id"),
-        primary_key=True,
-    )
-    workspace_id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        ForeignKey("workspace.id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-
-
-class OrganizationMembership(Base, TimestampMixin):
-    """Link table for users and organizations (many to many)."""
-
-    __tablename__ = "organization_membership"
-    __table_args__ = (
-        # Index for "get all members of org" queries
-        # (PK index covers user_id lookups, but not org_id alone)
-        Index("ix_org_membership_org_id", "organization_id"),
-    )
-
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        ForeignKey("user.id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-    organization_id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        ForeignKey("organization.id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-
-
 class Ownership(Base):
     """Table to map resources to owners.
 
@@ -453,8 +409,11 @@ class Workspace(OrganizationModel):
     )
     members: Mapped[list[User]] = relationship(
         "User",
-        secondary=Membership.__table__,
+        secondary=lambda: Membership.__table__,
+        primaryjoin="Workspace.id == Membership.workspace_id",
+        secondaryjoin="Membership.user_id == User.id",
         back_populates="workspaces",
+        viewonly=True,
     )
     workflows: Mapped[list[Workflow]] = relationship(
         "Workflow",
@@ -602,7 +561,10 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         "Workspace",
         back_populates="members",
         lazy="select",
-        secondary=Membership.__table__,
+        secondary=lambda: Membership.__table__,
+        primaryjoin="User.id == Membership.user_id",
+        secondaryjoin="Membership.workspace_id == Workspace.id",
+        viewonly=True,
     )
     assigned_cases: Mapped[list[Case]] = relationship(
         "Case",
@@ -625,13 +587,6 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         "UserRoleAssignment",
         back_populates="user",
         foreign_keys="UserRoleAssignment.user_id",
-        lazy="select",
-        passive_deletes=True,
-    )
-    organizations: Mapped[list[Organization]] = relationship(
-        "Organization",
-        secondary=OrganizationMembership.__table__,
-        back_populates="members",
         lazy="select",
         passive_deletes=True,
     )
@@ -5571,3 +5526,44 @@ class UserRoleAssignment(Base):
     )
     workspace: Mapped[Workspace | None] = relationship("Workspace")
     role: Mapped[Role] = relationship("Role", back_populates="user_assignments")
+
+
+def _role_paths(name: str) -> Subquery:
+    """Every (user, org, scope) role path, direct or via a group."""
+    ura = UserRoleAssignment.__table__
+    gra = GroupRoleAssignment.__table__
+    gm = GroupMember.__table__
+    return union_all(
+        select(ura.c.user_id, ura.c.organization_id, ura.c.workspace_id),
+        select(gm.c.user_id, gra.c.organization_id, gra.c.workspace_id).join_from(
+            gra, gm, gm.c.group_id == gra.c.group_id
+        ),
+    ).subquery(name)
+
+
+# Inline subqueries, not a CTE: a CTE referenced twice is materialized and
+# blocks predicate pushdown into the assignment tables.
+_scoped = _role_paths("scoped_paths")
+_org = _role_paths("org_paths")
+membership_select = union(
+    select(_scoped.c.user_id, _scoped.c.organization_id, _scoped.c.workspace_id),
+    select(_org.c.user_id, _org.c.organization_id, null().label("workspace_id")),
+).subquery("membership")
+
+
+class Membership(Base):
+    """Read-only membership derived from RBAC assignments."""
+
+    __table__ = membership_select
+
+    user_id: Mapped[uuid.UUID]
+    organization_id: Mapped[uuid.UUID]
+    workspace_id: Mapped[uuid.UUID | None]
+
+    __mapper_args__ = {
+        "primary_key": [
+            membership_select.c.user_id,
+            membership_select.c.organization_id,
+            membership_select.c.workspace_id,
+        ]
+    }

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -67,8 +67,9 @@ INITIAL_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
     "group_role_assignment",
 )
 
-# Reclassified so org-presence queries can read assignments from other workspaces.
-RECLASSIFIED_TO_ORG_SCOPED_TABLES = (
+# Assignment tables need org-wide reads for org-presence queries, but writes must
+# stay workspace-scoped. They carry a split policy instead of a plain org policy.
+ASSIGNMENT_SPLIT_POLICY_TABLES = (
     "user_role_assignment",
     "group_role_assignment",
 )
@@ -110,7 +111,12 @@ POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
 )
 
 SPECIAL_TENANT_POLICY_TABLES = frozenset(
-    {"agent_tag_link", "service_account_api_key", "service_account_scope"}
+    {
+        "agent_tag_link",
+        "service_account_api_key",
+        "service_account_scope",
+        *ASSIGNMENT_SPLIT_POLICY_TABLES,
+    }
 )
 
 # Workspace and oauth_state carry custom policy SQL. scope and agent_catalog
@@ -125,7 +131,6 @@ CURRENT_WORKSPACE_SCOPED_TABLES = (
 CURRENT_ORG_SCOPED_TABLES = (
     *INITIAL_ORG_SCOPED_TABLES,
     *POST_RLS_ORG_SCOPED_TABLES,
-    *RECLASSIFIED_TO_ORG_SCOPED_TABLES,
 )
 CURRENT_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = tuple(
     table
@@ -133,7 +138,7 @@ CURRENT_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = tuple(
         *INITIAL_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES,
         *POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES,
     )
-    if table not in RECLASSIFIED_TO_ORG_SCOPED_TABLES
+    if table not in ASSIGNMENT_SPLIT_POLICY_TABLES
 )
 
 WORKSPACE_POLICY_TABLES = frozenset(CURRENT_WORKSPACE_SCOPED_TABLES)
@@ -264,6 +269,60 @@ def enable_org_optional_workspace_table_rls(table: str) -> str:
 
 def disable_org_optional_workspace_table_rls(table: str) -> str:
     return disable_org_table_rls(table)
+
+
+def _assignment_org_read_policy(table: str) -> str:
+    return f"{policy_name(table)}_org_read"
+
+
+def enable_assignment_split_table_rls(table: str) -> str:
+    # Split policy so org-presence queries can read assignments in every
+    # workspace while writes stay pinned to the session's workspace. The FOR ALL
+    # policy keeps the original org+optional-workspace clause; the additive
+    # FOR SELECT policy widens reads to the whole org (permissive policies OR).
+    return f"""
+        ALTER TABLE "{table}" ENABLE ROW LEVEL SECURITY;
+
+        CREATE POLICY {policy_name(table)} ON "{table}"
+            FOR ALL
+            USING (
+                current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
+                OR (
+                    organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
+                    AND (
+                        workspace_id IS NULL
+                        OR workspace_id = NULLIF(current_setting('app.current_workspace_id', true), '')::uuid
+                        OR NULLIF(current_setting('app.current_workspace_id', true), '')::uuid IS NULL
+                    )
+                )
+            )
+            WITH CHECK (
+                current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
+                OR (
+                    organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
+                    AND (
+                        workspace_id IS NULL
+                        OR workspace_id = NULLIF(current_setting('app.current_workspace_id', true), '')::uuid
+                        OR NULLIF(current_setting('app.current_workspace_id', true), '')::uuid IS NULL
+                    )
+                )
+            );
+
+        CREATE POLICY {_assignment_org_read_policy(table)} ON "{table}"
+            FOR SELECT
+            USING (
+                current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
+                OR organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
+            );
+    """
+
+
+def disable_assignment_split_table_rls(table: str) -> str:
+    return f"""
+        DROP POLICY IF EXISTS {_assignment_org_read_policy(table)} ON "{table}";
+        DROP POLICY IF EXISTS {policy_name(table)} ON "{table}";
+        ALTER TABLE "{table}" DISABLE ROW LEVEL SECURITY;
+    """
 
 
 def enable_scope_table_rls() -> str:

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -42,7 +42,6 @@ INITIAL_WORKSPACE_SCOPED_TABLES = (
     "file",
     "chat",
     "chat_message",
-    "membership",
     "invitation",
     "oauth_integration",
     "oauth_provider",
@@ -53,7 +52,6 @@ INITIAL_ORG_SCOPED_TABLES = (
     "organization_secret",
     "organization_settings",
     "organization_domain",
-    "organization_membership",
     "organization_invitation",
     "organization_tier",
     "registry_repository",
@@ -65,6 +63,12 @@ INITIAL_ORG_SCOPED_TABLES = (
 )
 
 INITIAL_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
+    "user_role_assignment",
+    "group_role_assignment",
+)
+
+# Reclassified so org-presence queries can read assignments from other workspaces.
+RECLASSIFIED_TO_ORG_SCOPED_TABLES = (
     "user_role_assignment",
     "group_role_assignment",
 )
@@ -121,10 +125,15 @@ CURRENT_WORKSPACE_SCOPED_TABLES = (
 CURRENT_ORG_SCOPED_TABLES = (
     *INITIAL_ORG_SCOPED_TABLES,
     *POST_RLS_ORG_SCOPED_TABLES,
+    *RECLASSIFIED_TO_ORG_SCOPED_TABLES,
 )
-CURRENT_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
-    *INITIAL_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES,
-    *POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES,
+CURRENT_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = tuple(
+    table
+    for table in (
+        *INITIAL_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES,
+        *POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES,
+    )
+    if table not in RECLASSIFIED_TO_ORG_SCOPED_TABLES
 )
 
 WORKSPACE_POLICY_TABLES = frozenset(CURRENT_WORKSPACE_SCOPED_TABLES)

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -36,6 +36,22 @@ class TracecatConflictError(TracecatException):
     """Tracecat user-facing resource conflict error"""
 
 
+class GroupDerivedMembershipError(TracecatConflictError):
+    """Raised when removing a member whose access comes only from group membership.
+
+    Deleting the direct assignment would leave the member in place, so the caller
+    must change group membership instead.
+    """
+
+    def __init__(self, *args, group_names: list[str], **kwargs):
+        super().__init__(*args, **kwargs)
+        self.group_names = group_names
+        self.detail = {
+            "code": "group_derived_membership",
+            "group_names": group_names,
+        }
+
+
 class TracecatDSLError(TracecatValidationError):
     """Tracecat user-facing DSL error"""
 

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -56,7 +56,6 @@ from tracecat.db.engine import (
 from tracecat.db.models import (
     Membership,
     Organization,
-    OrganizationMembership,
     User,
     Workspace,
 )
@@ -1120,8 +1119,8 @@ async def resolve_org_membership(
 ) -> OrgRole:
     """Check the user belongs to a specific organization.
 
-    The OrganizationMembership model is a simple link table without a role
-    column. Membership presence means the user is at least a member.
+    Membership is derived from role assignments; presence of an org row means
+    the user is at least a member.
 
     Args:
         user_id: The user to look up.
@@ -1135,9 +1134,10 @@ async def resolve_org_membership(
     """
     async with get_async_session_bypass_rls_context_manager() as session:
         result = await session.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == user_id,
-                OrganizationMembership.organization_id == organization_id,
+            select(Membership).where(
+                Membership.user_id == user_id,
+                Membership.organization_id == organization_id,
+                Membership.workspace_id.is_(None),
             )
         )
         membership = result.scalars().first()
@@ -1262,12 +1262,11 @@ async def list_user_workspaces(
 
         # Resolve the user's organization(s)
         org_stmt = (
-            select(OrganizationMembership.organization_id)
-            .join(
-                Organization, Organization.id == OrganizationMembership.organization_id
-            )
+            select(Membership.organization_id)
+            .join(Organization, Organization.id == Membership.organization_id)
             .where(
-                OrganizationMembership.user_id == user.id,
+                Membership.user_id == user.id,
+                Membership.workspace_id.is_(None),
                 Organization.is_active.is_(True),
             )
         )
@@ -1435,12 +1434,11 @@ async def resolve_org_role_for_request(
 
     async with get_async_session_bypass_rls_context_manager() as session:
         result = await session.execute(
-            select(OrganizationMembership.organization_id)
-            .join(
-                Organization, Organization.id == OrganizationMembership.organization_id
-            )
+            select(Membership.organization_id)
+            .join(Organization, Organization.id == Membership.organization_id)
             .where(
-                OrganizationMembership.user_id == user.id,
+                Membership.user_id == user.id,
+                Membership.workspace_id.is_(None),
                 Organization.is_active.is_(True),
             )
         )

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -45,6 +45,7 @@ from tracecat.auth.credentials import compute_effective_scopes
 from tracecat.auth.types import Role
 from tracecat.authz.controls import has_scope
 from tracecat.authz.enums import OrgRole, WorkspaceRole
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.config import (
     REDIS_URL,
     TRACECAT__PUBLIC_APP_URL,
@@ -1135,9 +1136,7 @@ async def resolve_org_membership(
     async with get_async_session_bypass_rls_context_manager() as session:
         result = await session.execute(
             select(Membership).where(
-                Membership.user_id == user_id,
-                Membership.organization_id == organization_id,
-                Membership.workspace_id.is_(None),
+                org_membership_predicate(user_id, organization_id),
             )
         )
         membership = result.scalars().first()
@@ -1265,8 +1264,7 @@ async def list_user_workspaces(
             select(Membership.organization_id)
             .join(Organization, Organization.id == Membership.organization_id)
             .where(
-                Membership.user_id == user.id,
-                Membership.workspace_id.is_(None),
+                org_membership_predicate(user.id),
                 Organization.is_active.is_(True),
             )
         )
@@ -1437,8 +1435,7 @@ async def resolve_org_role_for_request(
             select(Membership.organization_id)
             .join(Organization, Organization.id == Membership.organization_id)
             .where(
-                Membership.user_id == user.id,
-                Membership.workspace_id.is_(None),
+                org_membership_predicate(user.id),
                 Organization.is_active.is_(True),
             )
         )

--- a/tracecat/mcp/oidc/session.py
+++ b/tracecat/mcp/oidc/session.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
-from tracecat.db.models import OrganizationMembership, User
+from tracecat.db.models import Membership, User
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 
@@ -80,8 +80,9 @@ async def _resolve_regular_user_org(
             membership.
     """
     result = await session.execute(
-        select(OrganizationMembership.organization_id).where(
-            OrganizationMembership.user_id == user.id
+        select(Membership.organization_id).where(
+            Membership.user_id == user.id,
+            Membership.workspace_id.is_(None),
         )
     )
     org_ids = {row[0] for row in result.all()}

--- a/tracecat/mcp/oidc/session.py
+++ b/tracecat/mcp/oidc/session.py
@@ -12,6 +12,7 @@ from enum import StrEnum, auto
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import Membership, User
 from tracecat.identifiers import OrganizationID
@@ -81,8 +82,7 @@ async def _resolve_regular_user_org(
     """
     result = await session.execute(
         select(Membership.organization_id).where(
-            Membership.user_id == user.id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user.id),
         )
     )
     org_ids = {row[0] for row in result.all()}

--- a/tracecat/mcp/personal_access_tokens/service.py
+++ b/tracecat/mcp/personal_access_tokens/service.py
@@ -21,7 +21,6 @@ from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import (
     MCPPersonalAccessToken,
     Membership,
-    OrganizationMembership,
     User,
     Workspace,
 )
@@ -70,8 +69,9 @@ async def _user_can_access_workspace(
     org_membership_exists = (
         select(1)
         .where(
-            OrganizationMembership.organization_id == organization_id,
-            OrganizationMembership.user_id == user_id,
+            Membership.organization_id == organization_id,
+            Membership.user_id == user_id,
+            Membership.workspace_id.is_(None),
         )
         .exists()
     )
@@ -309,9 +309,10 @@ async def verify_mcp_personal_access_token(raw_token: str) -> MCPPATIdentity | N
             return None
         if not user.is_superuser:
             result = await session.execute(
-                select(OrganizationMembership.user_id).where(
-                    OrganizationMembership.user_id == user.id,
-                    OrganizationMembership.organization_id == record.organization_id,
+                select(Membership.user_id).where(
+                    Membership.user_id == user.id,
+                    Membership.organization_id == record.organization_id,
+                    Membership.workspace_id.is_(None),
                 )
             )
             if result.scalar_one_or_none() is None:

--- a/tracecat/mcp/personal_access_tokens/service.py
+++ b/tracecat/mcp/personal_access_tokens/service.py
@@ -17,6 +17,7 @@ from tracecat.auth.api_keys import (
     verify_api_key,
 )
 from tracecat.authz.controls import require_scope
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import (
     MCPPersonalAccessToken,
@@ -69,9 +70,7 @@ async def _user_can_access_workspace(
     org_membership_exists = (
         select(1)
         .where(
-            Membership.organization_id == organization_id,
-            Membership.user_id == user_id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user_id, organization_id),
         )
         .exists()
     )
@@ -310,9 +309,7 @@ async def verify_mcp_personal_access_token(raw_token: str) -> MCPPATIdentity | N
         if not user.is_superuser:
             result = await session.execute(
                 select(Membership.user_id).where(
-                    Membership.user_id == user.id,
-                    Membership.organization_id == record.organization_id,
-                    Membership.workspace_id.is_(None),
+                    org_membership_predicate(user.id, record.organization_id),
                 )
             )
             if result.scalar_one_or_none() is None:

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -430,7 +430,7 @@ async def _resolve_org_role(
 ) -> Role:
     """Resolve a role with organization context for the caller's token.
 
-    Queries the caller's active OrganizationMembership rows directly. Errors
+    Queries the caller's active organization membership rows directly. Errors
     with a clear message on the multi-org case; multi-org callers must pass
     org_id explicitly unless the token itself is scoped to exactly one
     organization (see `resolve_org_role_for_request`).

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
 from tracecat.auth.types import Role
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.authz.seeding import seed_system_roles_for_org
 from tracecat.cases.service import CaseFieldsService
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
@@ -200,8 +201,7 @@ async def delete_organization_with_cleanup(
     organization are revoked before the org membership rows are removed.
     """
     org_member_user_ids = select(Membership.user_id).where(
-        Membership.organization_id == organization.id,
-        Membership.workspace_id.is_(None),
+        org_membership_predicate(None, organization.id),
     )
     await session.execute(
         delete(AccessToken).where(
@@ -439,9 +439,7 @@ async def ensure_single_tenant_user_defaults_in_session(
     # acceptable org-wide role, there is nothing to repair.
     membership_result = await session.execute(
         select(Membership).where(
-            Membership.user_id == user_id,
-            Membership.organization_id == organization_id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user_id, organization_id),
         )
     )
     membership = membership_result.scalar_one_or_none()

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -23,7 +23,6 @@ from tracecat.db.models import (
     MCPRefreshToken,
     Membership,
     Organization,
-    OrganizationMembership,
     OrganizationSecret,
     Ownership,
     RegistryAction,
@@ -200,8 +199,9 @@ async def delete_organization_with_cleanup(
     organization-scoped today, sessions for users linked to the deleted
     organization are revoked before the org membership rows are removed.
     """
-    org_member_user_ids = select(OrganizationMembership.user_id).where(
-        OrganizationMembership.organization_id == organization.id
+    org_member_user_ids = select(Membership.user_id).where(
+        Membership.organization_id == organization.id,
+        Membership.workspace_id.is_(None),
     )
     await session.execute(
         delete(AccessToken).where(
@@ -232,9 +232,8 @@ async def delete_organization_with_cleanup(
         case_fields_service = CaseFieldsService(session=session, role=bootstrap_role)
         await case_fields_service.drop_workspace_schema()
 
-        await session.execute(
-            delete(Membership).where(Membership.workspace_id == workspace.id)
-        )
+        # Workspace-scoped assignments cascade with the workspace, and
+        # membership is derived from them.
         await session.delete(workspace)
 
     if workspace_ids:
@@ -439,9 +438,10 @@ async def ensure_single_tenant_user_defaults_in_session(
     # Fast path: if the user already has default-org membership and an
     # acceptable org-wide role, there is nothing to repair.
     membership_result = await session.execute(
-        select(OrganizationMembership).where(
-            OrganizationMembership.user_id == user_id,
-            OrganizationMembership.organization_id == organization_id,
+        select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.organization_id == organization_id,
+            Membership.workspace_id.is_(None),
         )
     )
     membership = membership_result.scalar_one_or_none()
@@ -469,23 +469,9 @@ async def ensure_single_tenant_user_defaults_in_session(
     # and only runs after the fast path determines a repair may be needed.
     await seed_system_roles_for_org(session, organization_id)
 
+    # Membership is derived, so the org-wide assignment insert below is what
+    # repairs a missing membership.
     changed = False
-    if membership is None:
-        # Auth-path lazy repair can run concurrently for the same legacy user.
-        # Use an idempotent insert so one request repairs the row and the other
-        # continues without surfacing a unique-constraint failure.
-        membership_insert = pg_insert(OrganizationMembership).values(
-            user_id=user_id,
-            organization_id=organization_id,
-        )
-        membership_insert = membership_insert.on_conflict_do_nothing(
-            index_elements=[
-                OrganizationMembership.user_id,
-                OrganizationMembership.organization_id,
-            ]
-        )
-        membership_result = await session.execute(membership_insert)
-        changed = (membership_result.rowcount or 0) > 0  # pyright: ignore[reportAttributeAccessIssue]
 
     # Single-tenant defaults are intentionally minimal for regular users, while
     # superusers are granted default-org owner permissions.
@@ -531,10 +517,7 @@ async def ensure_single_tenant_user_defaults_in_session(
         changed = changed or (assignment_result.rowcount or 0) > 0  # pyright: ignore[reportAttributeAccessIssue]
         return changed
 
-    # At this point a repair is needed: either the membership row was missing,
-    # or a superuser still had a non-owner org-wide role. Keep the org-wide
-    # assignment aligned with the default role for this user type, but skip
-    # no-op writes.
+    # Only reached for a superuser holding a non-owner org-wide role.
     if assignment.role_id != role.id:
         assignment.role_id = role.id
         changed = True

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -11,6 +11,7 @@ from tracecat.auth.dependencies import OrgActorRole, OrgUserRole
 from tracecat.auth.schemas import SessionRead, UserUpdate
 from tracecat.auth.users import current_active_user
 from tracecat.authz.controls import require_scope
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.db.dependencies import AsyncDBSession, AsyncDBSessionBypass
 from tracecat.db.models import (
     Membership,
@@ -116,8 +117,7 @@ async def list_current_user_organization_memberships(
             Membership.organization_id == Organization.id,
         )
         .where(
-            Membership.user_id == role.user_id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(role.user_id),
             Organization.is_active.is_(True),
         )
         .order_by(Organization.name.asc(), Organization.id.asc())
@@ -259,8 +259,7 @@ async def get_current_org_member(
         .where(
             and_(
                 User.id == role.user_id,  # pyright: ignore[reportArgumentType]
-                Membership.organization_id == role.organization_id,  # pyright: ignore[reportArgumentType]
-                Membership.workspace_id.is_(None),
+                org_membership_predicate(None, role.organization_id),
             )
         )
     )

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -13,10 +13,10 @@ from tracecat.auth.users import current_active_user
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession, AsyncDBSessionBypass
 from tracecat.db.models import (
+    Membership,
     Organization,
     OrganizationDomain,
     OrganizationInvitation,
-    OrganizationMembership,
     User,
     UserRoleAssignment,
 )
@@ -112,11 +112,12 @@ async def list_current_user_organization_memberships(
     stmt = (
         select(Organization.id, Organization.name)
         .join(
-            OrganizationMembership,
-            OrganizationMembership.organization_id == Organization.id,
+            Membership,
+            Membership.organization_id == Organization.id,
         )
         .where(
-            OrganizationMembership.user_id == role.user_id,
+            Membership.user_id == role.user_id,
+            Membership.workspace_id.is_(None),
             Organization.is_active.is_(True),
         )
         .order_by(Organization.name.asc(), Organization.id.asc())
@@ -252,13 +253,14 @@ async def get_current_org_member(
     statement = (
         select(User)
         .join(
-            OrganizationMembership,
-            OrganizationMembership.user_id == User.id,  # pyright: ignore[reportArgumentType]
+            Membership,
+            Membership.user_id == User.id,  # pyright: ignore[reportArgumentType]
         )
         .where(
             and_(
                 User.id == role.user_id,  # pyright: ignore[reportArgumentType]
-                OrganizationMembership.organization_id == role.organization_id,  # pyright: ignore[reportArgumentType]
+                Membership.organization_id == role.organization_id,  # pyright: ignore[reportArgumentType]
+                Membership.workspace_id.is_(None),
             )
         )
     )

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -25,6 +25,7 @@ from tracecat.auth.users import (
     get_user_manager_context,
 )
 from tracecat.authz.controls import require_scope
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.authz.seeding import seed_system_roles_for_org
 from tracecat.authz.service import resolve_grantable_role
 from tracecat.db.models import (
@@ -180,9 +181,7 @@ async def accept_invitation_for_user(
         membership = (
             await session.execute(
                 select(Membership).where(
-                    Membership.user_id == user_id,
-                    Membership.organization_id == invitation.organization_id,
-                    Membership.workspace_id.is_(None),
+                    org_membership_predicate(user_id, invitation.organization_id),
                 )
             )
         ).scalar_one()
@@ -237,11 +236,7 @@ class OrgService(BaseOrgService):
         """
         statement = select(User).join(
             Membership,
-            and_(
-                Membership.user_id == User.id,
-                Membership.organization_id == self.organization_id,
-                Membership.workspace_id.is_(None),
-            ),
+            org_membership_predicate(User.id, self.organization_id),
         )
         result = await self.session.execute(statement)
         return result.scalars().all()
@@ -262,11 +257,7 @@ class OrgService(BaseOrgService):
             select(User)
             .join(
                 Membership,
-                and_(
-                    Membership.user_id == User.id,
-                    Membership.organization_id == self.organization_id,
-                    Membership.workspace_id.is_(None),
-                ),
+                org_membership_predicate(User.id, self.organization_id),
             )
             .where(cast(User.id, UUID) == user_id)
         )
@@ -420,9 +411,7 @@ class OrgService(BaseOrgService):
         return (
             await self.session.execute(
                 select(Membership).where(
-                    Membership.user_id == user_id,
-                    Membership.organization_id == organization_id,
-                    Membership.workspace_id.is_(None),
+                    org_membership_predicate(user_id, organization_id),
                 )
             )
         ).scalar_one()
@@ -460,11 +449,7 @@ class OrgService(BaseOrgService):
             .join(User, cast(AccessToken.user_id, UUID) == User.id)
             .join(
                 Membership,
-                and_(
-                    Membership.user_id == User.id,
-                    Membership.organization_id == self.organization_id,
-                    Membership.workspace_id.is_(None),
-                ),
+                org_membership_predicate(User.id, self.organization_id),
             )
             .options(contains_eager(AccessToken.user))
         )
@@ -488,11 +473,7 @@ class OrgService(BaseOrgService):
             .join(User, cast(AccessToken.user_id, UUID) == User.id)
             .join(
                 Membership,
-                and_(
-                    Membership.user_id == User.id,
-                    Membership.organization_id == self.organization_id,
-                    Membership.workspace_id.is_(None),
-                ),
+                org_membership_predicate(User.id, self.organization_id),
             )
             .where(AccessToken.id == session_id)
         )
@@ -539,8 +520,7 @@ class OrgService(BaseOrgService):
             select(Membership)
             .join(User, Membership.user_id == User.id)
             .where(
-                Membership.organization_id == self.organization_id,
-                Membership.workspace_id.is_(None),
+                org_membership_predicate(None, self.organization_id),
                 func.lower(User.email) == email.lower(),
             )
         )
@@ -760,9 +740,10 @@ class OrgService(BaseOrgService):
             membership = (
                 await self.session.execute(
                     select(Membership).where(
-                        Membership.user_id == self.role.user_id,
-                        Membership.organization_id == invitation.organization_id,
-                        Membership.workspace_id.is_(None),
+                        org_membership_predicate(
+                            self.role.user_id,
+                            invitation.organization_id,
+                        ),
                     )
                 )
             ).scalar_one()

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -25,6 +25,7 @@ from tracecat.auth.users import (
     get_user_manager_context,
 )
 from tracecat.authz.controls import require_scope
+from tracecat.authz.seeding import seed_system_roles_for_org
 from tracecat.authz.service import resolve_grantable_role
 from tracecat.db.models import (
     AccessToken,
@@ -35,10 +36,11 @@ from tracecat.db.models import (
     Membership,
     Organization,
     OrganizationInvitation,
-    OrganizationMembership,
     User,
     UserRoleAssignment,
-    Workspace,
+)
+from tracecat.db.models import (
+    Role as DBRole,
 )
 from tracecat.exceptions import (
     TracecatAuthorizationError,
@@ -59,8 +61,8 @@ async def accept_invitation_for_user(
     *,
     user_id: UserID,
     token: str,
-) -> OrganizationMembership:
-    """Accept an invitation and create organization membership + RBAC assignment.
+) -> Membership:
+    """Accept an invitation and assign the invitation's organization role.
 
     This is a standalone function (not a method) because invitation acceptance
     doesn't require organization context - the user may not belong to any
@@ -76,7 +78,7 @@ async def accept_invitation_for_user(
         token: The unique invitation token.
 
     Returns:
-        OrganizationMembership: The created membership record.
+        Membership: The derived organization membership row.
 
     Raises:
         TracecatNotFoundError: If the invitation doesn't exist.
@@ -150,34 +152,6 @@ async def accept_invitation_for_user(
             # Shouldn't reach here, but handle gracefully
             raise TracecatAuthorizationError("Invitation is no longer valid")
 
-        # Upsert membership — idempotent if single-tenant defaults already ran.
-        membership_stmt = (
-            pg_insert(OrganizationMembership)
-            .values(
-                user_id=user_id,
-                organization_id=invitation.organization_id,
-            )
-            .on_conflict_do_nothing(
-                index_elements=[
-                    OrganizationMembership.user_id,
-                    OrganizationMembership.organization_id,
-                ]
-            )
-            .returning(OrganizationMembership)
-        )
-        membership_result = await session.execute(membership_stmt)
-        membership = membership_result.scalar_one_or_none()
-        if membership is None:
-            # Row already existed; fetch it.
-            existing = await session.execute(
-                select(OrganizationMembership).where(
-                    OrganizationMembership.user_id == user_id,
-                    OrganizationMembership.organization_id
-                    == invitation.organization_id,
-                )
-            )
-            membership = existing.scalar_one()
-
         # Upsert the org-wide role assignment to the invitation's role.
         # Uses on_conflict_do_update so a pre-existing organization-member row
         # (written by single-tenant defaults during SSO auto-provisioning) is
@@ -202,7 +176,16 @@ async def accept_invitation_for_user(
         await session.execute(assignment_stmt)
 
         await session.commit()
-        await session.refresh(membership)
+
+        membership = (
+            await session.execute(
+                select(Membership).where(
+                    Membership.user_id == user_id,
+                    Membership.organization_id == invitation.organization_id,
+                    Membership.workspace_id.is_(None),
+                )
+            )
+        ).scalar_one()
     except TracecatAuthorizationError:
         # Re-raise auth errors without logging as failure (expected user errors)
         raise
@@ -247,16 +230,17 @@ class OrgService(BaseOrgService):
         Retrieve a list of all members in the organization.
 
         This method queries the database to obtain all user records
-        associated with the organization via OrganizationMembership.
+        associated with the organization via derived membership.
 
         Returns:
             Sequence[User]: A sequence of User objects.
         """
         statement = select(User).join(
-            OrganizationMembership,
+            Membership,
             and_(
-                OrganizationMembership.user_id == User.id,
-                OrganizationMembership.organization_id == self.organization_id,
+                Membership.user_id == User.id,
+                Membership.organization_id == self.organization_id,
+                Membership.workspace_id.is_(None),
             ),
         )
         result = await self.session.execute(statement)
@@ -277,10 +261,11 @@ class OrgService(BaseOrgService):
         statement = (
             select(User)
             .join(
-                OrganizationMembership,
+                Membership,
                 and_(
-                    OrganizationMembership.user_id == User.id,
-                    OrganizationMembership.organization_id == self.organization_id,
+                    Membership.user_id == User.id,
+                    Membership.organization_id == self.organization_id,
+                    Membership.workspace_id.is_(None),
                 ),
             )
             .where(cast(User.id, UUID) == user_id)
@@ -333,19 +318,12 @@ class OrgService(BaseOrgService):
             .values(revoked_at=datetime.now(UTC), revoked_by=self.role.user_id)
         )
 
-        workspace_ids = select(Workspace.id).where(
-            Workspace.organization_id == self.organization_id
-        )
         group_ids = select(Group.id).where(
             Group.organization_id == self.organization_id
         )
 
-        await self.session.execute(
-            delete(Membership).where(
-                Membership.user_id == user.id,
-                Membership.workspace_id.in_(workspace_ids),
-            )
-        )
+        # Removing every assignment and group membership in the org delists the
+        # user from the org and all its workspaces.
         await self.session.execute(
             delete(UserRoleAssignment).where(
                 UserRoleAssignment.user_id == user.id,
@@ -356,12 +334,6 @@ class OrgService(BaseOrgService):
             delete(GroupMember).where(
                 GroupMember.user_id == user.id,
                 GroupMember.group_id.in_(group_ids),
-            )
-        )
-        await self.session.execute(
-            delete(OrganizationMembership).where(
-                OrganizationMembership.user_id == user.id,
-                OrganizationMembership.organization_id == self.organization_id,
             )
         )
 
@@ -401,32 +373,59 @@ class OrgService(BaseOrgService):
         *,
         user_id: UserID,
         organization_id: OrganizationID,
-    ) -> OrganizationMembership:
+    ) -> Membership:
         """Add a user to an organization.
 
-        This method creates an OrganizationMembership record linking a user
-        to an organization. It is typically called from the invitation flow
-        when a user accepts an invitation.
+        Assigns the ``organization-member`` role, which is what makes the user
+        an organization member. Typically called from the invitation flow when
+        a user accepts an invitation.
 
         Note: This method does not require scope checks as it is
         intended to be called by internal services (e.g., invitation service).
-        RBAC role assignment is handled separately.
 
         Args:
             user_id: The unique identifier of the user to add.
             organization_id: The unique identifier of the organization.
 
         Returns:
-            OrganizationMembership: The created membership record.
+            Membership: The derived organization membership row.
+
+        Raises:
+            TracecatNotFoundError: If the organization-member role is missing.
         """
-        membership = OrganizationMembership(
-            user_id=user_id,
-            organization_id=organization_id,
+        role_stmt = select(DBRole.id).where(
+            DBRole.organization_id == organization_id,
+            DBRole.slug == "organization-member",
         )
-        self.session.add(membership)
+        role_id = (await self.session.execute(role_stmt)).scalar_one_or_none()
+        if role_id is None:
+            # Seeding is idempotent; orgs created before seeding still resolve.
+            await seed_system_roles_for_org(self.session, organization_id)
+            role_id = (await self.session.execute(role_stmt)).scalar_one_or_none()
+        if role_id is None:
+            raise TracecatNotFoundError(
+                "organization-member role not found for organization"
+            )
+
+        self.session.add(
+            UserRoleAssignment(
+                organization_id=organization_id,
+                user_id=user_id,
+                workspace_id=None,
+                role_id=role_id,
+            )
+        )
         await self.session.commit()
-        await self.session.refresh(membership)
-        return membership
+
+        return (
+            await self.session.execute(
+                select(Membership).where(
+                    Membership.user_id == user_id,
+                    Membership.organization_id == organization_id,
+                    Membership.workspace_id.is_(None),
+                )
+            )
+        ).scalar_one()
 
     @audit_log(resource_type="organization", action="delete")
     @require_scope("org:delete")
@@ -460,10 +459,11 @@ class OrgService(BaseOrgService):
             select(AccessToken)
             .join(User, cast(AccessToken.user_id, UUID) == User.id)
             .join(
-                OrganizationMembership,
+                Membership,
                 and_(
-                    OrganizationMembership.user_id == User.id,
-                    OrganizationMembership.organization_id == self.organization_id,
+                    Membership.user_id == User.id,
+                    Membership.organization_id == self.organization_id,
+                    Membership.workspace_id.is_(None),
                 ),
             )
             .options(contains_eager(AccessToken.user))
@@ -487,10 +487,11 @@ class OrgService(BaseOrgService):
             select(AccessToken)
             .join(User, cast(AccessToken.user_id, UUID) == User.id)
             .join(
-                OrganizationMembership,
+                Membership,
                 and_(
-                    OrganizationMembership.user_id == User.id,
-                    OrganizationMembership.organization_id == self.organization_id,
+                    Membership.user_id == User.id,
+                    Membership.organization_id == self.organization_id,
+                    Membership.workspace_id.is_(None),
                 ),
             )
             .where(AccessToken.id == session_id)
@@ -535,10 +536,11 @@ class OrgService(BaseOrgService):
 
         # Check if user with this email is already a member (case-insensitive)
         existing_member_stmt = (
-            select(OrganizationMembership)
-            .join(User, OrganizationMembership.user_id == User.id)
+            select(Membership)
+            .join(User, Membership.user_id == User.id)
             .where(
-                OrganizationMembership.organization_id == self.organization_id,
+                Membership.organization_id == self.organization_id,
+                Membership.workspace_id.is_(None),
                 func.lower(User.email) == email.lower(),
             )
         )
@@ -655,7 +657,7 @@ class OrgService(BaseOrgService):
             raise TracecatNotFoundError("Invitation not found")
         return invitation
 
-    async def accept_invitation(self, token: str) -> OrganizationMembership:
+    async def accept_invitation(self, token: str) -> Membership:
         """Accept an invitation and create organization membership + RBAC assignment.
 
         This method validates the invitation token, checks expiry and status,
@@ -671,7 +673,7 @@ class OrgService(BaseOrgService):
             token: The unique invitation token.
 
         Returns:
-            OrganizationMembership: The created membership record.
+            Membership: The derived organization membership row.
 
         Raises:
             TracecatNotFoundError: If the invitation doesn't exist.
@@ -743,14 +745,8 @@ class OrgService(BaseOrgService):
                 # Shouldn't reach here, but handle gracefully
                 raise TracecatAuthorizationError("Invitation is no longer valid")
 
-            # Create membership (still needed for org membership existence checks)
-            membership = OrganizationMembership(
-                user_id=self.role.user_id,
-                organization_id=invitation.organization_id,
-            )
-            self.session.add(membership)
-
-            # Create RBAC role assignment from invitation's role_id
+            # Create RBAC role assignment from invitation's role_id; org
+            # membership is derived from it.
             assignment = UserRoleAssignment(
                 organization_id=invitation.organization_id,
                 user_id=self.role.user_id,
@@ -760,7 +756,16 @@ class OrgService(BaseOrgService):
             self.session.add(assignment)
 
             await self.session.commit()
-            await self.session.refresh(membership)
+
+            membership = (
+                await self.session.execute(
+                    select(Membership).where(
+                        Membership.user_id == self.role.user_id,
+                        Membership.organization_id == invitation.organization_id,
+                        Membership.workspace_id.is_(None),
+                    )
+                )
+            ).scalar_one()
         except TracecatAuthorizationError:
             # Re-raise auth errors without logging as failure (expected user errors)
             raise

--- a/tracecat/workspaces/router.py
+++ b/tracecat/workspaces/router.py
@@ -235,7 +235,7 @@ async def list_workspace_memberships(
     return [
         WorkspaceMembershipRead(
             user_id=membership.user_id,
-            workspace_id=membership.workspace_id,
+            workspace_id=workspace_id,
         )
         for membership in memberships
     ]
@@ -291,7 +291,7 @@ async def get_workspace_membership(
     membership = membership_with_org.membership
     return WorkspaceMembershipRead(
         user_id=membership.user_id,
-        workspace_id=membership.workspace_id,
+        workspace_id=workspace_id,
     )
 
 

--- a/tracecat/workspaces/router.py
+++ b/tracecat/workspaces/router.py
@@ -15,6 +15,7 @@ from tracecat.authz.controls import require_scope
 from tracecat.authz.service import MembershipService
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import (
+    GroupDerivedMembershipError,
     TracecatAuthorizationError,
     TracecatManagementError,
     TracecatNotFoundError,
@@ -309,7 +310,13 @@ async def delete_workspace_membership(
 ) -> None:
     """Delete a workspace membership."""
     service = MembershipService(session, role=role)
-    await service.delete_membership(workspace_id, user_id=user_id)
+    try:
+        await service.delete_membership(workspace_id, user_id=user_id)
+    except GroupDerivedMembershipError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=e.detail,
+        ) from e
 
 
 # === Invitations === #

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 from pydantic import EmailStr, Field, computed_field, field_validator
 
@@ -125,12 +125,25 @@ class WorkspaceReadMinimal(Schema):
     name: str
 
 
+class WorkspaceMemberSource(Schema):
+    """Where a member's workspace access comes from.
+
+    ``kind`` is ``"direct"`` for a direct role assignment, or ``"group"`` when
+    access is derived only from group membership, in which case ``group_names``
+    lists the granting groups.
+    """
+
+    kind: Literal["direct", "group"]
+    group_names: list[str] = Field(default_factory=list)
+
+
 class WorkspaceMember(Schema):
     user_id: UserID
     first_name: str | None
     last_name: str | None
     email: EmailStr
     role_name: str
+    source: WorkspaceMemberSource
 
 
 class WorkspaceRead(Schema):

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -21,9 +21,7 @@ from tracecat.cases.service import CaseFieldsService
 from tracecat.db.models import (
     Invitation,
     Membership,
-    OrganizationMembership,
     Ownership,
-    User,
     UserRoleAssignment,
     Workspace,
 )
@@ -130,14 +128,11 @@ class WorkspaceService(BaseOrgService):
         name: str,
         *,
         override_id: UUID4 | None = None,
-        users: list[User] | None = None,
     ) -> Workspace:
         """Create a new workspace."""
         kwargs = {
             "name": name,
             "organization_id": self.organization_id,
-            # Workspace model defines the relationship as "members"
-            "members": users or [],
         }
         if override_id:
             kwargs["id"] = override_id
@@ -479,24 +474,15 @@ class WorkspaceService(BaseOrgService):
         workspace = invitation.workspace
         organization_id = workspace.organization_id
 
-        # Check if user is already a member of the organization
-        org_membership_stmt = select(OrganizationMembership).where(
-            OrganizationMembership.user_id == user_id,
-            OrganizationMembership.organization_id == organization_id,
+        # Org membership is derived from assignments: absence of any assignment
+        # in this org means we must also grant the org-member role.
+        org_membership_stmt = select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.organization_id == organization_id,
+            Membership.workspace_id.is_(None),
         )
         result = await self.session.execute(org_membership_stmt)
-        org_membership = result.scalar_one_or_none()
-
-        # If not in org, auto-create membership and assign org-member RBAC role
-        created_org_membership = False
-        if org_membership is None:
-            org_membership = OrganizationMembership(
-                user_id=user_id,
-                organization_id=organization_id,
-            )
-            self.session.add(org_membership)
-            created_org_membership = True
-            await self.session.flush()
+        created_org_membership = result.first() is None
 
         # Check if user is already a member of the workspace
         ws_membership_stmt = select(Membership).where(
@@ -530,14 +516,7 @@ class WorkspaceService(BaseOrgService):
             # Shouldn't reach here, but handle gracefully
             raise TracecatValidationError("Invitation is no longer valid")
 
-        # Create workspace membership
-        membership = Membership(
-            user_id=user_id,
-            workspace_id=invitation.workspace_id,
-        )
-        self.session.add(membership)
-
-        # Create RBAC role assignment for the workspace
+        # Create RBAC role assignment for the workspace; membership follows.
         ws_assignment = UserRoleAssignment(
             organization_id=organization_id,
             user_id=user_id,
@@ -565,7 +544,15 @@ class WorkspaceService(BaseOrgService):
                 self.session.add(org_assignment)
 
         await self.session.commit()
-        await self.session.refresh(membership)
+
+        membership = (
+            await self.session.execute(
+                select(Membership).where(
+                    Membership.user_id == user_id,
+                    Membership.workspace_id == invitation.workspace_id,
+                )
+            )
+        ).scalar_one()
         return membership
 
     @require_scope("workspace:member:remove")

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -15,6 +15,7 @@ from tracecat.audit.logger import audit_log
 from tracecat.auth.types import Role
 from tracecat.authz.controls import has_scope, require_scope
 from tracecat.authz.enums import OwnerType
+from tracecat.authz.membership import org_membership_predicate
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.authz.service import resolve_grantable_role
 from tracecat.cases.service import CaseFieldsService
@@ -477,9 +478,7 @@ class WorkspaceService(BaseOrgService):
         # Org membership is derived from assignments: absence of any assignment
         # in this org means we must also grant the org-member role.
         org_membership_stmt = select(Membership).where(
-            Membership.user_id == user_id,
-            Membership.organization_id == organization_id,
-            Membership.workspace_id.is_(None),
+            org_membership_predicate(user_id, organization_id),
         )
         result = await self.session.execute(org_membership_stmt)
         created_org_membership = result.first() is None


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaces the `membership` and `organization_membership` tables with a Postgres view derived from RBAC role assignments. Membership is now read-only; invite accept, SAML JIT, admin bootstrap, and member removal operate on role assignments only.

**Migration**
- Backfills a role assignment for every legacy member that has none before dropping the old tables, and fails if any member would be dropped.
- The downgrade restores both tables from the view.

**Behavior**
- Workspace member listings now show whether access is direct or group-derived, with the granting group names.
- Removing a member whose only access comes from a group returns 409 and names the granting groups.
- `user_role_assignment` and `group_role_assignment` now allow org-wide reads while keeping writes workspace-scoped.

<sup>Written for commit 8da5e32ddc5938c9033a4e4dede8bd4188abe6df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

