### PR TITLE
fix(engine): cap retry_until iterations with loop-limit error

### DIFF
--- a/tests/temporal/test_workflow_timers.py
+++ b/tests/temporal/test_workflow_timers.py
@@ -21,6 +21,8 @@ pytestmark = [
 
 import temporalio.api.enums.v1
 from temporalio import activity
+from temporalio.api.operatorservice.v1 import AddSearchAttributesRequest
+from temporalio.client import WorkflowFailureError
 from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 
@@ -34,7 +36,14 @@ from tracecat.dsl.worker import get_activities
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.executor.activities import ExecutorActivities
 from tracecat.logger import logger
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
 from tracecat.storage.object import InlineObject, StoredObject
+from tracecat.temporal.errors import extract_error_classification
+from tracecat.workflow.executions.enums import TemporalSearchAttr
 
 
 @pytest.fixture
@@ -42,6 +51,17 @@ async def env() -> AsyncGenerator[WorkflowEnvironment, None]:
     async with await WorkflowEnvironment.start_time_skipping(
         data_converter=get_data_converter(compression_enabled=False)
     ) as env:
+        # Register the error-owner search attribute so the runtime error
+        # attribution interceptor can stamp it on terminal workflow failures.
+        await env.client.operator_service.add_search_attributes(
+            AddSearchAttributesRequest(
+                search_attributes={
+                    TemporalSearchAttr.ERROR_OWNER.value: (
+                        temporalio.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
+                    )
+                }
+            )
+        )
         yield env
 
 
@@ -907,3 +927,84 @@ async def test_workflow_invalid_retry_until_expression(
                 ),
                 task_queue=task_queue,
             )
