### PR TITLE
infra(infra): drop platform tracing from Fargate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,12 +26,6 @@ NEXT_SERVER_API_URL=${INTERNAL_API_URL}
 # --- App and DB env vars ---
 # One of `development`, `staging`, or `production`
 TRACECAT__APP_ENV=development
-# Platform-owned distributed tracing (separate from tenant agent OTel settings)
-TRACECAT__PLATFORM_OTEL_ENABLED=false
-# OTLP/HTTP collector base URL (defaults to `http://localhost:4318`)
-OTEL_EXPORTER_OTLP_ENDPOINT=
-# Optional OTLP headers for API/worker only (`key=value,key2=value2`)
-OTEL_EXPORTER_OTLP_HEADERS=
 # Used to encrypt/decrypt sensitive keys in the database
 # Can be generated using `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
 TRACECAT__DB_ENCRYPTION_KEY=your-tracecat-db-fernet-key

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -71,9 +71,6 @@ module "ecs" {
 
   # Container environment variables
   tracecat_app_env                              = var.tracecat_app_env
-  platform_otel_enabled                         = var.platform_otel_enabled
-  otel_exporter_otlp_endpoint                   = var.otel_exporter_otlp_endpoint
-  otel_exporter_otlp_headers_arn                = var.otel_exporter_otlp_headers_arn
   audit_trusted_proxy_cidrs                     = var.audit_trusted_proxy_cidrs
   log_level                                     = var.log_level
   log_format                                    = var.log_format

--- a/deployments/fargate/modules/ecs/ecs-agent-worker.tf
+++ b/deployments/fargate/modules/ecs/ecs-agent-worker.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "agent_worker_task_definition" {
         }
       }
       environment = local.agent_worker_env
-      secrets     = local.tracecat_temporal_secrets
+      secrets     = local.agent_worker_secrets
     }
   ])
 }

--- a/deployments/fargate/modules/ecs/iam.tf
+++ b/deployments/fargate/modules/ecs/iam.tf
@@ -193,23 +193,6 @@ resource "aws_iam_policy" "temporal_payload_encryption_keyring_access" {
   })
 }
 
