### PR TITLE
feat(cases): add case field resolver

### DIFF
--- a/tests/unit/test_cases_query.py
+++ b/tests/unit/test_cases_query.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.elements import ColumnElement
+
+from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.query import (
+    BOOLEAN_OPS,
+    ENUM_OPS,
+    NUMBER_OPS,
+    RANKED_ENUM_OPS,
+    TEMPORAL_OPS,
+    TEXT_OPS,
+    UUID_OPS,
+    CaseFieldResolver,
+)
+from tracecat.db.models import Case
+from tracecat.exceptions import TracecatValidationError
+from tracecat.query.compiler import compile_filter
+from tracecat.query.filters import Condition, FilterOp
+from tracecat.query.resolver import FieldKind, FieldResolver
+from tracecat.tables.enums import SqlType
+
+WORKSPACE_ID = UUID("00000000-0000-4000-8000-000000000001")
+
+
+def _schema(**fields: str | Mapping[str, object]) -> dict[str, object]:
+    return {
+        name: {"type": definition} if isinstance(definition, str) else dict(definition)
+        for name, definition in fields.items()
+    }
+
+
+def _resolver(**fields: str | Mapping[str, object]) -> CaseFieldResolver:
+    return CaseFieldResolver(WORKSPACE_ID, _schema(**fields))
+
+
+def _compile(
+    condition: Condition,
+    resolver: CaseFieldResolver,
+    *,
+    literal_binds: bool = False,
+) -> tuple[str, Mapping[str, Any]]:
+    predicate = compile_filter(condition, resolver)
+    statement = sa.select(Case.id).where(predicate)
+    compiled = statement.compile(
+        dialect=postgresql.dialect(),
+        compile_kwargs={"literal_binds": literal_binds},
+    )
+    return str(compiled), compiled.params
+
+
+@pytest.mark.parametrize(
+    ("field", "expected_kind", "expected_ops"),
+    [
+        ("status", FieldKind.ENUM, ENUM_OPS),
+        ("priority", FieldKind.ENUM, RANKED_ENUM_OPS),
+        ("severity", FieldKind.ENUM, RANKED_ENUM_OPS),
+        ("assignee_id", FieldKind.UUID, UUID_OPS),
+        ("created_at", FieldKind.TEMPORAL, TEMPORAL_OPS),
+        ("updated_at", FieldKind.TEMPORAL, TEMPORAL_OPS),
+        ("summary", FieldKind.TEXT, TEXT_OPS),
+        ("description", FieldKind.TEXT, TEXT_OPS),
+        ("case_number", FieldKind.NUMBER, NUMBER_OPS),
+    ],
+)
+def test_resolves_fixed_filter_fields(
+    field: str,
+    expected_kind: FieldKind,
+    expected_ops: frozenset[FilterOp],
+) -> None:
+    resolved = _resolver().resolve(field)
+
+    assert resolved is not None
+    assert resolved.kind is expected_kind
+    assert resolved.allowed_ops == expected_ops
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "status",
+        "priority",
+        "severity",
+        "assignee_id",
+        "created_at",
+        "updated_at",
+    ],
+)
+def test_resolves_groupable_fixed_fields(field: str) -> None:
+    resolved = _resolver().resolve_aggregation(field)
+
+    assert resolved is not None
+    assert resolved.join is None
+
+
+@pytest.mark.parametrize("field", ["summary", "description", "case_number"])
+def test_filter_only_fixed_fields_are_not_aggregation_dimensions(field: str) -> None:
+    assert _resolver().resolve_aggregation(field) is None
+
+
+def test_short_id_is_not_resolvable() -> None:
+    resolver = _resolver()
+
+    assert resolver.resolve("short_id") is None
+    assert resolver.resolve_aggregation("short_id") is None
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("status", "new", CaseStatus.NEW),
+        ("priority", "high", CasePriority.HIGH),
+        ("severity", "fatal", CaseSeverity.FATAL),
+    ],
+)
+def test_enum_values_are_validated_from_lowercase_public_values(
+    field: str,
+    value: str,
+    expected: CaseStatus | CasePriority | CaseSeverity,
+) -> None:
+    _, params = _compile(
+        Condition(field=field, op=FilterOp.EQ, value=value),
+        _resolver(),
+    )
+
+    assert expected in params.values()
+
+
+@pytest.mark.parametrize("field", ["status", "priority", "severity"])
+@pytest.mark.parametrize("value", ["HIGH", "not_a_member"])
+def test_invalid_enum_values_are_rejected(field: str, value: str) -> None:
+    with pytest.raises(TracecatValidationError, match=field):
+        compile_filter(
+            Condition(field=field, op=FilterOp.EQ, value=value),
+            _resolver(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "members", "unordered"),
+    [
+        (
+            "priority",
+            "high",
+            ["low", "medium", "high", "critical"],
+            ["unknown", "other"],
+        ),
+        (
+            "severity",
+            "high",
+            ["informational", "low", "medium", "high", "critical", "fatal"],
+            ["unknown", "other"],
+        ),
+    ],
+)
+def test_ranked_enum_ranges_compile_dedicated_case_expression(
+    field: str,
+    value: str,
+    members: list[str],
+    unordered: list[str],
+) -> None:
+    sql, _ = _compile(
+        Condition(field=field, op=FilterOp.GTE, value=value),
+        _resolver(),
+        literal_binds=True,
+    )
+
+    assert "CASE" in sql
+    assert sql.count("WHEN") == len(members)
+    for member in members:
+        assert member.upper() in sql
+    for member in unordered:
+        assert member.upper() not in sql
+    # PostgreSQL CASE defaults to NULL when no ELSE branch is present, so
+    # unordered rows cannot satisfy the comparison.
+    assert "ELSE" not in sql
+    assert " END >=" in sql
+
+
+@pytest.mark.parametrize("field", ["priority", "severity"])
+@pytest.mark.parametrize("value", ["unknown", "other"])
+def test_unordered_enum_members_are_rejected_as_range_values(
+    field: str, value: str
+) -> None:
+    with pytest.raises(TracecatValidationError, match=field):
+        compile_filter(
+            Condition(field=field, op=FilterOp.GTE, value=value),
+            _resolver(),
+        )
+
+
+@pytest.mark.parametrize(
+    "op",
+    [FilterOp.GT, FilterOp.GTE, FilterOp.LT, FilterOp.LTE],
+)
+def test_status_rejects_range_operations(op: FilterOp) -> None:
+    with pytest.raises(TracecatValidationError, match="status"):
+        compile_filter(
+            Condition(field="status", op=op, value="new"),
+            _resolver(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("sql_type", "expected_kind", "expected_ops", "expected_sa_type"),
+    [
+        (SqlType.TEXT, FieldKind.TEXT, TEXT_OPS, sa.String),
+        (SqlType.INTEGER, FieldKind.NUMBER, NUMBER_OPS, sa.BigInteger),
+        (SqlType.NUMERIC, FieldKind.NUMBER, NUMBER_OPS, sa.Numeric),
+        (SqlType.BOOLEAN, FieldKind.BOOLEAN, BOOLEAN_OPS, sa.Boolean),
+        (SqlType.DATE, FieldKind.TEMPORAL, TEMPORAL_OPS, sa.Date),
+        (SqlType.TIMESTAMPTZ, FieldKind.TEMPORAL, TEMPORAL_OPS, sa.TIMESTAMP),
+        (SqlType.SELECT, FieldKind.ENUM, ENUM_OPS, sa.String),
+    ],
+)
+def test_resolves_supported_custom_field_types(
+    sql_type: SqlType,
+    expected_kind: FieldKind,
+    expected_ops: frozenset[FilterOp],
+    expected_sa_type: type[sa.types.TypeEngine[Any]],
+) -> None:
+    resolver = _resolver(custom=sql_type.value)
+
+    resolved = resolver.resolve("fields.custom")
+    aggregation = resolver.resolve_aggregation("fields.custom")
+
+    assert resolved is not None
+    assert resolved.kind is expected_kind
+    assert resolved.allowed_ops == expected_ops
+    assert resolved.value_type is not None
+    assert isinstance(resolved.value_type, expected_sa_type)
+    assert aggregation is not None
+    assert aggregation.field.kind is expected_kind
+    assert isinstance(aggregation.field.expr.type, expected_sa_type)
+    assert aggregation.join is not None
+    assert aggregation.join.is_outer is True
+
+
+def test_long_text_kind_behaves_as_text() -> None:
+    resolved = _resolver(
+        notes={"type": SqlType.TEXT.value, "kind": "LONG_TEXT"}
+    ).resolve("fields.notes")
+
+    assert resolved is not None
+    assert resolved.kind is FieldKind.TEXT
+    assert resolved.allowed_ops == TEXT_OPS
+
+
+def test_url_kind_uses_nested_url_as_text() -> None:
+    resolver = _resolver(link={"type": SqlType.JSONB.value, "kind": "URL"})
+
+    resolved = resolver.resolve("fields.link")
+    aggregation = resolver.resolve_aggregation("fields.link")
+    sql, params = _compile(
+        Condition(field="fields.link", op=FilterOp.CONTAINS, value="example.com"),
+        resolver,
+    )
+
+    assert resolved is not None
+    assert resolved.kind is FieldKind.TEXT
+    assert isinstance(resolved.value_type, sa.String)
+    assert aggregation is not None
+    assert aggregation.field.kind is FieldKind.TEXT
+    assert isinstance(aggregation.field.expr.type, sa.String)
+    assert "->>" in sql
+    assert "ILIKE" in sql
+    assert r"%example.com%" in params.values()
+
+
+@pytest.mark.parametrize("sql_type", [SqlType.JSONB, SqlType.MULTI_SELECT])
+def test_rejects_unsupported_custom_field_types(sql_type: SqlType) -> None:
+    resolver = _resolver(custom=sql_type.value)
+
+    with pytest.raises(TracecatValidationError) as filter_error:
+        resolver.resolve("fields.custom")
+    with pytest.raises(TracecatValidationError) as aggregation_error:
+        resolver.resolve_aggregation("fields.custom")
+
+    assert "custom" in str(filter_error.value)
+    assert sql_type.value in str(filter_error.value)
+    assert "custom" in str(aggregation_error.value)
+    assert sql_type.value in str(aggregation_error.value)
+
+
+def test_unknown_custom_field_is_unresolvable_without_physical_table_access() -> None:
+    resolver = _resolver()
+
+    assert resolver.resolve("fields.missing") is None
+    assert resolver.resolve_aggregation("fields.missing") is None
+    with pytest.raises(TracecatValidationError, match="fields.missing"):
+        compile_filter(
+            Condition(field="fields.missing", op=FilterOp.EQ, value="x"),
+            resolver,
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "fields.",
+        "fields.case_id",
+        "fields.created_at",
+        "fields.__tc_workspace_id",
+        'fields."; drop table case_fields; --',
+        "fields.a.b",
+        "field.custom",
+    ],
+)
+def test_invalid_or_reserved_custom_field_addresses_are_unresolvable(
+    field: str,
+) -> None:
+    assert _resolver(custom=SqlType.TEXT.value).resolve(field) is None
+
+
+def test_custom_filter_compiles_to_correlated_exists() -> None:
+    sql, params = _compile(
+        Condition(field="fields.region", op=FilterOp.EQ, value="emea"),
+        _resolver(region=SqlType.TEXT.value),
+    )
+
+    assert "WHERE EXISTS (SELECT 1" in sql
+    assert '.case_fields.case_id = "case".id' in sql
+    assert ".case_fields.region =" in sql
+    assert list(params.values()) == ["emea"]
+
+
+def test_custom_is_null_compiles_to_not_exists_non_null_form() -> None:
+    sql, params = _compile(
+        Condition(field="fields.region", op=FilterOp.IS_NULL),
+        _resolver(region=SqlType.TEXT.value),
+    )
+
+    assert "NOT (EXISTS (SELECT 1" in sql or "NOT EXISTS (SELECT 1" in sql
+    assert '.case_fields.case_id = "case".id' in sql
+    assert ".case_fields.region IS NOT NULL" in sql
+    assert params == {}
+
+
+def test_custom_text_filter_escapes_like_wildcards() -> None:
+    _, params = _compile(
+        Condition(field="fields.summary", op=FilterOp.CONTAINS, value="a%_\\"),
+        _resolver(summary=SqlType.TEXT.value),
+    )
+
+    assert list(params.values()) == [r"%a\%\_\\%"]
+
+
+def test_custom_number_filter_uses_physical_type_for_value_normalization() -> None:
+    _, params = _compile(
+        Condition(field="fields.score", op=FilterOp.GTE, value="42"),
+        _resolver(score=SqlType.INTEGER.value),
+    )
+
+    assert list(params.values()) == [42]
+
+
+def test_custom_aggregation_fields_share_one_left_join_spec() -> None:
+    resolver = _resolver(
+        region=SqlType.TEXT.value,
+        score=SqlType.INTEGER.value,
+    )
+
+    region = resolver.resolve_aggregation("fields.region")
+    score = resolver.resolve_aggregation("fields.score")
+
+    assert region is not None and region.join is not None
+    assert score is not None and score.join is not None
+    assert region.join is score.join
+    assert region.join.key == "case_fields"
+    statement = (
+        sa.select(Case.id)
+        .select_from(Case)
+        .join(
+            region.join.target,
+            region.join.onclause,
+            isouter=region.join.is_outer,
+        )
+    )
+    sql = str(statement.compile(dialect=postgresql.dialect()))
+    assert "LEFT OUTER JOIN" in sql
+    assert ".case_fields ON" in sql
+    assert '.case_fields.case_id = "case".id' in sql
+
+
+@pytest.mark.parametrize(
+    "field_schema",
+    [
+        {"field": "TEXT"},
+        {"field": {}},
+        {"field": {"type": "BLOB"}},
+        {"field": {"type": "TEXT", "kind": "RICH_TEXT"}},
+        {"case_id": {"type": "TEXT"}},
+        {'bad"name': {"type": "TEXT"}},
+    ],
+)
+def test_rejects_invalid_stored_custom_field_schema(
+    field_schema: Mapping[str, object],
+) -> None:
+    with pytest.raises(TracecatValidationError, match="field|case_id|bad"):
+        CaseFieldResolver(WORKSPACE_ID, field_schema)
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [
+        {"type": SqlType.TEXT.value, "kind": "URL"},
+        {"type": SqlType.JSONB.value, "kind": "LONG_TEXT"},
+    ],
+)
+def test_rejects_invalid_kind_storage_pair(definition: Mapping[str, object]) -> None:
+    resolver = _resolver(custom=definition)
+
+    with pytest.raises(TracecatValidationError, match="custom"):
+        resolver.resolve("fields.custom")
+
+
+def test_satisfies_field_resolver_protocol() -> None:
+    resolver: FieldResolver = _resolver()
+
+    assert resolver.resolve("missing") is None
+
+
+def test_compiled_filter_is_a_sqlalchemy_boolean_expression() -> None:
+    predicate = compile_filter(
+        Condition(field="priority", op=FilterOp.GTE, value="high"),
+        _resolver(),
+    )
+
+    assert isinstance(predicate, ColumnElement)

