### PR TITLE
fix(infra): remove Glacier transitions from Fargate buckets

### DIFF
--- a/deployments/fargate/modules/ecs/s3.tf
+++ b/deployments/fargate/modules/ecs/s3.tf
@@ -197,14 +197,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "registry" {
 
     filter {}
 
+    # Registry artifacts must remain immediately readable by executors.
     transition {
       days          = 30
       storage_class = "STANDARD_IA"
-    }
-
-    transition {
-      days          = 90
-      storage_class = "GLACIER"
     }
 
     noncurrent_version_expiration {

--- a/deployments/fargate/modules/ecs/s3.tf
+++ b/deployments/fargate/modules/ecs/s3.tf
@@ -72,11 +72,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "attachments" {
       storage_class = "STANDARD_IA"
     }
 
-    transition {
-      days          = 90
-      storage_class = "GLACIER"
-    }
-
     noncurrent_version_expiration {
       noncurrent_days = 90
     }


### PR DESCRIPTION
Fargate registry artifacts and case attachments are read directly by the application. Transitioning these objects to Glacier after 90 days makes ordinary downloads fail with `InvalidObjectState`.

Remove the Glacier transitions from both buckets. No Glacier or Deep Archive transitions remain in the Fargate configuration. Preserve Standard-IA transitions and existing expiration and multipart cleanup rules. Existing archived objects require separate restoration; this Terraform patch does not restore them.

Validation:
- Terraform formatting, diff whitespace checks, and commit hooks passed.
- Searched all Fargate configuration: no remaining `GLACIER` or `DEEP_ARCHIVE` transitions.
- Python lint/type checks are not applicable to Terraform files.
- Full Terraform validation remains unavailable because required providers are not installed in this checkout.
- Reviewed EKS Terraform and Helm: skills and attachments have no Glacier transitions there. Compose has no matching archival configuration.

| Change | + | - |
| --- | ---: | ---: |
| Infra/config | 1 | 10 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the Glacier transition from the Fargate registry and attachments bucket lifecycles so artifacts and attachments remain immediately readable. The 30-day Standard-IA transition, noncurrent-version expiration, and incomplete multipart upload cleanup are unchanged. Already archived objects require manual restoration.

<sup>Written for commit adb34c7bd035d15e503f3ef84940088163d5bef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

