### PR TITLE
feat(tables): add internal row aggregation endpoint

### DIFF
--- a/tests/unit/api/test_api_internal_tables.py
+++ b/tests/unit/api/test_api_internal_tables.py
@@ -399,7 +399,18 @@ async def test_internal_aggregate_rows_returns_serialized_response(
         mock_svc = AsyncMock()
         mock_svc.aggregate_rows.return_value = AggregateResponse.model_validate(
             {
-                "groups": [{"category": "alpha", "sum_amount": Decimal("3.5")}],
+                "groups": [
+                    {
+                        "category": "alpha",
+                        "numeric_key": Decimal("9007199254740992.1"),
+                        "sum_amount": 3.5,
+                    },
+                    {
+                        "category": "beta",
+                        "numeric_key": Decimal("9007199254740992.2"),
+                        "sum_amount": 4.5,
+                    },
+                ],
                 "truncated": False,
             }
         )
@@ -416,7 +427,18 @@ async def test_internal_aggregate_rows_returns_serialized_response(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
-        "groups": [{"category": "alpha", "sum_amount": 3.5}],
+        "groups": [
+            {
+                "category": "alpha",
+                "numeric_key": "9007199254740992.1",
+                "sum_amount": 3.5,
+            },
+            {
+                "category": "beta",
+                "numeric_key": "9007199254740992.2",
+                "sum_amount": 4.5,
+            },
+        ],
         "truncated": False,
     }
     mock_svc.aggregate_rows.assert_awaited_once()
@@ -484,3 +506,26 @@ async def test_internal_aggregate_rows_maps_errors(
         )
 
     assert response.status_code == expected_status
+
+
+@pytest.mark.anyio
+async def test_internal_aggregate_rows_sanitizes_unexpected_programming_error(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.aggregate_rows.side_effect = _programming_error(
+            ValueError("sensitive database detail")
+        )
+        MockService.return_value = mock_svc
+
+        response = action_gateway_client.post(
+            f"/internal/tables/{mock_table.name}/aggregate",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"group_by": []},
+        )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert "sensitive database detail" not in response.text

--- a/tests/unit/api/test_api_internal_tables.py
+++ b/tests/unit/api/test_api_internal_tables.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -12,7 +13,13 @@ from sqlalchemy.exc import ProgrammingError
 
 from tracecat.auth.types import Role
 from tracecat.db.models import Table, TableColumn, Workspace
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.query.errors import (
+    TracecatQueryOverflowError,
+    TracecatQueryTimeoutError,
+)
 from tracecat.tables import internal_router as internal_tables_router
+from tracecat.tables.schemas import AggregateResponse
 
 
 def _programming_error(cause: BaseException) -> ProgrammingError:
@@ -380,3 +387,100 @@ async def test_internal_lookup_table_error_returns_detail(
     assert response.json()["detail"] == (
         "Table lookup failed: database temporarily unavailable"
     )
+
+
+@pytest.mark.anyio
+async def test_internal_aggregate_rows_returns_serialized_response(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.aggregate_rows.return_value = AggregateResponse.model_validate(
+            {
+                "groups": [{"category": "alpha", "sum_amount": Decimal("3.5")}],
+                "truncated": False,
+            }
+        )
+        MockService.return_value = mock_svc
+
+        response = action_gateway_client.post(
+            f"/internal/tables/{mock_table.name}/aggregate",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "group_by": ["category"],
+                "aggs": [{"function": "sum", "field": "amount"}],
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "groups": [{"category": "alpha", "sum_amount": 3.5}],
+        "truncated": False,
+    }
+    mock_svc.aggregate_rows.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_internal_aggregate_rows_rejects_limit_above_maximum(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        response = action_gateway_client.post(
+            f"/internal/tables/{mock_table.name}/aggregate",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"group_by": [], "limit": 1001},
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    MockService.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("error", "expected_status"),
+    [
+        pytest.param(
+            TracecatValidationError("Unsupported aggregation"),
+            status.HTTP_400_BAD_REQUEST,
+            id="semantic-error",
+        ),
+        pytest.param(
+            TracecatNotFoundError("Table not found"),
+            status.HTTP_404_NOT_FOUND,
+            id="missing-table",
+        ),
+        pytest.param(
+            TracecatQueryTimeoutError(),
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            id="shared-timeout-contract",
+        ),
+        pytest.param(
+            TracecatQueryOverflowError(),
+            status.HTTP_400_BAD_REQUEST,
+            id="shared-overflow-contract",
+        ),
+    ],
+)
+async def test_internal_aggregate_rows_maps_errors(
+    action_gateway_client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+    error: Exception,
+    expected_status: int,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.aggregate_rows.side_effect = error
+        MockService.return_value = mock_svc
+
+        response = action_gateway_client.post(
+            f"/internal/tables/{mock_table.name}/aggregate",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"group_by": []},
+        )
+
+    assert response.status_code == expected_status

--- a/tests/unit/test_tables_query.py
+++ b/tests/unit/test_tables_query.py
@@ -109,6 +109,37 @@ def test_resolves_supported_column_types(
         assert resolved.expr.type.timezone is True
 
 
+@pytest.mark.parametrize(
+    ("sql_type", "expected_kind", "expected_sa_type"),
+    [
+        (SqlType.TEXT, FieldKind.TEXT, sa.String),
+        (SqlType.INTEGER, FieldKind.NUMBER, sa.BigInteger),
+        (SqlType.NUMERIC, FieldKind.NUMBER, sa.Numeric),
+        (SqlType.DATE, FieldKind.TEMPORAL, sa.Date),
+        (SqlType.BOOLEAN, FieldKind.BOOLEAN, sa.Boolean),
+        (SqlType.TIMESTAMPTZ, FieldKind.TEMPORAL, sa.TIMESTAMP),
+        (SqlType.SELECT, FieldKind.ENUM, sa.String),
+    ],
+)
+def test_resolves_supported_aggregation_column_types(
+    sql_type: SqlType,
+    expected_kind: FieldKind,
+    expected_sa_type: type[sa.types.TypeEngine[Any]],
+) -> None:
+    resolver = TableFieldResolver([_column("value", sql_type.value)])
+
+    resolved = resolver.resolve_aggregation("value")
+
+    assert resolved is not None
+    assert isinstance(resolved.expr, ColumnClause)
+    assert resolved.kind is expected_kind
+    assert resolved.is_multi_valued is False
+    assert isinstance(resolved.expr.type, expected_sa_type)
+    if sql_type is SqlType.TIMESTAMPTZ:
+        assert isinstance(resolved.expr.type, sa.TIMESTAMP)
+        assert resolved.expr.type.timezone is True
+
+
 @pytest.mark.parametrize("sql_type", [SqlType.JSONB, SqlType.MULTI_SELECT])
 def test_rejects_unsupported_column_types(sql_type: SqlType) -> None:
     resolver = TableFieldResolver([_column("tags", sql_type.value)])
@@ -118,6 +149,18 @@ def test_rejects_unsupported_column_types(sql_type: SqlType) -> None:
 
     assert "tags" in str(exc_info.value)
     assert sql_type.value in str(exc_info.value)
+
+
+@pytest.mark.parametrize("sql_type", [SqlType.JSONB, SqlType.MULTI_SELECT])
+def test_rejects_unsupported_aggregation_column_types(sql_type: SqlType) -> None:
+    resolver = TableFieldResolver([_column("payload", sql_type.value)])
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        resolver.resolve_aggregation("payload")
+
+    assert "payload" in str(exc_info.value)
+    assert sql_type.value in str(exc_info.value)
+    assert "aggregations" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -209,6 +252,27 @@ def test_system_columns_take_precedence_over_user_metadata() -> None:
 
     assert resolved is not None
     assert resolved.kind is FieldKind.TEMPORAL
+
+
+@pytest.mark.parametrize("field", ["created_at", "updated_at", "Created_At"])
+def test_resolves_system_columns_for_aggregation(field: str) -> None:
+    resolver = TableFieldResolver([])
+
+    resolved = resolver.resolve_aggregation(field)
+
+    assert resolved is not None
+    assert resolved.kind is FieldKind.TEMPORAL
+    assert resolved.is_multi_valued is False
+    assert isinstance(resolved.expr, ColumnClause)
+    assert isinstance(resolved.expr.type, sa.TIMESTAMP)
+    assert resolved.expr.type.timezone is True
+
+
+@pytest.mark.parametrize("field", ["id", "ID", "__tc_workspace_id", "missing"])
+def test_unresolvable_columns_are_not_available_for_aggregation(field: str) -> None:
+    resolver = TableFieldResolver([])
+
+    assert resolver.resolve_aggregation(field) is None
 
 
 def test_compiler_rejects_unknown_column_with_field_name() -> None:

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -2491,6 +2491,32 @@ class TestTableAggregations:
             },
         ]
 
+    async def test_numeric_group_keys_preserve_decimal_precision(
+        self,
+        tables_service: TablesService,
+    ) -> None:
+        table = await tables_service.create_table(
+            TableCreate(
+                name="precise_numeric_groups",
+                columns=[TableColumnCreate(name="value", type=SqlType.NUMERIC)],
+            )
+        )
+        first = Decimal("9007199254740992.1")
+        second = Decimal("9007199254740992.2")
+        await tables_service.batch_insert_rows(
+            table,
+            [{"value": first}, {"value": second}],
+        )
+
+        response = await tables_service.aggregate_rows(
+            table.name,
+            TableAggregateRequest(group_by=[GroupBySpec(field="value")]),
+        )
+
+        assert len(response.groups) == 2
+        assert {group["value"] for group in response.groups} == {first, second}
+        assert all(group["count"] == 1 for group in response.groups)
+
     async def test_text_groups_collapse_at_256_character_prefix(
         self,
         tables_service: TablesService,

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -15,9 +15,21 @@ from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import EDITOR_SCOPES, VIEWER_SCOPES
 from tracecat.db.models import Table, TableColumn, Workspace
-from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginationParams
+from tracecat.query.aggregations import (
+    AggFunction,
+    AggSpec,
+    GroupBySpec,
+    TimeBucket,
+)
+from tracecat.query.errors import TracecatQueryTimeoutError
+from tracecat.query.filters import Condition, FilterOp, FilterValue
 from tracecat.tables.common import (
     ColumnHasDuplicateValuesError,
     handle_default_value,
@@ -25,6 +37,7 @@ from tracecat.tables.common import (
 )
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import (
+    TableAggregateRequest,
     TableColumnCreate,
     TableColumnUpdate,
     TableCreate,
@@ -2308,3 +2321,450 @@ class TestTableDataTypes:
         assert retrieved_timestamptz.astimezone(UTC).replace(
             tzinfo=None
         ) == expected_timestamptz.astimezone(UTC).replace(tzinfo=None)
+
+
+@pytest.fixture
+async def aggregate_table(tables_service: TablesService) -> Table:
+    """Create a typed table with representative rows for aggregation tests."""
+    table = await tables_service.create_table(
+        TableCreate(
+            name="aggregate_table",
+            columns=[
+                TableColumnCreate(name="text_value", type=SqlType.TEXT),
+                TableColumnCreate(
+                    name="select_value",
+                    type=SqlType.SELECT,
+                    options=["red", "blue"],
+                ),
+                TableColumnCreate(name="integer_value", type=SqlType.INTEGER),
+                TableColumnCreate(name="numeric_value", type=SqlType.NUMERIC),
+                TableColumnCreate(name="boolean_value", type=SqlType.BOOLEAN),
+                TableColumnCreate(name="event_date", type=SqlType.DATE),
+                TableColumnCreate(name="event_at", type=SqlType.TIMESTAMPTZ),
+                TableColumnCreate(name="payload", type=SqlType.JSONB),
+                TableColumnCreate(
+                    name="tags",
+                    type=SqlType.MULTI_SELECT,
+                    options=["one", "two"],
+                ),
+            ],
+        )
+    )
+    await tables_service.batch_insert_rows(
+        table,
+        [
+            {
+                "text_value": "alpha",
+                "select_value": "red",
+                "integer_value": 1,
+                "numeric_value": Decimal("1.5"),
+                "boolean_value": True,
+                "event_date": date(2026, 3, 8),
+                "event_at": datetime(2026, 3, 8, 6, 30, tzinfo=UTC),
+                "payload": {"kind": "first"},
+                "tags": ["one"],
+            },
+            {
+                "text_value": "alpha",
+                "select_value": "red",
+                "integer_value": 3,
+                "numeric_value": Decimal("2.5"),
+                "boolean_value": True,
+                "event_date": date(2026, 3, 8),
+                "event_at": datetime(2026, 3, 8, 7, 30, tzinfo=UTC),
+                "payload": {"kind": "second"},
+                "tags": ["two"],
+            },
+            {
+                "text_value": "beta",
+                "select_value": "blue",
+                "integer_value": 5,
+                "numeric_value": None,
+                "boolean_value": False,
+                "event_date": date(2026, 3, 9),
+                "event_at": datetime(2026, 3, 9, 4, 30, tzinfo=UTC),
+                "payload": {"kind": "third"},
+                "tags": [],
+            },
+        ],
+    )
+    return table
+
+
+@pytest.mark.anyio
+class TestTableAggregations:
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            pytest.param(
+                "integer_value",
+                {
+                    "count_value": 3,
+                    "distinct_value": 3,
+                    "sum_value": 9.0,
+                    "mean_value": 3.0,
+                    "median_value": 3.0,
+                    "min_value": 1,
+                    "max_value": 5,
+                },
+                id="integer",
+            ),
+            pytest.param(
+                "numeric_value",
+                {
+                    "count_value": 2,
+                    "distinct_value": 2,
+                    "sum_value": 4.0,
+                    "mean_value": 2.0,
+                    "median_value": 2.0,
+                    "min_value": 1.5,
+                    "max_value": 2.5,
+                },
+                id="numeric",
+            ),
+        ],
+    )
+    async def test_all_aggregate_functions_on_numeric_types(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+        field: str,
+        expected: dict[str, int | float],
+    ) -> None:
+        response = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                group_by=[],
+                aggs=[
+                    AggSpec(
+                        function=AggFunction.COUNT, field=field, alias="count_value"
+                    ),
+                    AggSpec(
+                        function=AggFunction.COUNT_DISTINCT,
+                        field=field,
+                        alias="distinct_value",
+                    ),
+                    AggSpec(function=AggFunction.SUM, field=field, alias="sum_value"),
+                    AggSpec(function=AggFunction.MEAN, field=field, alias="mean_value"),
+                    AggSpec(
+                        function=AggFunction.MEDIAN,
+                        field=field,
+                        alias="median_value",
+                    ),
+                    AggSpec(function=AggFunction.MIN, field=field, alias="min_value"),
+                    AggSpec(function=AggFunction.MAX, field=field, alias="max_value"),
+                ],
+            ),
+        )
+
+        assert response.groups == [expected]
+        assert response.truncated is False
+
+    async def test_groups_text_select_and_boolean_columns(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+    ) -> None:
+        response = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                group_by=[
+                    GroupBySpec(field="text_value"),
+                    GroupBySpec(field="select_value"),
+                    GroupBySpec(field="boolean_value"),
+                ]
+            ),
+        )
+
+        assert response.groups == [
+            {
+                "text_value": "alpha",
+                "select_value": "red",
+                "boolean_value": True,
+                "count": 2,
+            },
+            {
+                "text_value": "beta",
+                "select_value": "blue",
+                "boolean_value": False,
+                "count": 1,
+            },
+        ]
+
+    async def test_text_groups_collapse_at_256_character_prefix(
+        self,
+        tables_service: TablesService,
+    ) -> None:
+        table = await tables_service.create_table(
+            TableCreate(
+                name="long_text_aggregate",
+                columns=[TableColumnCreate(name="message", type=SqlType.TEXT)],
+            )
+        )
+        prefix = "x" * 256
+        await tables_service.batch_insert_rows(
+            table,
+            [{"message": f"{prefix}a"}, {"message": f"{prefix}b"}],
+        )
+
+        response = await tables_service.aggregate_rows(
+            table.name,
+            TableAggregateRequest(group_by=[GroupBySpec(field="message")]),
+        )
+
+        assert response.groups == [{"message": prefix, "count": 2}]
+
+    @pytest.mark.parametrize(
+        ("bucket", "expected_group_count"),
+        [
+            pytest.param("hour", 3, id="hour"),
+            pytest.param("day", 2, id="day"),
+            pytest.param("week", 2, id="week"),
+            pytest.param("month", 1, id="month"),
+        ],
+    )
+    async def test_timestamptz_buckets_across_dst_boundary(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+        bucket: TimeBucket,
+        expected_group_count: int,
+    ) -> None:
+        response = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                group_by=[
+                    GroupBySpec(
+                        field="event_at",
+                        bucket=bucket,
+                        timezone="America/New_York",
+                    )
+                ]
+            ),
+        )
+
+        assert len(response.groups) == expected_group_count
+        total = 0
+        for group in response.groups:
+            count = group["count"]
+            assert isinstance(count, int)
+            total += count
+        assert total == 3
+        assert all(
+            isinstance(group["event_at"], datetime)
+            and group["event_at"].tzinfo is not None
+            for group in response.groups
+        )
+        if bucket == "day":
+            assert [group["event_at"] for group in response.groups] == [
+                datetime(2026, 3, 8, 5, tzinfo=UTC),
+                datetime(2026, 3, 9, 4, tzinfo=UTC),
+            ]
+
+    async def test_date_bucket_is_stable_under_non_utc_session_timezone(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+    ) -> None:
+        await tables_service.session.execute(
+            sa.text("SET LOCAL TIME ZONE 'Pacific/Auckland'")
+        )
+
+        response = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                group_by=[GroupBySpec(field="event_date", bucket="day")]
+            ),
+        )
+
+        assert response.groups == [
+            {"event_date": date(2026, 3, 8), "count": 2},
+            {"event_date": date(2026, 3, 9), "count": 1},
+        ]
+
+    async def test_system_timestamp_column_is_bucketable(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+    ) -> None:
+        response = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                group_by=[GroupBySpec(field="created_at", bucket="day")]
+            ),
+        )
+
+        assert len(response.groups) == 1
+        assert isinstance(response.groups[0]["created_at"], datetime)
+        assert response.groups[0]["count"] == 3
+
+    @pytest.mark.parametrize(
+        ("field", "op", "value", "expected_count"),
+        [
+            pytest.param("text_value", FilterOp.CONTAINS, "lph", 2, id="text"),
+            pytest.param("select_value", FilterOp.EQ, "red", 2, id="select"),
+            pytest.param("integer_value", FilterOp.GTE, 3, 2, id="integer"),
+            pytest.param("numeric_value", FilterOp.LT, "2", 1, id="numeric"),
+            pytest.param("boolean_value", FilterOp.EQ, True, 2, id="boolean"),
+            pytest.param("event_date", FilterOp.EQ, "2026-03-08", 2, id="date"),
+            pytest.param(
+                "event_at",
+                FilterOp.LT,
+                "2026-03-09T00:00:00Z",
+                2,
+                id="timestamptz",
+            ),
+        ],
+    )
+    async def test_filters_every_supported_type(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+        field: str,
+        op: FilterOp,
+        value: FilterValue,
+        expected_count: int,
+    ) -> None:
+        response = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                filters=Condition(field=field, op=op, value=value),
+                group_by=[],
+            ),
+        )
+
+        assert response.groups == [{"count": expected_count}]
+
+    async def test_empty_in_list_matches_no_rows(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+    ) -> None:
+        response = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                filters=Condition(
+                    field="text_value",
+                    op=FilterOp.IN,
+                    value=[],
+                ),
+                group_by=[],
+            ),
+        )
+
+        assert response.groups == [{"count": 0}]
+
+    async def test_limit_truncation_min_count_and_grand_total(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+    ) -> None:
+        truncated = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                group_by=[GroupBySpec(field="text_value")],
+                limit=1,
+            ),
+        )
+        assert truncated.groups == [{"text_value": "alpha", "count": 2}]
+        assert truncated.truncated is True
+
+        minimum = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(
+                group_by=[GroupBySpec(field="text_value")],
+                min_count=2,
+            ),
+        )
+        assert minimum.groups == [{"text_value": "alpha", "count": 2}]
+        assert minimum.truncated is False
+
+        total = await tables_service.aggregate_rows(
+            aggregate_table.name,
+            TableAggregateRequest(group_by=[]),
+        )
+        assert total.groups == [{"count": 3}]
+
+    @pytest.mark.parametrize("field", ["payload", "tags"])
+    async def test_jsonb_and_multi_select_are_rejected(
+        self,
+        tables_service: TablesService,
+        aggregate_table: Table,
+        field: str,
+    ) -> None:
+        with pytest.raises(TracecatValidationError, match=field):
+            await tables_service.aggregate_rows(
+                aggregate_table.name,
+                TableAggregateRequest(group_by=[GroupBySpec(field=field)]),
+            )
+
+        with pytest.raises(TracecatValidationError, match=field):
+            await tables_service.aggregate_rows(
+                aggregate_table.name,
+                TableAggregateRequest(
+                    filters=Condition(field=field, op=FilterOp.IS_NULL),
+                    group_by=[],
+                ),
+            )
+
+    async def test_same_table_name_is_isolated_between_workspaces(
+        self,
+        tables_service: TablesService,
+        other_tables_service: TablesService,
+    ) -> None:
+        definition = TableCreate(
+            name="shared_aggregate_name",
+            columns=[TableColumnCreate(name="category", type=SqlType.TEXT)],
+        )
+        table_a = await tables_service.create_table(definition)
+        table_b = await other_tables_service.create_table(definition)
+        await tables_service.batch_insert_rows(table_a, [{"category": "a"}])
+        await other_tables_service.batch_insert_rows(
+            table_b,
+            [{"category": "b"}, {"category": "b"}],
+        )
+
+        response_a = await tables_service.aggregate_rows(
+            table_a.name,
+            TableAggregateRequest(group_by=[GroupBySpec(field="category")]),
+        )
+        response_b = await other_tables_service.aggregate_rows(
+            table_b.name,
+            TableAggregateRequest(group_by=[GroupBySpec(field="category")]),
+        )
+
+        assert response_a.groups == [{"category": "a", "count": 1}]
+        assert response_b.groups == [{"category": "b", "count": 2}]
+
+    async def test_forced_statement_timeout_maps_to_shared_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tables_service: TablesService,
+    ) -> None:
+        table = await tables_service.create_table(
+            TableCreate(
+                name="slow_aggregate",
+                columns=[TableColumnCreate(name="value", type=SqlType.INTEGER)],
+            )
+        )
+        physical_table = sa.table(
+            table.name,
+            sa.column("value", sa.BigInteger()),
+            schema=tables_service._get_schema_name(),
+        )
+        await tables_service.session.execute(
+            sa.insert(physical_table).from_select(
+                ["value"],
+                sa.select(sa.func.generate_series(1, 200_000)),
+            )
+        )
+        monkeypatch.setattr(config, "TRACECAT__AGG_STATEMENT_TIMEOUT_MS", 1)
+
+        with pytest.raises(TracecatQueryTimeoutError):
+            await tables_service.aggregate_rows(
+                table.name,
+                TableAggregateRequest(
+                    group_by=[],
+                    aggs=[AggSpec(function=AggFunction.MEDIAN, field="value")],
+                ),
+            )

