### PR TITLE
feat(engine+ui): run a draft from a chosen action

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -115,6 +115,12 @@
   By default runs the current draft (unpublished edits) so changes can be tested before publishing. Set ``use_draft=False`` to run a published version instead.
 </ResponseField>
 
+<ResponseField name="run_workflow_from_action" type="tool">
+  Replay a draft run starting at ``action_ref``.
+
+  The selected action's immediate parents reuse their results from ``source_execution_id``, so the upstream is skipped and the selected action and everything downstream run fresh. The action must be a root-scope, non-control-flow action reached through success edges, and every parent needs a completed result in the source execution.
+</ResponseField>
+
 <ResponseField name="list_workflow_executions" type="tool">
   List recent executions for a workflow.
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -31310,6 +31310,64 @@ export const $WorkflowExecutionCreate = {
   title: "WorkflowExecutionCreate",
 } as const
 
+export const $WorkflowExecutionCreateFromAction = {
+  properties: {
+    workflow_id: {
+      anyOf: [
+        {
+          type: "string",
+          pattern: "wf_[0-9a-zA-Z]+",
+        },
+        {
+          type: "string",
+          pattern: "wf-[0-9a-f]{32}",
+        },
+      ],
+      title: "Workflow Id",
+    },
+    action_ref: {
+      type: "string",
+      title: "Action Ref",
+    },
+    source_execution_id: {
+      type: "string",
+      pattern:
+        "(wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/]((exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
+      title: "Source Execution Id",
+    },
+    inputs: {
+      anyOf: [
+        {},
+        {
+          type: "null",
+        },
+      ],
+      title: "Inputs",
+      description:
+        "Trigger inputs. Defaults to the source execution's trigger inputs when omitted.",
+    },
+    time_anchor: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Time Anchor",
+      description:
+        "Override the workflow's time anchor for FN.now() and related functions.",
+    },
+  },
+  type: "object",
+  required: ["workflow_id", "action_ref", "source_execution_id"],
+  title: "WorkflowExecutionCreateFromAction",
+  description:
+    "Start a draft run at a specific action, reusing its upstream results.",
+} as const
+
 export const $WorkflowExecutionCreateResponse = {
   properties: {
     message: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -2969,6 +2969,8 @@ export const workflowExecutionsCreateDraftWorkflowExecutionFromAction = (
     body: data.requestBody,
     mediaType: "application/json",
     errors: {
+      400: "Draft, replay source, or trigger inputs are invalid",
+      404: "Workflow or source execution not found",
       422: "Validation Error",
     },
   })

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -850,6 +850,8 @@ import type {
   WorkflowExecutionsCancelWorkflowExecutionData,
   WorkflowExecutionsCancelWorkflowExecutionResponse,
   WorkflowExecutionsCreateDraftWorkflowExecutionData,
+  WorkflowExecutionsCreateDraftWorkflowExecutionFromActionData,
+  WorkflowExecutionsCreateDraftWorkflowExecutionFromActionResponse,
   WorkflowExecutionsCreateDraftWorkflowExecutionResponse,
   WorkflowExecutionsCreateWorkflowExecutionData,
   WorkflowExecutionsCreateWorkflowExecutionResponse,
@@ -2930,6 +2932,37 @@ export const workflowExecutionsCreateDraftWorkflowExecution = (
   return __request(OpenAPI, {
     method: "POST",
     url: "/workspaces/{workspace_id}/workflow-executions/draft",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Draft Workflow Execution From Action
+ * Create and schedule a draft execution that starts at a specific action.
+ *
+ * The immediate parents of `action_ref` are pinned to their results in
+ * `source_execution_id`, so the exclusive upstream cone is skipped and the
+ * selected action and everything downstream run fresh. The workflow's stored
+ * draft pins are neither read nor modified.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns WorkflowExecutionCreateResponse Successful Response
+ * @throws ApiError
+ */
+export const workflowExecutionsCreateDraftWorkflowExecutionFromAction = (
+  data: WorkflowExecutionsCreateDraftWorkflowExecutionFromActionData
+): CancelablePromise<WorkflowExecutionsCreateDraftWorkflowExecutionFromActionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/workflow-executions/draft/from-action",
     path: {
       workspace_id: data.workspaceId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9342,6 +9342,23 @@ export type WorkflowExecutionCreate = {
   time_anchor?: string | null
 }
 
+/**
+ * Start a draft run at a specific action, reusing its upstream results.
+ */
+export type WorkflowExecutionCreateFromAction = {
+  workflow_id: string
+  action_ref: string
+  source_execution_id: string
+  /**
+   * Trigger inputs. Defaults to the source execution's trigger inputs when omitted.
+   */
+  inputs?: unknown | null
+  /**
+   * Override the workflow's time anchor for FN.now() and related functions.
+   */
+  time_anchor?: string | null
+}
+
 export type WorkflowExecutionCreateResponse = {
   message: string
   wf_id: string
@@ -10869,6 +10886,14 @@ export type WorkflowExecutionsCreateDraftWorkflowExecutionData = {
 }
 
 export type WorkflowExecutionsCreateDraftWorkflowExecutionResponse =
+  WorkflowExecutionCreateResponse
+
+export type WorkflowExecutionsCreateDraftWorkflowExecutionFromActionData = {
+  requestBody: WorkflowExecutionCreateFromAction
+  workspaceId: string
+}
+
+export type WorkflowExecutionsCreateDraftWorkflowExecutionFromActionResponse =
   WorkflowExecutionCreateResponse
 
 export type WorkflowExecutionsCancelWorkflowExecutionData = {
@@ -15190,6 +15215,21 @@ export type $OpenApiTs = {
   "/workspaces/{workspace_id}/workflow-executions/draft": {
     post: {
       req: WorkflowExecutionsCreateDraftWorkflowExecutionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: WorkflowExecutionCreateResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/workflow-executions/draft/from-action": {
+    post: {
+      req: WorkflowExecutionsCreateDraftWorkflowExecutionFromActionData
       res: {
         /**
          * Successful Response

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -15236,6 +15236,14 @@ export type $OpenApiTs = {
          */
         200: WorkflowExecutionCreateResponse
         /**
+         * Draft, replay source, or trigger inputs are invalid
+         */
+        400: unknown
+        /**
+         * Workflow or source execution not found
+         */
+        404: unknown
+        /**
          * Validation Error
          */
         422: HTTPValidationError

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CircleDot, PinIcon } from "lucide-react"
+import { CircleDot, PinIcon, PlayIcon } from "lucide-react"
 import { useState } from "react"
 import type { InteractionRead } from "@/client"
 import { ActionEventDetails } from "@/components/executions/action-event-details"
@@ -24,7 +24,9 @@ import {
   type WorkflowExecutionEventCompact,
   type WorkflowExecutionReadCompact,
 } from "@/lib/event-history"
+import { useCreateDraftWorkflowExecutionFromAction } from "@/lib/hooks"
 import {
+  getRunFromActionBlocker,
   getWorkflowDraftPins,
   isPinnableActionEvent,
   type WorkflowDraftPins,
@@ -41,10 +43,19 @@ export function ActionEventPane({
   execution: WorkflowExecutionReadCompact
   type: TabType
 }) {
-  const { workflowId, selectedActionEventRef, setSelectedActionEventRef } =
-    useWorkflowBuilder()
+  const {
+    workflowId,
+    selectedActionEventRef,
+    setSelectedActionEventRef,
+    setCurrentExecutionId,
+    sidebarRef,
+  } = useWorkflowBuilder()
   const { workflow, updateWorkflow } = useWorkflow()
   const [isSavingPins, setIsSavingPins] = useState(false)
+  const {
+    createDraftExecutionFromAction,
+    createDraftExecutionFromActionIsPending,
+  } = useCreateDraftWorkflowExecutionFromAction(workflowId ?? "")
   const draftPins = getWorkflowDraftPins(workflow)
   const isResultTab = type === "result"
 
@@ -79,6 +90,11 @@ export function ActionEventPane({
     selectedRefMatchesPinSource &&
     draftPins?.action_refs.includes(selectedActionEventRef)
   const canPinSelected = isPinnableActionEvent(
+    selectedActionEventRef,
+    groupedEvents,
+    workflow?.actions
+  )
+  const runFromBlocker = getRunFromActionBlocker(
     selectedActionEventRef,
     groupedEvents,
     workflow?.actions
@@ -143,6 +159,23 @@ export function ActionEventPane({
       title: "Unpinned action result",
       description: `ACTIONS.${selectedActionEventRef}.result will be computed again.`,
     })
+  }
+
+  const handleRunFromAction = async () => {
+    if (!selectedActionEventRef || runFromBlocker !== null) {
+      return
+    }
+    try {
+      const result = await createDraftExecutionFromAction({
+        workflow_id: workflowId,
+        action_ref: selectedActionEventRef,
+        source_execution_id: execution.id,
+      })
+      setCurrentExecutionId(result.wf_exec_id)
+      sidebarRef.current?.setActiveTab("workflow-events")
+    } catch {
+      // The mutation's onError already surfaced the failure.
+    }
   }
 
   const handleClearPins = async () => {
@@ -214,6 +247,22 @@ export function ActionEventPane({
             className="h-7 text-xs"
           >
             {selectedRefIsPinned ? "Unpin selected" : "Pin selected"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            disabled={
+              runFromBlocker !== null ||
+              createDraftExecutionFromActionIsPending ||
+              isSavingPins
+            }
+            title={runFromBlocker ?? undefined}
+            onClick={handleRunFromAction}
+            className="h-7 text-xs"
+          >
+            <PlayIcon className="mr-1 size-3" />
+            Run from this action
           </Button>
           <Button
             type="button"

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { CircleDot, PinIcon, PlayIcon } from "lucide-react"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import type { InteractionRead } from "@/client"
 import { ActionEventDetails } from "@/components/executions/action-event-details"
 import { JsonViewWithControls } from "@/components/json-viewer"
@@ -26,6 +26,7 @@ import {
 } from "@/lib/event-history"
 import { useCreateDraftWorkflowExecutionFromAction } from "@/lib/hooks"
 import {
+  buildWorkflowPinGraph,
   getRunFromActionBlocker,
   getWorkflowDraftPins,
   isPinnableActionEvent,
@@ -57,6 +58,10 @@ export function ActionEventPane({
     createDraftExecutionFromActionIsPending,
   } = useCreateDraftWorkflowExecutionFromAction(workflowId ?? "")
   const draftPins = getWorkflowDraftPins(workflow)
+  const pinGraph = useMemo(
+    () => buildWorkflowPinGraph(workflow?.actions),
+    [workflow?.actions]
+  )
   const isResultTab = type === "result"
 
   if (!workflowId)
@@ -90,12 +95,12 @@ export function ActionEventPane({
   const canPinSelected = isPinnableActionEvent(
     selectedActionEventRef,
     groupedEvents,
-    workflow?.actions
+    pinGraph
   )
   const runFromBlocker = getRunFromActionBlocker(
     selectedActionEventRef,
     groupedEvents,
-    workflow?.actions
+    pinGraph
   )
 
   const saveDraftPins = async (

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -338,6 +338,7 @@ import {
   type WebhookUpdate,
   type WorkflowDirectoryItem,
   type WorkflowExecutionCreate,
+  type WorkflowExecutionCreateFromAction,
   type WorkflowExecutionRead,
   type WorkflowExecutionReadMinimal,
   type WorkflowFolderCreate,
@@ -353,6 +354,7 @@ import {
   type WorkspaceReadMinimal,
   type WorkspaceUpdate,
   workflowExecutionsCreateDraftWorkflowExecution,
+  workflowExecutionsCreateDraftWorkflowExecutionFromAction,
   workflowExecutionsCreateWorkflowExecution,
   workflowExecutionsGetWorkflowExecution,
   workflowExecutionsGetWorkflowExecutionCompact,
@@ -1334,6 +1336,65 @@ export function useCreateDraftWorkflowExecution(workflowId: string) {
     createDraftExecution,
     createDraftExecutionIsPending,
     createDraftExecutionError,
+  }
+}
+
+/**
+ * Start a draft run at a specific action, reusing the upstream results of a
+ * source execution.
+ */
+export function useCreateDraftWorkflowExecutionFromAction(workflowId: string) {
+  const queryClient = useQueryClient()
+  const workspaceId = useWorkspaceId()
+
+  const {
+    mutateAsync: createDraftExecutionFromAction,
+    isPending: createDraftExecutionFromActionIsPending,
+    error: createDraftExecutionFromActionError,
+  } = useMutation({
+    mutationFn: async (params: WorkflowExecutionCreateFromAction) => {
+      return await workflowExecutionsCreateDraftWorkflowExecutionFromAction({
+        workspaceId,
+        requestBody: params,
+      })
+    },
+    onSuccess: async ({ wf_exec_id, message }) => {
+      toast({
+        title: `Draft workflow run started`,
+        description: `${wf_exec_id} ${message}`,
+      })
+
+      await queryClient.refetchQueries({
+        queryKey: ["last-manual-execution"],
+      })
+      await queryClient.refetchQueries({
+        queryKey: ["last-manual-execution", workflowId],
+      })
+      await queryClient.refetchQueries({
+        queryKey: ["workflow-executions", workflowId],
+      })
+      await queryClient.refetchQueries({
+        queryKey: ["compact-workflow-execution"],
+      })
+      await queryClient.refetchQueries({
+        queryKey: ["compact-workflow-execution", wf_exec_id],
+      })
+    },
+    onError: (error: TracecatApiError<Record<string, string>>) => {
+      console.error("Could not run from this action", error)
+      toast({
+        title: "Could not run from this action",
+        description:
+          getApiErrorDetail(error) ??
+          "Please check the run logs for more information.",
+      })
+    },
+  })
+
+  return {
+    createDraftExecutionFromAction,
+    createDraftExecutionFromActionIsPending,
+    createDraftExecutionFromActionError,
   }
 }
 

--- a/frontend/src/lib/workflow-pins.ts
+++ b/frontend/src/lib/workflow-pins.ts
@@ -24,6 +24,18 @@ export type PinDomains = {
   forceSkipRefs: Set<string>
 }
 
+/** Map action IDs to their slugified refs, skipping actions with empty refs. */
+function buildRefByActionId(actionList: ActionRead[]): Map<string, string> {
+  const refByActionId = new Map<string, string>()
+  for (const action of actionList) {
+    const actionRef = slugifyActionRef(action.title)
+    if (actionRef.length > 0) {
+      refByActionId.set(action.id, actionRef)
+    }
+  }
+  return refByActionId
+}
+
 const SCOPE_CLOSER_BY_OPENER = new Map([
   ["core.transform.scatter", "core.transform.gather"],
   ["core.loop.start", "core.loop.end"],
@@ -173,13 +185,7 @@ export function computePinDomains(
   const actionList = Object.values(actions)
   // Workflow reads describe the graph via `upstream_edges` keyed by action ID,
   // so resolve edges through an ID -> ref map rather than `depends_on`.
-  const refByActionId = new Map<string, string>()
-  for (const action of actionList) {
-    const actionRef = slugifyActionRef(action.title)
-    if (actionRef.length > 0) {
-      refByActionId.set(action.id, actionRef)
-    }
-  }
+  const refByActionId = buildRefByActionId(actionList)
   const allActionRefs = new Set<string>(refByActionId.values())
   const scopedRefs = computeScopedActionRefs(actions)
 
@@ -246,4 +252,75 @@ export function computePinDomains(
     Array.from(skipDomain).filter((actionRef) => !pinnedRefs.has(actionRef))
   )
   return { pinnedRefs, forceSkipRefs }
+}
+
+/** Why "Run from this action" is unavailable for `actionRef`, or null when it can run. */
+export function getRunFromActionBlocker(
+  actionRef: string | undefined,
+  groupedEvents: Record<string, WorkflowExecutionEventCompact[]>,
+  actions: Record<string, ActionRead> | null | undefined
+): string | null {
+  if (!actionRef || !actions) {
+    return "Select a workflow action"
+  }
+
+  const actionList = Object.values(actions)
+  const refByActionId = buildRefByActionId(actionList)
+  const action = actionList.find(
+    (candidate) => slugifyActionRef(candidate.title) === actionRef
+  )
+  if (!action) {
+    return "Select a workflow action"
+  }
+
+  if (
+    computeScopedActionRefs(actions).has(actionRef) ||
+    UNPINNABLE_ACTION_TYPES.has(action.type)
+  ) {
+    return "Cannot run from inside a scatter or loop"
+  }
+
+  const typeByRef = new Map<string, string>()
+  for (const candidate of actionList) {
+    const candidateRef = refByActionId.get(candidate.id)
+    if (candidateRef) {
+      typeByRef.set(candidateRef, candidate.type)
+    }
+  }
+
+  const parentRefs: string[] = []
+  for (const edge of action.upstream_edges ?? []) {
+    const sourceType = edge.source_type ?? "udf"
+    if (sourceType !== "udf") {
+      continue
+    }
+    const sourceRef = refByActionId.get(edge.source_id)
+    if (!sourceRef || sourceRef === actionRef) {
+      continue
+    }
+    if (edge.source_handle === "error") {
+      return "Cannot run from an error branch"
+    }
+    if (!parentRefs.includes(sourceRef)) {
+      parentRefs.push(sourceRef)
+    }
+  }
+
+  if (
+    parentRefs.some((parentRef) =>
+      UNPINNABLE_ACTION_TYPES.has(typeByRef.get(parentRef) ?? "")
+    )
+  ) {
+    return "Cannot run from directly after a gather or loop end"
+  }
+
+  if (
+    parentRefs.some(
+      (parentRef) => !isPinnableActionEvent(parentRef, groupedEvents, actions)
+    )
+  ) {
+    return "Every upstream action needs a completed result in this run"
+  }
+
+  return null
 }

--- a/frontend/src/lib/workflow-pins.ts
+++ b/frontend/src/lib/workflow-pins.ts
@@ -140,23 +140,41 @@ export function computeScopedActionRefs(
   return scopedRefs
 }
 
+export type WorkflowPinGraph = {
+  actionsByRef: ReadonlyMap<string, ActionRead>
+  refByActionId: ReadonlyMap<string, string>
+  scopedRefs: ReadonlySet<string>
+}
+
+/** Build once per draft graph, then reuse for each action eligibility check. */
+export function buildWorkflowPinGraph(
+  actions: Record<string, ActionRead> | null | undefined
+): WorkflowPinGraph {
+  const actionList = Object.values(actions ?? {})
+  return {
+    actionsByRef: new Map(
+      actionList.map((action) => [slugifyActionRef(action.title), action])
+    ),
+    refByActionId: buildRefByActionId(actionList),
+    scopedRefs: computeScopedActionRefs(actions),
+  }
+}
+
 /** Return whether a selected execution event is eligible to become a draft pin. */
 export function isPinnableActionEvent(
   actionRef: string | undefined,
   groupedEvents: Record<string, WorkflowExecutionEventCompact[]>,
-  actions: Record<string, ActionRead> | null | undefined
+  graph: WorkflowPinGraph
 ): boolean {
-  if (!actionRef || !groupedEvents[actionRef] || !actions) {
+  if (!actionRef || !groupedEvents[actionRef]) {
     return false
   }
 
-  if (computeScopedActionRefs(actions).has(actionRef)) {
+  if (graph.scopedRefs.has(actionRef)) {
     return false
   }
 
-  const action = Object.values(actions).find(
-    (candidate) => slugifyActionRef(candidate.title) === actionRef
-  )
+  const action = graph.actionsByRef.get(actionRef)
   if (
     !action ||
     UNPINNABLE_ACTION_TYPES.has(action.type) ||
@@ -273,34 +291,20 @@ export function computePinDomains(
 export function getRunFromActionBlocker(
   actionRef: string | undefined,
   groupedEvents: Record<string, WorkflowExecutionEventCompact[]>,
-  actions: Record<string, ActionRead> | null | undefined
+  graph: WorkflowPinGraph
 ): string | null {
-  if (!actionRef || !actions) {
+  if (!actionRef) {
     return "Select a workflow action"
   }
 
-  const actionList = Object.values(actions)
-  const refByActionId = buildRefByActionId(actionList)
-  const action = actionList.find(
-    (candidate) => slugifyActionRef(candidate.title) === actionRef
-  )
+  const { actionsByRef, refByActionId, scopedRefs } = graph
+  const action = actionsByRef.get(actionRef)
   if (!action) {
     return "Select a workflow action"
   }
 
-  if (
-    computeScopedActionRefs(actions).has(actionRef) ||
-    UNPINNABLE_ACTION_TYPES.has(action.type)
-  ) {
+  if (scopedRefs.has(actionRef) || UNPINNABLE_ACTION_TYPES.has(action.type)) {
     return "Cannot run from inside a scatter or loop"
-  }
-
-  const typeByRef = new Map<string, string>()
-  for (const candidate of actionList) {
-    const candidateRef = refByActionId.get(candidate.id)
-    if (candidateRef) {
-      typeByRef.set(candidateRef, candidate.type)
-    }
   }
 
   const parentRefs: string[] = []
@@ -323,7 +327,7 @@ export function getRunFromActionBlocker(
 
   if (
     parentRefs.some((parentRef) =>
-      UNPINNABLE_ACTION_TYPES.has(typeByRef.get(parentRef) ?? "")
+      UNPINNABLE_ACTION_TYPES.has(actionsByRef.get(parentRef)?.type ?? "")
     )
   ) {
     return "Cannot run from directly after a gather or loop end"
@@ -331,7 +335,7 @@ export function getRunFromActionBlocker(
 
   if (
     parentRefs.some(
-      (parentRef) => !isPinnableActionEvent(parentRef, groupedEvents, actions)
+      (parentRef) => !isPinnableActionEvent(parentRef, groupedEvents, graph)
     )
   ) {
     return "Every upstream action needs a completed result in this run"

--- a/frontend/src/lib/workflow-pins.ts
+++ b/frontend/src/lib/workflow-pins.ts
@@ -151,10 +151,16 @@ export function buildWorkflowPinGraph(
   actions: Record<string, ActionRead> | null | undefined
 ): WorkflowPinGraph {
   const actionList = Object.values(actions ?? {})
+  const actionsByRef = new Map<string, ActionRead>()
+  for (const action of actionList) {
+    const actionRef = slugifyActionRef(action.title)
+    // Match event navigation's first action when an editable draft has duplicates.
+    if (actionRef && !actionsByRef.has(actionRef)) {
+      actionsByRef.set(actionRef, action)
+    }
+  }
   return {
-    actionsByRef: new Map(
-      actionList.map((action) => [slugifyActionRef(action.title), action])
-    ),
+    actionsByRef,
     refByActionId: buildRefByActionId(actionList),
     scopedRefs: computeScopedActionRefs(actions),
   }

--- a/frontend/tests/action-event-details.test.tsx
+++ b/frontend/tests/action-event-details.test.tsx
@@ -93,6 +93,14 @@ jest.mock("@/providers/workflow", () => ({
   }),
 }))
 
+jest.mock("@/lib/hooks", () => ({
+  useCreateDraftWorkflowExecutionFromAction: jest.fn(() => ({
+    createDraftExecutionFromAction: jest.fn(),
+    createDraftExecutionFromActionIsPending: false,
+    createDraftExecutionFromActionError: null,
+  })),
+}))
+
 jest.mock("@/lib/stored-object", () => ({
   isCollectionStoredObject: (value: unknown) =>
     typeof value === "object" &&

--- a/frontend/tests/events-selected-action.test.tsx
+++ b/frontend/tests/events-selected-action.test.tsx
@@ -176,6 +176,14 @@ jest.mock("@/lib/api", () => ({
   getBaseUrl: jest.fn(() => "http://localhost:3000"),
 }))
 
+jest.mock("@/lib/hooks", () => ({
+  useCreateDraftWorkflowExecutionFromAction: jest.fn(() => ({
+    createDraftExecutionFromAction: jest.fn(),
+    createDraftExecutionFromActionIsPending: false,
+    createDraftExecutionFromActionError: null,
+  })),
+}))
+
 jest.mock("@/lib/stored-object", () => ({
   isCollectionStoredObject: jest.fn(() => false),
   isExternalStoredObject: jest.fn(() => false),

--- a/frontend/tests/workflow-pins.test.ts
+++ b/frontend/tests/workflow-pins.test.ts
@@ -1,6 +1,7 @@
 import type { ActionRead } from "@/client"
 import type { WorkflowExecutionEventCompact } from "@/lib/event-history"
 import {
+  buildWorkflowPinGraph,
   computePinDomains,
   computeScopedActionRefs,
   getRunFromActionBlocker,
@@ -45,6 +46,7 @@ const actions: Record<string, ActionRead> = {
   "id-d": action("id-d", "d", ["id-a"]),
   "id-e": action("id-e", "e", ["id-c", "id-d"]),
 }
+const pinGraph = buildWorkflowPinGraph(actions)
 
 function completedEvent(streamId: string): WorkflowExecutionEventCompact {
   return {
@@ -60,9 +62,20 @@ function completedEvent(streamId: string): WorkflowExecutionEventCompact {
 }
 
 describe("isPinnableActionEvent", () => {
+  it("reuses graph facts while evaluating changing run results", () => {
+    const graph = buildWorkflowPinGraph(actions)
+    expect(isPinnableActionEvent("c", {}, graph)).toBe(false)
+    expect(
+      isPinnableActionEvent("c", { c: [completedEvent("<root>:0")] }, graph)
+    ).toBe(true)
+    expect(
+      isPinnableActionEvent("c", {}, buildWorkflowPinGraph(undefined))
+    ).toBe(false)
+  })
+
   it("accepts completed root-stream events", () => {
     expect(
-      isPinnableActionEvent("c", { c: [completedEvent("<root>:0")] }, actions)
+      isPinnableActionEvent("c", { c: [completedEvent("<root>:0")] }, pinGraph)
     ).toBe(true)
   })
 
@@ -71,7 +84,7 @@ describe("isPinnableActionEvent", () => {
       isPinnableActionEvent(
         "c",
         { c: [completedEvent("<root>:0/scatter:0")] },
-        actions
+        pinGraph
       )
     ).toBe(false)
   })
@@ -202,7 +215,7 @@ describe("computeScopedActionRefs", () => {
       isPinnableActionEvent(
         "body",
         { body: [completedEvent("<root>:0")] },
-        loopActions
+        buildWorkflowPinGraph(loopActions)
       )
     ).toBe(false)
     expect(
@@ -299,19 +312,19 @@ describe("getRunFromActionBlocker", () => {
 
   it("allows running from an action whose parents all completed", () => {
     expect(
-      getRunFromActionBlocker("c", { b: [completedEventFor("b")] }, actions)
+      getRunFromActionBlocker("c", { b: [completedEventFor("b")] }, pinGraph)
     ).toBeNull()
   })
 
   it("allows running from a root action with no parents", () => {
-    expect(getRunFromActionBlocker("a", {}, actions)).toBeNull()
+    expect(getRunFromActionBlocker("a", {}, pinGraph)).toBeNull()
   })
 
   it("requires a selected workflow action", () => {
-    expect(getRunFromActionBlocker(undefined, {}, actions)).toBe(
+    expect(getRunFromActionBlocker(undefined, {}, pinGraph)).toBe(
       "Select a workflow action"
     )
-    expect(getRunFromActionBlocker("ghost", {}, actions)).toBe(
+    expect(getRunFromActionBlocker("ghost", {}, pinGraph)).toBe(
       "Select a workflow action"
     )
   })
@@ -337,7 +350,7 @@ describe("getRunFromActionBlocker", () => {
       getRunFromActionBlocker(
         "body",
         { loop_start: [completedEventFor("loop_start")] },
-        loopActions
+        buildWorkflowPinGraph(loopActions)
       )
     ).toBe("Cannot run from inside a scatter or loop")
   })
@@ -352,7 +365,7 @@ describe("getRunFromActionBlocker", () => {
       getRunFromActionBlocker(
         "handler",
         { a: [completedEventFor("a")] },
-        conditionalActions
+        buildWorkflowPinGraph(conditionalActions)
       )
     ).toBe("Cannot run from an error branch")
   })
@@ -379,20 +392,20 @@ describe("getRunFromActionBlocker", () => {
       getRunFromActionBlocker(
         "after",
         { gather: [completedEventFor("gather")] },
-        scatterActions
+        buildWorkflowPinGraph(scatterActions)
       )
     ).toBe("Cannot run from directly after a gather or loop end")
   })
 
   it("requires every parent to have a completed result in this run", () => {
-    expect(getRunFromActionBlocker("c", {}, actions)).toBe(
+    expect(getRunFromActionBlocker("c", {}, pinGraph)).toBe(
       "Every upstream action needs a completed result in this run"
     )
     expect(
       getRunFromActionBlocker(
         "c",
         { b: [completedEventFor("b", "<root>:0/scatter:0")] },
-        actions
+        pinGraph
       )
     ).toBe("Every upstream action needs a completed result in this run")
   })

--- a/frontend/tests/workflow-pins.test.ts
+++ b/frontend/tests/workflow-pins.test.ts
@@ -3,6 +3,7 @@ import type { WorkflowExecutionEventCompact } from "@/lib/event-history"
 import {
   computePinDomains,
   computeScopedActionRefs,
+  getRunFromActionBlocker,
   isPinnableActionEvent,
 } from "@/lib/workflow-pins"
 
@@ -237,5 +238,123 @@ describe("computeScopedActionRefs", () => {
     const scopedRefs = computeScopedActionRefs(nestedScatterActions)
     expect(scopedRefs.has("x")).toBe(true)
     expect(scopedRefs.has("y")).toBe(true)
+  })
+})
+
+describe("getRunFromActionBlocker", () => {
+  function completedEventFor(
+    actionRef: string,
+    streamId = "<root>:0"
+  ): WorkflowExecutionEventCompact {
+    return {
+      source_event_id: 1,
+      schedule_time: "2026-09-04T00:00:00Z",
+      curr_event_type: "ACTIVITY_TASK_COMPLETED",
+      status: "COMPLETED",
+      action_name: "core.noop",
+      action_ref: actionRef,
+      action_error: null,
+      stream_id: streamId,
+    }
+  }
+
+  it("allows running from an action whose parents all completed", () => {
+    expect(
+      getRunFromActionBlocker("c", { b: [completedEventFor("b")] }, actions)
+    ).toBeNull()
+  })
+
+  it("allows running from a root action with no parents", () => {
+    expect(getRunFromActionBlocker("a", {}, actions)).toBeNull()
+  })
+
+  it("requires a selected workflow action", () => {
+    expect(getRunFromActionBlocker(undefined, {}, actions)).toBe(
+      "Select a workflow action"
+    )
+    expect(getRunFromActionBlocker("ghost", {}, actions)).toBe(
+      "Select a workflow action"
+    )
+  })
+
+  it("rejects actions inside a loop scope", () => {
+    const loopActions = {
+      "id-loop-start": action(
+        "id-loop-start",
+        "loop_start",
+        [],
+        "core.loop.start"
+      ),
+      "id-body": action("id-body", "body", ["id-loop-start"]),
+      "id-loop-end": action(
+        "id-loop-end",
+        "loop_end",
+        ["id-body"],
+        "core.loop.end"
+      ),
+    }
+
+    expect(
+      getRunFromActionBlocker(
+        "body",
+        { loop_start: [completedEventFor("loop_start")] },
+        loopActions
+      )
+    ).toBe("Cannot run from inside a scatter or loop")
+  })
+
+  it("rejects actions on an error branch", () => {
+    const conditionalActions = {
+      "id-a": action("id-a", "a"),
+      "id-handler": action("id-handler", "handler", [["id-a", "error"]]),
+    }
+
+    expect(
+      getRunFromActionBlocker(
+        "handler",
+        { a: [completedEventFor("a")] },
+        conditionalActions
+      )
+    ).toBe("Cannot run from an error branch")
+  })
+
+  it("rejects actions directly after a gather", () => {
+    const scatterActions = {
+      "id-scatter": action(
+        "id-scatter",
+        "scatter",
+        [],
+        "core.transform.scatter"
+      ),
+      "id-body": action("id-body", "body", ["id-scatter"]),
+      "id-gather": action(
+        "id-gather",
+        "gather",
+        ["id-body"],
+        "core.transform.gather"
+      ),
+      "id-after": action("id-after", "after", ["id-gather"]),
+    }
+
+    expect(
+      getRunFromActionBlocker(
+        "after",
+        { gather: [completedEventFor("gather")] },
+        scatterActions
+      )
+    ).toBe("Cannot run from directly after a gather or loop end")
+  })
+
+  it("requires every parent to have a completed result in this run", () => {
+    expect(getRunFromActionBlocker("c", {}, actions)).toBe(
+      "Every upstream action needs a completed result in this run"
+    )
+    expect(
+      getRunFromActionBlocker(
+        "c",
+        { b: [completedEventFor("b", "<root>:0/scatter:0")] },
+        actions
+      )
+    ).toBe("Every upstream action needs a completed result in this run")
   })
 })

--- a/frontend/tests/workflow-pins.test.ts
+++ b/frontend/tests/workflow-pins.test.ts
@@ -99,7 +99,11 @@ describe("isPinnableActionEvent", () => {
       isPinnableActionEvent("c", { c: [completedEvent("<root>:0")] }, graph)
     ).toBe(true)
     expect(
-      isPinnableActionEvent("c", {}, buildWorkflowPinGraph(undefined))
+      isPinnableActionEvent(
+        "c",
+        { c: [completedEvent("<root>:0")] },
+        buildWorkflowPinGraph(undefined)
+      )
     ).toBe(false)
   })
 

--- a/frontend/tests/workflow-pins.test.ts
+++ b/frontend/tests/workflow-pins.test.ts
@@ -62,6 +62,36 @@ function completedEvent(streamId: string): WorkflowExecutionEventCompact {
 }
 
 describe("isPinnableActionEvent", () => {
+  it.each([true, false])(
+    "uses the first duplicate ref's mask setting (%s)",
+    (maskOutput) => {
+      const first = {
+        ...action("first", "Duplicate action"),
+        control_flow: { mask_output: maskOutput },
+      }
+      const second = {
+        ...action("second", "Duplicate Action"),
+        control_flow: { mask_output: !maskOutput },
+      }
+      const graph = buildWorkflowPinGraph({
+        first,
+        second,
+        downstream: action("downstream", "downstream", ["first"]),
+      })
+      const events = { duplicate_action: [completedEvent("<root>:0")] }
+
+      expect(graph.actionsByRef.get("duplicate_action")).toBe(first)
+      expect(isPinnableActionEvent("duplicate_action", events, graph)).toBe(
+        !maskOutput
+      )
+      expect(getRunFromActionBlocker("downstream", events, graph)).toBe(
+        maskOutput
+          ? "Every upstream action needs a completed result in this run"
+          : null
+      )
+    }
+  )
+
   it("reuses graph facts while evaluating changing run results", () => {
     const graph = buildWorkflowPinGraph(actions)
     expect(isPinnableActionEvent("c", {}, graph)).toBe(false)

--- a/tests/unit/test_draft_pin_resolution.py
+++ b/tests/unit/test_draft_pin_resolution.py
@@ -1,10 +1,12 @@
 """Unit tests for resolving draft action pins from prior executions."""
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from temporalio.api.enums.v1 import EventType
 from temporalio.client import Client
 from temporalio.service import RPCError, RPCStatusCode
 
@@ -26,6 +28,35 @@ from tracecat.workflow.executions.service import (
     WorkflowExecutionsService,
 )
 from tracecat.workflow.management.types import WorkflowDraftPinsData
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("has_start", [False, True])
+async def test_unreadable_source_inputs_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, has_start: bool
+) -> None:
+    service = _service()
+    monkeypatch.setattr(service, "require_execution", AsyncMock())
+
+    async def history():
+        if has_start:
+            yield SimpleNamespace(
+                event_type=EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+                workflow_execution_started_event_attributes=SimpleNamespace(input=None),
+            )
+
+    monkeypatch.setattr(
+        service, "handle", lambda _: SimpleNamespace(fetch_history_events=history)
+    )
+    monkeypatch.setattr(
+        "tracecat.workflow.executions.service.extract_first",
+        AsyncMock(return_value={"invalid": "start arguments"}),
+    )
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await service.get_execution_trigger_inputs(
+            generate_exec_id(WorkflowUUID.new_uuid4())
+        )
+    assert _detail(exc_info.value)["code"] == "source_inputs_unreadable"
 
 
 def _service() -> WorkflowExecutionsService:

--- a/tests/unit/test_draft_pin_resolution.py
+++ b/tests/unit/test_draft_pin_resolution.py
@@ -13,7 +13,7 @@ from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.enums import PlatformAction
 from tracecat.dsl.schemas import ActionStatement, TaskResult
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.storage.object import ExternalObject, InlineObject, ObjectRef
 from tracecat.workflow.executions.enums import (
@@ -564,12 +564,14 @@ async def test_run_from_action_requires_every_parent_result(
 async def test_run_from_root_action_needs_no_pins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Invariant: a root action runs a plain draft run with no source lookup."""
+    """A root action needs no pins but still requires source visibility."""
     wf_id = WorkflowUUID.new_uuid4()
     service = _service()
     list_events = AsyncMock(return_value=[])
     monkeypatch.setattr(service, "list_workflow_execution_events_compact", list_events)
 
+    require = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(service, "require_execution", require)
     result = await service.resolve_run_from_action_pins(
         wf_id=wf_id,
         dsl=_chain_dsl(),
@@ -578,6 +580,7 @@ async def test_run_from_root_action_needs_no_pins(
     )
 
     assert result == {}
+    require.assert_awaited_once()
     list_events.assert_not_awaited()
 
 
@@ -593,6 +596,7 @@ async def test_execution_trigger_inputs_returns_inline_data(
     """Invariant: inline trigger inputs are replayed verbatim."""
     wf_id = WorkflowUUID.new_uuid4()
     service = _service()
+    monkeypatch.setattr(service, "require_execution", AsyncMock())
     assert service.role is not None
     run_args = DSLRunArgs(
         role=service.role,
@@ -616,6 +620,7 @@ async def test_execution_trigger_inputs_rejects_external_object(
     """Invariant: offloaded trigger inputs must be supplied by the caller."""
     wf_id = WorkflowUUID.new_uuid4()
     service = _service()
+    monkeypatch.setattr(service, "require_execution", AsyncMock())
     assert service.role is not None
     run_args = DSLRunArgs(
         role=service.role,
@@ -639,3 +644,46 @@ async def test_execution_trigger_inputs_rejects_external_object(
         await service.get_execution_trigger_inputs(generate_exec_id(wf_id))
 
     assert _detail(exc_info.value)["code"] == "source_inputs_not_inline"
+
+
+@pytest.mark.anyio
+async def test_root_replay_rejects_other_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service()
+    require = AsyncMock()
+    monkeypatch.setattr(service, "require_execution", require)
+    with pytest.raises(TracecatValidationError) as exc:
+        await service.resolve_run_from_action_pins(
+            wf_id=WorkflowUUID.new_uuid4(),
+            dsl=_chain_dsl(),
+            action_ref="a",
+            source_execution_id=generate_exec_id(WorkflowUUID.new_uuid4()),
+        )
+    assert _detail(exc.value)["code"] == "source_workflow_mismatch"
+    require.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("read_inputs", [False, True])
+async def test_replay_denies_invisible_source_before_history(
+    monkeypatch: pytest.MonkeyPatch,
+    read_inputs: bool,
+) -> None:
+    service = _service()
+    wf_id = WorkflowUUID.new_uuid4()
+    source_id = generate_exec_id(wf_id)
+    monkeypatch.setattr(service, "get_execution", AsyncMock(return_value=None))
+    history = AsyncMock()
+    monkeypatch.setattr(service, "_get_run_start_args", history)
+    with pytest.raises(TracecatNotFoundError):
+        if read_inputs:
+            await service.get_execution_trigger_inputs(source_id)
+        else:
+            await service.resolve_run_from_action_pins(
+                wf_id=wf_id,
+                dsl=_chain_dsl(),
+                action_ref="a",
+                source_execution_id=source_id,
+            )
+    history.assert_not_awaited()

--- a/tests/unit/test_draft_pin_resolution.py
+++ b/tests/unit/test_draft_pin_resolution.py
@@ -1,6 +1,7 @@
 """Unit tests for resolving draft action pins from prior executions."""
 
 from datetime import UTC, datetime
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -12,8 +13,9 @@ from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.enums import PlatformAction
 from tracecat.dsl.schemas import ActionStatement, TaskResult
+from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
-from tracecat.storage.object import ExternalObject, ObjectRef
+from tracecat.storage.object import ExternalObject, InlineObject, ObjectRef
 from tracecat.workflow.executions.enums import (
     WorkflowEventType,
     WorkflowExecutionEventStatus,
@@ -55,6 +57,13 @@ def _event(action_ref: str) -> WorkflowExecutionEventCompact:
         action_ref=action_ref,
         action_result={"value": "source"},
     )
+
+
+def _detail(exc: TracecatValidationError) -> dict[str, Any]:
+    """Machine-readable rejection detail; assertions never read message text."""
+    detail = exc.detail
+    assert isinstance(detail, dict)
+    return cast(dict[str, Any], detail)
 
 
 def _pins(source_execution_id: str, *action_refs: str) -> WorkflowDraftPinsData:
@@ -355,3 +364,278 @@ async def test_stitching_preserves_original_pin_provenance(
     assert len(stitched) == 1
     assert stitched[0].pinned_source_execution_id == execution_a
     assert stitched[0].pinned_source_event_id == 7
+
+
+# ---------------------------------------------------------------------------
+# resolve_run_from_action_pins
+# ---------------------------------------------------------------------------
+
+
+def _chain_dsl() -> DSLInput:
+    """a -> b -> c, all root-scope success edges."""
+    return _dsl(
+        ActionStatement(ref="a", action="core.noop"),
+        ActionStatement(ref="b", action="core.noop", depends_on=["a"]),
+        ActionStatement(ref="c", action="core.noop", depends_on=["b"]),
+    )
+
+
+@pytest.mark.anyio
+async def test_run_from_action_pins_only_immediate_parents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: the cut set is exactly the selected action's parents."""
+    wf_id = WorkflowUUID.new_uuid4()
+    source_execution_id = generate_exec_id(wf_id)
+    service = _service()
+    monkeypatch.setattr(service, "get_execution", AsyncMock(return_value=MagicMock()))
+    list_events = AsyncMock(return_value=[_event("a"), _event("b")])
+    monkeypatch.setattr(service, "list_workflow_execution_events_compact", list_events)
+
+    result = await service.resolve_run_from_action_pins(
+        wf_id=wf_id,
+        dsl=_chain_dsl(),
+        action_ref="c",
+        source_execution_id=source_execution_id,
+    )
+
+    assert set(result) == {"b"}
+    list_events.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_run_from_action_rejects_unknown_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: a ref outside the current draft graph cannot start a run."""
+    wf_id = WorkflowUUID.new_uuid4()
+    service = _service()
+    list_events = AsyncMock(return_value=[])
+    monkeypatch.setattr(service, "list_workflow_execution_events_compact", list_events)
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await service.resolve_run_from_action_pins(
+            wf_id=wf_id,
+            dsl=_chain_dsl(),
+            action_ref="ghost",
+            source_execution_id=generate_exec_id(wf_id),
+        )
+
+    assert _detail(exc_info.value)["code"] == "unknown_action_ref"
+    list_events.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_run_from_action_rejects_scoped_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: actions inside a scatter scope are not restartable."""
+    wf_id = WorkflowUUID.new_uuid4()
+    service = _service()
+    list_events = AsyncMock(return_value=[])
+    monkeypatch.setattr(service, "list_workflow_execution_events_compact", list_events)
+
+    dsl = _dsl(
+        ActionStatement(ref="prepare", action="core.noop"),
+        ActionStatement(
+            ref="scatter",
+            action=PlatformAction.TRANSFORM_SCATTER,
+            args={"collection": "${{ ACTIONS.prepare.result }}"},
+            depends_on=["prepare"],
+        ),
+        ActionStatement(ref="body", action="core.noop", depends_on=["scatter"]),
+        ActionStatement(
+            ref="gather",
+            action=PlatformAction.TRANSFORM_GATHER,
+            args={"items": "${{ ACTIONS.body.result }}"},
+            depends_on=["body"],
+        ),
+    )
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await service.resolve_run_from_action_pins(
+            wf_id=wf_id,
+            dsl=dsl,
+            action_ref="body",
+            source_execution_id=generate_exec_id(wf_id),
+        )
+
+    assert _detail(exc_info.value)["code"] == "action_not_restartable"
+    list_events.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_run_from_action_rejects_error_edge_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: a failed parent result cannot be reused as a pinned success."""
+    wf_id = WorkflowUUID.new_uuid4()
+    service = _service()
+    list_events = AsyncMock(return_value=[])
+    monkeypatch.setattr(service, "list_workflow_execution_events_compact", list_events)
+
+    dsl = _dsl(
+        ActionStatement(ref="a", action="core.noop"),
+        ActionStatement(ref="handler", action="core.noop", depends_on=["a.error"]),
+    )
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await service.resolve_run_from_action_pins(
+            wf_id=wf_id,
+            dsl=dsl,
+            action_ref="handler",
+            source_execution_id=generate_exec_id(wf_id),
+        )
+
+    assert _detail(exc_info.value)["code"] == "error_edge_parent"
+    assert _detail(exc_info.value)["parent_refs"] == ["a"]
+    list_events.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_run_from_action_rejects_control_flow_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: a gather result cannot be reused as an upstream pin."""
+    wf_id = WorkflowUUID.new_uuid4()
+    service = _service()
+    list_events = AsyncMock(return_value=[])
+    monkeypatch.setattr(service, "list_workflow_execution_events_compact", list_events)
+
+    dsl = _dsl(
+        ActionStatement(ref="prepare", action="core.noop"),
+        ActionStatement(
+            ref="scatter",
+            action=PlatformAction.TRANSFORM_SCATTER,
+            args={"collection": "${{ ACTIONS.prepare.result }}"},
+            depends_on=["prepare"],
+        ),
+        ActionStatement(ref="body", action="core.noop", depends_on=["scatter"]),
+        ActionStatement(
+            ref="gather",
+            action=PlatformAction.TRANSFORM_GATHER,
+            args={"items": "${{ ACTIONS.body.result }}"},
+            depends_on=["body"],
+        ),
+        ActionStatement(ref="after", action="core.noop", depends_on=["gather"]),
+    )
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await service.resolve_run_from_action_pins(
+            wf_id=wf_id,
+            dsl=dsl,
+            action_ref="after",
+            source_execution_id=generate_exec_id(wf_id),
+        )
+
+    assert _detail(exc_info.value)["code"] == "control_flow_parent"
+    assert _detail(exc_info.value)["parent_refs"] == ["gather"]
+    list_events.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_run_from_action_requires_every_parent_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: a missing parent result fails instead of re-running upstream."""
+    wf_id = WorkflowUUID.new_uuid4()
+    source_execution_id = generate_exec_id(wf_id)
+    service = _service()
+    monkeypatch.setattr(service, "get_execution", AsyncMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        service,
+        "list_workflow_execution_events_compact",
+        AsyncMock(return_value=[]),
+    )
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await service.resolve_run_from_action_pins(
+            wf_id=wf_id,
+            dsl=_chain_dsl(),
+            action_ref="c",
+            source_execution_id=source_execution_id,
+        )
+
+    assert _detail(exc_info.value)["code"] == "unresolved_parents"
+    assert _detail(exc_info.value)["parent_refs"] == ["b"]
+
+
+@pytest.mark.anyio
+async def test_run_from_root_action_needs_no_pins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: a root action runs a plain draft run with no source lookup."""
+    wf_id = WorkflowUUID.new_uuid4()
+    service = _service()
+    list_events = AsyncMock(return_value=[])
+    monkeypatch.setattr(service, "list_workflow_execution_events_compact", list_events)
+
+    result = await service.resolve_run_from_action_pins(
+        wf_id=wf_id,
+        dsl=_chain_dsl(),
+        action_ref="a",
+        source_execution_id=generate_exec_id(wf_id),
+    )
+
+    assert result == {}
+    list_events.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# get_execution_trigger_inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_execution_trigger_inputs_returns_inline_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: inline trigger inputs are replayed verbatim."""
+    wf_id = WorkflowUUID.new_uuid4()
+    service = _service()
+    assert service.role is not None
+    run_args = DSLRunArgs(
+        role=service.role,
+        dsl=_chain_dsl(),
+        wf_id=wf_id,
+        trigger_inputs=InlineObject(data={"alpha": 1}),
+    )
+    monkeypatch.setattr(
+        service, "_get_run_start_args", AsyncMock(return_value=run_args)
+    )
+
+    assert await service.get_execution_trigger_inputs(generate_exec_id(wf_id)) == {
+        "alpha": 1
+    }
+
+
+@pytest.mark.anyio
+async def test_execution_trigger_inputs_rejects_external_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: offloaded trigger inputs must be supplied by the caller."""
+    wf_id = WorkflowUUID.new_uuid4()
+    service = _service()
+    assert service.role is not None
+    run_args = DSLRunArgs(
+        role=service.role,
+        dsl=_chain_dsl(),
+        wf_id=wf_id,
+        trigger_inputs=ExternalObject(
+            ref=ObjectRef(
+                bucket="test-bucket",
+                key="wf/test/trigger.json",
+                size_bytes=64,
+                sha256="abc123",
+            ),
+            typename="dict",
+        ),
+    )
+    monkeypatch.setattr(
+        service, "_get_run_start_args", AsyncMock(return_value=run_args)
+    )
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await service.get_execution_trigger_inputs(generate_exec_id(wf_id))
+
+    assert _detail(exc_info.value)["code"] == "source_inputs_not_inline"

--- a/tests/unit/test_run_from_action_contract.py
+++ b/tests/unit/test_run_from_action_contract.py
@@ -1,0 +1,14 @@
+"""The replay endpoint publishes its handled errors to API clients."""
+
+from fastapi import FastAPI
+
+from tracecat.workflow.executions.router import router
+
+
+def test_run_from_action_declares_handled_errors() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    operations = app.openapi()["paths"]
+    path = next(path for path in operations if path.endswith("/draft/from-action"))
+    responses = operations[path]["post"]["responses"]
+    assert {"200", "400", "404", "422"} <= responses.keys()

--- a/tests/unit/test_run_from_action_contract.py
+++ b/tests/unit/test_run_from_action_contract.py
@@ -1,8 +1,51 @@
 """The replay endpoint publishes its handled errors to API clients."""
 
-from fastapi import FastAPI
+import uuid
+from collections.abc import Iterator
+from typing import get_args
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
 from tracecat.workflow.executions.router import router
+from tracecat.workflow.management.management import WorkflowsManagementService
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    app = FastAPI()
+    app.include_router(router)
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"workflow:execute"}),
+    )
+    role_dependency = get_args(WorkspaceUserRouteRole)[1].dependency
+    app.dependency_overrides[role_dependency] = lambda: role
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def run_from_action(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    service = MagicMock(spec=WorkflowsManagementService)
+    run = AsyncMock()
+    service.run_workflow_from_action = run
+    session = AsyncMock()
+    session.__aenter__.return_value = service
+    monkeypatch.setattr(
+        WorkflowsManagementService, "with_session", MagicMock(return_value=session)
+    )
+    return run
 
 
 def test_run_from_action_declares_handled_errors() -> None:
@@ -12,3 +55,53 @@ def test_run_from_action_declares_handled_errors() -> None:
     path = next(path for path in operations if path.endswith("/draft/from-action"))
     responses = operations[path]["post"]["responses"]
     assert {"200", "400", "404", "422"} <= responses.keys()
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["unknown_action_ref", "unresolved_parents", "source_inputs_not_inline"],
+)
+def test_run_from_action_preserves_validation_error_detail(
+    client: TestClient, run_from_action: AsyncMock, code: str
+) -> None:
+    run_from_action.side_effect = TracecatValidationError(
+        "Cannot replay this action.", detail={"code": code, "parent_refs": ["upstream"]}
+    )
+    wf_id = WorkflowUUID.new_uuid4()
+    response = client.post(
+        "/workflow-executions/draft/from-action",
+        json={
+            "workflow_id": str(wf_id),
+            "action_ref": "start",
+            "source_execution_id": generate_exec_id(wf_id),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {
+            "type": "TracecatValidationError",
+            "message": "Cannot replay this action.",
+            "detail": {"code": code, "parent_refs": ["upstream"]},
+        }
+    }
+    run_from_action.assert_awaited_once()
+
+
+def test_run_from_action_preserves_not_found_error(
+    client: TestClient, run_from_action: AsyncMock
+) -> None:
+    run_from_action.side_effect = TracecatNotFoundError("Source execution not found")
+    wf_id = WorkflowUUID.new_uuid4()
+    response = client.post(
+        "/workflow-executions/draft/from-action",
+        json={
+            "workflow_id": str(wf_id),
+            "action_ref": "start",
+            "source_execution_id": generate_exec_id(wf_id),
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Source execution not found"}
+    run_from_action.assert_awaited_once()

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -1145,6 +1145,9 @@ class _FakeExecService:
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.pinned_action_results: dict[str, TaskResult] = {}
         self.parsed_draft_pins: WorkflowDraftPins | None = None
+        self.run_from_action_pins: dict[str, TaskResult] = {}
+        self.run_from_action_kwargs: dict[str, Any] | None = None
+        self.source_trigger_inputs: Any | None = None
 
     async def create_draft_workflow_execution_wait_for_start(self, **kwargs: Any):
         self.calls.append(("draft", kwargs))
@@ -1171,6 +1174,15 @@ class _FakeExecService:
         self, draft_pins: WorkflowDraftPinsData | None
     ) -> WorkflowDraftPins | None:
         return self.parsed_draft_pins
+
+    async def resolve_run_from_action_pins(
+        self, **kwargs: Any
+    ) -> dict[str, TaskResult]:
+        self.run_from_action_kwargs = kwargs
+        return self.run_from_action_pins
+
+    async def get_execution_trigger_inputs(self, wf_exec_id: str) -> Any | None:
+        return self.source_trigger_inputs
 
 
 def _patch_exec_service(monkeypatch: pytest.MonkeyPatch) -> _FakeExecService:
@@ -1436,3 +1448,81 @@ async def test_create_actions_from_dsl_persists_action_environment() -> None:
     by_ref = {a.ref: a for a in actions}
     assert by_ref["a"].control_flow["environment"] == "prod"
     assert by_ref["b"].control_flow["environment"] is None
+
+
+@pytest.mark.anyio
+async def test_run_workflow_from_action_forwards_pins_and_default_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: run-from-action pins the cut set and replays source inputs."""
+    wf_id = WorkflowUUID.new_uuid4()
+    source_execution_id = generate_exec_id(wf_id)
+    dsl = _run_dsl()
+    service = _service(_role())
+    # A stored draft_pins config must not leak into a run-from-action dispatch.
+    monkeypatch.setattr(
+        service,
+        "get_workflow",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                draft_pins={
+                    "source_execution_id": "wf-other/exec-other",
+                    "action_refs": ["stale"],
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "build_dsl_from_workflow", AsyncMock(return_value=dsl))
+    monkeypatch.setattr(management, "validate_dsl", AsyncMock(return_value=[]))
+    fake_exec = _patch_exec_service(monkeypatch)
+    pinned_result = TaskResult.from_result({"value": "parent"})
+    fake_exec.run_from_action_pins = {"parent": pinned_result}
+    fake_exec.source_trigger_inputs = {"alpha": 1}
+
+    resp = await service.run_workflow_from_action(
+        wf_id,
+        action_ref="child",
+        source_execution_id=source_execution_id,
+    )
+
+    assert resp["wf_exec_id"] == "wf-exec-draft"
+    assert fake_exec.run_from_action_kwargs is not None
+    assert fake_exec.run_from_action_kwargs["action_ref"] == "child"
+    assert (
+        fake_exec.run_from_action_kwargs["source_execution_id"] == source_execution_id
+    )
+    assert [name for name, _ in fake_exec.calls] == ["draft"]
+    _, kwargs = fake_exec.calls[0]
+    assert kwargs["pinned_action_results"] == {"parent": pinned_result}
+    assert kwargs["pinned_source_execution_id"] == source_execution_id
+    # Inputs default to the source execution's trigger inputs.
+    assert kwargs["payload"] == {"alpha": 1}
+
+
+@pytest.mark.anyio
+async def test_run_workflow_from_action_prefers_explicit_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant: caller-supplied inputs win over the source execution's."""
+    wf_id = WorkflowUUID.new_uuid4()
+    dsl = _run_dsl()
+    service = _service(_role())
+    monkeypatch.setattr(
+        service,
+        "get_workflow",
+        AsyncMock(return_value=SimpleNamespace(draft_pins=None)),
+    )
+    monkeypatch.setattr(service, "build_dsl_from_workflow", AsyncMock(return_value=dsl))
+    monkeypatch.setattr(management, "validate_dsl", AsyncMock(return_value=[]))
+    fake_exec = _patch_exec_service(monkeypatch)
+    fake_exec.source_trigger_inputs = {"alpha": 1}
+
+    await service.run_workflow_from_action(
+        wf_id,
+        action_ref="child",
+        source_execution_id=generate_exec_id(wf_id),
+        inputs={"beta": 2},
+    )
+
+    _, kwargs = fake_exec.calls[0]
+    assert kwargs["payload"] == {"beta": 2}

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -1526,3 +1526,31 @@ async def test_run_workflow_from_action_prefers_explicit_inputs(
 
     _, kwargs = fake_exec.calls[0]
     assert kwargs["payload"] == {"beta": 2}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("explicit", [False, True])
+@pytest.mark.parametrize("payload", [{"count": "not-an-int"}, {}])
+async def test_run_from_action_validates_inputs_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch, explicit: bool, payload: dict[str, Any]
+) -> None:
+    dsl = _run_dsl(expects={"count": {"type": "int"}})
+    service = _service(_role())
+    monkeypatch.setattr(
+        service,
+        "get_workflow",
+        AsyncMock(return_value=SimpleNamespace(draft_pins=None)),
+    )
+    monkeypatch.setattr(service, "build_dsl_from_workflow", AsyncMock(return_value=dsl))
+    monkeypatch.setattr(management, "validate_dsl", AsyncMock(return_value=[]))
+    fake_exec = _patch_exec_service(monkeypatch)
+    fake_exec.source_trigger_inputs = payload
+
+    with pytest.raises(TracecatValidationError):
+        await service.run_workflow_from_action(
+            WorkflowUUID.new_uuid4(),
+            action_ref="child",
+            source_execution_id=generate_exec_id(WorkflowUUID.new_uuid4()),
+            inputs=payload if explicit else None,
+        )
+    assert fake_exec.calls == []

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -4805,7 +4805,7 @@ async def run_workflow_from_action(
     workspace_id: uuid.UUID,
     workflow_id: MCPWorkflowUUID,
     action_ref: str,
-    source_execution_id: str,
+    source_execution_id: WorkflowExecutionID,
     inputs: dict[str, Any] | None = None,
 ) -> WorkflowRunStartedResponse:
     """Replay a draft run starting at ``action_ref``.

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -4801,6 +4801,76 @@ async def run_workflow(
 
 
 @mcp.tool()
+async def run_workflow_from_action(
+    workspace_id: uuid.UUID,
+    workflow_id: MCPWorkflowUUID,
+    action_ref: str,
+    source_execution_id: str,
+    inputs: dict[str, Any] | None = None,
+) -> WorkflowRunStartedResponse:
+    """Replay a draft run starting at ``action_ref``.
+
+    The selected action's immediate parents reuse their results from
+    ``source_execution_id``, so the upstream is skipped and the selected action
+    and everything downstream run fresh. The action must be a root-scope,
+    non-control-flow action reached through success edges, and every parent
+    needs a completed result in the source execution.
+
+    Args:
+        workspace_id: The workspace ID.
+        workflow_id: The workflow ID.
+        action_ref: Ref of the action to start the run from.
+        source_execution_id: Execution to reuse upstream results from.
+        inputs: Optional trigger inputs object. Defaults to the source
+            execution's own trigger inputs.
+
+    Returns JSON with workflow_id, execution_id, and a message.
+    """
+
+    try:
+        workflow_id = WorkflowUUID.new(workflow_id)
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with WorkflowsManagementService.with_session(role=role) as svc:
+            response = await svc.run_workflow_from_action(
+                workflow_id,
+                action_ref=action_ref,
+                source_execution_id=source_execution_id,
+                inputs=inputs,
+            )
+        response_workflow_id = WorkflowUUID.new(response["wf_id"])
+        return WorkflowRunStartedResponse(
+            workflow_id=response_workflow_id,
+            execution_id=response["wf_exec_id"],
+            message=response["message"],
+        )
+    except ToolError:
+        raise
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(
+            json.dumps(
+                {
+                    "type": "validation_error",
+                    "message": str(e),
+                    "status": "error",
+                    "detail": e.detail,
+                },
+                default=str,
+            )
+        ) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except BaseException as e:
+        msg = str(e)
+        if isinstance(e, BaseExceptionGroup):
+            msgs = [str(exc) for exc in e.exceptions]
+            msg = "; ".join(msgs)
+        logger.error("Failed to run workflow from action", error=msg)
+        raise ToolError(f"Failed to run workflow from action: {msg}") from None
+
+
+@mcp.tool()
 async def list_workflow_executions(
     workspace_id: uuid.UUID,
     workflow_id: MCPWorkflowUUID,

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -1146,7 +1146,13 @@ async def create_draft_workflow_execution(
         ) from e
 
 
-@router.post("/draft/from-action")
+@router.post(
+    "/draft/from-action",
+    responses={
+        400: {"description": "Draft, replay source, or trigger inputs are invalid"},
+        404: {"description": "Workflow or source execution not found"},
+    },
+)
 @require_scope("workflow:execute")
 async def create_draft_workflow_execution_from_action(
     role: WorkspaceUserRouteRole,

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -27,7 +27,7 @@ from tracecat.dsl.common import (
 )
 from tracecat.ee.interactions.schemas import InteractionRead
 from tracecat.ee.interactions.service import InteractionService
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.identifiers import UserID
 from tracecat.identifiers.workflow import (
     AnyWorkflowIDPath,
@@ -70,6 +70,7 @@ from tracecat.workflow.executions.schemas import (
     WorkflowExecutionCollectionPageRequest,
     WorkflowExecutionCollectionPageResponse,
     WorkflowExecutionCreate,
+    WorkflowExecutionCreateFromAction,
     WorkflowExecutionCreateResponse,
     WorkflowExecutionObjectDownloadResponse,
     WorkflowExecutionObjectPreviewResponse,
@@ -1134,6 +1135,42 @@ async def create_draft_workflow_execution(
             # For draft workflow executions, pass None to dynamically resolve the registry lock
         )
         return response
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "type": "TracecatValidationError",
+                "message": str(e),
+                "detail": e.detail,
+            },
+        ) from e
+
+
+@router.post("/draft/from-action")
+@require_scope("workflow:execute")
+async def create_draft_workflow_execution_from_action(
+    role: WorkspaceUserRouteRole,
+    params: WorkflowExecutionCreateFromAction,
+) -> WorkflowExecutionCreateResponse:
+    """Create and schedule a draft execution that starts at a specific action.
+
+    The immediate parents of `action_ref` are pinned to their results in
+    `source_execution_id`, so the exclusive upstream cone is skipped and the
+    selected action and everything downstream run fresh. The workflow's stored
+    draft pins are neither read nor modified.
+    """
+    wf_id = WorkflowUUID.new(params.workflow_id)
+    try:
+        async with WorkflowsManagementService.with_session(role=role) as mgmt_service:
+            return await mgmt_service.run_workflow_from_action(
+                wf_id,
+                action_ref=params.action_ref,
+                source_execution_id=params.source_execution_id,
+                inputs=params.inputs,
+                time_anchor=params.time_anchor,
+            )
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except TracecatValidationError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -1092,6 +1092,27 @@ class WorkflowExecutionCreate(BaseModel):
     )
 
 
+class WorkflowExecutionCreateFromAction(BaseModel):
+    """Start a draft run at a specific action, reusing its upstream results."""
+
+    workflow_id: AnyWorkflowID
+    action_ref: str
+    source_execution_id: WorkflowExecutionID
+    inputs: TriggerInputs | None = Field(
+        default=None,
+        description=(
+            "Trigger inputs. Defaults to the source execution's trigger inputs "
+            "when omitted."
+        ),
+    )
+    time_anchor: datetime | None = Field(
+        default=None,
+        description=(
+            "Override the workflow's time anchor for FN.now() and related functions."
+        ),
+    )
+
+
 class WorkflowExecutionCreateResponse(TypedDict):
     message: str
     wf_id: WorkflowID

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -803,9 +803,7 @@ class WorkflowExecutionsService:
         except WorkflowExecutionNotFoundError as e:
             raise TracecatNotFoundError("Source execution not found") from e
 
-    async def _get_run_start_args(
-        self, wf_exec_id: WorkflowExecutionID
-    ) -> DSLRunArgs | None:
+    async def _get_run_start_args(self, wf_exec_id: WorkflowExecutionID) -> DSLRunArgs:
         """Read a run's start args from the first history event."""
         handle = self.handle(wf_exec_id)
         async for event in handle.fetch_history_events():
@@ -814,15 +812,16 @@ class WorkflowExecutionsService:
             attrs = event.workflow_execution_started_event_attributes
             run_args_data = await extract_first(attrs.input)
             try:
-                return DSLRunArgs(**run_args_data)
+                return DSLRunArgs.model_validate(run_args_data)
             except ValidationError as e:
-                self.logger.warning(
-                    "Failed to parse workflow start args",
-                    wf_exec_id=wf_exec_id,
-                    error=e,
-                )
-                return None
-        return None
+                raise TracecatValidationError(
+                    "Source trigger inputs could not be read; supply inputs explicitly.",
+                    detail={"code": "source_inputs_unreadable"},
+                ) from e
+        raise TracecatValidationError(
+            "Source execution has no start event; supply inputs explicitly.",
+            detail={"code": "source_inputs_unreadable"},
+        )
 
     async def get_execution_trigger_inputs(
         self, wf_exec_id: WorkflowExecutionID
@@ -836,7 +835,7 @@ class WorkflowExecutionsService:
         """
         await self._require_replay_source(wf_exec_id)
         run_args = await self._get_run_start_args(wf_exec_id)
-        if run_args is None or run_args.trigger_inputs is None:
+        if run_args.trigger_inputs is None:
             return None
         trigger_inputs = run_args.trigger_inputs
         if isinstance(trigger_inputs, InlineObject):

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -48,7 +48,7 @@ from tracecat.dsl.types import Task
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.ee.interactions.schemas import InteractionInput
 from tracecat.ee.interactions.service import InteractionService
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.identifiers import UserID, WorkspaceID
 from tracecat.identifiers.workflow import (
     WorkflowExecutionID,
@@ -760,6 +760,14 @@ class WorkflowExecutionsService:
                 },
             )
 
+        source_wf_id, _ = exec_id_to_parts(source_execution_id)
+        if source_wf_id != wf_id:
+            raise TracecatValidationError(
+                "Source execution does not belong to this workflow.",
+                detail={"code": "source_workflow_mismatch"},
+            )
+        await self._require_replay_source(source_execution_id)
+
         if not parent_refs:
             # A root action: run the draft from the start with no pins.
             return {}
@@ -787,6 +795,13 @@ class WorkflowExecutionsService:
             )
 
         return pinned_results
+
+    async def _require_replay_source(self, wf_exec_id: WorkflowExecutionID) -> None:
+        """Authorize replay history reads without exposing inaccessible runs."""
+        try:
+            await self.require_execution(wf_exec_id)
+        except WorkflowExecutionNotFoundError as e:
+            raise TracecatNotFoundError("Source execution not found") from e
 
     async def _get_run_start_args(
         self, wf_exec_id: WorkflowExecutionID
@@ -819,6 +834,7 @@ class WorkflowExecutionsService:
         the payload was offloaded to object storage, since the caller must then
         supply inputs explicitly.
         """
+        await self._require_replay_source(wf_exec_id)
         run_args = await self._get_run_start_args(wf_exec_id)
         if run_args is None or run_args.trigger_inputs is None:
             return None

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -42,12 +42,13 @@ from tracecat.dsl.common import (
     edge_components_from_dep,
 )
 from tracecat.dsl.constants import PINNED_SKIPPED_REFS_MEMO_KEY
-from tracecat.dsl.enums import PlatformAction
+from tracecat.dsl.enums import EdgeType, PlatformAction
 from tracecat.dsl.schemas import ROOT_STREAM, TaskResult, TriggerInputs
 from tracecat.dsl.types import Task
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.ee.interactions.schemas import InteractionInput
 from tracecat.ee.interactions.service import InteractionService
+from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers import UserID, WorkspaceID
 from tracecat.identifiers.workflow import (
     WorkflowExecutionID,
@@ -684,6 +685,154 @@ class WorkflowExecutionsService:
             )
 
         return pinned_results
+
+    async def resolve_run_from_action_pins(
+        self,
+        *,
+        wf_id: WorkflowID,
+        dsl: DSLInput,
+        action_ref: str,
+        source_execution_id: WorkflowExecutionID,
+    ) -> dict[str, TaskResult]:
+        """Resolve the pinned results needed to restart a run at ``action_ref``.
+
+        The cut set is the selected action's immediate parents: pinning them
+        lets the scheduler force-skip the exclusive upstream cone and execute
+        ``action_ref`` and everything downstream fresh.
+
+        Unlike :meth:`resolve_draft_pinned_action_results` this is strict --
+        every rejection raises ``TracecatValidationError`` with a
+        machine-readable ``detail["code"]`` so callers never silently re-run
+        upstream actions.
+        """
+        dsl_actions = {task.ref: task for task in dsl.actions}
+        stmt = dsl_actions.get(action_ref)
+        if stmt is None:
+            raise TracecatValidationError(
+                f"Action {action_ref!r} is not part of the current workflow graph.",
+                detail={"code": "unknown_action_ref", "action_ref": action_ref},
+            )
+
+        if (
+            action_ref in dsl.scoped_action_refs()
+            or stmt.action in UNSUPPORTED_DRAFT_PIN_ACTIONS
+        ):
+            raise TracecatValidationError(
+                f"Action {action_ref!r} cannot start a run: control-flow actions "
+                "and actions inside scatter or loop scopes are not restartable.",
+                detail={"code": "action_not_restartable", "action_ref": action_ref},
+            )
+
+        parent_refs: list[str] = []
+        error_edge_parents: list[str] = []
+        for dep in stmt.depends_on:
+            src_ref, edge_type = edge_components_from_dep(dep)
+            if edge_type is EdgeType.ERROR:
+                error_edge_parents.append(src_ref)
+            if src_ref not in parent_refs:
+                parent_refs.append(src_ref)
+
+        if error_edge_parents:
+            raise TracecatValidationError(
+                f"Action {action_ref!r} runs on an error branch; a failed parent "
+                "result cannot be reused as a pinned success.",
+                detail={
+                    "code": "error_edge_parent",
+                    "action_ref": action_ref,
+                    "parent_refs": sorted(set(error_edge_parents)),
+                },
+            )
+
+        control_flow_parents = sorted(
+            ref
+            for ref in parent_refs
+            if (parent := dsl_actions.get(ref)) is not None
+            and parent.action in UNSUPPORTED_DRAFT_PIN_ACTIONS
+        )
+        if control_flow_parents:
+            raise TracecatValidationError(
+                f"Action {action_ref!r} depends on a control-flow action whose "
+                "result cannot be reused.",
+                detail={
+                    "code": "control_flow_parent",
+                    "action_ref": action_ref,
+                    "parent_refs": control_flow_parents,
+                },
+            )
+
+        if not parent_refs:
+            # A root action: run the draft from the start with no pins.
+            return {}
+
+        pinned_results = await self.resolve_draft_pinned_action_results(
+            wf_id=wf_id,
+            dsl=dsl,
+            draft_pins=WorkflowDraftPinsData(
+                source_execution_id=source_execution_id,
+                action_refs=parent_refs,
+            ),
+        )
+
+        missing_refs = sorted(set(parent_refs) - set(pinned_results))
+        if missing_refs:
+            raise TracecatValidationError(
+                f"Could not reuse every upstream result for {action_ref!r} from "
+                f"execution {source_execution_id}.",
+                detail={
+                    "code": "unresolved_parents",
+                    "action_ref": action_ref,
+                    "parent_refs": missing_refs,
+                    "source_execution_id": source_execution_id,
+                },
+            )
+
+        return pinned_results
+
+    async def _get_run_start_args(
+        self, wf_exec_id: WorkflowExecutionID
+    ) -> DSLRunArgs | None:
+        """Read a run's start args from the first history event."""
+        handle = self.handle(wf_exec_id)
+        async for event in handle.fetch_history_events():
+            if event.event_type != EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED:
+                continue
+            attrs = event.workflow_execution_started_event_attributes
+            run_args_data = await extract_first(attrs.input)
+            try:
+                return DSLRunArgs(**run_args_data)
+            except ValidationError as e:
+                self.logger.warning(
+                    "Failed to parse workflow start args",
+                    wf_exec_id=wf_exec_id,
+                    error=e,
+                )
+                return None
+        return None
+
+    async def get_execution_trigger_inputs(
+        self, wf_exec_id: WorkflowExecutionID
+    ) -> Any | None:
+        """Return the inline trigger inputs an execution was started with.
+
+        Returns ``None`` when the run had no trigger inputs. Raises
+        ``TracecatValidationError`` with code ``source_inputs_not_inline`` when
+        the payload was offloaded to object storage, since the caller must then
+        supply inputs explicitly.
+        """
+        run_args = await self._get_run_start_args(wf_exec_id)
+        if run_args is None or run_args.trigger_inputs is None:
+            return None
+        trigger_inputs = run_args.trigger_inputs
+        if isinstance(trigger_inputs, InlineObject):
+            return trigger_inputs.data
+        raise TracecatValidationError(
+            f"Execution {wf_exec_id} stored its trigger inputs outside the "
+            "workflow history; supply inputs explicitly.",
+            detail={
+                "code": "source_inputs_not_inline",
+                "source_execution_id": wf_exec_id,
+            },
+        )
 
     @staticmethod
     async def connect(role: Role | None = None) -> WorkflowExecutionsService:

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1259,6 +1259,18 @@ class WorkflowsManagementService(BaseWorkspaceService):
             if inputs is not None
             else await exec_service.get_execution_trigger_inputs(source_execution_id)
         )
+        if expects := dsl.entrypoint.expects:
+            try:
+                normalize_trigger_inputs(
+                    expects,
+                    {} if effective_inputs is None else effective_inputs,
+                    model_name="TriggerInputsValidator",
+                )
+            except ValidationError as e:
+                raise TracecatValidationError(
+                    "Trigger inputs do not match the workflow's input schema.",
+                    detail=ValidationDetail.list_from_pydantic(e),
+                ) from e
         return await exec_service.create_draft_workflow_execution_wait_for_start(
             dsl=dsl,
             wf_id=wf_id,

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -46,7 +46,7 @@ from tracecat.exceptions import (
     WorkflowAliasResolutionError,
 )
 from tracecat.expressions.eval import eval_templated_object
-from tracecat.identifiers import WorkflowID
+from tracecat.identifiers import WorkflowExecutionID, WorkflowID
 from tracecat.identifiers.workflow import (
     LEGACY_WF_ID_PATTERN,
     WF_ID_SHORT_PATTERN,
@@ -1190,6 +1190,83 @@ class WorkflowsManagementService(BaseWorkspaceService):
             payload=inputs,
             trigger_type=TriggerType.MANUAL,
             registry_lock=registry_lock,
+        )
+
+    @require_scope("workflow:execute")
+    async def run_workflow_from_action(
+        self,
+        workflow_id: WorkflowID,
+        *,
+        action_ref: str,
+        source_execution_id: WorkflowExecutionID,
+        inputs: Any | None = None,
+        time_anchor: datetime | None = None,
+    ) -> WorkflowExecutionCreateResponse:
+        """Run the current draft starting at ``action_ref``.
+
+        The immediate parents of ``action_ref`` are pinned to their results in
+        ``source_execution_id``, so the scheduler skips the exclusive upstream
+        cone and runs the selected action and everything downstream fresh.
+
+        This is stateless: the workflow's stored ``draft_pins`` are neither read
+        nor written.
+
+        Args:
+            workflow_id: Workflow UUID (short ``wf_...`` or full format).
+            action_ref: Ref of the action to start the run from.
+            source_execution_id: Execution whose results the upstream actions
+                are replayed from.
+            inputs: Trigger inputs. Defaults to the source execution's own
+                trigger inputs when omitted.
+            time_anchor: Override the workflow's time anchor.
+
+        Returns:
+            WorkflowExecutionCreateResponse with the workflow and execution IDs.
+
+        Raises:
+            TracecatNotFoundError: If the workflow does not exist.
+            TracecatValidationError: If the draft has no actions or fails
+                validation, or if the selected action cannot be run from.
+        """
+        wf_id = WorkflowUUID.new(workflow_id)
+        workflow = await self.get_workflow(wf_id)
+        if workflow is None:
+            raise TracecatNotFoundError(f"Workflow {wf_id.short()} not found")
+        # Raises TracecatValidationError on an empty/invalid draft graph.
+        dsl = await self.build_dsl_from_workflow(workflow)
+        if val_errors := await validate_dsl(
+            session=self.session, dsl=dsl, role=self.role
+        ):
+            raise TracecatValidationError(
+                f"Draft workflow validation failed with {len(val_errors)} "
+                "error(s). Fix the draft or publish a working version first.",
+                detail=[err.root.model_dump(mode="json") for err in val_errors],
+            )
+
+        # Import here to avoid pulling the Temporal-client execution stack into
+        # the management import chain.
+        from tracecat.workflow.executions.service import WorkflowExecutionsService
+
+        exec_service = await WorkflowExecutionsService.connect(role=self.role)
+        pinned_action_results = await exec_service.resolve_run_from_action_pins(
+            wf_id=wf_id,
+            dsl=dsl,
+            action_ref=action_ref,
+            source_execution_id=source_execution_id,
+        )
+        effective_inputs = (
+            inputs
+            if inputs is not None
+            else await exec_service.get_execution_trigger_inputs(source_execution_id)
+        )
+        return await exec_service.create_draft_workflow_execution_wait_for_start(
+            dsl=dsl,
+            wf_id=wf_id,
+            payload=effective_inputs,
+            trigger_type=TriggerType.MANUAL,
+            time_anchor=time_anchor,
+            pinned_action_results=pinned_action_results,
+            pinned_source_execution_id=source_execution_id,
         )
 
     @require_scope("workflow:update")

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -103,6 +103,22 @@ from tracecat.workflow.schedules import bridge
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
 
 
+def _validate_trigger_inputs(dsl: DSLInput, payload: Any) -> None:
+    """Validate inputs consistently before dispatching any workflow run."""
+    if expects := dsl.entrypoint.expects:
+        try:
+            normalize_trigger_inputs(
+                expects,
+                {} if payload is None else payload,
+                model_name="TriggerInputsValidator",
+            )
+        except ValidationError as e:
+            raise TracecatValidationError(
+                "Trigger inputs do not match the workflow's input schema.",
+                detail=ValidationDetail.list_from_pydantic(e),
+            ) from e
+
+
 class _ModelKey(NamedTuple):
     """Stable cross-environment identity of a model selection.
 
@@ -1147,18 +1163,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
         # Validate trigger inputs against the entrypoint schema up front so a
         # bad payload returns a fixable error here instead of failing inside the
         # (async) workflow run. Dispatch does not re-check inputs against expects.
-        if expects := dsl.entrypoint.expects:
-            try:
-                normalize_trigger_inputs(
-                    expects,
-                    {} if inputs is None else inputs,
-                    model_name="TriggerInputsValidator",
-                )
-            except ValidationError as e:
-                raise TracecatValidationError(
-                    "Trigger inputs do not match the workflow's input schema.",
-                    detail=ValidationDetail.list_from_pydantic(e),
-                ) from e
+        _validate_trigger_inputs(dsl, inputs)
 
         # Import here to avoid pulling the Temporal-client execution stack into
         # the management import chain.
@@ -1259,18 +1264,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
             if inputs is not None
             else await exec_service.get_execution_trigger_inputs(source_execution_id)
         )
-        if expects := dsl.entrypoint.expects:
-            try:
-                normalize_trigger_inputs(
-                    expects,
-                    {} if effective_inputs is None else effective_inputs,
-                    model_name="TriggerInputsValidator",
-                )
-            except ValidationError as e:
-                raise TracecatValidationError(
-                    "Trigger inputs do not match the workflow's input schema.",
-                    detail=ValidationDetail.list_from_pydantic(e),
-                ) from e
+        _validate_trigger_inputs(dsl, effective_inputs)
         return await exec_service.create_draft_workflow_execution_wait_for_start(
             dsl=dsl,
             wf_id=wf_id,


### PR DESCRIPTION
Stacked on #3395 (draft pins). Adds a "run from this action" operation on top of the pin mechanism: start a draft run at a chosen action, reusing its immediate upstream results from a source execution so the exclusive upstream cone is skipped and the selected action plus everything downstream run fresh.

## What

- **Engine / API**: `WorkflowExecutionsService.resolve_run_from_action_pins` computes the cut set (the action's immediate success-edge parents) and resolves them strictly from the source execution. Every rejection raises `TracecatValidationError` with a machine-readable `detail.code`: `unknown_action_ref`, `action_not_restartable` (control-flow or inside a scatter/loop scope), `error_edge_parent`, `control_flow_parent`, `unresolved_parents`, `source_inputs_not_inline`. `WorkflowsManagementService.run_workflow_from_action` is the shared entry point (mirrors `run_workflow`), exposed as `POST /workflow-executions/draft/from-action`. Inputs default to the source execution's inline trigger inputs. The operation is stateless: stored `draft_pins` are neither read nor modified.
- **MCP**: `run_workflow_from_action(workspace_id, workflow_id, action_ref, source_execution_id, inputs?)` next to `run_workflow`; MCP docs snippet regenerated.
- **UI**: "Run from this action" button in the events pane result tab, using the viewed execution as the source. `getRunFromActionBlocker` disables it with a reason (scoped or control-flow action, error branch, gather/loop-end parent, missing upstream result in this run). On success the sidebar switches to the new run.

## Review guide

1. `tracecat/workflow/executions/service.py` `resolve_run_from_action_pins`: the cut-set rules and rejection codes.
2. `tracecat/workflow/management/management.py` `run_workflow_from_action`: shared by the route and the MCP tool; compare with `run_workflow` directly above it.
3. `frontend/src/lib/workflow-pins.ts` `getRunFromActionBlocker`: the frontend mirror of the same rules.

## Not in scope

Restarting inside a scatter or loop body, or on an error branch, is rejected by design (the pin mechanism cannot represent per-item results or a replayed failure). A stored result map that would allow synthetic or edited results is a separate feature.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 554 | 13 |
| Tests | 510 | 1 |
| Generated | 131 | 0 |
| Docs | 6 | 0 |

https://claude.ai/code/session_01JLRmhHY39AkhDN5Hh9CCFE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "run from this action" operation: starting a draft run at a selected action reuses the action's immediate upstream results from a source execution, so the upstream cone is skipped and the selected action plus everything downstream run fresh.

- `run_workflow_from_action` mirrors `run_workflow` as the shared entry point, exposed as `POST /workflow-executions/draft/from-action`; inputs default to the source execution's inline trigger inputs and share `run_workflow`'s schema validation before dispatch.
- Rejections raise `TracecatValidationError` with machine-readable codes (`unknown_action_ref`, `action_not_restartable`, `error_edge_parent`, `control_flow_parent`, `unresolved_parents`, `source_workflow_mismatch`, `source_inputs_not_inline`, `source_inputs_unreadable`); the endpoint returns 400/404 and preserves the detail.
- Added the MCP tool `run_workflow_from_action` and a "Run from this action" button in the events pane result tab, using the viewed execution as the source.
- `getRunFromActionBlocker` disables the button with a reason for scoped or control-flow actions, error branches, gather/loop-end parents, and missing upstream results; duplicate draft refs resolve to the first action.
- The source execution must be visible to the caller, and the operation is stateless: stored draft pins are neither read nor modified.
- Restarting inside a scatter or loop body, or on an error branch, is rejected by design.

<sup>Written for commit 7914f2b26d1740845a54ed2066927ac6660804c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