-resource "aws_iam_policy" "platform_otel_headers_access" {
-  count       = var.otel_exporter_otlp_headers_arn != null ? 1 : 0
-  name        = "${var.iam_name_prefix}PlatformOTelHeadersAccessPolicy"
-  description = "Policy for accessing OTLP exporter headers"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["secretsmanager:GetSecretValue"]
-        Resource = [var.otel_exporter_otlp_headers_arn]
-      }
-    ]
-  })
-}
-
 resource "aws_iam_policy" "ui_secrets_access" {
   name        = "${var.iam_name_prefix}UISecretsAccessPolicy"
   description = "Policy for accessing Tracecat UI secrets"
@@ -270,12 +253,6 @@ resource "aws_iam_role_policy_attachment" "api_execution_api_only_secrets" {
   role       = aws_iam_role.api_execution.name
 }
 
-resource "aws_iam_role_policy_attachment" "api_execution_platform_otel_headers" {
-  count      = var.otel_exporter_otlp_headers_arn != null ? 1 : 0
-  policy_arn = aws_iam_policy.platform_otel_headers_access[0].arn
-  role       = aws_iam_role.api_execution.name
-}
-
 # Worker execution role
 resource "aws_iam_role" "worker_execution" {
   name               = "${var.iam_name_prefix}WorkerExecutionRole"
@@ -289,12 +266,6 @@ resource "aws_iam_role_policy_attachment" "worker_execution_ecs_poll" {
 
 resource "aws_iam_role_policy_attachment" "worker_execution_secrets" {
   policy_arn = aws_iam_policy.secrets_access.arn
-  role       = aws_iam_role.worker_execution.name
-}
-
-resource "aws_iam_role_policy_attachment" "worker_execution_platform_otel_headers" {
-  count      = var.otel_exporter_otlp_headers_arn != null ? 1 : 0
-  policy_arn = aws_iam_policy.platform_otel_headers_access[0].arn
   role       = aws_iam_role.worker_execution.name
 }
 

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -71,11 +71,6 @@ locals {
     TRACECAT__AUDIT_TRUSTED_PROXY_CIDRS = var.audit_trusted_proxy_cidrs
   }
 
-  tracecat_platform_otel_env = {
-    TRACECAT__PLATFORM_OTEL_ENABLED = var.platform_otel_enabled
-    OTEL_EXPORTER_OTLP_ENDPOINT     = var.otel_exporter_otlp_endpoint
-  }
-
   tracecat_temporal_payload_encryption_env = {
     TEMPORAL__PAYLOAD_ENCRYPTION_ENABLED           = var.temporal_payload_encryption_enabled
     TEMPORAL__PAYLOAD_ENCRYPTION_KEYRING_ARN       = var.temporal_payload_encryption_keyring_arn
@@ -105,7 +100,6 @@ locals {
   api_env = [
     for k, v in merge(
       local.tracecat_common_env,
-      local.tracecat_platform_otel_env,
       local.tracecat_litellm_env,
       local.tracecat_temporal_payload_encryption_env,
       local.tracecat_blob_storage_env,
@@ -136,7 +130,6 @@ locals {
   worker_env = [
     for k, v in merge(
       local.tracecat_common_env,
-      local.tracecat_platform_otel_env,
       local.tracecat_temporal_payload_encryption_env,
       local.tracecat_blob_storage_env,
       local.tracecat_db_configs,
@@ -186,7 +179,6 @@ locals {
   executor_env = [
     for k, v in merge(
       local.tracecat_common_env,
-      local.tracecat_platform_otel_env,
       local.tracecat_temporal_payload_encryption_env,
       local.tracecat_blob_storage_env,
       local.tracecat_db_configs,

--- a/deployments/fargate/modules/ecs/secrets.tf
+++ b/deployments/fargate/modules/ecs/secrets.tf
@@ -60,11 +60,6 @@ data "aws_secretsmanager_secret" "saml_idp_metadata_url" {
   arn   = var.saml_idp_metadata_url_arn
 }
 
-data "aws_secretsmanager_secret" "otel_exporter_otlp_headers" {
-  count = var.otel_exporter_otlp_headers_arn != null ? 1 : 0
-  arn   = var.otel_exporter_otlp_headers_arn
-}
-
 # Temporal UI authentication
 
 data "aws_secretsmanager_secret" "temporal_auth_client_id" {
@@ -125,11 +120,6 @@ data "aws_secretsmanager_secret_version" "user_auth_secret" {
 data "aws_secretsmanager_secret_version" "saml_idp_metadata_url" {
   count     = var.saml_idp_metadata_url_arn != null ? 1 : 0
   secret_id = data.aws_secretsmanager_secret.saml_idp_metadata_url[0].id
-}
-
-data "aws_secretsmanager_secret_version" "otel_exporter_otlp_headers" {
-  count     = var.otel_exporter_otlp_headers_arn != null ? 1 : 0
-  secret_id = data.aws_secretsmanager_secret.otel_exporter_otlp_headers[0].id
 }
 
 # Temporal UI secrets
@@ -266,16 +256,8 @@ locals {
     }
   ] : []
 
-  platform_otel_headers_secret = var.otel_exporter_otlp_headers_arn != null ? [
-    {
-      name      = "OTEL_EXPORTER_OTLP_HEADERS"
-      valueFrom = data.aws_secretsmanager_secret_version.otel_exporter_otlp_headers[0].arn
-    }
-  ] : []
-
   tracecat_api_secrets = concat(
     local.tracecat_temporal_secrets,
-    local.platform_otel_headers_secret,
     local.oauth_client_id_secret,
     local.oauth_client_secret_secret,
     local.oidc_client_id_secret,
@@ -303,16 +285,9 @@ locals {
     local.temporal_auth_client_secret_secret,
   )
 
-  worker_secrets = concat(
-    local.tracecat_temporal_secrets,
-    local.platform_otel_headers_secret,
-  )
-
-  # The direct executor backend passes its process environment to untrusted
-  # action subprocesses, so platform exporter credentials must stay out of the
-  # executor task. Operators can expose an unauthenticated collector endpoint
-  # on the executor's private network when executor spans are required.
-  executor_secrets = local.tracecat_temporal_secrets
+  worker_secrets       = local.tracecat_temporal_secrets
+  agent_worker_secrets = local.tracecat_temporal_secrets
+  executor_secrets     = local.tracecat_temporal_secrets
 
   litellm_secrets = local.tracecat_base_secrets
 

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -254,24 +254,6 @@ variable "tracecat_app_env" {
   default     = "production"
 }
 
-variable "platform_otel_enabled" {
-  type        = bool
-  description = "Enable platform-owned OpenTelemetry tracing for the API, worker, and executor services"
-  default     = false
-}
-
-variable "otel_exporter_otlp_endpoint" {
-  type        = string
-  description = "Base OTLP/HTTP collector endpoint for platform traces"
-  default     = null
-}
-
-variable "otel_exporter_otlp_headers_arn" {
-  type        = string
-  description = "Optional Secrets Manager ARN containing OTLP exporter headers for API and worker tracing"
-  default     = null
-}
-
 variable "audit_trusted_proxy_cidrs" {
   type        = string
   description = "Comma-separated CIDRs the API treats as its own proxy hops when resolving audit client IPs. Empty uses the built-in private-range default."

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -218,24 +218,6 @@ variable "tracecat_app_env" {
   default     = "production"
 }
 
-variable "platform_otel_enabled" {
-  type        = bool
-  description = "Enable platform-owned OpenTelemetry tracing for the API, worker, and executor services"
-  default     = false
-}
-
-variable "otel_exporter_otlp_endpoint" {
-  type        = string
-  description = "Base OTLP/HTTP collector endpoint for platform traces"
-  default     = null
-}
-
-variable "otel_exporter_otlp_headers_arn" {
-  type        = string
-  description = "Optional Secrets Manager ARN containing OTLP exporter headers for API and worker tracing"
-  default     = null
-}
-
 variable "audit_trusted_proxy_cidrs" {
   type        = string
   description = "Comma-separated CIDRs the API treats as its own proxy hops when resolving audit client IPs. Empty uses the built-in private-range default."

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -552,3 +552,10 @@ def test_bound_env_rejects_invalid_bounds() -> None:
         ValueError, match="lower \\(10\\) cannot be greater than upper \\(8\\)"
     ):
         bound_env("TEST_BOUND_ENV", 16, lower=10, upper=8)
+
+
+def test_platform_otel_operator_settings_are_not_advertised_in_env_example() -> None:
+    source = (REPO_ROOT / ".env.example").read_text()
+    assert "TRACECAT__PLATFORM_OTEL_ENABLED" not in source
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in source
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in source


### PR DESCRIPTION
## Summary

- Scope platform OpenTelemetry tracing to EKS: remove the Fargate `platform_otel_enabled`, `otel_exporter_otlp_endpoint`, and `otel_exporter_otlp_headers_arn` variables, the exporter-headers Secrets Manager data sources and IAM policy, and the agent-worker secret wiring that depended on them.
- Drop the platform OTel entries from `.env.example` and pin that they are not advertised there.

Split out of #3275 so the deployment-target decision is reviewed on its own.

## Context from review of #3275

Two pre-existing gaps in the Fargate wiring that main carries today, surfaced by cubic on #3275 and relevant to whether this removal lands or Fargate tracing gets fixed instead:

- The agent worker task never receives the platform OTel environment or `OTEL_EXPORTER_OTLP_HEADERS`, so its `initialize_platform_tracing` call stays disabled and no agent-worker spans are exported even with `platform_otel_enabled = true`.
- `platform_otel_enabled = true` with `otel_exporter_otlp_endpoint` unset falls back to `http://localhost:4318`, where nothing listens in the task, so traces are silently dropped with no validation error.

## Testing

- `terraform fmt -check -recursive deployments/fargate` — passed
- `tests/unit/test_config.py` — passed with the new `.env.example` assertion

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Tests | 7 | 0 |
| Infra/config | 4 | 111 |
| **Total** | **11** | **111** |

https://claude.ai/code/session_013nmekFtGsKnwKxWin5jTLt
