### PR TITLE
feat(engine): classify sandbox resource-limit failures

### DIFF
--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -150,7 +150,9 @@ The memory cap is `rlimit_as`: it bounds the virtual address space a process may
 
 The cap applies per process inside the sandbox. The executor pod's container memory limit still applies on top and covers every concurrent sandbox, so raising a sandbox cap without raising the pod limit trades a sandbox failure for an OOM kill of the executor.
 
-Tracecat reports an action or agent run that exceeds any of these limits as `sandbox.resource_limit_exceeded`. The failure is attributed to the workload, is not retried, and the error names the env var that controls the cap. Dependency installation is the exception: an install that hits a limit is reported as a package installation failure.
+Tracecat reports an action or agent run that exceeds the memory, CPU time, or file size limit as `sandbox.resource_limit_exceeded`. The failure is attributed to the workload, is not retried, and the error names the env var that controls the cap.
+
+Two limits fall outside that guarantee. Exceeding the process count fails process creation inside the sandbox with an ordinary error instead of killing the workload, so it surfaces as whatever the script or agent does with that error. Dependency installation is reported as a package installation failure whichever limit it hits.
 
 These limits apply only when nsjail is enabled. Without it Tracecat installs no rlimits, so a failure of the same shape is reported as an ordinary workload or platform failure.
 

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -146,6 +146,8 @@ Each sandbox runs under nsjail rlimits. The memory cap is the one you tune; the 
 | Dependency installation for `core.script.run_python` | 2048 MB | Fixed | 300 s | 256 MB | 64 |
 | Agents | 4096 MB | `TRACECAT__AGENT_SANDBOX_MEMORY_MB` | Agent timeout ceiling | 256 MB | 128 |
 
+Both variables are read by the `executor` and `agent-executor` processes, so setting one in a `.env` file is not enough on its own: your deployment has to pass it through to those two services. On Docker Compose add it to their `environment` blocks, and on Kubernetes to the corresponding values.
+
 The memory cap is `rlimit_as`: it bounds the virtual address space a process may map, not its resident memory. A runtime that reserves large address ranges up front hits the cap before it uses that much RAM, so size it above the peak virtual size of your workload rather than its RSS. Python raises `MemoryError` at the cap; native runtimes such as the agent's Claude Code CLI abort.
 
 The cap applies per process inside the sandbox. The executor pod's container memory limit still applies on top and covers every concurrent sandbox, so raising a sandbox cap without raising the pod limit trades a sandbox failure for an OOM kill of the executor.

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -150,7 +150,9 @@ The memory cap is `rlimit_as`: it bounds the virtual address space a process may
 
 The cap applies per process inside the sandbox. The executor pod's container memory limit still applies on top and covers every concurrent sandbox, so raising a sandbox cap without raising the pod limit trades a sandbox failure for an OOM kill of the executor.
 
-Tracecat reports a workload that exceeds any of these limits as `sandbox.resource_limit_exceeded`. The failure is attributed to the workload, is not retried, and the action or agent error names the env var that controls the cap.
+Tracecat reports an action or agent run that exceeds any of these limits as `sandbox.resource_limit_exceeded`. The failure is attributed to the workload, is not retried, and the error names the env var that controls the cap. Dependency installation is the exception: an install that hits a limit is reported as a package installation failure.
+
+These limits apply only when nsjail is enabled. Without it Tracecat installs no rlimits, so a failure of the same shape is reported as an ordinary workload or platform failure.
 
 ### No isolation
 

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -136,6 +136,22 @@ nsjail requires:
   nsjail is not supported on macOS or Windows. Use the `direct` backend on those platforms.
 </Info>
 
+### Resource limits
+
+Each sandbox runs under nsjail rlimits. The memory cap is the one you tune; the others are fixed.
+
+| Sandbox | Memory cap | Configure with | CPU time | File size | Processes |
+| :------ | :--------- | :------------- | :------- | :-------- | :-------- |
+| `core.script.run_python` and custom actions | 2048 MB | `TRACECAT__SANDBOX_DEFAULT_MEMORY_MB` | 300 s | 256 MB | 64 |
+| Dependency installation for `core.script.run_python` | 2048 MB | Fixed | 300 s | 256 MB | 64 |
+| Agents | 4096 MB | `TRACECAT__AGENT_SANDBOX_MEMORY_MB` | Agent timeout ceiling | 256 MB | 128 |
+
+The memory cap is `rlimit_as`: it bounds the virtual address space a process may map, not its resident memory. A runtime that reserves large address ranges up front hits the cap before it uses that much RAM, so size it above the peak virtual size of your workload rather than its RSS. Python raises `MemoryError` at the cap; native runtimes such as the agent's Claude Code CLI abort.
+
+The cap applies per process inside the sandbox. The executor pod's container memory limit still applies on top and covers every concurrent sandbox, so raising a sandbox cap without raising the pod limit trades a sandbox failure for an OOM kill of the executor.
+
+Tracecat reports a workload that exceeds any of these limits as `sandbox.resource_limit_exceeded`. The failure is attributed to the workload, is not retried, and the action or agent error names the env var that controls the cap.
+
 ### No isolation
 
 Without nsjail, scripts, custom actions, and agents run as regular subprocesses in the executor.

--- a/docs/snippets/environment-variables.mdx
+++ b/docs/snippets/environment-variables.mdx
@@ -73,6 +73,7 @@
 | :------- | :------ | :---------- |
 | `TRACECAT__EXECUTOR_BACKEND` | `direct` | Execution strategy for actions. `direct` runs a subprocess per action, `ephemeral` spawns a cold nsjail subprocess per action for full isolation, `auto` selects `ephemeral` if nsjail is available and falls back to `direct`. |
 | `TRACECAT__DISABLE_NSJAIL` | `true` | Disable nsjail sandboxing. Set to `false` only if nsjail is installed. |