--- a/tests/unit/test_cases_query.py
+++ b/tests/unit/test_cases_query.py
@@ -23,7 +23,7 @@ from tracecat.cases.query import (
 from tracecat.db.models import Case
 from tracecat.exceptions import TracecatValidationError
 from tracecat.query.compiler import compile_filter
-from tracecat.query.filters import Condition, FilterOp
+from tracecat.query.filters import Condition, Filter, FilterOp, NotClause
 from tracecat.query.resolver import FieldKind, FieldResolver
 from tracecat.tables.enums import SqlType
 
@@ -42,7 +42,7 @@ def _resolver(**fields: str | Mapping[str, object]) -> CaseFieldResolver:
 
 
 def _compile(
-    condition: Condition,
+    condition: Filter,
     resolver: CaseFieldResolver,
     *,
     literal_binds: bool = False,
@@ -325,9 +325,31 @@ def test_custom_filter_compiles_to_correlated_exists() -> None:
         _resolver(region=SqlType.TEXT.value),
     )
 
-    assert "WHERE EXISTS (SELECT 1" in sql
+    assert "WHERE CASE WHEN (EXISTS (SELECT 1" in sql
     assert '.case_fields.case_id = "case".id' in sql
+    assert ".case_fields.region IS NOT NULL" in sql
     assert ".case_fields.region =" in sql
+    assert " END" in sql
+    assert "ELSE" not in sql
+    assert list(params.values()) == ["emea"]
+
+
+def test_negated_custom_filter_preserves_nullable_column_semantics() -> None:
+    sql, params = _compile(
+        NotClause.model_validate(
+            {
+                "not": {
+                    "field": "fields.region",
+                    "op": FilterOp.EQ,
+                    "value": "emea",
+                }
+            }
+        ),
+        _resolver(region=SqlType.TEXT.value),
+    )
+
+    assert "WHERE NOT CASE WHEN (EXISTS (SELECT 1" in sql
+    assert "ELSE" not in sql
     assert list(params.values()) == ["emea"]
 
 

--- a/tracecat/cases/query.py
+++ b/tracecat/cases/query.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, assert_never, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy.sql.selectable import FromClause, TableClause
+
+from tracecat.cases.constants import RESERVED_CASE_FIELDS
+from tracecat.cases.enums import (
+    CaseFieldKind,
+    CasePriority,
+    CaseSeverity,
+)
+from tracecat.db.models import Case
+from tracecat.exceptions import TracecatValidationError
+from tracecat.identifiers.workflow import WorkspaceUUID
+from tracecat.query.filters import FilterOp
+from tracecat.query.resolver import (
+    FieldKind,
+    NormalizedFilterValue,
+    PredicateFactory,
+    ResolvedAggregationField,
+    ResolvedField,
+)
+from tracecat.tables.common import (
+    is_internal_column_name,
+    sa_type_for_column,
+    sanitize_identifier,
+    validate_identifier,
+)
+from tracecat.tables.enums import SqlType
+
+CUSTOM_FIELD_PREFIX = "fields."
+CUSTOM_FIELDS_JOIN_KEY = "case_fields"
+
+TEXT_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.CONTAINS,
+        FilterOp.STARTS_WITH,
+        FilterOp.IS_NULL,
+    }
+)
+NUMBER_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.GT,
+        FilterOp.GTE,
+        FilterOp.LT,
+        FilterOp.LTE,
+        FilterOp.IS_NULL,
+    }
+)
+BOOLEAN_OPS = frozenset({FilterOp.EQ, FilterOp.NE, FilterOp.IS_NULL})
+TEMPORAL_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.GT,
+        FilterOp.GTE,
+        FilterOp.LT,
+        FilterOp.LTE,
+        FilterOp.IS_NULL,
+    }
+)
+ENUM_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.IS_NULL,
+    }
+)
+RANKED_ENUM_OPS = ENUM_OPS | frozenset(
+    {FilterOp.GT, FilterOp.GTE, FilterOp.LT, FilterOp.LTE}
+)
+UUID_OPS = frozenset(
+    {
+        FilterOp.EQ,
+        FilterOp.NE,
+        FilterOp.IN,
+        FilterOp.NOT_IN,
+        FilterOp.IS_NULL,
+    }
+)
+
+_PRIORITY_RANKS: Mapping[CasePriority, int] = {
+    CasePriority.LOW: 0,
+    CasePriority.MEDIUM: 1,
+    CasePriority.HIGH: 2,
+    CasePriority.CRITICAL: 3,
+}
+_SEVERITY_RANKS: Mapping[CaseSeverity, int] = {
+    CaseSeverity.INFORMATIONAL: 0,
+    CaseSeverity.LOW: 1,
+    CaseSeverity.MEDIUM: 2,
+    CaseSeverity.HIGH: 3,
+    CaseSeverity.CRITICAL: 4,
+    CaseSeverity.FATAL: 5,
+}
+_RANGE_OPS = frozenset({FilterOp.GT, FilterOp.GTE, FilterOp.LT, FilterOp.LTE})
+_CUSTOM_FIELD_RESERVED_NAMES = frozenset(RESERVED_CASE_FIELDS)
+
+
+@dataclass(frozen=True, slots=True)
+class CaseFieldJoinSpec:
+    """A join required to use a case field in an aggregation."""
+
+    key: str
+    target: FromClause
+    onclause: ColumnElement[bool]
+    is_outer: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedCaseAggregationField:
+    """A case aggregation field and its optional backing-table join."""
+
+    field: ResolvedAggregationField
+    join: CaseFieldJoinSpec | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _CustomFieldDefinition:
+    """Validated custom-field metadata used to construct SQL expressions."""
+
+    name: str
+    physical_name: str
+    sql_type: SqlType
+    kind: CaseFieldKind | None
+
+
+_FIXED_FILTER_FIELDS: Mapping[str, ResolvedField] = {
+    "status": ResolvedField(
+        expr=Case.status,
+        kind=FieldKind.ENUM,
+        allowed_ops=ENUM_OPS,
+    ),
+    "assignee_id": ResolvedField(
+        expr=Case.assignee_id,
+        kind=FieldKind.UUID,
+        allowed_ops=UUID_OPS,
+    ),
+    "created_at": ResolvedField(
+        expr=Case.created_at,
+        kind=FieldKind.TEMPORAL,
+        allowed_ops=TEMPORAL_OPS,
+    ),
+    "updated_at": ResolvedField(
+        expr=Case.updated_at,
+        kind=FieldKind.TEMPORAL,
+        allowed_ops=TEMPORAL_OPS,
+    ),
+    "summary": ResolvedField(
+        expr=Case.summary,
+        kind=FieldKind.TEXT,
+        allowed_ops=TEXT_OPS,
+    ),
+    "description": ResolvedField(
+        expr=Case.description,
+        kind=FieldKind.TEXT,
+        allowed_ops=TEXT_OPS,
+    ),
+    "case_number": ResolvedField(
+        expr=Case.case_number,
+        kind=FieldKind.NUMBER,
+        allowed_ops=NUMBER_OPS,
+    ),
+}
+
+_FIXED_AGGREGATION_FIELDS: Mapping[str, ResolvedAggregationField] = {
+    "status": ResolvedAggregationField(expr=Case.status, kind=FieldKind.ENUM),
+    "priority": ResolvedAggregationField(expr=Case.priority, kind=FieldKind.ENUM),
+    "severity": ResolvedAggregationField(expr=Case.severity, kind=FieldKind.ENUM),
+    "assignee_id": ResolvedAggregationField(
+        expr=Case.assignee_id,
+        kind=FieldKind.UUID,
+    ),
+    "created_at": ResolvedAggregationField(
+        expr=Case.created_at,
+        kind=FieldKind.TEMPORAL,
+    ),
+    "updated_at": ResolvedAggregationField(
+        expr=Case.updated_at,
+        kind=FieldKind.TEMPORAL,
+    ),
+}
+
+
+class CaseFieldResolver:
+    """Resolve user-facing case field addresses to trusted SQL expressions."""
+
+    def __init__(
+        self,
+        workspace_id: UUID,
+        field_schema: Mapping[str, object],
+    ) -> None:
+        self._custom_fields = _parse_custom_field_schema(field_schema)
+        self._custom_fields_by_physical_name = {
+            field.physical_name: field for field in self._custom_fields.values()
+        }
+
+        schema_name = f"custom_fields_{WorkspaceUUID.new(workspace_id).short()}"
+        columns = [sa.column("case_id", postgresql.UUID(as_uuid=True))]
+        columns.extend(
+            sa.column(field.physical_name, sa_type_for_column(field.sql_type))
+            for field in self._custom_fields.values()
+        )
+        self._custom_fields_table = sa.table(
+            CUSTOM_FIELDS_JOIN_KEY,
+            *columns,
+            schema=schema_name,
+        )
+        self._custom_fields_join = CaseFieldJoinSpec(
+            key=CUSTOM_FIELDS_JOIN_KEY,
+            target=self._custom_fields_table,
+            onclause=self._custom_fields_table.c.case_id == Case.id,
+        )
+
+    def resolve(self, field: str) -> ResolvedField | None:
+        """Return the filter field, or ``None`` when the address is unknown."""
+        if field == "priority":
+            return _ranked_enum_field(
+                field,
+                Case.priority,
+                _PRIORITY_RANKS,
+            )
+        if field == "severity":
+            return _ranked_enum_field(
+                field,
+                Case.severity,
+                _SEVERITY_RANKS,
+            )
+        if resolved := _FIXED_FILTER_FIELDS.get(field):
+            return resolved
+        if custom_field := self._resolve_custom_field_address(field):
+            expression, kind, allowed_ops = self._custom_field_expression(custom_field)
+            return ResolvedField(
+                expr=_custom_field_predicate_factory(
+                    self._custom_fields_table,
+                    expression,
+                ),
+                kind=kind,
+                allowed_ops=allowed_ops,
+                value_type=expression.type,
+            )
+        return None
+
+    def resolve_aggregation(self, field: str) -> ResolvedCaseAggregationField | None:
+        """Return an aggregation field and any join needed to use it."""
+        if resolved := _FIXED_AGGREGATION_FIELDS.get(field):
+            return ResolvedCaseAggregationField(field=resolved)
+        if custom_field := self._resolve_custom_field_address(field):
+            expression, kind, _ = self._custom_field_expression(custom_field)
+            return ResolvedCaseAggregationField(
+                field=ResolvedAggregationField(expr=expression, kind=kind),
+                join=self._custom_fields_join,
+            )
+        return None
+
+    def _resolve_custom_field_address(
+        self, field: str
+    ) -> _CustomFieldDefinition | None:
+        if not field.startswith(CUSTOM_FIELD_PREFIX):
+            return None
+        name = field.removeprefix(CUSTOM_FIELD_PREFIX)
+        if not name or is_internal_column_name(name):
+            return None
+        try:
+            normalized_name = validate_identifier(name)
+        except ValueError:
+            return None
+        if normalized_name in _CUSTOM_FIELD_RESERVED_NAMES:
+            return None
+        return self._custom_fields.get(
+            name
+        ) or self._custom_fields_by_physical_name.get(normalized_name)
+
+    def _custom_field_expression(
+        self,
+        field: _CustomFieldDefinition,
+    ) -> tuple[ColumnElement[Any], FieldKind, frozenset[FilterOp]]:
+        column = self._custom_fields_table.c[field.physical_name]
+
+        if field.kind is CaseFieldKind.URL:
+            if field.sql_type is not SqlType.JSONB:
+                raise _invalid_custom_field(
+                    field,
+                    "URL fields must use JSONB storage",
+                )
+            return column["url"].as_string(), FieldKind.TEXT, TEXT_OPS
+        if field.kind is CaseFieldKind.LONG_TEXT and field.sql_type is not SqlType.TEXT:
+            raise _invalid_custom_field(
+                field,
+                "LONG_TEXT fields must use TEXT storage",
+            )
+
+        match field.sql_type:
+            case SqlType.TEXT:
+                return column, FieldKind.TEXT, TEXT_OPS
+            case SqlType.INTEGER | SqlType.NUMERIC:
+                return column, FieldKind.NUMBER, NUMBER_OPS
+            case SqlType.BOOLEAN:
+                return column, FieldKind.BOOLEAN, BOOLEAN_OPS
+            case SqlType.DATE | SqlType.TIMESTAMPTZ:
+                return column, FieldKind.TEMPORAL, TEMPORAL_OPS
+            case SqlType.SELECT:
+                return column, FieldKind.ENUM, ENUM_OPS
+            case SqlType.JSONB | SqlType.MULTI_SELECT:
+                raise _invalid_custom_field(
+                    field,
+                    f"{field.sql_type.value} fields cannot be used in queries",
+                )
+            case _ as unreachable:
+                assert_never(unreachable)
+
+
+def _parse_custom_field_schema(
+    field_schema: Mapping[str, object],
+) -> dict[str, _CustomFieldDefinition]:
+    parsed: dict[str, _CustomFieldDefinition] = {}
+    for name, metadata in field_schema.items():
+        try:
+            physical_name = validate_identifier(name)
+        except ValueError as exc:
+            raise TracecatValidationError(
+                f"Case custom field {name!r} has an invalid name"
+            ) from exc
+        if physical_name in _CUSTOM_FIELD_RESERVED_NAMES or is_internal_column_name(
+            physical_name
+        ):
+            raise TracecatValidationError(
+                f"Case custom field {name!r} uses a reserved name"
+            )
+
+        if not isinstance(metadata, Mapping):
+            raise TracecatValidationError(
+                f"Case custom field {name!r} has invalid schema metadata"
+            )
+
+        raw_type = metadata.get("type")
+        try:
+            sql_type = SqlType(raw_type) if isinstance(raw_type, str) else None
+        except ValueError as exc:
+            raise TracecatValidationError(
+                f"Case custom field {name!r} has invalid type {raw_type!r}"
+            ) from exc
+        if sql_type is None:
+            raise TracecatValidationError(
+                f"Case custom field {name!r} has invalid type {raw_type!r}"
+            )
+
+        raw_kind = metadata.get("kind")
+        try:
+            kind = CaseFieldKind(raw_kind) if isinstance(raw_kind, str) else None
+        except ValueError as exc:
+            raise TracecatValidationError(
+                f"Case custom field {name!r} has invalid kind {raw_kind!r}"
+            ) from exc
+        parsed[name] = _CustomFieldDefinition(
+            name=name,
+            physical_name=sanitize_identifier(name),
+            sql_type=sql_type,
+            kind=kind,
+        )
+    return parsed
+
+
+def _ranked_enum_field[
+    EnumT: Enum,
+](
+    field: str,
+    column: InstrumentedAttribute[Any],
+    ranks: Mapping[EnumT, int],
+) -> ResolvedField:
+    def predicate(
+        op: FilterOp,
+        value: NormalizedFilterValue | None,
+    ) -> ColumnElement[bool]:
+        if op not in _RANGE_OPS:
+            return _compile_predicate(column.expression, op, value)
+
+        if not isinstance(value, Enum):
+            raise TracecatValidationError(
+                f"Invalid range value {value!r} for case field {field!r}"
+            )
+        ranked_value = cast(EnumT, value)
+        if ranked_value not in ranks:
+            raise TracecatValidationError(
+                f"Invalid range value {value!r} for case field {field!r}"
+            )
+        rank_expression = sa.case(
+            *((column == member, rank) for member, rank in ranks.items()),
+            else_=None,
+        )
+        return _compile_predicate(rank_expression, op, ranks[ranked_value])
+
+    return ResolvedField(
+        expr=predicate,
+        kind=FieldKind.ENUM,
+        allowed_ops=RANKED_ENUM_OPS,
+        value_type=column.type,
+    )
+
+
+def _custom_field_predicate_factory(
+    table: TableClause,
+    expression: ColumnElement[Any],
+) -> PredicateFactory:
+    def predicate(
+        op: FilterOp,
+        value: NormalizedFilterValue | None,
+    ) -> ColumnElement[bool]:
+        if op is FilterOp.IS_NULL:
+            return sa.not_(
+                sa.exists(
+                    sa.select(1)
+                    .select_from(table)
+                    .where(
+                        table.c.case_id == Case.id,
+                        expression.is_not(None),
+                    )
+                    .correlate(Case)
+                )
+            )
+        return sa.exists(
+            sa.select(1)
+            .select_from(table)
+            .where(
+                table.c.case_id == Case.id,
+                _compile_predicate(expression, op, value),
+            )
+            .correlate(Case)
+        )
+
+    return predicate
+
+
+def _compile_predicate(
+    expression: ColumnElement[Any],
+    op: FilterOp,
+    value: NormalizedFilterValue | None,
+) -> ColumnElement[bool]:
+    match op:
+        case FilterOp.EQ:
+            return expression == value
+        case FilterOp.NE:
+            return expression != value
+        case FilterOp.IN:
+            assert isinstance(value, list)
+            return expression.in_(value)
+        case FilterOp.NOT_IN:
+            assert isinstance(value, list)
+            return expression.not_in(value)
+        case FilterOp.GT:
+            return expression > value
+        case FilterOp.GTE:
+            return expression >= value
+        case FilterOp.LT:
+            return expression < value
+        case FilterOp.LTE:
+            return expression <= value
+        case FilterOp.CONTAINS:
+            assert isinstance(value, str)
+            return expression.ilike(f"%{_escape_like(value)}%", escape="\\")
+        case FilterOp.STARTS_WITH:
+            assert isinstance(value, str)
+            return expression.ilike(f"{_escape_like(value)}%", escape="\\")
+        case FilterOp.IS_NULL:
+            return expression.is_(None)
+
+
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _invalid_custom_field(
+    field: _CustomFieldDefinition,
+    message: str,
+) -> TracecatValidationError:
+    return TracecatValidationError(
+        f"Case custom field {field.name!r} is invalid: {message}"
+    )