--- a/tracecat/tables/internal_router.py
+++ b/tracecat/tables/internal_router.py
@@ -18,13 +18,16 @@ from tracecat.auth.dependencies import ExecutorWorkspaceRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import Table, TableColumn
-from tracecat.exceptions import TracecatNotFoundError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.expressions.functions import tabulate
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
+from tracecat.query.errors import TracecatQueryOverflowError
 from tracecat.tables.common import coerce_optional_to_utc_datetime
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import (
+    AggregateResponse,
+    TableAggregateRequest,
     TableColumnCreate,
     TableColumnRead,
     TableColumnUpdate,
@@ -393,6 +396,42 @@ async def lookup_rows(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Table lookup failed: {exc}",
+        ) from exc
+
+
+@router.post(
+    "/{table_name}/aggregate",
+    response_model=AggregateResponse,
+    description=(
+        "Filter and aggregate rows in one PostgreSQL query. sum over INTEGER or "
+        "NUMERIC, every mean and median, and min/max over NUMERIC are widened to "
+        "float8 JSON numbers. TEXT and SELECT group keys use their first 256 "
+        "characters, so longer values with the same prefix collapse into one group."
+    ),
+)
+@require_scope("table:read")
+async def aggregate_rows(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    table_name: str,
+    params: TableAggregateRequest,
+) -> AggregateResponse:
+    """Filter, group, and aggregate rows in a workspace table."""
+    service = TablesService(session, role=role)
+    try:
+        return await service.aggregate_rows(table_name, params)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except TracecatQueryOverflowError:
+        raise
+    except (ValueError, TracecatValidationError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
         ) from exc
 
 

--- a/tracecat/tables/internal_router.py
+++ b/tracecat/tables/internal_router.py
@@ -406,7 +406,8 @@ async def lookup_rows(
         "Filter and aggregate rows in one PostgreSQL query. sum over INTEGER or "
         "NUMERIC, every mean and median, and min/max over NUMERIC are widened to "
         "float8 JSON numbers. TEXT and SELECT group keys use their first 256 "
-        "characters, so longer values with the same prefix collapse into one group."
+        "characters, so longer values with the same prefix collapse into one group. "
+        "NUMERIC group keys are returned as lossless decimal strings."
     ),
 )
 @require_scope("table:read")