+
+
+@pytest.mark.anyio
+async def test_workflow_retry_until_rejects_over_iteration_cap(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    test_worker_factory,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A retry_until condition that never succeeds fails at the iteration cap.
+
+    The failure must carry user attribution and a non-retryable
+    workflow.loop.limit_exceeded classification instead of terminating with
+    an opaque Temporal history-limit error.
+    """
+    low_cap = 3
+    monkeypatch.setattr("tracecat.dsl.workflow.MAX_RETRY_UNTIL_ITERATIONS", low_cap)
+
+    dsl = DSLInput(
+        title="retry_until_cap",
+        description="Test retry_until fails cleanly at the iteration cap",
+        entrypoint=DSLEntrypoint(ref="retry_action"),
+        actions=[
+            ActionStatement(
+                ref="retry_action",
+                action="core.transform.reshape",
+                args={"value": "test"},
+                retry_policy=ActionRetryPolicy(retry_until="${{ False }}"),
+            )
+        ],
+    )
+
+    num_activity_executions = 0
+
+    # Mock out the execute_action_activity; it never satisfies the condition.
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
+    async def execute_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> StoredObject:
+        nonlocal num_activity_executions
+        num_activity_executions += 1
+        return InlineObject(data={"status": "loading"})
+
+    # Get base activities and add the mock
+    activities = get_activities()
+    activities.append(execute_action_activity_mock)
+
+    client = env.client
+    task_queue = config.TEMPORAL__CLUSTER_QUEUE
+    async with (
+        test_worker_factory(client, activities=activities),
+        test_worker_factory(
+            client,
+            activities=[execute_action_activity_mock],
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await client.execute_workflow(
+                DSLWorkflow.run,
+                DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+                id=generate_test_exec_id(
+                    "test_workflow_retry_until_rejects_over_iteration_cap"
+                ),
+                task_queue=task_queue,
+            )
+
+    # The action ran exactly `low_cap` times before the cap fired.
+    assert num_activity_executions == low_cap
+
+    cause = exc_info.value.cause
+    assert isinstance(cause, ApplicationError)
+    assert "exceeded the retry_until iteration limit" in str(cause)
+    assert str(low_cap) in str(cause)
+    assert cause.non_retryable is True
+
+    classification = extract_error_classification(exc_info.value)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.WORKFLOW_LOOP_LIMIT_EXCEEDED
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE

--- a/tests/unit/test_dsl_workflow_retry_until.py
+++ b/tests/unit/test_dsl_workflow_retry_until.py
@@ -1,0 +1,159 @@
+"""Unit tests for the retry_until iteration cap classification steel thread.
+
+The end-to-end behavior is covered by
+``tests/temporal/test_workflow_timers.py::test_workflow_retry_until_rejects_over_iteration_cap``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from tracecat.auth.types import Role
+from tracecat.dsl.schemas import (
+    ActionRetryPolicy,
+    ActionStatement,
+    DSLConfig,
+    ExecutionContext,
+    RunContext,
+    TaskResult,
+)
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
+from tracecat.temporal.errors import extract_error_classification
+
+
+def _build_workflow() -> DSLWorkflow:
+    workflow = object.__new__(DSLWorkflow)
+    workflow.role = Role(
+        type="service",
+        service_id="tracecat-runner",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    assert workflow.role.organization_id is not None
+    workflow.organization_id = workflow.role.organization_id
+    workflow.logger = AsyncMock()
+    workflow.runtime_config = DSLConfig()
+    workflow._tier_limits = None
+    workflow._action_execution_count = 0
+    workflow.run_context = RunContext(
+        wf_id=WorkflowUUID.new("wf-00000000000000000000000000000001"),
+        wf_exec_id=(
+            "wf-00000000000000000000000000000001:exec-00000000000000000000000000000001"
+        ),
+        wf_run_id=uuid.uuid4(),
+        environment="__TEST__",
+        logical_time=datetime.now(UTC),
+    )
+    workflow.context = ExecutionContext(ACTIONS={}, TRIGGER=None)
+    workflow.wf_exec_id = workflow.run_context.wf_exec_id
+    return workflow
+
+
+def _retry_until_task() -> ActionStatement:
+    return ActionStatement(
+        ref="retry_action",
+        action="core.transform.reshape",
+        retry_policy=ActionRetryPolicy(
+            retry_until="${{ ACTIONS.retry_action.result.status == 'success' }}"
+        ),
+    )
+
+
+async def _run_until_condition(
+    workflow: DSLWorkflow,
+    attempts: list[TaskResult],
+    *,
+    evaluate_results: list[bool],
+) -> tuple[TaskResult | None, AsyncMock, AsyncMock]:
+    """Drive ``_execute_task_until_condition`` with stubbed collaborators.
+
+    Returns the task result plus the execute-task and expression-evaluation
+    stubs so tests can assert how many iterations ran.
+    """
+    task = _retry_until_task()
+    execute_task = AsyncMock(side_effect=attempts)
+    evaluate_activity = AsyncMock(side_effect=evaluate_results)
+    with (
+        patch.object(workflow, "_execute_task", new=execute_task),
+        patch.object(workflow, "_set_logical_time_context", return_value=None),
+        patch(
+            "tracecat.dsl.workflow.workflow.execute_activity",
+            new=evaluate_activity,
+        ),
+    ):
+        return (
+            await workflow._execute_task_until_condition(task),
+            execute_task,
+            evaluate_activity,
+        )
+
+
+@pytest.mark.anyio
+async def test_retry_until_cap_is_user_attributed_non_retryable_loop_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exhausting the cap raises a classified, non-retryable loop-limit error."""
+    import tracecat.dsl.workflow as dsl_workflow_module
+
+    workflow = _build_workflow()
+    low_cap = 3
+    monkeypatch.setattr(dsl_workflow_module, "MAX_RETRY_UNTIL_ITERATIONS", low_cap)
+
+    attempts = [TaskResult.from_result({"status": "loading"}) for _ in range(low_cap)]
+
+    with pytest.raises(ApplicationError) as exc_info:
+        await _run_until_condition(
+            workflow,
+            attempts,
+            evaluate_results=[False] * low_cap,
+        )
+
+    cause = exc_info.value
+    assert cause.non_retryable is True
+    assert "exceeded the retry_until iteration limit" in str(cause)
+    assert str(low_cap) in str(cause)
+
+    classification = extract_error_classification(cause)
+    assert classification is not None
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.kind is RuntimeErrorKind.WORKFLOW_LOOP_LIMIT_EXCEEDED
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+
+
+@pytest.mark.anyio
+async def test_retry_until_success_within_cap_returns_satisfied_iteration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A condition satisfied inside the cap returns that iteration's result."""
+    import tracecat.dsl.workflow as dsl_workflow_module
+
+    workflow = _build_workflow()
+    low_cap = 3
+    monkeypatch.setattr(dsl_workflow_module, "MAX_RETRY_UNTIL_ITERATIONS", low_cap)
+
+    attempts = [
+        TaskResult.from_result({"status": "loading"}),
+        TaskResult.from_result({"status": "success"}),
+    ]
+
+    result, execute_task, evaluate_activity = await _run_until_condition(
+        workflow,
+        attempts,
+        evaluate_results=[False, True],
+    )
+
+    assert result is not None
+    assert result.get_data() == {"status": "success"}
+    assert execute_task.await_count == 2
+    assert evaluate_activity.await_count == 2

--- a/tracecat/dsl/constants.py
+++ b/tracecat/dsl/constants.py
@@ -1,2 +1,9 @@
 DEFAULT_ACTION_TIMEOUT = 300  # Seconds
 MAX_DO_WHILE_ITERATIONS = 2048
+
+# Safety cap for `retry_until` loops. Semantically retry_until is a do-while
+# (it always executes at least once), so it reuses the do-while cap value
+# under a distinct name to keep the intent explicit. Without this cap, a
+# retry_until condition that never evaluates truthy runs unbounded until
+# Temporal's history limits reject the execution with an opaque error.
+MAX_RETRY_UNTIL_ITERATIONS = MAX_DO_WHILE_ITERATIONS

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -75,6 +75,7 @@ with workflow.unsafe.imports_passed_through():
         dsl_execution_error_from_exception,
         get_trigger_type,
     )
+    from tracecat.dsl.constants import MAX_RETRY_UNTIL_ITERATIONS
     from tracecat.dsl.enums import (
         FailStrategy,
         LoopStrategy,
@@ -784,7 +785,7 @@ class DSLWorkflow:
             raise ValueError("Retry until is not set")
         ctx = self.context.copy()
         result = None
-        while True:
+        for _iteration in range(MAX_RETRY_UNTIL_ITERATIONS):
             if self._is_executable_action(task):
                 # retry_until executes the action repeatedly; enforce per attempt.
                 self._check_action_execution_limit()
@@ -807,6 +808,18 @@ class DSLWorkflow:
                     ) from None
             if retry_until_result:
                 break
+        else:
+            raise_application_error_from_classification(
+                RuntimeErrorClassification.user(
+                    kind=RuntimeErrorKind.WORKFLOW_LOOP_LIMIT_EXCEEDED,
+                    message=(
+                        f"Task '{task.ref}' exceeded the retry_until iteration limit "
+                        f"of {MAX_RETRY_UNTIL_ITERATIONS}. "
+                        "Update the `retry_until` condition so it can be satisfied."
+                    ),
+                    retry_disposition=RetryDisposition.NON_RETRYABLE,
+                )
+            )
         return result
 
     @staticmethod


### PR DESCRIPTION
## Summary

- Adds `MAX_RETRY_UNTIL_ITERATIONS = 2048` to `tracecat/dsl/constants.py`, reusing the do-while cap value under a distinct name so the intent stays explicit
- Bounds the `retry_until` retry loop in `_execute_task_until_condition` with a deterministic local counter, which is safe for replay
- When the cap is reached, raises a user-attributed, non-retryable `workflow.loop.limit_exceeded` application error via `raise_application_error_from_classification`, mirroring the scheduler's do-while loop-limit error
- Fixes #3411

## Why

A `retry_until` condition that never evaluates true loops with no bound today. With the default config (no workflow timeout, no execution timeout, and no tier limits in the OSS default), the only backstop is Temporal's history limits, which surface as an opaque error. The new cap fails cleanly at the limit with a message that names the task and suggests fixing the condition. Workflows whose conditions succeed normally are unaffected.

## Testing

- New unit tests in `tests/unit/test_dsl_workflow_retry_until.py`: cap exhaustion raises a non-retryable `ApplicationError` whose classification is `USER` / `WORKFLOW_LOOP_LIMIT_EXCEEDED`; a condition satisfied within the cap returns that iteration's result with exact call counts
- New temporal test `test_workflow_retry_until_rejects_over_iteration_cap` in `tests/temporal/test_workflow_timers.py`: with the cap monkeypatched to 3, the action runs exactly 3 times, the failure cause is a non-retryable `ApplicationError` with the limit message, and `extract_error_classification` yields user ownership with `WORKFLOW_LOOP_LIMIT_EXCEEDED`
- All 31 unit tests across the touched suites pass, and the temporal test passes against the time-skipping environment
- `ruff check`, `ruff format --check`, and `basedpyright --warnings` are clean on all touched files

## LOC breakdown

| Category | Added | Removed |
| --- | --- | --- |
| Logic | 21 | 1 |
| Tests | 260 | 0 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `retry_until` loops at 2048 iterations so a condition that never evaluates true fails with a clear, non-retryable error instead of looping until Temporal's history limits surface an opaque failure. Fixes #3411.

- Adds `MAX_RETRY_UNTIL_ITERATIONS = 2048` in `tracecat/dsl/constants.py`, reusing the do-while cap value under a distinct name.
- Bounds the loop with a deterministic local counter that is safe for replay.
- On cap exhaustion, raises a user-attributed `workflow.loop.limit_exceeded` error that names the task and suggests fixing the condition.
- Workflows whose conditions succeed within the cap are unaffected.
- Adds unit and Temporal tests covering cap exhaustion and in-cap success, with the Temporal test asserting exactly the capped number of executions.

<sup>Written for commit c5837c4c6d7d28be5c66f0bfd5310ddb8fa1c9da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

