### PR TITLE
feat(cases): add rich text comments

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.12",
     "@tiptap/extension-code-block": "3.7.1",
+    "@tiptap/extension-hard-break": "3.7.1",
     "@tiptap/extension-highlight": "3.7.1",
     "@tiptap/extension-horizontal-rule": "3.7.1",
     "@tiptap/extension-image": "3.7.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@tiptap/extension-code-block':
         specifier: 3.7.1
         version: 3.7.1(@tiptap/core@3.7.1(@tiptap/pm@3.7.1))(@tiptap/pm@3.7.1)
+      '@tiptap/extension-hard-break':
+        specifier: 3.7.1
+        version: 3.7.1(@tiptap/core@3.7.1(@tiptap/pm@3.7.1))
       '@tiptap/extension-highlight':
         specifier: 3.7.1
         version: 3.7.1(@tiptap/core@3.7.1(@tiptap/pm@3.7.1))

--- a/frontend/src/components/cases/case-comment-editor.tsx
+++ b/frontend/src/components/cases/case-comment-editor.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import type { Editor } from "@tiptap/react"
+import * as React from "react"
+import { SimpleEditor } from "@/components/tiptap-templates/simple/simple-editor"
+import { useCaseImageUpload } from "@/lib/cases/use-case-image-upload"
+import { cn } from "@/lib/utils"
+
+import "./editor.css"
+
+interface CaseCommentEditorProps {
+  value: string
+  onChange: (value: string) => void
+  caseId: string
+  workspaceId: string
+  placeholder: string
+  mode?: "default" | "inline"
+  autoFocus?: boolean
+  onBlur?: () => void
+  onFocus?: () => void
+  onUploadingChange?: (isUploading: boolean) => void
+  onEditorReady?: (editor: Editor | null) => void
+}
+
+/**
+ * TipTap Markdown editor styled to occupy the existing comment-composer shell.
+ */
+export function CaseCommentEditor({
+  value,
+  onChange,
+  caseId,
+  workspaceId,
+  placeholder,
+  mode = "default",
+  autoFocus = false,
+  onBlur,
+  onFocus,
+  onUploadingChange,
+  onEditorReady,
+}: CaseCommentEditorProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const [uploadingCount, setUploadingCount] = React.useState(0)
+  const { uploadImage } = useCaseImageUpload(caseId, workspaceId)
+
+  React.useEffect(() => {
+    onUploadingChange?.(uploadingCount > 0)
+  }, [onUploadingChange, uploadingCount])
+
+  const handleImageUpload = React.useCallback(
+    async (file: File) => {
+      setUploadingCount((count) => count + 1)
+      try {
+        return (await uploadImage(file)).src
+      } finally {
+        setUploadingCount((count) => Math.max(0, count - 1))
+      }
+    },
+    [uploadImage]
+  )
+
+  const handleContainerBlur = React.useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      const nextTarget = event.relatedTarget as Node | null
+      if (
+        !containerRef.current ||
+        !nextTarget ||
+        !containerRef.current.contains(nextTarget)
+      ) {
+        onBlur?.()
+      }
+    },
+    [onBlur]
+  )
+
+  const handleContainerFocus = React.useCallback(() => {
+    onFocus?.()
+  }, [onFocus])
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "case-comment-editor",
+        mode === "inline" && "case-comment-editor--inline"
+      )}
+      onBlur={handleContainerBlur}
+      onFocusCapture={handleContainerFocus}
+    >
+      <SimpleEditor
+        value={value}
+        onChange={onChange}
+        showToolbar={false}
+        placeholder={placeholder}
+        className="case-comment-editor__tiptap"
+        autoFocus={autoFocus}
+        enableImages
+        imageWorkspaceId={workspaceId}
+        onImageUpload={handleImageUpload}
+        onEditorReady={onEditorReady}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/cases/case-comment-editor.tsx
+++ b/frontend/src/components/cases/case-comment-editor.tsx
@@ -97,6 +97,7 @@ export function CaseCommentEditor({
         imageWorkspaceId={workspaceId}
         onImageUpload={handleImageUpload}
         onEditorReady={onEditorReady}
+        allowCommentMentionUris
       />
     </div>
   )

--- a/frontend/src/components/cases/case-comments-section.tsx
+++ b/frontend/src/components/cases/case-comments-section.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import type React from "react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import type { CaseCommentRead, CaseCommentThreadRead } from "@/client"
@@ -631,13 +631,17 @@ function CommentComposer({
     ]
   )
 
-  const handleMentionKeyDown = mentions.handleKeyDown
+  const handleMentionKeyDownRef = useRef(mentions.handleKeyDown)
+  useEffect(() => {
+    handleMentionKeyDownRef.current = mentions.handleKeyDown
+  }, [mentions.handleKeyDown])
+
   useEffect(() => {
     if (!editor) {
       return
     }
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (handleMentionKeyDown(event)) {
+      if (handleMentionKeyDownRef.current(event)) {
         event.stopPropagation()
         return
       }
@@ -659,14 +663,7 @@ function CommentComposer({
     return () => {
       editorElement.removeEventListener("keydown", handleKeyDown, true)
     }
-  }, [
-    createCommentIsPending,
-    editor,
-    form,
-    handleMentionKeyDown,
-    handleSubmit,
-    imageUploading,
-  ])
+  }, [createCommentIsPending, editor, form, handleSubmit, imageUploading])
 
   return (
     <div

--- a/frontend/src/components/cases/case-comments-section.tsx
+++ b/frontend/src/components/cases/case-comments-section.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import type { Editor } from "@tiptap/react"
 import {
   AlertCircle,
   ArrowUpIcon,
@@ -16,22 +17,21 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import type React from "react"
-import type { RefObject } from "react"
-import { useCallback, useLayoutEffect, useRef, useState } from "react"
-import { type UseFormReturn, useForm } from "react-hook-form"
+import { useCallback, useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
 import { z } from "zod"
 import type { CaseCommentRead, CaseCommentThreadRead } from "@/client"
 import {
   CaseCommentAgentAttribution,
   CaseCommentAgentInvocationList,
 } from "@/components/cases/case-comment-agent"
+import { CaseCommentEditor } from "@/components/cases/case-comment-editor"
 import { CaseCommentViewer } from "@/components/cases/case-description-editor"
 import {
   CaseEventTimestamp,
   CaseUserAvatar,
 } from "@/components/cases/case-panel-common"
 import { MentionHint } from "@/components/mentions/mention-hint"
-import { MentionOverlay } from "@/components/mentions/mention-overlay"
 import { MentionPopover } from "@/components/mentions/mention-popover"
 import {
   AlertDialog,
@@ -51,26 +51,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from "@/components/ui/form"
+import { Form, FormField, FormItem, FormMessage } from "@/components/ui/form"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
 import { useAuth } from "@/hooks/use-auth"
 import { useEntitlements } from "@/hooks/use-entitlements"
-import { useMentions } from "@/hooks/use-mentions"
+import { useTiptapMentions } from "@/hooks/use-tiptap-mentions"
 import { SYSTEM_USER_READ, User } from "@/lib/auth"
-import {
-  createPastedImageFile,
-  extractImageFiles,
-  useCaseImageUpload,
-} from "@/lib/cases/use-case-image-upload"
 import { executionId, getWorkflowExecutionUrl } from "@/lib/event-history"
 import {
   useCaseComments,
@@ -80,7 +68,6 @@ import {
   useDeleteCaseComment,
   useUpdateCaseComment,
 } from "@/lib/hooks"
-import type { TextSplice } from "@/lib/mentions"
 import { cn, INSET_SURFACE } from "@/lib/utils"
 
 /**
@@ -559,84 +546,6 @@ function CommentThreadSkeleton() {
   )
 }
 
-/**
- * Enable pasting images into a plain comment `<Textarea>`.
- *
- * Pasted images are uploaded as case attachments and inserted as
- * `![name](attachment://...)` markdown at the cursor, preserving surrounding
- * text. Exposes an `isUploading` flag so callers can keep submit disabled.
- */
-function useCommentImagePaste({
-  caseId,
-  workspaceId,
-  form,
-  textareaRef,
-  adjustTextareaHeight,
-  onSplice,
-}: {
-  caseId: string
-  workspaceId: string
-  form: UseFormReturn<CommentFormSchema>
-  textareaRef: RefObject<HTMLTextAreaElement | null>
-  adjustTextareaHeight: () => void
-  /** Reports the edit so callers can keep mention offsets aligned. */
-  onSplice?: (splice: TextSplice) => void
-}) {
-  const { uploadImage } = useCaseImageUpload(caseId, workspaceId)
-  const [uploadingCount, setUploadingCount] = useState(0)
-
-  const insertAtCursor = useCallback(
-    (text: string) => {
-      const textarea = textareaRef.current
-      const current = form.getValues("content")
-      const start = textarea?.selectionStart ?? current.length
-      const end = textarea?.selectionEnd ?? current.length
-      const next = current.slice(0, start) + text + current.slice(end)
-      onSplice?.({ start, deleted: end - start, inserted: text.length })
-      form.setValue("content", next, {
-        shouldDirty: true,
-        shouldValidate: true,
-      })
-      const cursor = start + text.length
-      requestAnimationFrame(() => {
-        const node = textareaRef.current
-        if (node) {
-          node.focus()
-          node.setSelectionRange(cursor, cursor)
-        }
-        adjustTextareaHeight()
-      })
-    },
-    [adjustTextareaHeight, form, onSplice, textareaRef]
-  )
-
-  const handlePaste = useCallback(
-    async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
-      const files = extractImageFiles(event.clipboardData)
-      if (files.length === 0) {
-        return
-      }
-      event.preventDefault()
-      setUploadingCount((count) => count + files.length)
-      for (const file of files) {
-        try {
-          const { src, fileName } = await uploadImage(
-            createPastedImageFile(file)
-          )
-          insertAtCursor(`![${fileName}](${src})`)
-        } catch {
-          // Error toast is surfaced by uploadImage.
-        } finally {
-          setUploadingCount((count) => Math.max(0, count - 1))
-        }
-      }
-    },
-    [insertAtCursor, uploadImage]
-  )
-
-  return { handlePaste, isUploading: uploadingCount > 0 }
-}
-
 function CommentComposer({
   caseId,
   workspaceId,
@@ -659,13 +568,9 @@ function CommentComposer({
     workspaceId,
   })
   const isInline = mode === "inline"
-  // Shared by the textarea and its highlight overlay. If these drift apart the
-  // two layers wrap differently and the caret stops matching the visible text.
-  const textMetricsClassName = isInline
-    ? "px-0 py-1 text-sm"
-    : "px-0 py-0 text-sm"
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const [editor, setEditor] = useState<Editor | null>(null)
   const [isFocused, setIsFocused] = useState(false)
+  const [imageUploading, setImageUploading] = useState(false)
   const form = useForm<CommentFormSchema>({
     resolver: zodResolver(commentFormSchema),
     defaultValues: {
@@ -673,97 +578,95 @@ function CommentComposer({
     },
     mode: "onSubmit",
   })
-
-  const adjustTextareaHeight = useCallback(() => {
-    const textarea = textareaRef.current
-    if (!textarea) return
-
-    textarea.style.height = "auto"
-    textarea.style.height = `${Math.max(textarea.scrollHeight, isInline ? 36 : 72)}px`
-    textarea.style.overflowY = "hidden"
-  }, [isInline])
-
-  // Mentions live as display text (`@Label`, `/Label`) in the textarea; the
-  // hook maps them back to the wire value on submit.
-  const getContent = useCallback(() => form.getValues("content"), [form])
-  const setContent = useCallback(
-    (next: string) => {
-      form.setValue("content", next, {
-        shouldDirty: true,
-        shouldValidate: true,
-      })
-    },
-    [form]
-  )
-  const mentions = useMentions({
+  const mentions = useTiptapMentions({
+    editor,
     workspaceId,
-    textareaRef,
-    getText: getContent,
-    setText: setContent,
     // A comment may invoke several agents, but runs at most one workflow.
     agents: { entitlements: ["agent_addons", "case_addons"] },
     workflows: { entitlements: ["case_addons"], single: true },
   })
 
-  const { handlePaste, isUploading: imageUploading } = useCommentImagePaste({
-    caseId,
-    workspaceId,
-    form,
-    textareaRef,
-    adjustTextareaHeight,
-    onSplice: mentions.applySplice,
-  })
-
   const content = form.watch("content")
   const trimmedContent = content.trim()
-
-  useLayoutEffect(() => {
-    adjustTextareaHeight()
-  }, [adjustTextareaHeight, content])
-
-  const handleSubmit = async (values: CommentFormSchema) => {
-    const workflowId = mentions.workflowId
-    const nextContent = mentions.serialize(values.content).trim()
-    // A bare `/Workflow` command still runs and saves with an empty body.
-    if (!nextContent && !workflowId) {
-      return
-    }
-    // The length limit applies to what the API receives, not the shorter
-    // display text, so check the serialized value.
-    const serialized = commentWireSchema.safeParse(nextContent)
-    if (!serialized.success) {
-      form.setError("content", {
-        message: serialized.error.issues[0]?.message,
-      })
-      return
-    }
-    try {
-      await createComment({
-        content: nextContent,
-        parent_id: parentId,
-        ...(workflowId ? { workflow_id: workflowId } : {}),
-      })
-      form.reset({ content: "" })
-      mentions.reset()
-      onSubmitted?.()
-    } catch (error) {
-      console.error("Error creating comment:", error)
-    }
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // The mention layer owns popover keys and atomic mention backspace.
-    if (mentions.handleKeyDown(event)) {
-      return
-    }
-    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-      event.preventDefault()
-      if (createCommentIsPending || imageUploading) {
+  const serializeMentions = mentions.serialize
+  const resetMentions = mentions.reset
+  const handleSubmit = useCallback(
+    async (values: CommentFormSchema) => {
+      const serializedComment = serializeMentions(values.content)
+      const nextContent = serializedComment.content.trim()
+      const workflowId = serializedComment.workflowId
+      // A bare `/Workflow` command still runs and saves with an empty body.
+      if (!nextContent && !workflowId) {
         return
       }
-      form.handleSubmit(handleSubmit)()
+      // Validate after removing the transient workflow marker so the limit
+      // applies to the exact Markdown sent over the wire.
+      const serialized = commentWireSchema.safeParse(nextContent)
+      if (!serialized.success) {
+        form.setError("content", {
+          message: serialized.error.issues[0]?.message,
+        })
+        return
+      }
+      try {
+        await createComment({
+          content: nextContent,
+          parent_id: parentId,
+          ...(workflowId ? { workflow_id: workflowId } : {}),
+        })
+        form.reset({ content: "" })
+        resetMentions()
+        onSubmitted?.()
+      } catch (error) {
+        console.error("Error creating comment:", error)
+      }
+    },
+    [
+      createComment,
+      form,
+      onSubmitted,
+      parentId,
+      resetMentions,
+      serializeMentions,
+    ]
+  )
+
+  const handleMentionKeyDown = mentions.handleKeyDown
+  useEffect(() => {
+    if (!editor) {
+      return
     }
-  }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (handleMentionKeyDown(event)) {
+        event.stopPropagation()
+        return
+      }
+      if (
+        event.key === "Enter" &&
+        (event.metaKey || event.ctrlKey) &&
+        !event.isComposing
+      ) {
+        event.preventDefault()
+        event.stopPropagation()
+        if (createCommentIsPending || imageUploading) {
+          return
+        }
+        void form.handleSubmit(handleSubmit)()
+      }
+    }
+    const editorElement = editor.view.dom
+    editorElement.addEventListener("keydown", handleKeyDown, true)
+    return () => {
+      editorElement.removeEventListener("keydown", handleKeyDown, true)
+    }
+  }, [
+    createCommentIsPending,
+    editor,
+    form,
+    handleMentionKeyDown,
+    handleSubmit,
+    imageUploading,
+  ])
 
   return (
     <div
@@ -795,48 +698,23 @@ function CommentComposer({
                   hasError={mentions.hasError}
                   onSelect={mentions.selectSuggestion}
                 >
-                  <MentionOverlay
-                    text={content}
-                    mentions={mentions.ranges}
-                    className={textMetricsClassName}
+                  <CaseCommentEditor
+                    value={field.value}
+                    onChange={field.onChange}
+                    caseId={caseId}
+                    workspaceId={workspaceId}
+                    placeholder={placeholder}
+                    mode={mode}
+                    autoFocus={autoFocus}
+                    onBlur={() => {
+                      field.onBlur()
+                      setIsFocused(false)
+                      mentions.dismiss()
+                    }}
+                    onFocus={() => setIsFocused(true)}
+                    onUploadingChange={setImageUploading}
+                    onEditorReady={setEditor}
                   />
-                  <FormControl>
-                    <Textarea
-                      autoFocus={autoFocus}
-                      ref={(node) => {
-                        field.ref(node)
-                        textareaRef.current = node
-                      }}
-                      // Text is painted by the overlay behind, so only the
-                      // caret stays visible here.
-                      className={cn(
-                        "relative resize-none border-none bg-transparent text-transparent caret-foreground shadow-none focus-visible:ring-0",
-                        textMetricsClassName,
-                        isInline ? "min-h-9" : "min-h-[72px]"
-                      )}
-                      name={field.name}
-                      onBlur={() => {
-                        field.onBlur()
-                        setIsFocused(false)
-                        mentions.dismiss()
-                      }}
-                      onFocus={() => setIsFocused(true)}
-                      onChange={(event) => {
-                        mentions.handleTextChange(
-                          event.target.value,
-                          event.target.selectionStart ??
-                            event.target.value.length
-                        )
-                        field.onChange(event)
-                        adjustTextareaHeight()
-                      }}
-                      onKeyDown={handleKeyDown}
-                      onSelect={mentions.handleSelectionChange}
-                      onPaste={(event) => void handlePaste(event)}
-                      placeholder={placeholder}
-                      value={field.value}
-                    />
-                  </FormControl>
                 </MentionPopover>
                 <FormMessage />
               </FormItem>
@@ -892,7 +770,8 @@ function InlineCommentEdit({
     workspaceId,
     commentId: comment.id,
   })
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const [editor, setEditor] = useState<Editor | null>(null)
+  const [imageUploading, setImageUploading] = useState(false)
   const form = useForm<CommentFormSchema>({
     resolver: zodResolver(commentEditFormSchema),
     defaultValues: {
@@ -900,53 +779,50 @@ function InlineCommentEdit({
     },
   })
 
-  const adjustTextareaHeight = useCallback(() => {
-    const textarea = textareaRef.current
-    if (!textarea) return
-
-    textarea.style.height = "auto"
-    textarea.style.height = `${Math.max(textarea.scrollHeight, 72)}px`
-    textarea.style.overflowY = "hidden"
-  }, [])
-
-  const { handlePaste, isUploading: imageUploading } = useCommentImagePaste({
-    caseId,
-    workspaceId,
-    form,
-    textareaRef,
-    adjustTextareaHeight,
-  })
-
   const content = form.watch("content")
+  const handleSubmit = useCallback(
+    async (values: CommentFormSchema) => {
+      try {
+        await updateComment({
+          content: values.content,
+        })
+        onStopEditing()
+        toast({
+          title: "Comment updated",
+          description: "Your comment has been updated successfully.",
+        })
+      } catch (error) {
+        console.error("Error updating comment:", error)
+      }
+    },
+    [onStopEditing, updateComment]
+  )
 
-  useLayoutEffect(() => {
-    adjustTextareaHeight()
-  }, [adjustTextareaHeight, content])
-
-  const handleSubmit = async (values: CommentFormSchema) => {
-    try {
-      await updateComment({
-        content: values.content,
-      })
-      onStopEditing()
-      toast({
-        title: "Comment updated",
-        description: "Your comment has been updated successfully.",
-      })
-    } catch (error) {
-      console.error("Error updating comment:", error)
+  useEffect(() => {
+    if (!editor) {
+      return
     }
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key !== "Enter" ||
+        (!event.metaKey && !event.ctrlKey) ||
+        event.isComposing
+      ) {
+        return
+      }
       event.preventDefault()
+      event.stopPropagation()
       if (updateCommentIsPending || imageUploading) {
         return
       }
-      form.handleSubmit(handleSubmit)()
+      void form.handleSubmit(handleSubmit)()
     }
-  }
+    const editorElement = editor.view.dom
+    editorElement.addEventListener("keydown", handleKeyDown, true)
+    return () => {
+      editorElement.removeEventListener("keydown", handleKeyDown, true)
+    }
+  }, [editor, form, handleSubmit, imageUploading, updateCommentIsPending])
 
   return (
     <Form {...form}>
@@ -956,25 +832,17 @@ function InlineCommentEdit({
           name="content"
           render={({ field }) => (
             <FormItem>
-              <FormControl>
-                <Textarea
-                  autoFocus
-                  ref={(node) => {
-                    field.ref(node)
-                    textareaRef.current = node
-                  }}
-                  className="min-h-[72px] border-none px-0 py-0 text-sm shadow-none focus-visible:ring-0"
-                  name={field.name}
-                  onBlur={field.onBlur}
-                  onChange={(event) => {
-                    field.onChange(event)
-                    adjustTextareaHeight()
-                  }}
-                  onKeyDown={handleKeyDown}
-                  onPaste={(event) => void handlePaste(event)}
-                  value={field.value}
-                />
-              </FormControl>
+              <CaseCommentEditor
+                value={field.value}
+                onChange={field.onChange}
+                caseId={caseId}
+                workspaceId={workspaceId}
+                placeholder="Edit comment..."
+                autoFocus
+                onBlur={field.onBlur}
+                onUploadingChange={setImageUploading}
+                onEditorReady={setEditor}
+              />
               <FormMessage />
             </FormItem>
           )}

--- a/frontend/src/components/cases/case-description-editor.tsx
+++ b/frontend/src/components/cases/case-description-editor.tsx
@@ -121,6 +121,7 @@ export function CaseCommentViewer({
         className="case-comment-viewer"
         enableImages={Boolean(workspaceId)}
         imageWorkspaceId={workspaceId ?? null}
+        allowCommentMentionUris
       />
     </div>
   )

--- a/frontend/src/components/cases/editor.css
+++ b/frontend/src/components/cases/editor.css
@@ -173,6 +173,44 @@
   height: auto;
 }
 
+.case-comment-editor {
+  width: 100%;
+  min-width: 0;
+}
+
+.case-comment-editor .simple-editor-content .tiptap.ProseMirror.simple-editor {
+  min-height: 72px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.case-comment-editor--inline
+  .simple-editor-content
+  .tiptap.ProseMirror.simple-editor {
+  min-height: 36px;
+  padding-block: 0.25rem;
+}
+
+.case-comment-editor
+  .simple-editor-content
+  .tiptap.ProseMirror.simple-editor
+  a[href^="mention://agent/"],
+.case-comment-editor
+  .simple-editor-content
+  .tiptap.ProseMirror.simple-editor
+  a[href^="workflow-mention://"] {
+  border-radius: 0.125rem;
+  background: hsl(var(--primary) / 0.1);
+  color: hsl(var(--primary));
+  text-decoration: none;
+  box-shadow: 0 0 0 2px hsl(var(--primary) / 0.1);
+}
+
 .text-part-editor .simple-editor-content .simple-editor {
   white-space: inherit;
 }

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -855,6 +855,8 @@ export function SimpleEditor({
           transaction = transaction.removeMark(range.from, range.to, linkMark)
         }
       }
+      // Undo the user's edit directly; never restore a hidden internal link first.
+      transaction = transaction.setMeta("addToHistory", false)
       editor.view.dispatch(transaction)
     }
     editor.on("update", handleUpdate)

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -110,7 +110,10 @@ import {
   preventCommentMentionNavigation,
   WORKFLOW_MENTION_URI_SCHEME,
 } from "@/lib/tiptap-comment-mentions"
-import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
+import {
+  deleteImagePasteSelection,
+  mapImageUploadPosition,
+} from "@/lib/tiptap-image-upload-position"
 import { MarkdownHardBreak } from "@/lib/tiptap-markdown-hard-break"
 import {
   handleImageUpload,
@@ -735,12 +738,21 @@ export function SimpleEditor({
           return false
         }
         event.preventDefault()
+        const { from, to } = view.state.selection
+        const deleteTransaction = deleteImagePasteSelection(
+          view.state.tr,
+          from,
+          to
+        )
+        if (deleteTransaction) {
+          view.dispatch(deleteTransaction)
+        }
         void uploadAndInsertImages(
           currentEditor,
           view,
           files.map(createPastedImageFile),
           upload,
-          view.state.selection.to
+          from
         )
         return true
       },

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -110,7 +110,10 @@ import {
   preventCommentMentionNavigation,
   WORKFLOW_MENTION_URI_SCHEME,
 } from "@/lib/tiptap-comment-mentions"
-import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
+import {
+  mapImageUploadPosition,
+  sanitizeMarkdownImageAlt,
+} from "@/lib/tiptap-image-upload-position"
 import { MarkdownHardBreak } from "@/lib/tiptap-markdown-hard-break"
 import {
   handleImageUpload,
@@ -145,7 +148,10 @@ async function uploadAndInsertImages(
         if (!imageType) {
           continue
         }
-        const node = imageType.create({ src, alt: file.name })
+        const node = imageType.create({
+          src,
+          alt: sanitizeMarkdownImageAlt(file.name),
+        })
         const transaction = view.state.tr
         if (replaceTo !== null && replaceTo > insertPos) {
           transaction.replaceWith(insertPos, replaceTo, node)

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -110,10 +110,7 @@ import {
   preventCommentMentionNavigation,
   WORKFLOW_MENTION_URI_SCHEME,
 } from "@/lib/tiptap-comment-mentions"
-import {
-  deleteImagePasteSelection,
-  mapImageUploadPosition,
-} from "@/lib/tiptap-image-upload-position"
+import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
 import { MarkdownHardBreak } from "@/lib/tiptap-markdown-hard-break"
 import {
   handleImageUpload,
@@ -128,11 +125,16 @@ async function uploadAndInsertImages(
   view: EditorView,
   files: File[],
   upload: (file: File) => Promise<string>,
-  startPos: number
+  startPos: number,
+  endPos?: number
 ): Promise<void> {
   let insertPos = startPos
+  let replaceTo = endPos !== undefined && endPos > startPos ? endPos : null
   const handleTransaction = ({ transaction }: { transaction: Transaction }) => {
     insertPos = mapImageUploadPosition(insertPos, transaction)
+    if (replaceTo !== null) {
+      replaceTo = mapImageUploadPosition(replaceTo, transaction, -1)
+    }
   }
   editor.on("transaction", handleTransaction)
   try {
@@ -144,7 +146,14 @@ async function uploadAndInsertImages(
           continue
         }
         const node = imageType.create({ src, alt: file.name })
-        view.dispatch(view.state.tr.insert(insertPos, node))
+        const transaction = view.state.tr
+        if (replaceTo !== null && replaceTo > insertPos) {
+          transaction.replaceWith(insertPos, replaceTo, node)
+        } else {
+          transaction.insert(insertPos, node)
+        }
+        view.dispatch(transaction)
+        replaceTo = null
       } catch {
         // Upload failures are surfaced by the upload function's own toast.
       }
@@ -739,20 +748,13 @@ export function SimpleEditor({
         }
         event.preventDefault()
         const { from, to } = view.state.selection
-        const deleteTransaction = deleteImagePasteSelection(
-          view.state.tr,
-          from,
-          to
-        )
-        if (deleteTransaction) {
-          view.dispatch(deleteTransaction)
-        }
         void uploadAndInsertImages(
           currentEditor,
           view,
           files.map(createPastedImageFile),
           upload,
-          from
+          from,
+          to
         )
         return true
       },

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -102,6 +102,10 @@ import {
   extractImageFiles,
 } from "@/lib/cases/use-case-image-upload"
 import {
+  AGENT_MENTION_URI_SCHEME,
+  WORKFLOW_MENTION_URI_SCHEME,
+} from "@/lib/tiptap-comment-mentions"
+import {
   handleImageUpload,
   MAX_FILE_SIZE,
   sanitizeUrl,
@@ -566,6 +570,8 @@ export interface SimpleEditorProps {
    * `attachment://<caseId>/<attachmentId>`). Required to enable paste/drop.
    */
   onImageUpload?: (file: File) => Promise<string>
+  /** Called when the TipTap editor instance becomes available or is removed. */
+  onEditorReady?: (editor: Editor | null) => void
 }
 
 export function SimpleEditor({
@@ -587,6 +593,7 @@ export function SimpleEditor({
   enableImages = false,
   imageWorkspaceId = null,
   onImageUpload,
+  onEditorReady,
 }: SimpleEditorProps) {
   const isMobile = useIsMobile()
   const { height } = useWindowSize()
@@ -610,6 +617,10 @@ export function SimpleEditor({
         link: {
           openOnClick: false,
           enableClickSelection: true,
+          isAllowedUri: (url, { defaultValidate }) =>
+            url.startsWith(AGENT_MENTION_URI_SCHEME) ||
+            url.startsWith(WORKFLOW_MENTION_URI_SCHEME) ||
+            defaultValidate(url),
         },
       }),
       HorizontalRule,
@@ -744,6 +755,11 @@ export function SimpleEditor({
 
   const shouldShowToolbar = showToolbar && editable
   const canRenderToolbar = editable && (showToolbar || preserveToolbarSpace)
+
+  React.useEffect(() => {
+    onEditorReady?.(editor)
+    return () => onEditorReady?.(null)
+  }, [editor, onEditorReady])
 
   const rect = useCursorVisibility({
     editor,

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -12,6 +12,7 @@ import { TextAlign } from "@tiptap/extension-text-align"
 import { Typography } from "@tiptap/extension-typography"
 import { Selection } from "@tiptap/extensions"
 import { Markdown } from "@tiptap/markdown"
+import type { Transaction } from "@tiptap/pm/state"
 import type { EditorView } from "@tiptap/pm/view"
 import {
   type Editor,
@@ -103,9 +104,13 @@ import {
 } from "@/lib/cases/use-case-image-upload"
 import {
   AGENT_MENTION_URI_SCHEME,
+  type CommentMentionLinkSnapshot,
+  findCommentMentionLinkRanges,
+  findEditedCommentMentionIndexes,
   preventCommentMentionNavigation,
   WORKFLOW_MENTION_URI_SCHEME,
 } from "@/lib/tiptap-comment-mentions"
+import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
 import {
   handleImageUpload,
   MAX_FILE_SIZE,
@@ -115,26 +120,33 @@ import { cn } from "@/lib/utils"
 
 /** Upload images then insert image nodes at the drop position or selection. */
 async function uploadAndInsertImages(
+  editor: Editor,
   view: EditorView,
   files: File[],
   upload: (file: File) => Promise<string>,
-  startPos?: number
+  startPos: number
 ): Promise<void> {
   let insertPos = startPos
-  for (const file of files) {
-    try {
-      const src = await upload(file)
-      const imageType = view.state.schema.nodes.image
-      if (!imageType) {
-        continue
+  const handleTransaction = ({ transaction }: { transaction: Transaction }) => {
+    insertPos = mapImageUploadPosition(insertPos, transaction)
+  }
+  editor.on("transaction", handleTransaction)
+  try {
+    for (const file of files) {
+      try {
+        const src = await upload(file)
+        const imageType = view.state.schema.nodes.image
+        if (!imageType) {
+          continue
+        }
+        const node = imageType.create({ src, alt: file.name })
+        view.dispatch(view.state.tr.insert(insertPos, node))
+      } catch {
+        // Upload failures are surfaced by the upload function's own toast.
       }
-      const node = imageType.create({ src, alt: file.name })
-      const pos = insertPos ?? view.state.selection.to
-      view.dispatch(view.state.tr.insert(pos, node))
-      insertPos = pos + node.nodeSize
-    } catch {
-      // Upload failures are surfaced by the upload function's own toast.
     }
+  } finally {
+    editor.off("transaction", handleTransaction)
   }
 }
 
@@ -608,6 +620,8 @@ export function SimpleEditor({
   const markdownRef = React.useRef<string>(value ?? "")
   const previousEditableRef = React.useRef(editable)
   const imageUploadRef = React.useRef(onImageUpload)
+  const editorRef = React.useRef<Editor | null>(null)
+  const commentMentionLinksRef = React.useRef<CommentMentionLinkSnapshot[]>([])
 
   React.useEffect(() => {
     imageUploadRef.current = onImageUpload
@@ -709,7 +723,8 @@ export function SimpleEditor({
       },
       handlePaste: (view, event) => {
         const upload = imageUploadRef.current
-        if (!upload) {
+        const currentEditor = editorRef.current
+        if (!upload || !currentEditor) {
           return false
         }
         const files = extractImageFiles(event.clipboardData)
@@ -718,15 +733,18 @@ export function SimpleEditor({
         }
         event.preventDefault()
         void uploadAndInsertImages(
+          currentEditor,
           view,
           files.map(createPastedImageFile),
-          upload
+          upload,
+          view.state.selection.to
         )
         return true
       },
       handleDrop: (view, event) => {
         const upload = imageUploadRef.current
-        if (!upload) {
+        const currentEditor = editorRef.current
+        if (!upload || !currentEditor) {
           return false
         }
         const files = extractImageFiles(event.dataTransfer)
@@ -738,7 +756,13 @@ export function SimpleEditor({
           left: event.clientX,
           top: event.clientY,
         })
-        void uploadAndInsertImages(view, files, upload, coords?.pos)
+        void uploadAndInsertImages(
+          currentEditor,
+          view,
+          files,
+          upload,
+          coords?.pos ?? view.state.selection.to
+        )
         return true
       },
     },
@@ -768,6 +792,47 @@ export function SimpleEditor({
 
   const shouldShowToolbar = showToolbar && editable
   const canRenderToolbar = editable && (showToolbar || preserveToolbarSpace)
+
+  React.useEffect(() => {
+    editorRef.current = editor
+    return () => {
+      editorRef.current = null
+    }
+  }, [editor])
+
+  React.useEffect(() => {
+    if (!editor || !editable || !allowCommentMentionUris) {
+      commentMentionLinksRef.current = []
+      return
+    }
+    commentMentionLinksRef.current = findCommentMentionLinkRanges(
+      editor.state.doc
+    )
+    const handleUpdate = () => {
+      const ranges = findCommentMentionLinkRanges(editor.state.doc)
+      const editedIndexes = findEditedCommentMentionIndexes(
+        commentMentionLinksRef.current,
+        ranges
+      )
+      commentMentionLinksRef.current = ranges
+      const linkMark = editor.state.schema.marks.link
+      if (!linkMark || editedIndexes.length === 0) {
+        return
+      }
+      let transaction = editor.state.tr
+      for (const index of editedIndexes) {
+        const range = ranges[index]
+        if (range) {
+          transaction = transaction.removeMark(range.from, range.to, linkMark)
+        }
+      }
+      editor.view.dispatch(transaction)
+    }
+    editor.on("update", handleUpdate)
+    return () => {
+      editor.off("update", handleUpdate)
+    }
+  }, [allowCommentMentionUris, editable, editor])
 
   React.useEffect(() => {
     onEditorReady?.(editor)

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -113,6 +113,7 @@ import {
 import {
   mapImageUploadPosition,
   sanitizeMarkdownImageAlt,
+  transactionTouchesImageReplacement,
 } from "@/lib/tiptap-image-upload-position"
 import { MarkdownHardBreak } from "@/lib/tiptap-markdown-hard-break"
 import {
@@ -134,6 +135,12 @@ async function uploadAndInsertImages(
   let insertPos = startPos
   let replaceTo = endPos !== undefined && endPos > startPos ? endPos : null
   const handleTransaction = ({ transaction }: { transaction: Transaction }) => {
+    if (
+      replaceTo !== null &&
+      transactionTouchesImageReplacement(insertPos, replaceTo, transaction)
+    ) {
+      replaceTo = null
+    }
     insertPos = mapImageUploadPosition(insertPos, transaction)
     if (replaceTo !== null) {
       replaceTo = mapImageUploadPosition(replaceTo, transaction, -1)

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -573,6 +573,8 @@ export interface SimpleEditorProps {
   onImageUpload?: (file: File) => Promise<string>
   /** Called when the TipTap editor instance becomes available or is removed. */
   onEditorReady?: (editor: Editor | null) => void
+  /** Allow the internal URI schemes used by case comment mentions. */
+  allowCommentMentionUris?: boolean
 }
 
 export function SimpleEditor({
@@ -595,6 +597,7 @@ export function SimpleEditor({
   imageWorkspaceId = null,
   onImageUpload,
   onEditorReady,
+  allowCommentMentionUris = false,
 }: SimpleEditorProps) {
   const isMobile = useIsMobile()
   const { height } = useWindowSize()
@@ -619,8 +622,9 @@ export function SimpleEditor({
           openOnClick: false,
           enableClickSelection: true,
           isAllowedUri: (url, { defaultValidate }) =>
-            url.startsWith(AGENT_MENTION_URI_SCHEME) ||
-            url.startsWith(WORKFLOW_MENTION_URI_SCHEME) ||
+            (allowCommentMentionUris &&
+              (url.startsWith(AGENT_MENTION_URI_SCHEME) ||
+                url.startsWith(WORKFLOW_MENTION_URI_SCHEME))) ||
             defaultValidate(url),
         },
       }),
@@ -666,7 +670,12 @@ export function SimpleEditor({
         },
       }),
     ],
-    [renderMermaidWhenBlurred, enableImages, imageWorkspaceId]
+    [
+      allowCommentMentionUris,
+      renderMermaidWhenBlurred,
+      enableImages,
+      imageWorkspaceId,
+    ]
   )
 
   const editor = useEditor({
@@ -684,7 +693,9 @@ export function SimpleEditor({
         ...(placeholder ? { "data-placeholder": placeholder } : {}),
       },
       handleClick: (_view, _pos, event) => {
-        if (preventCommentMentionNavigation(event)) return true
+        if (allowCommentMentionUris && preventCommentMentionNavigation(event)) {
+          return true
+        }
         if (!event.metaKey && !event.ctrlKey) return false
         const href = (event.target as HTMLElement | null)
           ?.closest("a")

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -103,6 +103,7 @@ import {
 } from "@/lib/cases/use-case-image-upload"
 import {
   AGENT_MENTION_URI_SCHEME,
+  preventCommentMentionNavigation,
   WORKFLOW_MENTION_URI_SCHEME,
 } from "@/lib/tiptap-comment-mentions"
 import {
@@ -683,6 +684,7 @@ export function SimpleEditor({
         ...(placeholder ? { "data-placeholder": placeholder } : {}),
       },
       handleClick: (_view, _pos, event) => {
+        if (preventCommentMentionNavigation(event)) return true
         if (!event.metaKey && !event.ctrlKey) return false
         const href = (event.target as HTMLElement | null)
           ?.closest("a")

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -104,7 +104,7 @@ import {
 } from "@/lib/cases/use-case-image-upload"
 import {
   AGENT_MENTION_URI_SCHEME,
-  type CommentMentionLinkSnapshot,
+  type CommentMentionLinkRange,
   findCommentMentionLinkRanges,
   findEditedCommentMentionIndexes,
   preventCommentMentionNavigation,
@@ -640,7 +640,7 @@ export function SimpleEditor({
   const previousEditableRef = React.useRef(editable)
   const imageUploadRef = React.useRef(onImageUpload)
   const editorRef = React.useRef<Editor | null>(null)
-  const commentMentionLinksRef = React.useRef<CommentMentionLinkSnapshot[]>([])
+  const commentMentionLinksRef = React.useRef<CommentMentionLinkRange[]>([])
 
   React.useEffect(() => {
     imageUploadRef.current = onImageUpload
@@ -831,11 +831,17 @@ export function SimpleEditor({
     commentMentionLinksRef.current = findCommentMentionLinkRanges(
       editor.state.doc
     )
-    const handleUpdate = () => {
+    const handleUpdate = ({
+      transaction: updateTransaction,
+    }: {
+      transaction: Transaction
+    }) => {
       const ranges = findCommentMentionLinkRanges(editor.state.doc)
       const editedIndexes = findEditedCommentMentionIndexes(
         commentMentionLinksRef.current,
-        ranges
+        ranges,
+        (position, association) =>
+          updateTransaction.mapping.map(position, association)
       )
       commentMentionLinksRef.current = ranges
       const linkMark = editor.state.schema.marks.link

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.tsx
@@ -111,6 +111,7 @@ import {
   WORKFLOW_MENTION_URI_SCHEME,
 } from "@/lib/tiptap-comment-mentions"
 import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
+import { MarkdownHardBreak } from "@/lib/tiptap-markdown-hard-break"
 import {
   handleImageUpload,
   MAX_FILE_SIZE,
@@ -630,6 +631,7 @@ export function SimpleEditor({
   const extensions = React.useMemo(
     () => [
       StarterKit.configure({
+        hardBreak: false,
         horizontalRule: false,
         codeBlock: false,
         link: {
@@ -642,6 +644,7 @@ export function SimpleEditor({
             defaultValidate(url),
         },
       }),
+      MarkdownHardBreak,
       HorizontalRule,
       MermaidCodeBlock.configure({
         renderWhenBlurred: renderMermaidWhenBlurred,
@@ -708,7 +711,7 @@ export function SimpleEditor({
       },
       handleClick: (_view, _pos, event) => {
         if (allowCommentMentionUris && preventCommentMentionNavigation(event)) {
-          return true
+          return false
         }
         if (!event.metaKey && !event.ctrlKey) return false
         const href = (event.target as HTMLElement | null)

--- a/frontend/src/hooks/use-mentions.ts
+++ b/frontend/src/hooks/use-mentions.ts
@@ -78,6 +78,29 @@ export interface MentionSection {
   items: MentionSuggestion[]
 }
 
+/** The mention query currently active at an editor caret. */
+export interface MentionQuery {
+  kind: MentionKind
+  query: string
+}
+
+interface UseMentionSuggestionsOptions {
+  workspaceId: string
+  activeMention?: MentionQuery
+  agents?: MentionSourceConfig
+  workflows?: MentionSourceConfig
+}
+
+/** Shared suggestion data used by textarea and TipTap mention adapters. */
+export interface MentionSuggestions {
+  agents: MentionSourceState
+  workflows: MentionSourceState
+  sections: MentionSection[]
+  locked: boolean
+  isLoading: boolean
+  hasError: boolean
+}
+
 /**
  * Wiring the hook needs from the composer that owns the textarea. The composer
  * keeps the text in its own form state, so the hook reads and writes it through
@@ -185,41 +208,23 @@ function resolveSourceState(
 }
 
 /**
- * Mentions in a plain `<textarea>` composer: `@`-autocomplete for agent
- * presets, `/`-autocomplete for workflows to run, plus the display-value
- * mapping that turns highlighted display text into the wire value on submit.
+ * Resolve access and suggestions for the mention query at an editor caret.
  *
- * Scopes are intrinsic to a source, so they are checked here: `agent:execute`
- * plus `agent:read` for agents, `workflow:execute` plus `workflow:read` for
- * workflows. Entitlements vary by surface and are passed in per source; a
- * source the caller omits leaves its trigger character as plain text.
- *
- * While the popover is open with no rows to pick — including the locked
- * state — Enter, Tab, and the arrow keys fall through to the textarea so the
- * user can still type a newline or submit.
+ * This deliberately contains no textarea or ProseMirror position handling so
+ * both editor implementations share identical permissions, entitlement, and
+ * filtering behavior.
  */
-export function useMentions({
+export function useMentionSuggestions({
   workspaceId,
-  textareaRef,
-  getText,
-  setText,
+  activeMention,
   agents: agentsConfig,
   workflows: workflowsConfig,
-}: UseMentionsOptions): Mentions {
-  // `agent:read` is required as well as `agent:execute`: the suggestion list
-  // comes from the preset-list endpoint, which is guarded by `agent:read`.
-  // Without it the request 403s and the popover would claim there are no
-  // agents. Mirrors the workspace chat gate.
+}: UseMentionSuggestionsOptions): MentionSuggestions {
   const canUseAgents = useScopeCheck(
     undefined,
     ["agent:execute", "agent:read"],
     { all: true }
   )
-  // `workflow:read` is required as well as `workflow:execute`: the suggestion
-  // list comes from the workflow and folder list endpoints, which are guarded
-  // by `workflow:read`. Without it the requests 403 and the popover would claim
-  // there are no workflows. `workflow:execute` mirrors the API's check on
-  // workflow-backed comments.
   const canExecuteWorkflows = useScopeCheck(
     undefined,
     ["workflow:execute", "workflow:read"],
@@ -245,21 +250,19 @@ export function useMentions({
   )
   const { items: workflowItems, isLoading: workflowsIsLoading } =
     useCommentWorkflows(workspaceId, workflows === "enabled")
-  const [ranges, setRanges] = useState<MentionRange[]>([])
-  const [session, setSession] = useState<ActiveSession | undefined>(undefined)
 
-  let sessionState: MentionSourceState | undefined
-  if (session) {
-    sessionState = session.kind === "agent" ? agents : workflows
+  let activeState: MentionSourceState | undefined
+  if (activeMention) {
+    activeState = activeMention.kind === "agent" ? agents : workflows
   }
-  const locked = sessionState === "locked"
+  const locked = activeState === "locked"
 
   const sections = useMemo<MentionSection[]>(() => {
-    if (!session || sessionState === "locked") {
+    if (!activeMention || activeState === "locked") {
       return []
     }
-    const query = session.query.toLowerCase()
-    if (session.kind === "workflow") {
+    const query = activeMention.query.toLowerCase()
+    if (activeMention.kind === "workflow") {
       const items = workflowItems
         .filter(
           (workflow) =>
@@ -281,10 +284,6 @@ export function useMentions({
       return [{ section: "workflows", label: "Workflows", items }]
     }
     const items = (presets ?? [])
-      // Matched on slug as well as name, the way the workflow rows above match
-      // an alias. The slug is what tells two presets of the same name apart, so
-      // showing it as the hint without letting the query reach it would leave
-      // the duplicate past the result cap with no way to narrow to it.
       .filter(
         (preset) =>
           preset.name.toLowerCase().includes(query) ||
@@ -295,9 +294,6 @@ export function useMentions({
         (preset: AgentPresetReadMinimal): MentionSuggestion => ({
           id: preset.id,
           kind: "agent",
-          // Names are not unique -- only the slug is -- so show it the way the
-          // workflow rows show an alias. Two presets sharing a name would
-          // otherwise render as identical rows bound to different agents.
           hint: preset.slug,
           label: preset.name,
         })
@@ -306,7 +302,59 @@ export function useMentions({
       return []
     }
     return [{ section: "agents", label: "Agents", items }]
-  }, [session, sessionState, presets, workflowItems])
+  }, [activeMention, activeState, presets, workflowItems])
+
+  let isLoading = false
+  if (!locked && activeMention?.kind === "agent") {
+    isLoading = presetsIsLoading
+  } else if (!locked && activeMention?.kind === "workflow") {
+    isLoading = workflowsIsLoading
+  }
+
+  const hasError =
+    !locked && activeMention?.kind === "agent" && Boolean(presetsError)
+
+  return {
+    agents,
+    workflows,
+    sections,
+    locked,
+    isLoading,
+    hasError,
+  }
+}
+
+/**
+ * Mentions in a plain `<textarea>` composer: `@`-autocomplete for agent
+ * presets, `/`-autocomplete for workflows to run, plus the display-value
+ * mapping that turns highlighted display text into the wire value on submit.
+ *
+ * Scopes are intrinsic to a source, so they are checked here: `agent:execute`
+ * plus `agent:read` for agents, `workflow:execute` plus `workflow:read` for
+ * workflows. Entitlements vary by surface and are passed in per source; a
+ * source the caller omits leaves its trigger character as plain text.
+ *
+ * While the popover is open with no rows to pick — including the locked
+ * state — Enter, Tab, and the arrow keys fall through to the textarea so the
+ * user can still type a newline or submit.
+ */
+export function useMentions({
+  workspaceId,
+  textareaRef,
+  getText,
+  setText,
+  agents: agentsConfig,
+  workflows: workflowsConfig,
+}: UseMentionsOptions): Mentions {
+  const [ranges, setRanges] = useState<MentionRange[]>([])
+  const [session, setSession] = useState<ActiveSession | undefined>(undefined)
+  const { agents, workflows, sections, locked, isLoading, hasError } =
+    useMentionSuggestions({
+      workspaceId,
+      activeMention: session,
+      agents: agentsConfig,
+      workflows: workflowsConfig,
+    })
 
   const items = useMemo(
     () => sections.flatMap((section) => section.items),
@@ -317,18 +365,6 @@ export function useMentions({
   const activeIndex = session
     ? Math.min(session.activeIndex, Math.max(items.length - 1, 0))
     : 0
-
-  // A locked source is never fetched, so it reports neither spinner nor error.
-  let isLoading = false
-  if (!locked && session?.kind === "agent") {
-    isLoading = presetsIsLoading
-  } else if (!locked && session?.kind === "workflow") {
-    isLoading = workflowsIsLoading
-  }
-
-  // A failed lookup returns no rows, which would otherwise read as "no agents
-  // found" and hide the fact that the request needs retrying.
-  const hasError = !locked && session?.kind === "agent" && Boolean(presetsError)
 
   // A query may span spaces so a multi-word name can be typed out, but once it
   // matches nothing the user is writing prose after a stray trigger. Release

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -18,6 +18,7 @@ import type { CaretCoordinates } from "@/lib/textarea-caret"
 import {
   buildAgentMentionHref,
   buildWorkflowMentionHref,
+  type CommentMentionLinkRange,
   commentMentionLeafText,
   findCommentMentionLinkRanges,
   nodeAllowsCommentMention,
@@ -70,6 +71,38 @@ function measureCaret(editor: Editor, pos: number): CaretCoordinates {
     left: caret.left - wrapperRect.left,
     height: Math.max(caret.bottom - caret.top, 1),
   }
+}
+
+/** Locate a document link in its Markdown serialization without matching literals. */
+function findMentionMarkdownOffset(
+  editor: Editor,
+  mention: CommentMentionLinkRange
+): number | undefined {
+  const linkMarkType = editor.schema.marks.link
+  const linkMark = editor.state.doc
+    .nodeAt(mention.from)
+    ?.marks.find((mark) => mark.type === linkMarkType)
+  if (!editor.markdown || !linkMarkType || !linkMark) {
+    return undefined
+  }
+
+  const sentinelHref = `https://tracecat.invalid/${crypto.randomUUID()}`
+  const transaction = editor.state.tr
+    .removeMark(mention.from, mention.to, linkMarkType)
+    .addMark(
+      mention.from,
+      mention.to,
+      linkMarkType.create({ ...linkMark.attrs, href: sentinelHref })
+    )
+  const sentinelMarkdown = editor.markdown.serialize(transaction.doc.toJSON())
+  const hrefOffset = sentinelMarkdown.indexOf(sentinelHref)
+  const prefix = `[${mention.text}](`
+  const markerOffset = hrefOffset - prefix.length
+  return hrefOffset !== -1 &&
+    markerOffset >= 0 &&
+    sentinelMarkdown.startsWith(prefix, markerOffset)
+    ? markerOffset
+    : undefined
 }
 
 function deleteMentionBeforeCaret(editor: Editor): boolean {
@@ -293,9 +326,14 @@ export function useTiptapMentions({
   const serialize = useCallback(
     (markdown: string) => {
       const workflowMentions = editor
-        ? findCommentMentionLinkRanges(editor.state.doc).filter((range) =>
-            range.href.startsWith(WORKFLOW_MENTION_URI_SCHEME)
-          )
+        ? findCommentMentionLinkRanges(editor.state.doc)
+            .filter((range) =>
+              range.href.startsWith(WORKFLOW_MENTION_URI_SCHEME)
+            )
+            .map((range) => ({
+              ...range,
+              markdownOffset: findMentionMarkdownOffset(editor, range),
+            }))
         : []
       return serializeTiptapComment(markdown, workflowMentions)
     },

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -292,12 +292,12 @@ export function useTiptapMentions({
 
   const serialize = useCallback(
     (markdown: string) => {
-      const workflowMention = editor
-        ? (findCommentMentionLinkRanges(editor.state.doc).find((range) =>
+      const workflowMentions = editor
+        ? findCommentMentionLinkRanges(editor.state.doc).filter((range) =>
             range.href.startsWith(WORKFLOW_MENTION_URI_SCHEME)
-          ) ?? null)
-        : null
-      return serializeTiptapComment(markdown, workflowMention)
+          )
+        : []
+      return serializeTiptapComment(markdown, workflowMentions)
     },
     [editor]
   )

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -79,30 +79,33 @@ function findMentionMarkdownOffset(
   mention: CommentMentionLinkRange
 ): number | undefined {
   const linkMarkType = editor.schema.marks.link
-  const linkMark = editor.state.doc
-    .nodeAt(mention.from)
-    ?.marks.find((mark) => mark.type === linkMarkType)
-  if (!editor.markdown || !linkMarkType || !linkMark) {
+  const mentionNode = editor.state.doc.nodeAt(mention.from)
+  const linkMark = mentionNode?.marks.find((mark) => mark.type === linkMarkType)
+  if (!editor.markdown || !linkMarkType || !linkMark || !mentionNode?.isText) {
     return undefined
   }
 
-  const sentinelHref = `https://tracecat.invalid/${crypto.randomUUID()}`
-  const transaction = editor.state.tr
-    .removeMark(mention.from, mention.to, linkMarkType)
-    .addMark(
-      mention.from,
-      mention.to,
-      linkMarkType.create({ ...linkMark.attrs, href: sentinelHref })
-    )
+  const sentinelId = crypto.randomUUID()
+  const sentinelText = `tracecatworkflow${sentinelId.replaceAll("-", "")}`
+  const sentinelHref = `https://tracecat.invalid/${sentinelId}`
+  const sentinelMarks = mentionNode.marks.map((mark) =>
+    mark.type === linkMarkType
+      ? linkMarkType.create({ ...mark.attrs, href: sentinelHref })
+      : mark
+  )
+  const transaction = editor.state.tr.replaceWith(
+    mention.from,
+    mention.to,
+    editor.schema.text(sentinelText, sentinelMarks)
+  )
   const sentinelMarkdown = editor.markdown.serialize(transaction.doc.toJSON())
-  const hrefOffset = sentinelMarkdown.indexOf(sentinelHref)
-  const prefix = `[${mention.text}](`
-  const markerOffset = hrefOffset - prefix.length
-  return hrefOffset !== -1 &&
-    markerOffset >= 0 &&
-    sentinelMarkdown.startsWith(prefix, markerOffset)
-    ? markerOffset
-    : undefined
+  const markerOffset = sentinelMarkdown.indexOf(
+    `[${sentinelText}](${sentinelHref})`
+  )
+  if (markerOffset === -1) {
+    return undefined
+  }
+  return markerOffset
 }
 
 function deleteMentionBeforeCaret(editor: Editor): boolean {

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -1,9 +1,8 @@
 "use client"
 
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
 import { TextSelection } from "@tiptap/pm/state"
 import type { Editor } from "@tiptap/react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   type MentionSourceConfig,
   type MentionSourceState,
@@ -19,10 +18,8 @@ import type { CaretCoordinates } from "@/lib/textarea-caret"
 import {
   buildAgentMentionHref,
   buildWorkflowMentionHref,
-  type CommentMentionLinkSnapshot,
   commentMentionLeafText,
-  findEditedCommentMentionIndexes,
-  isCommentMentionHref,
+  findCommentMentionLinkRanges,
   nodeAllowsCommentMention,
   serializeTiptapComment,
   WORKFLOW_MENTION_URI_SCHEME,
@@ -35,13 +32,6 @@ interface TiptapMentionSession {
   kind: MentionKind
   activeIndex: number
   caret: CaretCoordinates
-}
-
-interface MentionLinkRange {
-  from: number
-  to: number
-  href: string
-  text: string
 }
 
 interface UseTiptapMentionsOptions {
@@ -71,34 +61,6 @@ export interface TiptapMentions {
   reset: () => void
 }
 
-function findMentionLinkRanges(doc: ProseMirrorNode): MentionLinkRange[] {
-  const ranges: MentionLinkRange[] = []
-  doc.descendants((node, pos) => {
-    if (!node.isText) {
-      return
-    }
-    const href = node.marks
-      .find((mark) => mark.type.name === "link")
-      ?.attrs.href?.toString()
-    if (!isCommentMentionHref(href)) {
-      return
-    }
-    const previous = ranges.at(-1)
-    if (previous && previous.href === href && previous.to === pos) {
-      previous.to = pos + node.nodeSize
-      previous.text += node.text ?? ""
-      return
-    }
-    ranges.push({
-      from: pos,
-      to: pos + node.nodeSize,
-      href,
-      text: node.text ?? "",
-    })
-  })
-  return ranges
-}
-
 function measureCaret(editor: Editor, pos: number): CaretCoordinates {
   const caret = editor.view.coordsAtPos(pos)
   const wrapper = editor.view.dom.closest(".simple-editor-wrapper")
@@ -115,7 +77,7 @@ function deleteMentionBeforeCaret(editor: Editor): boolean {
   if (!selection.empty) {
     return false
   }
-  const range = findMentionLinkRanges(doc).find(
+  const range = findCommentMentionLinkRanges(doc).find(
     (candidate) => candidate.to === selection.from
   )
   if (!range) {
@@ -144,7 +106,6 @@ export function useTiptapMentions({
   workflows: workflowsConfig,
 }: UseTiptapMentionsOptions): TiptapMentions {
   const [session, setSession] = useState<TiptapMentionSession | undefined>()
-  const mentionLinksRef = useRef<CommentMentionLinkSnapshot[]>([])
   const { agents, workflows, sections, locked, isLoading, hasError } =
     useMentionSuggestions({
       workspaceId,
@@ -197,9 +158,9 @@ export function useTiptapMentions({
     }
     const from = $from.start() + token.start
     const to = $from.start() + token.end
-    const isInsideBoundMention = findMentionLinkRanges(editor.state.doc).some(
-      (range) => from >= range.from && from < range.to
-    )
+    const isInsideBoundMention = findCommentMentionLinkRanges(
+      editor.state.doc
+    ).some((range) => from >= range.from && from < range.to)
     const sourceState = token.kind === "agent" ? agents : workflows
     if (isInsideBoundMention || sourceState === "unavailable") {
       setSession(undefined)
@@ -221,34 +182,7 @@ export function useTiptapMentions({
       setSession(undefined)
       return
     }
-    mentionLinksRef.current = findMentionLinkRanges(editor.state.doc)
-    const handleChange = () => {
-      const ranges = findMentionLinkRanges(editor.state.doc)
-      const editedIndexes = findEditedCommentMentionIndexes(
-        mentionLinksRef.current,
-        ranges
-      )
-      mentionLinksRef.current = ranges
-      if (editedIndexes.length > 0) {
-        const linkMark = editor.state.schema.marks.link
-        if (linkMark) {
-          let transaction = editor.state.tr
-          for (const index of editedIndexes) {
-            const range = ranges[index]
-            if (range) {
-              transaction = transaction.removeMark(
-                range.from,
-                range.to,
-                linkMark
-              )
-            }
-          }
-          editor.view.dispatch(transaction)
-          return
-        }
-      }
-      syncSession()
-    }
+    const handleChange = () => syncSession()
     const handleBlur = () => setSession(undefined)
     editor.on("update", handleChange)
     editor.on("selectionUpdate", handleChange)
@@ -274,7 +208,7 @@ export function useTiptapMentions({
       }
       let transaction = editor.state.tr
       if (suggestion.kind === "workflow") {
-        const existing = findMentionLinkRanges(editor.state.doc)
+        const existing = findCommentMentionLinkRanges(editor.state.doc)
           .filter((range) => range.href.startsWith(WORKFLOW_MENTION_URI_SCHEME))
           .reverse()
         for (const range of existing) {

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -20,6 +20,7 @@ import {
   buildWorkflowMentionHref,
   type CommentMentionLinkRange,
   commentMentionLeafText,
+  expandCommentMentionDeletionRange,
   findCommentMentionLinkRanges,
   nodeAllowsCommentMention,
   serializeTiptapComment,
@@ -246,6 +247,9 @@ export function useTiptapMentions({
       if (suggestion.kind === "workflow") {
         const existing = findCommentMentionLinkRanges(editor.state.doc)
           .filter((range) => range.href.startsWith(WORKFLOW_MENTION_URI_SCHEME))
+          .map((range) =>
+            expandCommentMentionDeletionRange(editor.state.doc, range)
+          )
           .reverse()
         for (const range of existing) {
           transaction = transaction.delete(range.from, range.to)

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -3,7 +3,7 @@
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
 import { TextSelection } from "@tiptap/pm/state"
 import type { Editor } from "@tiptap/react"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   type MentionSourceConfig,
   type MentionSourceState,
@@ -19,8 +19,11 @@ import type { CaretCoordinates } from "@/lib/textarea-caret"
 import {
   buildAgentMentionHref,
   buildWorkflowMentionHref,
+  type CommentMentionLinkSnapshot,
   commentMentionLeafText,
+  findEditedCommentMentionIndexes,
   isCommentMentionHref,
+  nodeAllowsCommentMention,
   serializeTiptapComment,
   WORKFLOW_MENTION_URI_SCHEME,
 } from "@/lib/tiptap-comment-mentions"
@@ -38,6 +41,7 @@ interface MentionLinkRange {
   from: number
   to: number
   href: string
+  text: string
 }
 
 interface UseTiptapMentionsOptions {
@@ -82,9 +86,15 @@ function findMentionLinkRanges(doc: ProseMirrorNode): MentionLinkRange[] {
     const previous = ranges.at(-1)
     if (previous && previous.href === href && previous.to === pos) {
       previous.to = pos + node.nodeSize
+      previous.text += node.text ?? ""
       return
     }
-    ranges.push({ from: pos, to: pos + node.nodeSize, href })
+    ranges.push({
+      from: pos,
+      to: pos + node.nodeSize,
+      href,
+      text: node.text ?? "",
+    })
   })
   return ranges
 }
@@ -134,6 +144,7 @@ export function useTiptapMentions({
   workflows: workflowsConfig,
 }: UseTiptapMentionsOptions): TiptapMentions {
   const [session, setSession] = useState<TiptapMentionSession | undefined>()
+  const mentionLinksRef = useRef<CommentMentionLinkSnapshot[]>([])
   const { agents, workflows, sections, locked, isLoading, hasError } =
     useMentionSuggestions({
       workspaceId,
@@ -165,7 +176,11 @@ export function useTiptapMentions({
       return
     }
     const { $from } = editor.state.selection
-    if (!$from.parent.isTextblock) {
+    const linkMark = editor.state.schema.marks.link
+    if (
+      !$from.parent.isTextblock ||
+      !nodeAllowsCommentMention($from.parent, linkMark)
+    ) {
       setSession(undefined)
       return
     }
@@ -206,7 +221,34 @@ export function useTiptapMentions({
       setSession(undefined)
       return
     }
-    const handleChange = () => syncSession()
+    mentionLinksRef.current = findMentionLinkRanges(editor.state.doc)
+    const handleChange = () => {
+      const ranges = findMentionLinkRanges(editor.state.doc)
+      const editedIndexes = findEditedCommentMentionIndexes(
+        mentionLinksRef.current,
+        ranges
+      )
+      mentionLinksRef.current = ranges
+      if (editedIndexes.length > 0) {
+        const linkMark = editor.state.schema.marks.link
+        if (linkMark) {
+          let transaction = editor.state.tr
+          for (const index of editedIndexes) {
+            const range = ranges[index]
+            if (range) {
+              transaction = transaction.removeMark(
+                range.from,
+                range.to,
+                linkMark
+              )
+            }
+          }
+          editor.view.dispatch(transaction)
+          return
+        }
+      }
+      syncSession()
+    }
     const handleBlur = () => setSession(undefined)
     editor.on("update", handleChange)
     editor.on("selectionUpdate", handleChange)

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -19,6 +19,7 @@ import type { CaretCoordinates } from "@/lib/textarea-caret"
 import {
   buildAgentMentionHref,
   buildWorkflowMentionHref,
+  commentMentionLeafText,
   isCommentMentionHref,
   serializeTiptapComment,
   WORKFLOW_MENTION_URI_SCHEME,
@@ -168,7 +169,12 @@ export function useTiptapMentions({
       setSession(undefined)
       return
     }
-    const text = $from.parent.textBetween(0, $from.parentOffset, "\n", "\ufffc")
+    const text = $from.parent.textBetween(
+      0,
+      $from.parentOffset,
+      "\n",
+      commentMentionLeafText
+    )
     const token = getMentionToken(text, text.length)
     if (!token) {
       setSession(undefined)

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -1,0 +1,329 @@
+"use client"
+
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+import { TextSelection } from "@tiptap/pm/state"
+import type { Editor } from "@tiptap/react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  type MentionSourceConfig,
+  type MentionSourceState,
+  type MentionSuggestion,
+  useMentionSuggestions,
+} from "@/hooks/use-mentions"
+import {
+  getMentionToken,
+  type MentionKind,
+  mentionDisplayText,
+} from "@/lib/mentions"
+import type { CaretCoordinates } from "@/lib/textarea-caret"
+import {
+  buildAgentMentionHref,
+  buildWorkflowMentionHref,
+  isCommentMentionHref,
+  serializeTiptapComment,
+  WORKFLOW_MENTION_URI_SCHEME,
+} from "@/lib/tiptap-comment-mentions"
+
+interface TiptapMentionSession {
+  from: number
+  to: number
+  query: string
+  kind: MentionKind
+  activeIndex: number
+  caret: CaretCoordinates
+}
+
+interface MentionLinkRange {
+  from: number
+  to: number
+  href: string
+}
+
+interface UseTiptapMentionsOptions {
+  editor: Editor | null
+  workspaceId: string
+  agents?: MentionSourceConfig
+  workflows?: MentionSourceConfig
+}
+
+/** Mention behavior exposed to a TipTap comment composer. */
+export interface TiptapMentions {
+  agents: MentionSourceState
+  workflows: MentionSourceState
+  isOpen: boolean
+  locked: boolean
+  kind: MentionKind | undefined
+  sections: ReturnType<typeof useMentionSuggestions>["sections"]
+  itemCount: number
+  activeIndex: number
+  caret: CaretCoordinates | undefined
+  isLoading: boolean
+  hasError: boolean
+  selectSuggestion: (suggestion: MentionSuggestion) => void
+  dismiss: () => void
+  handleKeyDown: (event: KeyboardEvent) => boolean
+  serialize: typeof serializeTiptapComment
+  reset: () => void
+}
+
+function findMentionLinkRanges(doc: ProseMirrorNode): MentionLinkRange[] {
+  const ranges: MentionLinkRange[] = []
+  doc.descendants((node, pos) => {
+    if (!node.isText) {
+      return
+    }
+    const href = node.marks
+      .find((mark) => mark.type.name === "link")
+      ?.attrs.href?.toString()
+    if (!isCommentMentionHref(href)) {
+      return
+    }
+    const previous = ranges.at(-1)
+    if (previous && previous.href === href && previous.to === pos) {
+      previous.to = pos + node.nodeSize
+      return
+    }
+    ranges.push({ from: pos, to: pos + node.nodeSize, href })
+  })
+  return ranges
+}
+
+function measureCaret(editor: Editor, pos: number): CaretCoordinates {
+  const caret = editor.view.coordsAtPos(pos)
+  const wrapper = editor.view.dom.closest(".simple-editor-wrapper")
+  const wrapperRect = (wrapper ?? editor.view.dom).getBoundingClientRect()
+  return {
+    top: caret.top - wrapperRect.top,
+    left: caret.left - wrapperRect.left,
+    height: Math.max(caret.bottom - caret.top, 1),
+  }
+}
+
+function deleteMentionBeforeCaret(editor: Editor): boolean {
+  const { selection, doc } = editor.state
+  if (!selection.empty) {
+    return false
+  }
+  const range = findMentionLinkRanges(doc).find(
+    (candidate) => candidate.to === selection.from
+  )
+  if (!range) {
+    return false
+  }
+  let transaction = editor.state.tr.delete(range.from, range.to)
+  transaction = transaction.setSelection(
+    TextSelection.create(transaction.doc, range.from)
+  )
+  editor.view.dispatch(transaction)
+  editor.view.focus()
+  return true
+}
+
+/**
+ * TipTap-native adapter for the existing agent/workflow comment mentions.
+ *
+ * Selected agents are link marks whose Markdown is the existing persisted
+ * `mention://agent/...` token. Selected workflows use a transient link scheme
+ * that is removed by `serialize` and returned as the API's `workflow_id`.
+ */
+export function useTiptapMentions({
+  editor,
+  workspaceId,
+  agents: agentsConfig,
+  workflows: workflowsConfig,
+}: UseTiptapMentionsOptions): TiptapMentions {
+  const [session, setSession] = useState<TiptapMentionSession | undefined>()
+  const { agents, workflows, sections, locked, isLoading, hasError } =
+    useMentionSuggestions({
+      workspaceId,
+      activeMention: session,
+      agents: agentsConfig,
+      workflows: workflowsConfig,
+    })
+  const items = useMemo(
+    () => sections.flatMap((section) => section.items),
+    [sections]
+  )
+  const activeIndex = session
+    ? Math.min(session.activeIndex, Math.max(items.length - 1, 0))
+    : 0
+  const abandoned =
+    session !== undefined &&
+    !locked &&
+    !hasError &&
+    !isLoading &&
+    /\s/.test(session.query) &&
+    items.length === 0
+  const isOpen = session !== undefined && !abandoned
+
+  const dismiss = useCallback(() => setSession(undefined), [])
+
+  const syncSession = useCallback(() => {
+    if (!editor?.isFocused || !editor.state.selection.empty) {
+      setSession(undefined)
+      return
+    }
+    const { $from } = editor.state.selection
+    if (!$from.parent.isTextblock) {
+      setSession(undefined)
+      return
+    }
+    const text = $from.parent.textBetween(0, $from.parentOffset, "\n", "\ufffc")
+    const token = getMentionToken(text, text.length)
+    if (!token) {
+      setSession(undefined)
+      return
+    }
+    const from = $from.start() + token.start
+    const to = $from.start() + token.end
+    const isInsideBoundMention = findMentionLinkRanges(editor.state.doc).some(
+      (range) => from >= range.from && from < range.to
+    )
+    const sourceState = token.kind === "agent" ? agents : workflows
+    if (isInsideBoundMention || sourceState === "unavailable") {
+      setSession(undefined)
+      return
+    }
+    setSession((current) => ({
+      from,
+      to,
+      query: token.query,
+      kind: token.kind,
+      activeIndex: current?.from === from ? current.activeIndex : 0,
+      caret:
+        current?.from === from ? current.caret : measureCaret(editor, from),
+    }))
+  }, [agents, editor, workflows])
+
+  useEffect(() => {
+    if (!editor) {
+      setSession(undefined)
+      return
+    }
+    const handleChange = () => syncSession()
+    const handleBlur = () => setSession(undefined)
+    editor.on("update", handleChange)
+    editor.on("selectionUpdate", handleChange)
+    editor.on("focus", handleChange)
+    editor.on("blur", handleBlur)
+    syncSession()
+    return () => {
+      editor.off("update", handleChange)
+      editor.off("selectionUpdate", handleChange)
+      editor.off("focus", handleChange)
+      editor.off("blur", handleBlur)
+    }
+  }, [editor, syncSession])
+
+  const selectSuggestion = useCallback(
+    (suggestion: MentionSuggestion) => {
+      if (!editor || !session) {
+        return
+      }
+      const link = editor.state.schema.marks.link
+      if (!link) {
+        return
+      }
+      let transaction = editor.state.tr
+      if (suggestion.kind === "workflow") {
+        const existing = findMentionLinkRanges(editor.state.doc)
+          .filter((range) => range.href.startsWith(WORKFLOW_MENTION_URI_SCHEME))
+          .reverse()
+        for (const range of existing) {
+          transaction = transaction.delete(range.from, range.to)
+        }
+      }
+      const from = transaction.mapping.map(session.from)
+      const to = transaction.mapping.map(session.to)
+      const href =
+        suggestion.kind === "agent"
+          ? buildAgentMentionHref(suggestion.id)
+          : buildWorkflowMentionHref(suggestion.id)
+      const display = mentionDisplayText(suggestion.kind, suggestion.label)
+      const mentionText = editor.state.schema.text(display, [
+        link.create({ href }),
+      ])
+      transaction = transaction.replaceWith(from, to, mentionText)
+      const cursor = from + mentionText.nodeSize
+      transaction = transaction
+        // Insert a genuinely unmarked spacer. `insertText` inherits the link
+        // mark at the mention boundary and would serialize the label as
+        // `[@Agent ](...)`, changing the existing wire token.
+        .insert(cursor, editor.state.schema.text(" "))
+        .setSelection(TextSelection.create(transaction.doc, cursor + 1))
+        .setStoredMarks([])
+      setSession(undefined)
+      editor.view.dispatch(transaction)
+      editor.view.focus()
+    },
+    [editor, session]
+  )
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent): boolean => {
+      if (event.isComposing) {
+        return false
+      }
+      if (isOpen) {
+        if (event.key === "Escape") {
+          event.preventDefault()
+          setSession(undefined)
+          return true
+        }
+        if (items.length > 0) {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault()
+            const step = event.key === "ArrowDown" ? 1 : items.length - 1
+            setSession((current) =>
+              current
+                ? {
+                    ...current,
+                    activeIndex: (activeIndex + step) % items.length,
+                  }
+                : current
+            )
+            return true
+          }
+          if (
+            event.key === "Enter" ||
+            (event.key === "Tab" && !event.shiftKey)
+          ) {
+            event.preventDefault()
+            const selected = items[activeIndex]
+            if (selected) {
+              selectSuggestion(selected)
+            }
+            return true
+          }
+        }
+      }
+      if (event.key === "Backspace" && editor) {
+        if (deleteMentionBeforeCaret(editor)) {
+          event.preventDefault()
+          return true
+        }
+      }
+      return false
+    },
+    [activeIndex, editor, isOpen, items, selectSuggestion]
+  )
+
+  return {
+    agents,
+    workflows,
+    isOpen,
+    locked,
+    kind: session?.kind,
+    sections,
+    itemCount: items.length,
+    activeIndex,
+    caret: session?.caret,
+    isLoading,
+    hasError,
+    selectSuggestion,
+    dismiss,
+    handleKeyDown,
+    serialize: serializeTiptapComment,
+    reset: dismiss,
+  }
+}

--- a/frontend/src/hooks/use-tiptap-mentions.ts
+++ b/frontend/src/hooks/use-tiptap-mentions.ts
@@ -57,7 +57,7 @@ export interface TiptapMentions {
   selectSuggestion: (suggestion: MentionSuggestion) => void
   dismiss: () => void
   handleKeyDown: (event: KeyboardEvent) => boolean
-  serialize: typeof serializeTiptapComment
+  serialize: (markdown: string) => ReturnType<typeof serializeTiptapComment>
   reset: () => void
 }
 
@@ -290,6 +290,18 @@ export function useTiptapMentions({
     [activeIndex, editor, isOpen, items, selectSuggestion]
   )
 
+  const serialize = useCallback(
+    (markdown: string) => {
+      const workflowMention = editor
+        ? (findCommentMentionLinkRanges(editor.state.doc).find((range) =>
+            range.href.startsWith(WORKFLOW_MENTION_URI_SCHEME)
+          ) ?? null)
+        : null
+      return serializeTiptapComment(markdown, workflowMention)
+    },
+    [editor]
+  )
+
   return {
     agents,
     workflows,
@@ -305,7 +317,7 @@ export function useTiptapMentions({
     selectSuggestion,
     dismiss,
     handleKeyDown,
-    serialize: serializeTiptapComment,
+    serialize,
     reset: dismiss,
   }
 }

--- a/frontend/src/lib/cases/use-case-image-upload.ts
+++ b/frontend/src/lib/cases/use-case-image-upload.ts
@@ -106,10 +106,10 @@ export function createPastedImageFile(blob: Blob): File {
 /**
  * Upload case images as attachments and produce stable markdown references.
  *
- * Used by both the description editor (TipTap) and the comment composers
- * (plain textareas) so paste/drop behaviour stays consistent. On success the
- * case attachments list and activity queries are invalidated; on failure a
- * descriptive toast is shown and the error is rethrown for the caller.
+ * Used by both the description and comment TipTap editors so paste/drop
+ * behaviour stays consistent. On success the case attachments list and
+ * activity queries are invalidated; on failure a descriptive toast is shown
+ * and the error is rethrown for the caller.
  *
  * @param caseId - The case to attach images to.
  * @param workspaceId - The workspace that owns the case.

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -79,6 +79,22 @@ describe("TipTap comment mention serialization", () => {
     ).toEqual({ content: "Before after", workflowId })
   })
 
+  it("handles raw closing brackets in TipTap workflow labels", () => {
+    expect(
+      serializeTiptapComment(
+        `Before [/Review ] alert](${buildWorkflowMentionHref(workflowId)}) after`
+      )
+    ).toEqual({ content: "Before after", workflowId })
+  })
+
+  it("does not consume an earlier bracketed slash literal", () => {
+    expect(
+      serializeTiptapComment(
+        `Keep [/literal] before [/Review ] alert](${buildWorkflowMentionHref(workflowId)}) after`
+      )
+    ).toEqual({ content: "Keep [/literal] before after", workflowId })
+  })
+
   it("does not change ordinary links or text containing slash commands", () => {
     const markdown = "Run /Enrich or read [the docs](https://example.com)"
     expect(serializeTiptapComment(markdown)).toEqual({
@@ -288,6 +304,25 @@ describe("TipTap comment mention serialization", () => {
         [{ ...workflowMention, text: "/Enrich" }]
       )
     ).toEqual([0])
+  })
+
+  it("preserves a duplicate target with an unchanged historical label", () => {
+    const href = buildAgentMentionHref("agent-id")
+    const currentMention = {
+      href,
+      text: "@Current agent name",
+      hasFormatting: false,
+    }
+
+    expect(
+      findEditedCommentMentionIndexes(
+        [
+          { href, text: "@Historical agent name", hasFormatting: false },
+          currentMention,
+        ],
+        [currentMention]
+      )
+    ).toEqual([])
   })
 
   it("does not treat inserted or replaced mentions as label edits", () => {

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -244,6 +244,32 @@ describe("TipTap comment mention serialization", () => {
     ).toEqual([0])
   })
 
+  it("detects every range when a line break splits a mention link", () => {
+    const href = buildAgentMentionHref("agent-id")
+
+    expect(
+      findEditedCommentMentionIndexes(
+        [{ href, text: "@Triage agent", hasFormatting: false }],
+        [
+          { href, text: "@Triage", hasFormatting: false },
+          { href, text: " agent", hasFormatting: false },
+        ]
+      )
+    ).toEqual([0, 1])
+  })
+
+  it("does not treat an additional intact mention as a split", () => {
+    const mention = {
+      href: buildAgentMentionHref("agent-id"),
+      text: "@Triage agent",
+      hasFormatting: false,
+    }
+
+    expect(
+      findEditedCommentMentionIndexes([mention], [mention, mention])
+    ).toEqual([])
+  })
+
   it("does not treat inserted or replaced mentions as label edits", () => {
     expect(
       findEditedCommentMentionIndexes(

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -4,7 +4,9 @@ import {
   buildAgentMentionHref,
   buildWorkflowMentionHref,
   commentMentionLeafText,
+  findEditedCommentMentionIndexes,
   isCommentMentionHref,
+  nodeAllowsCommentMention,
   preventCommentMentionNavigation,
   serializeTiptapComment,
 } from "@/lib/tiptap-comment-mentions"
@@ -148,5 +150,53 @@ describe("TipTap comment mention serialization", () => {
         commentMentionLeafText
       )
     ).toBe("First line\n@triage")
+  })
+
+  it("recognizes text blocks that can carry mention links", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { content: "inline*", group: "block" },
+        codeBlock: {
+          content: "text*",
+          group: "block",
+          marks: "",
+          code: true,
+        },
+        text: { group: "inline" },
+      },
+      marks: { link: { attrs: { href: {} } } },
+    })
+
+    expect(
+      nodeAllowsCommentMention(schema.node("paragraph"), schema.marks.link)
+    ).toBe(true)
+    expect(
+      nodeAllowsCommentMention(schema.node("codeBlock"), schema.marks.link)
+    ).toBe(false)
+  })
+
+  it("detects a selected mention whose visible label was edited", () => {
+    expect(
+      findEditedCommentMentionIndexes(
+        [{ href: buildAgentMentionHref("agent-id"), text: "@Triage agent" }],
+        [{ href: buildAgentMentionHref("agent-id"), text: "@Triage agnt" }]
+      )
+    ).toEqual([0])
+  })
+
+  it("does not treat inserted or replaced mentions as label edits", () => {
+    expect(
+      findEditedCommentMentionIndexes(
+        [],
+        [{ href: buildAgentMentionHref("agent-id"), text: "@Triage agent" }]
+      )
+    ).toEqual([])
+    expect(
+      findEditedCommentMentionIndexes(
+        [{ href: buildAgentMentionHref("old-agent"), text: "@Old agent" }],
+        [{ href: buildAgentMentionHref("new-agent"), text: "@New agent" }]
+      )
+    ).toEqual([])
   })
 })

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -14,12 +14,15 @@ import {
 
 describe("TipTap comment mention serialization", () => {
   const workflowId = "11111111-1111-4111-8111-111111111111"
+  function workflowMention(text: string) {
+    return { href: buildWorkflowMentionHref(workflowId), text }
+  }
 
   it("keeps the existing agent mention wire format intact", () => {
     const agentId = "22222222-2222-4222-8222-222222222222"
     const markdown = `Ask [@Response agent](${buildAgentMentionHref(agentId)}) for help`
 
-    expect(serializeTiptapComment(markdown)).toEqual({
+    expect(serializeTiptapComment(markdown, null)).toEqual({
       content: markdown,
       workflowId: null,
     })
@@ -31,7 +34,8 @@ describe("TipTap comment mention serialization", () => {
   it("removes a workflow marker and returns its request id", () => {
     expect(
       serializeTiptapComment(
-        `[/Enrich case](${buildWorkflowMentionHref(workflowId)}) investigate this`
+        `[/Enrich case](${buildWorkflowMentionHref(workflowId)}) investigate this`,
+        workflowMention("/Enrich case")
       )
     ).toEqual({
       content: "investigate this",
@@ -42,7 +46,8 @@ describe("TipTap comment mention serialization", () => {
   it("allows a bare workflow command to produce an empty body", () => {
     expect(
       serializeTiptapComment(
-        `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`
+        `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`,
+        workflowMention("/Enrich case")
       )
     ).toEqual({ content: "", workflowId })
   })
@@ -56,7 +61,12 @@ describe("TipTap comment mention serialization", () => {
   ])("removes an empty %s around a workflow marker", (_label, template) => {
     const marker = `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`
 
-    expect(serializeTiptapComment(template.replace("%s", marker))).toEqual({
+    expect(
+      serializeTiptapComment(
+        template.replace("%s", marker),
+        workflowMention("/Enrich case")
+      )
+    ).toEqual({
       content: "",
       workflowId,
     })
@@ -65,16 +75,19 @@ describe("TipTap comment mention serialization", () => {
   it("preserves a rich-text container when it has other content", () => {
     const marker = `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`
 
-    expect(serializeTiptapComment(`- ${marker} investigate this`)).toEqual({
-      content: "- investigate this",
-      workflowId,
-    })
+    expect(
+      serializeTiptapComment(
+        `- ${marker} investigate this`,
+        workflowMention("/Enrich case")
+      )
+    ).toEqual({ content: "- investigate this", workflowId })
   })
 
   it("handles escaped closing brackets in workflow labels", () => {
     expect(
       serializeTiptapComment(
-        `Before [/Enrich \\] case](${buildWorkflowMentionHref(workflowId)}) after`
+        `Before [/Enrich \\] case](${buildWorkflowMentionHref(workflowId)}) after`,
+        workflowMention("/Enrich \\] case")
       )
     ).toEqual({ content: "Before after", workflowId })
   })
@@ -82,7 +95,8 @@ describe("TipTap comment mention serialization", () => {
   it("handles raw closing brackets in TipTap workflow labels", () => {
     expect(
       serializeTiptapComment(
-        `Before [/Review ] alert](${buildWorkflowMentionHref(workflowId)}) after`
+        `Before [/Review ] alert](${buildWorkflowMentionHref(workflowId)}) after`,
+        workflowMention("/Review ] alert")
       )
     ).toEqual({ content: "Before after", workflowId })
   })
@@ -90,14 +104,24 @@ describe("TipTap comment mention serialization", () => {
   it("does not consume an earlier bracketed slash literal", () => {
     expect(
       serializeTiptapComment(
-        `Keep [/literal] before [/Review ] alert](${buildWorkflowMentionHref(workflowId)}) after`
+        `Keep [/literal] before [/Review ] alert](${buildWorkflowMentionHref(workflowId)}) after`,
+        workflowMention("/Review ] alert")
       )
     ).toEqual({ content: "Keep [/literal] before after", workflowId })
   })
 
+  it("handles nested slash brackets in a workflow title", () => {
+    expect(
+      serializeTiptapComment(
+        `Before [/Review [/ alert](${buildWorkflowMentionHref(workflowId)}) after`,
+        workflowMention("/Review [/ alert")
+      )
+    ).toEqual({ content: "Before after", workflowId })
+  })
+
   it("does not change ordinary links or text containing slash commands", () => {
     const markdown = "Run /Enrich or read [the docs](https://example.com)"
-    expect(serializeTiptapComment(markdown)).toEqual({
+    expect(serializeTiptapComment(markdown, null)).toEqual({
       content: markdown,
       workflowId: null,
     })

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -110,6 +110,21 @@ describe("TipTap comment mention serialization", () => {
     ).toEqual({ content: "Keep [/literal] before after", workflowId })
   })
 
+  it("does not consume an identical marker inside a fenced code block", () => {
+    const marker = `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`
+    const markdown = `\`\`\`md\n${marker}\n\`\`\`\n${marker} investigate this`
+    const mention = workflowMention("/Enrich case")[0]
+
+    expect(
+      serializeTiptapComment(markdown, [
+        { ...mention, markdownOffset: markdown.lastIndexOf(marker) },
+      ])
+    ).toEqual({
+      content: `\`\`\`md\n${marker}\n\`\`\`\ninvestigate this`,
+      workflowId,
+    })
+  })
+
   it("handles nested slash brackets in a workflow title", () => {
     expect(
       serializeTiptapComment(

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -4,6 +4,7 @@ import {
   buildAgentMentionHref,
   buildWorkflowMentionHref,
   commentMentionLeafText,
+  findCommentMentionLinkRanges,
   findEditedCommentMentionIndexes,
   isCommentMentionHref,
   nodeAllowsCommentMention,
@@ -176,11 +177,69 @@ describe("TipTap comment mention serialization", () => {
     ).toBe(false)
   })
 
+  it("marks mention links that carry additional formatting", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { content: "inline*", group: "block" },
+        text: { group: "inline" },
+      },
+      marks: {
+        link: { attrs: { href: {} } },
+        strong: {},
+      },
+    })
+    const href = buildAgentMentionHref("agent-id")
+    const paragraph = schema.node("paragraph", null, [
+      schema.text("@Triage agent", [
+        schema.mark("link", { href }),
+        schema.mark("strong"),
+      ]),
+    ])
+    const doc = schema.node("doc", null, [paragraph])
+
+    expect(findCommentMentionLinkRanges(doc)).toEqual([
+      {
+        from: 1,
+        to: 14,
+        href,
+        text: "@Triage agent",
+        hasFormatting: true,
+      },
+    ])
+  })
+
   it("detects a selected mention whose visible label was edited", () => {
     expect(
       findEditedCommentMentionIndexes(
-        [{ href: buildAgentMentionHref("agent-id"), text: "@Triage agent" }],
-        [{ href: buildAgentMentionHref("agent-id"), text: "@Triage agnt" }]
+        [
+          {
+            href: buildAgentMentionHref("agent-id"),
+            text: "@Triage agent",
+            hasFormatting: false,
+          },
+        ],
+        [
+          {
+            href: buildAgentMentionHref("agent-id"),
+            text: "@Triage agnt",
+            hasFormatting: false,
+          },
+        ]
+      )
+    ).toEqual([0])
+  })
+
+  it("detects a mention with an additional formatting mark", () => {
+    const mention = {
+      href: buildAgentMentionHref("agent-id"),
+      text: "@Triage agent",
+    }
+
+    expect(
+      findEditedCommentMentionIndexes(
+        [{ ...mention, hasFormatting: false }],
+        [{ ...mention, hasFormatting: true }]
       )
     ).toEqual([0])
   })
@@ -189,13 +248,31 @@ describe("TipTap comment mention serialization", () => {
     expect(
       findEditedCommentMentionIndexes(
         [],
-        [{ href: buildAgentMentionHref("agent-id"), text: "@Triage agent" }]
+        [
+          {
+            href: buildAgentMentionHref("agent-id"),
+            text: "@Triage agent",
+            hasFormatting: false,
+          },
+        ]
       )
     ).toEqual([])
     expect(
       findEditedCommentMentionIndexes(
-        [{ href: buildAgentMentionHref("old-agent"), text: "@Old agent" }],
-        [{ href: buildAgentMentionHref("new-agent"), text: "@New agent" }]
+        [
+          {
+            href: buildAgentMentionHref("old-agent"),
+            text: "@Old agent",
+            hasFormatting: false,
+          },
+        ],
+        [
+          {
+            href: buildAgentMentionHref("new-agent"),
+            text: "@New agent",
+            hasFormatting: false,
+          },
+        ]
       )
     ).toEqual([])
   })

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -1,9 +1,11 @@
 import { Schema } from "@tiptap/pm/model"
+import { EditorState } from "@tiptap/pm/state"
 import {
   AGENT_MENTION_URI_SCHEME,
   buildAgentMentionHref,
   buildWorkflowMentionHref,
   commentMentionLeafText,
+  expandCommentMentionDeletionRange,
   findCommentMentionLinkRanges,
   findEditedCommentMentionIndexes,
   isCommentMentionHref,
@@ -287,6 +289,43 @@ describe("TipTap comment mention serialization", () => {
         formatting: '13:[{"type":"strong"}]',
       },
     ])
+  })
+
+  it("expands a sole workflow mention deletion to its list item", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { group: "block", content: "inline*" },
+        bulletList: { group: "block", content: "listItem+" },
+        listItem: { content: "paragraph block*" },
+        text: { group: "inline" },
+      },
+      marks: { link: { attrs: { href: {} } } },
+    })
+    const href = buildWorkflowMentionHref("workflow-id")
+    const link = schema.mark("link", { href })
+    const doc = schema.node("doc", null, [
+      schema.node("bulletList", null, [
+        schema.node("listItem", null, [
+          schema.node("paragraph", null, [schema.text("Keep this item")]),
+        ]),
+        schema.node("listItem", null, [
+          schema.node("paragraph", null, [schema.text("/Replace me", [link])]),
+        ]),
+      ]),
+    ])
+    const mention = findCommentMentionLinkRanges(doc)[0]
+    if (!mention) {
+      throw new Error("Expected the workflow mention range")
+    }
+    const deletion = expandCommentMentionDeletionRange(doc, mention)
+    const nextDoc = EditorState.create({ doc }).tr.delete(
+      deletion.from,
+      deletion.to
+    ).doc
+
+    expect(nextDoc.textContent).toBe("Keep this item")
+    expect(nextDoc.firstChild?.childCount).toBe(1)
   })
 
   it("detects a selected mention whose visible label was edited", () => {

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -1,7 +1,9 @@
+import { Schema } from "@tiptap/pm/model"
 import {
   AGENT_MENTION_URI_SCHEME,
   buildAgentMentionHref,
   buildWorkflowMentionHref,
+  commentMentionLeafText,
   isCommentMentionHref,
   preventCommentMentionNavigation,
   serializeTiptapComment,
@@ -40,6 +42,30 @@ describe("TipTap comment mention serialization", () => {
         `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`
       )
     ).toEqual({ content: "", workflowId })
+  })
+
+  it.each([
+    ["bullet item", "- %s"],
+    ["task item", "- [ ] %s"],
+    ["block quote", "> %s"],
+    ["heading", "### %s"],
+    ["strong text", "**%s**"],
+  ])("removes an empty %s around a workflow marker", (_label, template) => {
+    const marker = `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`
+
+    expect(serializeTiptapComment(template.replace("%s", marker))).toEqual({
+      content: "",
+      workflowId,
+    })
+  })
+
+  it("preserves a rich-text container when it has other content", () => {
+    const marker = `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`
+
+    expect(serializeTiptapComment(`- ${marker} investigate this`)).toEqual({
+      content: "- investigate this",
+      workflowId,
+    })
   })
 
   it("handles escaped closing brackets in workflow labels", () => {
@@ -97,5 +123,30 @@ describe("TipTap comment mention serialization", () => {
       } as unknown as MouseEvent)
     ).toBe(false)
     expect(preventDefault).not.toHaveBeenCalled()
+  })
+
+  it("treats a hard break as whitespace when scanning for mentions", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { content: "inline*", group: "block" },
+        text: { group: "inline" },
+        hardBreak: { inline: true, group: "inline" },
+      },
+    })
+    const paragraph = schema.node("paragraph", null, [
+      schema.text("First line"),
+      schema.node("hardBreak"),
+      schema.text("@triage"),
+    ])
+
+    expect(
+      paragraph.textBetween(
+        0,
+        paragraph.content.size,
+        "\n",
+        commentMentionLeafText
+      )
+    ).toBe("First line\n@triage")
   })
 })

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -1,0 +1,67 @@
+import {
+  AGENT_MENTION_URI_SCHEME,
+  buildAgentMentionHref,
+  buildWorkflowMentionHref,
+  isCommentMentionHref,
+  serializeTiptapComment,
+} from "@/lib/tiptap-comment-mentions"
+
+describe("TipTap comment mention serialization", () => {
+  const workflowId = "11111111-1111-4111-8111-111111111111"
+
+  it("keeps the existing agent mention wire format intact", () => {
+    const agentId = "22222222-2222-4222-8222-222222222222"
+    const markdown = `Ask [@Response agent](${buildAgentMentionHref(agentId)}) for help`
+
+    expect(serializeTiptapComment(markdown)).toEqual({
+      content: markdown,
+      workflowId: null,
+    })
+    expect(buildAgentMentionHref(agentId)).toBe(
+      `${AGENT_MENTION_URI_SCHEME}${agentId}`
+    )
+  })
+
+  it("removes a workflow marker and returns its request id", () => {
+    expect(
+      serializeTiptapComment(
+        `[/Enrich case](${buildWorkflowMentionHref(workflowId)}) investigate this`
+      )
+    ).toEqual({
+      content: "investigate this",
+      workflowId,
+    })
+  })
+
+  it("allows a bare workflow command to produce an empty body", () => {
+    expect(
+      serializeTiptapComment(
+        `[/Enrich case](${buildWorkflowMentionHref(workflowId)})`
+      )
+    ).toEqual({ content: "", workflowId })
+  })
+
+  it("handles escaped closing brackets in workflow labels", () => {
+    expect(
+      serializeTiptapComment(
+        `Before [/Enrich \\] case](${buildWorkflowMentionHref(workflowId)}) after`
+      )
+    ).toEqual({ content: "Before after", workflowId })
+  })
+
+  it("does not change ordinary links or text containing slash commands", () => {
+    const markdown = "Run /Enrich or read [the docs](https://example.com)"
+    expect(serializeTiptapComment(markdown)).toEqual({
+      content: markdown,
+      workflowId: null,
+    })
+  })
+
+  it("recognizes only the two internal mention link schemes", () => {
+    expect(isCommentMentionHref(buildAgentMentionHref("agent-id"))).toBe(true)
+    expect(isCommentMentionHref(buildWorkflowMentionHref("workflow-id"))).toBe(
+      true
+    )
+    expect(isCommentMentionHref("https://example.com")).toBe(false)
+  })
+})

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -270,6 +270,26 @@ describe("TipTap comment mention serialization", () => {
     ).toEqual([])
   })
 
+  it("matches an edited mention after a different mention is removed", () => {
+    const agentMention = {
+      href: buildAgentMentionHref("agent-id"),
+      text: "@Triage agent",
+      hasFormatting: false,
+    }
+    const workflowMention = {
+      href: buildWorkflowMentionHref("workflow-id"),
+      text: "/Enrich case",
+      hasFormatting: false,
+    }
+
+    expect(
+      findEditedCommentMentionIndexes(
+        [agentMention, workflowMention],
+        [{ ...workflowMention, text: "/Enrich" }]
+      )
+    ).toEqual([0])
+  })
+
   it("does not treat inserted or replaced mentions as label edits", () => {
     expect(
       findEditedCommentMentionIndexes(

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -3,6 +3,7 @@ import {
   buildAgentMentionHref,
   buildWorkflowMentionHref,
   isCommentMentionHref,
+  preventCommentMentionNavigation,
   serializeTiptapComment,
 } from "@/lib/tiptap-comment-mentions"
 
@@ -63,5 +64,38 @@ describe("TipTap comment mention serialization", () => {
       true
     )
     expect(isCommentMentionHref("https://example.com")).toBe(false)
+  })
+
+  it.each([
+    buildAgentMentionHref("agent-id"),
+    buildWorkflowMentionHref("workflow-id"),
+  ])("prevents native navigation for %s links", (href) => {
+    const anchor = document.createElement("a")
+    const label = document.createElement("span")
+    anchor.href = href
+    anchor.append(label)
+    const preventDefault = jest.fn()
+
+    expect(
+      preventCommentMentionNavigation({
+        target: label,
+        preventDefault,
+      } as unknown as MouseEvent)
+    ).toBe(true)
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not intercept ordinary links", () => {
+    const anchor = document.createElement("a")
+    anchor.href = "https://example.com"
+    const preventDefault = jest.fn()
+
+    expect(
+      preventCommentMentionNavigation({
+        target: anchor,
+        preventDefault,
+      } as unknown as MouseEvent)
+    ).toBe(false)
+    expect(preventDefault).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -262,7 +262,7 @@ describe("TipTap comment mention serialization", () => {
         to: 14,
         href,
         text: "@Triage agent",
-        hasFormatting: true,
+        formatting: '13:[{"type":"strong"}]',
       },
     ])
   })
@@ -274,14 +274,14 @@ describe("TipTap comment mention serialization", () => {
           {
             href: buildAgentMentionHref("agent-id"),
             text: "@Triage agent",
-            hasFormatting: false,
+            formatting: "",
           },
         ],
         [
           {
             href: buildAgentMentionHref("agent-id"),
             text: "@Triage agnt",
-            hasFormatting: false,
+            formatting: "",
           },
         ]
       )
@@ -296,10 +296,20 @@ describe("TipTap comment mention serialization", () => {
 
     expect(
       findEditedCommentMentionIndexes(
-        [{ ...mention, hasFormatting: false }],
-        [{ ...mention, hasFormatting: true }]
+        [{ ...mention, formatting: "" }],
+        [{ ...mention, formatting: "bold" }]
       )
     ).toEqual([0])
+  })
+
+  it("preserves an already-formatted mention after an unrelated edit", () => {
+    const mention = {
+      href: buildAgentMentionHref("agent-id"),
+      text: "@Triage agent",
+      formatting: "bold",
+    }
+
+    expect(findEditedCommentMentionIndexes([mention], [mention])).toEqual([])
   })
 
   it("detects every range when a line break splits a mention link", () => {
@@ -307,10 +317,10 @@ describe("TipTap comment mention serialization", () => {
 
     expect(
       findEditedCommentMentionIndexes(
-        [{ href, text: "@Triage agent", hasFormatting: false }],
+        [{ href, text: "@Triage agent", formatting: "" }],
         [
-          { href, text: "@Triage", hasFormatting: false },
-          { href, text: " agent", hasFormatting: false },
+          { href, text: "@Triage", formatting: "" },
+          { href, text: " agent", formatting: "" },
         ]
       )
     ).toEqual([0, 1])
@@ -320,7 +330,7 @@ describe("TipTap comment mention serialization", () => {
     const mention = {
       href: buildAgentMentionHref("agent-id"),
       text: "@Triage agent",
-      hasFormatting: false,
+      formatting: "",
     }
 
     expect(
@@ -332,12 +342,12 @@ describe("TipTap comment mention serialization", () => {
     const agentMention = {
       href: buildAgentMentionHref("agent-id"),
       text: "@Triage agent",
-      hasFormatting: false,
+      formatting: "",
     }
     const workflowMention = {
       href: buildWorkflowMentionHref("workflow-id"),
       text: "/Enrich case",
-      hasFormatting: false,
+      formatting: "",
     }
 
     expect(
@@ -353,13 +363,13 @@ describe("TipTap comment mention serialization", () => {
     const currentMention = {
       href,
       text: "@Current agent name",
-      hasFormatting: false,
+      formatting: "",
     }
 
     expect(
       findEditedCommentMentionIndexes(
         [
-          { href, text: "@Historical agent name", hasFormatting: false },
+          { href, text: "@Historical agent name", formatting: "" },
           currentMention,
         ],
         [currentMention]
@@ -375,7 +385,7 @@ describe("TipTap comment mention serialization", () => {
           {
             href: buildAgentMentionHref("agent-id"),
             text: "@Triage agent",
-            hasFormatting: false,
+            formatting: "",
           },
         ]
       )
@@ -386,14 +396,14 @@ describe("TipTap comment mention serialization", () => {
           {
             href: buildAgentMentionHref("old-agent"),
             text: "@Old agent",
-            hasFormatting: false,
+            formatting: "",
           },
         ],
         [
           {
             href: buildAgentMentionHref("new-agent"),
             text: "@New agent",
-            hasFormatting: false,
+            formatting: "",
           },
         ]
       )

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -15,14 +15,14 @@ import {
 describe("TipTap comment mention serialization", () => {
   const workflowId = "11111111-1111-4111-8111-111111111111"
   function workflowMention(text: string) {
-    return { href: buildWorkflowMentionHref(workflowId), text }
+    return [{ href: buildWorkflowMentionHref(workflowId), text }]
   }
 
   it("keeps the existing agent mention wire format intact", () => {
     const agentId = "22222222-2222-4222-8222-222222222222"
     const markdown = `Ask [@Response agent](${buildAgentMentionHref(agentId)}) for help`
 
-    expect(serializeTiptapComment(markdown, null)).toEqual({
+    expect(serializeTiptapComment(markdown, [])).toEqual({
       content: markdown,
       workflowId: null,
     })
@@ -119,9 +119,27 @@ describe("TipTap comment mention serialization", () => {
     ).toEqual({ content: "Before after", workflowId })
   })
 
+  it("removes every pasted workflow marker and selects the first", () => {
+    const secondWorkflowId = "33333333-3333-4333-8333-333333333333"
+    const first = {
+      href: buildWorkflowMentionHref(workflowId),
+      text: "/Enrich case",
+    }
+    const second = {
+      href: buildWorkflowMentionHref(secondWorkflowId),
+      text: "/Review alert",
+    }
+    const markdown = `[${first.text}](${first.href}) investigate\n[${second.text}](${second.href})`
+
+    expect(serializeTiptapComment(markdown, [first, second])).toEqual({
+      content: "investigate",
+      workflowId,
+    })
+  })
+
   it("does not change ordinary links or text containing slash commands", () => {
     const markdown = "Run /Enrich or read [the docs](https://example.com)"
-    expect(serializeTiptapComment(markdown, null)).toEqual({
+    expect(serializeTiptapComment(markdown, [])).toEqual({
       content: markdown,
       workflowId: null,
     })

--- a/frontend/src/lib/tiptap-comment-mentions.test.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.test.ts
@@ -14,6 +14,13 @@ import {
 
 describe("TipTap comment mention serialization", () => {
   const workflowId = "11111111-1111-4111-8111-111111111111"
+  function mentionRange(
+    mention: { href: string; text: string; formatting: string },
+    from = 1
+  ) {
+    return { ...mention, from, to: from + mention.text.length }
+  }
+
   function workflowMention(text: string) {
     return [{ href: buildWorkflowMentionHref(workflowId), text }]
   }
@@ -286,18 +293,18 @@ describe("TipTap comment mention serialization", () => {
     expect(
       findEditedCommentMentionIndexes(
         [
-          {
+          mentionRange({
             href: buildAgentMentionHref("agent-id"),
             text: "@Triage agent",
             formatting: "",
-          },
+          }),
         ],
         [
-          {
+          mentionRange({
             href: buildAgentMentionHref("agent-id"),
             text: "@Triage agnt",
             formatting: "",
-          },
+          }),
         ]
       )
     ).toEqual([0])
@@ -311,8 +318,8 @@ describe("TipTap comment mention serialization", () => {
 
     expect(
       findEditedCommentMentionIndexes(
-        [{ ...mention, formatting: "" }],
-        [{ ...mention, formatting: "bold" }]
+        [mentionRange({ ...mention, formatting: "" })],
+        [mentionRange({ ...mention, formatting: "bold" })]
       )
     ).toEqual([0])
   })
@@ -324,7 +331,12 @@ describe("TipTap comment mention serialization", () => {
       formatting: "bold",
     }
 
-    expect(findEditedCommentMentionIndexes([mention], [mention])).toEqual([])
+    expect(
+      findEditedCommentMentionIndexes(
+        [mentionRange(mention)],
+        [mentionRange(mention)]
+      )
+    ).toEqual([])
   })
 
   it("detects every range when a line break splits a mention link", () => {
@@ -332,10 +344,10 @@ describe("TipTap comment mention serialization", () => {
 
     expect(
       findEditedCommentMentionIndexes(
-        [{ href, text: "@Triage agent", formatting: "" }],
+        [mentionRange({ href, text: "@Triage agent", formatting: "" }, 1)],
         [
-          { href, text: "@Triage", formatting: "" },
-          { href, text: " agent", formatting: "" },
+          mentionRange({ href, text: "@Triage", formatting: "" }, 1),
+          mentionRange({ href, text: " agent", formatting: "" }, 9),
         ]
       )
     ).toEqual([0, 1])
@@ -349,7 +361,10 @@ describe("TipTap comment mention serialization", () => {
     }
 
     expect(
-      findEditedCommentMentionIndexes([mention], [mention, mention])
+      findEditedCommentMentionIndexes(
+        [mentionRange(mention, 1)],
+        [mentionRange(mention, 1), mentionRange(mention, 14)]
+      )
     ).toEqual([])
   })
 
@@ -367,8 +382,9 @@ describe("TipTap comment mention serialization", () => {
 
     expect(
       findEditedCommentMentionIndexes(
-        [agentMention, workflowMention],
-        [{ ...workflowMention, text: "/Enrich" }]
+        [mentionRange(agentMention, 1), mentionRange(workflowMention, 20)],
+        [mentionRange({ ...workflowMention, text: "/Enrich" }, 1)],
+        (position) => (position >= 20 ? position - 19 : position)
       )
     ).toEqual([0])
   })
@@ -384,12 +400,38 @@ describe("TipTap comment mention serialization", () => {
     expect(
       findEditedCommentMentionIndexes(
         [
-          { href, text: "@Historical agent name", formatting: "" },
-          currentMention,
+          mentionRange(
+            { href, text: "@Historical agent name", formatting: "" },
+            1
+          ),
+          mentionRange(currentMention, 30),
         ],
-        [currentMention]
+        [mentionRange(currentMention, 1)],
+        (position) => (position < 30 ? 1 : position - 29)
       )
     ).toEqual([])
+  })
+
+  it("keeps duplicate targets paired to their document positions", () => {
+    const href = buildAgentMentionHref("agent-id")
+    const currentMention = {
+      href,
+      text: "@Current agent name",
+      formatting: "",
+    }
+
+    expect(
+      findEditedCommentMentionIndexes(
+        [
+          mentionRange(
+            { href, text: "@Historical agent name", formatting: "" },
+            1
+          ),
+          mentionRange(currentMention, 30),
+        ],
+        [mentionRange(currentMention, 1), mentionRange(currentMention, 30)]
+      )
+    ).toEqual([0])
   })
 
   it("does not treat inserted or replaced mentions as label edits", () => {
@@ -397,29 +439,29 @@ describe("TipTap comment mention serialization", () => {
       findEditedCommentMentionIndexes(
         [],
         [
-          {
+          mentionRange({
             href: buildAgentMentionHref("agent-id"),
             text: "@Triage agent",
             formatting: "",
-          },
+          }),
         ]
       )
     ).toEqual([])
     expect(
       findEditedCommentMentionIndexes(
         [
-          {
+          mentionRange({
             href: buildAgentMentionHref("old-agent"),
             text: "@Old agent",
             formatting: "",
-          },
+          }),
         ],
         [
-          {
+          mentionRange({
             href: buildAgentMentionHref("new-agent"),
             text: "@New agent",
             formatting: "",
-          },
+          }),
         ]
       )
     ).toEqual([])

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -1,3 +1,5 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+
 /** URI prefix used only while a workflow command is visible in TipTap. */
 export const WORKFLOW_MENTION_URI_SCHEME = "workflow-mention://"
 
@@ -36,6 +38,11 @@ export function preventCommentMentionNavigation(event: MouseEvent): boolean {
   return true
 }
 
+/** Convert hard breaks to whitespace while scanning for a mention token. */
+export function commentMentionLeafText(node: ProseMirrorNode): string {
+  return node.type.name === "hardBreak" ? "\n" : "\ufffc"
+}
+
 /** Content and workflow metadata ready for the existing comments API. */
 export interface SerializedTiptapComment {
   content: string
@@ -49,6 +56,9 @@ const WORKFLOW_MENTION_PATTERN = new RegExp(
   "g"
 )
 
+const EMPTY_MARKDOWN_CONTAINER_PATTERN =
+  /^\s*(?:>\s*)*(?:(?:#{1,6}|[-+*]|\d+[.)])\s*(?:\[[ xX]\]\s*)?)?[*_~`]*\s*$/
+
 /**
  * Remove TipTap-only workflow links and return the selected workflow id.
  *
@@ -60,12 +70,22 @@ export function serializeTiptapComment(
   markdown: string
 ): SerializedTiptapComment {
   let workflowId: string | null = null
-  const content = markdown.replace(
+  const workflowMentionLines = new Set<number>()
+  const withoutWorkflowMention = markdown.replace(
     WORKFLOW_MENTION_PATTERN,
-    (_match, targetId: string) => {
+    (_match, targetId: string, offset: number) => {
       workflowId ??= targetId
+      workflowMentionLines.add(markdown.slice(0, offset).split("\n").length - 1)
       return ""
     }
   )
+  const content = withoutWorkflowMention
+    .split("\n")
+    .filter(
+      (line, index) =>
+        !workflowMentionLines.has(index) ||
+        !EMPTY_MARKDOWN_CONTAINER_PATTERN.test(line)
+    )
+    .join("\n")
   return { content, workflowId }
 }

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -55,7 +55,7 @@ export function nodeAllowsCommentMention(
 export interface CommentMentionLinkSnapshot {
   href: string
   text: string
-  hasFormatting: boolean
+  formatting: string
 }
 
 /** A comment mention link and its current document range. */
@@ -80,11 +80,15 @@ export function findCommentMentionLinkRanges(
       return
     }
     const previous = ranges.at(-1)
-    const hasFormatting = node.marks.some((mark) => mark.type.name !== "link")
+    const formatting = `${node.nodeSize}:${JSON.stringify(
+      node.marks
+        .filter((mark) => mark.type.name !== "link")
+        .map((mark) => mark.toJSON())
+    )}`
     if (previous && previous.href === href && previous.to === pos) {
       previous.to = pos + node.nodeSize
       previous.text += node.text ?? ""
-      previous.hasFormatting ||= hasFormatting
+      previous.formatting += `|${formatting}`
       return
     }
     ranges.push({
@@ -92,7 +96,7 @@ export function findCommentMentionLinkRanges(
       to: pos + node.nodeSize,
       href,
       text: node.text ?? "",
-      hasFormatting,
+      formatting,
     })
   })
   return ranges
@@ -124,15 +128,23 @@ export function findEditedCommentMentionIndexes(
     const nextMentions = currentByHref.get(href) ?? []
     const matchedOldIndexes = new Set<number>()
     const unmatchedNextMentions = nextMentions.filter((mention) => {
-      const matchingIndex = oldMentions.findIndex(
+      let matchingIndex = oldMentions.findIndex(
         (oldMention, index) =>
-          !matchedOldIndexes.has(index) && oldMention.text === mention.text
+          !matchedOldIndexes.has(index) &&
+          oldMention.text === mention.text &&
+          oldMention.formatting === mention.formatting
       )
+      if (matchingIndex === -1) {
+        matchingIndex = oldMentions.findIndex(
+          (oldMention, index) =>
+            !matchedOldIndexes.has(index) && oldMention.text === mention.text
+        )
+      }
       if (matchingIndex === -1) {
         return true
       }
       matchedOldIndexes.add(matchingIndex)
-      if (mention.hasFormatting) {
+      if (oldMentions[matchingIndex]?.formatting !== mention.formatting) {
         editedIndexes.add(mention.index)
       }
       return false

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -1,0 +1,57 @@
+/** URI prefix used only while a workflow command is visible in TipTap. */
+export const WORKFLOW_MENTION_URI_SCHEME = "workflow-mention://"
+
+/** Existing agent-mention URI prefix persisted in comment Markdown. */
+export const AGENT_MENTION_URI_SCHEME = "mention://agent/"
+
+/** Build the link target persisted for an agent mention. */
+export function buildAgentMentionHref(targetId: string): string {
+  return `${AGENT_MENTION_URI_SCHEME}${targetId}`
+}
+
+/** Build the transient link target used for a selected workflow command. */
+export function buildWorkflowMentionHref(targetId: string): string {
+  return `${WORKFLOW_MENTION_URI_SCHEME}${targetId}`
+}
+
+/** Return whether a link belongs to either comment mention kind. */
+export function isCommentMentionHref(href: string | null | undefined): boolean {
+  return Boolean(
+    href?.startsWith(AGENT_MENTION_URI_SCHEME) ||
+      href?.startsWith(WORKFLOW_MENTION_URI_SCHEME)
+  )
+}
+
+/** Content and workflow metadata ready for the existing comments API. */
+export interface SerializedTiptapComment {
+  content: string
+  workflowId: string | null
+}
+
+// Labels may contain escaped Markdown characters. Match escaped characters as
+// one unit so an escaped `]` does not terminate the link text early.
+const WORKFLOW_MENTION_PATTERN = new RegExp(
+  `\\[(?:\\\\.|[^\\]])*\\]\\(${WORKFLOW_MENTION_URI_SCHEME}([^\\s)]+)\\)[ \\t]?`,
+  "g"
+)
+
+/**
+ * Remove TipTap-only workflow links and return the selected workflow id.
+ *
+ * Agent mention links intentionally remain byte-for-byte Markdown links; the
+ * backend already parses their `mention://agent/...` targets. Workflows use a
+ * separate request field, so their editor marker must never reach storage.
+ */
+export function serializeTiptapComment(
+  markdown: string
+): SerializedTiptapComment {
+  let workflowId: string | null = null
+  const content = markdown.replace(
+    WORKFLOW_MENTION_PATTERN,
+    (_match, targetId: string) => {
+      workflowId ??= targetId
+      return ""
+    }
+  )
+  return { content, workflowId }
+}

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -69,6 +69,20 @@ export type MapCommentMentionPosition = (
   association: -1 | 1
 ) => number
 
+export interface CommentMentionDeletionRange {
+  from: number
+  to: number
+}
+
+const REMOVABLE_EMPTY_MENTION_CONTAINERS = new Set([
+  "blockquote",
+  "bulletList",
+  "listItem",
+  "orderedList",
+  "taskItem",
+  "taskList",
+])
+
 /** Find all internal mention-link ranges in a ProseMirror document. */
 export function findCommentMentionLinkRanges(
   doc: ProseMirrorNode
@@ -105,6 +119,37 @@ export function findCommentMentionLinkRanges(
     })
   })
   return ranges
+}
+
+/** Expand a sole mention to the smallest rich container it would empty. */
+export function expandCommentMentionDeletionRange(
+  doc: ProseMirrorNode,
+  range: CommentMentionLinkRange
+): CommentMentionDeletionRange {
+  const $from = doc.resolve(range.from)
+  const $to = doc.resolve(range.to)
+  if (
+    $from.parent !== $to.parent ||
+    range.from !== $from.start() ||
+    range.to !== $from.end()
+  ) {
+    return range
+  }
+
+  let deletionDepth = $from.depth
+  while (
+    deletionDepth > 1 &&
+    $from.node(deletionDepth - 1).childCount === 1 &&
+    REMOVABLE_EMPTY_MENTION_CONTAINERS.has(
+      $from.node(deletionDepth - 1).type.name
+    )
+  ) {
+    deletionDepth -= 1
+  }
+  return {
+    from: $from.before(deletionDepth),
+    to: $from.after(deletionDepth),
+  }
 }
 
 /** Find mention links whose label, formatting, or range shape was edited. */

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -55,6 +55,7 @@ export function nodeAllowsCommentMention(
 export interface CommentMentionLinkSnapshot {
   href: string
   text: string
+  hasFormatting: boolean
 }
 
 /** A comment mention link and its current document range. */
@@ -79,9 +80,11 @@ export function findCommentMentionLinkRanges(
       return
     }
     const previous = ranges.at(-1)
+    const hasFormatting = node.marks.some((mark) => mark.type.name !== "link")
     if (previous && previous.href === href && previous.to === pos) {
       previous.to = pos + node.nodeSize
       previous.text += node.text ?? ""
+      previous.hasFormatting ||= hasFormatting
       return
     }
     ranges.push({
@@ -89,6 +92,7 @@ export function findCommentMentionLinkRanges(
       to: pos + node.nodeSize,
       href,
       text: node.text ?? "",
+      hasFormatting,
     })
   })
   return ranges
@@ -104,7 +108,10 @@ export function findEditedCommentMentionIndexes(
   }
   return current.flatMap((mention, index) => {
     const oldMention = previous[index]
-    if (oldMention?.href === mention.href && oldMention.text !== mention.text) {
+    if (
+      oldMention?.href === mention.href &&
+      (oldMention.text !== mention.text || mention.hasFormatting)
+    ) {
       return [index]
     }
     return []

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -189,12 +189,14 @@ export function serializeTiptapComment(
     }
     const targetId = mention.href.slice(WORKFLOW_MENTION_URI_SCHEME.length)
     const marker = `[${mention.text}](${mention.href})`
-    const offset =
-      mention.markdownOffset === undefined
-        ? markdown.indexOf(marker, searchFrom)
-        : markdown.startsWith(marker, mention.markdownOffset)
-          ? mention.markdownOffset
-          : -1
+    let offset: number
+    if (mention.markdownOffset === undefined) {
+      offset = markdown.indexOf(marker, searchFrom)
+    } else if (markdown.startsWith(marker, mention.markdownOffset)) {
+      offset = mention.markdownOffset
+    } else {
+      offset = -1
+    }
     if (targetId && offset !== -1) {
       workflowId ??= targetId
       workflowMentionLines.add(markdown.slice(0, offset).split("\n").length - 1)

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -64,6 +64,11 @@ export interface CommentMentionLinkRange extends CommentMentionLinkSnapshot {
   to: number
 }
 
+export type MapCommentMentionPosition = (
+  position: number,
+  association: -1 | 1
+) => number
+
 /** Find all internal mention-link ranges in a ProseMirror document. */
 export function findCommentMentionLinkRanges(
   doc: ProseMirrorNode
@@ -104,88 +109,46 @@ export function findCommentMentionLinkRanges(
 
 /** Find mention links whose label, formatting, or range shape was edited. */
 export function findEditedCommentMentionIndexes(
-  previous: CommentMentionLinkSnapshot[],
-  current: CommentMentionLinkSnapshot[]
+  previous: CommentMentionLinkRange[],
+  current: CommentMentionLinkRange[],
+  mapPosition: MapCommentMentionPosition = (position) => position
 ): number[] {
   const editedIndexes = new Set<number>()
-  const previousByHref = new Map<string, CommentMentionLinkSnapshot[]>()
-  for (const mention of previous) {
-    const mentions = previousByHref.get(mention.href) ?? []
-    mentions.push(mention)
-    previousByHref.set(mention.href, mentions)
-  }
-  const currentByHref = new Map<
-    string,
-    Array<CommentMentionLinkSnapshot & { index: number }>
-  >()
-  current.forEach((mention, index) => {
-    const mentions = currentByHref.get(mention.href) ?? []
-    mentions.push({ ...mention, index })
-    currentByHref.set(mention.href, mentions)
-  })
+  const claimedCurrentIndexes = new Set<number>()
 
-  for (const [href, oldMentions] of previousByHref) {
-    const nextMentions = currentByHref.get(href) ?? []
-    const matchedOldIndexes = new Set<number>()
-    const unmatchedNextMentions = nextMentions.filter((mention) => {
-      let matchingIndex = oldMentions.findIndex(
-        (oldMention, index) =>
-          !matchedOldIndexes.has(index) &&
-          oldMention.text === mention.text &&
-          oldMention.formatting === mention.formatting
-      )
-      if (matchingIndex === -1) {
-        matchingIndex = oldMentions.findIndex(
-          (oldMention, index) =>
-            !matchedOldIndexes.has(index) && oldMention.text === mention.text
-        )
-      }
-      if (matchingIndex === -1) {
-        return true
-      }
-      matchedOldIndexes.add(matchingIndex)
-      if (oldMentions[matchingIndex]?.formatting !== mention.formatting) {
-        editedIndexes.add(mention.index)
-      }
-      return false
-    })
-    const unmatchedOldMentions = oldMentions.filter(
-      (_mention, index) => !matchedOldIndexes.has(index)
-    )
-    const pairedCount = Math.min(
-      unmatchedOldMentions.length,
-      unmatchedNextMentions.length
-    )
-    for (let index = 0; index < pairedCount; index += 1) {
-      const mention = unmatchedNextMentions[index]
-      if (mention) {
-        editedIndexes.add(mention.index)
-      }
+  for (const oldMention of previous) {
+    let mappedFrom = mapPosition(oldMention.from, 1)
+    let mappedTo = mapPosition(oldMention.to, -1)
+    if (mappedFrom >= mappedTo) {
+      mappedFrom = mapPosition(oldMention.from, -1)
+      mappedTo = mapPosition(oldMention.to, 1)
     }
-    if (unmatchedNextMentions.length <= unmatchedOldMentions.length) {
+    const candidates = current
+      .map((mention, index) => ({ mention, index }))
+      .filter(
+        ({ mention, index }) =>
+          !claimedCurrentIndexes.has(index) &&
+          mention.href === oldMention.href &&
+          mention.from < mappedTo &&
+          mention.to > mappedFrom
+      )
+
+    for (const { index } of candidates) {
+      claimedCurrentIndexes.add(index)
+    }
+    if (candidates.length !== 1) {
+      for (const { index } of candidates) {
+        editedIndexes.add(index)
+      }
       continue
     }
-    let nextIndex = 0
-    for (const oldMention of unmatchedOldMentions) {
-      let combinedText = ""
-      const consumedIndexes: number[] = []
-      while (
-        nextIndex < unmatchedNextMentions.length &&
-        combinedText.length < oldMention.text.length
-      ) {
-        const nextMention = unmatchedNextMentions[nextIndex]
-        if (!nextMention) {
-          break
-        }
-        combinedText += nextMention.text
-        consumedIndexes.push(nextMention.index)
-        nextIndex += 1
-      }
-      if (combinedText === oldMention.text && consumedIndexes.length > 1) {
-        for (const index of consumedIndexes) {
-          editedIndexes.add(index)
-        }
-      }
+    const candidate = candidates[0]
+    if (
+      candidate &&
+      (candidate.mention.text !== oldMention.text ||
+        candidate.mention.formatting !== oldMention.formatting)
+    ) {
+      editedIndexes.add(candidate.index)
     }
   }
 

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -1,4 +1,4 @@
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+import type { MarkType, Node as ProseMirrorNode } from "@tiptap/pm/model"
 
 /** URI prefix used only while a workflow command is visible in TipTap. */
 export const WORKFLOW_MENTION_URI_SCHEME = "workflow-mention://"
@@ -41,6 +41,37 @@ export function preventCommentMentionNavigation(event: MouseEvent): boolean {
 /** Convert hard breaks to whitespace while scanning for a mention token. */
 export function commentMentionLeafText(node: ProseMirrorNode): string {
   return node.type.name === "hardBreak" ? "\n" : "\ufffc"
+}
+
+/** Return whether a text block can represent a comment mention link. */
+export function nodeAllowsCommentMention(
+  node: ProseMirrorNode,
+  linkMark: MarkType | undefined
+): boolean {
+  return Boolean(linkMark && node.type.allowsMarkType(linkMark))
+}
+
+/** A comment mention's stable identity and visible label. */
+export interface CommentMentionLinkSnapshot {
+  href: string
+  text: string
+}
+
+/** Find mention links whose visible label was edited in place. */
+export function findEditedCommentMentionIndexes(
+  previous: CommentMentionLinkSnapshot[],
+  current: CommentMentionLinkSnapshot[]
+): number[] {
+  if (previous.length !== current.length) {
+    return []
+  }
+  return current.flatMap((mention, index) => {
+    const oldMention = previous[index]
+    if (oldMention?.href === mention.href && oldMention.text !== mention.text) {
+      return [index]
+    }
+    return []
+  })
 }
 
 /** Content and workflow metadata ready for the existing comments API. */

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -103,18 +103,7 @@ export function findEditedCommentMentionIndexes(
   previous: CommentMentionLinkSnapshot[],
   current: CommentMentionLinkSnapshot[]
 ): number[] {
-  const editedIndexes = new Set(
-    current.flatMap((mention, index) => {
-      const oldMention = previous[index]
-      if (
-        oldMention?.href === mention.href &&
-        (oldMention.text !== mention.text || mention.hasFormatting)
-      ) {
-        return [index]
-      }
-      return []
-    })
-  )
+  const editedIndexes = new Set<number>()
   const previousByHref = new Map<string, CommentMentionLinkSnapshot[]>()
   for (const mention of previous) {
     const mentions = previousByHref.get(mention.href) ?? []
@@ -133,6 +122,15 @@ export function findEditedCommentMentionIndexes(
 
   for (const [href, oldMentions] of previousByHref) {
     const nextMentions = currentByHref.get(href) ?? []
+    nextMentions.forEach((mention, occurrenceIndex) => {
+      const oldMention = oldMentions[occurrenceIndex]
+      if (
+        oldMention &&
+        (oldMention.text !== mention.text || mention.hasFormatting)
+      ) {
+        editedIndexes.add(mention.index)
+      }
+    })
     if (nextMentions.length <= oldMentions.length) {
       continue
     }

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -122,27 +122,46 @@ export function findEditedCommentMentionIndexes(
 
   for (const [href, oldMentions] of previousByHref) {
     const nextMentions = currentByHref.get(href) ?? []
-    nextMentions.forEach((mention, occurrenceIndex) => {
-      const oldMention = oldMentions[occurrenceIndex]
-      if (
-        oldMention &&
-        (oldMention.text !== mention.text || mention.hasFormatting)
-      ) {
+    const matchedOldIndexes = new Set<number>()
+    const unmatchedNextMentions = nextMentions.filter((mention) => {
+      const matchingIndex = oldMentions.findIndex(
+        (oldMention, index) =>
+          !matchedOldIndexes.has(index) && oldMention.text === mention.text
+      )
+      if (matchingIndex === -1) {
+        return true
+      }
+      matchedOldIndexes.add(matchingIndex)
+      if (mention.hasFormatting) {
         editedIndexes.add(mention.index)
       }
+      return false
     })
-    if (nextMentions.length <= oldMentions.length) {
+    const unmatchedOldMentions = oldMentions.filter(
+      (_mention, index) => !matchedOldIndexes.has(index)
+    )
+    const pairedCount = Math.min(
+      unmatchedOldMentions.length,
+      unmatchedNextMentions.length
+    )
+    for (let index = 0; index < pairedCount; index += 1) {
+      const mention = unmatchedNextMentions[index]
+      if (mention) {
+        editedIndexes.add(mention.index)
+      }
+    }
+    if (unmatchedNextMentions.length <= unmatchedOldMentions.length) {
       continue
     }
     let nextIndex = 0
-    for (const oldMention of oldMentions) {
+    for (const oldMention of unmatchedOldMentions) {
       let combinedText = ""
       const consumedIndexes: number[] = []
       while (
-        nextIndex < nextMentions.length &&
+        nextIndex < unmatchedNextMentions.length &&
         combinedText.length < oldMention.text.length
       ) {
-        const nextMention = nextMentions[nextIndex]
+        const nextMention = unmatchedNextMentions[nextIndex]
         if (!nextMention) {
           break
         }
@@ -167,10 +186,10 @@ export interface SerializedTiptapComment {
   workflowId: string | null
 }
 
-// Labels may contain escaped Markdown characters. Match escaped characters as
-// one unit so an escaped `]` does not terminate the link text early.
+// TipTap may leave `]` raw inside link text. Treat it as label content unless
+// it opens this workflow target, and stop before another workflow label start.
 const WORKFLOW_MENTION_PATTERN = new RegExp(
-  `\\[(?:\\\\.|[^\\]])*\\]\\(${WORKFLOW_MENTION_URI_SCHEME}([^\\s)]+)\\)[ \\t]?`,
+  `\\[\\/(?:\\\\.|\\](?!\\(${WORKFLOW_MENTION_URI_SCHEME})|(?!\\[\\/)[^\\]])*\\]\\(${WORKFLOW_MENTION_URI_SCHEME}([^\\s)]+)\\)[ \\t]?`,
   "g"
 )
 

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -98,24 +98,69 @@ export function findCommentMentionLinkRanges(
   return ranges
 }
 
-/** Find mention links whose visible label was edited in place. */
+/** Find mention links whose label, formatting, or range shape was edited. */
 export function findEditedCommentMentionIndexes(
   previous: CommentMentionLinkSnapshot[],
   current: CommentMentionLinkSnapshot[]
 ): number[] {
-  if (previous.length !== current.length) {
-    return []
+  const editedIndexes = new Set(
+    current.flatMap((mention, index) => {
+      const oldMention = previous[index]
+      if (
+        oldMention?.href === mention.href &&
+        (oldMention.text !== mention.text || mention.hasFormatting)
+      ) {
+        return [index]
+      }
+      return []
+    })
+  )
+  const previousByHref = new Map<string, CommentMentionLinkSnapshot[]>()
+  for (const mention of previous) {
+    const mentions = previousByHref.get(mention.href) ?? []
+    mentions.push(mention)
+    previousByHref.set(mention.href, mentions)
   }
-  return current.flatMap((mention, index) => {
-    const oldMention = previous[index]
-    if (
-      oldMention?.href === mention.href &&
-      (oldMention.text !== mention.text || mention.hasFormatting)
-    ) {
-      return [index]
-    }
-    return []
+  const currentByHref = new Map<
+    string,
+    Array<CommentMentionLinkSnapshot & { index: number }>
+  >()
+  current.forEach((mention, index) => {
+    const mentions = currentByHref.get(mention.href) ?? []
+    mentions.push({ ...mention, index })
+    currentByHref.set(mention.href, mentions)
   })
+
+  for (const [href, oldMentions] of previousByHref) {
+    const nextMentions = currentByHref.get(href) ?? []
+    if (nextMentions.length <= oldMentions.length) {
+      continue
+    }
+    let nextIndex = 0
+    for (const oldMention of oldMentions) {
+      let combinedText = ""
+      const consumedIndexes: number[] = []
+      while (
+        nextIndex < nextMentions.length &&
+        combinedText.length < oldMention.text.length
+      ) {
+        const nextMention = nextMentions[nextIndex]
+        if (!nextMention) {
+          break
+        }
+        combinedText += nextMention.text
+        consumedIndexes.push(nextMention.index)
+        nextIndex += 1
+      }
+      if (combinedText === oldMention.text && consumedIndexes.length > 1) {
+        for (const index of consumedIndexes) {
+          editedIndexes.add(index)
+        }
+      }
+    }
+  }
+
+  return [...editedIndexes].sort((left, right) => left - right)
 }
 
 /** Content and workflow metadata ready for the existing comments API. */

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -186,13 +186,6 @@ export interface SerializedTiptapComment {
   workflowId: string | null
 }
 
-// TipTap may leave `]` raw inside link text. Treat it as label content unless
-// it opens this workflow target, and stop before another workflow label start.
-const WORKFLOW_MENTION_PATTERN = new RegExp(
-  `\\[\\/(?:\\\\.|\\](?!\\(${WORKFLOW_MENTION_URI_SCHEME})|(?!\\[\\/)[^\\]])*\\]\\(${WORKFLOW_MENTION_URI_SCHEME}([^\\s)]+)\\)[ \\t]?`,
-  "g"
-)
-
 const EMPTY_MARKDOWN_CONTAINER_PATTERN =
   /^\s*(?:>\s*)*(?:(?:#{1,6}|[-+*]|\d+[.)])\s*(?:\[[ xX]\]\s*)?)?[*_~`]*\s*$/
 
@@ -204,18 +197,29 @@ const EMPTY_MARKDOWN_CONTAINER_PATTERN =
  * separate request field, so their editor marker must never reach storage.
  */
 export function serializeTiptapComment(
-  markdown: string
+  markdown: string,
+  workflowMention: Pick<CommentMentionLinkSnapshot, "href" | "text"> | null
 ): SerializedTiptapComment {
   let workflowId: string | null = null
   const workflowMentionLines = new Set<number>()
-  const withoutWorkflowMention = markdown.replace(
-    WORKFLOW_MENTION_PATTERN,
-    (_match, targetId: string, offset: number) => {
-      workflowId ??= targetId
+  let withoutWorkflowMention = markdown
+  if (workflowMention?.href.startsWith(WORKFLOW_MENTION_URI_SCHEME)) {
+    const targetId = workflowMention.href.slice(
+      WORKFLOW_MENTION_URI_SCHEME.length
+    )
+    const marker = `[${workflowMention.text}](${workflowMention.href})`
+    const offset = markdown.indexOf(marker)
+    if (targetId && offset !== -1) {
+      workflowId = targetId
       workflowMentionLines.add(markdown.slice(0, offset).split("\n").length - 1)
-      return ""
+      let markerEnd = offset + marker.length
+      if (markdown[markerEnd] === " " || markdown[markerEnd] === "\t") {
+        markerEnd += 1
+      }
+      withoutWorkflowMention =
+        markdown.slice(0, offset) + markdown.slice(markerEnd)
     }
-  )
+  }
   const content = withoutWorkflowMention
     .split("\n")
     .filter(

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -198,27 +198,35 @@ const EMPTY_MARKDOWN_CONTAINER_PATTERN =
  */
 export function serializeTiptapComment(
   markdown: string,
-  workflowMention: Pick<CommentMentionLinkSnapshot, "href" | "text"> | null
+  workflowMentions: Array<Pick<CommentMentionLinkSnapshot, "href" | "text">>
 ): SerializedTiptapComment {
   let workflowId: string | null = null
   const workflowMentionLines = new Set<number>()
-  let withoutWorkflowMention = markdown
-  if (workflowMention?.href.startsWith(WORKFLOW_MENTION_URI_SCHEME)) {
-    const targetId = workflowMention.href.slice(
-      WORKFLOW_MENTION_URI_SCHEME.length
-    )
-    const marker = `[${workflowMention.text}](${workflowMention.href})`
-    const offset = markdown.indexOf(marker)
+  const removalRanges: Array<{ from: number; to: number }> = []
+  let searchFrom = 0
+  for (const mention of workflowMentions) {
+    if (!mention.href.startsWith(WORKFLOW_MENTION_URI_SCHEME)) {
+      continue
+    }
+    const targetId = mention.href.slice(WORKFLOW_MENTION_URI_SCHEME.length)
+    const marker = `[${mention.text}](${mention.href})`
+    const offset = markdown.indexOf(marker, searchFrom)
     if (targetId && offset !== -1) {
-      workflowId = targetId
+      workflowId ??= targetId
       workflowMentionLines.add(markdown.slice(0, offset).split("\n").length - 1)
       let markerEnd = offset + marker.length
       if (markdown[markerEnd] === " " || markdown[markerEnd] === "\t") {
         markerEnd += 1
       }
-      withoutWorkflowMention =
-        markdown.slice(0, offset) + markdown.slice(markerEnd)
+      removalRanges.push({ from: offset, to: markerEnd })
+      searchFrom = markerEnd
     }
+  }
+  let withoutWorkflowMention = markdown
+  for (const range of removalRanges.reverse()) {
+    withoutWorkflowMention =
+      withoutWorkflowMention.slice(0, range.from) +
+      withoutWorkflowMention.slice(range.to)
   }
   const content = withoutWorkflowMention
     .split("\n")

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -57,6 +57,43 @@ export interface CommentMentionLinkSnapshot {
   text: string
 }
 
+/** A comment mention link and its current document range. */
+export interface CommentMentionLinkRange extends CommentMentionLinkSnapshot {
+  from: number
+  to: number
+}
+
+/** Find all internal mention-link ranges in a ProseMirror document. */
+export function findCommentMentionLinkRanges(
+  doc: ProseMirrorNode
+): CommentMentionLinkRange[] {
+  const ranges: CommentMentionLinkRange[] = []
+  doc.descendants((node, pos) => {
+    if (!node.isText) {
+      return
+    }
+    const href = node.marks
+      .find((mark) => mark.type.name === "link")
+      ?.attrs.href?.toString()
+    if (!isCommentMentionHref(href)) {
+      return
+    }
+    const previous = ranges.at(-1)
+    if (previous && previous.href === href && previous.to === pos) {
+      previous.to = pos + node.nodeSize
+      previous.text += node.text ?? ""
+      return
+    }
+    ranges.push({
+      from: pos,
+      to: pos + node.nodeSize,
+      href,
+      text: node.text ?? "",
+    })
+  })
+  return ranges
+}
+
 /** Find mention links whose visible label was edited in place. */
 export function findEditedCommentMentionIndexes(
   previous: CommentMentionLinkSnapshot[],

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -22,6 +22,20 @@ export function isCommentMentionHref(href: string | null | undefined): boolean {
   )
 }
 
+/** Prevent internal mention links from triggering native browser navigation. */
+export function preventCommentMentionNavigation(event: MouseEvent): boolean {
+  const target = event.target
+  if (!(target instanceof Element)) {
+    return false
+  }
+  const href = target.closest("a")?.getAttribute("href")
+  if (!isCommentMentionHref(href)) {
+    return false
+  }
+  event.preventDefault()
+  return true
+}
+
 /** Content and workflow metadata ready for the existing comments API. */
 export interface SerializedTiptapComment {
   content: string

--- a/frontend/src/lib/tiptap-comment-mentions.ts
+++ b/frontend/src/lib/tiptap-comment-mentions.ts
@@ -210,7 +210,11 @@ const EMPTY_MARKDOWN_CONTAINER_PATTERN =
  */
 export function serializeTiptapComment(
   markdown: string,
-  workflowMentions: Array<Pick<CommentMentionLinkSnapshot, "href" | "text">>
+  workflowMentions: Array<
+    Pick<CommentMentionLinkSnapshot, "href" | "text"> & {
+      markdownOffset?: number
+    }
+  >
 ): SerializedTiptapComment {
   let workflowId: string | null = null
   const workflowMentionLines = new Set<number>()
@@ -222,7 +226,12 @@ export function serializeTiptapComment(
     }
     const targetId = mention.href.slice(WORKFLOW_MENTION_URI_SCHEME.length)
     const marker = `[${mention.text}](${mention.href})`
-    const offset = markdown.indexOf(marker, searchFrom)
+    const offset =
+      mention.markdownOffset === undefined
+        ? markdown.indexOf(marker, searchFrom)
+        : markdown.startsWith(marker, mention.markdownOffset)
+          ? mention.markdownOffset
+          : -1
     if (targetId && offset !== -1) {
       workflowId ??= targetId
       workflowMentionLines.add(markdown.slice(0, offset).split("\n").length - 1)

--- a/frontend/src/lib/tiptap-image-upload-position.test.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.test.ts
@@ -3,6 +3,7 @@ import { EditorState } from "@tiptap/pm/state"
 import {
   mapImageUploadPosition,
   sanitizeMarkdownImageAlt,
+  transactionTouchesImageReplacement,
 } from "@/lib/tiptap-image-upload-position"
 
 describe("TipTap image upload position", () => {
@@ -47,6 +48,29 @@ describe("TipTap image upload position", () => {
     expect(mapImageUploadPosition(8, startTransaction, -1)).toBe(8)
     expect(mapImageUploadPosition(16, endTransaction, -1)).toBe(16)
     expect(mapImageUploadPosition(16, endTransaction, 1)).toBe(20)
+  })
+
+  it("detects edits inside a pending image replacement", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { content: "text*", group: "block" },
+        text: {},
+      },
+    })
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, schema.text("before selected after")),
+      ]),
+    })
+
+    expect(
+      transactionTouchesImageReplacement(8, 16, state.tr.insertText("x", 12))
+    ).toBe(true)
+    expect(
+      transactionTouchesImageReplacement(8, 16, state.tr.insertText("x", 1))
+    ).toBe(false)
   })
 
   it("sanitizes image filenames that would break Markdown alt syntax", () => {

--- a/frontend/src/lib/tiptap-image-upload-position.test.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.test.ts
@@ -1,6 +1,9 @@
 import { Schema } from "@tiptap/pm/model"
 import { EditorState } from "@tiptap/pm/state"
-import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
+import {
+  mapImageUploadPosition,
+  sanitizeMarkdownImageAlt,
+} from "@/lib/tiptap-image-upload-position"
 
 describe("TipTap image upload position", () => {
   it("maps a pending insertion point through intervening edits", () => {
@@ -44,5 +47,11 @@ describe("TipTap image upload position", () => {
     expect(mapImageUploadPosition(8, startTransaction, -1)).toBe(8)
     expect(mapImageUploadPosition(16, endTransaction, -1)).toBe(16)
     expect(mapImageUploadPosition(16, endTransaction, 1)).toBe(20)
+  })
+
+  it("sanitizes image filenames that would break Markdown alt syntax", () => {
+    expect(sanitizeMarkdownImageAlt("report[final]\\copy.png")).toBe(
+      "report_final__copy.png"
+    )
   })
 })

--- a/frontend/src/lib/tiptap-image-upload-position.test.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.test.ts
@@ -37,9 +37,12 @@ describe("TipTap image upload position", () => {
         schema.node("paragraph", null, schema.text("before selected after")),
       ]),
     })
-    const transaction = state.tr.insertText("new ", 1)
+    const startTransaction = state.tr.insertText("new ", 8)
+    const endTransaction = state.tr.insertText("new ", 16)
 
-    expect(mapImageUploadPosition(8, transaction, 1)).toBe(12)
-    expect(mapImageUploadPosition(16, transaction, -1)).toBe(20)
+    expect(mapImageUploadPosition(8, startTransaction, 1)).toBe(12)
+    expect(mapImageUploadPosition(8, startTransaction, -1)).toBe(8)
+    expect(mapImageUploadPosition(16, endTransaction, -1)).toBe(16)
+    expect(mapImageUploadPosition(16, endTransaction, 1)).toBe(20)
   })
 })

--- a/frontend/src/lib/tiptap-image-upload-position.test.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.test.ts
@@ -1,6 +1,9 @@
 import { Schema } from "@tiptap/pm/model"
 import { EditorState } from "@tiptap/pm/state"
-import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
+import {
+  deleteImagePasteSelection,
+  mapImageUploadPosition,
+} from "@/lib/tiptap-image-upload-position"
 
 describe("TipTap image upload position", () => {
   it("maps a pending insertion point through intervening edits", () => {
@@ -21,5 +24,38 @@ describe("TipTap image upload position", () => {
     const transaction = state.tr.insertText("new ", 1)
 
     expect(mapImageUploadPosition(dropPosition, transaction)).toBe(12)
+  })
+
+  it("deletes the active selection before inserting a pasted image", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { content: "text*", group: "block" },
+        text: {},
+      },
+    })
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, schema.text("before selected after")),
+      ]),
+    })
+    const transaction = deleteImagePasteSelection(state.tr, 8, 16)
+
+    expect(transaction).not.toBeNull()
+    expect(transaction?.doc.textContent).toBe("before  after")
+  })
+
+  it("does not create a transaction for an empty selection", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { content: "text*", group: "block" },
+        text: {},
+      },
+    })
+    const state = EditorState.create({ schema })
+
+    expect(deleteImagePasteSelection(state.tr, 1, 1)).toBeNull()
   })
 })

--- a/frontend/src/lib/tiptap-image-upload-position.test.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.test.ts
@@ -1,9 +1,6 @@
 import { Schema } from "@tiptap/pm/model"
 import { EditorState } from "@tiptap/pm/state"
-import {
-  deleteImagePasteSelection,
-  mapImageUploadPosition,
-} from "@/lib/tiptap-image-upload-position"
+import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
 
 describe("TipTap image upload position", () => {
   it("maps a pending insertion point through intervening edits", () => {
@@ -26,7 +23,7 @@ describe("TipTap image upload position", () => {
     expect(mapImageUploadPosition(dropPosition, transaction)).toBe(12)
   })
 
-  it("deletes the active selection before inserting a pasted image", () => {
+  it("maps both ends of a pending image replacement", () => {
     const schema = new Schema({
       nodes: {
         doc: { content: "block+" },
@@ -40,22 +37,9 @@ describe("TipTap image upload position", () => {
         schema.node("paragraph", null, schema.text("before selected after")),
       ]),
     })
-    const transaction = deleteImagePasteSelection(state.tr, 8, 16)
+    const transaction = state.tr.insertText("new ", 1)
 
-    expect(transaction).not.toBeNull()
-    expect(transaction?.doc.textContent).toBe("before  after")
-  })
-
-  it("does not create a transaction for an empty selection", () => {
-    const schema = new Schema({
-      nodes: {
-        doc: { content: "block+" },
-        paragraph: { content: "text*", group: "block" },
-        text: {},
-      },
-    })
-    const state = EditorState.create({ schema })
-
-    expect(deleteImagePasteSelection(state.tr, 1, 1)).toBeNull()
+    expect(mapImageUploadPosition(8, transaction, 1)).toBe(12)
+    expect(mapImageUploadPosition(16, transaction, -1)).toBe(20)
   })
 })

--- a/frontend/src/lib/tiptap-image-upload-position.test.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.test.ts
@@ -1,0 +1,25 @@
+import { Schema } from "@tiptap/pm/model"
+import { EditorState } from "@tiptap/pm/state"
+import { mapImageUploadPosition } from "@/lib/tiptap-image-upload-position"
+
+describe("TipTap image upload position", () => {
+  it("maps a pending insertion point through intervening edits", () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: "block+" },
+        paragraph: { content: "text*", group: "block" },
+        text: {},
+      },
+    })
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, schema.text("before after")),
+      ]),
+    })
+    const dropPosition = 8
+    const transaction = state.tr.insertText("new ", 1)
+
+    expect(mapImageUploadPosition(dropPosition, transaction)).toBe(12)
+  })
+})

--- a/frontend/src/lib/tiptap-image-upload-position.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.ts
@@ -8,3 +8,8 @@ export function mapImageUploadPosition(
 ): number {
   return transaction.mapping.map(position, association)
 }
+
+/** Replace characters that can break TipTap's unescaped Markdown image alt. */
+export function sanitizeMarkdownImageAlt(filename: string): string {
+  return filename.replace(/[\\[\]\r\n]/g, "_")
+}

--- a/frontend/src/lib/tiptap-image-upload-position.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.ts
@@ -9,6 +9,32 @@ export function mapImageUploadPosition(
   return transaction.mapping.map(position, association)
 }
 
+/** Return whether an intervening transaction edits inside a pending selection. */
+export function transactionTouchesImageReplacement(
+  from: number,
+  to: number,
+  transaction: Transaction
+): boolean {
+  let mappedFrom = from
+  let mappedTo = to
+  for (const stepMap of transaction.mapping.maps) {
+    let touchesRange = false
+    stepMap.forEach((oldStart, oldEnd) => {
+      if (oldStart === oldEnd) {
+        touchesRange ||= oldStart > mappedFrom && oldStart < mappedTo
+      } else {
+        touchesRange ||= oldStart < mappedTo && oldEnd > mappedFrom
+      }
+    })
+    if (touchesRange) {
+      return true
+    }
+    mappedFrom = stepMap.map(mappedFrom, 1)
+    mappedTo = stepMap.map(mappedTo, -1)
+  }
+  return false
+}
+
 /** Replace characters that can break TipTap's unescaped Markdown image alt. */
 export function sanitizeMarkdownImageAlt(filename: string): string {
   return filename.replace(/[\\[\]\r\n]/g, "_")

--- a/frontend/src/lib/tiptap-image-upload-position.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.ts
@@ -7,3 +7,12 @@ export function mapImageUploadPosition(
 ): number {
   return transaction.mapping.map(position, 1)
 }
+
+/** Delete selected text before an image paste, returning a dispatchable edit. */
+export function deleteImagePasteSelection(
+  transaction: Transaction,
+  from: number,
+  to: number
+): Transaction | null {
+  return from === to ? null : transaction.delete(from, to)
+}

--- a/frontend/src/lib/tiptap-image-upload-position.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.ts
@@ -1,0 +1,9 @@
+import type { Transaction } from "@tiptap/pm/state"
+
+/** Map a pending image insertion point through an editor transaction. */
+export function mapImageUploadPosition(
+  position: number,
+  transaction: Transaction
+): number {
+  return transaction.mapping.map(position, 1)
+}

--- a/frontend/src/lib/tiptap-image-upload-position.ts
+++ b/frontend/src/lib/tiptap-image-upload-position.ts
@@ -3,16 +3,8 @@ import type { Transaction } from "@tiptap/pm/state"
 /** Map a pending image insertion point through an editor transaction. */
 export function mapImageUploadPosition(
   position: number,
-  transaction: Transaction
-): number {
-  return transaction.mapping.map(position, 1)
-}
-
-/** Delete selected text before an image paste, returning a dispatchable edit. */
-export function deleteImagePasteSelection(
   transaction: Transaction,
-  from: number,
-  to: number
-): Transaction | null {
-  return from === to ? null : transaction.delete(from, to)
+  association: -1 | 1 = 1
+): number {
+  return transaction.mapping.map(position, association)
 }

--- a/frontend/src/lib/tiptap-markdown-hard-break.test.ts
+++ b/frontend/src/lib/tiptap-markdown-hard-break.test.ts
@@ -1,0 +1,21 @@
+import { MarkdownHardBreak } from "@/lib/tiptap-markdown-hard-break"
+
+describe("TipTap Markdown hard breaks", () => {
+  it("maps Markdown br tokens to TipTap hardBreak nodes", () => {
+    const parseMarkdown = MarkdownHardBreak.config.parseMarkdown
+    if (!parseMarkdown) {
+      throw new Error("Hard-break Markdown parser is missing")
+    }
+    const createNode = jest.fn(() => ({ type: "hardBreak" }))
+    const token = { type: "br", raw: "  \n" } as unknown as Parameters<
+      typeof parseMarkdown
+    >[0]
+    const helpers = { createNode } as unknown as Parameters<
+      typeof parseMarkdown
+    >[1]
+
+    expect(MarkdownHardBreak.config.markdownTokenName).toBe("br")
+    expect(parseMarkdown(token, helpers)).toEqual({ type: "hardBreak" })
+    expect(createNode).toHaveBeenCalledWith("hardBreak")
+  })
+})

--- a/frontend/src/lib/tiptap-markdown-hard-break.ts
+++ b/frontend/src/lib/tiptap-markdown-hard-break.ts
@@ -1,0 +1,11 @@
+import { HardBreak } from "@tiptap/extension-hard-break"
+
+const parseMarkdownHardBreak: NonNullable<
+  typeof HardBreak.config.parseMarkdown
+> = (_token, helpers) => helpers.createNode("hardBreak")
+
+/** A hard-break extension that restores Markdown's `br` token on parse. */
+export const MarkdownHardBreak = HardBreak.extend({
+  markdownTokenName: "br",
+  parseMarkdown: parseMarkdownHardBreak,
+})

--- a/frontend/tests/case-comments-section.test.tsx
+++ b/frontend/tests/case-comments-section.test.tsx
@@ -92,6 +92,177 @@ jest.mock("@/components/cases/case-description-editor", () => ({
   ),
 }))
 
+// Keep these orchestration tests independent of TipTap's ESM-only Markdown
+// parser. The adapter deliberately exposes the old textarea interaction model
+// while routing mentions through the shared suggestion/serialization logic.
+jest.mock("@/components/cases/case-comment-editor", () => {
+  const React = jest.requireActual<typeof import("react")>("react")
+  const { MentionOverlay } = jest.requireActual<
+    typeof import("@/components/mentions/mention-overlay")
+  >("@/components/mentions/mention-overlay")
+  type MentionRange = import("@/lib/mentions").MentionRange
+
+  interface TestEditor {
+    view: { dom: HTMLTextAreaElement }
+    textareaRef: React.RefObject<HTMLTextAreaElement | null>
+    getText: () => string
+    setText: (next: string) => void
+    ranges: MentionRange[]
+    handleTextChange?: (next: string, caret: number) => void
+    handleSelectionChange?: () => void
+  }
+
+  interface TestEditorProps {
+    value: string
+    onChange: (value: string) => void
+    placeholder: string
+    mode?: "default" | "inline"
+    autoFocus?: boolean
+    onBlur?: () => void
+    onFocus?: () => void
+    onUploadingChange?: (isUploading: boolean) => void
+    onEditorReady?: (editor: TestEditor | null) => void
+  }
+
+  function CaseCommentEditor({
+    value,
+    onChange,
+    placeholder,
+    mode,
+    autoFocus,
+    onBlur,
+    onFocus,
+    onUploadingChange,
+    onEditorReady,
+  }: TestEditorProps) {
+    const textareaRef = React.useRef<HTMLTextAreaElement>(null)
+    const valueRef = React.useRef(value)
+    const onChangeRef = React.useRef(onChange)
+    const editorRef = React.useRef<TestEditor | null>(null)
+    valueRef.current = value
+    onChangeRef.current = onChange
+
+    React.useEffect(() => {
+      const dom = textareaRef.current
+      if (!dom) {
+        return
+      }
+      const editor: TestEditor = {
+        view: { dom },
+        textareaRef,
+        getText: () => valueRef.current,
+        setText: (next) => onChangeRef.current(next),
+        ranges: [],
+      }
+      editorRef.current = editor
+      onEditorReady?.(editor)
+      onUploadingChange?.(false)
+      return () => {
+        editorRef.current = null
+        onEditorReady?.(null)
+      }
+    }, [onEditorReady, onUploadingChange])
+
+    return (
+      <div>
+        <MentionOverlay
+          text={value}
+          mentions={editorRef.current?.ranges ?? []}
+          className="text-sm"
+        />
+        <textarea
+          autoFocus={autoFocus}
+          ref={textareaRef}
+          className={mode === "inline" ? "resize-none min-h-9" : "resize-none"}
+          placeholder={placeholder}
+          value={value}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          onChange={(event) => {
+            const caret =
+              event.currentTarget.selectionStart ??
+              event.currentTarget.value.length
+            editorRef.current?.handleTextChange?.(
+              event.currentTarget.value,
+              caret
+            )
+            onChange(event.currentTarget.value)
+          }}
+          onSelect={() => editorRef.current?.handleSelectionChange?.()}
+        />
+      </div>
+    )
+  }
+
+  return { CaseCommentEditor }
+})
+
+jest.mock("@/hooks/use-tiptap-mentions", () => {
+  const React = jest.requireActual<typeof import("react")>("react")
+  const { useMentions } = jest.requireActual<
+    typeof import("@/hooks/use-mentions")
+  >("@/hooks/use-mentions")
+  type MentionSourceConfig = import("@/hooks/use-mentions").MentionSourceConfig
+  type MentionRange = import("@/lib/mentions").MentionRange
+
+  interface TestEditor {
+    textareaRef: React.RefObject<HTMLTextAreaElement | null>
+    getText: () => string
+    setText: (next: string) => void
+    ranges: MentionRange[]
+    handleTextChange?: (next: string, caret: number) => void
+    handleSelectionChange?: () => void
+  }
+
+  interface TestHookOptions {
+    editor: TestEditor | null
+    workspaceId: string
+    agents?: MentionSourceConfig
+    workflows?: MentionSourceConfig
+  }
+
+  return {
+    useTiptapMentions: ({
+      editor,
+      workspaceId,
+      agents,
+      workflows,
+    }: TestHookOptions) => {
+      const fallbackRef = React.useRef<HTMLTextAreaElement>(null)
+      const mentions = useMentions({
+        workspaceId,
+        agents,
+        workflows,
+        textareaRef: editor?.textareaRef ?? fallbackRef,
+        getText: () => editor?.getText() ?? "",
+        setText: (next) => {
+          editor?.setText(next)
+        },
+      })
+      if (editor) {
+        editor.ranges = mentions.ranges
+        editor.handleTextChange = mentions.handleTextChange
+        editor.handleSelectionChange = mentions.handleSelectionChange
+      }
+      return {
+        ...mentions,
+        handleKeyDown: (event: KeyboardEvent) =>
+          mentions.handleKeyDown({
+            currentTarget: editor?.textareaRef.current ?? event.target,
+            key: event.key,
+            shiftKey: event.shiftKey,
+            nativeEvent: event,
+            preventDefault: () => event.preventDefault(),
+          } as React.KeyboardEvent<HTMLTextAreaElement>),
+        serialize: (text: string) => ({
+          content: mentions.serialize(text),
+          workflowId: mentions.workflowId,
+        }),
+      }
+    },
+  }
+})
+
 jest.mock("@/components/cases/case-panel-common", () => ({
   CaseEventTimestamp: ({
     createdAt,
@@ -1471,7 +1642,10 @@ describe("CommentSection", () => {
     })
 
     function getCaretMarker(textarea: HTMLElement) {
-      const marker = textarea.parentElement?.querySelector("span[aria-hidden]")
+      const marker =
+        textarea.parentElement?.parentElement?.querySelector(
+          "span[aria-hidden]"
+        )
       if (!(marker instanceof HTMLElement)) {
         throw new Error("Expected a caret marker next to the composer")
       }


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and follows the repository convention.
- [x] PR implements a single feature.
- [x] Focused tests are passing.
- [x] Lint, formatting, pre-commit hooks, and frontend type checks are passing.

## Description

This PR replaces the plain case comment textarea with the existing TipTap editor while preserving the current comment-composer styling and keeping the editor toolbar hidden.

- Supports rich text editing and rendering without changing the comment shell.
- Supports pasted and dropped images through the existing case attachment API.
- Preserves the existing `mention://agent/...` wire format and agent invocation behavior.
- Prevents internal agent and workflow mention links from triggering native browser navigation.
- Opens mention autocomplete after hard line breaks and removes empty rich-text containers around workflow-only commands.
- Scopes custom mention URIs to comment editors, keeps the keyboard listener stable, dissolves edited mention bindings, and suppresses suggestions in mark-free blocks.
- Applies mention-integrity handling to inline edits and maps pending image insertion points through concurrent editor transactions.
- Preserves TipTap link selection for internal mentions, dissolves mention bindings before extra formatting can corrupt their Markdown, and round-trips hard line breaks.
- Dissolves every fragment when a line break splits a bound mention and replaces selected text when an image is pasted.
- Matches surviving mention edits by internal target even when deleting an earlier mention shifts their document order.
- Handles raw closing brackets in workflow titles, preserves selected text when image upload fails, and keeps unchanged duplicate-target mentions bound.
- Removes workflow markers using the exact TipTap document range and target instead of parsing ambiguous Markdown labels.
- Verifies both selection-boundary association directions for image upload position mapping.
- Removes every pasted workflow marker from stored content while selecting only the first workflow to run.
- Preserves pre-existing formatted agent mentions across unrelated edits while still dissolving bindings when their formatting changes.
- Sanitizes uploaded image filenames before Markdown serialization so bracket, backslash, and newline characters cannot corrupt image markup.
- Locates workflow markers from their TipTap document links so identical Markdown inside code blocks remains untouched.
- Tracks edited mention identity through ProseMirror transaction positions so duplicate-agent labels cannot be paired to the wrong occurrence.
- Uses safe temporary text and URL sentinels when locating workflow links, independent of Markdown escaping in workflow titles.
- Keeps mention-integrity cleanup out of undo history so Undo cannot restore a hidden target around edited text.
- Removes an emptied list, quote, or task container when replacing its sole workflow mention.
- Preserves user edits made inside a selected range while an image upload is pending instead of deleting them on completion.
- Preserves workflow command selection and submission behavior.
- Keeps keyboard submission with `Cmd+Enter` / `Ctrl+Enter`.
- Applies the same editor behavior to new comments, replies, and inline edits.
- Requires no database migration, API schema change, generated client update, or data-model change.

## Related Issues

ENG-1740

## Screenshots / Recordings

The screenshots and recordings below cover the toolbar-free composer, agent mention picker, rich draft with a pasted image, persisted renderer, inline edit state, and an independent visible-Chrome verification.

## Steps to QA

1. Open a case and focus the root comment composer or a reply composer.
2. Confirm the input has the existing dimensions and styling, with no TipTap toolbar shown.
3. Type `@`, select an agent, and confirm the mention remains visually atomic.
4. Add rich formatting with keyboard shortcuts and paste or drop an image.
5. Submit with `Cmd+Enter` / `Ctrl+Enter` and confirm the rich comment renders correctly.
6. Edit the comment and confirm the mention, formatting, and image reload without exposing a toolbar.

## Validation

- Focused comment, mention, Markdown, and image-position suites — 91 tests passed.
- `pnpm -C frontend run typecheck` — passed.
- `pnpm -C frontend check` — 1,063 files passed.
- Pre-commit hooks — passed.
- Live Tracecat cluster — comment creation, attachment upload, persisted rendering, inline editing, and agent mention dispatch verified.
- Browser console — no new errors or repeated TipTap custom-protocol warnings.

The synthetic QA agent was selectable and its invocation was dispatched. Its run could not finish because the local QA cluster does not have model credentials configured.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 1,222 | 355 |
| Tests | 785 | 1 |
| Infra/config | 1 | 0 |
| Generated | 3 | 0 |
| **Total** | **2,011** | **356** |

<img width="1280" height="720" alt="01-focused-comment-no-toolbar" src="https://github.com/user-attachments/assets/06437924-e229-43c7-8282-f7884274db1a" />
<img width="1280" height="720" alt="02-mention-picker-no-toolbar" src="https://github.com/user-attachments/assets/148bf771-612b-45bd-add4-d5fedefac64d" />
<img width="1280" height="720" alt="03-rich-comment-no-toolbar" src="https://github.com/user-attachments/assets/724db5ee-2f53-45bb-869a-4c809a70342f" />
<img width="1280" height="720" alt="04-rendered-comment-no-toolbar" src="https://github.com/user-attachments/assets/57619c52-2344-4d42-a4b3-ad6c60aeebd8" />
<img width="1280" height="720" alt="05-edit-comment-no-toolbar" src="https://github.com/user-attachments/assets/0c835744-c728-438b-90bc-8743df82a5bf" />
<img width="1136" height="768" alt="06-computer-use-visible-chrome" src="https://github.com/user-attachments/assets/73a5186d-d489-431e-9fd7-4654f3015c2b" />

https://github.com/user-attachments/assets/b02e7f91-bbf5-4f9b-832b-545a203c9aa3

https://github.com/user-attachments/assets/8b2d3c84-7e11-4e93-a56a-b72d202e5c0e
