### PR TITLE
feat(logging): emit a real root span for schedule-started workflow runs

### DIFF
--- a/tests/unit/test_platform_otel.py
+++ b/tests/unit/test_platform_otel.py
@@ -337,9 +337,9 @@ def test_headerless_workflow_run_spans_share_one_deterministic_trace(
 ) -> None:
     """A Temporal-started run has no trace header, yet forms a single trace.
 
-    Every command span of the run hangs off the same never-exported parent that
-    is derived from the run ID, so the trace stays intact across replays, and a
-    different run gets a different trace.
+    Every command span of the run hangs off the same parent that is derived
+    from the run ID, so the trace stays intact across replays, and a different
+    run gets a different trace.
     """
     monkeypatch.setattr(config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
     exporter = InMemorySpanExporter()
@@ -361,14 +361,13 @@ def test_headerless_workflow_run_spans_share_one_deterministic_trace(
         assert isinstance(run_id, str)
         spans_by_run.setdefault(run_id, []).append(span)
     run_1 = spans_by_run["run-1"]
-    assert len(run_1) == 3
+    children = [span for span in run_1 if span.parent is not None]
+    assert len(children) == 3
     trace_ids = {span.context.trace_id for span in run_1}
     assert len(trace_ids) == 1
-    parent_ids = {span.parent.span_id for span in run_1 if span.parent is not None}
+    parent_ids = {span.parent.span_id for span in children}
     assert len(parent_ids) == 1
     assert parent_ids != {0}
-    # The synthetic parent is never exported.
-    assert parent_ids.isdisjoint({span.context.span_id for span in run_1})
     assert spans_by_run["run-2"][0].context.trace_id not in trace_ids
 
     # Replaying the run reproduces the same trace.
@@ -429,3 +428,124 @@ def test_headerless_workflow_run_sampling_ignores_ambient_span(
 
     assert traceparent.endswith("-00")
     assert [span.name for span in exporter.get_finished_spans()] == ["ambient"]
+
+
+def test_headerless_run_root_span_is_the_synthetic_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exported root must *be* the parent the children point at.
+
+    A schedule-started run reaches the backend as an orphan unless the
+    deterministic parent is materialized. If the root's identifiers ever drift
+    from the ones ``_headerless_run_context`` derives, the emitted span becomes
+    a sibling of the parent instead of the parent, and the trace goes back to
+    showing no root while gaining a stray span. Comparing raw identifiers,
+    rather than merely asserting a root exists, is what catches that drift.
+    """
+    monkeypatch.setattr(config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
+    exporter = InMemorySpanExporter()
+    initialize_platform_tracing("tracecat-worker", exporter=exporter)
+    interceptor = _headerless_interceptor()
+
+    for name in ("RunWorkflow:Traced", "StartActivity:probe"):
+        _complete_headerless_span(interceptor, name, "run-1")
+
+    expected = platform_otel._deterministic_run_ids("run-1")
+    spans = exporter.get_finished_spans()
+    roots = [span for span in spans if span.name == "ScheduledRun:Traced"]
+    assert len(roots) == 1
+    root = roots[0]
+    assert root.kind is SpanKind.SERVER
+    assert root.parent is None
+    assert root.context is not None
+    assert root.context.trace_id == expected.trace_id
+    assert root.context.span_id == expected.span_id
+    assert root.attributes is not None
+    assert root.attributes["temporalRunID"] == "run-1"
+    assert root.attributes["temporalWorkflowID"] == "synthetic-wf"
+
+    children = [span for span in spans if span is not root]
+    assert children
+    for child in children:
+        assert child.parent is not None
+        assert child.parent.span_id == root.context.span_id
+        assert child.context is not None
+        assert child.context.trace_id == root.context.trace_id
+
+
+def test_headerless_run_root_span_is_emitted_once_per_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the ``RunWorkflow:`` command stands in for the whole run.
+
+    Signals, queries and updates are headerless too and go through the same
+    completion path, so emitting on every headerless span would give one run as
+    many competing roots as it has inbound commands.
+    """
+    monkeypatch.setattr(config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
+    exporter = InMemorySpanExporter()
+    initialize_platform_tracing("tracecat-worker", exporter=exporter)
+    interceptor = _headerless_interceptor()
+
+    for name in (
+        "RunWorkflow:Traced",
+        "SignalWorkflow:nudge",
+        "QueryWorkflow:status",
+        "HandleUpdate:patch",
+        "CompleteWorkflow:Traced",
+    ):
+        _complete_headerless_span(interceptor, name, "run-1")
+
+    root_names = [
+        span.name
+        for span in exporter.get_finished_spans()
+        if span.name.startswith("ScheduledRun:")
+    ]
+    assert root_names == ["ScheduledRun:Traced"]
+
+
+def test_headerless_run_root_span_follows_the_configured_sampler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The root must not smuggle a dropped run past the sampler.
+
+    It carries the run's trace ID, so it has to inherit the same single root
+    decision the children get; otherwise an operator who samples traces down
+    still pays for one exported span per scheduled run.
+    """
+    monkeypatch.setattr(config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
+    monkeypatch.setenv("OTEL_TRACES_SAMPLER", "always_off")
+    exporter = InMemorySpanExporter()
+    initialize_platform_tracing("tracecat-worker", exporter=exporter)
+    interceptor = _headerless_interceptor()
+
+    _complete_headerless_span(interceptor, "RunWorkflow:Traced", "run-1")
+
+    assert exporter.get_finished_spans() == ()
+
+
+def test_pinned_run_ids_do_not_leak_to_later_spans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The identifier pin must live only for the root span it was set for.
+
+    The pin overrides the provider's ID generator, so a pin that outlived its
+    span would stamp unrelated work with the run's trace and span IDs and merge
+    independent traces into one.
+    """
+    monkeypatch.setattr(config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
+    exporter = InMemorySpanExporter()
+    runtime = initialize_platform_tracing("tracecat-worker", exporter=exporter)
+    assert runtime is not None
+    interceptor = _headerless_interceptor()
+
+    _complete_headerless_span(interceptor, "RunWorkflow:Traced", "run-1")
+    assert platform_otel._pinned_span_ids.get() is None
+
+    with runtime.tracer("test.unrelated").start_as_current_span("unrelated") as span:
+        span_context = span.get_span_context()
+
+    pinned = platform_otel._deterministic_run_ids("run-1")
+    assert span_context.trace_id != pinned.trace_id
+    assert span_context.span_id != pinned.span_id
+    assert span_context.trace_flags.random_trace_id

--- a/tracecat/observability/otel.py
+++ b/tracecat/observability/otel.py
@@ -11,6 +11,7 @@ import logging
 import os
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import StrEnum
 from threading import Lock
@@ -29,6 +30,7 @@ from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
     SpanExporter,
 )
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 from opentelemetry.sdk.trace.sampling import Sampler
 from opentelemetry.trace import Link, Span, SpanKind, Status, StatusCode, TraceFlags
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -53,8 +55,17 @@ logger = logging.getLogger(__name__)
 TRACE_ID_HEADER: Final = "X-Trace-ID"
 # Set by the Temporal SDK on every workflow command span.
 _TEMPORAL_RUN_ID_ATTRIBUTE: Final = "temporalRunID"
+_TEMPORAL_WORKFLOW_ID_ATTRIBUTE: Final = "temporalWorkflowID"
 # Name the sampler sees for the per-run root decision of a headerless run.
 _HEADERLESS_RUN_SPAN_NAME: Final = "RunWorkflow"
+# The one Temporal command span per run that stands in for the whole run.
+_RUN_WORKFLOW_SPAN_PREFIX: Final = f"{_HEADERLESS_RUN_SPAN_NAME}:"
+# Name the exported root of a headerless run carries in the trace backend.
+_SCHEDULED_RUN_SPAN_PREFIX: Final = "ScheduledRun:"
+# Identifiers only; never messages, stack traces, or workflow inputs.
+_RUN_ROOT_SPAN_ATTRIBUTES: Final = frozenset(
+    (_TEMPORAL_WORKFLOW_ID_ATTRIBUTE, _TEMPORAL_RUN_ID_ATTRIBUTE)
+)
 TRACE_SAMPLED_HEADER: Final = "X-Trace-Sampled"
 
 _EXCLUDED_FASTAPI_URLS: Final = ",".join(
@@ -111,6 +122,81 @@ class _CompletedWorkflowSpanInput(Protocol):
 
     @property
     def parent_missing(self) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _RunSpanIds:
+    """The deterministic identifiers one headerless Temporal run resolves to."""
+
+    trace_id: int
+    span_id: int
+
+
+# Set only while the interceptor starts the single root span of a headerless
+# run. A context variable rather than a module global so a concurrent worker
+# thread starting an unrelated span never picks up these identifiers.
+_pinned_span_ids: ContextVar[_RunSpanIds | None] = ContextVar(
+    "tracecat_pinned_span_ids", default=None
+)
+
+
+def _deterministic_run_ids(run_id: str) -> _RunSpanIds:
+    """Derive one run's trace and span identifiers from its Temporal run ID.
+
+    Both the exported root span and the parent that every child span of the run
+    points at come from here, so the two can never drift apart.
+    """
+    digest = hashlib.sha256(f"tracecat.temporal.run:{run_id}".encode()).digest()
+    return _RunSpanIds(
+        trace_id=int.from_bytes(digest[:16], "big") or 1,
+        span_id=int.from_bytes(digest[16:24], "big") or 1,
+    )
+
+
+def _headerless_run_id(params: _CompletedWorkflowSpanInput) -> str | None:
+    """Return the Temporal run ID a headerless span belongs to, if it has one."""
+    run_id = (params.attributes or {}).get(_TEMPORAL_RUN_ID_ATTRIBUTE)
+    if not isinstance(run_id, str) or not run_id:
+        return None
+    return run_id
+
+
+class _PinnedIdGenerator(RandomIdGenerator):
+    """Hand out pinned identifiers to the span started inside a pin.
+
+    Starting the root of a headerless run through the tracer is what puts it
+    through the configured sampler and span processors, but the tracer always
+    mints its own identifiers. Pinning them makes the span the SDK creates *be*
+    the synthetic per-run parent instead of a sibling of it.
+    """
+
+    def generate_trace_id(self) -> int:
+        pinned = _pinned_span_ids.get()
+        if pinned is not None:
+            return pinned.trace_id
+        return super().generate_trace_id()
+
+    def generate_span_id(self) -> int:
+        pinned = _pinned_span_ids.get()
+        if pinned is not None:
+            return pinned.span_id
+        return super().generate_span_id()
+
+    def is_trace_id_random(self) -> bool:
+        # A pinned trace ID is derived, not sampled from a random source, so it
+        # must not claim the W3C random-trace-id flag that the run's children
+        # (parented to a plain synthetic context) do not carry either.
+        return _pinned_span_ids.get() is None and super().is_trace_id_random()
+
+
+@contextmanager
+def _pin_span_ids(ids: _RunSpanIds) -> Iterator[None]:
+    """Pin the identifiers the next span started on this context receives."""
+    token = _pinned_span_ids.set(ids)
+    try:
+        yield None
+    finally:
+        _pinned_span_ids.reset(token)
 
 
 @dataclass(frozen=True, slots=True)
@@ -180,7 +266,8 @@ def initialize_platform_tracing(
                         "service.version": __version__,
                         "deployment.environment.name": config.TRACECAT__APP_ENV,
                     }
-                )
+                ),
+                id_generator=_PinnedIdGenerator(),
             )
             if exporter is None:
                 provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
@@ -314,6 +401,7 @@ class _TraceContextOnlyTracingInterceptor(TracingInterceptor):
             if not self._always_create_workflow_spans:
                 return None
             span_context = self._headerless_run_context(params)
+            self._emit_headerless_run_root(params)
         else:
             span_context = self.text_map_propagator.extract(params.context)
         links: Sequence[Link] = []
@@ -350,30 +438,29 @@ class _TraceContextOnlyTracingInterceptor(TracingInterceptor):
         Runs started by Temporal itself (schedules) carry no trace header, so
         the SDK would make each workflow command span its own root and one run
         would fragment into many traces. The parent is derived from the run ID,
-        so it is identical across replays and cache evictions, and it is never
-        exported: the run shows as one trace whose root is deliberately absent.
-        The configured sampler makes a single root decision per run so the whole
-        run is kept or dropped together.
+        so it is identical across replays and cache evictions. The configured
+        sampler makes a single root decision per run, so the whole run is kept
+        or dropped together, and ``_emit_headerless_run_root`` exports one span
+        carrying exactly these identifiers, which is what gives the trace a root
+        that can be searched by name.
         """
-        run_id = (params.attributes or {}).get(_TEMPORAL_RUN_ID_ATTRIBUTE)
-        if not isinstance(run_id, str) or not run_id:
+        run_id = _headerless_run_id(params)
+        if run_id is None:
             return self.text_map_propagator.extract(params.context)
-        digest = hashlib.sha256(f"tracecat.temporal.run:{run_id}".encode()).digest()
-        trace_id = int.from_bytes(digest[:16], "big") or 1
-        span_id = int.from_bytes(digest[16:24], "big") or 1
+        ids = _deterministic_run_ids(run_id)
         # An explicit empty parent context forces a root decision; ``None``
         # would let the parent-based sampler inherit whatever span happens to
         # be current on the worker thread.
         sampling = self._sampler.should_sample(
             otel_context.Context(),
-            trace_id,
+            ids.trace_id,
             _HEADERLESS_RUN_SPAN_NAME,
             kind=SpanKind.SERVER,
         )
         parent = trace.NonRecordingSpan(
             trace.SpanContext(
-                trace_id=trace_id,
-                span_id=span_id,
+                trace_id=ids.trace_id,
+                span_id=ids.span_id,
                 is_remote=True,
                 trace_flags=TraceFlags(
                     TraceFlags.SAMPLED
@@ -384,6 +471,42 @@ class _TraceContextOnlyTracingInterceptor(TracingInterceptor):
             )
         )
         return trace.set_span_in_context(parent, otel_context.Context())
+
+    def _emit_headerless_run_root(self, params: _CompletedWorkflowSpanInput) -> None:
+        """Materialize the synthetic per-run parent as one searchable root span.
+
+        Without it a schedule-started run reaches the trace backend as an
+        orphan: complete children hanging off a parent that was never exported,
+        so the trace has no service and no name to search by. The span is
+        started through the tracer with the run's own identifiers pinned, which
+        keeps every child's parent intact while routing the root through the
+        configured sampler and span processors.
+
+        Only the ``RunWorkflow:`` command span emits it, so signals, queries and
+        updates on the same run do not each produce their own root.
+        """
+        if not params.name.startswith(_RUN_WORKFLOW_SPAN_PREFIX):
+            return
+        run_id = _headerless_run_id(params)
+        if run_id is None:
+            return
+        attributes = {
+            key: value
+            for key, value in (params.attributes or {}).items()
+            if key in _RUN_ROOT_SPAN_ATTRIBUTES
+        }
+        workflow_type = params.name.removeprefix(_RUN_WORKFLOW_SPAN_PREFIX)
+        with _pin_span_ids(_deterministic_run_ids(run_id)):
+            root = self.tracer.start_span(
+                f"{_SCHEDULED_RUN_SPAN_PREFIX}{workflow_type}",
+                context=otel_context.Context(),
+                attributes=attributes,
+                start_time=params.time_ns,
+                kind=SpanKind.SERVER,
+                record_exception=False,
+                set_status_on_exception=False,
+            )
+        root.end(end_time=params.time_ns)
 
     def workflow_interceptor_class(
         self, input: WorkflowInterceptorClassInput


### PR DESCRIPTION
## Summary

In Tempo, a schedule-started workflow run lists as `<root span not yet received>` with no Service and no Name. The children are complete and the trace is intact, but it cannot be found in the trace list without already knowing its trace ID. Webhook runs are fine because the HTTP request supplies a real root.

This is by design: `_headerless_run_context` parents headerless runs under a deterministic synthetic span derived from the run ID, and that parent is never exported. That is what keeps a scheduled run on one trace instead of fragmenting across every activity, so the fix keeps it.

This PR materializes that synthetic parent as one real SERVER span named `ScheduledRun:<WorkflowType>` carrying the same derived `(trace_id, span_id)`. Existing children keep their parent, and the trace gains a searchable root.

## Mechanism

- A `_PinnedIdGenerator` (subclass of `RandomIdGenerator`) is installed on the platform `TracerProvider`. It reads a `ContextVar`; when set, it returns the pinned ids instead of random ones.
- Id derivation moved into a shared `_deterministic_run_ids(run_id)` helper used by both `_headerless_run_context` (the children's parent) and the new `_emit_headerless_run_root`, so the two cannot drift.
- On a headerless `RunWorkflow:` completion, the interceptor starts one span through the tracer with the ids pinned for exactly that `start_span` call, an explicit empty parent context (same root sampling decision as the children), and `start_time == end_time`. Signals, queries, and updates on the same run emit nothing.

Why this is safe:

- **Sampling is unchanged.** Ratio sampling is a pure function of trace_id, which is identical either way. Dropped runs export no root (covered by a test).
- **Replays are idempotent.** A replay re-emits a byte-identical span; Tempo dedups it.
- **The pin cannot leak.** It is a context variable reset in `finally`, so a concurrent worker thread starting an unrelated span never picks up the run's ids (covered by a test).

## Caveats

- The root is zero-duration, emitted at run start. The value is searchability, not duration. Ending it at `CompleteWorkflow` would need cross-command state and would break replay idempotence.
- `_headerless_run_context` asks the sampler about `RunWorkflow` while the root goes through `start_span` as `ScheduledRun:<Type>`. Ratio, always-on, and always-off samplers ignore the name so decisions agree. A name-based sampler could disagree.
- The pin is only honoured by providers this module builds. An externally supplied `TracerProvider` would make the root a random-id sibling. Not reachable today.

## Tests

- `test_headerless_run_root_span_is_the_synthetic_parent` pins raw span-id equality against `_deterministic_run_ids`. Flipping one bit of the pinned span id makes it fail, so drift between root and parent cannot pass silently.
- Root emitted once per run across `RunWorkflow`, signal, query, update, and complete spans.
- `always_off` sampler exports no root.
- Ids do not leak to a later unrelated span.

## Sequencing

**Do not merge before the US upgrade to rc.23.** This changes what every worker exports, and US is still on rc.15 with no tracing infrastructure staged. Draft until then.

Refs ENG-1772.

## LOC breakdown

| Category | + | - |
| --- | --- | --- |
| Logic | 136 | 13 |
| Tests | 127 | 7 |

https://claude.ai/code/session_01G6Ch7wK4YyDhGzDKrkodFX


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scheduled workflow runs now export a real root span, so they show up in trace lists with a service and name instead of "<root span not yet received>". The deterministic synthetic parent that keeps a run on one trace is materialized as a zero-duration `ScheduledRun:<WorkflowType>` span with the same `(trace_id, span_id)`, and existing children keep their parent.

- Only the `RunWorkflow:` command emits the root; signals, queries, and updates on the same run do not.
- Sampling is unchanged because the run's trace ID is the same; dropped runs still export no root.
- Replays re-emit a byte-identical root span, making the change idempotent.
- The pinned IDs are scoped to the single `start_span` call via a context variable, so unrelated concurrent spans cannot pick them up.

**Rollout**
- Do not merge before the US upgrade to rc.23, as this changes what every worker exports.

<sup>Written for commit 9c5086cf20d5fb8fe9fa2dd5bf3292afd9ac2d3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