--- a/tracecat/cases/query.py
+++ b/tracecat/cases/query.py
@@ -437,7 +437,16 @@ def _custom_field_predicate_factory(
                     .correlate(Case)
                 )
             )
-        return sa.exists(
+        has_non_null_value = sa.exists(
+            sa.select(1)
+            .select_from(table)
+            .where(
+                table.c.case_id == Case.id,
+                expression.is_not(None),
+            )
+            .correlate(Case)
+        )
+        matches = sa.exists(
             sa.select(1)
             .select_from(table)
             .where(
@@ -446,6 +455,10 @@ def _custom_field_predicate_factory(
             )
             .correlate(Case)
         )
+        # EXISTS is always two-valued. Wrap it so a missing row or NULL custom
+        # value stays SQL NULL when a surrounding NOT negates the predicate,
+        # matching the semantics of filtering a nullable ordinary column.
+        return sa.case((has_non_null_value, matches), else_=None)
 
     return predicate
 

--- a/tracecat/cases/query.py
+++ b/tracecat/cases/query.py
@@ -21,6 +21,7 @@ from tracecat.cases.enums import (
 from tracecat.db.models import Case
 from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers.workflow import WorkspaceUUID
+from tracecat.query.compiler import compile_predicate
 from tracecat.query.filters import FilterOp
 from tracecat.query.resolver import (
     FieldKind,
@@ -392,7 +393,7 @@ def _ranked_enum_field[
         value: NormalizedFilterValue | None,
     ) -> ColumnElement[bool]:
         if op not in _RANGE_OPS:
-            return _compile_predicate(column.expression, op, value)
+            return compile_predicate(column.expression, op, value)
 
         if not isinstance(value, Enum):
             raise TracecatValidationError(
@@ -407,7 +408,7 @@ def _ranked_enum_field[
             *((column == member, rank) for member, rank in ranks.items()),
             else_=None,
         )
-        return _compile_predicate(rank_expression, op, ranks[ranked_value])
+        return compile_predicate(rank_expression, op, ranks[ranked_value])
 
     return ResolvedField(
         expr=predicate,
@@ -451,7 +452,7 @@ def _custom_field_predicate_factory(
             .select_from(table)
             .where(
                 table.c.case_id == Case.id,
-                _compile_predicate(expression, op, value),
+                compile_predicate(expression, op, value),
             )
             .correlate(Case)
         )
@@ -461,44 +462,6 @@ def _custom_field_predicate_factory(
         return sa.case((has_non_null_value, matches), else_=None)
 
     return predicate
-
-
-def _compile_predicate(
-    expression: ColumnElement[Any],
-    op: FilterOp,
-    value: NormalizedFilterValue | None,
-) -> ColumnElement[bool]:
-    match op:
-        case FilterOp.EQ:
-            return expression == value
-        case FilterOp.NE:
-            return expression != value
-        case FilterOp.IN:
-            assert isinstance(value, list)
-            return expression.in_(value)
-        case FilterOp.NOT_IN:
-            assert isinstance(value, list)
-            return expression.not_in(value)
-        case FilterOp.GT:
-            return expression > value
-        case FilterOp.GTE:
-            return expression >= value
-        case FilterOp.LT:
-            return expression < value
-        case FilterOp.LTE:
-            return expression <= value
-        case FilterOp.CONTAINS:
-            assert isinstance(value, str)
-            return expression.ilike(f"%{_escape_like(value)}%", escape="\\")
-        case FilterOp.STARTS_WITH:
-            assert isinstance(value, str)
-            return expression.ilike(f"{_escape_like(value)}%", escape="\\")
-        case FilterOp.IS_NULL:
-            return expression.is_(None)
-
-
-def _escape_like(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _invalid_custom_field(

--- a/tracecat/query/compiler.py
+++ b/tracecat/query/compiler.py
@@ -466,7 +466,7 @@ def _compile_condition(
     normalized = _normalize_value(
         condition, resolved.kind, column_expression.type, value
     )
-    return _compile_expression(condition, column_expression, normalized)
+    return compile_predicate(column_expression, condition.op, normalized)
 
 
 def _validate_value_shape(condition: Condition) -> FilterValue | None:
@@ -655,12 +655,13 @@ def _parse_iso_datetime(value: str) -> datetime:
     return datetime.fromisoformat(text)
 
 
-def _compile_expression(
-    condition: Condition,
+def compile_predicate(
     expression: ColumnElement[Any],
-    value: object | list[object] | None,
+    op: FilterOp,
+    value: NormalizedFilterValue | None,
 ) -> ColumnElement[bool]:
-    match condition.op:
+    """Compile a normalized filter operation against a SQL expression."""
+    match op:
         case FilterOp.EQ:
             return expression == value
         case FilterOp.NE:


### PR DESCRIPTION
## Checklist

- [x] PR title is short and follows the repository commit conventions.
- [x] PR only implements a single feature.
- [x] Focused and adjacent tests pass.
- [x] Commit-time lint, generated-client, and type-check hooks pass.

## Description

Adds the schema-driven `CaseFieldResolver` used by the shared query model.

- Resolves supported fixed case fields with type-appropriate filter operations.
- Adds explicit priority and severity ranks for range comparisons while keeping unknown and other values unordered.
- Resolves schema-defined custom fields through correlated `EXISTS` predicates.
- Reuses the shared predicate compiler for SQL operators and LIKE escaping.
- Treats a missing custom-field row and a stored SQL `NULL` consistently for `is_null`.
- Supports custom-field aggregation through one reusable workspace-scoped `LEFT JOIN` specification.
- Extracts the nested `url` value from URL-kind JSONB fields while keeping labels presentation-only.
- Rejects unsupported JSONB, multi-select, reserved, internal, and hostile field addresses.

## Related Issues

- ENG-1749

## Screenshots / Recordings

Not applicable; this is backend query-resolution infrastructure.

## Steps to QA

1. Run `uv run pytest tests/unit/test_cases_query.py -q`.
2. Run `uv run pytest tests/unit/query tests/unit/test_tables_query.py tests/unit/test_cases_query.py -q`.
3. Confirm the commit-time pre-commit hooks pass.

The focused resolver suite passes 73 tests. The adjacent query/table suite passes 409 tests. Disposable PostgreSQL smoke tests also exercised ranked comparisons, custom-field `EXISTS` and null semantics (including negation), URL extraction, and aggregation joins against a real database.

The complete local unit suite was also attempted: 8,951 passed and 41 skipped, with unrelated failures and errors remaining in existing MCP, organization, workspace-sync, table, and service areas.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 479 | 5 |
| Tests | 458 | 0 |
