### PR TITLE
fix(mcp): support regional Datadog OAuth endpoints

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -16559,6 +16559,13 @@ export const $MCPHTTPOAuth2ConnectionSpec = {
       ],
       title: "Oauth Resource",
     },
+    oauth_resource_ignored_query_params: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Oauth Resource Ignored Query Params",
+    },
     oauth_authorization_endpoint: {
       anyOf: [
         {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -5098,6 +5098,7 @@ export type MCPHTTPOAuth2ConnectionSpec = {
   server_uri: string
   scopes?: Array<string>
   oauth_resource?: string | null
+  oauth_resource_ignored_query_params?: Array<string>
   oauth_authorization_endpoint?: string | null
   oauth_token_endpoint?: string | null
   oauth_authorize_params?: {

--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -417,6 +417,9 @@
         "auth_type": "OAUTH2",
         "server_uri": "https://mcp.datadoghq.com/v1/mcp",
         "scopes": [],
+        "oauth_resource_ignored_query_params": [
+          "toolsets"
+        ],
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
         "credentials": [

--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -411,22 +411,35 @@
     },
     {
       "slug": "datadog-mcp",
-      "docs": "https://docs.datadoghq.com/bits_ai/mcp_server/",
+      "docs": "https://docs.datadoghq.com/mcp_server/setup/",
       "connection_spec": {
         "server_type": "http",
         "auth_type": "OAUTH2",
-        "server_uri": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+        "server_uri": "https://mcp.datadoghq.com/v1/mcp",
         "scopes": [],
         "oauth_authorization_endpoint": null,
         "oauth_token_endpoint": null,
-        "credentials": [],
+        "credentials": [
+          {
+            "key": "server_url",
+            "label": "Datadog MCP Region Endpoint",
+            "description": "The regional Datadog MCP endpoint matching your Datadog site. US1: https://mcp.datadoghq.com/v1/mcp , US3: https://mcp.us3.datadoghq.com/v1/mcp , US5: https://mcp.us5.datadoghq.com/v1/mcp , EU: https://mcp.datadoghq.eu/v1/mcp , AP1: https://mcp.ap1.datadoghq.com/v1/mcp , AP2: https://mcp.ap2.datadoghq.com/v1/mcp , UK1: https://mcp.uk1.datadoghq.com/v1/mcp . The US1-FED / GovCloud site (app.ddog-gov.com) is NOT supported. An optional ?toolsets= query parameter may be appended to select tools, e.g. ?toolsets=core (default), ?toolsets=all, or a comma-separated list such as ?toolsets=apm,llmobs. Authentication is handled via OAuth browser sign-in; no token is pasted by the user.",
+            "required": true,
+            "secret": false,
+            "default_value": "https://mcp.datadoghq.com/v1/mcp",
+            "placeholder": "https://mcp.datadoghq.com/v1/mcp",
+            "type": "url",
+            "target": "server_uri"
+          }
+        ],
         "_research": {
           "confidence": "high",
           "docker_only": false,
-          "notes": "Official Datadog MCP Server (Bits AI). Verified first-party from docs.datadoghq.com. Transport: Streamable HTTP (remote). Endpoint path is /api/unstable/mcp-server/mcp; hostname is site-specific. US1 host is mcp.datadoghq.com (full URL: https://mcp.datadoghq.com/api/unstable/mcp-server/mcp). Other sites replace the host: EU=mcp.datadoghq.eu, US3=mcp.us3.datadoghq.com, US5=mcp.us5.datadoghq.com, AP1/AP2 analogous; same path. app.ddog-gov.com (GovCloud) is NOT supported. Primary auth is OAuth 2.0 with a browser-based sign-in/redirect (\"You are prompted to login through OAuth\"). The docs do not state whether DCR or discovery metadata is used; as a modern remote MCP server it almost certainly advertises authorization/token endpoints via OAuth discovery (.well-known), so oauth_authorization_endpoint/token_endpoint are left null and OAuth endpoints are discovered from the MCP metadata chain. No specific OAuth scopes are documented. ALTERNATIVE auth (not chosen here, since intended transport is HTTP+OAuth) for headless/server environments: pass two HTTP headers DD_API_KEY and DD_APPLICATION_KEY (Datadog recommends a scoped service-account API key + application key). If the catalog instead wants the API-key path, switch auth_type to CUSTOM with two required secret credentials keyed DD_API_KEY and DD_APPLICATION_KEY plus an optional non-secret site/host field for region selection. A toolsets query param controls available tools (?toolsets=all, default core, or comma-separated e.g. apm,llmobs,monitors,logs). No npx/uvx/pip package — it is a hosted remote server, so packages[] is empty.",
+          "notes": "Official Datadog MCP Server (Bits AI). Verified first-party from docs.datadoghq.com. Transport: Streamable HTTP (remote). The current documented endpoint path is /v1/mcp; the older /api/unstable/mcp-server/mcp path is deprecated but still routed as of 2026-08. Hostname is site-specific, one host per Datadog site: US1=mcp.datadoghq.com, US3=mcp.us3.datadoghq.com, US5=mcp.us5.datadoghq.com, EU=mcp.datadoghq.eu, AP1=mcp.ap1.datadoghq.com, AP2=mcp.ap2.datadoghq.com, UK1=mcp.uk1.datadoghq.com — all sharing the same /v1/mcp path. The US1-FED / GovCloud site (app.ddog-gov.com) is NOT supported. Because the host varies per site, the server URI is user-supplied: a non-secret required credential with target 'server_uri' (default_value US1) lets the user pick their regional endpoint, and the resolver's server_uri_is_user_supplied() therefore accepts any user-chosen host instead of pinning the US1 URL exactly. Verified live: an unauthenticated MCP initialize POST to /v1/mcp returns 401 auth-required on both mcp.datadoghq.com and mcp.datadoghq.eu, while non-existent paths return 404, confirming the path is routed on both commercial and EU sites. Per-site host map cross-checked against the mcp_server_endpoint entries in regions.config.js in the DataDog/documentation repo. Primary auth is OAuth 2.0 with a browser-based sign-in/redirect (\"You are prompted to login through OAuth\"). The docs do not state whether DCR or discovery metadata is used; as a modern remote MCP server it almost certainly advertises authorization/token endpoints via OAuth discovery (.well-known), so oauth_authorization_endpoint/token_endpoint are left null and OAuth endpoints are discovered from the MCP metadata chain. Verified live 2026-08-31: GET /.well-known/oauth-authorization-server/v1/mcp returns complete RFC 8414 metadata on all seven sites, and each site advertises authorization, token, and DCR registration endpoints on a sibling host rather than on mcp.* itself. OAuth endpoints reached through the discovery chain may use a different host from the MCP server; they must still use HTTPS and pass SSRF validation. No specific OAuth scopes are documented (metadata advertises a single supported scope, mcp_all). An optional toolsets query param controls available tools (?toolsets=all, default core, or comma-separated e.g. apm,llmobs,monitors,logs) and may be appended to any regional URL. ALTERNATIVE auth (not chosen here, since intended transport is HTTP+OAuth) for headless/server environments: pass two HTTP headers DD_API_KEY and DD_APPLICATION_KEY (Datadog recommends a scoped service-account API key + application key). If the catalog instead wants the API-key path, switch auth_type to CUSTOM with two required secret credentials keyed DD_API_KEY and DD_APPLICATION_KEY plus an optional non-secret site/host field for region selection. No npx/uvx/pip package — it is a hosted remote server, so packages[] is empty.",
           "sources": [
-            "https://docs.datadoghq.com/bits_ai/mcp_server/",
-            "https://docs.datadoghq.com/bits_ai/mcp_server/setup/",
+            "https://docs.datadoghq.com/mcp_server/setup/",
+            "https://docs.datadoghq.com/mcp_server/",
+            "https://github.com/DataDog/documentation/blob/master/hugo/assets/scripts/config/regions.config.js",
             "https://www.datadoghq.com/blog/datadog-remote-mcp-server/",
             "https://www.datadoghq.com/knowledge-center/mcp-server/"
           ]

--- a/tests/unit/test_mcp_catalog_loader.py
+++ b/tests/unit/test_mcp_catalog_loader.py
@@ -743,6 +743,25 @@ def test_private_catalog_overlay_does_not_drop_public_rows() -> None:
     assert splunk_oauth_credentials["client_secret"].secret is True
 
 
+def test_datadog_row_uses_configurable_regional_v1_endpoint() -> None:
+    """Datadog users can select their regional /v1/mcp endpoint."""
+    _clear_catalog_cache()
+    entry = loader.get_platform_mcp_catalog_entry_by_slug(
+        "datadog-mcp", include_private=True
+    )
+    assert entry is not None
+    spec = entry.connection_spec
+    assert spec is not None
+    assert spec.kind == "http_oauth2"
+    assert spec.server_uri == "https://mcp.datadoghq.com/v1/mcp"
+    assert spec.requires_config is True
+    assert spec.oauth_authorization_endpoint is None
+    assert spec.oauth_token_endpoint is None
+    assert {credential.key: credential.target for credential in spec.credentials} == {
+        "server_url": "server_uri",
+    }
+
+
 def test_google_secops_row_ships_templated_uri_and_pinned_authorize_params() -> None:
     """Google's managed remote SecOps server needs a region and offline consent."""
     _clear_catalog_cache()

--- a/tests/unit/test_mcp_catalog_loader.py
+++ b/tests/unit/test_mcp_catalog_loader.py
@@ -755,6 +755,7 @@ def test_datadog_row_uses_configurable_regional_v1_endpoint() -> None:
     assert spec.kind == "http_oauth2"
     assert spec.server_uri == "https://mcp.datadoghq.com/v1/mcp"
     assert spec.requires_config is True
+    assert spec.oauth_resource_ignored_query_params == ["toolsets"]
     assert spec.oauth_authorization_endpoint is None
     assert spec.oauth_token_endpoint is None
     assert {credential.key: credential.target for credential in spec.credentials} == {

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -4900,6 +4900,7 @@ class TestMCPProviderOAuth:
             "https://mcp.example.com/.well-known/oauth-protected-resource": None,
             "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": None,
             "https://mcp.example.com/.well-known/oauth-authorization-server": {
+                "issuer": "https://mcp.example.com",
                 "authorization_endpoint": "https://mcp.example.com/oauth/authorize",
                 "token_endpoint": "https://mcp.example.com/oauth/token",
                 "registration_endpoint": "https://mcp.example.com/oauth/register",
@@ -4934,13 +4935,16 @@ class TestMCPProviderOAuth:
         docs = {
             "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": {
                 "resource": "https://mcp.example.com/mcp",
+                "authorization_servers": ["https://mcp.example.com"],
+            },
+            "https://mcp.example.com/.well-known/oauth-protected-resource": None,
+            "https://mcp.example.com/.well-known/oauth-authorization-server": {
+                "issuer": "https://mcp.example.com",
                 "authorization_endpoint": "https://mcp.example.com/oauth/authorize",
                 "token_endpoint": "https://mcp.example.com/oauth/token",
                 "registration_endpoint": "https://mcp.example.com/oauth/register",
                 "token_endpoint_auth_methods_supported": ["none"],
             },
-            "https://mcp.example.com/.well-known/oauth-protected-resource": None,
-            "https://mcp.example.com/.well-known/oauth-authorization-server": None,
         }
 
         async def fake_fetch(url: str) -> OAuthServerMetadata | None:
@@ -4962,12 +4966,14 @@ class TestMCPProviderOAuth:
     ) -> None:
         """Generic MCP DCR follows authorization_servers from the resource."""
         docs = {
-            "https://tenant.example.com/.well-known/oauth-protected-resource": {
-                "authorization_servers": ["https://login.example-idp.com"]
+            "https://tenant.example.com/.well-known/oauth-protected-resource/mcp": {
+                "resource": "https://tenant.example.com/mcp",
+                "authorization_servers": ["https://login.example-idp.com"],
             },
-            "https://tenant.example.com/.well-known/oauth-protected-resource/mcp": None,
+            "https://tenant.example.com/.well-known/oauth-protected-resource": None,
             "https://tenant.example.com/.well-known/oauth-authorization-server": None,
             "https://login.example-idp.com/.well-known/oauth-authorization-server": {
+                "issuer": "https://login.example-idp.com",
                 "authorization_endpoint": (
                     "https://login.example-idp.com/oauth/authorize"
                 ),
@@ -5006,7 +5012,8 @@ class TestMCPProviderOAuth:
         """RFC 8414 inserts the well-known path before a path-scoped issuer."""
         docs = {
             "https://tenant.example.com/.well-known/oauth-protected-resource/mcp": {
-                "authorization_servers": ["https://login.example-idp.com/tenant"]
+                "resource": "https://tenant.example.com/mcp",
+                "authorization_servers": ["https://login.example-idp.com/tenant"],
             },
             "https://tenant.example.com/.well-known/oauth-protected-resource": None,
             "https://tenant.example.com/.well-known/oauth-authorization-server": None,
@@ -5014,6 +5021,7 @@ class TestMCPProviderOAuth:
                 "https://login.example-idp.com"
                 "/.well-known/oauth-authorization-server/tenant"
             ): {
+                "issuer": "https://login.example-idp.com/tenant",
                 "authorization_endpoint": (
                     "https://login.example-idp.com/tenant/oauth/authorize"
                 ),
@@ -5053,12 +5061,16 @@ class TestMCPProviderOAuth:
         """Generic MCP DCR preserves an explicit root slash in resource URIs."""
         docs = {
             "https://mcp.app.wiz.io/.well-known/oauth-protected-resource": {
+                "resource": "https://mcp.app.wiz.io/",
+                "authorization_servers": ["https://mcp.app.wiz.io"],
+            },
+            "https://mcp.app.wiz.io/.well-known/oauth-authorization-server": {
+                "issuer": "https://mcp.app.wiz.io",
                 "authorization_endpoint": ("https://mcp.app.wiz.io/oauth/authorize"),
                 "token_endpoint": "https://mcp.app.wiz.io/oauth/token",
                 "registration_endpoint": "https://mcp.app.wiz.io/oauth/register",
                 "token_endpoint_auth_methods_supported": ["none"],
             },
-            "https://mcp.app.wiz.io/.well-known/oauth-authorization-server": None,
         }
 
         async def fake_fetch(url: str) -> OAuthServerMetadata | None:
@@ -5082,6 +5094,7 @@ class TestMCPProviderOAuth:
             "https://mcp.example.com/.well-known/oauth-protected-resource": None,
             "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": None,
             "https://mcp.example.com/.well-known/oauth-authorization-server": {
+                "issuer": "https://mcp.example.com",
                 "authorization_endpoint": "https://mcp.example.com/oauth/authorize",
                 "token_endpoint": "https://mcp.example.com/oauth/token",
                 "registration_endpoint": "https://mcp.example.com/oauth/register",
@@ -6179,11 +6192,13 @@ class TestMCPProviderOAuth:
         """OAuth metadata may advertise endpoints on separate HTTPS hosts."""
         docs = {
             "https://mcp.example.com/.well-known/oauth-protected-resource/v1/mcp": {
-                "authorization_servers": ["https://mcp.example.com/v1/mcp"]
+                "resource": "https://mcp.example.com/v1/mcp",
+                "authorization_servers": ["https://mcp.example.com/v1/mcp"],
             },
             "https://mcp.example.com/.well-known/oauth-protected-resource": None,
             "https://mcp.example.com/.well-known/oauth-authorization-server": None,
             "https://mcp.example.com/.well-known/oauth-authorization-server/v1/mcp": {
+                "issuer": "https://mcp.example.com/v1/mcp",
                 "authorization_endpoint": "https://identity.example.net/oauth/authorize",
                 "token_endpoint": "https://identity.example.net/oauth/token",
                 "registration_endpoint": "https://identity.example.net/oauth/register",
@@ -6207,6 +6222,59 @@ class TestMCPProviderOAuth:
         assert endpoints.registration_endpoint == (
             "https://identity.example.net/oauth/register"
         )
+
+    async def test_generic_mcp_discovery_rejects_mismatched_resource_identity(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Protected-resource metadata cannot impersonate another MCP resource."""
+        docs = {
+            "https://malicious-mcp.example/.well-known/oauth-protected-resource/mcp": {
+                "resource": "https://victim-mcp.example/mcp",
+                "authorization_servers": ["https://victim-idp.example"],
+            }
+        }
+
+        async def fake_fetch(url: str) -> OAuthServerMetadata | None:
+            return OAuthServerMetadata.from_json(docs[url])
+
+        monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
+
+        with pytest.raises(ValueError, match="does not match the MCP resource"):
+            await integration_service._discover_mcp_oauth_endpoints(
+                server_uri="https://malicious-mcp.example/mcp",
+            )
+
+    async def test_generic_mcp_discovery_rejects_mismatched_issuer_identity(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Authorization-server metadata cannot substitute another issuer."""
+        docs = {
+            "https://malicious-mcp.example/.well-known/oauth-protected-resource/mcp": {
+                "resource": "https://malicious-mcp.example/mcp",
+                "authorization_servers": ["https://malicious-metadata.example"],
+            },
+            "https://malicious-metadata.example/.well-known/oauth-authorization-server": {
+                "issuer": "https://victim-idp.example",
+                "authorization_endpoint": "https://victim-idp.example/oauth/authorize",
+                "token_endpoint": "https://malicious-metadata.example/capture-code",
+                "registration_endpoint": "https://victim-idp.example/oauth/register",
+                "token_endpoint_auth_methods_supported": ["none"],
+            },
+        }
+
+        async def fake_fetch(url: str) -> OAuthServerMetadata | None:
+            return OAuthServerMetadata.from_json(docs[url])
+
+        monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
+
+        with pytest.raises(ValueError, match="issuer does not match"):
+            await integration_service._discover_mcp_oauth_endpoints(
+                server_uri="https://malicious-mcp.example/mcp",
+            )
 
     async def test_connect_mcp_oauth_discovery_forwards_catalog_oauth_resource(
         self,
@@ -6268,6 +6336,7 @@ class TestMCPProviderOAuth:
             "https://tenant.example.com/.well-known/oauth-protected-resource": None,
             "https://tenant.example.com/.well-known/oauth-authorization-server": None,
             "https://login.example-idp.com/.well-known/oauth-authorization-server": {
+                "issuer": "https://login.example-idp.com",
                 "authorization_endpoint": (
                     "https://login.example-idp.com/oauth/authorize"
                 ),

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -5084,6 +5084,54 @@ class TestMCPProviderOAuth:
 
         assert endpoints.resource == "https://mcp.app.wiz.io/"
 
+    @pytest.mark.parametrize(
+        ("server_uri", "metadata_url"),
+        [
+            (
+                "https://mcp.example.com/mcp?tenant=alpha",
+                "https://mcp.example.com/.well-known/"
+                "oauth-protected-resource/mcp?tenant=alpha",
+            ),
+            (
+                "https://mcp.example.com?tenant=alpha",
+                "https://mcp.example.com/.well-known/"
+                "oauth-protected-resource?tenant=alpha",
+            ),
+        ],
+    )
+    async def test_generic_mcp_discovery_preserves_query_resource_identity(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+        server_uri: str,
+        metadata_url: str,
+    ) -> None:
+        """RFC 9728 query components remain part of the resource identity."""
+        docs = {
+            metadata_url: {
+                "resource": server_uri,
+                "authorization_servers": ["https://login.example-idp.com"],
+            },
+            "https://login.example-idp.com/.well-known/oauth-authorization-server": {
+                "issuer": "https://login.example-idp.com",
+                "authorization_endpoint": (
+                    "https://login.example-idp.com/oauth/authorize"
+                ),
+                "token_endpoint": "https://login.example-idp.com/oauth/token",
+            },
+        }
+
+        async def fake_fetch(url: str) -> OAuthServerMetadata | None:
+            return OAuthServerMetadata.from_json(docs[url])
+
+        monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
+
+        endpoints = await integration_service._discover_mcp_oauth_endpoints(
+            server_uri=server_uri,
+        )
+
+        assert endpoints.resource == server_uri
+
     async def test_generic_mcp_discovery_captures_scopes_supported(
         self,
         integration_service: IntegrationService,
@@ -6318,9 +6366,20 @@ class TestMCPProviderOAuth:
         self,
     ) -> None:
         """Saved Feedly connections can recover the audience after OAuth redirect."""
-        assert IntegrationService._catalog_mcp_oauth_resource("feedly-mcp") == (
-            "https://mcp.feedly.com"
-        )
+        assert IntegrationService._catalog_mcp_oauth_resource(
+            "feedly-mcp",
+            server_uri="https://mcp.feedly.com/mcp",
+        ) == ("https://mcp.feedly.com")
+
+    def test_datadog_catalog_ignores_only_toolsets_in_oauth_resource(self) -> None:
+        """Datadog tool selection does not alter its OAuth resource identity."""
+        assert IntegrationService._catalog_mcp_oauth_resource(
+            "datadog-mcp",
+            server_uri=(
+                "https://mcp.us3.datadoghq.com/v1/mcp"
+                "?tenant=alpha&toolsets=core%2Call&mode=strict"
+            ),
+        ) == ("https://mcp.us3.datadoghq.com/v1/mcp?tenant=alpha&mode=strict")
 
     async def test_generic_mcp_discovery_uses_protected_resource_identifier(
         self,

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -6171,19 +6171,22 @@ class TestMCPProviderOAuth:
         assert "10.0.0.10" not in message
         assert "private" not in message.lower()
 
-    async def test_generic_mcp_discovery_rejects_untrusted_endpoint_hosts(
+    async def test_generic_mcp_discovery_allows_cross_host_endpoints(
         self,
         integration_service: IntegrationService,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Generic MCP DCR endpoints must stay on the metadata document host."""
+        """OAuth metadata may advertise endpoints on separate HTTPS hosts."""
         docs = {
-            "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": None,
+            "https://mcp.example.com/.well-known/oauth-protected-resource/v1/mcp": {
+                "authorization_servers": ["https://mcp.example.com/v1/mcp"]
+            },
             "https://mcp.example.com/.well-known/oauth-protected-resource": None,
-            "https://mcp.example.com/.well-known/oauth-authorization-server": {
-                "authorization_endpoint": "https://evil.example/oauth/authorize",
-                "token_endpoint": "https://evil.example/oauth/token",
-                "registration_endpoint": "https://evil.example/oauth/register",
+            "https://mcp.example.com/.well-known/oauth-authorization-server": None,
+            "https://mcp.example.com/.well-known/oauth-authorization-server/v1/mcp": {
+                "authorization_endpoint": "https://identity.example.net/oauth/authorize",
+                "token_endpoint": "https://identity.example.net/oauth/token",
+                "registration_endpoint": "https://identity.example.net/oauth/register",
                 "token_endpoint_auth_methods_supported": ["none"],
             },
         }
@@ -6192,75 +6195,33 @@ class TestMCPProviderOAuth:
             return OAuthServerMetadata.from_json(docs[url])
 
         monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
-
-        with pytest.raises(ValueError, match="does not match expected domain"):
-            await integration_service._discover_mcp_oauth_endpoints(
-                server_uri="https://mcp.example.com/mcp",
-            )
-
-    async def test_generic_mcp_discovery_allows_catalog_pinned_endpoint_hosts(
-        self,
-        integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Hosts of catalog-pinned OAuth endpoints are trusted in discovery.
-
-        Mirrors incident.io: metadata on mcp.* advertises authorization/token
-        endpoints on app.*, with registration staying on the metadata host.
-        """
-        docs = {
-            "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": None,
-            "https://mcp.example.com/.well-known/oauth-protected-resource": None,
-            "https://mcp.example.com/.well-known/oauth-authorization-server": {
-                "authorization_endpoint": "https://app.example.com/oauth/authorize",
-                "token_endpoint": "https://app.example.com/oauth/token",
-                "registration_endpoint": "https://mcp.example.com/oauth/register",
-                "token_endpoint_auth_methods_supported": ["none"],
-            },
-        }
-
-        async def fake_fetch(url: str) -> OAuthServerMetadata | None:
-            return OAuthServerMetadata.from_json(docs[url])
-
-        monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
-
-        # Unrelated hosts are still rejected even with an allowlist present.
-        with pytest.raises(ValueError, match="does not match expected domain"):
-            await integration_service._discover_mcp_oauth_endpoints(
-                server_uri="https://mcp.example.com/mcp",
-                allowed_endpoint_hosts=frozenset({"other.example.com"}),
-            )
 
         endpoints = await integration_service._discover_mcp_oauth_endpoints(
-            server_uri="https://mcp.example.com/mcp",
-            allowed_endpoint_hosts=frozenset({"app.example.com"}),
+            server_uri="https://mcp.example.com/v1/mcp",
         )
 
         assert endpoints.authorization_endpoint == (
-            "https://app.example.com/oauth/authorize"
+            "https://identity.example.net/oauth/authorize"
         )
-        assert endpoints.token_endpoint == "https://app.example.com/oauth/token"
+        assert endpoints.token_endpoint == "https://identity.example.net/oauth/token"
         assert endpoints.registration_endpoint == (
-            "https://mcp.example.com/oauth/register"
+            "https://identity.example.net/oauth/register"
         )
 
-    async def test_connect_mcp_oauth_discovery_trusts_catalog_pinned_hosts(
+    async def test_connect_mcp_oauth_discovery_forwards_catalog_oauth_resource(
         self,
         integration_service: IntegrationService,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Connect derives trusted endpoint hosts from catalog-pinned endpoints."""
-        captured_hosts: list[frozenset[str]] = []
+        """Connect forwards a catalog-pinned OAuth resource to discovery."""
         captured_resources: list[str | None] = []
 
         async def fake_discover(
             *,
             server_uri: str,
             oauth_resource: str | None = None,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
             _ = server_uri
-            captured_hosts.append(allowed_endpoint_hosts)
             captured_resources.append(oauth_resource)
             raise RuntimeError("stop after capture")
 
@@ -6271,21 +6232,18 @@ class TestMCPProviderOAuth:
         catalog_spec = MCPHTTPOAuth2ConnectionSpec(
             server_uri="https://mcp.example.com/mcp",
             oauth_resource="https://mcp.example.com",
-            oauth_authorization_endpoint="https://app.example.com/oauth/authorize",
-            oauth_token_endpoint="https://app.example.com/oauth/token",
         )
 
         with pytest.raises(RuntimeError, match="stop after capture"):
             await integration_service.connect_mcp_oauth_discovery(
                 params=MCPHttpIntegrationCreate(
-                    name="Pinned Hosts MCP",
+                    name="Pinned Resource MCP",
                     server_uri="https://mcp.example.com/mcp",
                     auth_type=MCPAuthType.OAUTH2,
                 ),
                 resolved_catalog=_resolved_catalog(catalog_spec),
             )
 
-        assert captured_hosts == [frozenset({"app.example.com"})]
         assert captured_resources == ["https://mcp.example.com"]
 
     def test_feedly_catalog_pins_origin_level_oauth_resource(
@@ -6979,9 +6937,8 @@ class TestMCPProviderOAuth:
         async def fake_discover(
             *,
             server_uri: str,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
-            _ = server_uri, allowed_endpoint_hosts
+            _ = server_uri
             return endpoints
 
         monkeypatch.setattr(
@@ -7064,9 +7021,8 @@ class TestMCPProviderOAuth:
         async def fake_discover(
             *,
             server_uri: str,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
-            _ = server_uri, allowed_endpoint_hosts
+            _ = server_uri
             return endpoints
 
         monkeypatch.setattr(
@@ -7339,9 +7295,8 @@ class TestMCPProviderOAuth:
             *,
             server_uri: str,
             oauth_resource: str | None = None,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
-            _ = server_uri, oauth_resource, allowed_endpoint_hosts
+            _ = server_uri, oauth_resource
             return endpoints
 
         async def fake_register(
@@ -7616,9 +7571,8 @@ class TestMCPProviderOAuth:
             *,
             server_uri: str,
             oauth_resource: str | None = None,
-            allowed_endpoint_hosts: frozenset[str] = frozenset(),
         ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
-            _ = server_uri, oauth_resource, allowed_endpoint_hosts
+            _ = server_uri, oauth_resource
             return integration_service_module.MCPOAuthDiscoveryEndpoints(
                 authorization_endpoint="https://auth.example.test/oauth/authorize",
                 token_endpoint="https://auth.example.test/oauth/token",

--- a/tests/unit/test_mcp_oauth_discovery.py
+++ b/tests/unit/test_mcp_oauth_discovery.py
@@ -1,0 +1,37 @@
+import pytest
+
+from tracecat.integrations.service import IntegrationService
+from tracecat.integrations.types import OAuthServerMetadata
+
+
+@pytest.mark.anyio
+async def test_discovery_rejects_resource_without_authorization_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MCP resource metadata must select an authorization server."""
+    integration_service = object.__new__(IntegrationService)
+    root_metadata_url = "https://mcp.example.com/.well-known/oauth-protected-resource"
+    docs = {
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp": {
+            "resource": "https://mcp.example.com/mcp",
+        },
+        # A different resource's metadata must not supply the missing issuer.
+        root_metadata_url: {
+            "resource": "https://mcp.example.com",
+            "authorization_servers": ["https://login.example-idp.com"],
+        },
+    }
+    fetched_urls: list[str] = []
+
+    async def fake_fetch(url: str) -> OAuthServerMetadata | None:
+        fetched_urls.append(url)
+        return OAuthServerMetadata.from_json(docs[url])
+
+    monkeypatch.setattr(integration_service, "_fetch_oauth_json", fake_fetch)
+
+    with pytest.raises(ValueError, match="missing authorization_servers"):
+        await integration_service._discover_mcp_oauth_endpoints(
+            server_uri="https://mcp.example.com/mcp",
+        )
+
+    assert root_metadata_url not in fetched_urls

--- a/tracecat/integrations/catalog/loader.py
+++ b/tracecat/integrations/catalog/loader.py
@@ -114,6 +114,9 @@ def _http_spec(raw_spec: RawHttpConnectionSpec) -> MCPConnectionSpec | None:
                 credentials=credentials,
                 scopes=raw_spec.scopes or [],
                 oauth_resource=raw_spec.oauth_resource,
+                oauth_resource_ignored_query_params=(
+                    raw_spec.oauth_resource_ignored_query_params or []
+                ),
                 oauth_authorization_endpoint=raw_spec.oauth_authorization_endpoint,
                 oauth_token_endpoint=raw_spec.oauth_token_endpoint,
                 oauth_authorize_params=raw_spec.oauth_authorize_params or {},

--- a/tracecat/integrations/catalog/types.py
+++ b/tracecat/integrations/catalog/types.py
@@ -88,6 +88,7 @@ class RawHttpConnectionSpec(BaseModel):
     credentials: list[RawCredential] | None = None
     scopes: list[str] | None = None
     oauth_resource: str | None = None
+    oauth_resource_ignored_query_params: list[str] | None = None
     oauth_authorization_endpoint: str | None = None
     oauth_token_endpoint: str | None = None
     oauth_authorize_params: dict[str, str] | None = None

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -751,6 +751,12 @@ class MCPHTTPOAuth2ConnectionSpec(_MCPConnectionSpecBase):
     This may differ from ``server_uri`` when a provider protects every MCP
     route under one origin-level audience.
     """
+    oauth_resource_ignored_query_params: list[str] = Field(default_factory=list)
+    """Transport-only query parameters omitted from the OAuth resource URI.
+
+    This exception is catalog-controlled because query components are part of
+    generic RFC 9728 resource identities unless a provider defines otherwise.
+    """
     oauth_authorization_endpoint: str | None = None
     """Known OAuth authorization endpoint pinned by the repo-owned catalog row.
 

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1064,6 +1064,10 @@ class IntegrationService(BaseWorkspaceService):
             if oauth_resource is None:
                 resource_uri = discovered_resource
             authorization_server_issuers = metadata.authorization_servers
+            if not authorization_server_issuers:
+                raise ValueError(
+                    "OAuth protected-resource metadata is missing authorization_servers"
+                )
             break
 
         if not authorization_server_issuers:

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, TypedDict, cast
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import unquote_plus, urlparse, urlunparse
 from uuid import uuid4
 
 import httpx
@@ -756,40 +756,75 @@ class IntegrationService(BaseWorkspaceService):
 
     @staticmethod
     def _mcp_oauth_resource_metadata_urls(
-        server_uri: str,
+        resource_uri: str,
     ) -> list[tuple[str, str]]:
         """Build RFC 9728 URLs paired with their expected resource identifiers."""
-        parsed = urlparse(server_uri)
-        base_url = IntegrationService._mcp_resource_base_url(server_uri)
+        resource_uri = IntegrationService._mcp_resource_uri(resource_uri)
+        parsed = urlparse(resource_uri)
+        base_url = IntegrationService._mcp_resource_base_url(resource_uri)
         urls: list[tuple[str, str]] = []
         if parsed.path and parsed.path != "/":
-            resource_uri = IntegrationService._mcp_resource_uri(server_uri)
-            parsed_resource = urlparse(resource_uri)
-            # Query parameters configure the MCP transport (for example,
-            # Datadog toolsets) but are not part of its OAuth resource identity.
-            expected_resource = urlunparse(
-                (
-                    parsed_resource.scheme,
-                    parsed_resource.netloc,
-                    parsed_resource.path,
-                    "",
-                    "",
-                    "",
-                )
-            )
             urls.append(
                 (
-                    f"{base_url}/.well-known/oauth-protected-resource{parsed.path}",
-                    expected_resource,
+                    urlunparse(
+                        (
+                            "https",
+                            parsed.netloc,
+                            f"/.well-known/oauth-protected-resource{parsed.path}",
+                            "",
+                            parsed.query,
+                            "",
+                        )
+                    ),
+                    resource_uri,
                 )
             )
-        root_resource = (
-            IntegrationService._mcp_resource_uri(server_uri)
-            if parsed.path == "/"
-            else base_url
-        )
-        urls.append((f"{base_url}/.well-known/oauth-protected-resource", root_resource))
+            urls.append((f"{base_url}/.well-known/oauth-protected-resource", base_url))
+        else:
+            metadata_url = urlunparse(
+                (
+                    "https",
+                    parsed.netloc,
+                    "/.well-known/oauth-protected-resource",
+                    "",
+                    parsed.query,
+                    "",
+                )
+            )
+            urls.append((metadata_url, resource_uri))
         return urls
+
+    @classmethod
+    def _catalog_spec_mcp_oauth_resource(
+        cls,
+        catalog_spec: MCPHTTPOAuth2ConnectionSpec,
+        *,
+        server_uri: str,
+    ) -> str | None:
+        """Return a catalog-pinned or provider-normalized OAuth resource URI."""
+        if catalog_spec.oauth_resource is not None:
+            return catalog_spec.oauth_resource
+        ignored_params = set(catalog_spec.oauth_resource_ignored_query_params)
+        if not ignored_params:
+            return None
+
+        resource_uri = cls._mcp_resource_uri(server_uri)
+        parsed = urlparse(resource_uri)
+        query_parts = [
+            part
+            for part in parsed.query.split("&")
+            if unquote_plus(part.partition("=")[0]) not in ignored_params
+        ]
+        return urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path,
+                "",
+                "&".join(query_parts),
+                "",
+            )
+        )
 
     @staticmethod
     def _validate_mcp_oauth_resource_metadata(
@@ -1017,7 +1052,7 @@ class IntegrationService(BaseWorkspaceService):
         # after this chain of authority has been established.
         authorization_server_issuers: list[str] = []
         for metadata_url, expected_resource in self._mcp_oauth_resource_metadata_urls(
-            server_uri
+            resource_uri
         ):
             metadata = await self._fetch_oauth_json(metadata_url)
             if not metadata:
@@ -1032,7 +1067,7 @@ class IntegrationService(BaseWorkspaceService):
             break
 
         if not authorization_server_issuers:
-            authorization_server_issuers = [self._mcp_resource_base_url(server_uri)]
+            authorization_server_issuers = [self._mcp_resource_base_url(resource_uri)]
 
         direct_metadata: OAuthServerMetadata | None = None
         for raw_issuer in authorization_server_issuers:
@@ -1332,7 +1367,10 @@ class IntegrationService(BaseWorkspaceService):
             if not isinstance(catalog_spec, MCPHTTPOAuth2ConnectionSpec):
                 raise ValueError("Catalog option is not an HTTP OAuth MCP server")
             scopes = catalog_spec.scopes
-            oauth_resource = catalog_spec.oauth_resource
+            oauth_resource = self._catalog_spec_mcp_oauth_resource(
+                catalog_spec,
+                server_uri=params.server_uri,
+            )
             # Fail before any discovery or registration call so a row that
             # cannot connect is never half-created.
             self._validate_required_catalog_headers(
@@ -1719,7 +1757,8 @@ class IntegrationService(BaseWorkspaceService):
             server_uri=mcp_integration.server_uri,
             provider_config=provider_config,
             oauth_resource=self._catalog_mcp_oauth_resource(
-                mcp_integration.catalog_slug
+                mcp_integration.catalog_slug,
+                server_uri=mcp_integration.server_uri,
             ),
         )
         client_secret = (
@@ -1796,7 +1835,8 @@ class IntegrationService(BaseWorkspaceService):
             server_uri=mcp_integration.server_uri,
             provider_config=provider_config,
             oauth_resource=self._catalog_mcp_oauth_resource(
-                mcp_integration.catalog_slug
+                mcp_integration.catalog_slug,
+                server_uri=mcp_integration.server_uri,
             ),
         )
         client_secret = (
@@ -3196,7 +3236,8 @@ class IntegrationService(BaseWorkspaceService):
             server_uri=mcp_integration.server_uri,
             provider_config=provider_config,
             oauth_resource=self._catalog_mcp_oauth_resource(
-                mcp_integration.catalog_slug
+                mcp_integration.catalog_slug,
+                server_uri=mcp_integration.server_uri,
             ),
         )
         client_secret = (
@@ -3489,7 +3530,12 @@ class IntegrationService(BaseWorkspaceService):
         return ResolvedCatalogConnection(entry=catalog, option=default_option)
 
     @classmethod
-    def _catalog_mcp_oauth_resource(cls, catalog_slug: str | None) -> str | None:
+    def _catalog_mcp_oauth_resource(
+        cls,
+        catalog_slug: str | None,
+        *,
+        server_uri: str,
+    ) -> str | None:
         """Return a catalog-pinned OAuth resource for a saved MCP integration."""
         if catalog_slug is None:
             return None
@@ -3500,7 +3546,10 @@ class IntegrationService(BaseWorkspaceService):
             return None
         if not isinstance(catalog.connection_spec, MCPHTTPOAuth2ConnectionSpec):
             return None
-        return catalog.connection_spec.oauth_resource
+        return cls._catalog_spec_mcp_oauth_resource(
+            catalog.connection_spec,
+            server_uri=server_uri,
+        )
 
     @classmethod
     def _catalog_mcp_authorize_params(cls, catalog_slug: str | None) -> dict[str, str]:

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -755,15 +755,72 @@ class IntegrationService(BaseWorkspaceService):
         return urlunparse(("https", netloc, path, "", parsed.query, ""))
 
     @staticmethod
-    def _mcp_oauth_metadata_urls(server_uri: str) -> list[str]:
+    def _mcp_oauth_resource_metadata_urls(
+        server_uri: str,
+    ) -> list[tuple[str, str]]:
+        """Build RFC 9728 URLs paired with their expected resource identifiers."""
         parsed = urlparse(server_uri)
         base_url = IntegrationService._mcp_resource_base_url(server_uri)
-        urls: list[str] = []
+        urls: list[tuple[str, str]] = []
         if parsed.path and parsed.path != "/":
-            urls.append(f"{base_url}/.well-known/oauth-protected-resource{parsed.path}")
-        urls.append(f"{base_url}/.well-known/oauth-protected-resource")
-        urls.append(f"{base_url}/.well-known/oauth-authorization-server")
+            resource_uri = IntegrationService._mcp_resource_uri(server_uri)
+            parsed_resource = urlparse(resource_uri)
+            # Query parameters configure the MCP transport (for example,
+            # Datadog toolsets) but are not part of its OAuth resource identity.
+            expected_resource = urlunparse(
+                (
+                    parsed_resource.scheme,
+                    parsed_resource.netloc,
+                    parsed_resource.path,
+                    "",
+                    "",
+                    "",
+                )
+            )
+            urls.append(
+                (
+                    f"{base_url}/.well-known/oauth-protected-resource{parsed.path}",
+                    expected_resource,
+                )
+            )
+        root_resource = (
+            IntegrationService._mcp_resource_uri(server_uri)
+            if parsed.path == "/"
+            else base_url
+        )
+        urls.append((f"{base_url}/.well-known/oauth-protected-resource", root_resource))
         return urls
+
+    @staticmethod
+    def _validate_mcp_oauth_resource_metadata(
+        metadata: OAuthServerMetadata,
+        *,
+        expected_resource: str,
+    ) -> str:
+        """Validate the RFC 9728 resource identity for a metadata response."""
+        if metadata.resource is None:
+            raise ValueError("OAuth protected-resource metadata is missing resource")
+        resource = IntegrationService._mcp_resource_uri(metadata.resource)
+        if resource != expected_resource:
+            raise ValueError(
+                "OAuth protected-resource metadata does not match the MCP resource"
+            )
+        return resource
+
+    @staticmethod
+    def _validate_mcp_oauth_server_metadata(
+        metadata: OAuthServerMetadata,
+        *,
+        expected_issuer: str,
+    ) -> None:
+        """Validate the RFC 8414 issuer identity for a metadata response."""
+        if metadata.issuer is None:
+            raise ValueError("OAuth authorization-server metadata is missing issuer")
+        if metadata.issuer != expected_issuer:
+            raise ValueError(
+                "OAuth authorization-server metadata issuer does not match "
+                "the discovered issuer"
+            )
 
     @classmethod
     def _catalog_pinned_oauth_endpoints(
@@ -953,38 +1010,50 @@ class IntegrationService(BaseWorkspaceService):
         oauth_resource: str | None = None,
     ) -> MCPOAuthDiscoveryEndpoints:
         resource_uri = self._mcp_resource_uri(oauth_resource or server_uri)
-        resource_host = urlparse(resource_uri).hostname
-        if resource_host is None:
-            raise ValueError("MCP server URI is missing a hostname")
 
-        # Two-tier OAuth discovery (RFC 9728 + RFC 8414): first try the server's
-        # own .well-known metadata. If it advertises the endpoints directly we use
-        # them; otherwise it points at separate authorization servers whose
-        # .well-known metadata we fetch in the second pass below.
-        auth_server_metadata_urls: list[str] = []
-        direct_metadata: OAuthServerMetadata | None = None
-        for metadata_url in self._mcp_oauth_metadata_urls(server_uri):
+        # Two-tier OAuth discovery (RFC 9728 + RFC 8414): validate the protected
+        # resource identity, then validate the authorization server metadata
+        # against the issuer that selected it. Endpoint hosts may differ only
+        # after this chain of authority has been established.
+        authorization_server_issuers: list[str] = []
+        for metadata_url, expected_resource in self._mcp_oauth_resource_metadata_urls(
+            server_uri
+        ):
             metadata = await self._fetch_oauth_json(metadata_url)
             if not metadata:
                 continue
-            # Metadata may override the canonical resource identifier we send as
-            # the OAuth `resource` parameter; re-validate it before trusting it.
-            if metadata.resource and oauth_resource is None:
-                resource_uri = self._mcp_resource_uri(metadata.resource)
-            if metadata.is_complete:
+            discovered_resource = self._validate_mcp_oauth_resource_metadata(
+                metadata,
+                expected_resource=expected_resource,
+            )
+            if oauth_resource is None:
+                resource_uri = discovered_resource
+            authorization_server_issuers = metadata.authorization_servers
+            break
+
+        if not authorization_server_issuers:
+            authorization_server_issuers = [self._mcp_resource_base_url(server_uri)]
+
+        direct_metadata: OAuthServerMetadata | None = None
+        for raw_issuer in authorization_server_issuers:
+            issuer = raw_issuer.strip()
+            metadata_urls = oauth_authorization_server_metadata_urls(issuer)
+            if not metadata_urls:
+                raise ValueError("OAuth authorization-server issuer is invalid")
+            for metadata_url in metadata_urls:
+                metadata = await self._fetch_oauth_json(metadata_url)
+                if metadata is None:
+                    continue
+                self._validate_mcp_oauth_server_metadata(
+                    metadata,
+                    expected_issuer=issuer,
+                )
+                if not metadata.is_complete:
+                    continue
                 direct_metadata = metadata
                 break
-            for issuer in metadata.authorization_servers:
-                auth_server_metadata_urls.extend(
-                    oauth_authorization_server_metadata_urls(issuer)
-                )
-
-        if direct_metadata is None:
-            for metadata_url in auth_server_metadata_urls:
-                metadata = await self._fetch_oauth_json(metadata_url)
-                if metadata and metadata.is_complete:
-                    direct_metadata = metadata
-                    break
+            if direct_metadata is not None:
+                break
 
         if direct_metadata is None:
             raise ValueError(f"Could not discover OAuth endpoints from {server_uri}")

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -772,7 +772,6 @@ class IntegrationService(BaseWorkspaceService):
         *,
         server_uri: str,
         oauth_resource: str | None,
-        allowed_endpoint_hosts: frozenset[str],
     ) -> MCPOAuthDiscoveryEndpoints | None:
         """Use a catalog row's pinned OAuth endpoints instead of discovery.
 
@@ -788,40 +787,23 @@ class IntegrationService(BaseWorkspaceService):
             return None
         return MCPOAuthDiscoveryEndpoints(
             authorization_endpoint=cls._validate_mcp_oauth_endpoint(
-                authorization_endpoint, allowed_hosts=allowed_endpoint_hosts
+                authorization_endpoint
             ),
-            token_endpoint=cls._validate_mcp_oauth_endpoint(
-                token_endpoint, allowed_hosts=allowed_endpoint_hosts
-            ),
+            token_endpoint=cls._validate_mcp_oauth_endpoint(token_endpoint),
             token_methods=[],
             registration_endpoint=None,
             resource=cls._mcp_resource_uri(oauth_resource or server_uri),
         )
 
     @staticmethod
-    def _validate_mcp_oauth_endpoint(
-        endpoint: str,
-        *,
-        base_domain: str | None = None,
-        allowed_hosts: frozenset[str] = frozenset(),
-    ) -> str:
-        """Validate a generic MCP OAuth endpoint discovered from metadata.
+    def _validate_mcp_oauth_endpoint(endpoint: str) -> str:
+        """Validate a generic MCP OAuth endpoint.
 
-        Generic BYO/catalog DCR follows the trust chain from the user-supplied
-        MCP server URI to protected-resource or authorization-server metadata.
-        Endpoint hosts must match the metadata host that advertised them,
-        except for exact hosts of OAuth endpoints pinned on the repo-owned
-        catalog row (still SSRF-validated).
+        OAuth endpoints discovered from provider metadata may use a different
+        host from the MCP resource server. They still require HTTPS and undergo
+        DNS-backed SSRF validation before server-side requests.
         """
-        hostname = urlparse(endpoint).hostname
-        if not hostname:
-            raise InsecureOAuthEndpointError(
-                f"oauth_endpoint must include a hostname: {endpoint}"
-            )
-        if hostname in allowed_hosts:
-            validate_oauth_endpoint(endpoint)
-            return endpoint
-        validate_oauth_endpoint(endpoint, base_domain=base_domain)
+        validate_oauth_endpoint(endpoint)
         return endpoint
 
     @staticmethod
@@ -969,7 +951,6 @@ class IntegrationService(BaseWorkspaceService):
         *,
         server_uri: str,
         oauth_resource: str | None = None,
-        allowed_endpoint_hosts: frozenset[str] = frozenset(),
     ) -> MCPOAuthDiscoveryEndpoints:
         resource_uri = self._mcp_resource_uri(oauth_resource or server_uri)
         resource_host = urlparse(resource_uri).hostname
@@ -982,7 +963,6 @@ class IntegrationService(BaseWorkspaceService):
         # .well-known metadata we fetch in the second pass below.
         auth_server_metadata_urls: list[str] = []
         direct_metadata: OAuthServerMetadata | None = None
-        direct_metadata_host: str | None = None
         for metadata_url in self._mcp_oauth_metadata_urls(server_uri):
             metadata = await self._fetch_oauth_json(metadata_url)
             if not metadata:
@@ -993,7 +973,6 @@ class IntegrationService(BaseWorkspaceService):
                 resource_uri = self._mcp_resource_uri(metadata.resource)
             if metadata.is_complete:
                 direct_metadata = metadata
-                direct_metadata_host = urlparse(metadata_url).hostname
                 break
             for issuer in metadata.authorization_servers:
                 auth_server_metadata_urls.extend(
@@ -1005,7 +984,6 @@ class IntegrationService(BaseWorkspaceService):
                 metadata = await self._fetch_oauth_json(metadata_url)
                 if metadata and metadata.is_complete:
                     direct_metadata = metadata
-                    direct_metadata_host = urlparse(metadata_url).hostname
                     break
 
         if direct_metadata is None:
@@ -1021,20 +999,12 @@ class IntegrationService(BaseWorkspaceService):
 
         return MCPOAuthDiscoveryEndpoints(
             authorization_endpoint=self._validate_mcp_oauth_endpoint(
-                authorization_endpoint,
-                base_domain=direct_metadata_host,
-                allowed_hosts=allowed_endpoint_hosts,
+                authorization_endpoint
             ),
-            token_endpoint=self._validate_mcp_oauth_endpoint(
-                token_endpoint,
-                base_domain=direct_metadata_host,
-                allowed_hosts=allowed_endpoint_hosts,
-            ),
+            token_endpoint=self._validate_mcp_oauth_endpoint(token_endpoint),
             token_methods=token_methods,
             registration_endpoint=self._validate_mcp_oauth_endpoint(
-                registration_endpoint,
-                base_domain=direct_metadata_host,
-                allowed_hosts=allowed_endpoint_hosts,
+                registration_endpoint
             )
             if registration_endpoint
             else None,
@@ -1288,24 +1258,12 @@ class IntegrationService(BaseWorkspaceService):
             )
 
         scopes: list[str] | None = None
-        allowed_endpoint_hosts: frozenset[str] = frozenset()
         oauth_resource: str | None = None
         if catalog_spec is not None:
             if not isinstance(catalog_spec, MCPHTTPOAuth2ConnectionSpec):
                 raise ValueError("Catalog option is not an HTTP OAuth MCP server")
             scopes = catalog_spec.scopes
             oauth_resource = catalog_spec.oauth_resource
-            # Hosts of catalog-pinned OAuth endpoints are trusted during
-            # discovery; the catalog is repo-owned, so a pinned endpoint
-            # states explicitly where the provider serves OAuth.
-            allowed_endpoint_hosts = frozenset(
-                hostname
-                for endpoint in (
-                    catalog_spec.oauth_authorization_endpoint,
-                    catalog_spec.oauth_token_endpoint,
-                )
-                if endpoint and (hostname := urlparse(endpoint).hostname)
-            )
             # Fail before any discovery or registration call so a row that
             # cannot connect is never half-created.
             self._validate_required_catalog_headers(
@@ -1332,7 +1290,6 @@ class IntegrationService(BaseWorkspaceService):
                 catalog_spec,
                 server_uri=params.server_uri,
                 oauth_resource=oauth_resource,
-                allowed_endpoint_hosts=allowed_endpoint_hosts,
             )
             if catalog_spec is not None and not needs_dcr
             else None
@@ -1343,12 +1300,10 @@ class IntegrationService(BaseWorkspaceService):
             endpoints = await self._discover_mcp_oauth_endpoints(
                 server_uri=params.server_uri,
                 oauth_resource=oauth_resource,
-                allowed_endpoint_hosts=allowed_endpoint_hosts,
             )
         else:
             endpoints = await self._discover_mcp_oauth_endpoints(
                 server_uri=params.server_uri,
-                allowed_endpoint_hosts=allowed_endpoint_hosts,
             )
         # Request offline_access only when the AS advertises it, so refresh
         # tokens survive session-bound authorization policies. Computed once and

--- a/tracecat/integrations/types.py
+++ b/tracecat/integrations/types.py
@@ -13,6 +13,7 @@ class OAuthServerMetadata(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
+    issuer: str | None = None
     resource: str | None = None
     authorization_servers: list[str] = Field(default_factory=list)
     authorization_endpoint: str | None = None
@@ -23,6 +24,7 @@ class OAuthServerMetadata(BaseModel):
 
     @field_validator(
         "resource",
+        "issuer",
         "authorization_endpoint",
         "token_endpoint",
         "registration_endpoint",


### PR DESCRIPTION
## Summary

Re-lands #3352 (reverted on `main` in f069109a4) together with the OAuth metadata identity checks that follow it, so the Datadog regional-endpoint change and its hardening are reviewed and shipped as one unit.

- re-apply #3352: Datadog `/v1/mcp` path, user-selected regional server URI, and cross-host OAuth endpoints discovered from metadata
- validate RFC 9728 protected-resource metadata against the MCP resource that selected it, and require `authorization_servers`
- validate RFC 8414 authorization-server metadata against the advertised issuer
- keep query components in the RFC 9728 resource identity; catalog rows may mark transport-only params via `oauth_resource_ignored_query_params` (Datadog `toolsets`)

## Why the revert and re-land

#3352 removed the rule that discovered OAuth endpoints must live on the metadata host's domain, because Datadog serves its authorization and token endpoints on a sibling host (`app.datadoghq.com` next to `mcp.datadoghq.com`). That rule cannot be restored without breaking Datadog, so `main` was reverted to its prior posture while the replacement checks in this PR were finished. This PR supersedes #3352.

## Security rationale

Before this change a malicious MCP server's protected-resource metadata could name a different `resource`, and Tracecat would send that value as the RFC 8707 audience. A token minted for the victim's MCP resource by the victim's legitimate authorization server would then be handed to the attacker's server as a bearer token. Discovery now binds `resource` to the configured server URI, requires the protected-resource document to name its authorization servers, and requires the authorization-server document's `issuer` to match the issuer that selected it.

What this does not restore: the pre-#3352 endpoint host check. A self-consistent malicious MCP server can still point `authorization_endpoint` and `token_endpoint` at different hosts. Under the MCP trust model that server already receives the bearer token after a legitimate flow, and the user must consent on the provider's screen to the attacker's registered client, so the practical gain for an attacker is small. A follow-up could require endpoint hosts to share a registrable domain with the issuer host, which passes Datadog and blocks that case. HTTPS and DNS-backed SSRF validation remain in place for every discovered URL.

## Testing

- `tests/unit/test_mcp_oauth_discovery.py`, `tests/unit/test_mcp_catalog_loader.py`, `tests/unit/test_mcp_integrations.py`: 254 passed locally against a running cluster.
- Live discovery verified against `mcp.datadoghq.com` and `mcp.datadoghq.eu`: both publish `resource` and `issuer` values that match the new validators.
- Branch tree is byte-identical to the previously reviewed head 91bf2fc2f; only the base changed.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 183 | 94 |
| Tests | 204 | 65 |
| Infra/config | 22 | 6 |
| Generated | 8 | 0 |

https://claude.ai/code/session_015XGVMhc4mG4gA4XiiJCQHm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates RFC 9728 protected-resource and RFC 8414 authorization-server metadata identities during MCP OAuth discovery so a substituted metadata document can no longer pair a legitimate authorization endpoint with an attacker-controlled token endpoint, and re-lands the Datadog regional endpoint change to ship alongside this hardening.

- Cross-host OAuth endpoints are now accepted when the metadata identity checks pass; the catalog host allowlist is removed.
- Datadog's regional `/v1/mcp` endpoint is user-supplied via a `server_url` credential targeting `server_uri`; `toolsets` query params don't alter the OAuth audience.

**Testing**
- 229 unit tests pass in `tests/unit/test_mcp_integrations.py`.
- `ruff check`, `ruff format --check`, and `basedpyright` pass on the changed files.
- Live OAuth discovery verified against all seven documented Datadog regional MCP endpoints.

<sup>Written for commit d72f137a44b94e7caaff675a8b30206ce06c89a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