--- a/tracecat/tables/query.py
+++ b/tracecat/tables/query.py
@@ -1,12 +1,16 @@
 from collections.abc import Sequence
-from typing import assert_never
+from typing import Literal, assert_never
 
 import sqlalchemy as sa
 
 from tracecat.db.models import TableColumn
 from tracecat.exceptions import TracecatValidationError
 from tracecat.query.filters import FilterOp
-from tracecat.query.resolver import FieldKind, ResolvedField
+from tracecat.query.resolver import (
+    FieldKind,
+    ResolvedAggregationField,
+    ResolvedField,
+)
 from tracecat.tables.common import (
     is_internal_column_name,
     sa_type_for_column,
@@ -63,6 +67,7 @@ ENUM_OPS = frozenset(
 
 _SYSTEM_TEMPORAL_COLUMNS = frozenset({"created_at", "updated_at"})
 _UNRESOLVABLE_SYSTEM_COLUMNS = frozenset({"id"})
+type FieldUsage = Literal["filters", "aggregations"]
 
 
 class TableFieldResolver:
@@ -73,12 +78,53 @@ class TableFieldResolver:
 
     def resolve(self, field: str) -> ResolvedField | None:
         """Return the resolved table field, or ``None`` when it is unknown."""
+        resolved = self._resolve_typed_column(field, usage="filters")
+        if resolved is None:
+            return None
+        expression, kind = resolved
+        return ResolvedField(
+            expr=expression,
+            kind=kind,
+            allowed_ops=self._allowed_filter_ops(kind),
+        )
+
+    def resolve_aggregation(self, field: str) -> ResolvedAggregationField | None:
+        """Return a trusted, single-valued table aggregation field."""
+        resolved = self._resolve_typed_column(field, usage="aggregations")
+        if resolved is None:
+            return None
+        expression, kind = resolved
+        return ResolvedAggregationField(
+            expr=expression,
+            kind=kind,
+            is_multi_valued=False,
+        )
+
+    def _resolve_typed_column(
+        self,
+        field: str,
+        *,
+        usage: FieldUsage,
+    ) -> tuple[sa.ColumnClause, FieldKind] | None:
+        resolved = self._resolve_column(field)
+        if resolved is None:
+            return None
+        name, column = resolved
+        if column is None:
+            return sa.column(name, sa.TIMESTAMP(timezone=True)), FieldKind.TEMPORAL
+
+        sql_type = self._sql_type(column)
+        kind = self._field_kind(column, sql_type, usage=usage)
+        physical_name = sanitize_identifier(column.name)
+        return sa.column(physical_name, sa_type_for_column(sql_type)), kind
+
+    def _resolve_column(self, field: str) -> tuple[str, TableColumn | None] | None:
         if is_internal_column_name(field):
             return None
 
         exact_column = self._columns_by_name.get(field)
         if field in _SYSTEM_TEMPORAL_COLUMNS:
-            return self._resolve_system_column(field)
+            return field, None
         if field in _UNRESOLVABLE_SYSTEM_COLUMNS:
             return None
 
@@ -87,62 +133,65 @@ class TableFieldResolver:
         except ValueError:
             if exact_column is None:
                 return None
-            return self._resolve_user_column(exact_column)
+            return exact_column.name, exact_column
 
         if normalized_name in _SYSTEM_TEMPORAL_COLUMNS:
-            return self._resolve_system_column(normalized_name)
+            return normalized_name, None
         if normalized_name in _UNRESOLVABLE_SYSTEM_COLUMNS:
             return None
 
         column = exact_column or self._columns_by_name.get(normalized_name)
         if column is None:
             return None
-        return self._resolve_user_column(column)
+        return column.name, column
 
     @staticmethod
-    def _resolve_system_column(name: str) -> ResolvedField:
-        return ResolvedField(
-            expr=sa.column(name, sa.TIMESTAMP(timezone=True)),
-            kind=FieldKind.TEMPORAL,
-            allowed_ops=TEMPORAL_OPS,
-        )
-
-    @staticmethod
-    def _resolve_user_column(column: TableColumn) -> ResolvedField:
+    def _sql_type(column: TableColumn) -> SqlType:
         try:
-            sql_type = SqlType(column.type)
+            return SqlType(column.type)
         except ValueError as exc:
             raise TracecatValidationError(
                 f"Column {column.name!r} has invalid stored type {column.type!r}"
             ) from exc
 
+    @staticmethod
+    def _field_kind(
+        column: TableColumn,
+        sql_type: SqlType,
+        *,
+        usage: FieldUsage,
+    ) -> FieldKind:
         match sql_type:
             case SqlType.TEXT:
-                kind = FieldKind.TEXT
-                allowed_ops = TEXT_OPS
+                return FieldKind.TEXT
             case SqlType.INTEGER | SqlType.NUMERIC:
-                kind = FieldKind.NUMBER
-                allowed_ops = NUMBER_OPS
+                return FieldKind.NUMBER
             case SqlType.BOOLEAN:
-                kind = FieldKind.BOOLEAN
-                allowed_ops = BOOLEAN_OPS
+                return FieldKind.BOOLEAN
             case SqlType.DATE | SqlType.TIMESTAMPTZ:
-                kind = FieldKind.TEMPORAL
-                allowed_ops = TEMPORAL_OPS
+                return FieldKind.TEMPORAL
             case SqlType.SELECT:
-                kind = FieldKind.ENUM
-                allowed_ops = ENUM_OPS
+                return FieldKind.ENUM
             case SqlType.JSONB | SqlType.MULTI_SELECT:
                 raise TracecatValidationError(
                     f"Column {column.name!r} of type {sql_type.value} "
-                    "cannot be used in filters"
+                    f"cannot be used in {usage}"
                 )
             case _ as unreachable:
                 assert_never(unreachable)
 
-        physical_name = sanitize_identifier(column.name)
-        return ResolvedField(
-            expr=sa.column(physical_name, sa_type_for_column(sql_type)),
-            kind=kind,
-            allowed_ops=allowed_ops,
-        )
+    @staticmethod
+    def _allowed_filter_ops(kind: FieldKind) -> frozenset[FilterOp]:
+        match kind:
+            case FieldKind.TEXT:
+                return TEXT_OPS
+            case FieldKind.NUMBER:
+                return NUMBER_OPS
+            case FieldKind.BOOLEAN:
+                return BOOLEAN_OPS
+            case FieldKind.TEMPORAL:
+                return TEMPORAL_OPS
+            case FieldKind.ENUM:
+                return ENUM_OPS
+            case FieldKind.UUID | FieldKind.TAG:
+                raise AssertionError(f"Unsupported table field kind: {kind}")

--- a/tracecat/tables/schemas.py
+++ b/tracecat/tables/schemas.py
@@ -1,5 +1,6 @@
 import re
 from datetime import date, datetime
+from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
@@ -193,7 +194,7 @@ class TableRowBatchUpdateResponse(BaseModel):
     rows_updated: int
 
 
-type TableAggregateValue = str | bool | int | float | datetime | date | None
+type TableAggregateValue = str | bool | int | float | Decimal | datetime | date | None
 
 
 class TableAggregateRequest(AggregationSpec):
@@ -202,7 +203,8 @@ class TableAggregateRequest(AggregationSpec):
     ``sum`` over INTEGER or NUMERIC, every ``mean`` and ``median``, and
     ``min``/``max`` over NUMERIC are widened to float8 JSON numbers. TEXT and
     SELECT group keys use their first 256 characters, so longer values with the
-    same prefix collapse into one group.
+    same prefix collapse into one group. NUMERIC group keys serialize as decimal
+    strings so distinct values retain their exact identities.
     """
 
     filters: Filter | None = Field(default=None)

--- a/tracecat/tables/schemas.py
+++ b/tracecat/tables/schemas.py
@@ -1,12 +1,15 @@
 import re
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from tracecat import config
 from tracecat.core.schemas import Schema
 from tracecat.identifiers import TableColumnID, TableID, TableRowID
+from tracecat.query.aggregations import AggregationSpec
+from tracecat.query.filters import Filter
 from tracecat.tables.common import (
     coerce_multi_select_value,
     coerce_select_value,
@@ -188,6 +191,35 @@ class TableRowBatchUpdateResponse(BaseModel):
     """Response for batch update operation."""
 
     rows_updated: int
+
+
+type TableAggregateValue = str | bool | int | float | datetime | date | None
+
+
+class TableAggregateRequest(AggregationSpec):
+    """Filter and aggregate rows in one workspace table.
+
+    ``sum`` over INTEGER or NUMERIC, every ``mean`` and ``median``, and
+    ``min``/``max`` over NUMERIC are widened to float8 JSON numbers. TEXT and
+    SELECT group keys use their first 256 characters, so longer values with the
+    same prefix collapse into one group.
+    """
+
+    filters: Filter | None = Field(default=None)
+    limit: int = Field(
+        default=config.TRACECAT__LIMIT_AGG_GROUPS_DEFAULT,
+        ge=1,
+        le=config.TRACECAT__LIMIT_AGG_GROUPS_MAX,
+    )
+
+
+class AggregateResponse(BaseModel):
+    """Flat aggregation groups and whether the configured limit was exceeded."""
+
+    # Output keys are caller-defined aliases, so a fixed object model cannot
+    # describe each group. Values remain a closed union of supported SQL types.
+    groups: list[dict[str, TableAggregateValue]]
+    truncated: bool
 
 
 class TableReadMinimal(Schema):

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -1222,7 +1222,7 @@ class BaseTablesService(BaseWorkspaceService):
                     raise TracecatNotFoundError(
                         f"Table '{table_name}' does not exist"
                     ) from exc
-                raise ValueError(str(root)) from exc
+                raise
 
         truncated = len(rows) > request.limit
         return AggregateResponse(

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -45,6 +45,8 @@ from tracecat.pagination import (
     PaginationError,
     paginate,
 )
+from tracecat.query.compiler import compile_aggregation, compile_filter
+from tracecat.query.execution import query_execution_context
 from tracecat.service import BaseWorkspaceService
 from tracecat.tables.common import (
     INTERNAL_COLUMN_PREFIX as INTERNAL_COLUMN_PREFIX,
@@ -82,7 +84,10 @@ from tracecat.tables.importer import (
     InferredCSVColumn,
     generate_table_name,
 )
+from tracecat.tables.query import TableFieldResolver
 from tracecat.tables.schemas import (
+    AggregateResponse,
+    TableAggregateRequest,
     TableColumnCreate,
     TableColumnUpdate,
     TableCreate,
@@ -1146,6 +1151,84 @@ class BaseTablesService(BaseWorkspaceService):
         result = await conn.execute(stmt)
         await self.session.flush()
         return result.rowcount
+
+    @retry(
+        retry=retry_if_exception_type(_RETRYABLE_DB_EXCEPTIONS),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.2, max=2),
+        reraise=True,
+    )
+    async def aggregate_rows(
+        self,
+        table_name: str,
+        request: TableAggregateRequest,
+    ) -> AggregateResponse:
+        """Filter and aggregate rows in a workspace-scoped table."""
+        table = await self.get_table_by_name(table_name)
+        schema_name = self._get_schema_name()
+        sanitized_table_name = self._sanitize_identifier(table.name)
+        physical_table = sa.table(sanitized_table_name, schema=schema_name)
+        resolver = TableFieldResolver(table.columns)
+
+        statement = sa.select(sa.literal(1)).select_from(physical_table)
+        if request.filters is not None:
+            statement = statement.where(compile_filter(request.filters, resolver))
+
+        requested_fields = {group.field for group in request.group_by}
+        requested_fields.update(
+            agg.field for agg in request.aggs if agg.field is not None
+        )
+        resolved_fields = {
+            field: resolved
+            for field in requested_fields
+            if (resolved := resolver.resolve_aggregation(field)) is not None
+        }
+        statement = compile_aggregation(
+            statement,
+            request,
+            resolved_fields,
+            limit=request.limit,
+            base_has_multi_valued_join=False,
+        )
+
+        txn_cm = (
+            self.session.begin_nested()
+            if self.session.in_transaction()
+            else self.session.begin()
+        )
+        async with txn_cm as txn:
+            conn = await txn.session.connection()
+            try:
+                async with query_execution_context(txn.session):
+                    result = await conn.execute(
+                        statement,
+                        execution_options={"isolation_level": "READ COMMITTED"},
+                    )
+                rows = [dict(row) for row in result.mappings().all()]
+            except _RETRYABLE_DB_EXCEPTIONS as exc:
+                self.logger.warning(
+                    "Retryable DB exception occurred during table aggregation",
+                    kind=type(exc).__name__,
+                    error=str(exc),
+                    table=table_name,
+                    schema=schema_name,
+                )
+                raise
+            except ProgrammingError as exc:
+                root: BaseException = exc
+                while root.__cause__ is not None:
+                    root = root.__cause__
+                if isinstance(root, UndefinedTableError):
+                    raise TracecatNotFoundError(
+                        f"Table '{table_name}' does not exist"
+                    ) from exc
+                raise ValueError(str(root)) from exc
+
+        truncated = len(rows) > request.limit
+        return AggregateResponse(
+            groups=rows[: request.limit],
+            truncated=truncated,
+        )
 
     @retry(
         retry=retry_if_exception_type(_RETRYABLE_DB_EXCEPTIONS),

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -1152,12 +1152,6 @@ class BaseTablesService(BaseWorkspaceService):
         await self.session.flush()
         return result.rowcount
 
-    @retry(
-        retry=retry_if_exception_type(_RETRYABLE_DB_EXCEPTIONS),
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=0.1, min=0.2, max=2),
-        reraise=True,
-    )
     async def aggregate_rows(
         self,
         table_name: str,


### PR DESCRIPTION
## Description

Adds `POST /internal/tables/{table_name}/aggregate` so internal callers can filter, group, and summarize workspace-table rows in one PostgreSQL query.

The endpoint:

- accepts the shared aggregation shape for groupings, aggregate functions, ordering, minimum counts, and limits
- resolves only supported table columns and rejects internal, JSONB, and multi-select columns
- supports TEXT, SELECT, BOOLEAN, INTEGER, NUMERIC, DATE, TIMESTAMPTZ, and system timestamp fields where semantically valid
- applies workspace scoping before accessing the physical table
- uses the shared transaction-local query timeout and preserves its HTTP 422 response contract
- returns one extra database group internally to report whether the requested result was truncated

## Related Issues

- [ENG-1748](https://linear.app/tracecat/issue/ENG-1748/tables-tablesserviceaggregate-rows-post-internaltablestable)

## Validation

- `653 passed` across the complete serial table/query regression suite
- real PostgreSQL coverage for aggregate functions, filtering, time buckets, daylight-saving boundaries, truncation, minimum counts, workspace isolation, and forced statement timeout
- API coverage for success serialization, request validation, HTTP 400/404 errors, shared timeout HTTP 422, and structured overflow handling
- regression coverage for lossless NUMERIC group keys and sanitized unexpected database errors
- commit hooks passed: Ruff, formatting, hardcoded-secret detection, OpenAPI/client generation, and repository-wide Python type checking

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 235 | 35 |
| Tests | 700 | 1 |

## Screenshots / Recordings

Not applicable; this change adds an internal API endpoint with no visual changes.

## Steps to QA

1. Create a workspace table with representative text, numeric, boolean, date, and timestamp columns.
2. Insert rows with repeated grouping values and a mix of matching and non-matching filter values.
3. Call `POST /internal/tables/{table_name}/aggregate` with a filter, group-by fields, and one or more aggregates.
4. Confirm the response contains the expected groups and that `truncated` becomes `true` when more than `limit` groups exist.
5. Force the configured aggregation statement timeout and confirm the existing shared HTTP 422 query-timeout response is returned.