+| `TRACECAT__SANDBOX_DEFAULT_MEMORY_MB` | `2048` | Address-space cap (`rlimit_as`) in MB for each `core.script.run_python` and custom action sandbox. A workload that exceeds it fails as `sandbox.resource_limit_exceeded`. The container memory limit still applies on top. See [Resource limits](/self-hosting/security#resource-limits). |
 | `TRACECAT__RESULT_EXTERNALIZATION_ENABLED` | `true` | Store large action results in blob storage instead of Temporal history. |
 | `TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES` | `128000` | Byte threshold above which payloads are externalized to blob storage. |
 | `TRACECAT__WORKFLOW_ARTIFACT_RETENTION_DAYS` | `30` | Retention period in days for workflow artifacts. Objects older than this are automatically deleted via S3 lifecycle rules. Set to `0` to disable. |
@@ -86,6 +87,7 @@
 | `TRACECAT__AGENT_SANDBOX_TIMEOUT` | `3600` | Ceiling in seconds for the `timeout` of `ai.agent`, `ai.action`, and `ai.preset_agent`. Tracecat clamps explicit values between `1800` and this value, and unset means `1800`. A ceiling below `1800` replaces both the floor and the default. |
 | `TRACECAT__AGENT_EXECUTOR_GRACEFUL_SHUTDOWN_TIMEOUT` | `3660` | Seconds the agent executor worker waits for running agent activities to finish during a planned shutdown. Defaults to `TRACECAT__AGENT_SANDBOX_TIMEOUT` plus `60`. |
 | `TRACECAT__LLM_PROXY_READ_TIMEOUT` | `600` | Seconds the sandbox LLM proxy waits for the next byte from the model gateway before failing the request with `504`. Separate from the agent timeout. |
+| `TRACECAT__AGENT_SANDBOX_MEMORY_MB` | `4096` | Address-space cap (`rlimit_as`) in MB for each agent sandbox. An agent run that exceeds it fails as `sandbox.resource_limit_exceeded`. The container memory limit still applies on top. See [Resource limits](/self-hosting/security#resource-limits). |
 
 ### Blob storage
 

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -780,6 +780,29 @@ def test_is_memory_exhaustion_ignores_other_oserrors() -> None:
     assert not minimal_runner.is_memory_exhaustion(ValueError("nope"))
 
 
+def test_serialize_result_reports_limit_when_model_dump_exhausts_memory() -> None:
+    """Invariant: the orjson default hook must not swallow memory exhaustion.
+
+    ``_orjson_default`` treats a failing ``model_dump()`` as an unserializable
+    type and raises ``TypeError``. A ``MemoryError`` raised in there is the
+    address-space cap, not a type problem, so swallowing it would strip the
+    resource-limit code off a failure that really did hit the cap.
+    """
+
+    class _HungryModel:
+        def model_dump(self, mode: str = "json") -> dict[str, Any]:
+            raise MemoryError()
+
+    encoded = minimal_runner.serialize_result(
+        {"success": True, "result": _HungryModel()},
+        {"resolved_context": {"action_impl": {"module": "m", "name": "n"}}},
+    )
+    decoded = orjson.loads(encoded)
+
+    assert decoded["success"] is False
+    assert decoded["error_code"] == "resource_limit_exceeded"
+
+
 def test_serialize_result_degrades_to_resource_limit_envelope_on_memory_error(
     monkeypatch,
 ) -> None:

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -685,3 +685,44 @@ def test_json_dumps_rejects_broken_model_dump():
     result = {"success": True, "result": _FakeModel()}
     with pytest.raises(TypeError, match="Type is not JSON serializable"):
         minimal_runner.json_dumps(result)
+
+
+def test_main_minimal_reports_memory_error_as_resource_limit(
+    monkeypatch,
+) -> None:
+    """Invariant: an action's MemoryError carries the resource-limit envelope code.
+
+    The action path raises the typed sandbox exception from this code before
+    it ever parses the structured error, so the code is what the host reads.
+    """
+    test_module: Any = types.ModuleType("test_module")
+
+    def hungry_action() -> None:
+        raise MemoryError()
+
+    test_module.hungry_action = hungry_action
+
+    monkeypatch.setattr(
+        minimal_runner.importlib,
+        "import_module",
+        lambda _p, *args, **kwargs: test_module,
+    )
+
+    result = minimal_runner.main_minimal(
+        {
+            "resolved_context": {
+                "action_impl": {
+                    "type": "udf",
+                    "module": "test_module",
+                    "name": "hungry_action",
+                },
+                "evaluated_args": {},
+            },
+            "secret_env": {},
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "resource_limit_exceeded"
+    assert result["error"]["type"] == "MemoryError"
+    assert result["error"]["action_name"] == "test_module.hungry_action"

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -726,3 +726,46 @@ def test_main_minimal_reports_memory_error_as_resource_limit(
     assert result["error_code"] == "resource_limit_exceeded"
     assert result["error"]["type"] == "MemoryError"
     assert result["error"]["action_name"] == "test_module.hungry_action"
+
+
+def test_serialize_result_degrades_to_resource_limit_envelope_on_memory_error(
+    monkeypatch,
+) -> None:
+    """Invariant: a MemoryError while serializing still reports the limit code.
+
+    The allocation that dies can be the serialization itself, long after the
+    action returned. Without this fallback the process exits before writing
+    result.json and the host sees only a generic workload failure.
+    """
+    calls: list[dict[str, Any]] = []
+    real_json_dumps = minimal_runner.json_dumps
+
+    def flaky_json_dumps(obj: dict[str, Any]) -> bytes:
+        calls.append(obj)
+        if len(calls) == 1:
+            raise MemoryError()
+        return real_json_dumps(obj)
+
+    monkeypatch.setattr(minimal_runner, "json_dumps", flaky_json_dumps)
+
+    payload = minimal_runner.serialize_result(
+        {"success": True, "result": "an oversized value"},
+        {
+            "resolved_context": {
+                "action_impl": {"module": "test_module", "name": "hungry_action"}
+            }
+        },
+    )
+
+    decoded = orjson.loads(payload)
+    assert decoded["success"] is False
+    assert decoded["error_code"] == "resource_limit_exceeded"
+    assert decoded["error"]["type"] == "MemoryError"
+    assert decoded["error"]["action_name"] == "test_module.hungry_action"
+
+
+def test_serialize_result_passes_through_when_serialization_succeeds() -> None:
+    """Invariant: the fallback never fires on the ordinary path."""
+    payload = minimal_runner.serialize_result({"success": True, "result": 1}, {})
+
+    assert orjson.loads(payload) == {"success": True, "result": 1}

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import io
 import sys
 import types
@@ -726,6 +727,57 @@ def test_main_minimal_reports_memory_error_as_resource_limit(
     assert result["error_code"] == "resource_limit_exceeded"
     assert result["error"]["type"] == "MemoryError"
     assert result["error"]["action_name"] == "test_module.hungry_action"
+
+
+def test_main_minimal_reports_enomem_oserror_as_resource_limit(
+    monkeypatch,
+) -> None:
+    """Invariant: an ENOMEM syscall failure is the same cap as MemoryError.
+
+    Exhausting ``rlimit_as`` through ``mmap`` and friends raises ``OSError``
+    with ``errno.ENOMEM``, not ``MemoryError``. Matching on the errno rather
+    than on message text keeps that failure inside the resource-limit
+    guarantee instead of degrading it to a generic action failure.
+    """
+    test_module: Any = types.ModuleType("test_module")
+
+    def mapping_action() -> None:
+        raise OSError(errno.ENOMEM, "Cannot allocate memory")
+
+    test_module.mapping_action = mapping_action
+
+    monkeypatch.setattr(
+        minimal_runner.importlib,
+        "import_module",
+        lambda _p, *args, **kwargs: test_module,
+    )
+
+    result = minimal_runner.main_minimal(
+        {
+            "resolved_context": {
+                "action_impl": {
+                    "type": "udf",
+                    "module": "test_module",
+                    "name": "mapping_action",
+                },
+                "evaluated_args": {},
+            },
+            "secret_env": {},
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "resource_limit_exceeded"
+    assert result["error"]["action_name"] == "test_module.mapping_action"
+
+
+def test_is_memory_exhaustion_ignores_other_oserrors() -> None:
+    """Invariant: only ENOMEM counts, so unrelated OSErrors keep their own kind."""
+    assert minimal_runner.is_memory_exhaustion(MemoryError())
+    assert minimal_runner.is_memory_exhaustion(OSError(errno.ENOMEM, "no memory"))
+    assert not minimal_runner.is_memory_exhaustion(OSError(errno.EAGAIN, "would block"))
+    assert not minimal_runner.is_memory_exhaustion(OSError(errno.ENOENT, "missing"))
+    assert not minimal_runner.is_memory_exhaustion(ValueError("nope"))
 
 
 def test_serialize_result_degrades_to_resource_limit_envelope_on_memory_error(

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -771,13 +771,24 @@ def test_main_minimal_reports_enomem_oserror_as_resource_limit(
     assert result["error"]["action_name"] == "test_module.mapping_action"
 
 
-def test_is_memory_exhaustion_ignores_other_oserrors() -> None:
-    """Invariant: only ENOMEM counts, so unrelated OSErrors keep their own kind."""
-    assert minimal_runner.is_memory_exhaustion(MemoryError())
-    assert minimal_runner.is_memory_exhaustion(OSError(errno.ENOMEM, "no memory"))
-    assert not minimal_runner.is_memory_exhaustion(OSError(errno.EAGAIN, "would block"))
-    assert not minimal_runner.is_memory_exhaustion(OSError(errno.ENOENT, "missing"))
-    assert not minimal_runner.is_memory_exhaustion(ValueError("nope"))
+def test_resource_limit_from_error_ignores_other_oserrors() -> None:
+    """Unrelated syscall failures must retain their ordinary classification."""
+    assert minimal_runner.resource_limit_from_error(MemoryError()) == "memory"
+    assert (
+        minimal_runner.resource_limit_from_error(OSError(errno.ENOMEM, "no memory"))
+        == "memory"
+    )
+    assert (
+        minimal_runner.resource_limit_from_error(OSError(errno.EFBIG, "too large"))
+        == "file_size"
+    )
+    assert not minimal_runner.resource_limit_from_error(
+        OSError(errno.EAGAIN, "would block")
+    )
+    assert not minimal_runner.resource_limit_from_error(
+        OSError(errno.ENOENT, "missing")
+    )
+    assert not minimal_runner.resource_limit_from_error(ValueError("nope"))
 
 
 def test_serialize_result_reports_limit_when_model_dump_exhausts_memory() -> None:

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -14,7 +14,7 @@ from uuid import UUID
 import httpx
 import orjson
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 from tracecat.executor import minimal_runner
 
@@ -796,6 +796,26 @@ def test_serialize_result_reports_limit_when_model_dump_exhausts_memory() -> Non
     encoded = minimal_runner.serialize_result(
         {"success": True, "result": _HungryModel()},
         {"resolved_context": {"action_impl": {"module": "m", "name": "n"}}},
+    )
+    decoded = orjson.loads(encoded)
+
+    assert decoded["success"] is False
+    assert decoded["error_code"] == "resource_limit_exceeded"
+
+
+@pytest.mark.parametrize("error", [MemoryError(), OSError(errno.ENOMEM, "no memory")])
+def test_serialize_result_preserves_pydantic_serializer_memory_cause(
+    error: Exception,
+) -> None:
+    class HungryModel(BaseModel):
+        value: int = 1
+
+        @field_serializer("value")
+        def serialize_value(self, value: int) -> int:
+            raise error
+
+    encoded = minimal_runner.serialize_result(
+        {"success": True, "result": HungryModel()}, {}
     )
     decoded = orjson.loads(encoded)
 

--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -1511,27 +1511,43 @@ if __name__ == "__main__":
         )
 
 
+@pytest.mark.parametrize(
+    "raise_stmt",
+    [
+        pytest.param("raise MemoryError()", id="python-allocator"),
+        pytest.param(
+            "raise OSError(errno.ENOMEM, 'Cannot allocate memory')",
+            id="enomem-syscall",
+        ),
+    ],
+)
 def test_nsjail_wrapper_reports_memory_error_as_resource_limit(
     tmp_path: Path,
+    raise_stmt: str,
 ) -> None:
-    """Invariant: MemoryError inside the jail becomes a structured envelope code.
+    """Invariant: either shape of memory exhaustion becomes the envelope code.
 
     The host must classify the address-space cap without inspecting error
     text, so the wrapper emits ``error_code: resource_limit_exceeded`` and
-    skips traceback formatting that could need memory it no longer has.
+    skips traceback formatting that could need memory it no longer has. The
+    cap surfaces as ``MemoryError`` from Python's own allocator and as
+    ``OSError``/``ENOMEM`` from a syscall such as ``mmap``; both are matched
+    on a machine-readable attribute.
     """
     result = _run_wrapper_source(
         WRAPPER_SCRIPT,
         tmp_path,
-        """
+        f"""
+import errno
+
 def main():
-    raise MemoryError()
+    {raise_stmt}
 """,
     )
 
     assert result["success"] is False
     assert result["error_code"] == "resource_limit_exceeded"
-    assert result["error"].startswith("MemoryError")
+    assert result["error"] == "Script exceeded the sandbox memory limit"
     assert result["traceback"] is None
 
 

--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -1509,3 +1509,27 @@ if __name__ == "__main__":
             "Usage: python -m tests.unit.executor.test_run_python_sdk_context "
             "[--run-nsjail-sdk-context-smoke|--run-nsjail-sdk-gateway-smoke]"
         )
+
+
+def test_nsjail_wrapper_reports_memory_error_as_resource_limit(
+    tmp_path: Path,
+) -> None:
+    """Invariant: MemoryError inside the jail becomes a structured envelope code.
+
+    The host must classify the address-space cap without inspecting error
+    text, so the wrapper emits ``error_code: resource_limit_exceeded`` and
+    skips traceback formatting that could need memory it no longer has.
+    """
+    result = _run_wrapper_source(
+        WRAPPER_SCRIPT,
+        tmp_path,
+        """
+def main():
+    raise MemoryError()
+""",
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "resource_limit_exceeded"
+    assert result["error"].startswith("MemoryError")
+    assert result["traceback"] is None

--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -1533,3 +1533,32 @@ def main():
     assert result["error_code"] == "resource_limit_exceeded"
     assert result["error"].startswith("MemoryError")
     assert result["traceback"] is None
+
+
+def test_nsjail_wrapper_reports_resource_limit_when_output_serialization_dies(
+    tmp_path: Path,
+) -> None:
+    """Invariant: a MemoryError while serializing output still writes an envelope.
+
+    ``to_json_safe`` falls back to ``repr`` for unknown types, so a value whose
+    repr exhausts memory kills ``json.dumps`` after the script itself finished.
+    The wrapper must still leave a result file carrying the resource-limit code
+    rather than dying and degrading to a generic workload failure.
+    """
+    result = _run_wrapper_source(
+        WRAPPER_SCRIPT,
+        tmp_path,
+        """
+class _Unrepresentable:
+    def __repr__(self):
+        raise MemoryError()
+
+
+def main():
+    return _Unrepresentable()
+""",
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "resource_limit_exceeded"
+    assert result["output"] is None

--- a/tests/unit/test_agent_error_policy.py
+++ b/tests/unit/test_agent_error_policy.py
@@ -17,11 +17,14 @@ from tracecat_ee.agent.workflows.durable import (
     _executor_activity_classification,
 )
 
+from tracecat.agent.common.exceptions import AgentSandboxProcessExitError
 from tracecat.agent.error_policy import (
     agent_executor_protocol_failed,
     agent_executor_timed_out,
     agent_executor_unavailable,
     agent_preparation_failed,
+    agent_runtime_failure,
+    agent_sandbox_resource_limit_exceeded,
     agent_session_initialization_failed,
     agent_workflow_internal_error,
     invalid_agent_configuration,
@@ -113,6 +116,12 @@ def _activity_error(cause: BaseException) -> ActivityError:
             agent_workflow_internal_error,
             RuntimeErrorOwner.PLATFORM,
             RuntimeErrorKind.AGENT_WORKFLOW_INTERNAL_ERROR,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            agent_sandbox_resource_limit_exceeded,
+            RuntimeErrorOwner.USER,
+            RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED,
             RetryDisposition.NON_RETRYABLE,
         ),
     ],
@@ -248,3 +257,90 @@ def test_loopback_classification_is_copied_to_executor_result() -> None:
     )
 
     assert result.classification == classification
+
+
+@pytest.mark.parametrize("exit_code", [134, 137], ids=["sigabrt", "sigkill"])
+def test_agent_runtime_failure_attributes_resource_limit_exit_to_user(
+    exit_code: int,
+) -> None:
+    """Invariant: a jailed runtime that died from an rlimit is user-owned.
+
+    ``ProcessError`` is erased by the SDK, so the typed exit error is what the
+    chain carries. Its exit code alone selects the dedicated kind, the failure
+    is non-retryable (the cap is deterministic), and the message names the
+    agent memory env var without echoing the SDK's raw text.
+    """
+    sdk_error = Exception("Sandbox shim failed with exit code raw stderr tail")
+    exit_error = AgentSandboxProcessExitError(exit_code)
+    exit_error.__cause__ = sdk_error
+
+    failure = agent_runtime_failure(exit_error, fallback_message=str(sdk_error))
+
+    assert failure.classification.owner is RuntimeErrorOwner.USER
+    assert (
+        failure.classification.kind is RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED
+    )
+    assert failure.classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert failure.classification.cause_type == "AgentSandboxProcessExitError"
+    assert failure.message == failure.classification.message
+    assert "TRACECAT__AGENT_SANDBOX_MEMORY_MB" in failure.message
+    assert "raw stderr tail" not in failure.message
+
+
+def test_agent_runtime_failure_finds_resource_limit_exit_in_chain() -> None:
+    """Invariant: the typed exit error is matched anywhere in the cause chain."""
+    wrapper = RuntimeError("broker turn failed")
+    wrapper.__cause__ = AgentSandboxProcessExitError(137)
+
+    failure = agent_runtime_failure(wrapper, fallback_message="fallback")
+
+    assert (
+        failure.classification.kind is RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(AgentSandboxProcessExitError(1), id="ordinary-nonzero-exit"),
+        pytest.param(RuntimeError("opaque crash"), id="untyped-crash"),
+    ],
+)
+def test_agent_runtime_failure_keeps_other_failures_platform_owned(
+    error: Exception,
+) -> None:
+    """Invariant: only resource-limit exit codes leave executor-unavailable.
+
+    Every other runtime failure keeps today's platform-owned retryable
+    attribution and surfaces the caller's fallback message unchanged.
+    """
+    failure = agent_runtime_failure(error, fallback_message="fallback text")
+
+    assert failure.message == "fallback text"
+    assert failure.classification.owner is RuntimeErrorOwner.PLATFORM
+    assert failure.classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+    assert failure.classification.retry_disposition is RetryDisposition.RETRYABLE
+
+
+@pytest.mark.anyio
+async def test_loopback_send_error_keeps_trusted_runtime_classification() -> None:
+    """Invariant: a classification the runtime boundary supplies is not overwritten.
+
+    The loopback previously stamped every runtime error as executor-unavailable;
+    a resource-limit attribution from the runtime must survive into the result.
+    """
+    handler = LoopbackHandler(
+        input=LoopbackInput(
+            session_id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+        )
+    )
+    sink = _StreamSink()
+    handler._stream_sink = cast(LoopbackEventSink, sink)
+    classification = agent_sandbox_resource_limit_exceeded()
+
+    await handler.send_error(classification.message, classification=classification)
+    result = handler.build_result()
+
+    assert result.classification == classification
+    assert sink.errors == [classification.message]

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -3622,6 +3622,7 @@ async def test_run_rebuilds_sandbox_process_exit_from_transport_exit_code(
     mock_socket_writer: MagicMock,
     mock_claude_sdk_client: MagicMock,
     sample_init_payload: RuntimeInitPayload,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Invariant: a dead sandbox process is attributed from the transport's exit code.
 
@@ -3629,7 +3630,9 @@ async def test_run_rebuilds_sandbox_process_exit_from_transport_exit_code(
     runtime must not parse. The transport keeps the exit code, the runtime
     rebuilds the typed exit error from it, the loopback receives the
     resource-limit classification, and the typed error is what propagates.
+    Attribution requires a jail, so nsjail is enabled explicitly here.
     """
+    monkeypatch.setattr(runtime_module, "TRACECAT__DISABLE_NSJAIL", False)
     mock_claude_sdk_client.query = AsyncMock(
         side_effect=Exception("Sandbox shim failed with exit code 134")
     )
@@ -3657,6 +3660,42 @@ async def test_run_rebuilds_sandbox_process_exit_from_transport_exit_code(
     assert classification.kind is RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED
     assert await_args.args[0] == classification.message
     mock_socket_writer.send_done.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_run_does_not_attribute_process_exit_when_nsjail_is_disabled(
+    mock_socket_writer: MagicMock,
+    mock_claude_sdk_client: MagicMock,
+    sample_init_payload: RuntimeInitPayload,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: without a jail an exit code carries no resource-limit meaning.
+
+    TRACECAT__DISABLE_NSJAIL installs no rlimits, so a direct process that
+    aborts or is OOM-killed by the host must stay platform-owned rather than
+    blaming the caller for a cap this deployment never enforced.
+    """
+    monkeypatch.setattr(runtime_module, "TRACECAT__DISABLE_NSJAIL", True)
+    mock_claude_sdk_client.query = AsyncMock(side_effect=ValueError("Test error"))
+    transport = MagicMock(spec=SandboxedCLITransport)
+    transport.exit_code = 137
+
+    with (
+        patch(
+            "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+            return_value=mock_claude_sdk_client,
+        ),
+        pytest.raises(ValueError, match="Test error"),
+    ):
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: transport
+        )
+        await runtime.run(sample_init_payload)
+
+    await_args = mock_socket_writer.send_error.await_args
+    assert await_args is not None
+    classification = await_args.kwargs["classification"]
+    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -3709,6 +3709,45 @@ async def test_run_does_not_attribute_process_exit_when_nsjail_is_disabled(
 
 
 @pytest.mark.anyio
+async def test_run_keeps_original_error_for_non_resource_limit_exit_code(
+    mock_socket_writer: MagicMock,
+    mock_claude_sdk_client: MagicMock,
+    sample_init_payload: RuntimeInitPayload,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: only a resource-limit exit code may replace the raised error.
+
+    Rebuilding the typed exit error for any other code would change nothing
+    about the classification while destroying the original exception's type,
+    so a failure that carries its own attribution would reach the activity as
+    a process exit and lose it.
+    """
+    monkeypatch.setattr(runtime_module, "TRACECAT__DISABLE_NSJAIL", False)
+    mock_claude_sdk_client.query = AsyncMock(
+        side_effect=AgentSandboxValidationError("Bad agent config")
+    )
+    transport = MagicMock(spec=SandboxedCLITransport)
+    transport.exit_code = 1
+
+    with (
+        patch(
+            "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+            return_value=mock_claude_sdk_client,
+        ),
+        pytest.raises(AgentSandboxValidationError, match="Bad agent config"),
+    ):
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: transport
+        )
+        await runtime.run(sample_init_payload)
+
+    await_args = mock_socket_writer.send_error.await_args
+    assert await_args is not None
+    classification = await_args.kwargs["classification"]
+    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+
+
+@pytest.mark.anyio
 async def test_run_keeps_original_error_when_sandbox_process_did_not_exit(
     mock_socket_writer: MagicMock,
     mock_claude_sdk_client: MagicMock,

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -28,7 +28,10 @@ from claude_agent_sdk.types import (
 )
 
 import tracecat.agent.runtime.claude_code.runtime as runtime_module
-from tracecat.agent.common.exceptions import AgentSandboxValidationError
+from tracecat.agent.common.exceptions import (
+    AgentSandboxProcessExitError,
+    AgentSandboxValidationError,
+)
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.socket_io import SocketStreamWriter
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
@@ -54,8 +57,10 @@ from tracecat.agent.runtime.claude_code.runtime import (
 from tracecat.agent.runtime.claude_code.session_lines import (
     MODEL_CONTEXT_PROMPT_PREFIX,
 )
+from tracecat.agent.runtime.claude_code.transport import SandboxedCLITransport
 from tracecat.agent.subagents import AgentSubagentsConfig
 from tracecat.agent.types import AgentConfig
+from tracecat.runtime.errors import RuntimeErrorKind
 from tracecat.sandbox.exceptions import SandboxFileSafetyError
 
 
@@ -3610,3 +3615,79 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
             internal=False,
         )
         assert runtime._last_seen_byte_offset == len(child_bytes)
+
+
+@pytest.mark.anyio
+async def test_run_rebuilds_sandbox_process_exit_from_transport_exit_code(
+    mock_socket_writer: MagicMock,
+    mock_claude_sdk_client: MagicMock,
+    sample_init_payload: RuntimeInitPayload,
+) -> None:
+    """Invariant: a dead sandbox process is attributed from the transport's exit code.
+
+    The SDK erases ``ProcessError`` into a plain ``Exception`` whose text the
+    runtime must not parse. The transport keeps the exit code, the runtime
+    rebuilds the typed exit error from it, the loopback receives the
+    resource-limit classification, and the typed error is what propagates.
+    """
+    mock_claude_sdk_client.query = AsyncMock(
+        side_effect=Exception("Sandbox shim failed with exit code 134")
+    )
+    transport = MagicMock(spec=SandboxedCLITransport)
+    transport.exit_code = 134
+
+    with (
+        patch(
+            "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+            return_value=mock_claude_sdk_client,
+        ),
+        pytest.raises(AgentSandboxProcessExitError) as excinfo,
+    ):
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: transport
+        )
+        await runtime.run(sample_init_payload)
+
+    assert excinfo.value.exit_code == 134
+    assert str(excinfo.value.__cause__) == "Sandbox shim failed with exit code 134"
+    mock_socket_writer.send_error.assert_awaited_once()
+    await_args = mock_socket_writer.send_error.await_args
+    assert await_args is not None
+    classification = await_args.kwargs["classification"]
+    assert classification.kind is RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED
+    assert await_args.args[0] == classification.message
+    mock_socket_writer.send_done.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_run_keeps_original_error_when_sandbox_process_did_not_exit(
+    mock_socket_writer: MagicMock,
+    mock_claude_sdk_client: MagicMock,
+    sample_init_payload: RuntimeInitPayload,
+) -> None:
+    """Invariant: without a recorded process exit the runtime error is untouched.
+
+    The failure stays platform-owned executor unavailability and the original
+    exception type and text reach the caller.
+    """
+    mock_claude_sdk_client.query = AsyncMock(side_effect=ValueError("Test error"))
+    transport = MagicMock(spec=SandboxedCLITransport)
+    transport.exit_code = None
+
+    with (
+        patch(
+            "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+            return_value=mock_claude_sdk_client,
+        ),
+        pytest.raises(ValueError, match="Test error"),
+    ):
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: transport
+        )
+        await runtime.run(sample_init_payload)
+
+    await_args = mock_socket_writer.send_error.await_args
+    assert await_args is not None
+    assert await_args.args[0] == "Test error"
+    classification = await_args.kwargs["classification"]
+    assert classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -3653,6 +3653,16 @@ async def test_run_rebuilds_sandbox_process_exit_from_transport_exit_code(
 
     assert excinfo.value.exit_code == 134
     assert str(excinfo.value.__cause__) == "Sandbox shim failed with exit code 134"
+
+    # The runtime log describes one exception at a time: the attributed error's
+    # type and message together, with the SDK's erased text kept as the cause.
+    log_args = mock_socket_writer.send_log.await_args
+    assert log_args is not None
+    assert log_args.kwargs["error_type"] == "AgentSandboxProcessExitError"
+    assert log_args.kwargs["error_message"] == str(excinfo.value)
+    assert log_args.kwargs["cause_type"] == "Exception"
+    assert log_args.kwargs["cause_message"] == "Sandbox shim failed with exit code 134"
+
     mock_socket_writer.send_error.assert_awaited_once()
     await_args = mock_socket_writer.send_error.await_args
     assert await_args is not None
@@ -3730,3 +3740,10 @@ async def test_run_keeps_original_error_when_sandbox_process_did_not_exit(
     assert await_args.args[0] == "Test error"
     classification = await_args.kwargs["classification"]
     assert classification.kind is RuntimeErrorKind.AGENT_EXECUTOR_UNAVAILABLE
+
+    # Nothing was re-attributed, so the log carries no cause fields.
+    log_args = mock_socket_writer.send_log.await_args
+    assert log_args is not None
+    assert log_args.kwargs["error_type"] == "ValueError"
+    assert log_args.kwargs["error_message"] == "Test error"
+    assert "cause_type" not in log_args.kwargs

--- a/tests/unit/test_agent_runtime_broker.py
+++ b/tests/unit/test_agent_runtime_broker.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 import orjson
 import pytest
 from claude_agent_sdk import ClaudeAgentOptions
-from claude_agent_sdk._errors import ProcessError
+from claude_agent_sdk._errors import CLIConnectionError, ProcessError
 from claude_agent_sdk.types import (
     AgentDefinition,
     McpHttpServerConfig,
@@ -636,3 +636,30 @@ async def test_transport_records_shim_exit_code_when_stream_ends(
 
     assert excinfo.value.exit_code == 134
     assert transport.exit_code == 134
+
+
+@pytest.mark.anyio
+async def test_transport_records_shim_exit_code_observed_on_write(
+    tmp_path: Path,
+) -> None:
+    """Invariant: a shim death seen at write time is still attributable.
+
+    The SDK cancels its reader task when a write fails, so ``read_messages``
+    may never reach its own recording point. A resource-limit death observed
+    while writing a prompt must not degrade to retryable executor
+    unavailability for want of the exit code.
+    """
+    transport = _make_transport(tmp_path, use_jailed_paths=False)
+
+    class _ExitedProcess:
+        returncode = 137
+        stdin = SimpleNamespace()
+        stdout = SimpleNamespace()
+
+    transport._process = cast(Any, _ExitedProcess())
+    transport._ready = True
+
+    with pytest.raises(CLIConnectionError):
+        await transport.write('{"type":"user"}\n')
+
+    assert transport.exit_code == 137

--- a/tests/unit/test_agent_runtime_broker.py
+++ b/tests/unit/test_agent_runtime_broker.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import orjson
 import pytest
 from claude_agent_sdk import ClaudeAgentOptions
+from claude_agent_sdk._errors import ProcessError
 from claude_agent_sdk.types import (
     AgentDefinition,
     McpHttpServerConfig,
@@ -600,3 +601,38 @@ async def test_transport_close_preserves_caller_owned_job_directory(
     assert job_dir.is_dir()
     assert uv_file.is_file()
     assert transport._spawned_runtime is None
+
+
+@pytest.mark.anyio
+async def test_transport_records_shim_exit_code_when_stream_ends(
+    tmp_path: Path,
+) -> None:
+    """Invariant: the shim exit code survives the ProcessError the SDK erases.
+
+    ``read_messages`` still raises ``ProcessError`` for the SDK, and the same
+    exit code stays readable on the transport for the runtime to attribute.
+    """
+    transport = _make_transport(tmp_path, use_jailed_paths=False)
+
+    class _ExitedStdout:
+        @staticmethod
+        async def readline() -> bytes:
+            return b""
+
+    class _ExitedProcess:
+        returncode = 134
+        stdout = _ExitedStdout()
+        stderr = None
+
+        @staticmethod
+        async def wait() -> int:
+            return 134
+
+    transport._process = cast(Any, _ExitedProcess())
+
+    with pytest.raises(ProcessError) as excinfo:
+        async for _ in transport.read_messages():
+            pass
+
+    assert excinfo.value.exit_code == 134
+    assert transport.exit_code == 134

--- a/tests/unit/test_agent_sandbox_entrypoint.py
+++ b/tests/unit/test_agent_sandbox_entrypoint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import signal
 import socket
 import tempfile
 from collections.abc import Iterator
@@ -19,6 +20,7 @@ from tracecat.agent.sandbox.shim_entrypoint import (
     LLM_SOCKET_ENV_VAR,
     MCP_SOCKET_ENV_VAR,
     SandboxSocketBridge,
+    _forward_exit_code,
     _pump_stdin_to_process,
     _read_stdin_chunk,
     _resolve_init_payload_path,
@@ -561,3 +563,24 @@ async def test_shim_sets_otel_env_only_after_drop_mode_bridge_starts(
         assert captured_env["OTEL_EXPORTER_OTLP_ENDPOINT"] == (
             f"http://{BRIDGE_HOST}:{otel_port}"
         )
+
+
+@pytest.mark.parametrize(
+    ("return_code", "expected"),
+    [
+        pytest.param(0, 0, id="clean-exit"),
+        pytest.param(1, 1, id="nonzero-exit-passes-through"),
+        pytest.param(-signal.SIGABRT, 134, id="sigabrt-forwards-as-134"),
+        pytest.param(-signal.SIGKILL, 137, id="sigkill-forwards-as-137"),
+    ],
+)
+def test_forward_exit_code_maps_signal_death_to_nsjail_contract(
+    return_code: int,
+    expected: int,
+) -> None:
+    """Invariant: the shim forwards the Claude child's death as ``128 + signal``.
+
+    Without this the shim exits 1 for every failure and the host can never
+    observe which signal killed the jailed runtime.
+    """
+    assert _forward_exit_code(return_code) == expected

--- a/tests/unit/test_executor_activities.py
+++ b/tests/unit/test_executor_activities.py
@@ -404,11 +404,23 @@ class TestExecuteActionActivity:
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(
-        "error_code",
+        ("error_code", "kind"),
         [
-            SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED,
-            SandboxErrorCode.POLICY_VIOLATION,
-            SandboxErrorCode.WORKLOAD_FAILURE,
+            pytest.param(
+                SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED,
+                RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED,
+                id="resource_limit_exceeded",
+            ),
+            pytest.param(
+                SandboxErrorCode.POLICY_VIOLATION,
+                RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+                id="policy_violation",
+            ),
+            pytest.param(
+                SandboxErrorCode.WORKLOAD_FAILURE,
+                RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+                id="workload_failure",
+            ),
         ],
     )
     async def test_sandbox_workload_failure_is_user_owned_and_non_retryable(
@@ -416,7 +428,15 @@ class TestExecuteActionActivity:
         mock_run_action_input: RunActionInput,
         mock_role: Role,
         error_code: SandboxErrorCode,
+        kind: RuntimeErrorKind,
     ) -> None:
+        """Invariant: a sandbox workload failure is the caller's and is not retried.
+
+        A resource-limit death additionally earns its own kind so fleet-wide
+        alerting can key on it; every other workload code keeps the generic
+        action-failure kind. The ``ApplicationError`` type carries the kind
+        verbatim, which is the string those alerts match on.
+        """
         workload_error = SandboxWorkloadError(
             "synthetic sandbox workload diagnostic",
             error_code=error_code,
@@ -453,10 +473,12 @@ class TestExecuteActionActivity:
         classification = extract_error_classification(app_error)
         assert classification is not None
         assert classification.owner is RuntimeErrorOwner.USER
-        assert classification.kind is RuntimeErrorKind.ACTION_EXECUTION_FAILED
+        assert classification.kind is kind
+        assert app_error.type == kind.value
         assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
         assert classification.cause_type == "SandboxWorkloadError"
         assert app_error.non_retryable is True
+        assert "synthetic sandbox workload diagnostic" not in str(app_error)
 
     @pytest.mark.anyio
     async def test_executor_backend_initialization_failure_is_classified(

--- a/tests/unit/test_executor_error_policy.py
+++ b/tests/unit/test_executor_error_policy.py
@@ -15,7 +15,10 @@ from tracecat.runtime.errors import (
     RuntimeErrorKind,
     RuntimeErrorOwner,
 )
-from tracecat.sandbox.exceptions import SandboxWorkloadError
+from tracecat.sandbox.exceptions import (
+    SandboxWorkloadError,
+    raise_for_sandbox_error_code,
+)
 from tracecat.sandbox.types import SandboxErrorCode
 
 
@@ -122,3 +125,74 @@ def test_loop_retry_requires_every_failed_iteration_to_be_retryable() -> None:
 
     assert result.owner is RuntimeErrorOwner.PLATFORM
     assert result.retry_disposition is RetryDisposition.RETRYABLE
+
+
+def test_sandbox_resource_limit_gets_dedicated_user_owned_kind() -> None:
+    """A workload that exceeded a published sandbox cap is the caller's to fix.
+
+    Invariant: ``SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED`` maps to the
+    dedicated ``sandbox.resource_limit_exceeded`` kind, stays user-owned, is
+    never retried (the cap is deterministic), and names the memory env var.
+    """
+    workload_error = SandboxWorkloadError(
+        "sandbox-controlled text",
+        error_code=SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED,
+    )
+
+    classification = classify_execute_action_error(
+        _iteration_error(workload_error, index=0),
+        action_name="test_action",
+    )
+
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert classification.cause_type == "SandboxWorkloadError"
+    assert "TRACECAT__SANDBOX_DEFAULT_MEMORY_MB" in classification.message
+    assert "sandbox-controlled text" not in classification.message
+
+
+@pytest.mark.parametrize(
+    ("error_code", "retry_disposition"),
+    [
+        (SandboxErrorCode.WORKLOAD_FAILURE, RetryDisposition.NON_RETRYABLE),
+        (SandboxErrorCode.POLICY_VIOLATION, RetryDisposition.NON_RETRYABLE),
+        (SandboxErrorCode.TIMEOUT, RetryDisposition.RETRYABLE),
+    ],
+)
+def test_other_sandbox_workload_codes_keep_action_execution_failed(
+    error_code: SandboxErrorCode,
+    retry_disposition: RetryDisposition,
+) -> None:
+    """Invariant: only the resource-limit code leaves ``action.execution.failed``."""
+    workload_error = SandboxWorkloadError("stopped", error_code=error_code)
+
+    classification = classify_execute_action_error(
+        _iteration_error(workload_error, index=0),
+        action_name="test_action",
+    )
+
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.ACTION_EXECUTION_FAILED
+    assert classification.retry_disposition is retry_disposition
+
+
+def test_resource_limit_envelope_code_reaches_classification_without_text() -> None:
+    """Invariant: the envelope's ``resource_limit_exceeded`` code alone drives it.
+
+    ``raise_for_sandbox_error_code`` is the only bridge from a decoded sandbox
+    result to the executor error chain, so the code it receives from an
+    in-jail ``MemoryError`` envelope must survive as a typed exception.
+    """
+    with pytest.raises(SandboxWorkloadError) as excinfo:
+        raise_for_sandbox_error_code(
+            SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED,
+            "MemoryError: script exceeded the sandbox memory limit",
+        )
+
+    assert excinfo.value.error_code is SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED
+    classification = classify_execute_action_error(
+        _iteration_error(excinfo.value, index=0),
+        action_name="core.script.run_python",
+    )
+    assert classification.kind is RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED

--- a/tests/unit/test_sandbox_executor_exit_attribution.py
+++ b/tests/unit/test_sandbox_executor_exit_attribution.py
@@ -62,6 +62,16 @@ from tracecat.sandbox.types import SandboxErrorCode
             SandboxErrorCode.POLICY_VIOLATION,
             id="workload-seccomp-policy",
         ),
+        # SIGABRT stays a workload failure on the core path: Python reports
+        # allocation failure in-band as MemoryError (structured envelope code),
+        # and an abort has other causes the exit code cannot separate.
+        pytest.param(
+            128 + signal.SIGABRT,
+            False,
+            True,
+            SandboxErrorCode.WORKLOAD_FAILURE,
+            id="workload-sigabrt-stays-workload-failure",
+        ),
         pytest.param(
             1,
             False,

--- a/tests/unit/test_sandbox_resource_limits.py
+++ b/tests/unit/test_sandbox_resource_limits.py
@@ -112,3 +112,96 @@ def main():
     )
     assert result.success is False
     assert result.error_code is None
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        pytest.param(
+            "def main():\n    raise MemoryError()",
+            id="execution",
+        ),
+        pytest.param(
+            """import sys
+class HungryBuffer:
+    def getvalue(self):
+        raise MemoryError()
+def main():
+    sys.stdout = HungryBuffer()
+    return 1
+""",
+            id="capture",
+        ),
+        pytest.param(
+            """class HungryRepr:
+    def __repr__(self):
+        raise MemoryError()
+def main():
+    return HungryRepr()
+""",
+            id="serialization",
+        ),
+        pytest.param(
+            """class HungryRepr:
+    def __repr__(self):
+        raise MemoryError()
+def main():
+    return {(1, 2): HungryRepr()}
+""",
+            id="fallback-repr",
+        ),
+        pytest.param(
+            """import json
+class FallbackRepr:
+    def __repr__(self):
+        def fail_encoding(*args, **kwargs):
+            json.dumps = original_dumps
+            raise MemoryError()
+        original_dumps = json.dumps
+        json.dumps = fail_encoding
+        return "fallback"
+def main():
+    return {(1, 2): FallbackRepr()}
+""",
+            id="fallback-encoding",
+        ),
+    ],
+)
+def test_wrapper_recovers_memory_failure_across_result_pipeline(
+    tmp_path: Path, script: str
+) -> None:
+    result = _run_runner(tmp_path, "script", script)
+    assert result.success is False
+    assert result.error_code is SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED
+    assert result.error == "Script exceeded the sandbox memory limit"
+    assert result.output is None
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_wrapper_preserves_non_json_fallback(tmp_path: Path) -> None:
+    result = _run_runner(
+        tmp_path, "script", 'def main():\n    return {(1, 2): "value"}'
+    )
+    assert result.success is False
+    assert result.error_code is None
+    assert result.output == "{(1, 2): 'value'}"
+    assert isinstance(result.error, str)
+    assert result.error.startswith("Output not JSON-serializable: TypeError:")
+
+
+def test_wrapper_preserves_async_results_and_captured_streams(tmp_path: Path) -> None:
+    result = _run_runner(
+        tmp_path,
+        "script",
+        """import sys
+async def main():
+    print("ordinary stdout")
+    print("ordinary stderr", file=sys.stderr)
+    return {"value": 1}
+""",
+    )
+    assert result.success is True
+    assert result.output == {"value": 1}
+    assert result.stdout == "ordinary stdout\n"
+    assert result.stderr == "ordinary stderr\n"

--- a/tests/unit/test_sandbox_resource_limits.py
+++ b/tests/unit/test_sandbox_resource_limits.py
@@ -1,0 +1,114 @@
+"""Exercise standalone runner failures and their host-side envelope decoding."""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Literal
+
+import orjson
+import pytest
+
+from tracecat.executor import minimal_runner
+from tracecat.sandbox.result_envelope import decode_result_envelope
+from tracecat.sandbox.types import SandboxErrorCode, SandboxResult
+from tracecat.sandbox.wrapper import WRAPPER_SCRIPT
+
+
+def _run_runner(
+    tmp_path: Path, runner: Literal["script", "action"], script: str
+) -> SandboxResult:
+    (tmp_path / "script.py").write_text(script)
+    (tmp_path / "inputs.json").write_text("{}")
+    (tmp_path / "input.json").write_bytes(
+        orjson.dumps(
+            {
+                "resolved_context": {
+                    "action_impl": {"type": "udf", "module": "script", "name": "main"},
+                    "evaluated_args": {},
+                },
+                "secret_env": {},
+            }
+        )
+    )
+    source = (
+        WRAPPER_SCRIPT
+        if runner == "script"
+        else Path(minimal_runner.__file__).read_text()
+    )
+    runner_path = tmp_path / "runner.py"
+    runner_path.write_text(source.replace('"/work/', f'"{tmp_path}/'))
+    completed = subprocess.run(
+        [sys.executable, "-B", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    outcome = decode_result_envelope(
+        tmp_path,
+        output_key="output" if runner == "script" else "result",
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        stderr_limit=4096,
+        invalid_result_error="Invalid result",
+        log_label="sandbox" if runner == "script" else "action",
+        exit_code=completed.returncode,
+        execution_time_ms=0,
+        max_bytes=1024 * 1024,
+        stream_source="envelope",
+        include_error_code=True,
+    )
+    assert outcome is not None, completed.stderr
+    assert outcome.valid_envelope, completed.stderr
+    return outcome.result
+
+
+@pytest.mark.parametrize("runner", ["script", "action"])
+@pytest.mark.parametrize("target", ["user_file", "result_file"])
+def test_file_size_limit_produces_resource_envelope(
+    tmp_path: Path,
+    runner: Literal["script", "action"],
+    target: str,
+) -> None:
+    operation = (
+        'with open("payload.bin", "wb") as output:\n        output.write(b"x" * 8192)'
+        if target == "user_file"
+        else 'return "x" * 8192'
+    )
+    result = _run_runner(
+        tmp_path,
+        runner,
+        f"""import resource
+
+def main():
+    resource.setrlimit(resource.RLIMIT_FSIZE, (4096, 4096))
+    {operation}
+""",
+    )
+    assert result.success is False
+    assert result.error_code is SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED
+    message = (
+        result.error["message"] if isinstance(result.error, dict) else result.error
+    )
+    assert isinstance(message, str)
+    assert "file size limit" in message
+    assert "memory" not in message
+
+
+@pytest.mark.parametrize("runner", ["script", "action"])
+@pytest.mark.parametrize("error_name", ["ENOSPC", "EACCES", "EAGAIN"])
+def test_other_oserrors_remain_ordinary_workload_errors(
+    tmp_path: Path, runner: Literal["script", "action"], error_name: str
+) -> None:
+    result = _run_runner(
+        tmp_path,
+        runner,
+        f"""import errno
+
+def main():
+    raise OSError(errno.{error_name}, "synthetic syscall failure")
+""",
+    )
+    assert result.success is False
+    assert result.error_code is None

--- a/tests/unit/test_sandbox_result_envelope.py
+++ b/tests/unit/test_sandbox_result_envelope.py
@@ -251,3 +251,30 @@ def test_decode_result_envelope_can_preserve_process_streams(tmp_path: Path) -> 
     assert outcome is not None
     assert outcome.result.stdout == "process stdout"
     assert outcome.result.stderr == "process stderr"
+
+
+def test_decode_result_envelope_passes_resource_limit_code_through(
+    tmp_path: Path,
+) -> None:
+    """Invariant: the in-jail ``MemoryError`` code is not clamped at the boundary.
+
+    Only unknown codes and INFRASTRUCTURE_FAILURE degrade to WORKLOAD_FAILURE;
+    ``resource_limit_exceeded`` must reach the host so the error policy can
+    classify it without parsing error text.
+    """
+    (tmp_path / "result.json").write_bytes(
+        orjson.dumps(
+            {
+                "success": False,
+                "output": None,
+                "error": "MemoryError: script exceeded the sandbox memory limit",
+                "error_code": "resource_limit_exceeded",
+            }
+        )
+    )
+
+    outcome = _decode(tmp_path)
+
+    assert outcome is not None
+    assert outcome.valid_envelope is True
+    assert outcome.result.error_code is SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED

--- a/tracecat/agent/common/exceptions.py
+++ b/tracecat/agent/common/exceptions.py
@@ -17,3 +17,17 @@ class AgentSandboxTimeoutError(AgentSandboxError):
 
 class AgentSandboxExecutionError(AgentSandboxError):
     """Raised when agent execution fails."""
+
+
+class AgentSandboxProcessExitError(AgentSandboxExecutionError):
+    """Raised when the jailed agent runtime process exited with a failure code.
+
+    The Claude SDK erases the transport's typed process error into a plain
+    ``Exception``, so the runtime rebuilds this from the exit code the sandbox
+    transport recorded. The code follows the nsjail contract: a signal death
+    is ``128 + signal``.
+    """
+
+    def __init__(self, exit_code: int) -> None:
+        super().__init__(f"Agent sandbox process exited with code {exit_code}")
+        self.exit_code = exit_code

--- a/tracecat/agent/common/socket_io.py
+++ b/tracecat/agent/common/socket_io.py
@@ -16,12 +16,17 @@ from __future__ import annotations
 
 import asyncio
 from enum import IntEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import orjson
 
 from tracecat.agent.common.protocol import RuntimeEventEnvelope
 from tracecat.agent.common.stream_types import UnifiedStreamEvent
+
+if TYPE_CHECKING:
+    # Type-only: this module is imported inside the sandbox and must keep its
+    # runtime import surface minimal (no pydantic_core).
+    from tracecat.runtime.errors import RuntimeErrorClassification
 
 # Header size: 1 byte msg_type + 4 bytes length
 HEADER_SIZE = 5
@@ -181,8 +186,21 @@ class SocketStreamWriter:
             )
         )
 
-    async def send_error(self, error: str) -> None:
-        """Send error event to the orchestrator."""
+    async def send_error(
+        self,
+        error: str,
+        *,
+        classification: RuntimeErrorClassification | None = None,
+    ) -> None:
+        """Send error event to the orchestrator.
+
+        ``classification`` is accepted for signature compatibility with the
+        in-process writer and then dropped. This writer sits on the sandbox
+        side of an untrusted boundary, so the envelope protocol deliberately
+        carries no ownership metadata; the orchestrator classifies a socket
+        error itself rather than believing what the runtime claims.
+        """
+        del classification
         await self._send(RuntimeEventEnvelope.from_error(error))
 
     async def send_done(self) -> None:

--- a/tracecat/agent/error_policy.py
+++ b/tracecat/agent/error_policy.py
@@ -2,11 +2,41 @@
 
 from __future__ import annotations
 
+import signal
+from dataclasses import dataclass
+
+from tracecat.agent.common.config import TRACECAT__AGENT_SANDBOX_MEMORY_MB
+from tracecat.agent.common.exceptions import AgentSandboxProcessExitError
 from tracecat.runtime.errors import (
     RetryDisposition,
     RuntimeErrorClassification,
     RuntimeErrorKind,
 )
+from tracecat.sandbox.exceptions import sandbox_resource_limit_message
+from tracecat.temporal.errors import iter_error_chain
+
+# Exit codes (``128 + signal``) that mean the jailed agent runtime hit one of
+# its nsjail rlimits. SIGABRT is included here, unlike the core sandbox: the
+# jailed process is the trusted shim plus the Claude Code CLI, whose JavaScript
+# engine aborts on allocation failure and has no in-band channel comparable to
+# Python's MemoryError. SIGKILL covers the OOM killer and the wall-clock limit,
+# SIGXCPU the CPU-time limit, and SIGXFSZ the file-size limit.
+AGENT_SANDBOX_RESOURCE_LIMIT_EXIT_CODES = frozenset(
+    {
+        128 + signal.SIGABRT,
+        128 + signal.SIGKILL,
+        128 + signal.SIGXCPU,
+        128 + signal.SIGXFSZ,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRuntimeFailure:
+    """Terminal attribution plus the message safe to surface for a runtime failure."""
+
+    message: str
+    classification: RuntimeErrorClassification
 
 
 def invalid_agent_configuration(
@@ -90,6 +120,52 @@ def agent_executor_unavailable(
         message="Tracecat agent executor is unavailable",
         retry_disposition=RetryDisposition.RETRYABLE,
         cause=error,
+    )
+
+
+def agent_sandbox_resource_limit_exceeded(
+    error: BaseException | None = None,
+) -> RuntimeErrorClassification:
+    """Classify a jailed agent runtime that died from one of its rlimits.
+
+    The cap is published deployment configuration the caller's workload
+    exceeded, and a retry hits the same cap deterministically.
+    """
+    return RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED,
+        message=sandbox_resource_limit_message(
+            memory_mb=TRACECAT__AGENT_SANDBOX_MEMORY_MB,
+            memory_env_var="TRACECAT__AGENT_SANDBOX_MEMORY_MB",
+        ),
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=error,
+    )
+
+
+def agent_runtime_failure(
+    error: BaseException,
+    *,
+    fallback_message: str,
+) -> AgentRuntimeFailure:
+    """Classify an exception raised out of a Claude runtime turn.
+
+    A jailed process that exited with a resource-limit code is attributed to
+    the caller and carries its own message. Every other failure remains
+    platform-owned executor unavailability, surfacing ``fallback_message``.
+    """
+    for cause in iter_error_chain(error):
+        if (
+            isinstance(cause, AgentSandboxProcessExitError)
+            and cause.exit_code in AGENT_SANDBOX_RESOURCE_LIMIT_EXIT_CODES
+        ):
+            classification = agent_sandbox_resource_limit_exceeded(cause)
+            return AgentRuntimeFailure(
+                message=classification.message,
+                classification=classification,
+            )
+    return AgentRuntimeFailure(
+        message=fallback_message,
+        classification=agent_executor_unavailable(error),
     )
 
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -49,7 +49,7 @@ from tracecat.agent.common.types import (
 from tracecat.agent.error_policy import (
     agent_executor_protocol_failed,
     agent_executor_timed_out,
-    agent_executor_unavailable,
+    agent_runtime_failure,
     invalid_agent_configuration,
 )
 from tracecat.agent.executor.loopback import (
@@ -692,12 +692,16 @@ class SandboxedAgentExecutor:
             result.classification = invalid_agent_configuration(e)
         except AgentSandboxExecutionError as e:
             logger.error("Agent sandbox execution failed", error=str(e))
-            result.error = str(e)
-            result.classification = agent_executor_unavailable(e)
+            failure = agent_runtime_failure(e, fallback_message=str(e))
+            result.error = failure.message
+            result.classification = failure.classification
         except Exception as e:
             logger.exception("Unexpected error in agent executor", error=str(e))
-            result.error = f"Unexpected error: {e}"
-            result.classification = agent_executor_unavailable(e)
+            failure = agent_runtime_failure(
+                e, fallback_message=f"Unexpected error: {e}"
+            )
+            result.error = failure.message
+            result.classification = failure.classification
         finally:
             await self._cleanup()
 
@@ -937,8 +941,11 @@ class SandboxedAgentExecutor:
                     )
                     broker_task = None
         except Exception as e:
-            result.error = str(e)
-            result.classification = agent_executor_unavailable(e)
+            # A jailed runtime that died from an rlimit is the caller's failure
+            # and must win over the generic executor-unavailable attribution.
+            failure = agent_runtime_failure(e, fallback_message=str(e))
+            result.error = failure.message
+            result.classification = failure.classification
             result.terminal_stream_error_emitted = await handler.emit_terminal_error(
                 result.error
             )

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -911,20 +911,31 @@ class LoopbackHandler:
         self._result.result_usage = usage
         self._result.result_num_turns = num_turns
 
-    async def _handle_error(self, error: str) -> bool:
+    async def _handle_error(
+        self,
+        error: str,
+        *,
+        classification: RuntimeErrorClassification | None = None,
+    ) -> bool:
         """Handle a terminal runtime error."""
         stream_sink = await self.prepare()
         logger.error("Runtime error", error=error)
         await self._emit_terminal_stream_error(stream_sink, error)
         self._result.error = error
-        # Top-level runtime errors are emitted by the runtime's unexpected-error
-        # boundary and carry no trusted ownership metadata.
-        self._result.classification = agent_executor_unavailable()
+        # A classification is trusted only when the host-side runtime hands it
+        # over in-process. Error envelopes arriving over the sandbox socket
+        # carry no ownership metadata by design, so those stay platform-owned.
+        self._result.classification = classification or agent_executor_unavailable()
         return True
 
-    async def send_error(self, error: str) -> None:
+    async def send_error(
+        self,
+        error: str,
+        *,
+        classification: RuntimeErrorClassification | None = None,
+    ) -> None:
         """Handle a terminal runtime error."""
-        await self._handle_error(error)
+        await self._handle_error(error, classification=classification)
 
     async def _handle_done(self) -> bool:
         """Handle runtime completion."""

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -1947,12 +1947,18 @@ class ClaudeAgentRuntime:
             # recover the exit code the transport recorded before attributing.
             error: Exception = _sandbox_process_exit_error(transport) or e
             failure = agent_runtime_failure(error, fallback_message=str(e))
-            await self._event_writer.send_log(
-                "error",
-                "Runtime error",
-                error_type=type(error).__name__,
-                error_message=str(e),
-            )
+            # Log the attributed error's own type and message together, so the
+            # two never describe different exceptions. When attribution
+            # replaced the SDK's exception, its text is kept alongside as the
+            # cause rather than being passed off as the attributed error's.
+            log_fields: dict[str, object] = {
+                "error_type": type(error).__name__,
+                "error_message": str(error),
+            }
+            if error is not e:
+                log_fields["cause_type"] = type(e).__name__
+                log_fields["cause_message"] = str(e)
+            await self._event_writer.send_log("error", "Runtime error", **log_fields)
             await self._event_writer.send_error(
                 failure.message,
                 classification=failure.classification,

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -77,7 +77,10 @@ from tracecat.agent.common.types import (
     MCPToolDefinition,
     requires_sandbox_internet_access,
 )
-from tracecat.agent.error_policy import agent_runtime_failure
+from tracecat.agent.error_policy import (
+    AGENT_SANDBOX_RESOURCE_LIMIT_EXIT_CODES,
+    agent_runtime_failure,
+)
 from tracecat.agent.llm_routing import get_litellm_route_model
 from tracecat.agent.mcp.metadata import (
     PROXY_TOOL_CALL_ID_KEY,
@@ -185,9 +188,11 @@ def _sandbox_process_exit_error(
 ) -> AgentSandboxProcessExitError | None:
     """Rebuild the typed process failure the SDK erased from its exception.
 
-    Only a positive exit code counts: ``0`` means the process did not fail, and
-    a negative code means the host itself terminated the process during
-    transport teardown rather than the jailed runtime dying.
+    Only a resource-limit exit code counts. Rebuilding for any other code would
+    replace the propagating exception's type without changing its
+    classification, so a genuinely typed failure raised late in the turn --
+    ``AgentSandboxValidationError``, say -- would reach the activity as a
+    process exit and lose its own attribution.
     """
     if TRACECAT__DISABLE_NSJAIL:
         # Without a jail no rlimit was installed, so the exit code carries no
@@ -198,7 +203,7 @@ def _sandbox_process_exit_error(
     if not isinstance(transport, SandboxedCLITransport):
         return None
     exit_code = transport.exit_code
-    if exit_code is None or exit_code <= 0:
+    if exit_code is None or exit_code not in AGENT_SANDBOX_RESOURCE_LIMIT_EXIT_CODES:
         return None
     return AgentSandboxProcessExitError(exit_code)
 

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -54,7 +54,10 @@ from tracecat.agent.common.config import (
     TRACECAT__AGENT_MCP_BRIDGE_PORT,
     TRACECAT__DISABLE_NSJAIL,
 )
-from tracecat.agent.common.exceptions import AgentSandboxValidationError
+from tracecat.agent.common.exceptions import (
+    AgentSandboxProcessExitError,
+    AgentSandboxValidationError,
+)
 from tracecat.agent.common.output_format import build_sdk_output_format
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.socket_io import MAX_PAYLOAD_SIZE
@@ -74,6 +77,7 @@ from tracecat.agent.common.types import (
     MCPToolDefinition,
     requires_sandbox_internet_access,
 )
+from tracecat.agent.error_policy import agent_runtime_failure
 from tracecat.agent.llm_routing import get_litellm_route_model
 from tracecat.agent.mcp.metadata import (
     PROXY_TOOL_CALL_ID_KEY,
@@ -94,8 +98,10 @@ from tracecat.agent.runtime.claude_code.session_lines import (
     is_model_context_session_line,
     is_synthetic_session_line,
 )
+from tracecat.agent.runtime.claude_code.transport import SandboxedCLITransport
 from tracecat.integrations.mcp_validation import sanitize_mcp_command_args
 from tracecat.logger import logger
+from tracecat.runtime.errors import RuntimeErrorClassification
 from tracecat.sandbox.exceptions import SandboxFileSafetyError
 from tracecat.sandbox.file_io import (
     atomic_write_file_beneath,
@@ -159,14 +165,36 @@ class RuntimeEventWriter(Protocol):
     ) -> None:
         """Send the final Claude result."""
 
-    async def send_error(self, error: str) -> None:
-        """Send a terminal runtime error."""
+    async def send_error(
+        self,
+        error: str,
+        *,
+        classification: RuntimeErrorClassification | None = None,
+    ) -> None:
+        """Send a terminal runtime error with optional trusted attribution."""
 
     async def send_done(self) -> None:
         """Signal that the runtime turn is complete."""
 
     async def send_log(self, level: str, message: str, **extra: object) -> None:
         """Send a structured runtime log event."""
+
+
+def _sandbox_process_exit_error(
+    transport: Transport | None,
+) -> AgentSandboxProcessExitError | None:
+    """Rebuild the typed process failure the SDK erased from its exception.
+
+    Only a positive exit code counts: ``0`` means the process did not fail, and
+    a negative code means the host itself terminated the process during
+    transport teardown rather than the jailed runtime dying.
+    """
+    if not isinstance(transport, SandboxedCLITransport):
+        return None
+    exit_code = transport.exit_code
+    if exit_code is None or exit_code <= 0:
+        return None
+    return AgentSandboxProcessExitError(exit_code)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1696,6 +1724,7 @@ class ClaudeAgentRuntime:
         )
 
         session_flush_task: asyncio.Task[None] | None = None
+        transport: Transport | None = None
 
         # Stable per-session working directory for the Claude Code CLI.
         # IMPORTANT: Must be deterministic per session_id. The CLI indexes
@@ -1908,14 +1937,23 @@ class ClaudeAgentRuntime:
             log_benchmark_phase("runtime_complete")
 
         except Exception as e:
+            # The SDK reports a dead sandbox process as a plain Exception, so
+            # recover the exit code the transport recorded before attributing.
+            error: Exception = _sandbox_process_exit_error(transport) or e
+            failure = agent_runtime_failure(error, fallback_message=str(e))
             await self._event_writer.send_log(
                 "error",
                 "Runtime error",
-                error_type=type(e).__name__,
+                error_type=type(error).__name__,
                 error_message=str(e),
             )
-            await self._event_writer.send_error(str(e))
-            raise
+            await self._event_writer.send_error(
+                failure.message,
+                classification=failure.classification,
+            )
+            if error is e:
+                raise
+            raise error from e
         finally:
             if session_flush_task is not None:
                 session_flush_task.cancel()

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -189,6 +189,12 @@ def _sandbox_process_exit_error(
     a negative code means the host itself terminated the process during
     transport teardown rather than the jailed runtime dying.
     """
+    if TRACECAT__DISABLE_NSJAIL:
+        # Without a jail no rlimit was installed, so the exit code carries no
+        # resource-limit meaning. A direct process that aborts or that the host
+        # OOM-kills is a platform failure, and attributing it to the caller
+        # would name a cap this deployment never enforced.
+        return None
     if not isinstance(transport, SandboxedCLITransport):
         return None
     exit_code = transport.exit_code

--- a/tracecat/agent/runtime/claude_code/transport.py
+++ b/tracecat/agent/runtime/claude_code/transport.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import socket
 from collections.abc import AsyncIterator, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, replace
 from pathlib import Path
 from time import perf_counter
@@ -41,6 +41,10 @@ from tracecat.agent.sandbox.nsjail import (
 from tracecat.logger import logger
 
 _TRUSTED_MCP_BRIDGE_PATH = "/mcp"
+
+# How long a broken write waits for the shim to be reaped before giving up on
+# recording its exit code. Short enough not to stall the error path.
+_EXIT_REAP_TIMEOUT_SECONDS = 0.5
 
 
 class ClaudeShimInitPayload(TypedDict):
@@ -234,9 +238,15 @@ class SandboxedCLITransport(Transport):
             try:
                 await self._process.stdin.drain()
             except (BrokenPipeError, ConnectionResetError):
-                # A dead shim breaks the pipe. Record the code if the process
-                # has already been reaped; never wait for it here, because the
-                # child may have closed stdin while still running.
+                # A dead shim breaks the pipe, but the child may not be reaped
+                # yet at the moment the write fails. Give it a bounded moment
+                # rather than losing the exit code to that race -- and bounded
+                # rather than open-ended, because a child that merely closed
+                # stdin while still running must not block the error path.
+                with suppress(TimeoutError):
+                    await asyncio.wait_for(
+                        self._process.wait(), timeout=_EXIT_REAP_TIMEOUT_SECONDS
+                    )
                 returncode = self._process.returncode
                 if returncode is not None:
                     self._record_process_exit(returncode)

--- a/tracecat/agent/runtime/claude_code/transport.py
+++ b/tracecat/agent/runtime/claude_code/transport.py
@@ -122,6 +122,7 @@ class SandboxedCLITransport(Transport):
         self._stderr_buffer: list[str] = []
         self._connect_started_at: float | None = None
         self._logged_first_message = False
+        self._exit_code: int | None = None
 
     def _log_benchmark_phase(self, phase: str, **extra: object) -> None:
         """Emit a temporary structured benchmark log for transport phases."""
@@ -267,6 +268,9 @@ class SandboxedCLITransport(Transport):
             await self._process.wait()
 
         returncode = self._process.returncode or 0
+        # The SDK erases ProcessError into a plain Exception before the runtime
+        # sees it, so keep the exit code observable on the transport itself.
+        self._exit_code = returncode
         if returncode != 0:
             stderr_output = await self._collect_error_stderr()
             raise ProcessError(
@@ -301,6 +305,8 @@ class SandboxedCLITransport(Transport):
                     self._process.kill()
                     await self._process.wait()
 
+        if self._process is not None:
+            self._exit_code = self._process.returncode
         self._process = None
         if self._spawned_runtime is not None:
             cleanup_spawned_runtime(self._spawned_runtime)
@@ -309,6 +315,15 @@ class SandboxedCLITransport(Transport):
     def is_ready(self) -> bool:
         """Return whether the shim is ready for Claude SDK traffic."""
         return self._ready
+
+    @property
+    def exit_code(self) -> int | None:
+        """Exit code of the sandbox shim once it has exited, else ``None``.
+
+        The value survives ``close()`` so the runtime can attribute a process
+        death after the SDK has already torn the transport down.
+        """
+        return self._exit_code
 
     async def end_input(self) -> None:
         """Close the shim stdin to signal end-of-input."""

--- a/tracecat/agent/runtime/claude_code/transport.py
+++ b/tracecat/agent/runtime/claude_code/transport.py
@@ -305,8 +305,12 @@ class SandboxedCLITransport(Transport):
                     self._process.kill()
                     await self._process.wait()
 
-        if self._process is not None:
-            self._exit_code = self._process.returncode
+        # Deliberately not recording the exit code here. By this point the host
+        # may have terminated or killed the process itself, and treating that
+        # as a runtime death would re-attribute an unrelated error. Only
+        # ``read_messages`` records a code, where a non-zero exit is the jailed
+        # process dying on its own; that value is never cleared, so it still
+        # survives this teardown.
         self._process = None
         if self._spawned_runtime is not None:
             cleanup_spawned_runtime(self._spawned_runtime)

--- a/tracecat/agent/runtime/claude_code/transport.py
+++ b/tracecat/agent/runtime/claude_code/transport.py
@@ -206,18 +206,41 @@ class SandboxedCLITransport(Transport):
         if self._process.stderr is not None:
             self._stderr_task = asyncio.create_task(self._drain_stderr())
 
+    def _record_process_exit(self, returncode: int) -> None:
+        """Record a shim exit observed while the transport was still live.
+
+        The SDK erases ``ProcessError`` into a plain ``Exception`` before the
+        runtime sees it, so keep the exit code observable on the transport
+        itself. Called from every point that observes the shim dying on its
+        own, and deliberately never from ``close()``, where the host may have
+        killed the process itself.
+        """
+        self._exit_code = returncode
+
     async def write(self, data: str) -> None:
         """Write raw stream-json data to the sandbox shim stdin."""
         async with self._write_lock:
             if not self._ready or self._process is None or self._process.stdin is None:
                 raise CLIConnectionError("Sandbox transport is not ready for writing")
-            if self._process.returncode is not None:
-                raise CLIConnectionError(
-                    f"Sandbox shim exited with code {self._process.returncode}"
-                )
+            returncode = self._process.returncode
+            if returncode is not None:
+                # The shim died on its own before this write. Record it here
+                # too: the SDK cancels its reader task on a write failure, so
+                # ``read_messages`` may never reach its own recording point.
+                self._record_process_exit(returncode)
+                raise CLIConnectionError(f"Sandbox shim exited with code {returncode}")
 
             self._process.stdin.write(data.encode("utf-8"))
-            await self._process.stdin.drain()
+            try:
+                await self._process.stdin.drain()
+            except (BrokenPipeError, ConnectionResetError):
+                # A dead shim breaks the pipe. Record the code if the process
+                # has already been reaped; never wait for it here, because the
+                # child may have closed stdin while still running.
+                returncode = self._process.returncode
+                if returncode is not None:
+                    self._record_process_exit(returncode)
+                raise
 
     def read_messages(self) -> AsyncIterator[dict[str, Any]]:
         """Read JSON messages emitted by sandboxed Claude Code."""
@@ -268,9 +291,7 @@ class SandboxedCLITransport(Transport):
             await self._process.wait()
 
         returncode = self._process.returncode or 0
-        # The SDK erases ProcessError into a plain Exception before the runtime
-        # sees it, so keep the exit code observable on the transport itself.
-        self._exit_code = returncode
+        self._record_process_exit(returncode)
         if returncode != 0:
             stderr_output = await self._collect_error_stderr()
             raise ProcessError(

--- a/tracecat/agent/sandbox/shim_entrypoint.py
+++ b/tracecat/agent/sandbox/shim_entrypoint.py
@@ -271,8 +271,25 @@ def _rewrite_mcp_bridge_command_port(
     return [arg.replace(requested_url, actual_url) for arg in command]
 
 
-async def run_sandboxed_claude_shim() -> None:
-    """Read shim config, start the LLM bridge, and proxy Claude stdio."""
+def _forward_exit_code(return_code: int) -> int:
+    """Map the Claude child's termination onto the shim's own exit code.
+
+    asyncio reports a signal death as a negative return code. Forward it as
+    ``128 + signal`` so the host observes the same exit-code contract nsjail
+    applies to its direct child; a normal exit code passes through unchanged.
+    """
+    if return_code < 0:
+        return 128 - return_code
+    return return_code
+
+
+async def run_sandboxed_claude_shim() -> int:
+    """Read shim config, start the LLM bridge, and proxy Claude stdio.
+
+    Returns:
+        The exit code the shim must exit with, forwarding the Claude child's
+        termination so the host can attribute a signal death.
+    """
     llm_bridge: SandboxSocketBridge | None = None
     mcp_bridge: SandboxSocketBridge | None = None
     otel_bridge: SandboxSocketBridge | None = None
@@ -368,7 +385,8 @@ async def run_sandboxed_claude_shim() -> None:
         await stdout_task
         await stderr_task
         if return_code != 0:
-            raise RuntimeError(f"Claude subprocess exited with code {return_code}")
+            LOGGER.error("Claude subprocess exited with code %s", return_code)
+        return _forward_exit_code(return_code)
 
     finally:
         if stdout_task is not None and not stdout_task.done():
@@ -560,7 +578,7 @@ def main() -> None:
         level=os.environ.get("LOG_LEVEL", "INFO").upper(),
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
-    asyncio.run(run_sandboxed_claude_shim())
+    sys.exit(asyncio.run(run_sandboxed_claude_shim()))
 
 
 if __name__ == "__main__":

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -43,7 +43,10 @@ from tracecat.executor.secret_preprocessors import (
     project_secret_env,
 )
 from tracecat.logger import logger
-from tracecat.sandbox.exceptions import raise_for_sandbox_error_code
+from tracecat.sandbox.exceptions import (
+    raise_for_sandbox_error_code,
+    sandbox_resource_limit_message,
+)
 from tracecat.sandbox.executor import ActionSandboxConfig, NsjailExecutor
 from tracecat.sandbox.types import ResourceLimits, SandboxErrorCode
 from tracecat.sandbox.utils import (
@@ -110,6 +113,20 @@ def _is_sandbox_available() -> bool:
         return False
 
     return True
+
+
+def _sandbox_failure_message(error_code: SandboxErrorCode | None) -> str:
+    """Return the message carried by the typed exception a sandbox code selects."""
+    match error_code:
+        case SandboxErrorCode.INFRASTRUCTURE_FAILURE:
+            return "Action sandbox infrastructure failed before producing a result"
+        case SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED:
+            return sandbox_resource_limit_message(
+                memory_mb=config.TRACECAT__SANDBOX_DEFAULT_MEMORY_MB,
+                memory_env_var="TRACECAT__SANDBOX_DEFAULT_MEMORY_MB",
+            )
+        case _:
+            return "Action sandbox workload stopped before producing a result"
 
 
 def _direct_subprocess_command(minimal_runner_path: Path) -> list[str]:
@@ -344,9 +361,7 @@ class ActionRunner:
 
             raise_for_sandbox_error_code(
                 result.error_code,
-                "Action sandbox infrastructure failed before producing a result"
-                if result.error_code is SandboxErrorCode.INFRASTRUCTURE_FAILURE
-                else "Action sandbox workload stopped before producing a result",
+                _sandbox_failure_message(result.error_code),
             )
 
             # Handle error from sandbox

--- a/tracecat/executor/error_policy.py
+++ b/tracecat/executor/error_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from temporalio.exceptions import ApplicationError
 
+from tracecat import config
 from tracecat.exceptions import (
     EntitlementRequired,
     ExecutionError,
@@ -24,6 +25,7 @@ from tracecat.runtime.errors import (
 from tracecat.sandbox.exceptions import (
     SandboxInfrastructureError,
     SandboxWorkloadError,
+    sandbox_resource_limit_message,
 )
 from tracecat.sandbox.types import SandboxErrorCode
 from tracecat.storage.utils import is_retryable_storage_transport_error
@@ -79,6 +81,18 @@ def _chained_error_classification(
                 cause=cause,
             )
         if isinstance(cause, SandboxWorkloadError):
+            if cause.error_code is SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED:
+                # A published cap the workload exceeded is the caller's to fix,
+                # and a second attempt hits the same cap deterministically.
+                return RuntimeErrorClassification.user(
+                    kind=RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED,
+                    message=sandbox_resource_limit_message(
+                        memory_mb=config.TRACECAT__SANDBOX_DEFAULT_MEMORY_MB,
+                        memory_env_var="TRACECAT__SANDBOX_DEFAULT_MEMORY_MB",
+                    ),
+                    retry_disposition=RetryDisposition.NON_RETRYABLE,
+                    cause=cause,
+                )
             return RuntimeErrorClassification.user(
                 kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
                 message="The action sandbox workload stopped before producing a result",

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -38,8 +38,12 @@ try:
         if hasattr(obj, "model_dump"):
             try:
                 return obj.model_dump(mode="json")
-            except Exception:
-                pass
+            except Exception as exc:
+                if is_memory_exhaustion(exc):
+                    # The address-space cap, not an unserializable type. Let it
+                    # out so serialize_result can degrade to the resource-limit
+                    # envelope instead of reporting a TypeError.
+                    raise
         raise TypeError(f"Type is not JSON serializable: {type(obj).__name__}")
 
     def json_dumps(obj: dict) -> bytes:
@@ -556,6 +560,24 @@ def is_memory_exhaustion(error: BaseException) -> bool:
     return isinstance(error, OSError) and error.errno == errno.ENOMEM
 
 
+def caused_by_memory_exhaustion(error: BaseException) -> bool:
+    """Report whether memory exhaustion produced ``error``, directly or as a cause.
+
+    orjson reports an exception raised inside its ``default`` hook as its own
+    ``JSONEncodeError`` carrying the original on ``__cause__``, so a model whose
+    ``model_dump()`` hits the cap arrives here one level down rather than as
+    itself.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        if is_memory_exhaustion(current):
+            return True
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return False
+
+
 def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> bytes:
     """Serialize the runner result, degrading to a fixed envelope on MemoryError.
 
@@ -567,8 +589,12 @@ def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> byte
     """
     try:
         return json_dumps(result)
-    except MemoryError:
-        # Drop the oversized result before allocating anything else.
+    except Exception as exc:
+        if not caused_by_memory_exhaustion(exc):
+            raise
+        # Drop the oversized result, and the traceback pinning it through the
+        # serializer's frame locals, before allocating anything else.
+        exc.__traceback__ = None
         result.clear()
         return json_dumps(
             _resource_limit_envelope(

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -521,7 +521,9 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         if is_memory_exhaustion(e):
             # Skip the traceback walk, which needs memory the process may not
             # have, and report a structured code so the host classifies the
-            # failure without inspecting error text.
+            # failure without inspecting error text. Release the frames first:
+            # the action's own locals are what exhausted the cap.
+            release_exception_chain(e)
             return _resource_limit_envelope(
                 "Action ran out of memory",
                 action_name=_action_display_name(action_impl),
@@ -578,6 +580,26 @@ def caused_by_memory_exhaustion(error: BaseException) -> bool:
     return False
 
 
+def release_exception_chain(error: BaseException) -> None:
+    """Drop the tracebacks, and the chain itself, of ``error`` and its causes.
+
+    A traceback keeps its frames alive, and a frame's locals can be the very
+    object that exhausted memory. Clearing only the outermost one is not
+    enough: orjson reports a failure inside its ``default`` hook as its own
+    error, so the frame still holding the oversized object hangs off
+    ``__cause__`` rather than off the exception that was caught.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        current.__traceback__ = None
+        following = current.__cause__ or current.__context__
+        current.__cause__ = None
+        current.__context__ = None
+        current = following
+
+
 def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> bytes:
     """Serialize the runner result, degrading to a fixed envelope on MemoryError.
 
@@ -592,9 +614,9 @@ def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> byte
     except Exception as exc:
         if not caused_by_memory_exhaustion(exc):
             raise
-        # Drop the oversized result, and the traceback pinning it through the
-        # serializer's frame locals, before allocating anything else.
-        exc.__traceback__ = None
+        # Drop the oversized result, and every frame still pinning it through
+        # the serializer's locals, before allocating anything else.
+        release_exception_chain(exc)
         result.clear()
         return json_dumps(
             _resource_limit_envelope(

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -517,19 +517,10 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         # traceback walk, which needs memory the process may not have, and
         # report a structured code so the host classifies the failure
         # without inspecting error text.
-        return {
-            "success": False,
-            "result": None,
-            "error": {
-                "type": "MemoryError",
-                "message": "Action exceeded the sandbox memory limit",
-                "action_name": _action_display_name(action_impl),
-                "filename": "<sandbox>",
-                "function": "run_action_minimal",
-                "lineno": None,
-            },
-            "error_code": "resource_limit_exceeded",
-        }
+        return _resource_limit_envelope(
+            "Action exceeded the sandbox memory limit",
+            action_name=_action_display_name(action_impl),
+        )
 
     except Exception as e:
         import traceback
@@ -550,6 +541,52 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
                 "lineno": last_frame.lineno if last_frame else None,
             },
         }
+
+
+def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> bytes:
+    """Serialize the runner result, degrading to a fixed envelope on MemoryError.
+
+    An action whose return value fits under the address-space cap can still
+    exhaust it while being serialized, and that ``MemoryError`` is raised after
+    ``main_minimal`` has already returned. Without this the process would die
+    before writing ``result.json`` and the failure would degrade to a generic
+    workload error, losing the resource-limit code.
+    """
+    try:
+        return json_dumps(result)
+    except MemoryError:
+        # Drop the oversized result before allocating anything else.
+        result.clear()
+        return json_dumps(
+            _resource_limit_envelope(
+                "Action result exceeded the sandbox memory limit "
+                "while being serialized",
+                action_name=_action_display_name(
+                    input_data.get("resolved_context", {}).get("action_impl")
+                ),
+            )
+        )
+
+
+def _resource_limit_envelope(message: str, *, action_name: str) -> dict[str, Any]:
+    """Build the structured envelope reported when the memory cap is hit.
+
+    Allocates only small, fixed-size values so it stays usable in a process
+    that has already exhausted its address space.
+    """
+    return {
+        "success": False,
+        "result": None,
+        "error": {
+            "type": "MemoryError",
+            "message": message,
+            "action_name": action_name,
+            "filename": "<sandbox>",
+            "function": "run_action_minimal",
+            "lineno": None,
+        },
+        "error_code": "resource_limit_exceeded",
+    }
 
 
 def _action_display_name(action_impl: dict[str, Any] | None) -> str:
@@ -624,7 +661,7 @@ if __name__ == "__main__":
     result = main_minimal(input_data)
 
     # Output result
-    result_bytes = json_dumps(result)
+    result_bytes = serialize_result(result, input_data)
 
     if use_file_io:
         output_path.write_bytes(result_bytes)

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -512,6 +512,25 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
 
         return {"success": True, "result": result}
 
+    except MemoryError:
+        # The sandbox address-space cap surfaces as MemoryError. Skip the
+        # traceback walk, which needs memory the process may not have, and
+        # report a structured code so the host classifies the failure
+        # without inspecting error text.
+        return {
+            "success": False,
+            "result": None,
+            "error": {
+                "type": "MemoryError",
+                "message": "Action exceeded the sandbox memory limit",
+                "action_name": _action_display_name(action_impl),
+                "filename": "<sandbox>",
+                "function": "run_action_minimal",
+                "lineno": None,
+            },
+            "error_code": "resource_limit_exceeded",
+        }
+
     except Exception as e:
         import traceback
 
@@ -519,28 +538,31 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         tb = traceback.extract_tb(e.__traceback__)
         last_frame = tb[-1] if tb else None
 
-        # Build action name from impl if available
-        action_name = "<unknown>"
-        if action_impl:
-            module = action_impl.get("module", "")
-            name = action_impl.get("name", "")
-            if module and name:
-                action_name = f"{module}.{name}"
-            elif name:
-                action_name = name
-
         return {
             "success": False,
             "result": None,
             "error": {
                 "type": type(e).__name__,
                 "message": str(e),
-                "action_name": action_name,
+                "action_name": _action_display_name(action_impl),
                 "filename": last_frame.filename if last_frame else "<unknown>",
                 "function": last_frame.name if last_frame else "<unknown>",
                 "lineno": last_frame.lineno if last_frame else None,
             },
         }
+
+
+def _action_display_name(action_impl: dict[str, Any] | None) -> str:
+    """Build the action name reported in a structured runner error."""
+    if not action_impl:
+        return "<unknown>"
+    module = action_impl.get("module", "")
+    name = action_impl.get("name", "")
+    if module and name:
+        return f"{module}.{name}"
+    if name:
+        return name
+    return "<unknown>"
 
 
 def _enforce_nproc_limit() -> None:

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import importlib
 import os
 import resource
@@ -512,17 +513,16 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
 
         return {"success": True, "result": result}
 
-    except MemoryError:
-        # The sandbox address-space cap surfaces as MemoryError. Skip the
-        # traceback walk, which needs memory the process may not have, and
-        # report a structured code so the host classifies the failure
-        # without inspecting error text.
-        return _resource_limit_envelope(
-            "Action ran out of memory",
-            action_name=_action_display_name(action_impl),
-        )
-
     except Exception as e:
+        if is_memory_exhaustion(e):
+            # Skip the traceback walk, which needs memory the process may not
+            # have, and report a structured code so the host classifies the
+            # failure without inspecting error text.
+            return _resource_limit_envelope(
+                "Action ran out of memory",
+                action_name=_action_display_name(action_impl),
+            )
+
         import traceback
 
         # Extract traceback info for ExecutorActionErrorInfo compatibility
@@ -541,6 +541,19 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
                 "lineno": last_frame.lineno if last_frame else None,
             },
         }
+
+
+def is_memory_exhaustion(error: BaseException) -> bool:
+    """Report whether an exception means the address-space cap was reached.
+
+    Python's own allocator raises ``MemoryError``, but a syscall that fails
+    under ``rlimit_as`` -- ``mmap`` most commonly -- surfaces as ``OSError``
+    with ``errno.ENOMEM`` instead. Both mean the same cap, and both are matched
+    on a machine-readable attribute rather than on message text.
+    """
+    if isinstance(error, MemoryError):
+        return True
+    return isinstance(error, OSError) and error.errno == errno.ENOMEM
 
 
 def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> bytes:

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -518,7 +518,7 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         # report a structured code so the host classifies the failure
         # without inspecting error text.
         return _resource_limit_envelope(
-            "Action exceeded the sandbox memory limit",
+            "Action ran out of memory",
             action_name=_action_display_name(action_impl),
         )
 
@@ -559,8 +559,7 @@ def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> byte
         result.clear()
         return json_dumps(
             _resource_limit_envelope(
-                "Action result exceeded the sandbox memory limit "
-                "while being serialized",
+                "Action ran out of memory while serializing its result",
                 action_name=_action_display_name(
                     input_data.get("resolved_context", {}).get("action_impl")
                 ),
@@ -573,6 +572,12 @@ def _resource_limit_envelope(message: str, *, action_name: str) -> dict[str, Any
 
     Allocates only small, fixed-size values so it stays usable in a process
     that has already exhausted its address space.
+
+    The message stays neutral about where the memory ran out. This runner also
+    executes unjailed, under the default direct backend, where no address-space
+    rlimit exists; the host names the cap only on the sandboxed path, from
+    ``sandbox_resource_limit_message()``, and the direct path drops
+    ``error_code`` and surfaces this message as an ordinary action failure.
     """
     return {
         "success": False,

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -590,14 +590,21 @@ def release_exception_chain(error: BaseException) -> None:
     ``__cause__`` rather than off the exception that was caught.
     """
     seen: set[int] = set()
-    current: BaseException | None = error
-    while current is not None and id(current) not in seen:
+    pending: list[BaseException] = [error]
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
         seen.add(id(current))
         current.__traceback__ = None
-        following = current.__cause__ or current.__context__
+        # Both links, not the first one that happens to be set: an exception
+        # can carry a distinct cause and context, and either frame can be the
+        # one holding what exhausted the cap.
+        for following in (current.__cause__, current.__context__):
+            if following is not None:
+                pending.append(following)
         current.__cause__ = None
         current.__context__ = None
-        current = following
 
 
 def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> bytes:
@@ -715,13 +722,34 @@ if __name__ == "__main__":
     input_path = Path("/work/input.json")
     output_path = Path("/work/result.json")
 
-    if input_path.exists():
-        input_data = json_loads(input_path.read_bytes())
-        use_file_io = True
-    else:
-        input_bytes = sys.stdin.buffer.read()
-        input_data = json_loads(input_bytes)
-        use_file_io = False
+    # A large enough payload can exhaust the cap while it is being read or
+    # decoded, before main_minimal's handlers exist. Dying here would leave no
+    # result.json and report a generic workload failure for what really was
+    # the memory limit.
+    try:
+        if input_path.exists():
+            input_data = json_loads(input_path.read_bytes())
+            use_file_io = True
+        else:
+            input_bytes = sys.stdin.buffer.read()
+            input_data = json_loads(input_bytes)
+            use_file_io = False
+    except Exception as exc:
+        if not caused_by_memory_exhaustion(exc):
+            raise
+        release_exception_chain(exc)
+        envelope = json_dumps(
+            _resource_limit_envelope(
+                "Action inputs ran out of memory while being decoded",
+                action_name="<unknown>",
+            )
+        )
+        if input_path.exists():
+            output_path.write_bytes(envelope)
+        else:
+            sys.stdout.buffer.write(envelope)
+            sys.stdout.buffer.flush()
+        raise SystemExit(1) from None
 
     # Run the action
     result = main_minimal(input_data)

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -21,8 +21,9 @@ import resource
 import sys
 import warnings
 from collections.abc import Mapping
+from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, Literal
 
 # Only import what we absolutely need - no tracecat imports!
 # Prefer orjson for performance (4-12x faster), fall back to stdlib json
@@ -39,8 +40,8 @@ try:
             try:
                 return obj.model_dump(mode="json")
             except Exception as exc:
-                if caused_by_memory_exhaustion(exc):
-                    # The address-space cap, not an unserializable type. Let it
+                if resource_limit_from_error(exc):
+                    # A resource limit, not an unserializable type. Let it
                     # out so serialize_result can degrade to the resource-limit
                     # envelope instead of reporting a TypeError.
                     raise
@@ -518,14 +519,14 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         return {"success": True, "result": result}
 
     except Exception as e:
-        if is_memory_exhaustion(e):
+        if (limit := resource_limit_from_error(e)) is not None:
             # Skip the traceback walk, which needs memory the process may not
             # have, and report a structured code so the host classifies the
             # failure without inspecting error text. Release the frames first:
             # the action's own locals are what exhausted the cap.
             release_exception_chain(e)
             return _resource_limit_envelope(
-                "Action ran out of memory",
+                limit,
                 action_name=_action_display_name(action_impl),
             )
 
@@ -549,35 +550,33 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         }
 
 
-def is_memory_exhaustion(error: BaseException) -> bool:
-    """Report whether an exception means the address-space cap was reached.
+def resource_limit_from_error(
+    error: BaseException,
+) -> Literal["memory", "file_size"] | None:
+    """Identify allocation or file-size failures through serializer wrappers.
 
-    Python's own allocator raises ``MemoryError``, but a syscall that fails
-    under ``rlimit_as`` -- ``mmap`` most commonly -- surfaces as ``OSError``
-    with ``errno.ENOMEM`` instead. Both mean the same cap, and both are matched
-    on a machine-readable attribute rather than on message text.
-    """
-    if isinstance(error, MemoryError):
-        return True
-    return isinstance(error, OSError) and error.errno == errno.ENOMEM
-
-
-def caused_by_memory_exhaustion(error: BaseException) -> bool:
-    """Report whether memory exhaustion produced ``error``, directly or as a cause.
-
-    orjson reports an exception raised inside its ``default`` hook as its own
-    ``JSONEncodeError`` carrying the original on ``__cause__``, so a model whose
-    ``model_dump()`` hits the cap arrives here one level down rather than as
-    itself.
+    Python ignores SIGXFSZ by default, so RLIMIT_FSIZE surfaces as EFBIG
+    rather than a signal exit. Pydantic and orjson can wrap these exceptions;
+    inspect both cause links without relying on error-message text.
     """
     seen: set[int] = set()
-    current: BaseException | None = error
-    while current is not None and id(current) not in seen:
-        if is_memory_exhaustion(current):
-            return True
+    pending = [error]
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
         seen.add(id(current))
-        current = current.__cause__ or current.__context__
-    return False
+        if isinstance(current, MemoryError):
+            return "memory"
+        if isinstance(current, OSError):
+            if current.errno == errno.ENOMEM:
+                return "memory"
+            if current.errno == errno.EFBIG:
+                return "file_size"
+        for following in (current.__context__, current.__cause__):
+            if following is not None:
+                pending.append(following)
+    return None
 
 
 def release_exception_chain(error: BaseException) -> None:
@@ -608,7 +607,7 @@ def release_exception_chain(error: BaseException) -> None:
 
 
 def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> bytes:
-    """Serialize the runner result, degrading to a fixed envelope on MemoryError.
+    """Serialize the runner result, recovering structured resource failures.
 
     An action whose return value fits under the address-space cap can still
     exhaust it while being serialized, and that ``MemoryError`` is raised after
@@ -619,7 +618,7 @@ def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> byte
     try:
         return json_dumps(result)
     except Exception as exc:
-        if not caused_by_memory_exhaustion(exc):
+        if (limit := resource_limit_from_error(exc)) is None:
             raise
         # Drop the oversized result, and every frame still pinning it through
         # the serializer's locals, before allocating anything else.
@@ -627,7 +626,7 @@ def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> byte
         result.clear()
         return json_dumps(
             _resource_limit_envelope(
-                "Action ran out of memory while serializing its result",
+                limit,
                 action_name=_action_display_name(
                     input_data.get("resolved_context", {}).get("action_impl")
                 ),
@@ -635,8 +634,10 @@ def serialize_result(result: dict[str, Any], input_data: dict[str, Any]) -> byte
         )
 
 
-def _resource_limit_envelope(message: str, *, action_name: str) -> dict[str, Any]:
-    """Build the structured envelope reported when the memory cap is hit.
+def _resource_limit_envelope(
+    limit: Literal["memory", "file_size"], *, action_name: str
+) -> dict[str, Any]:
+    """Build a small structured envelope for an exhausted resource limit.
 
     Allocates only small, fixed-size values so it stays usable in a process
     that has already exhausted its address space.
@@ -651,8 +652,12 @@ def _resource_limit_envelope(message: str, *, action_name: str) -> dict[str, Any
         "success": False,
         "result": None,
         "error": {
-            "type": "MemoryError",
-            "message": message,
+            "type": "MemoryError" if limit == "memory" else "OSError",
+            "message": (
+                "Action ran out of memory"
+                if limit == "memory"
+                else "Action exceeded the file size limit"
+            ),
             "action_name": action_name,
             "filename": "<sandbox>",
             "function": "run_action_minimal",
@@ -660,6 +665,18 @@ def _resource_limit_envelope(message: str, *, action_name: str) -> dict[str, Any
         },
         "error_code": "resource_limit_exceeded",
     }
+
+
+def write_result_file(output_path: Path, result_bytes: bytes) -> None:
+    """Replace a result that exceeds RLIMIT_FSIZE with a small error envelope."""
+    try:
+        output_path.write_bytes(result_bytes)
+    except OSError as exc:
+        if exc.errno != errno.EFBIG:
+            raise
+        output_path.write_bytes(
+            json_dumps(_resource_limit_envelope("file_size", action_name="<unknown>"))
+        )
 
 
 def _action_display_name(action_impl: dict[str, Any] | None) -> str:
@@ -714,7 +731,6 @@ def _enforce_nproc_limit() -> None:
 if __name__ == "__main__":
     """Standalone entry point for subprocess execution."""
     import sys
-    from pathlib import Path
 
     _enforce_nproc_limit()
 
@@ -735,12 +751,12 @@ if __name__ == "__main__":
             input_data = json_loads(input_bytes)
             use_file_io = False
     except Exception as exc:
-        if not caused_by_memory_exhaustion(exc):
+        if (limit := resource_limit_from_error(exc)) is None:
             raise
         release_exception_chain(exc)
         envelope = json_dumps(
             _resource_limit_envelope(
-                "Action inputs ran out of memory while being decoded",
+                limit,
                 action_name="<unknown>",
             )
         )
@@ -758,7 +774,7 @@ if __name__ == "__main__":
     result_bytes = serialize_result(result, input_data)
 
     if use_file_io:
-        output_path.write_bytes(result_bytes)
+        write_result_file(output_path, result_bytes)
     else:
         sys.stdout.buffer.write(result_bytes)
         sys.stdout.buffer.flush()

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -39,7 +39,7 @@ try:
             try:
                 return obj.model_dump(mode="json")
             except Exception as exc:
-                if is_memory_exhaustion(exc):
+                if caused_by_memory_exhaustion(exc):
                     # The address-space cap, not an unserializable type. Let it
                     # out so serialize_result can degrade to the resource-limit
                     # envelope instead of reporting a TypeError.

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -64,6 +64,7 @@ class RuntimeErrorKind(StrEnum):
     EXECUTOR_REGISTRY_CAPACITY_EXHAUSTED = "executor.registry.capacity_exhausted"
     EXECUTOR_REGISTRY_EXTRACTION_FAILED = "executor.registry.extraction_failed"
     EXECUTOR_SANDBOX_INFRASTRUCTURE_FAILED = "executor.sandbox.infrastructure_failed"
+    SANDBOX_RESOURCE_LIMIT_EXCEEDED = "sandbox.resource_limit_exceeded"
     WORKFLOW_DEFINITION_NOT_FOUND = "workflow.definition.not_found"
     WORKFLOW_DEFINITION_LOOKUP_UNAVAILABLE = "workflow.definition.lookup_unavailable"
     WORKFLOW_DEFINITION_INVALID_DATA = "workflow.definition.invalid_data"

--- a/tracecat/sandbox/exceptions.py
+++ b/tracecat/sandbox/exceptions.py
@@ -35,6 +35,21 @@ class SandboxValidationError(SandboxError):
     """Input validation failed for sandbox configuration."""
 
 
+def sandbox_resource_limit_message(*, memory_mb: int, memory_env_var: str) -> str:
+    """Return the user-facing explanation for a sandbox resource-limit failure.
+
+    The message names every limit the sandbox enforces and the memory cap the
+    deployment configured, because the address-space cap is the limit a
+    workload most often hits. It deliberately carries no host paths or
+    sandbox-controlled text.
+    """
+    return (
+        "The sandbox exceeded a resource limit (memory, CPU time, file size, "
+        f"or process count). Memory is capped at {memory_mb} MB of address "
+        f"space by {memory_env_var}."
+    )
+
+
 def raise_for_sandbox_error_code(
     error_code: SandboxErrorCode | None,
     message: str,

--- a/tracecat/sandbox/exceptions.py
+++ b/tracecat/sandbox/exceptions.py
@@ -38,15 +38,17 @@ class SandboxValidationError(SandboxError):
 def sandbox_resource_limit_message(*, memory_mb: int, memory_env_var: str) -> str:
     """Return the user-facing explanation for a sandbox resource-limit failure.
 
-    The message names every limit the sandbox enforces and the memory cap the
-    deployment configured, because the address-space cap is the limit a
-    workload most often hits. It deliberately carries no host paths or
-    sandbox-controlled text.
+    The message names the limits that can select this kind, plus the memory cap
+    the deployment configured, because the address-space cap is the limit a
+    workload most often hits. The process-count limit is deliberately absent:
+    exhausting ``RLIMIT_NPROC`` fails process creation with ``EAGAIN`` inside
+    the sandbox rather than killing the workload, so it never reaches here. The
+    message carries no host paths and no sandbox-controlled text.
     """
     return (
-        "The sandbox exceeded a resource limit (memory, CPU time, file size, "
-        f"or process count). Memory is capped at {memory_mb} MB of address "
-        f"space by {memory_env_var}."
+        "The sandbox exceeded a resource limit (memory, CPU time, or file "
+        f"size). Memory is capped at {memory_mb} MB of address space by "
+        f"{memory_env_var}."
     )
 
 

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -124,6 +124,12 @@ def _nsjail_failure_hint(stderr: str) -> str | None:
 
 _NSJAIL_LAUNCH_FAILURE_EXIT_CODE = 0xFF
 _NSJAIL_POLICY_VIOLATION_EXIT_CODES = {128 + signal.SIGSYS}
+# SIGABRT (134) is deliberately absent. A Python workload reports allocation
+# failure in-band as MemoryError, which the wrapper and minimal runner turn
+# into a structured ``resource_limit_exceeded`` envelope code. A SIGABRT from
+# Python has other structural causes (os.abort(), native assertion failures,
+# glibc heap-corruption checks), and the exit code alone cannot separate them
+# without inspecting stderr text, which this codebase forbids.
 _NSJAIL_RESOURCE_LIMIT_EXIT_CODES = {
     128 + signal.SIGKILL,
     128 + signal.SIGXCPU,

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -31,6 +31,7 @@ from tracecat.sandbox.exceptions import (
     SandboxFileSafetyError,
     SandboxInfrastructureError,
     raise_for_sandbox_error_code,
+    sandbox_resource_limit_message,
 )
 from tracecat.sandbox.executor import RUN_PYTHON_ACTION_GATEWAY_SOCKET, NsjailExecutor
 from tracecat.sandbox.file_io import copy_tree_without_following_symlinks
@@ -637,12 +638,19 @@ class SandboxService:
                     stderr=result.stderr[:500] if result.stderr else None,
                 )
                 # Envelope errors may carry a structured dict; the typed
-                # exceptions take plain strings only.
-                message = (
-                    error_msg
-                    if isinstance(error_msg, str)
-                    else "Sandbox execution failed"
-                )
+                # exceptions take plain strings only. A resource-limit death
+                # gets a host-authored message naming the configured cap.
+                if result.error_code is SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED:
+                    message = sandbox_resource_limit_message(
+                        memory_mb=TRACECAT__SANDBOX_DEFAULT_MEMORY_MB,
+                        memory_env_var="TRACECAT__SANDBOX_DEFAULT_MEMORY_MB",
+                    )
+                else:
+                    message = (
+                        error_msg
+                        if isinstance(error_msg, str)
+                        else "Sandbox execution failed"
+                    )
                 raise_for_sandbox_error_code(result.error_code, message)
                 raise SandboxExecutionError(message)
 

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -196,26 +196,55 @@ def _release_exception_chain(error):
     against a cap that is still fully consumed.
     """
     seen = set()
-    current = error
-    while current is not None and id(current) not in seen:
+    pending = [error]
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
         seen.add(id(current))
         current.__traceback__ = None
-        following = current.__cause__ or current.__context__
+        # Both links, not the first one that happens to be set: an exception
+        # can carry a distinct cause and context, and either frame can be the
+        # one holding what exhausted the cap.
+        for following in (current.__cause__, current.__context__):
+            if following is not None:
+                pending.append(following)
         current.__cause__ = None
         current.__context__ = None
-        current = following
 
 
 def main():
     """Execute user script and capture results."""
     _enforce_nproc_limit()
 
-    # Read inputs from file
+    # Read inputs from file. A large enough inputs.json can exhaust the cap
+    # here, before any handler below exists, so guard it too: dying at this
+    # point would leave no result.json and report a generic workload failure
+    # for what really was the memory limit.
     inputs_path = Path("/work/inputs.json")
-    if inputs_path.exists():
-        inputs = json.loads(inputs_path.read_text())
-    else:
-        inputs = {}
+    try:
+        if inputs_path.exists():
+            inputs = json.loads(inputs_path.read_text())
+        else:
+            inputs = {}
+    except (MemoryError, OSError) as exc:
+        if not _is_memory_exhaustion(exc):
+            raise
+        _release_exception_chain(exc)
+        Path("/work/result.json").write_text(
+            json.dumps(
+                {
+                    "success": False,
+                    "output": None,
+                    "error": "Script inputs exceeded the sandbox memory limit",
+                    "traceback": None,
+                    "stdout": "",
+                    "stderr": "",
+                    "error_code": "resource_limit_exceeded",
+                }
+            )
+        )
+        sys.exit(1)
 
     result = {
         "success": False,
@@ -292,6 +321,13 @@ def main():
             if not _is_memory_exhaustion(exc):
                 raise
             _release_exception_chain(exc)
+            # Restore the real streams first. That drops the capture buffers,
+            # which are the very thing that exhausted the cap, so the envelope
+            # below is allocated against memory that has actually been freed.
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+            output = None
+            call = None
             result.clear()
             result["success"] = False
             result["output"] = None

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -263,6 +263,28 @@ def main():
         result["success"] = False
         result["output"] = repr(result["output"])
         result_path.write_text(json.dumps(result))
+    except MemoryError:
+        # An output that fits under the address-space cap can still exhaust it
+        # while being serialized. Drop the oversized value and write a small
+        # fixed envelope, so the failure still reports the resource-limit code
+        # instead of dying before result.json exists.
+        result_path.write_text(
+            json.dumps(
+                {
+                    "success": False,
+                    "output": None,
+                    "error": (
+                        "MemoryError: script output exceeded the sandbox "
+                        "memory limit while being serialized"
+                    ),
+                    "traceback": None,
+                    "stdout": "",
+                    "stderr": "",
+                    "error_code": "resource_limit_exceeded",
+                }
+            )
+        )
+        result["success"] = False
 
     # Exit with appropriate code
     sys.exit(0 if result["success"] else 1)

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -235,6 +235,14 @@ def main():
         result["success"] = True
         result["output"] = output
 
+    except MemoryError:
+        # The sandbox address-space cap surfaces as MemoryError. Skip the
+        # traceback: formatting it needs memory the process may not have.
+        # Report a structured code so the host classifies the failure
+        # without inspecting error text.
+        result["error"] = "MemoryError: script exceeded the sandbox memory limit"
+        result["error_code"] = "resource_limit_exceeded"
+
     except Exception as e:
         result["error"] = f"{type(e).__name__}: {e}"
         result["traceback"] = traceback.format_exc()

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -175,6 +175,37 @@ def _enforce_nproc_limit() -> None:
         ) from exc
 
 
+def _is_memory_exhaustion(error):
+    """Report whether an exception means the address-space cap was reached.
+
+    Python's own allocator raises MemoryError, but a syscall that fails under
+    rlimit_as -- mmap most commonly -- surfaces as OSError with errno.ENOMEM
+    instead. Both mean the same cap, matched on a machine-readable attribute
+    rather than on message text.
+    """
+    if isinstance(error, MemoryError):
+        return True
+    return isinstance(error, OSError) and error.errno == errno.ENOMEM
+
+
+def _release_exception_chain(error):
+    """Drop the tracebacks, and the chain itself, of an exception and its causes.
+
+    A traceback keeps its frames alive, and a frame's locals can be the very
+    object that exhausted memory, so the fallback envelope would allocate
+    against a cap that is still fully consumed.
+    """
+    seen = set()
+    current = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        current.__traceback__ = None
+        following = current.__cause__ or current.__context__
+        current.__cause__ = None
+        current.__context__ = None
+        current = following
+
+
 def main():
     """Execute user script and capture results."""
     _enforce_nproc_limit()
@@ -237,16 +268,12 @@ def main():
         result["output"] = output
 
     except Exception as e:
-        # The address-space cap surfaces as MemoryError from Python's own
-        # allocator, and as OSError with errno.ENOMEM from a syscall such as
-        # mmap. Both mean the same cap, matched on a machine-readable
-        # attribute rather than on message text.
-        if isinstance(e, MemoryError) or (
-            isinstance(e, OSError) and e.errno == errno.ENOMEM
-        ):
+        if _is_memory_exhaustion(e):
             # Skip the traceback: formatting it needs memory the process may
-            # not have. Report a structured code so the host classifies the
-            # failure without inspecting error text.
+            # not have, and its frames still hold what exhausted the cap.
+            # Report a structured code so the host classifies the failure
+            # without inspecting error text.
+            _release_exception_chain(e)
             result["error"] = "Script exceeded the sandbox memory limit"
             result["error_code"] = "resource_limit_exceeded"
         else:
@@ -261,8 +288,10 @@ def main():
         try:
             result["stdout"] = sys.stdout.getvalue()
             result["stderr"] = sys.stderr.getvalue()
-        except MemoryError as exc:
-            exc.__traceback__ = None
+        except (MemoryError, OSError) as exc:
+            if not _is_memory_exhaustion(exc):
+                raise
+            _release_exception_chain(exc)
             result.clear()
             result["success"] = False
             result["output"] = None
@@ -284,14 +313,17 @@ def main():
         result["success"] = False
         result["output"] = repr(result["output"])
         result_path.write_text(json.dumps(result))
-    except MemoryError as exc:
+    except (MemoryError, OSError) as exc:
+        if not _is_memory_exhaustion(exc):
+            # A write failure such as ENOSPC or EACCES is not the memory cap.
+            raise
         # An output that fits under the address-space cap can still exhaust it
         # while being serialized. Release every reference to the oversized
         # value before allocating anything else, then write a small fixed
         # envelope, so the failure still reports the resource-limit code
-        # instead of dying before result.json exists. The traceback counts:
-        # it pins to_json_safe's frame locals, which hold the value itself.
-        exc.__traceback__ = None
+        # instead of dying before result.json exists. The tracebacks count:
+        # they pin to_json_safe's frame locals, which hold the value itself.
+        _release_exception_chain(exc)
         output = None
         call = None
         result.clear()

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -15,6 +15,7 @@ import dataclasses
 import datetime
 import decimal
 import enum
+import errno
 import importlib
 import inspect
 import json
@@ -235,17 +236,22 @@ def main():
         result["success"] = True
         result["output"] = output
 
-    except MemoryError:
-        # The sandbox address-space cap surfaces as MemoryError. Skip the
-        # traceback: formatting it needs memory the process may not have.
-        # Report a structured code so the host classifies the failure
-        # without inspecting error text.
-        result["error"] = "MemoryError: script exceeded the sandbox memory limit"
-        result["error_code"] = "resource_limit_exceeded"
-
     except Exception as e:
-        result["error"] = f"{type(e).__name__}: {e}"
-        result["traceback"] = traceback.format_exc()
+        # The address-space cap surfaces as MemoryError from Python's own
+        # allocator, and as OSError with errno.ENOMEM from a syscall such as
+        # mmap. Both mean the same cap, matched on a machine-readable
+        # attribute rather than on message text.
+        if isinstance(e, MemoryError) or (
+            isinstance(e, OSError) and e.errno == errno.ENOMEM
+        ):
+            # Skip the traceback: formatting it needs memory the process may
+            # not have. Report a structured code so the host classifies the
+            # failure without inspecting error text.
+            result["error"] = "Script exceeded the sandbox memory limit"
+            result["error_code"] = "resource_limit_exceeded"
+        else:
+            result["error"] = f"{type(e).__name__}: {e}"
+            result["traceback"] = traceback.format_exc()
 
     finally:
         # Capture stdout/stderr

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -265,9 +265,13 @@ def main():
         result_path.write_text(json.dumps(result))
     except MemoryError:
         # An output that fits under the address-space cap can still exhaust it
-        # while being serialized. Drop the oversized value and write a small
-        # fixed envelope, so the failure still reports the resource-limit code
+        # while being serialized. Release every reference to the oversized
+        # value before allocating anything else, then write a small fixed
+        # envelope, so the failure still reports the resource-limit code
         # instead of dying before result.json exists.
+        output = None
+        call = None
+        result.clear()
         result_path.write_text(
             json.dumps(
                 {

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -254,9 +254,24 @@ def main():
             result["traceback"] = traceback.format_exc()
 
     finally:
-        # Capture stdout/stderr
-        result["stdout"] = sys.stdout.getvalue()
-        result["stderr"] = sys.stderr.getvalue()
+        # Capture stdout/stderr. Joining a large capture buffer allocates a
+        # second copy of it, so a script that exhausted the cap by printing
+        # can raise here, outside every handler above, and die before
+        # result.json exists. Degrade to the same fixed envelope instead.
+        try:
+            result["stdout"] = sys.stdout.getvalue()
+            result["stderr"] = sys.stderr.getvalue()
+        except MemoryError as exc:
+            exc.__traceback__ = None
+            result.clear()
+            result["success"] = False
+            result["output"] = None
+            result["error"] = "Script exceeded the sandbox memory limit"
+            result["traceback"] = None
+            result["stdout"] = ""
+            result["stderr"] = ""
+            result["error_code"] = "resource_limit_exceeded"
+        # Dropping the capture buffers releases whatever the script printed.
         sys.stdout = old_stdout
         sys.stderr = old_stderr
 
@@ -269,12 +284,14 @@ def main():
         result["success"] = False
         result["output"] = repr(result["output"])
         result_path.write_text(json.dumps(result))
-    except MemoryError:
+    except MemoryError as exc:
         # An output that fits under the address-space cap can still exhaust it
         # while being serialized. Release every reference to the oversized
         # value before allocating anything else, then write a small fixed
         # envelope, so the failure still reports the resource-limit code
-        # instead of dying before result.json exists.
+        # instead of dying before result.json exists. The traceback counts:
+        # it pins to_json_safe's frame locals, which hold the value itself.
+        exc.__traceback__ = None
         output = None
         call = None
         result.clear()

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -18,6 +18,7 @@ import enum
 import errno
 import importlib
 import inspect
+import io
 import json
 import os
 import resource
@@ -212,23 +213,91 @@ def _release_exception_chain(error):
         current.__context__ = None
 
 
-def main():
-    """Execute user script and capture results."""
-    _enforce_nproc_limit()
+def _execute_script(inputs):
+    """Keep workload locals in a frame that can unwind before recovery."""
+    script_path = Path("/work/script.py")
+    script_code = script_path.read_text()
+    _init_tracecat_context()
 
-    # Read inputs from file. A large enough inputs.json can exhaust the cap
-    # here, before any handler below exists, so guard it too: dying at this
-    # point would leave no result.json and report a generic workload failure
-    # for what really was the memory limit.
+    script_globals = {"__name__": "__main__", "__file__": str(script_path)}
+    exec(script_code, script_globals)
+    main_func = script_globals.get("main")
+    if main_func is None:
+        # Only user-defined functions qualify, not imported callable objects.
+        for name, obj in script_globals.items():
+            if inspect.isfunction(obj) and not name.startswith("_"):
+                main_func = obj
+                break
+    if main_func is None:
+        raise ValueError("No callable function found in script")
+
+    call = main_func(**inputs) if inputs else main_func()
+    return _resolve_output(call)
+
+
+def _capture_result():
+    """Read inputs, execute the script, and capture ordinary workload errors."""
     inputs_path = Path("/work/inputs.json")
+    inputs = json.loads(inputs_path.read_text()) if inputs_path.exists() else {}
+    result = {
+        "success": False,
+        "output": None,
+        "error": None,
+        "traceback": None,
+        "stdout": "",
+        "stderr": "",
+    }
+    old_stdout, old_stderr = sys.stdout, sys.stderr
     try:
-        if inputs_path.exists():
-            inputs = json.loads(inputs_path.read_text())
-        else:
-            inputs = {}
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        try:
+            result["output"] = _execute_script(inputs)
+            result["success"] = True
+        except Exception as exc:
+            if _resource_limit_message(exc) is not None:
+                # The outer boundary must unwind workload frames and release
+                # their allocations before building the resource envelope.
+                raise
+            result["error"] = f"{type(exc).__name__}: {exc}"
+            result["traceback"] = traceback.format_exc()
+
+        # Extraction can allocate another copy of the capture buffers. Keep
+        # it inside the outer recovery boundary, but always restore streams.
+        result["stdout"] = sys.stdout.getvalue()
+        result["stderr"] = sys.stderr.getvalue()
+    finally:
+        sys.stdout, sys.stderr = old_stdout, old_stderr
+    return result
+
+
+def _write_result():
+    """Write normal results, including the existing non-JSON output fallback."""
+    result = _capture_result()
+    try:
+        encoded = json.dumps(result, default=to_json_safe)
+    except (TypeError, ValueError, RecursionError) as exc:
+        result["error"] = f"Output not JSON-serializable: {type(exc).__name__}: {exc}"
+        result["success"] = False
+        result["output"] = repr(result["output"])
+        encoded = json.dumps(result)
+    Path("/work/result.json").write_text(encoded)
+    return result["success"]
+
+
+def main():
+    """Recover resource failures across input, execution, capture, and output."""
+    _enforce_nproc_limit()
+    try:
+        success = _write_result()
     except (MemoryError, OSError) as exc:
-        if (message := _resource_limit_message(exc)) is None:
+        message = _resource_limit_message(exc)
+        if message is None:
             raise
+        # All workload and serialization frames have unwound, and streams
+        # are restored. Drop their tracebacks before allocating the fixed
+        # envelope. Opening the result file anew also truncates a partial
+        # write left by EFBIG.
         _release_exception_chain(exc)
         Path("/work/result.json").write_text(
             json.dumps(
@@ -243,142 +312,8 @@ def main():
                 }
             )
         )
-        sys.exit(1)
-
-    result = {
-        "success": False,
-        "output": None,
-        "error": None,
-        "traceback": None,
-        "stdout": "",
-        "stderr": "",
-    }
-
-    # Capture stdout/stderr
-    import io
-    old_stdout = sys.stdout
-    old_stderr = sys.stderr
-    sys.stdout = io.StringIO()
-    sys.stderr = io.StringIO()
-
-    try:
-        # Read and execute the user script
-        script_path = Path("/work/script.py")
-        script_code = script_path.read_text()
-
-        _init_tracecat_context()
-
-        script_globals = {"__name__": "__main__", "__file__": str(script_path)}
-        exec(script_code, script_globals)
-
-        # Find the callable function
-        main_func = script_globals.get("main")
-        if main_func is None:
-            # Look for the first non-private user-defined function.
-            # Use inspect.isfunction to match only functions created with 'def',
-            # not imported classes or other callables.
-            for name, obj in script_globals.items():
-                if inspect.isfunction(obj) and not name.startswith("_"):
-                    main_func = obj
-                    break
-
-        if main_func is None:
-            raise ValueError("No callable function found in script")
-
-        # Call the function with inputs
-        if inputs:
-            call = main_func(**inputs)
-        else:
-            call = main_func()
-        output = _resolve_output(call)
-
-        result["success"] = True
-        result["output"] = output
-
-    except Exception as e:
-        if (message := _resource_limit_message(e)) is not None:
-            # Skip the traceback: formatting it needs memory the process may
-            # not have, and its frames still hold what exhausted the cap.
-            # Report a structured code so the host classifies the failure
-            # without inspecting error text.
-            _release_exception_chain(e)
-            result["error"] = message
-            result["error_code"] = "resource_limit_exceeded"
-        else:
-            result["error"] = f"{type(e).__name__}: {e}"
-            result["traceback"] = traceback.format_exc()
-
-    finally:
-        # Capture stdout/stderr. Joining a large capture buffer allocates a
-        # second copy of it, so a script that exhausted the cap by printing
-        # can raise here, outside every handler above, and die before
-        # result.json exists. Degrade to the same fixed envelope instead.
-        try:
-            result["stdout"] = sys.stdout.getvalue()
-            result["stderr"] = sys.stderr.getvalue()
-        except (MemoryError, OSError) as exc:
-            if (message := _resource_limit_message(exc)) is None:
-                raise
-            _release_exception_chain(exc)
-            # Restore the real streams first. That drops the capture buffers,
-            # which are the very thing that exhausted the cap, so the envelope
-            # below is allocated against memory that has actually been freed.
-            sys.stdout = old_stdout
-            sys.stderr = old_stderr
-            output = None
-            call = None
-            result.clear()
-            result["success"] = False
-            result["output"] = None
-            result["error"] = message
-            result["traceback"] = None
-            result["stdout"] = ""
-            result["stderr"] = ""
-            result["error_code"] = "resource_limit_exceeded"
-        # Dropping the capture buffers releases whatever the script printed.
-        sys.stdout = old_stdout
-        sys.stderr = old_stderr
-
-    # Write result to file
-    result_path = Path("/work/result.json")
-    try:
-        result_path.write_text(json.dumps(result, default=to_json_safe))
-    except (TypeError, ValueError, RecursionError) as e:
-        result["error"] = f"Output not JSON-serializable: {type(e).__name__}: {e}"
-        result["success"] = False
-        result["output"] = repr(result["output"])
-        result_path.write_text(json.dumps(result))
-    except (MemoryError, OSError) as exc:
-        if (message := _resource_limit_message(exc)) is None:
-            # A write failure such as ENOSPC or EACCES is not the memory cap.
-            raise
-        # An output that fits under the address-space cap can still exhaust it
-        # while being serialized. Release every reference to the oversized
-        # value before allocating anything else, then write a small fixed
-        # envelope, so the failure still reports the resource-limit code
-        # instead of dying before result.json exists. The tracebacks count:
-        # they pin to_json_safe's frame locals, which hold the value itself.
-        _release_exception_chain(exc)
-        output = None
-        call = None
-        result.clear()
-        result_path.write_text(
-            json.dumps(
-                {
-                    "success": False,
-                    "output": None,
-                    "error": message,
-                    "traceback": None,
-                    "stdout": "",
-                    "stderr": "",
-                    "error_code": "resource_limit_exceeded",
-                }
-            )
-        )
-        result["success"] = False
-
-    # Exit with appropriate code
-    sys.exit(0 if result["success"] else 1)
+        success = False
+    sys.exit(0 if success else 1)
 
 if __name__ == "__main__":
     main()

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -175,17 +175,16 @@ def _enforce_nproc_limit() -> None:
         ) from exc
 
 
-def _is_memory_exhaustion(error):
-    """Report whether an exception means the address-space cap was reached.
-
-    Python's own allocator raises MemoryError, but a syscall that fails under
-    rlimit_as -- mmap most commonly -- surfaces as OSError with errno.ENOMEM
-    instead. Both mean the same cap, matched on a machine-readable attribute
-    rather than on message text.
-    """
+def _resource_limit_message(error):
+    """Recognize Python allocator and syscall resource failures by type/errno."""
     if isinstance(error, MemoryError):
-        return True
-    return isinstance(error, OSError) and error.errno == errno.ENOMEM
+        return "Script exceeded the sandbox memory limit"
+    if isinstance(error, OSError):
+        if error.errno == errno.ENOMEM:
+            return "Script exceeded the sandbox memory limit"
+        if error.errno == errno.EFBIG:
+            return "Script exceeded the sandbox file size limit"
+    return None
 
 
 def _release_exception_chain(error):
@@ -228,7 +227,7 @@ def main():
         else:
             inputs = {}
     except (MemoryError, OSError) as exc:
-        if not _is_memory_exhaustion(exc):
+        if (message := _resource_limit_message(exc)) is None:
             raise
         _release_exception_chain(exc)
         Path("/work/result.json").write_text(
@@ -236,7 +235,7 @@ def main():
                 {
                     "success": False,
                     "output": None,
-                    "error": "Script inputs exceeded the sandbox memory limit",
+                    "error": message,
                     "traceback": None,
                     "stdout": "",
                     "stderr": "",
@@ -297,13 +296,13 @@ def main():
         result["output"] = output
 
     except Exception as e:
-        if _is_memory_exhaustion(e):
+        if (message := _resource_limit_message(e)) is not None:
             # Skip the traceback: formatting it needs memory the process may
             # not have, and its frames still hold what exhausted the cap.
             # Report a structured code so the host classifies the failure
             # without inspecting error text.
             _release_exception_chain(e)
-            result["error"] = "Script exceeded the sandbox memory limit"
+            result["error"] = message
             result["error_code"] = "resource_limit_exceeded"
         else:
             result["error"] = f"{type(e).__name__}: {e}"
@@ -318,7 +317,7 @@ def main():
             result["stdout"] = sys.stdout.getvalue()
             result["stderr"] = sys.stderr.getvalue()
         except (MemoryError, OSError) as exc:
-            if not _is_memory_exhaustion(exc):
+            if (message := _resource_limit_message(exc)) is None:
                 raise
             _release_exception_chain(exc)
             # Restore the real streams first. That drops the capture buffers,
@@ -331,7 +330,7 @@ def main():
             result.clear()
             result["success"] = False
             result["output"] = None
-            result["error"] = "Script exceeded the sandbox memory limit"
+            result["error"] = message
             result["traceback"] = None
             result["stdout"] = ""
             result["stderr"] = ""
@@ -350,7 +349,7 @@ def main():
         result["output"] = repr(result["output"])
         result_path.write_text(json.dumps(result))
     except (MemoryError, OSError) as exc:
-        if not _is_memory_exhaustion(exc):
+        if (message := _resource_limit_message(exc)) is None:
             # A write failure such as ENOSPC or EACCES is not the memory cap.
             raise
         # An output that fits under the address-space cap can still exhaust it
@@ -368,10 +367,7 @@ def main():
                 {
                     "success": False,
                     "output": None,
-                    "error": (
-                        "MemoryError: script output exceeded the sandbox "
-                        "memory limit while being serialized"
-                    ),
+                    "error": message,
                     "traceback": None,
                     "stdout": "",
                     "stderr": "",


### PR DESCRIPTION
## Problem

rc.23 (#3088) fixed the nsjail resource-limit units, so the address-space cap inside every sandbox is enforced for the first time: 4 GiB for agents, 2 GiB for `core.script.run_python` and custom actions. Nothing in the platform could tell that failure apart from any other.

- **Core sandbox**: `RESOURCE_LIMIT_EXCEEDED` became a `SandboxWorkloadError` like every other non-infrastructure code, and the error policy flattened all of them to user-owned `action.execution.failed`. An in-jail Python `MemoryError` never even got that far — it returned a generic error payload and landed on the same kind.
- **Agent sandbox**: the exit code was never used for classification at all. A runtime that died from its cap surfaced as platform-owned, **retryable** `agent.executor.unavailable`, so the same run was retried straight back into the same cap.

Neither told the user what happened, and neither gave fleet-wide alerting anything to key on.

## Changes

### A new kind

`RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED = "sandbox.resource_limit_exceeded"`. Owner stays `user` — the cap is published deployment configuration the workload exceeded — and the disposition is `NON_RETRYABLE`, because a deterministic cap gives the same answer on the second attempt.

`sandbox_resource_limit_message()` is the single message author for both paths. It names the limits that can actually select this kind (memory, CPU time, file size) and the env var controlling the memory cap. It carries no sandbox-controlled text and no host paths.

The process-count limit is deliberately absent from that list. Exhausting `RLIMIT_NPROC` makes `fork` fail with `EAGAIN` inside the sandbox rather than killing the workload, so it produces none of the signals this classification reads; naming it would advertise a guarantee the implementation cannot keep. The documented guarantee is narrowed to match.

### Core path

`SandboxWorkloadError` carrying `SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED` now selects the new kind. Every other code keeps `action.execution.failed` with its existing disposition.

An in-jail memory exhaustion had no way to reach that code. It takes two shapes: Python's own allocator raises `MemoryError`, while a syscall that fails under `rlimit_as` -- `mmap` most commonly -- raises `OSError` with `errno.ENOMEM`. Both wrappers now match on the errno, a machine-readable attribute, rather than on the exception class alone. Both in-jail entrypoints — `minimal_runner.py` for actions and `wrapper.py` for `run_python` — now emit a structured `error_code: resource_limit_exceeded` in the result envelope and **skip traceback formatting**, which needs memory the process may not have. `decode_result_envelope` already passes that code through unclamped (now pinned by a test), and `raise_for_sandbox_error_code` turns it into the typed exception the error policy reads. No string matching anywhere in the chain.

Keeping that code through every way the cap can fire took more than the two handlers. A `MemoryError` raised inside orjson's `default` hook came back as an unserializable-type error with the original on `__cause__`; both serialization recoveries held the oversized value alive through the raised exception's traceback, which pins the serializer's frame locals; and the wrapper's `finally` joined the captured stdout buffer outside every handler, so a script that exhausted the cap by printing died before `result.json` existed. Each is now closed, and each is pinned. Releasing the value takes the whole exception chain, not just the outermost traceback: orjson's wrapper puts the frame holding the object on `__cause__`, so both runners clear every traceback in the chain -- following cause and context, not whichever is set first -- and detach the links before allocating the fallback. Reading and decoding the input payload is guarded the same way, since it is the one step guaranteed to touch caller-controlled bytes, and the wrapper restores the real streams before building its envelope so the capture buffers are actually freed.

### Agent path

Three separate gaps had to close before the exit code was observable at all:

1. **The shim erased the signal.** `shim_entrypoint.py` exited `1` for every failure. It now forwards the Claude child's termination as `128 + signal`, matching the exit-code contract nsjail already applies to its own direct child.
2. **The SDK erases the typed error.** The Claude SDK turns the transport's `ProcessError` into a plain `Exception` whose text must not be parsed. `SandboxedCLITransport` now records the exit code on itself, and the value survives `close()` so it is still readable after the SDK tears the transport down.
3. **Nothing rebuilt it.** The runtime reconstructs `AgentSandboxProcessExitError(exit_code)` from that recorded code and classifies on the code alone. Only a positive code counts: `0` means the process did not fail, and a negative code means the host killed it during teardown.

`agent_runtime_failure()` in `tracecat/agent/error_policy.py` walks the cause chain for that typed error and returns the resource-limit classification, or falls through to today's `agent_executor_unavailable` unchanged.

**How it beats the generic attribution** (the "race" in the brief turned out not to be one). In production the runtime is constructed only by `broker.py`, host-side in the agent-executor worker, with the `LoopbackHandler` passed in-process — `LoopbackHandler.handle_connection`, the untrusted socket path that stamps `agent_executor_unavailable`, has no production caller. So there are two ordered points, not a race: the runtime hands the classification to the loopback in-process, then re-raises the typed error so the executor activity's `except` independently reaches the same verdict. Both run before any generic default is assigned.

`SocketStreamWriter.send_error` accepts and drops the classification. It sits on the sandbox side of an untrusted boundary where the envelope protocol deliberately carries no ownership metadata, so the orchestrator keeps classifying socket errors itself.

### Attribution requires a jail (from review)

`TRACECAT__DISABLE_NSJAIL` defaults to `true`, and in that mode the transport still spawns a direct shim and still records its exit code. The first cut therefore reported a direct process that aborted, or that the host OOM-killed, as exceeding the configured 4096 MB cap — user-owned and non-retryable — on the *default* deployment, where no rlimit exists at all. Attribution is now gated on nsjail being enabled; without a jail the exit code carries no resource-limit meaning and the failure stays platform-owned and retryable.

Relatedly, `close()` used to record the exit code after the host had itself terminated or killed the process, so an unrelated error could be re-attributed to a process death and lose its original type. `close()` records nothing now. `read_messages` and `write` both record, since each observes the shim dying on its own while the transport is still live; the value is never cleared, so it still survives teardown. `write` matters because the SDK cancels its reader task on a write failure, so a shim that dies before message EOF would otherwise have no recorded code and a real resource-limit death would degrade to retryable executor unavailability.

Two further narrowings, both of the same shape — never assert more than the code can establish:

- **Only a resource-limit exit code may replace the raised exception.** Rebuilding the typed exit error for any positive code changed nothing about the classification while destroying the original exception's type, so a failure carrying its own attribution — `AgentSandboxValidationError`, say — would have reached the activity as a process exit and lost it.
- **The minimal runner's message stays neutral about where the memory ran out.** It also executes unjailed under the default direct backend, where no address-space rlimit exists. The direct path drops `error_code` entirely, so there was never a misclassification, but the message named a cap that mode never installs. The host still names the cap on the sandboxed path, from `sandbox_resource_limit_message()`. `wrapper.py` keeps its sandbox-specific wording because it is nsjail-only: `UnsafePidExecutor` has its own `SAFE_WRAPPER_SCRIPT`, and both `WRAPPER_SCRIPT` consumers sit behind an nsjail check.

## The exit-134 decision

**SIGABRT stays `WORKLOAD_FAILURE` on the core path, and counts as a resource limit on the agent path.** The asymmetry is structural, not a guess:

- The core sandbox runs Python. Allocation failure there is reported **in-band** as `MemoryError`, which now carries its own structured envelope code — so exit 134 adds no information about memory. What it does carry is `os.abort()`, native assertion failures and glibc heap-corruption checks, and the exit code alone cannot separate those from a memory abort without inspecting stderr text, which this repo forbids.
- The agent sandbox runs the Claude Code CLI. Its JavaScript engine **aborts** on allocation failure and has no in-band channel comparable to `MemoryError`, so the exit code is the only signal that exists.

Both directions are pinned by tests so the asymmetry cannot drift silently.

## Review guide

Each new test pins one invariant:

| Test | Invariant |
| :--- | :--- |
| `test_executor_error_policy.py::test_sandbox_resource_limit_gets_dedicated_user_owned_kind` | `RESOURCE_LIMIT_EXCEEDED` → user / `sandbox.resource_limit_exceeded` / non-retryable, message names the env var and never echoes sandbox text |
| `…::test_other_sandbox_workload_codes_keep_action_execution_failed` | Only the resource-limit code leaves `action.execution.failed`; other codes keep their disposition |
| `…::test_resource_limit_envelope_code_reaches_classification_without_text` | The envelope code alone drives classification end to end, with no string matching |
| `test_executor_activities.py::test_sandbox_workload_failure_is_user_owned_and_non_retryable` | At the activity boundary the `ApplicationError` type carries the kind verbatim — the exact string fleet alerting matches on — and sandbox diagnostic text never reaches the error |
| `test_sandbox_executor_exit_attribution.py::…workload-sigabrt-stays-workload-failure` | Exit 134 on the core path is **not** a resource limit (the decision above, pinned) |
| `test_sandbox_result_envelope.py::test_decode_result_envelope_passes_resource_limit_code_through` | The decode boundary does not clamp `resource_limit_exceeded` down to `WORKLOAD_FAILURE` |
| `test_minimal_runner_protocol.py::test_main_minimal_reports_memory_error_as_resource_limit` | An action's `MemoryError` emits the structured code, not a generic payload |
| `test_run_python_sdk_context.py::test_nsjail_wrapper_reports_memory_error_as_resource_limit` | Same for `run_python`, and the traceback is skipped rather than formatted |
| `test_agent_runtime.py::test_run_does_not_attribute_process_exit_when_nsjail_is_disabled` | With no jail the exit code is ignored and the failure stays platform-owned |
| `test_minimal_runner_protocol.py::test_main_minimal_reports_enomem_oserror_as_resource_limit` | An `OSError`/`ENOMEM` from a syscall is the same cap as `MemoryError` |
| `…::test_is_memory_exhaustion_ignores_other_oserrors` | Only `ENOMEM` counts; `EAGAIN` and `ENOENT` stay ordinary failures |
| `test_minimal_runner_protocol.py::test_serialize_result_reports_limit_when_model_dump_exhausts_memory` | orjson's `default` hook does not swallow the cap into an unserializable-type error |
| `test_agent_runtime_broker.py::test_transport_records_shim_exit_code_observed_on_write` (bounded reap) | A shim reaped just after a broken write is still recorded |
| `test_minimal_runner_protocol.py::test_serialize_result_degrades_to_resource_limit_envelope_on_memory_error` | A `MemoryError` raised *while serializing* still reports the resource-limit code |
| `test_run_python_sdk_context.py::test_nsjail_wrapper_reports_resource_limit_when_output_serialization_dies` | Same for the wrapper, driven through a real subprocess |
| `test_agent_error_policy.py::test_agent_runtime_failure_attributes_resource_limit_exit_to_user` | Exit 134 and 137 on the agent path → user / non-retryable, message names the agent env var, SDK stderr text never leaks |
| `…::test_agent_runtime_failure_finds_resource_limit_exit_in_chain` | The typed exit error is matched anywhere in the cause chain, not just at the top |
| `…::test_agent_runtime_failure_keeps_other_failures_platform_owned` | Every other failure keeps today's platform-owned retryable attribution |
| `…::test_loopback_send_error_keeps_trusted_runtime_classification` | A classification from the in-process runtime survives into the result instead of being overwritten |
| `test_agent_runtime.py::test_run_rebuilds_sandbox_process_exit_from_transport_exit_code` | The runtime rebuilds the typed error from the transport's code and propagates it |
| `…::test_run_keeps_original_error_when_sandbox_process_did_not_exit` | With no recorded exit, the original exception and platform attribution are untouched |
| `test_agent_runtime.py::test_run_keeps_original_error_for_non_resource_limit_exit_code` | A non-resource-limit exit code leaves the raised exception's type and attribution alone |
| `test_agent_runtime_broker.py::test_transport_records_shim_exit_code_observed_on_write` | A shim death seen at write time is recorded, so it is still attributable after the SDK cancels the reader |
| `test_agent_runtime_broker.py::test_transport_records_shim_exit_code_when_stream_ends` | The exit code survives the `ProcessError` the SDK erases |
| `test_agent_sandbox_entrypoint.py::test_forward_exit_code_maps_signal_death_to_nsjail_contract` | The shim forwards signal death as `128 + signal` instead of collapsing to 1 |

## Verification

- `uv run ruff check .` / `uv run ruff format --check .` — pass
- `uv run basedpyright --warnings --threads 4` (includes `tests/`) — 0 errors, 0 warnings
- `uv run pytest` on all touched test files — pass. Five pre-existing failures in `test_run_python_sdk_context.py` are macOS-only (`nsjail not available`, `unshare binary not found`) and reproduce unchanged on `main`.
- `just check-pr-title` — pass

One pre-existing test had to change: `test_executor_activities.py` asserted that *every* sandbox workload code, the resource-limit one included, classifies as `action.execution.failed`. That is precisely the behaviour this PR changes, so its expected kind is now parametrized per code.

## Out of scope

The hardcoded `memory_mb=2048` in the `run_python` install phase (`tracecat/sandbox/executor.py`) is left alone; it is documented as fixed rather than made configurable.

## LOC

| Category | + | - |
| :--- | ---: | ---: |
| Logic | 665 | 77 |
| Tests | 726 | 7 |
| Docs | 22 | 0 |

https://claude.ai/code/session_01G6Ch7wK4YyDhGzDKrkodFX






