### PR TITLE
fix(engine): withhold secret-dependent errors

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py
+++ b/packages/tracecat-registry/tracecat_registry/_internal/jsonpath.py
@@ -82,7 +82,7 @@ def eval_jsonpath(
     """Evaluate a jsonpath expression on the target object (operand)."""
 
     if operand is None or not isinstance(operand, dict | list):
-        logger.error(f"Invalid operand for jsonpath: {operand}")
+        logger.error(f"Invalid operand for jsonpath: {type(operand)}")
         raise TracecatExpressionError(
             f"A dict or list operand is required as jsonpath target. Got {type(operand)}"
         )
@@ -140,10 +140,12 @@ def eval_jsonpath(
         if strict:
             # We know that if this function is called, there was a templated field.
             # Therefore, it means the jsonpath was valid but there was no match.
-            logger.error(f"Jsonpath no match: {expr!r} in {operand}")
+            # Operands may contain sensitive values, so report the expression
+            # only
+            logger.error(f"Jsonpath no match: {expr!r}")
             raise TracecatExpressionError(
                 f"Couldn't resolve expression {expr!r} in the context",
-                detail={"expression": expr, "operand": operand},
+                detail={"expression": expr},
             )
         # Return None instead of empty list
         return None

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -574,9 +574,10 @@ def test_main_minimal_errors_when_secret_value_stringify_fails(monkeypatch) -> N
     )
 
     assert result["success"] is False
+    # Secrets are in scope, so the message is withheld like any other failure.
     assert result["error"]["type"] == "TypeError"
-    assert "BROKEN" in result["error"]["message"]
-    assert "BrokenSecret" in result["error"]["message"]
+    assert "Details withheld" in result["error"]["message"]
+    assert "BROKEN" not in result["error"]["message"]
 
 
 def test_main_minimal_still_succeeds_when_warnings_raise(monkeypatch) -> None:
@@ -875,3 +876,39 @@ def test_serialize_result_passes_through_when_serialization_succeeds() -> None:
     payload = minimal_runner.serialize_result({"success": True, "result": 1}, {})
 
     assert orjson.loads(payload) == {"success": True, "result": 1}
+
+
+def test_main_minimal_withholds_error_when_secrets_in_scope(monkeypatch) -> None:
+    """With secrets in scope the raw message is withheld, phrased like the gate."""
+    test_module: Any = types.ModuleType("test_module")
+
+    def boom_action() -> None:
+        raise ValueError("invalid literal: 'sk_live_CANARY\nMULTILINE'")
+
+    test_module.boom_action = boom_action
+
+    monkeypatch.setattr(
+        minimal_runner.importlib,
+        "import_module",
+        lambda _p, *args, **kwargs: test_module,
+    )
+
+    result = minimal_runner.main_minimal(
+        {
+            "resolved_context": {
+                "action_impl": {
+                    "type": "udf",
+                    "module": "test_module",
+                    "name": "boom_action",
+                },
+                "evaluated_args": {},
+            },
+            "secret_env": {"API_KEY": "sk_live_CANARY\nMULTILINE"},
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"]["type"] == "ValueError"
+    assert "CANARY" not in result["error"]["message"]
+    # Phrasing pinned to the expression gate's "Details withheld:" contract.
+    assert "Details withheld:" in result["error"]["message"]

--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -289,7 +289,7 @@ class TestActionRunner:
 
             assert isinstance(result, ExecutorActionErrorInfo)
             assert result.type == "SubprocessError"
-            assert "Segmentation fault" in result.message
+            assert result.message == "Subprocess exited with code 1"
 
     @pytest.mark.anyio
     async def test_execute_action_success(
@@ -738,9 +738,19 @@ class TestActionRunner:
 
     @pytest.mark.anyio
     async def test_execute_action_invalid_json_response(
-        self, temp_cache_dir, mock_run_action_input, mock_role
+        self,
+        temp_cache_dir,
+        mock_run_action_input,
+        mock_role,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test handling of invalid JSON response from subprocess."""
+        canary = "SYNTHETIC_SECRET_CARRIER_92"
+        recorded: list[dict[str, object]] = []
+        monkeypatch.setattr(
+            action_runner.logger,
+            "error",
+            lambda _message, **kwargs: recorded.append(kwargs),
+        )
         runner = ActionRunner(cache_dir=temp_cache_dir)
         base_dir = temp_cache_dir / "base"
         base_dir.mkdir()
@@ -748,7 +758,8 @@ class TestActionRunner:
         with patch("asyncio.create_subprocess_exec") as mock_subprocess:
             mock_proc = AsyncMock()
             mock_proc.returncode = 0
-            mock_proc.communicate = AsyncMock(return_value=(b"not valid json {{{", b""))
+            stdout = b"A" * 490 + canary.encode() + b"{"
+            mock_proc.communicate = AsyncMock(return_value=(stdout, b""))
             mock_subprocess.return_value = mock_proc
 
             result = await runner._execute_direct(
@@ -761,11 +772,28 @@ class TestActionRunner:
 
             assert isinstance(result, ExecutorActionErrorInfo)
             assert result.type == "ProtocolError"
+            assert canary not in result.message
+            assert recorded
+            assert canary not in repr(recorded)
+            assert recorded[0]["stdout_bytes"] == len(stdout)
+            assert isinstance(recorded[0]["parser_position"], int)
 
     @pytest.mark.anyio
-    async def test_execute_action_masks_stderr_on_subprocess_crash(
-        self, temp_cache_dir, mock_run_action_input, mock_role
+    async def test_execute_action_omits_stderr_on_subprocess_crash(
+        self,
+        temp_cache_dir,
+        mock_run_action_input,
+        mock_role,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        secret = "SYNTHETIC-LINE-ONE\nSYNTHETIC-LINE-TWO"
+        stderr = repr(secret).encode()
+        recorded: list[dict[str, object]] = []
+        monkeypatch.setattr(
+            action_runner.logger,
+            "error",
+            lambda _message, **kwargs: recorded.append(kwargs),
+        )
         runner = ActionRunner(cache_dir=temp_cache_dir)
         base_dir = temp_cache_dir / "base"
         base_dir.mkdir()
@@ -773,9 +801,7 @@ class TestActionRunner:
         with patch("asyncio.create_subprocess_exec") as mock_subprocess:
             mock_proc = AsyncMock()
             mock_proc.returncode = 17
-            mock_proc.communicate = AsyncMock(
-                return_value=(b"", b"token=temp_token secret=temp_secret")
-            )
+            mock_proc.communicate = AsyncMock(return_value=(b"", stderr))
             mock_subprocess.return_value = mock_proc
 
             result = await runner._execute_direct(
@@ -784,16 +810,22 @@ class TestActionRunner:
                 registry_paths=[base_dir],
                 secret_projection=SecretEnvProjection(
                     env={},
-                    mask_values={"temp_token", "temp_secret"},
+                    mask_values={secret},
                 ),
                 timeout=10.0,
             )
 
         assert isinstance(result, ExecutorActionErrorInfo)
         assert result.type == "SubprocessError"
-        assert "temp_token" not in result.message
-        assert "temp_secret" not in result.message
-        assert "***" in result.message
+        assert result.message == "Subprocess exited with code 17"
+        assert recorded == [
+            {
+                "action": mock_run_action_input.task.action,
+                "returncode": 17,
+                "stderr_bytes": len(stderr),
+            }
+        ]
+        assert "SYNTHETIC-LINE-TWO" not in repr(recorded)
 
     @pytest.mark.anyio
     async def test_execute_action_holds_registry_lease_for_whole_subprocess(

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -947,7 +947,7 @@ async def test_dispatcher(
             await dispatch_action(backend, input)
         assert len(e.value.loop_errors) == 1
         assert e.value.loop_errors[0].info.loop_iteration == 2
-        assert e.value.loop_errors[0].info.loop_vars == {"x": None}
+        assert e.value.loop_errors[0].info.loop_vars is None
 
         # Try another dispatch with a different error
 
@@ -968,7 +968,7 @@ async def test_dispatcher(
             await dispatch_action(backend, input)
         assert len(e.value.loop_errors) == 1
         assert e.value.loop_errors[0].info.loop_iteration == 1
-        assert e.value.loop_errors[0].info.loop_vars == {"x": None}
+        assert e.value.loop_errors[0].info.loop_vars is None
     finally:
         ctx_role.reset(token)
 
@@ -1054,7 +1054,6 @@ async def test_dispatch_action_for_each_finishes_after_iteration_error(
                     filename=__file__,
                     function="fake_invoke_once",
                     loop_iteration=iteration,
-                    loop_vars=local_vars,
                 )
             )
         return value
@@ -1080,7 +1079,7 @@ async def test_dispatch_action_for_each_finishes_after_iteration_error(
     assert seen == [1, 2, 3]
     assert len(e.value.loop_errors) == 1
     assert e.value.loop_errors[0].info.loop_iteration == 1
-    assert e.value.loop_errors[0].info.loop_vars == {"x": 2}
+    assert e.value.loop_errors[0].info.loop_vars is None
 
 
 @pytest.fixture

--- a/tests/unit/test_executor_aws_assume_role.py
+++ b/tests/unit/test_executor_aws_assume_role.py
@@ -17,6 +17,7 @@ from tracecat.dsl.schemas import RunContext
 from tracecat.exceptions import TracecatCredentialsError
 from tracecat.executor.secret_preprocessors import (
     _AWS_ROLE_ARN_PATTERN,
+    AwsAssumeRoleSecretPreprocessor,
     _assume_role_via_irsa,
     project_secret_env,
 )
@@ -525,3 +526,58 @@ class TestProjectSecretEnv:
         )
 
         assert projection.env["API_KEY"] == "some-key"
+
+
+class TestSecretValuesNeverEchoed:
+    """Preprocessor errors name the key, never the value.
+
+    Masks are exact-substring on the raw leaf; a stripped or escaped copy of
+    the value does not match, so the only safe message is a constant one.
+    """
+
+    def test_invalid_role_arn_error_omits_the_value(self) -> None:
+        padded = "  SUPERSECRET-not-an-arn  "
+        with pytest.raises(TracecatCredentialsError) as exc_info:
+            AwsAssumeRoleSecretPreprocessor()._get_role_arn(
+                {"AWS_ROLE_ARN": padded}, "aws"
+            )
+        assert padded.strip() not in str(exc_info.value)
+        assert "AWS_ROLE_ARN" in str(exc_info.value)
+
+    @pytest.mark.anyio
+    async def test_sts_failure_error_omits_the_role_arn(self) -> None:
+        role_arn = "arn:aws:iam::123456789012:role/SUPERSECRET-role"
+        error = ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDenied",
+                    "Message": f"not authorized to assume {role_arn}",
+                }
+            },
+            "AssumeRole",
+        )
+        fake_sts = AsyncMock()
+        fake_sts.assume_role = AsyncMock(side_effect=error)
+        with (
+            patch(
+                "tracecat.executor.secret_preprocessors.aioboto3.Session"
+            ) as mock_session_cls,
+            pytest.raises(TracecatCredentialsError) as exc_info,
+        ):
+            mock_session = mock_session_cls.return_value
+            mock_session.client.return_value.__aenter__.return_value = fake_sts
+            await _assume_role_via_irsa(
+                role_arn=role_arn,
+                external_id="ext",
+                workspace_id=str(uuid.uuid4()),
+                run_id=str(uuid.uuid4()),
+            )
+        assert role_arn not in str(exc_info.value)
+        assert "AccessDenied" in str(exc_info.value)
+
+    def test_collect_mask_values_covers_stripped_form(self) -> None:
+        from tracecat.executor.secret_preprocessors import collect_mask_values
+
+        masks = collect_mask_values([{"aws": {"AWS_ROLE_ARN": "  padded-value \n"}}])
+        assert "padded-value" in masks
+        assert "  padded-value \n" in masks

--- a/tests/unit/test_executor_error_boundary.py
+++ b/tests/unit/test_executor_error_boundary.py
@@ -1,0 +1,372 @@
+"""Classification must survive sanitization without carrying secret plaintext."""
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock
+from uuid import UUID
+
+import pytest
+from temporalio.api.failure.v1 import Failure
+from temporalio.converter import DataConverter
+
+from tracecat.auth.types import Role
+from tracecat.dsl.common import create_default_execution_context
+from tracecat.dsl.schemas import ActionStatement, RunActionInput, RunContext
+from tracecat.exceptions import EntitlementRequired, ExecutionError, LoopExecutionError
+from tracecat.executor import service
+from tracecat.executor.error_policy import classify_execute_action_error
+from tracecat.executor.registry_artifacts import (
+    RegistryArtifactCacheCapacityError,
+    RegistryArtifactCacheLeaseContentionError,
+    RegistryArtifactExtractionError,
+)
+from tracecat.executor.schemas import (
+    ActionImplementation,
+    ExecutorActionErrorInfo,
+    ExecutorResultFailure,
+    ResolvedContext,
+)
+from tracecat.expressions.policy import build_provenance
+from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
+from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorClassification,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
+from tracecat.sandbox.exceptions import SandboxInfrastructureError, SandboxWorkloadError
+from tracecat.sandbox.types import SandboxErrorCode
+from tracecat.temporal.errors import application_error_from_classification
+
+CANARY = "synthetic-secret\nclassification-canary"
+pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("prepared")]
+
+
+@pytest.fixture(params=[0, 2], ids=["direct", "nested"])
+def template_depth(request: pytest.FixtureRequest) -> int:
+    return request.param
+
+
+@pytest.fixture(params=[False, True], ids=["plain", "secret"])
+def secret_backed(request: pytest.FixtureRequest) -> bool:
+    return request.param
+
+
+@pytest.fixture
+def role() -> Role:
+    return Role(
+        type="service",
+        organization_id=UUID(int=1),
+        workspace_id=UUID(int=2),
+        service_id="tracecat-executor",
+    )
+
+
+@pytest.fixture
+def action_input(secret_backed: bool) -> RunActionInput:
+    wf_id = WorkflowUUID.new_uuid4()
+    return RunActionInput(
+        task=ActionStatement(
+            ref="a",
+            action="testing.level0",
+            args={"value": "${{ SECRETS.svc.TOKEN }}" if secret_backed else "plain"},
+        ),
+        exec_context=create_default_execution_context(),
+        run_context=RunContext(
+            wf_id=wf_id,
+            wf_exec_id=generate_exec_id(wf_id),
+            wf_run_id=UUID(int=3, version=4),
+            environment="default",
+            logical_time=datetime.now(UTC),
+        ),
+        registry_lock=RegistryLock(origins={}, actions={}),
+    )
+
+
+@pytest.fixture
+def prepared(
+    monkeypatch: pytest.MonkeyPatch,
+    action_input: RunActionInput,
+    role: Role,
+    template_depth: int,
+    secret_backed: bool,
+) -> service.PreparedContext:
+    implementations = {
+        f"testing.level{template_depth}": ActionImplementation(
+            type="udf", action_name=f"testing.level{template_depth}"
+        )
+    }
+    for level in range(template_depth):
+        name = f"level{level}"
+        implementations[f"testing.{name}"] = ActionImplementation(
+            type="template",
+            action_name=f"testing.{name}",
+            template_definition={
+                "name": name,
+                "namespace": "testing",
+                "title": name,
+                "description": "Synthetic error boundary",
+                "display_group": "Testing",
+                "expects": {},
+                "steps": [
+                    {
+                        "ref": "child",
+                        "action": f"testing.level{level + 1}",
+                        "args": {"value": "${{ inputs.value }}"},
+                    }
+                ],
+                "returns": "${{ steps.child.result }}",
+            },
+        )
+    resolved = ResolvedContext(
+        secrets={"svc": {"TOKEN": CANARY}} if secret_backed else {},
+        variables={},
+        action_impl=implementations[action_input.task.action],
+        evaluated_args={"value": CANARY if secret_backed else "plain"},
+        workspace_id=str(role.workspace_id),
+        workflow_id=str(action_input.run_context.wf_id),
+        run_id=str(action_input.run_context.wf_run_id),
+        executor_token="synthetic-token",
+    )
+    context = service.PreparedContext(
+        resolved_context=resolved,
+        mask_values={CANARY} if secret_backed else set(),
+        provenance=build_provenance(action_input.task.args),
+    )
+    monkeypatch.setattr(service.registry_resolver, "prefetch_lock", AsyncMock())
+    monkeypatch.setattr(
+        service.registry_resolver,
+        "resolve_action",
+        AsyncMock(side_effect=lambda name, *_args: implementations[name]),
+    )
+    monkeypatch.setattr(
+        service.registry_resolver,
+        "collect_action_secrets_from_manifest",
+        AsyncMock(return_value=set()),
+    )
+    monkeypatch.setattr(
+        service, "_mint_action_executor_token", Mock(return_value="token")
+    )
+    monkeypatch.setattr(
+        service, "prepare_resolved_context", AsyncMock(return_value=context)
+    )
+    return context
+
+
+@pytest.mark.parametrize(
+    ("make_error", "kind", "owner", "retry"),
+    [
+        (
+            lambda: SandboxWorkloadError(
+                CANARY, error_code=SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED
+            ),
+            RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED,
+            RuntimeErrorOwner.USER,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            lambda: SandboxWorkloadError(CANARY, error_code=SandboxErrorCode.TIMEOUT),
+            RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+            RuntimeErrorOwner.USER,
+            RetryDisposition.RETRYABLE,
+        ),
+        (
+            lambda: RegistryArtifactCacheCapacityError(
+                current_bytes=80, additional_bytes=30, max_bytes=100
+            ),
+            RuntimeErrorKind.EXECUTOR_REGISTRY_CAPACITY_EXHAUSTED,
+            RuntimeErrorOwner.PLATFORM,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            lambda: RegistryArtifactCacheLeaseContentionError(
+                current_bytes=80, additional_bytes=30, max_bytes=100
+            ),
+            RuntimeErrorKind.EXECUTOR_REGISTRY_LEASE_CONTENTION,
+            RuntimeErrorOwner.PLATFORM,
+            RetryDisposition.RETRYABLE,
+        ),
+        (
+            RegistryArtifactExtractionError,
+            RuntimeErrorKind.EXECUTOR_REGISTRY_EXTRACTION_FAILED,
+            RuntimeErrorOwner.PLATFORM,
+            RetryDisposition.NON_RETRYABLE,
+        ),
+        (
+            lambda: SandboxInfrastructureError(CANARY),
+            RuntimeErrorKind.EXECUTOR_SANDBOX_INFRASTRUCTURE_FAILED,
+            RuntimeErrorOwner.PLATFORM,
+            RetryDisposition.RETRYABLE,
+        ),
+        (
+            lambda: ValueError(CANARY),
+            RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+            RuntimeErrorOwner.USER,
+            RetryDisposition.RETRYABLE,
+        ),
+    ],
+)
+async def test_backend_classification_survives_sanitization(
+    action_input: RunActionInput,
+    role: Role,
+    secret_backed: bool,
+    make_error: Callable[[], Exception],
+    kind: RuntimeErrorKind,
+    owner: RuntimeErrorOwner,
+    retry: RetryDisposition,
+) -> None:
+    original = make_error()
+    backend = Mock(execute=AsyncMock(side_effect=original))
+    with pytest.raises(ExecutionError) as caught:
+        await service.invoke_once(
+            backend, action_input, service.DispatchActionContext(role)
+        )
+
+    error = caught.value
+    classification = classify_execute_action_error(
+        error, action_name=action_input.task.action
+    )
+    assert classification.kind is kind
+    assert classification.owner is owner
+    assert classification.retry_disposition is retry
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    if owner is RuntimeErrorOwner.PLATFORM:
+        expected = classify_execute_action_error(
+            original, action_name=action_input.task.action
+        )
+        assert classification.message == expected.message
+        assert classification.message != str(original)
+        assert "classification-canary" not in classification.model_dump_json()
+        if secret_backed:
+            assert error.info.message == classification.message
+            assert "Details withheld" not in str(error)
+    if secret_backed:
+        assert CANARY not in str(error)
+        assert "classification-canary" not in classification.model_dump_json()
+        if owner is RuntimeErrorOwner.USER:
+            assert "Details withheld" in classification.message
+        # Exercise both raw Python failure conversion and the classified transport.
+        for transported in (
+            error,
+            application_error_from_classification(classification),
+        ):
+            failure = Failure()
+            await DataConverter.default.encode_failure(transported, failure)
+            assert b"classification-canary" not in failure.SerializeToString()
+            assert not failure.HasField("cause")
+
+
+async def test_prefetch_entitlement_remains_non_retryable(
+    monkeypatch: pytest.MonkeyPatch, action_input: RunActionInput, role: Role
+) -> None:
+    monkeypatch.setattr(
+        service.registry_resolver,
+        "prefetch_lock",
+        AsyncMock(side_effect=EntitlementRequired("synthetic_feature")),
+    )
+    with pytest.raises(ExecutionError) as caught:
+        await service.invoke_once(
+            Mock(), action_input, service.DispatchActionContext(role)
+        )
+    classification = classify_execute_action_error(
+        caught.value, action_name=action_input.task.action
+    )
+    assert classification.kind is RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert classification.cause_type == "EntitlementRequired"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+async def test_backend_diagnostic_type_cannot_control_retry_policy(
+    action_input: RunActionInput, role: Role
+) -> None:
+    result = ExecutorResultFailure(
+        error=ExecutorActionErrorInfo(
+            action_name=action_input.task.action,
+            type="EntitlementRequired",
+            message="Synthetic action-controlled diagnostic",
+            filename="action.py",
+            function="run",
+        )
+    )
+    with pytest.raises(ExecutionError) as caught:
+        await service.invoke_once(
+            Mock(execute=AsyncMock(return_value=result)),
+            action_input,
+            service.DispatchActionContext(role),
+        )
+    classification = classify_execute_action_error(
+        caught.value, action_name=action_input.task.action
+    )
+    assert classification.kind is RuntimeErrorKind.ACTION_EXECUTION_FAILED
+    assert classification.owner is RuntimeErrorOwner.USER
+    assert classification.retry_disposition is RetryDisposition.RETRYABLE
+
+
+async def test_preserved_metadata_cannot_restore_an_old_plaintext_message(
+    action_input: RunActionInput, role: Role
+) -> None:
+    original = ExecutionError(
+        info=ExecutorActionErrorInfo(
+            action_name=action_input.task.action,
+            type="EntitlementRequired",
+            message="Safe diagnostic",
+            filename="executor.py",
+            function="run",
+        ),
+        classification=RuntimeErrorClassification.user(
+            kind=RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED,
+            message=CANARY,
+            retry_disposition=RetryDisposition.NON_RETRYABLE,
+        ),
+    )
+    with pytest.raises(ExecutionError) as caught:
+        await service.invoke_once(
+            Mock(execute=AsyncMock(side_effect=original)),
+            action_input,
+            service.DispatchActionContext(role),
+        )
+    classification = classify_execute_action_error(
+        caught.value, action_name=action_input.task.action
+    )
+    assert classification.kind is RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    assert classification.message == caught.value.info.message
+    assert "classification-canary" not in classification.model_dump_json()
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+async def test_sanitized_mixed_loop_preserves_ownership_and_retry_policy(
+    action_input: RunActionInput, role: Role
+) -> None:
+    errors: list[ExecutionError] = []
+    for iteration, cause in enumerate(
+        [
+            RegistryArtifactCacheLeaseContentionError(
+                current_bytes=80, additional_bytes=30, max_bytes=100
+            ),
+            SandboxWorkloadError(
+                CANARY, error_code=SandboxErrorCode.RESOURCE_LIMIT_EXCEEDED
+            ),
+        ]
+    ):
+        with pytest.raises(ExecutionError) as caught:
+            await service.invoke_once(
+                Mock(execute=AsyncMock(side_effect=cause)),
+                action_input,
+                service.DispatchActionContext(role),
+                iteration=iteration,
+            )
+        errors.append(caught.value)
+        assert caught.value.info.loop_iteration == iteration
+        assert caught.value.info.loop_vars is None
+    classification = classify_execute_action_error(
+        LoopExecutionError(errors), action_name=action_input.task.action
+    )
+    assert classification.owner is RuntimeErrorOwner.PLATFORM
+    assert classification.kind is RuntimeErrorKind.EXECUTOR_REGISTRY_LEASE_CONTENTION
+    assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -19,6 +19,7 @@ from tracecat.exceptions import TracecatCredentialsError
 from tracecat.executor import service as executor_service
 from tracecat.executor.schemas import (
     ActionImplementation,
+    ExecutorActionErrorInfo,
     ExecutorResultSuccess,
     ResolvedContext,
 )
@@ -559,7 +560,11 @@ async def test_prepare_resolved_context_preserves_only_mapped_parameter(
         "action_secrets": action_secrets,
     }
     assert get_workspace_variables.await_args.kwargs["variable_exprs"] == {"runtime"}
-    assert prepared.mask_values == {"runtime-secret"}
+    # Masks union the raw fetched secrets (derived before argument evaluation so
+    # they exist when it raises) with the projection's own masks. "declared-secret"
+    # is fetched into the evaluation context, so it must be masked even though the
+    # stubbed projection above only reports "runtime-secret".
+    assert prepared.mask_values == {"runtime-secret", "declared-secret"}
 
 
 @pytest.mark.parametrize("service_id", ["tracecat-executor", "tracecat-mcp"])
@@ -1159,3 +1164,152 @@ async def test_omitted_template_default_seeds_preserve_provenance(mocker):
         "workflow_id": "wf-123",
         "patch_ops": default_ops,
     }
+
+
+@pytest.mark.anyio
+async def test_invoke_once_returns_none_result_as_success(mocker):
+    """Actions declared `-> None` must round-trip as a real result.
+
+    If the success path ever treats `None` as "no result" (e.g. a sentinel
+    check that regresses to `is None`), a successful `core.cases.delete_case`
+    is reported as a failure and retried after its side effect landed.
+    """
+    role = _expression_policy_role("tracecat-executor")
+    action_input = _expression_policy_input("core.cases.delete_case", {})
+    resolved_context = mocker.Mock(logical_time=mocker.sentinel.logical_time)
+    prepared_context = executor_service.PreparedContext(
+        resolved_context=resolved_context,
+        mask_values={"secret"},
+    )
+
+    mocker.patch.object(
+        executor_service.registry_resolver,
+        "prefetch_lock",
+        new=mocker.AsyncMock(),
+    )
+    mocker.patch.object(
+        executor_service,
+        "prepare_resolved_context",
+        new=mocker.AsyncMock(return_value=prepared_context),
+    )
+    mocker.patch.object(
+        executor_service,
+        "_invoke_step",
+        new=mocker.AsyncMock(return_value=None),
+    )
+
+    result = await executor_service.invoke_once(
+        backend=mocker.Mock(),
+        input=action_input,
+        ctx=executor_service.DispatchActionContext(role=role),
+    )
+
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_invoke_once_withholds_carrier_derived_action_error(mocker):
+    """No declared secrets does not mean no secrets.
+
+    ACTIONS/var inputs can be secret-derived, so the original exception must
+    not ride along as __cause__/__context__: Temporal serializes the chain and
+    the run view surfaces its deepest message.
+    """
+    from tracecat.exceptions import ExecutionError
+
+    canary = "SUPERSECRET-chain-canary"
+    role = _expression_policy_role("tracecat-executor")
+    action_input = _expression_policy_input(
+        "core.probe", {"value": "${{ ACTIONS.fetch.result }}"}
+    )
+    resolved_context = mocker.Mock(logical_time=mocker.sentinel.logical_time)
+    prepared_context = executor_service.PreparedContext(
+        resolved_context=resolved_context,
+        mask_values=set(),
+    )
+    mocker.patch.object(
+        executor_service.registry_resolver,
+        "prefetch_lock",
+        new=mocker.AsyncMock(),
+    )
+    mocker.patch.object(
+        executor_service,
+        "prepare_resolved_context",
+        new=mocker.AsyncMock(return_value=prepared_context),
+    )
+    action_error = ExecutionError(
+        info=ExecutorActionErrorInfo(
+            action_name="core.probe",
+            type="ValueError",
+            message=f"rejected {canary}",
+            filename="probe.py",
+            function="run",
+        )
+    )
+    mocker.patch.object(
+        executor_service,
+        "_invoke_step",
+        new=mocker.AsyncMock(side_effect=action_error),
+    )
+
+    with pytest.raises(ExecutionError) as exc_info:
+        await executor_service.invoke_once(
+            backend=mocker.Mock(),
+            input=action_input,
+            ctx=executor_service.DispatchActionContext(role=role),
+        )
+
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert "Details withheld:" in str(exc_info.value)
+    assert canary not in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_template_expects_validation_leaves_no_plaintext_in_chain(mocker):
+    """The sanitized message is only clean if nothing plaintext is chained."""
+    from tracecat.exceptions import RegistryValidationError
+
+    canary = "SUPERSECRET-expects-canary"
+    action_input = _expression_policy_input("testing.typed", {"count": canary})
+    role = _expression_policy_role("tracecat-executor")
+    resolved = ResolvedContext(
+        secrets={},
+        variables={},
+        action_impl=ActionImplementation(
+            type="template",
+            action_name="testing.typed",
+            template_definition={
+                "name": "typed",
+                "namespace": "testing",
+                "title": "Typed",
+                "description": "Rejects non-int input",
+                "display_group": "Testing",
+                "expects": {"count": {"type": "int", "description": "n"}},
+                "steps": [
+                    {"ref": "noop", "action": "core.noop", "args": {}},
+                ],
+                "returns": "${{ inputs.count }}",
+            },
+        ),
+        evaluated_args={"count": canary},
+        workspace_id=str(role.workspace_id),
+        workflow_id=str(action_input.run_context.wf_id),
+        run_id=str(action_input.run_context.wf_run_id),
+        executor_token="parent-token",
+    )
+
+    with pytest.raises(RegistryValidationError) as exc_info:
+        await executor_service._execute_template_action(
+            backend=mocker.Mock(),
+            input=action_input,
+            ctx=executor_service.DispatchActionContext(role=role),
+            resolved_context=resolved,
+            timeout=30,
+            provenance=_policy_source_provenance({"count": canary}),
+        )
+
+    err = exc_info.value
+    assert err.__cause__ is None
+    assert err.__context__ is None
+    assert canary not in str(err)

--- a/tests/unit/test_expression_policy.py
+++ b/tests/unit/test_expression_policy.py
@@ -390,7 +390,11 @@ def test_redact_secret_expressions_rejects_secret_dependent_keys() -> None:
     with pytest.raises(TracecatExpressionError) as exc_info:
         _redact(value)
 
-    assert exc_info.value.detail == {"code": "secret_expression_in_key"}
+    assert "Details withheld:" in str(exc_info.value)
+    assert exc_info.value.detail == {
+        "expression": "SECRETS.api.KEY",
+        "secret_dependent": True,
+    }
 
 
 def test_redact_secret_expressions_recurses_through_values() -> None:
@@ -730,7 +734,11 @@ def test_secret_dependent_input_key_is_rejected_only_at_sink() -> None:
             {"payload": "${{ inputs.context }}"},
         )
 
-    assert exc_info.value.detail == {"code": "secret_expression_in_key"}
+    assert "Details withheld:" in str(exc_info.value)
+    assert exc_info.value.detail == {
+        "expression": "inputs.context",
+        "secret_dependent": True,
+    }
 
 
 def test_compound_dependency_propagates_across_template_boundaries() -> None:

--- a/tests/unit/test_secret_masking_errors.py
+++ b/tests/unit/test_secret_masking_errors.py
@@ -216,10 +216,13 @@ def _walk_exception_chain(exc: BaseException) -> list[BaseException]:
     that the plaintext is absent from the graph, not merely flagged as hidden.
     """
     seen: list[BaseException] = []
-    cur: BaseException | None = exc
-    while cur is not None and len(seen) < 16:
+    todo: list[BaseException] = [exc]
+    while todo and len(seen) < 16:
+        cur = todo.pop()
+        if any(cur is s for s in seen):
+            continue
         seen.append(cur)
-        cur = cur.__cause__ or cur.__context__
+        todo.extend(link for link in (cur.__cause__, cur.__context__) if link)
     return seen
 
 
@@ -253,7 +256,7 @@ async def test_await_with_masked_errors_severs_context() -> None:
         assert CANARY not in str(link)
 
 
-@pytest.mark.parametrize("module_path", ["tracecat/observability/sentry.py"])
+@pytest.mark.parametrize("module_path", ["tracecat.observability.sentry"])
 def test_workers_disable_sentry_local_variable_capture(module_path: str) -> None:
     """Sentry captures frame locals by default, and those frames hold secrets.
 
@@ -263,9 +266,11 @@ def test_workers_disable_sentry_local_variable_capture(module_path: str) -> None
     like `evaled_args` — so collection has to be disabled at init.
     """
     import ast
+    import importlib
     from pathlib import Path
 
-    source = Path(module_path).read_text()
+    module = importlib.import_module(module_path)
+    source = Path(str(module.__file__)).read_text()
     tree = ast.parse(source)
 
     init_calls = [

--- a/tests/unit/test_secret_masking_errors.py
+++ b/tests/unit/test_secret_masking_errors.py
@@ -1,0 +1,834 @@
+"""Regression tests for secret text in execution errors.
+
+Secret plaintext must not reach exception messages, error info payloads, or log
+sinks when expression evaluation fails with a secret as the operand.
+"""
+
+import io
+from typing import Any
+
+import pytest
+
+from tracecat.exceptions import TracecatExpressionError
+from tracecat.executor.schemas import ExecutorActionErrorInfo
+from tracecat.executor.secret_preprocessors import collect_mask_values
+from tracecat.expressions.common import ExprContext
+from tracecat.expressions.eval import eval_templated_object
+from tracecat.secrets.common import (
+    MaskedSecretError,
+    await_with_masked_errors,
+    call_with_masked_errors,
+    mask_exception,
+)
+
+CANARY = "sk-CANARY-7f3a91d4e6b2"
+
+
+@pytest.fixture
+def secrets() -> dict[str, dict[str, str]]:
+    return {"svc": {"value": CANARY}}
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "${{ int(SECRETS.svc.value) }}",
+        # Trailing-typecast form must behave the same.
+        "${{ SECRETS.svc.value -> int }}",
+    ],
+)
+def test_arg_evaluation_error_masks_secret_value(
+    expression: str, secrets: dict[str, dict[str, str]]
+) -> None:
+    context = {ExprContext.SECRETS: secrets}
+
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        eval_templated_object({"value": expression}, operand=context)
+
+    assert CANARY not in str(exc_info.value)
+    assert CANARY not in str(getattr(exc_info.value, "detail", ""))
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+
+
+def test_mask_exception_records_original_type(
+    secrets: dict[str, dict[str, str]],
+) -> None:
+    masks = collect_mask_values([secrets])
+    with pytest.raises(ValueError) as exc_info:
+        int(CANARY)
+    masked = mask_exception(exc_info.value, masks=masks)
+
+    assert isinstance(masked, MaskedSecretError)
+    assert masked.captured is not None
+    assert masked.captured.original_type == "ValueError"
+    assert masked.captured.filename.endswith(".py")
+    assert masked.captured.lineno is not None
+    assert masked.__traceback__ is None
+    assert CANARY not in str(masked)
+
+
+def test_evaluator_logging_omits_resolved_values(
+    secrets: dict[str, dict[str, str]],
+) -> None:
+    from tracecat.logger import logger
+
+    sink = io.StringIO()
+    handler_id = logger.add(sink, level="TRACE", format="{message} | {extra}")
+    try:
+        with pytest.raises(TracecatExpressionError):
+            eval_templated_object(
+                {"value": "${{ int(SECRETS.svc.value) }}"},
+                operand={ExprContext.SECRETS: secrets},
+            )
+    finally:
+        logger.remove(handler_id)
+
+    assert CANARY not in sink.getvalue()
+
+
+def test_jsonpath_no_match_does_not_log_or_attach_operand(
+    secrets: dict[str, dict[str, str]],
+) -> None:
+    """A strict jsonpath miss must not attach or log the operand.
+
+    Operands may carry sensitive values, so the failure reports the expression
+    only. The sole production strict caller is _select_input(), whose operand is
+    authored source rather than resolved secrets, so this is data minimization
+    rather than a secret-bearing operand on that path.
+    """
+    from tracecat.expressions.common import eval_jsonpath
+    from tracecat.logger import logger
+
+    operand: dict[str, Any] = {ExprContext.SECRETS: secrets}
+    sink = io.StringIO()
+    handler_id = logger.add(sink, level="ERROR", format="{message} | {extra}")
+    try:
+        with pytest.raises(TracecatExpressionError) as exc_info:
+            eval_jsonpath("ACTIONS.missing.result", operand, strict=True)
+    finally:
+        logger.remove(handler_id)
+
+    assert CANARY not in sink.getvalue()
+    assert CANARY not in str(getattr(exc_info.value, "detail", ""))
+
+
+@pytest.mark.parametrize(
+    "secret_value",
+    [
+        "sk-CANARY-7f3a91d4e6b2",
+        # repr() escaping defeats exact-string masking for these two: the secret
+        # is present in the message but not spelled the same way.
+        "line-one\nline-two",
+        "back\\slash",
+    ],
+)
+def test_static_gate_survives_repr_escaping(secret_value: str) -> None:
+    context = {ExprContext.SECRETS: {"svc": {"value": secret_value}}}
+
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        eval_templated_object(
+            {"value": "${{ int(SECRETS.svc.value) }}"}, operand=context
+        )
+
+    message = str(exc_info.value)
+    escaped = secret_value.encode("unicode_escape").decode()
+    assert secret_value not in message
+    assert escaped not in message
+
+
+def test_untainted_expression_keeps_full_error() -> None:
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        eval_templated_object(
+            {"value": "${{ int(TRIGGER.count) }}"},
+            operand={ExprContext.TRIGGER: {"count": "abc"}},
+        )
+
+    # The operand is not a secret, so the underlying error is reported in full.
+    assert "invalid literal for int()" in str(exc_info.value)
+    assert "abc" in str(exc_info.value)
+
+
+def test_structured_error_codes_do_not_bypass_secret_gate() -> None:
+    from tracecat.expressions.policy import _CollectionPolicy
+
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        eval_templated_object(
+            {"${{ SECRETS.api.KEY }}": "value"},
+            policy=_CollectionPolicy(),
+            key_policy=_CollectionPolicy(reject=True),
+        )
+
+    assert "Details withheld:" in str(exc_info.value)
+    assert exc_info.value.detail == {
+        "expression": "SECRETS.api.KEY",
+        "secret_dependent": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_registry_jsonpath_miss_omits_runtime_operand() -> None:
+    import logging as stdlib_logging
+
+    from tracecat_registry.core.transform import deduplicate
+
+    secret = "sk_live_CANARY_9f3a91d4e6b2"
+    items = [{"id": 1, "auth_header": f"Bearer {secret}"}]
+
+    stream = io.StringIO()
+    handler = stdlib_logging.StreamHandler(stream)
+    handler.setLevel(stdlib_logging.ERROR)
+    root = stdlib_logging.getLogger()
+    root.addHandler(handler)
+    try:
+        with pytest.raises(Exception) as exc_info:  # noqa: B017
+            await deduplicate(items=items, keys=["nonexistent_key"])
+    finally:
+        root.removeHandler(handler)
+
+    assert secret not in stream.getvalue()
+    assert secret not in str(getattr(exc_info.value, "detail", ""))
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "${{ int(inputs.value) }}",
+        "${{ inputs.value -> int }}",
+    ],
+)
+def test_template_input_expressions_are_gated(expression: str) -> None:
+    secret = "line-one\nline-two-CANARY"
+    context = {ExprContext.TEMPLATE_ACTION_INPUTS: {"value": secret}}
+
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        eval_templated_object({"value": expression}, operand=context)
+
+    message = str(exc_info.value)
+    assert secret not in message
+    assert secret.encode("unicode_escape").decode() not in message
+
+
+def _walk_exception_chain(exc: BaseException) -> list[BaseException]:
+    """Every exception reachable from `exc`, ignoring __suppress_context__.
+
+    A renderer is free not to honour suppression, so the guarantee under test is
+    that the plaintext is absent from the graph, not merely flagged as hidden.
+    """
+    seen: list[BaseException] = []
+    cur: BaseException | None = exc
+    while cur is not None and len(seen) < 16:
+        seen.append(cur)
+        cur = cur.__cause__ or cur.__context__
+    return seen
+
+
+def test_call_with_masked_errors_severs_context() -> None:
+    """The boundary helper owns the capture-then-raise contract: the masked
+    copy is raised after its handler has exited, so nothing is attached."""
+    with pytest.raises(MaskedSecretError) as exc_info:
+        call_with_masked_errors(lambda: int(CANARY), masks={CANARY})
+
+    assert exc_info.value.__context__ is None
+    assert exc_info.value.__cause__ is None
+    for link in _walk_exception_chain(exc_info.value):
+        assert CANARY not in str(link)
+    info = ExecutorActionErrorInfo.from_exc(exc_info.value, action_name="a")
+    assert info.type == "ValueError"
+    assert info.function == "<lambda>"
+    assert info.lineno is not None
+
+
+@pytest.mark.anyio
+async def test_await_with_masked_errors_severs_context() -> None:
+    async def boom() -> None:
+        int(CANARY)
+
+    with pytest.raises(MaskedSecretError) as exc_info:
+        await await_with_masked_errors(boom(), masks={CANARY})
+
+    assert exc_info.value.__context__ is None
+    assert exc_info.value.__cause__ is None
+    for link in _walk_exception_chain(exc_info.value):
+        assert CANARY not in str(link)
+
+
+@pytest.mark.parametrize("module_path", ["tracecat/observability/sentry.py"])
+def test_workers_disable_sentry_local_variable_capture(module_path: str) -> None:
+    """Sentry captures frame locals by default, and those frames hold secrets.
+
+    A sanitized exception has a clean message, but `raise` builds a new traceback
+    rooted at the raising frame, whose locals still hold the resolved `secrets`
+    dict. Name-based scrubbing cannot cover it — secrets also live under names
+    like `evaled_args` — so collection has to be disabled at init.
+    """
+    import ast
+    from pathlib import Path
+
+    source = Path(module_path).read_text()
+    tree = ast.parse(source)
+
+    init_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "init"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "sentry_sdk"
+    ]
+    assert init_calls, f"no sentry_sdk.init() found in {module_path}"
+
+    for call in init_calls:
+        kwargs = {kw.arg: kw.value for kw in call.keywords}
+        assert "include_local_variables" in kwargs, (
+            f"{module_path}: sentry_sdk.init() must disable local variable capture"
+        )
+        value = kwargs["include_local_variables"]
+        assert isinstance(value, ast.Constant) and value.value is False
+
+
+def test_from_exc_does_not_duck_type_unrelated_exceptions() -> None:
+    """Only a MaskedSecretError carries a captured location.
+
+    `filename` is a real attribute on some stdlib exceptions (OSError,
+    SyntaxError), so probing for it with getattr() would misread them as
+    carrying a captured failure. The check is by type, not by attribute name.
+    """
+    err = OSError("boom")
+    err.filename = "/etc/passwd"
+
+    info = ExecutorActionErrorInfo.from_exc(err, action_name="t")
+
+    assert info.filename != "/etc/passwd"
+    assert info.type == "OSError"
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "steps.fetch.result",
+        "int(steps.fetch.result)",
+        "ACTIONS.fetch.result",
+        "int(ACTIONS.fetch.result)",
+        "int(ACTIONS.fetch.result.token)",
+        "var.item",
+        "int(var.item)",
+        "int(inputs.value)",
+    ],
+)
+def test_secret_capable_carriers_are_gated(expression: str) -> None:
+    """Every context that can carry a secret-derived value must gate.
+
+    Result masking does not make `ACTIONS.*` safe. It is conditional on the
+    *current* action having its own secrets (`service.py:1011`), so an action
+    that merely reads a prior secret-bearing result never masks it; it is
+    defeated by the same repr() escaping this gate exists to avoid; and AI
+    actions and child workflows populate ACTIONS without passing through
+    invoke_once at all (`dsl/workflow.py:897`). `var.*` receives those values
+    through for_each, and template `steps.*` results are stored unmasked
+    outright. Without taint there is nothing to resolve `inputs.*` or
+    `steps.*` against, so both stay coarse here.
+    """
+    from tracecat.expressions.parser.core import parser
+    from tracecat.expressions.policy import references_secret_derived_value
+
+    assert references_secret_derived_value(parser.parse(expression)) is True
+
+
+@pytest.mark.parametrize(
+    "expression",
+    ["int(TRIGGER.value)", "int(VARS.workspace_var)", "int(ENV.some_var)"],
+)
+def test_non_secret_carriers_still_report_their_error(expression: str) -> None:
+    """The gate must not swallow diagnostics for contexts that carry no secret.
+
+    Pins the other direction: over-gating everything would satisfy the test
+    above while destroying ordinary debuggability. Trigger payloads, workspace
+    variables, and runtime env are not secret carriers.
+    """
+    from tracecat.expressions.parser.core import parser
+    from tracecat.expressions.policy import references_secret_derived_value
+
+    assert references_secret_derived_value(parser.parse(expression)) is False
+
+
+@pytest.mark.anyio
+async def test_stdio_env_value_validation_does_not_echo_resolved_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keys are resolved before the string check, so a key can be plaintext."""
+    from unittest import mock
+    from uuid import UUID
+
+    from tracecat.agent.preset import service as preset_module
+    from tracecat.exceptions import TracecatValidationError
+
+    monkeypatch.setattr(
+        preset_module.secrets_manager,
+        "get_action_secrets",
+        mock.AsyncMock(return_value={"api": {"TOKEN": CANARY}}),
+    )
+    monkeypatch.setattr(
+        preset_module, "get_workspace_variables", mock.AsyncMock(return_value={})
+    )
+    svc = preset_module.AgentPresetService.__new__(preset_module.AgentPresetService)
+    svc.role = mock.Mock(workspace_id=UUID(int=1))  # type: ignore[attr-defined]
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await svc.resolve_stdio_env(
+            stdio_env={"${{ SECRETS.api.TOKEN }}": "${{ 1 }}"},
+            mcp_integration_id=UUID(int=2),
+            mcp_integration_slug="stub",
+        )
+
+    message = str(exc_info.value)
+    assert CANARY not in message
+    assert "invalid entries: [1]" in message
+
+
+def test_mcp_env_validation_does_not_echo_the_key() -> None:
+    """A resolved stdio env key can be secret plaintext.
+
+    `resolve_stdio_env()` evaluates expressions in env KEYS, so a key authored as
+    `${{ SECRETS.api.TOKEN }}` becomes plaintext before validation runs. That
+    error reaches durable probe results and the API, and a resolved secret lands
+    in this branch precisely because it is not a valid POSIX name.
+    """
+    from tracecat.integrations.mcp_validation import (
+        MCPValidationError,
+        validate_mcp_env,
+    )
+
+    with pytest.raises(MCPValidationError) as exc_info:
+        validate_mcp_env({"GOOD": "value", f"{CANARY}-key": "value"})
+
+    message = str(exc_info.value)
+    assert CANARY not in message
+    assert "entry 2" in message, "the entry must still be locatable by position"
+
+
+WITHHELD_TEXT = "Details withheld: the expression may reference a secret."
+
+
+async def _run_template(
+    caller_args: dict[str, Any],
+    steps: list[tuple[str, dict[str, Any]]],
+    returns: Any,
+    inputs: dict[str, Any],
+    step_results: dict[str, Any] | None = None,
+    steps_declaring_secrets: set[str] | None = None,
+    failing_steps: set[str] | None = None,
+) -> Any:
+    """Drive canonical template orchestration with external IO stubbed."""
+    from unittest import mock
+    from uuid import UUID
+
+    from tracecat_registry import RegistrySecret
+
+    from tracecat.auth.types import Role
+    from tracecat.executor import service as service_module
+    from tracecat.executor.schemas import (
+        ActionImplementation,
+        ExecutorResultFailure,
+        ExecutorResultSuccess,
+        ResolvedContext,
+    )
+    from tracecat.expressions.policy import build_provenance
+
+    results = step_results or {}
+    declaring = steps_declaring_secrets or set()
+    failures = failing_steps or set()
+    role = Role(
+        type="service",
+        organization_id=UUID(int=1),
+        workspace_id=UUID(int=2),
+        service_id="tracecat-executor",
+    )
+    run_input = mock.Mock(registry_lock=mock.sentinel.lock, exec_context={})
+    resolved = ResolvedContext(
+        secrets={},
+        variables={},
+        action_impl=ActionImplementation(
+            type="template",
+            action_name="testing.stub",
+            template_definition={
+                "name": "stub",
+                "namespace": "testing",
+                "title": "stub",
+                "description": "taint regression",
+                "display_group": "testing",
+                "steps": [
+                    {"ref": ref, "action": f"testing.{ref}", "args": args}
+                    for ref, args in steps
+                ],
+                "returns": returns,
+                "expects": {},
+            },
+        ),
+        evaluated_args=inputs,
+        workspace_id=str(role.workspace_id),
+        workflow_id="00000000-0000-0000-0000-000000000003",
+        run_id="00000000-0000-0000-0000-000000000004",
+        executor_token="parent-token",
+    )
+
+    def load(action_name: str, *_args: Any) -> ActionImplementation:
+        return ActionImplementation(type="udf", action_name=action_name)
+
+    def secrets(action_name: str, *_args: Any) -> set[RegistrySecret]:
+        ref = action_name.rsplit(".", 1)[-1]
+        return (
+            {RegistrySecret(name="runtime", keys=["TOKEN"])}
+            if ref in declaring
+            else set()
+        )
+
+    async def execute(
+        **kwargs: Any,
+    ) -> ExecutorResultSuccess | ExecutorResultFailure:
+        action_name = kwargs["resolved_context"].action_impl.action_name
+        ref = action_name.rsplit(".", 1)[-1]
+        if ref in failures:
+            return ExecutorResultFailure(
+                error=ExecutorActionErrorInfo(
+                    action_name=action_name,
+                    type="ValueError",
+                    message=f"rejected {CANARY}",
+                    filename="probe.py",
+                    function="run",
+                )
+            )
+        return ExecutorResultSuccess(result=results.get(ref, {}).get("result", "x"))
+
+    backend = mock.Mock(execute=mock.AsyncMock(side_effect=execute))
+    with (
+        mock.patch.object(
+            service_module.registry_resolver,
+            "resolve_action",
+            mock.AsyncMock(side_effect=load),
+        ),
+        mock.patch.object(
+            service_module.registry_resolver,
+            "collect_action_secrets_from_manifest",
+            mock.AsyncMock(side_effect=secrets),
+        ),
+        mock.patch.object(
+            service_module, "_mint_action_executor_token", return_value="step-token"
+        ),
+    ):
+        return await service_module._execute_template_action(
+            backend=backend,
+            input=run_input,
+            ctx=service_module.DispatchActionContext(role=role),
+            resolved_context=resolved,
+            timeout=30,
+            provenance=build_provenance(caller_args),
+        )
+
+
+@pytest.mark.anyio
+async def test_non_secret_template_input_keeps_full_error() -> None:
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        await _run_template(
+            caller_args={"value": "abc"},
+            steps=[("convert", {"n": "${{ int(inputs.value) }}"})],
+            returns="ok",
+            inputs={"value": "abc"},
+        )
+
+    message = str(exc_info.value)
+    assert "invalid literal for int()" in message
+    assert WITHHELD_TEXT not in message
+
+
+@pytest.mark.anyio
+async def test_secret_backed_template_input_is_withheld() -> None:
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        await _run_template(
+            caller_args={"value": "${{ SECRETS.svc.value }}"},
+            steps=[("convert", {"n": "${{ int(inputs.value) }}"})],
+            returns="ok",
+            inputs={"value": CANARY},
+        )
+
+    assert WITHHELD_TEXT in str(exc_info.value)
+    assert CANARY not in str(exc_info.value)
+    assert exc_info.value.detail == {
+        "expression": "int(inputs.value)",
+        "secret_dependent": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_step_reference_inherits_secret_taint() -> None:
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        await _run_template(
+            caller_args={"value": "${{ SECRETS.svc.value }}"},
+            steps=[
+                ("fetch", {"token": "${{ inputs.value }}"}),
+                ("convert", {"n": "${{ int(steps.fetch.result) }}"}),
+            ],
+            returns="ok",
+            inputs={"value": CANARY},
+            step_results={"fetch": {"result": CANARY}},
+        )
+
+    assert WITHHELD_TEXT in str(exc_info.value)
+    assert CANARY not in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_step_reference_without_taint_keeps_full_error() -> None:
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        await _run_template(
+            caller_args={"value": "abc"},
+            steps=[
+                ("fetch", {"token": "${{ inputs.value }}"}),
+                ("convert", {"n": "${{ int(steps.fetch.result) }}"}),
+            ],
+            returns="ok",
+            inputs={"value": "abc"},
+            step_results={"fetch": {"result": "abc"}},
+        )
+
+    message = str(exc_info.value)
+    assert "invalid literal for int()" in message
+    assert WITHHELD_TEXT not in message
+
+
+@pytest.mark.anyio
+async def test_step_taint_is_transitive() -> None:
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        await _run_template(
+            caller_args={"value": "${{ SECRETS.svc.value }}"},
+            steps=[
+                ("a", {"token": "${{ inputs.value }}"}),
+                ("b", {"passthrough": "${{ steps.a.result }}"}),
+                ("c", {"n": "${{ int(steps.b.result) }}"}),
+            ],
+            returns="ok",
+            inputs={"value": CANARY},
+            step_results={"a": {"result": CANARY}, "b": {"result": CANARY}},
+        )
+
+    assert WITHHELD_TEXT in str(exc_info.value)
+    assert CANARY not in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_step_with_declared_secrets_taints_despite_clean_args() -> None:
+    """A registry action's own secrets taint its result.
+
+    The step's args are literals, so arg inspection alone clears it. The secret
+    arrives through the environment sandbox instead, and the result is still
+    secret-derived.
+    """
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        await _run_template(
+            caller_args={"url": "https://example.test/usage"},
+            steps=[
+                ("fetch", {"url": "https://example.test/usage"}),
+                ("convert", {"n": "${{ int(steps.fetch.result) }}"}),
+            ],
+            returns="ok",
+            inputs={},
+            step_results={"fetch": {"result": CANARY}},
+            steps_declaring_secrets={"fetch"},
+        )
+
+    message = str(exc_info.value)
+    assert WITHHELD_TEXT in message
+    assert CANARY not in message
+
+
+@pytest.mark.anyio
+async def test_step_without_declared_secrets_keeps_full_error() -> None:
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        await _run_template(
+            caller_args={"url": "https://example.test/usage"},
+            steps=[
+                ("fetch", {"url": "https://example.test/usage"}),
+                ("convert", {"n": "${{ int(steps.fetch.result) }}"}),
+            ],
+            returns="ok",
+            inputs={},
+            step_results={"fetch": {"result": "abc"}},
+        )
+
+    message = str(exc_info.value)
+    assert "invalid literal for int()" in message
+    assert WITHHELD_TEXT not in message
+
+
+@pytest.mark.anyio
+async def test_returns_expression_follows_the_same_rules() -> None:
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        await _run_template(
+            caller_args={"value": "${{ SECRETS.svc.value }}"},
+            steps=[("fetch", {"token": "${{ inputs.value }}"})],
+            returns="${{ int(steps.fetch.result) }}",
+            inputs={"value": CANARY},
+            step_results={"fetch": {"result": CANARY}},
+        )
+
+    assert WITHHELD_TEXT in str(exc_info.value)
+
+    with pytest.raises(TracecatExpressionError) as safe_info:
+        await _run_template(
+            caller_args={"value": "abc"},
+            steps=[("fetch", {"token": "${{ inputs.value }}"})],
+            returns="${{ int(steps.fetch.result) }}",
+            inputs={"value": "abc"},
+            step_results={"fetch": {"result": "abc"}},
+        )
+
+    assert "invalid literal for int()" in str(safe_info.value)
+
+
+@pytest.mark.parametrize(
+    ("caller_args", "inputs", "declaring", "withheld"),
+    [
+        pytest.param({"value": "abc"}, {"value": "abc"}, set(), False, id="clean"),
+        pytest.param(
+            {"value": "${{ SECRETS.svc.value }}"},
+            {"value": CANARY},
+            set(),
+            True,
+            id="secret-input",
+        ),
+        pytest.param(
+            {"value": "abc"},
+            {"value": "abc"},
+            {"probe"},
+            True,
+            id="declared-secret",
+        ),
+    ],
+)
+@pytest.mark.anyio
+async def test_template_action_error_uses_canonical_taint(
+    caller_args: dict[str, Any],
+    inputs: dict[str, Any],
+    declaring: set[str],
+    withheld: bool,
+) -> None:
+    from tracecat.exceptions import ExecutionError
+
+    with pytest.raises(ExecutionError) as exc_info:
+        await _run_template(
+            caller_args=caller_args,
+            steps=[("probe", {"value": "${{ inputs.value }}"})],
+            returns="ok",
+            inputs=inputs,
+            steps_declaring_secrets=declaring,
+            failing_steps={"probe"},
+        )
+
+    message = str(exc_info.value)
+    if withheld:
+        assert "Details withheld:" in message
+        assert CANARY not in message
+    else:
+        assert CANARY in message
+
+
+def test_unparseable_step_ref_fails_closed() -> None:
+    from tracecat.expressions.parser.core import parser
+    from tracecat.expressions.policy import TaintState, references_secret_derived_value
+
+    taint = TaintState(provenance={})
+    assert references_secret_derived_value(parser.parse("steps[*].result"), taint=taint)
+
+
+@pytest.mark.parametrize(
+    ("carrier", "tainted_steps"),
+    [
+        ("${{ ACTIONS.fetch.result }}", frozenset()),
+        ("${{ var.item }}", frozenset()),
+        ("${{ steps.fetch.result }}", frozenset({"fetch"})),
+    ],
+)
+def test_runtime_carrier_renamed_to_child_input_is_withheld(
+    carrier: str, tainted_steps: frozenset[str]
+) -> None:
+    from tracecat.expressions.policy import TaintState, build_provenance
+
+    parent_taint = TaintState(tainted_steps=tainted_steps)
+    child = build_provenance({"value": carrier}, taint=parent_taint)
+    assert child["value"].tainted
+
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        eval_templated_object(
+            {"n": "${{ int(inputs.value) }}"},
+            operand={ExprContext.TEMPLATE_ACTION_INPUTS: {"value": CANARY}},
+            taint=TaintState(provenance=child),
+        )
+
+    assert WITHHELD_TEXT in str(exc_info.value)
+    assert CANARY not in str(exc_info.value)
+    assert CANARY not in repr(exc_info.value.detail)
+    for link in _walk_exception_chain(exc_info.value):
+        assert CANARY not in str(link)
+
+
+def test_non_carrier_renamed_to_child_input_keeps_full_error() -> None:
+    from tracecat.expressions.policy import TaintState, build_provenance
+
+    child = build_provenance({"value": "${{ TRIGGER.value }}"})
+    assert not child["value"].tainted
+
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        eval_templated_object(
+            {"n": "${{ int(inputs.value) }}"},
+            operand={ExprContext.TEMPLATE_ACTION_INPUTS: {"value": "abc"}},
+            taint=TaintState(provenance=child),
+        )
+
+    message = str(exc_info.value)
+    assert "invalid literal for int()" in message
+    assert WITHHELD_TEXT not in message
+
+
+def test_carrier_taint_is_transitive_through_nested_inputs() -> None:
+    from tracecat.expressions.policy import TaintState, build_provenance
+
+    parent = build_provenance({"v": "${{ ACTIONS.fetch.result }}"})
+    child = build_provenance(
+        {"value": "${{ inputs.v }}"},
+        parent,
+        taint=TaintState(provenance=parent),
+    )
+    assert child["value"].tainted
+
+    with pytest.raises(TracecatExpressionError) as exc_info:
+        eval_templated_object(
+            {"n": "${{ int(inputs.value) }}"},
+            operand={ExprContext.TEMPLATE_ACTION_INPUTS: {"value": CANARY}},
+            taint=TaintState(provenance=child),
+        )
+
+    assert WITHHELD_TEXT in str(exc_info.value)
+    assert CANARY not in str(exc_info.value)
+
+
+def test_loop_context_withholds_loop_variables() -> None:
+    """`var.*` is always withheld by the expression gate; errors must match.
+
+    A for_each over a secret-derived action result otherwise prints the failing
+    item verbatim, since masking is skipped when the action declares no secrets.
+    """
+
+    from tracecat.executor.service import _attach_loop_context
+
+    with pytest.raises(ValueError) as exc_info:
+        int(CANARY)
+    info = ExecutorActionErrorInfo.from_exc(exc_info.value, action_name="a")
+    info.message = "bad loop item"
+
+    _attach_loop_context(info, 0)
+
+    assert info.loop_vars is None
+    rendered = str(info)
+    assert CANARY not in rendered
+    assert "Iteration 0" in rendered

--- a/tests/unit/test_template_actions.py
+++ b/tests/unit/test_template_actions.py
@@ -29,7 +29,6 @@ from tracecat.dsl.schemas import (
 )
 from tracecat.exceptions import (
     ExecutionError,
-    RegistryValidationError,
     TracecatValidationError,
 )
 from tracecat.executor import service
@@ -693,9 +692,11 @@ async def test_template_action_runs(
 
     if should_raise:
         # Production path wraps RegistryValidationError in ExecutionError
+        # without chaining it: the pydantic original echoes the rejected value.
         with pytest.raises(ExecutionError) as exc_info:
             await run_action_test(input=input, role=test_role)
-        assert isinstance(exc_info.value.__cause__, RegistryValidationError)
+        assert exc_info.value.info.type == "RegistryValidationError"
+        assert exc_info.value.__cause__ is None
     else:
         result = await run_action_test(input=input, role=test_role)
         assert result == expected
@@ -813,9 +814,11 @@ async def test_template_action_with_enums(
 
     if should_raise:
         # Production path wraps RegistryValidationError in ExecutionError
+        # without chaining it: the pydantic original echoes the rejected value.
         with pytest.raises(ExecutionError) as exc_info:
             await run_action_test(input=input, role=test_role)
-        assert isinstance(exc_info.value.__cause__, RegistryValidationError)
+        assert exc_info.value.info.type == "RegistryValidationError"
+        assert exc_info.value.__cause__ is None
     else:
         result = await run_action_test(input=input, role=test_role)
         assert result == expected

--- a/tracecat/AGENTS.md
+++ b/tracecat/AGENTS.md
@@ -121,6 +121,17 @@ Common role types:
 - In `tracecat/config.py`, prefer `int(os.environ.get("VAR") or default)` for
   numeric config so empty environment variables do not break parsing.
 - Prefer `orjson` over stdlib `json` when the dependency is available.
+- Expression errors can carry secret plaintext: failing operations echo their
+  operand, and `repr()` escaping means exact-string masking will not match it.
+  `Expression.result()` withholds the error when the parse tree references a
+  secret. Callers that evaluate templates against a secret-bearing operand wrap
+  the call themselves and mask with the secrets in that operand — see the
+  `call_with_masked_errors()` sites.
+- A sanitized replacement exception must be raised only after the handler has
+  exited: `raise ... from None` clears `__cause__` but not `__context__`, so
+  raising in place leaves the plaintext original attached. Use
+  `call_with_masked_errors()` / `await_with_masked_errors()`, which own that
+  capture-then-raise dance, instead of hand-rolling it.
 
 ## Readability rules
 

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -69,6 +69,7 @@ from tracecat.db.models import (
 from tracecat.db.soft_delete import with_deleted
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.executor.secret_preprocessors import collect_mask_values
 from tracecat.executor.service import get_workspace_variables
 from tracecat.expressions.eval import collect_expressions, eval_templated_object
 from tracecat.integrations.enums import MCPAuthType
@@ -89,6 +90,7 @@ from tracecat.pagination import (
 )
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets import secrets_manager
+from tracecat.secrets.common import call_with_masked_errors
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
 
@@ -1324,19 +1326,27 @@ class AgentPresetService(BaseWorkspaceService):
         context["SECRETS"] = secrets
         context["VARS"] = vars_map
 
-        resolved = eval_templated_object(stdio_env, operand=context)
+        # Expression errors echo their operand and can carry secret plaintext:
+        # failures surface as a chainless masked copy.
+        resolved = call_with_masked_errors(
+            lambda: eval_templated_object(stdio_env, operand=context),
+            masks=collect_mask_values([secrets]),
+        )
         if not isinstance(resolved, dict):
             raise TracecatValidationError(
                 "Resolved stdio_env must be a JSON object with string values"
             )
 
-        non_string_keys = [
-            key for key, value in resolved.items() if not isinstance(value, str)
+        # Keys are resolved too and may be secret plaintext: locate by position.
+        non_string_entries = [
+            position
+            for position, value in enumerate(resolved.values(), start=1)
+            if not isinstance(value, str)
         ]
-        if non_string_keys:
+        if non_string_entries:
             raise TracecatValidationError(
                 "Resolved stdio_env values must be strings "
-                f"(invalid keys: {sorted(non_string_keys)})"
+                f"(invalid entries: {non_string_entries})"
             )
 
         logger.info(

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from tracecat.runtime.errors import RuntimeErrorOwner
+
 if TYPE_CHECKING:
     import httpx
     from pydantic_core import ValidationError
@@ -18,6 +20,7 @@ if TYPE_CHECKING:
     from tracecat.executor.schemas import ExecutorActionErrorInfo
     from tracecat.registry.actions.schemas import RegistryActionValidationErrorInfo
     from tracecat.registry.sync.schemas import SyncErrorCode
+    from tracecat.runtime.errors import RuntimeErrorClassification
 
 
 class TracecatException(Exception):
@@ -199,8 +202,22 @@ class ExecutionError(TracecatException):
     """Exception raised when an error occurs during action execution.
     Use this to wrap errors from the executor so that we should reraise"""
 
-    def __init__(self, info: ExecutorActionErrorInfo):
+    def __init__(
+        self,
+        info: ExecutorActionErrorInfo,
+        *,
+        classification: RuntimeErrorClassification | None = None,
+    ):
         self.info = info
+        # Host-derived metadata, never decoded from a backend error payload.
+        # Platform messages are neutral and policy-authored; user messages must
+        # follow the diagnostic's sanitization rather than retain old plaintext.
+        self.classification = (
+            classification.model_copy(update={"message": info.message})
+            if classification is not None
+            and classification.owner is RuntimeErrorOwner.USER
+            else classification
+        )
         # Build a user-friendly error message from the info
         message = (
             f"There was an error in the executor when calling action '{info.action_name}'."

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -53,7 +53,7 @@ from tracecat.sandbox.utils import (
     communicate_process_group,
     terminate_supervised_process,
 )
-from tracecat.secrets.common import apply_masks, apply_masks_object
+from tracecat.secrets.common import apply_masks_object
 
 if TYPE_CHECKING:
     from tracecat.auth.types import Role
@@ -503,37 +503,33 @@ class ActionRunner:
             )
         # Check for subprocess crash
         if proc.returncode != 0:
-            stderr_text = apply_masks(
-                stderr.decode(errors="replace"),
-                masks=secret_projection.mask_values,
-            )
             logger.error(
                 "Subprocess failed",
                 action=input.task.action,
                 returncode=proc.returncode,
-                stderr=stderr_text,
+                stderr_bytes=len(stderr),
             )
             return ExecutorActionErrorInfo(
                 type="SubprocessError",
-                message=f"Subprocess exited with code {proc.returncode}: {stderr_text[:500]}",
+                message=f"Subprocess exited with code {proc.returncode}",
                 action_name=input.task.action,
                 filename="<subprocess>",
                 function="execute_action",
             )
 
-        # Parse result from stdout
+        # Parse result from stdout. Child-controlled bytes are never logged.
         try:
             result_data = orjson.loads(stdout)
         except orjson.JSONDecodeError as e:
             logger.error(
                 "Failed to parse subprocess output",
                 action=input.task.action,
-                stdout=stdout.decode()[:500],
-                error=str(e),
+                stdout_bytes=len(stdout),
+                parser_position=e.pos,
             )
             return ExecutorActionErrorInfo(
                 type="ProtocolError",
-                message=f"Failed to parse subprocess output: {e}",
+                message=f"Failed to parse subprocess output at byte {e.pos}",
                 action_name=input.task.action,
                 filename="<subprocess>",
                 function="execute_action",

--- a/tracecat/executor/error_policy.py
+++ b/tracecat/executor/error_policy.py
@@ -36,15 +36,20 @@ from tracecat.temporal.errors import (
 from tracecat.temporal.exceptions import UserError
 
 
-def _chained_error_classification(
+def chained_error_classification(
     error: BaseException,
 ) -> RuntimeErrorClassification | None:
-    """Classify the first known executor or sandbox failure in the chain.
+    """Extract preserved metadata or classify a known failure before dropping its chain.
+
+    The returned message must be sanitized before attaching it to a new error.
+    Unknown failures return None so each boundary keeps its existing fallback.
 
     ``RegistryArtifactCacheLeaseContentionError`` subclasses
     ``RegistryArtifactCacheCapacityError``, so it must be matched first.
     """
     for cause in iter_error_chain(error):
+        if isinstance(cause, ExecutionError) and cause.classification is not None:
+            return cause.classification
         if isinstance(cause, EntitlementRequired):
             return RuntimeErrorClassification.user(
                 kind=RuntimeErrorKind.TENANT_ENTITLEMENT_DENIED,
@@ -110,7 +115,7 @@ def _execution_error_classification(
     error: ExecutionError,
 ) -> RuntimeErrorClassification:
     """Classify one executor invocation failure."""
-    return _chained_error_classification(error) or RuntimeErrorClassification.user(
+    return chained_error_classification(error) or RuntimeErrorClassification.user(
         kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
         message=str(error),
         retry_disposition=RetryDisposition.RETRYABLE,
@@ -206,7 +211,7 @@ def classify_execute_action_error(
         return _loop_error_classification(error)
     if isinstance(error, ApplicationError):
         return _application_error_classification(error)
-    return _chained_error_classification(error) or RuntimeErrorClassification.platform(
+    return chained_error_classification(error) or RuntimeErrorClassification.platform(
         kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
         message="Tracecat could not execute the action",
         retry_disposition=RetryDisposition.NON_RETRYABLE,

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -473,11 +473,11 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         Dict with 'success', 'result', and optionally 'error'
     """
     action_impl: dict[str, Any] | None = None
+    secret_env: dict[str, str] = input_data.get("secret_env", {})
     try:
         # Extract what we need from resolved_context
         resolved_context = input_data.get("resolved_context", {})
         action_impl = resolved_context.get("action_impl")
-        secret_env = input_data.get("secret_env", {})
         evaluated_args = resolved_context.get("evaluated_args", {})
 
         if not action_impl:
@@ -536,12 +536,18 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         tb = traceback.extract_tb(e.__traceback__)
         last_frame = tb[-1] if tb else None
 
+        # Action exceptions can echo transformed secrets that exact masking misses.
+        if secret_env:
+            message = "The action failed. Details withheld: this action uses secrets."
+        else:
+            message = str(e)
+
         return {
             "success": False,
             "result": None,
             "error": {
                 "type": type(e).__name__,
-                "message": str(e),
+                "message": message,
                 "action_name": _action_display_name(action_impl),
                 "filename": last_frame.filename if last_frame else "<unknown>",
                 "function": last_frame.name if last_frame else "<unknown>",

--- a/tracecat/executor/schemas.py
+++ b/tracecat/executor/schemas.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-import traceback
 from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
@@ -13,6 +11,18 @@ from tracecat import config
 from tracecat.config import TRACECAT__APP_ENV
 from tracecat.executor.secret_preprocessors import SecretEnvProjection
 from tracecat.logger import logger
+from tracecat.secrets.common import CapturedFailure, MaskedSecretError
+
+
+def _failure_site(e: Exception) -> CapturedFailure:
+    """Original failure type and location.
+
+    A masked exception's own traceback points at the masking boundary; prefer
+    the site captured before the original traceback was dropped.
+    """
+    if isinstance(e, MaskedSecretError) and e.captured is not None:
+        return e.captured
+    return CapturedFailure.from_exc(e)
 
 
 class ExecutorResultSuccess(BaseModel):
@@ -196,7 +206,10 @@ class ExecutorActionErrorInfo(BaseModel):
     """Iteration number of the loop that caused the error."""
 
     loop_vars: dict[str, Any] | None = None
-    """Variables of the loop that caused the error."""
+    """Deprecated. Never populated: loop values are withheld like `var.*`.
+
+    Retained because the generated API client still declares the field.
+    """
 
     def __str__(self) -> str:
         parts = []
@@ -204,8 +217,7 @@ class ExecutorActionErrorInfo(BaseModel):
         if self.loop_iteration is not None:
             parts.append(
                 f"\n[for_each] (Iteration {self.loop_iteration})"
-                f"\n\nLoop variables:\n```\n{json.dumps(self.loop_vars or {}, indent=2)}\n```"
-                f"\n\n{msg}"
+                f"\n{msg}"
                 "\n\nPlease ensure that the loop is iterable and that the loop variable has the correct type."
             )
         else:
@@ -222,12 +234,12 @@ class ExecutorActionErrorInfo(BaseModel):
     @staticmethod
     def from_exc(e: Exception, action_name: str) -> ExecutorActionErrorInfo:
         """Create an error info from an exception."""
-        tb = traceback.extract_tb(e.__traceback__)[-1]  # Get the last frame
+        site = _failure_site(e)
         return ExecutorActionErrorInfo(
             action_name=action_name,
-            type=e.__class__.__name__,
+            type=site.original_type,
             message=str(e),
-            filename=tb.filename,
-            function=tb.name,
-            lineno=tb.lineno,
+            filename=site.filename,
+            function=site.function,
+            lineno=site.lineno,
         )

--- a/tracecat/executor/secret_preprocessors.py
+++ b/tracecat/executor/secret_preprocessors.py
@@ -74,8 +74,11 @@ async def _assume_role_via_irsa(
                 ExternalId=external_id,
             )
     except ClientError as e:
+        # Constant detail: STS messages echo the role ARN, which masking
+        # cannot match once it has been stripped or escaped.
+        code = e.response.get("Error", {}).get("Code", "Unknown")
         raise TracecatCredentialsError(
-            f"Failed to assume AWS role '{role_arn}': {e}"
+            f"Failed to assume AWS role via STS (error code {code})"
         ) from e
 
     creds = response["Credentials"]
@@ -131,8 +134,10 @@ class AwsAssumeRoleSecretPreprocessor:
             secret_values.pop("AWS_ROLE_ARN", None)
             return None
         if not _AWS_ROLE_ARN_PATTERN.match(role_arn):
+            # Never echo the value: the stripped form escapes exact masking.
             raise TracecatCredentialsError(
-                f"Invalid AWS role ARN format in secret '{secret_name}': {role_arn}"
+                f"Invalid AWS role ARN format in secret '{secret_name}' "
+                "key 'AWS_ROLE_ARN'"
             )
         return role_arn
 
@@ -214,7 +219,7 @@ class AwsAssumeRoleSecretPreprocessor:
         return projected_secrets
 
 
-def _collect_mask_values(secret_sources: Sequence[Mapping[str, Any]]) -> set[str]:
+def collect_mask_values(secret_sources: Sequence[Mapping[str, Any]]) -> set[str]:
     """Collect all string-like secret values that should be masked in outputs."""
     mask_values: set[str] = set()
     for secret_source in secret_sources:
@@ -226,6 +231,9 @@ def _collect_mask_values(secret_sources: Sequence[Mapping[str, Any]]) -> set[str
                 mask_values.add(secret_str)
             if isinstance(secret_value, str) and len(secret_value) > 1:
                 mask_values.add(secret_value)
+            # Consumers commonly strip() before echoing; cover that form too.
+            if len(stripped := secret_str.strip()) > 1:
+                mask_values.add(stripped)
     return mask_values
 
 
@@ -255,4 +263,4 @@ async def project_secret_env(
     sources = (
         (secrets, projected_secrets) if projected_secrets is not secrets else (secrets,)
     )
-    return SecretEnvProjection(env=env, mask_values=_collect_mask_values(sources))
+    return SecretEnvProjection(env=env, mask_values=collect_mask_values(sources))

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import itertools
-from collections.abc import Iterator, Mapping, MutableMapping
+from collections.abc import Collection, Iterator, Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, cast
 
 from aiocache import Cache
+from pydantic import ValidationError
 from sqlalchemy import and_, or_, select, union_all
 
 from tracecat import config
@@ -50,6 +51,7 @@ from tracecat.executor.schemas import (
     ResolvedContext,
 )
 from tracecat.executor.secret_preprocessors import (
+    collect_mask_values,
     project_secret_env,
 )
 from tracecat.expressions.common import ExprContext
@@ -62,6 +64,7 @@ from tracecat.expressions.expectations import create_expectation_model
 from tracecat.expressions.policy import (
     ActionArgumentPlan,
     ProvenanceMap,
+    TaintState,
     build_provenance,
     resolve_action_args,
 )
@@ -69,8 +72,13 @@ from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 from tracecat.registry.actions.schemas import TemplateActionDefinition
 from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
+from tracecat.registry.lock.types import RegistryLock
 from tracecat.secrets import secrets_manager
-from tracecat.secrets.common import apply_masks_object
+from tracecat.secrets.common import (
+    apply_masks_object,
+    await_with_masked_errors,
+    call_with_masked_errors,
+)
 from tracecat.variables.schemas import VariableSearch
 from tracecat.variables.service import VariablesService
 
@@ -79,6 +87,22 @@ from tracecat.variables.service import VariablesService
 
 type ArgsT = Mapping[str, Any]
 type ExecutionResult = Any | ExecutorActionErrorInfo
+
+
+def _withhold_error_info(info: ExecutorActionErrorInfo) -> ExecutorActionErrorInfo:
+    """Return a copy without free text that may contain derived secrets."""
+    return info.model_copy(
+        update={
+            "message": "The action failed. Details withheld: secrets may be in scope.",
+            "loop_vars": None,
+        }
+    )
+
+
+def _error_may_contain_secrets(
+    args: Mapping[str, Any], masks: Collection[str] | None
+) -> bool:
+    return bool(masks) or TaintState().step_args_are_secret_dependent(args)
 
 
 def _execution_origin_for_role(role: Role) -> ExecutionOrigin:
@@ -274,6 +298,57 @@ async def get_registry_artifacts_for_lock(
     return sorted(all_artifacts, key=lambda x: x.origin)
 
 
+def _sanitized_validation_message(
+    exc: Exception, *, action: str, expects: Mapping[str, Any]
+) -> str:
+    """Render a validation failure without echoing the submitted value.
+
+    Pydantic reports the rejected input verbatim, and repr() escaping means a
+    secret can survive exact-string masking there. Both the value and the `loc`
+    path are dropped: `loc` carries user-controlled mapping keys for dict-typed
+    fields. Only field names the template itself declares are named back.
+    """
+    if not isinstance(exc, ValidationError):
+        return f"Validation error for template action {action!r}."
+
+    details: list[str] = []
+    for error in exc.errors(
+        include_input=False, include_context=False, include_url=False
+    ):
+        loc = error.get("loc") or ()
+        head = loc[0] if loc else None
+        field = head if isinstance(head, str) and head in expects else "<input>"
+        details.append(f"{field}: {error.get('msg', 'invalid')} [{error.get('type')}]")
+
+    joined = "; ".join(details) or "invalid input"
+    return f"Validation error for template action {action!r}: {joined}"
+
+
+async def _step_action_reaches_secrets(
+    action_name: str,
+    registry_lock: RegistryLock,
+    organization_id: OrganizationID | None,
+) -> bool:
+    """Whether a step's action declares secrets, walking nested templates.
+
+    Fails closed: an unresolvable manifest taints the step.
+    """
+    if organization_id is None:
+        # Unreachable: run_action_from_input rejects a missing organization.
+        raise ValueError("organization_id is required for template step execution")
+    try:
+        secrets = await registry_resolver.collect_action_secrets_from_manifest(
+            action_name, registry_lock, organization_id
+        )
+    except Exception:
+        logger.warning(
+            "Could not resolve step action secrets; tainting step",
+            step_action=action_name,
+        )
+        return True
+    return bool(secrets)
+
+
 async def _prepare_step_context(
     step_action: str,
     evaluated_args: dict[str, Any],
@@ -312,6 +387,50 @@ async def _prepare_step_context(
         logical_time=parent_resolved.logical_time,
         secret_projection=parent_resolved.secret_projection,
     )
+
+
+async def _invoke_template_step(
+    *,
+    backend: ExecutorBackend,
+    resolved_context: ResolvedContext,
+    input: RunActionInput,
+    ctx: DispatchActionContext,
+    timeout: float,
+    provenance: ProvenanceMap,
+    taint: TaintState,
+    step_ref: str,
+    step_action: str,
+) -> Any:
+    """Run one template step and sever unsafe exception chains.
+
+    Built inside the handler, raised after it: the original can carry
+    plaintext and a chained __cause__/__context__ is re-serialized downstream.
+    """
+    try:
+        return await _invoke_step(
+            backend=backend,
+            resolved_context=resolved_context,
+            input=input,
+            ctx=ctx,
+            timeout=timeout,
+            provenance=provenance,
+        )
+    except ExecutionError as e:
+        if e.info is None or step_ref not in taint.tainted_steps:
+            raise
+        error = ExecutionError(info=_withhold_error_info(e.info))
+    except Exception as e:
+        logger.error(
+            "Template step failed",
+            step_ref=step_ref,
+            step_action=step_action,
+            error_type=type(e).__name__,
+        )
+        info = ExecutorActionErrorInfo.from_exc(e, action_name=step_action)
+        if step_ref in taint.tainted_steps:
+            info = _withhold_error_info(info)
+        error = ExecutionError(info=info)
+    raise error
 
 
 async def _execute_template_action(
@@ -353,6 +472,7 @@ async def _execute_template_action(
     # Validate input args against the template's expects schema
     # This applies defaults and validates types (including enums)
     validated_input_args: dict[str, Any] = {}
+    validation_error: RegistryValidationError | None = None
     if template_def.expects:
         try:
             args_model = create_expectation_model(
@@ -361,12 +481,18 @@ async def _execute_template_action(
             validated = args_model.model_validate(resolved_context.evaluated_args)
             validated_input_args = validated.model_dump(mode="json")
         except Exception as e:
-            raise RegistryValidationError(
-                f"Validation error for template action {template_def.action!r}: {e}",
+            validation_error = RegistryValidationError(
+                _sanitized_validation_message(
+                    e, action=template_def.action, expects=template_def.expects
+                ),
                 key=template_def.action,
-            ) from e
+            )
     else:
         validated_input_args = dict(resolved_context.evaluated_args)
+    # Raised outside the handler: the pydantic original echoes the rejected
+    # value, and a chained __cause__/__context__ is re-serialized downstream.
+    if validation_error is not None:
+        raise validation_error
 
     # Defaults enter the runtime input mapping during validation rather than
     # through the caller's action arguments. Seed their authored source here so
@@ -400,6 +526,8 @@ async def _execute_template_action(
         steps=len(template_def.steps),
     )
 
+    taint = TaintState(provenance=provenance)
+
     # Execute each step
     for step in template_def.steps:
         logger.trace(
@@ -408,11 +536,22 @@ async def _execute_template_action(
             step_action=step.action,
         )
 
+        # Declared secrets reach the step through the environment sandbox, never
+        # through authored args; the manifest walk already recurses nested steps.
+        taint = taint.after_step(
+            step.ref,
+            step.args,
+            action_reaches_secrets=await _step_action_reaches_secrets(
+                step.action, input.registry_lock, role.organization_id
+            ),
+        )
+
         evaled_args = resolve_action_args(
             step.action,
             step.args,
             template_context,
             provenance,
+            taint,
         )
 
         # Prepare step context (reuses parent secrets, no re-fetch)
@@ -426,35 +565,23 @@ async def _execute_template_action(
 
         # Nested templates receive provenance derived in this scope.
         child_provenance = (
-            build_provenance(step.args, provenance)
+            build_provenance(step.args, provenance, taint=taint)
             if step_resolved.action_impl.type == "template"
             else {}
         )
 
         # Execute step via _invoke_step (handles nested templates)
-        try:
-            step_result = await _invoke_step(
-                backend=backend,
-                resolved_context=step_resolved,
-                input=input,
-                ctx=ctx,
-                timeout=timeout,
-                provenance=child_provenance,
-            )
-        except ExecutionError:
-            # Re-raise with step context preserved
-            raise
-        except Exception as e:
-            # Wrap other exceptions
-            logger.error(
-                "Template step failed",
-                step_ref=step.ref,
-                step_action=step.action,
-                error=str(e),
-            )
-            raise ExecutionError(
-                info=ExecutorActionErrorInfo.from_exc(e, action_name=step.action)
-            ) from e
+        step_result = await _invoke_template_step(
+            backend=backend,
+            resolved_context=step_resolved,
+            input=input,
+            ctx=ctx,
+            timeout=timeout,
+            provenance=child_provenance,
+            taint=taint,
+            step_ref=step.ref,
+            step_action=step.action,
+        )
 
         # Store step result for subsequent steps (materialized for expression access)
         template_context["steps"][step.ref] = TaskResult.from_result(
@@ -463,7 +590,9 @@ async def _execute_template_action(
         logger.trace("Template step completed", step_ref=step.ref)
 
     # Evaluate returns expression with final template context
-    return eval_templated_object(template_def.returns, operand=template_context)
+    return eval_templated_object(
+        template_def.returns, operand=template_context, taint=taint
+    )
 
 
 async def _invoke_step(
@@ -521,6 +650,14 @@ async def _invoke_step(
             raise ValueError(
                 f"Unknown action type: {resolved_context.action_impl.type}"
             )
+
+
+def _attach_loop_context(info: ExecutorActionErrorInfo, iteration: int | None) -> None:
+    """Record which for_each iteration failed, when running inside one."""
+    if iteration is None:
+        return
+    # Loop values are runtime carriers and are withheld like `var.*`.
+    info.loop_iteration = iteration
 
 
 @dataclass
@@ -582,6 +719,15 @@ async def prepare_resolved_context(
     context["SECRETS"] = secrets
     context["VARS"] = workspace_variables
 
+    # Derive masks from the raw secrets before they can reach an exception.
+    # project_secret_env() runs preprocessors that may hit the network, so it
+    # stays below; its projection masks are unioned in once it has run.
+    early_mask_values = (
+        set()
+        if config.TRACECAT__UNSAFE_DISABLE_SM_MASKING
+        else collect_mask_values([secrets])
+    )
+
     # Extract and set logical_time BEFORE evaluating args
     # This ensures FN.now(), FN.utcnow(), FN.today() use the deterministic time
     env_context = context.get(ExprContext.ENV) or {}
@@ -605,7 +751,11 @@ async def prepare_resolved_context(
             logical_time=logical_time,
             has_interaction=input.interaction_context is not None,
         )
-        evaluated_args = argument_plan.evaluate(context)
+        # Expression errors echo their operand, so the raw secret can be in the
+        # message: failures surface as a chainless masked copy.
+        evaluated_args = call_with_masked_errors(
+            lambda: argument_plan.evaluate(context), masks=early_mask_values
+        )
     finally:
         ctx_logical_time.reset(logical_time_token)
         ctx_interaction.reset(interaction_token)
@@ -613,10 +763,12 @@ async def prepare_resolved_context(
     if role.workspace_id is None:
         raise ValueError("workspace_id is required for action execution")
 
-    secret_projection = await project_secret_env(
-        secrets=secrets,
-        role=role,
-        run_context=input.run_context,
+    # Preprocessors handle live credentials (e.g. AWS STS), so their errors can
+    # carry secret-derived values. invoke_once() has no mask set until this
+    # function returns, so fail closed here instead.
+    secret_projection = await await_with_masked_errors(
+        project_secret_env(secrets=secrets, role=role, run_context=input.run_context),
+        masks=early_mask_values,
     )
 
     # Build root-level masks from the runtime projection so host-side credential
@@ -627,7 +779,7 @@ async def prepare_resolved_context(
         )
         mask_values = None
     else:
-        mask_values = set(secret_projection.mask_values)
+        mask_values = early_mask_values | set(secret_projection.mask_values)
 
     # Generate executor token for SDK authentication
     executor_token = _mint_action_executor_token(input, role)
@@ -674,6 +826,9 @@ async def invoke_once(
     if role.organization_id is None:
         raise ValueError("organization_id is required for action dispatch")
 
+    # Bound before the try so context-preparation failures stay safe.
+    mask_values: set[str] | None = None
+
     try:
         # Prefetch registry lock manifests into cache for O(1) resolution.
         # Keep this inside the error wrapper so entitlement failures are
@@ -705,33 +860,42 @@ async def invoke_once(
 
     except ExecutionError as e:
         # ExecutionError already has proper error info, just add loop context if needed
-        if iteration is not None and e.info is not None:
-            e.info.loop_iteration = iteration
-            e.info.loop_vars = input.exec_context.get(ExprContext.LOCAL_VARS)
-        raise
+        if e.info is None:
+            raise
+        _attach_loop_context(e.info, iteration)
+        if not _error_may_contain_secrets(input.task.args, mask_values):
+            raise
+        safe_error = ExecutionError(info=_withhold_error_info(e.info))
     except Exception as e:
         # Infrastructure errors need to be wrapped for consistent error handling
+        exec_result = ExecutorActionErrorInfo.from_exc(e, action_name=action_name)
+        _attach_loop_context(exec_result, iteration)
+        if _error_may_contain_secrets(input.task.args, mask_values):
+            exec_result = _withhold_error_info(exec_result)
+        # Log only the withheld message when secrets may be in scope.
         logger.error(
             "Backend execution failed",
             action=action_name,
-            error=str(e),
-            error_type=type(e).__name__,
+            error=exec_result.message,
+            error_type=exec_result.type,
             backend=type(backend).__name__,
         )
-        exec_result = ExecutorActionErrorInfo.from_exc(e, action_name=action_name)
-        if iteration is not None:
-            exec_result.loop_iteration = iteration
-            exec_result.loop_vars = input.exec_context.get(ExprContext.LOCAL_VARS)
-        raise ExecutionError(info=exec_result) from e
-
-    # Apply secret masking at root level only. Large action results can make this
-    # CPU-bound traversal expensive, so keep it off the activity event loop where
-    # it could otherwise delay heartbeats for every activity on the worker.
-    if mask_values:
-        action_result = await asyncio.to_thread(
-            apply_masks_object, action_result, masks=mask_values
-        )
-    return action_result
+        # Drop the cause AND the context even with no masks: secret-derived
+        # ACTIONS/var inputs mean the original can carry plaintext, and a
+        # chained __cause__/__context__ is re-serialized downstream.
+        safe_error = ExecutionError(info=exec_result)
+    else:
+        # Apply secret masking at root level only. Large action results can make
+        # this CPU-bound traversal expensive, so keep it off the activity event
+        # loop where it could otherwise delay heartbeats for every activity on
+        # the worker.
+        if mask_values:
+            action_result = await asyncio.to_thread(
+                apply_masks_object, action_result, masks=mask_values
+            )
+        return action_result
+    # Raise outside the handlers so the plaintext original is not attached.
+    raise safe_error
 
 
 async def dispatch_action(backend: ExecutorBackend, input: RunActionInput) -> Any:

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -45,6 +45,7 @@ from tracecat.exceptions import (
 )
 from tracecat.executor import registry_resolver
 from tracecat.executor.backends.base import ExecutorBackend
+from tracecat.executor.error_policy import chained_error_classification
 from tracecat.executor.schemas import (
     ExecutorActionErrorInfo,
     ExecutorResultSuccess,
@@ -73,6 +74,7 @@ from tracecat.logger import logger
 from tracecat.registry.actions.schemas import TemplateActionDefinition
 from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import RuntimeErrorClassification, RuntimeErrorOwner
 from tracecat.secrets import secrets_manager
 from tracecat.secrets.common import (
     apply_masks_object,
@@ -89,11 +91,17 @@ type ArgsT = Mapping[str, Any]
 type ExecutionResult = Any | ExecutorActionErrorInfo
 
 
-def _withhold_error_info(info: ExecutorActionErrorInfo) -> ExecutorActionErrorInfo:
-    """Return a copy without free text that may contain derived secrets."""
+def _withhold_error_info(
+    info: ExecutorActionErrorInfo,
+    classification: RuntimeErrorClassification | None,
+) -> ExecutorActionErrorInfo:
+    """Replace unsafe diagnostics, retaining policy-authored platform messages."""
     return info.model_copy(
         update={
-            "message": "The action failed. Details withheld: secrets may be in scope.",
+            "message": classification.message
+            if classification is not None
+            and classification.owner is RuntimeErrorOwner.PLATFORM
+            else "The action failed. Details withheld: secrets may be in scope.",
             "loop_vars": None,
         }
     )
@@ -418,7 +426,11 @@ async def _invoke_template_step(
     except ExecutionError as e:
         if e.info is None or step_ref not in taint.tainted_steps:
             raise
-        error = ExecutionError(info=_withhold_error_info(e.info))
+        classification = chained_error_classification(e)
+        error = ExecutionError(
+            info=_withhold_error_info(e.info, classification),
+            classification=classification,
+        )
     except Exception as e:
         logger.error(
             "Template step failed",
@@ -427,9 +439,10 @@ async def _invoke_template_step(
             error_type=type(e).__name__,
         )
         info = ExecutorActionErrorInfo.from_exc(e, action_name=step_action)
+        classification = chained_error_classification(e)
         if step_ref in taint.tainted_steps:
-            info = _withhold_error_info(info)
-        error = ExecutionError(info=info)
+            info = _withhold_error_info(info, classification)
+        error = ExecutionError(info=info, classification=classification)
     raise error
 
 
@@ -865,14 +878,19 @@ async def invoke_once(
         _attach_loop_context(e.info, iteration)
         if not _error_may_contain_secrets(input.task.args, mask_values):
             raise
-        safe_error = ExecutionError(info=_withhold_error_info(e.info))
+        classification = chained_error_classification(e)
+        safe_error = ExecutionError(
+            info=_withhold_error_info(e.info, classification),
+            classification=classification,
+        )
     except Exception as e:
         # Infrastructure errors need to be wrapped for consistent error handling
         exec_result = ExecutorActionErrorInfo.from_exc(e, action_name=action_name)
+        classification = chained_error_classification(e)
         _attach_loop_context(exec_result, iteration)
         if _error_may_contain_secrets(input.task.args, mask_values):
-            exec_result = _withhold_error_info(exec_result)
-        # Log only the withheld message when secrets may be in scope.
+            exec_result = _withhold_error_info(exec_result, classification)
+        # Log only the safe diagnostic when secrets may be in scope.
         logger.error(
             "Backend execution failed",
             action=action_name,
@@ -883,7 +901,7 @@ async def invoke_once(
         # Drop the cause AND the context even with no masks: secret-derived
         # ACTIONS/var inputs mean the original can carry plaintext, and a
         # chained __cause__/__context__ is re-serialized downstream.
-        safe_error = ExecutionError(info=exec_result)
+        safe_error = ExecutionError(info=exec_result, classification=classification)
     else:
         # Apply secret masking at root level only. Large action results can make
         # this CPU-bound traversal expensive, so keep it off the activity event

--- a/tracecat/expressions/common.py
+++ b/tracecat/expressions/common.py
@@ -178,7 +178,9 @@ def eval_jsonpath(
     """Evaluate a jsonpath expression on the target object (operand)."""
 
     if operand is None or not isinstance(operand, dict | list):
-        logger.error("Invalid operand for jsonpath", operand=operand)
+        logger.error(
+            "Invalid operand for jsonpath", operand_type=type(operand).__name__
+        )
         raise TracecatExpressionError(
             f"A dict or list operand is required as jsonpath target. Got {type(operand)}"
         )
@@ -239,11 +241,13 @@ def eval_jsonpath(
         if strict:
             # We know that if this function is called, there was a templated field.
             # Therefore, it means the jsonpath was valid but there was no match.
-            logger.error("Jsonpath no match", expr=repr(expr), operand=operand)
+            # Operands may contain sensitive values, so log and report the
+            # expression only.
+            logger.error("Jsonpath no match", expr=repr(expr))
             formatted_expr = _expr_with_context(expr, context_type)
             raise TracecatExpressionError(
                 f"Couldn't resolve expression {formatted_expr!r} in the context",
-                detail={"expression": formatted_expr, "operand": operand},
+                detail={"expression": formatted_expr},
             )
         # Return None instead of empty list
         return None

--- a/tracecat/expressions/core.py
+++ b/tracecat/expressions/core.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import Any, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 from lark import Token, Tree, Visitor
 
@@ -17,6 +17,9 @@ from tracecat.expressions.parser.evaluator import ExprEvaluator
 from tracecat.expressions.validator.validator import BaseExprValidator
 from tracecat.logger import logger
 from tracecat.parse import traverse_expressions
+
+if TYPE_CHECKING:
+    from tracecat.expressions.policy import TaintState
 
 ExtractorResult = TypeVar("ExtractorResult", covariant=True)
 ValidatorResult = TypeVar("ValidatorResult")
@@ -62,6 +65,7 @@ class Expression:
         policy: ExprResolutionPolicy | None = None,
         source: str | None = None,
         standalone: bool = True,
+        taint: TaintState | None = None,
     ) -> None:
         self._expr = expression
         self._operand = operand
@@ -70,6 +74,7 @@ class Expression:
         self._policy = policy
         self._source = source
         self._standalone = standalone
+        self._taint = taint
 
     def __str__(self) -> str:
         return self.__repr__()
@@ -105,6 +110,7 @@ class Expression:
                 detail=str(e),
             ) from e
 
+        secret_error: TracecatExpressionError | None = None
         try:
             visitor = ExprEvaluator(operand=self._operand)
             if parse_tree is None:
@@ -122,10 +128,22 @@ class Expression:
                 )
             return default()
         except TracecatExpressionError as e:
-            raise TracecatExpressionError(
-                f"Error evaluating expression `{self._expr}`\n\n{e}",
-                detail=e.detail if e.detail is not None else str(e),
-            ) from e
+            # Local import: tracecat.expressions.policy imports this module transitively.
+            from tracecat.expressions.policy import references_secret_derived_value
+
+            if references_secret_derived_value(parse_tree, taint=self._taint):
+                secret_error = TracecatExpressionError(
+                    f"Error evaluating expression `{self._expr}`\n\n"
+                    "Details withheld: the expression may reference a secret.",
+                    detail={"expression": self._expr, "secret_dependent": True},
+                )
+            else:
+                raise TracecatExpressionError(
+                    f"Error evaluating expression `{self._expr}`\n\n{e}",
+                    detail=e.detail if e.detail is not None else str(e),
+                ) from e
+        # Outside the handler: no exception is in flight, so nothing is attached.
+        raise secret_error
 
     def validate(
         self,
@@ -189,6 +207,7 @@ class TemplateExpression:
         pattern: re.Pattern[str] = patterns.TEMPLATE_STRING,
         policy: ExprResolutionPolicy | None = None,
         standalone: bool = True,
+        taint: TaintState | None = None,
         **kwargs: Any,
     ) -> None:
         match = pattern.match(template)
@@ -207,6 +226,7 @@ class TemplateExpression:
             policy=policy,
             source=match.group("template"),
             standalone=standalone,
+            taint=taint,
         )
 
     def __str__(self) -> str:

--- a/tracecat/expressions/eval.py
+++ b/tracecat/expressions/eval.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import re
 from collections.abc import Callable
 from functools import partial
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from tracecat.exceptions import TracecatExpressionError
 from tracecat.expressions import patterns
@@ -15,6 +17,9 @@ from tracecat.expressions.core import (
     TemplateExpression,
 )
 from tracecat.parse import traverse_expressions
+
+if TYPE_CHECKING:
+    from tracecat.expressions.policy import TaintState
 
 
 def _eval_templated_obj_rec(
@@ -55,6 +60,7 @@ def _eval_expression_op(
     match: re.Match[str],
     operand: ExprOperand | None,
     policy: ExprResolutionPolicy | None,
+    taint: TaintState | None,
 ) -> str:
     expr = match.group("template")
     result = TemplateExpression(
@@ -62,6 +68,7 @@ def _eval_expression_op(
         operand=operand,
         policy=policy,
         standalone=False,
+        taint=taint,
     ).result()
     try:
         return str(result)
@@ -74,13 +81,18 @@ def _make_templated_string_operator(
     operand: ExprOperand | None,
     pattern: re.Pattern[str],
     policy: ExprResolutionPolicy | None,
+    taint: TaintState | None,
 ) -> Callable[[str], Any]:
-    evaluator = partial(_eval_expression_op, operand=operand, policy=policy)
+    evaluator = partial(
+        _eval_expression_op, operand=operand, policy=policy, taint=taint
+    )
 
     def operator(line: str) -> Any:
         """Evaluate one standalone or inline templated string."""
         if is_template_only(line) and len(pattern.findall(line)) == 1:
-            return TemplateExpression(line, operand=operand, policy=policy).result()
+            return TemplateExpression(
+                line, operand=operand, policy=policy, taint=taint
+            ).result()
         return pattern.sub(evaluator, line)
 
     return operator
@@ -93,18 +105,21 @@ def eval_templated_object(
     pattern: re.Pattern[str] = patterns.TEMPLATE_STRING,
     policy: ExprResolutionPolicy | None = None,
     key_policy: ExprResolutionPolicy | None = None,
+    taint: TaintState | None = None,
 ) -> Any:
     """Populate templated fields with actual values."""
     operator = _make_templated_string_operator(
         operand=operand,
         pattern=pattern,
         policy=policy,
+        taint=taint,
     )
     key_operator = (
         _make_templated_string_operator(
             operand=operand,
             pattern=pattern,
             policy=key_policy,
+            taint=taint,
         )
         if key_policy is not None
         else None

--- a/tracecat/expressions/parser/evaluator.py
+++ b/tracecat/expressions/parser/evaluator.py
@@ -33,10 +33,12 @@ class ExprEvaluator(Transformer[Token, Any]):
         try:
             return self.transform(tree)
         except VisitError as e:
+            # The operand can be a secret value, so log the node type only.
+            # The raised error is masked by the caller; a log line is not.
             logger.error(
                 "Evaluation failed at node",
-                node=e.obj,
-                reason=e.orig_exc,
+                node_type=type(e.obj).__name__,
+                reason_type=type(e.orig_exc).__name__,
             )
             raise TracecatExpressionError(
                 f"[evaluator] Evaluation failed at node:\n```\n{tree.pretty()}\n```\nReason: {e}",
@@ -50,8 +52,7 @@ class ExprEvaluator(Transformer[Token, Any]):
             selected_node = true_node if condition else false_node
             selected_value = self._transform_child(selected_node)
             self.logger.trace(
-                "Visiting ternary:",
-                condition=condition,
+                "Visiting ternary",
                 selected_branch="true" if condition else "false",
             )
             return selected_value
@@ -64,43 +65,37 @@ class ExprEvaluator(Transformer[Token, Any]):
 
     @v_args(inline=True)
     def root(self, node: Tree[Token]) -> Tree[Token]:
-        logger.trace("Visiting root:", node=node)
+        logger.trace("Visiting root")
         return node
 
     @v_args(inline=True)
     def trailing_typecast_expression(self, value: Any, typename: str):
-        logger.trace(
-            "Visiting trailing_typecast_expression:", value=value, typename=typename
-        )
+        logger.trace("Visiting trailing_typecast_expression", typename=typename)
         return functions.cast(value, typename)
 
     @v_args(inline=True)
     def expression(self, value: Any):
-        logger.trace("Visiting expression:", args=value)
+        logger.trace("Visiting expression", value_type=type(value).__name__)
         return value
 
     @v_args(inline=True)
     def context(self, value: Any):
-        logger.trace("Visiting context:", args=value)
+        logger.trace("Visiting context", value_type=type(value).__name__)
         return value
 
     @v_args(inline=True)
     def base_expr(self, value: Any):
-        logger.trace("Visiting base_expr:", value=value)
+        logger.trace("Visiting base_expr", value_type=type(value).__name__)
         return value
 
     @v_args(inline=True)
     def indexer(self, index: Any):
-        logger.trace("Visiting indexer:", index=index)
+        logger.trace("Visiting indexer", index_type=type(index).__name__)
         return index
 
     @v_args(inline=True)
     def primary_expr(self, base: Any, *indexers: Any):
-        logger.trace(
-            "Visiting primary_expr:",
-            base=base,
-            indexers=indexers,
-        )
+        logger.trace("Visiting primary_expr", indexer_count=len(indexers))
         result = base
         for index in indexers:
             result = self._apply_index(result, index)
@@ -111,7 +106,7 @@ class ExprEvaluator(Transformer[Token, Any]):
         self.logger.trace(
             "Visit iterator expression",
             iter_var_expr=iter_var_expr,
-            collection=collection,
+            collection_type=type(collection).__name__,
         )
         # Ensure that our collection is an iterable
         # We have to evaluate the collection expression
@@ -125,27 +120,27 @@ class ExprEvaluator(Transformer[Token, Any]):
 
     @v_args(inline=True)
     def typecast(self, typename: str, value: Any):
-        logger.trace("Visiting typecast:", args=value)
+        logger.trace("Visiting typecast", value_type=type(value).__name__)
         return functions.cast(value, typename)
 
     @v_args(inline=True)
     def ternary(self, true_value: Any, condition: bool, false_value: Any):
-        logger.trace("Visiting ternary:", true_value=true_value, condition=condition)
+        logger.trace("Visiting ternary", condition=bool(condition))
         return true_value if condition else false_value
 
     @v_args(inline=True)
     def list(self, *args):
-        logger.trace("Visiting list:", args=args)
+        logger.trace("Visiting list", arity=len(args))
         return list(*args)
 
     @v_args(inline=True)
     def dict(self, *args):
-        logger.trace("Visiting dict:", args=args)
+        logger.trace("Visiting dict", arity=len(args))
         return dict(args)
 
     @v_args(inline=True)
     def kvpair(self, *args):
-        logger.trace("Visiting kvpair:", args=args)
+        logger.trace("Visiting kvpair", arity=len(args))
         return args
 
     @v_args(inline=True)
@@ -221,7 +216,7 @@ class ExprEvaluator(Transformer[Token, Any]):
         self.logger.trace(
             "Visit function expression",
             fn_name=fn_name,
-            fn_args=fn_args,
+            arity=len(fn_args),
             is_mapped=is_mapped,
         )
         fn = functions.FUNCTION_MAPPING.get(fn_name)
@@ -229,128 +224,132 @@ class ExprEvaluator(Transformer[Token, Any]):
             raise TracecatExpressionError(f"Unknown function {fn_name!r}")
         final_fn = fn.map if is_mapped else fn  # pyright: ignore[reportFunctionMemberAccess] # type: ignore[possibly-missing-attribute]
         result = final_fn(*fn_args)
-        self.logger.trace(f"Function {fn_name!r} returned {result!r}")
+        self.logger.trace(
+            "Function returned",
+            fn_name=fn_name,
+            result_type=type(result).__name__,
+        )
         return result
 
     @v_args(inline=True)
     def arg_list(self, *args):
-        logger.trace("Visiting arg_list:", args=args)
+        logger.trace("Visiting arg_list", arity=len(args))
         return args
 
     @v_args(inline=True)
     def literal(self, value: LiteralT) -> LiteralT:
-        logger.trace("Visiting literal:", value=value)
+        logger.trace("Visiting literal", value_type=type(value).__name__)
         return value
 
     @v_args(inline=True)
     def binary_op(self, lhs: Any, op: str, rhs: Any):
-        logger.trace("Visiting binary_op:", lhs=lhs, op=op, rhs=rhs)
+        logger.trace("Visiting binary_op", op=op)
         return functions.OPERATORS[op](lhs, rhs)
 
     # Logical operators
     @v_args(inline=True)
     def or_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting or_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting or_op")
         return functions.OPERATORS["||"](lhs, rhs)
 
     @v_args(inline=True)
     def and_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting and_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting and_op")
         return functions.OPERATORS["&&"](lhs, rhs)
 
     @v_args(inline=True)
     def not_op(self, value: Any):
-        logger.trace("Visiting not_op:", value=value)
+        logger.trace("Visiting not_op")
         return not value
 
     # Comparison operators
     @v_args(inline=True)
     def eq_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting eq_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting eq_op")
         return functions.OPERATORS["=="](lhs, rhs)
 
     @v_args(inline=True)
     def ne_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting ne_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting ne_op")
         return functions.OPERATORS["!="](lhs, rhs)
 
     @v_args(inline=True)
     def gt_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting gt_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting gt_op")
         return functions.OPERATORS[">"](lhs, rhs)
 
     @v_args(inline=True)
     def ge_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting ge_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting ge_op")
         return functions.OPERATORS[">="](lhs, rhs)
 
     @v_args(inline=True)
     def lt_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting lt_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting lt_op")
         return functions.OPERATORS["<"](lhs, rhs)
 
     @v_args(inline=True)
     def le_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting le_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting le_op")
         return functions.OPERATORS["<="](lhs, rhs)
 
     # Inclusion operators
     @v_args(inline=True)
     def in_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting in_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting in_op")
         return functions.OPERATORS["in"](lhs, rhs)
 
     @v_args(inline=True)
     def not_in_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting not_in_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting not_in_op")
         return functions.OPERATORS["not in"](lhs, rhs)
 
     # Identity operators
     @v_args(inline=True)
     def is_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting is_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting is_op")
         return functions.OPERATORS["is"](lhs, rhs)
 
     @v_args(inline=True)
     def is_not_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting is_not_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting is_not_op")
         return functions.OPERATORS["is not"](lhs, rhs)
 
     # Arithmetic operators
     @v_args(inline=True)
     def add_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting add_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting add_op")
         return functions.OPERATORS["+"](lhs, rhs)
 
     @v_args(inline=True)
     def sub_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting sub_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting sub_op")
         return functions.OPERATORS["-"](lhs, rhs)
 
     @v_args(inline=True)
     def mul_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting mul_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting mul_op")
         return functions.OPERATORS["*"](lhs, rhs)
 
     @v_args(inline=True)
     def div_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting div_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting div_op")
         return functions.OPERATORS["/"](lhs, rhs)
 
     @v_args(inline=True)
     def mod_op(self, lhs: Any, rhs: Any):
-        logger.trace("Visiting mod_op:", lhs=lhs, rhs=rhs)
+        logger.trace("Visiting mod_op")
         return functions.OPERATORS["%"](lhs, rhs)
 
     # Unary operators
     @v_args(inline=True)
     def neg_op(self, value: Any):
-        logger.trace("Visiting neg_op:", value=value)
+        logger.trace("Visiting neg_op")
         return -value
 
     @v_args(inline=True)
     def pos_op(self, value: Any):
-        logger.trace("Visiting pos_op:", value=value)
+        logger.trace("Visiting pos_op")
         return +value
 
     def PARTIAL_JSONPATH_EXPR(self, token: Token):
@@ -414,7 +413,7 @@ class ExprEvaluator(Transformer[Token, Any]):
         return token.value
 
     def _apply_index(self, value: Any, index: Any) -> Any:
-        self.logger.trace("Applying index", value=value, index=index)
+        self.logger.trace("Applying index", index_type=type(index).__name__)
         if isinstance(value, Mapping):
             try:
                 return value[index]

--- a/tracecat/expressions/policy.py
+++ b/tracecat/expressions/policy.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import ast
 import re
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Collection, Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from typing import Any
@@ -24,14 +24,17 @@ from tracecat.expressions import patterns
 from tracecat.expressions.common import eval_jsonpath
 from tracecat.expressions.eval import eval_templated_object
 from tracecat.expressions.parser.core import parser
+from tracecat.parse import traverse_expressions
 from tracecat.secrets.constants import MASK_VALUE
 
 __all__ = (
     "ActionArgumentPlan",
     "ExpressionPolicy",
     "ProvenanceMap",
+    "TaintState",
     "build_provenance",
     "expression_policy",
+    "references_secret_derived_value",
     "resolve_action_args",
 )
 
@@ -268,8 +271,151 @@ class _InputProvenance:
     dependencies: _SecretDependencies
     """Secret dependencies that directly or transitively apply to the value."""
 
+    tainted: bool = False
+    """Authored arg referenced a runtime carrier; gates error text only, never masking."""
+
 
 type ProvenanceMap = Mapping[str, _InputProvenance]
+
+
+@dataclass(frozen=True, slots=True)
+class TaintState:
+    """Secret taint known at a template invocation's evaluation boundary.
+
+    One lookup table per runtime-born namespace:
+
+    - ``provenance`` answers "is ``inputs.x`` secret-backed?" — decided by the
+      caller's authored args, fixed before the run starts.
+    - ``tainted_steps`` answers "is ``steps.x`` secret-derived?" — decided step
+      by step while the template runs.
+
+    Provenance also seeds step taint: a step referencing ``inputs.*`` is
+    tainted only if that input is. Without it every input-touching step would
+    cascade to conservative, and the failure gate would coarsen back to
+    withholding every template error.
+    """
+
+    provenance: ProvenanceMap | None = None
+    """Authored input sources and their secret dependencies, when known."""
+
+    tainted_steps: frozenset[str] = frozenset()
+    """Refs of prior template steps whose arguments are secret-dependent."""
+
+    @property
+    def tainted_inputs(self) -> frozenset[str]:
+        """Parameters whose authored argument referenced a runtime carrier."""
+        if self.provenance is None:
+            return frozenset()
+        return frozenset(
+            parameter
+            for parameter, binding in self.provenance.items()
+            if binding.tainted
+        )
+
+    def after_step(
+        self, ref: str, args: Any, *, action_reaches_secrets: bool = False
+    ) -> TaintState:
+        """The taint state after this step ran: ``ref`` is marked iff its args are
+        secret-dependent or its action can reach secrets. Encapsulates
+        classify-then-mark so callers cannot reorder it.
+
+        ``action_reaches_secrets`` covers secrets that never appear in authored
+        args: a registry action declaring its own secrets receives them through
+        the environment sandbox, so its result is secret-derived even when the
+        args are literals.
+        """
+        if action_reaches_secrets or self.step_args_are_secret_dependent(args):
+            return replace(self, tainted_steps=self.tainted_steps | {ref})
+        return self
+
+    def step_args_are_secret_dependent(self, args: Any) -> bool:
+        """Whether a template step's authored arguments depend on a secret.
+
+        Fails closed on anything ambiguous, so an unparseable argument taints
+        the step rather than silently clearing it.
+        """
+        try:
+            for expression in traverse_expressions(args):
+                tree = parser.parse(expression)
+                if references_secret_derived_value(tree, taint=self):
+                    return True
+            return False
+        except Exception:
+            return True
+
+    def step_ref_is_tainted(self, tree: Tree[Token]) -> bool:
+        """Whether any ``steps.*`` reference resolves to a tainted step.
+
+        Fails closed when a step ref cannot be extracted from the reference.
+        """
+        return _ref_is_tainted(tree, "template_action_steps", self.tainted_steps)
+
+    def input_ref_is_tainted(self, tree: Tree[Token]) -> bool:
+        """Whether any ``inputs.*`` reference resolves to a tainted parameter.
+
+        Fails closed when an input ref cannot be extracted from the reference.
+        """
+        return _ref_is_tainted(tree, "template_action_inputs", self.tainted_inputs)
+
+
+def _ref_is_tainted(tree: Tree[Token], rule: str, tainted: Collection[str]) -> bool:
+    """Whether any ``rule`` reference names a tainted root, failing closed."""
+    for node in tree.find_data(rule):
+        token = node.children[0]
+        if not isinstance(token, Token):
+            return True
+        _, concrete_prefix = _parse_path_segments(str(token))
+        if not concrete_prefix:
+            return True
+        ref = concrete_prefix[0]
+        if not isinstance(ref, str) or ref in tainted:
+            return True
+    return False
+
+
+def references_secret_derived_value(
+    parse_tree: Tree[Token] | None,
+    *,
+    taint: TaintState | None = None,
+) -> bool:
+    """Whether the expression references any value that may derive from a secret.
+
+    Reads the parse tree only, never the failing text, so repr() escaping
+    cannot defeat it. Runs only after evaluation has already failed. Fails
+    closed: whole-expression gating, and any internal error returns True.
+
+    Per namespace:
+
+    - ``SECRETS.*``: always secret.
+    - ``inputs.*`` / ``steps.*``: exact via ``taint`` when supplied; assumed
+      secret without it. Runtime-carrier taint is carried per parameter, so an
+      ``inputs.*`` renamed from a carrier is withheld too.
+    - ``ACTIONS.*`` / ``var.*``: always assumed secret. Result masking does not
+      clear them — it is conditional on the *current* action's secrets
+      (`service.py:1011`), repr-defeatable, and bypassed by AI actions and
+      child workflows (`dsl/workflow.py:897`).
+    """
+    if parse_tree is None:
+        return False
+    provenance = taint.provenance if taint is not None else None
+    try:
+        # Always-withheld namespaces; inputs/steps join only when no taint
+        # state can resolve them exactly.
+        coarse_rules = ["secrets", "actions", "local_vars"]
+        if provenance is None:
+            coarse_rules.append("template_action_inputs")
+        if taint is None:
+            coarse_rules.append("template_action_steps")
+        for rule in coarse_rules:
+            if any(True for _ in parse_tree.find_data(rule)):
+                return True
+        if taint is not None and taint.step_ref_is_tainted(parse_tree):
+            return True
+        if taint is not None and taint.input_ref_is_tainted(parse_tree):
+            return True
+        return _tree_dependencies(parse_tree, provenance).secret
+    except Exception:
+        return True
 
 
 @dataclass(frozen=True, slots=True)
@@ -287,8 +433,10 @@ class _InputSelection:
 def build_provenance(
     arguments: Mapping[str, Any],
     parent: ProvenanceMap | None = None,
+    taint: TaintState | None = None,
 ) -> dict[str, _InputProvenance]:
     """Scan authored arguments once and build the template-input mapping."""
+    taint = taint or TaintState(provenance=parent)
     provenance: dict[str, _InputProvenance] = {}
     for parameter, value in arguments.items():
         dependencies = _derive_dependencies(value, parent)
@@ -303,6 +451,9 @@ def build_provenance(
         provenance[parameter] = _InputProvenance(
             source=source,
             dependencies=dependencies,
+            # ponytail: coarse per parameter; path-sensitive taint if a mixed
+            # dict input ever needs it
+            tainted=taint.step_args_are_secret_dependent(value),
         )
     return provenance
 
@@ -466,6 +617,7 @@ def resolve_action_args(
     arguments: Mapping[str, Any],
     context: Mapping[str, Any],
     provenance: ProvenanceMap,
+    taint: TaintState | None = None,
 ) -> dict[str, Any]:
     """Resolve one template step at the target action's policy boundary."""
     redaction_policy = _RedactionPolicy(provenance)
@@ -475,13 +627,16 @@ def resolve_action_args(
     for parameter, value in arguments.items():
         match expression_policy(action, parameter):
             case ExpressionPolicy.RESOLVE:
-                resolved[parameter] = eval_templated_object(value, operand=context)
+                resolved[parameter] = eval_templated_object(
+                    value, operand=context, taint=taint
+                )
             case ExpressionPolicy.REDACT_SECRETS:
                 resolved[parameter] = eval_templated_object(
                     value,
                     operand=context,
                     policy=redaction_policy,
                     key_policy=key_policy,
+                    taint=taint,
                 )
             case ExpressionPolicy.PRESERVE:
                 preserve_policy = _PreservePolicy(

--- a/tracecat/expressions/policy.py
+++ b/tracecat/expressions/policy.py
@@ -396,7 +396,7 @@ def references_secret_derived_value(
       child workflows (`dsl/workflow.py:897`).
     """
     if parse_tree is None:
-        return False
+        return True
     provenance = taint.provenance if taint is not None else None
     try:
         # Always-withheld namespaces; inputs/steps join only when no taint

--- a/tracecat/integrations/mcp_validation.py
+++ b/tracecat/integrations/mcp_validation.py
@@ -288,13 +288,16 @@ def validate_mcp_env_key(key: str) -> None:
             f"Env key too long: {len(key)} > {MAX_ENV_KEY_LENGTH} characters"
         )
 
-    # Must be valid POSIX env var name
+    # Must be valid POSIX env var name. The key is not echoed: a resolved secret
+    # expression lands here precisely because its plaintext is not a valid name.
+    #
     if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
         raise MCPValidationError(
-            f"Invalid env var name '{key}': must match [A-Za-z_][A-Za-z0-9_]*"
+            "Invalid env var name: must match [A-Za-z_][A-Za-z0-9_]*"
         )
 
-    # Cannot override protected variables
+    # Cannot override protected variables. Safe to name: this key matched the
+    # POSIX pattern above and equals a known constant.
     if key in PROTECTED_ENV_VARS:
         raise MCPValidationError(f"Cannot override protected env var: {key}")
 
@@ -345,16 +348,21 @@ def validate_mcp_env(env: dict[str, str] | None) -> None:
     if not isinstance(env, dict):
         raise MCPValidationError(f"Env must be a dict, got {type(env).__name__}")
 
-    for key, value in env.items():
+    for position, (key, value) in enumerate(env.items(), start=1):
+        # An env key may be a resolved secret expression, so its text is
+        # potentially plaintext. Locate the entry by position rather than by
+        # content: this error reaches probe results and the API.
+        #
+        locator = f"entry {position}"
         try:
             validate_mcp_env_key(key)
         except MCPValidationError as e:
-            raise MCPValidationError(f"Invalid env key '{key}': {e}") from e
+            raise MCPValidationError(f"Invalid env key ({locator}): {e}") from e
 
         try:
             validate_mcp_env_value(value)
         except MCPValidationError as e:
-            raise MCPValidationError(f"Invalid env value for '{key}': {e}") from e
+            raise MCPValidationError(f"Invalid env value for {locator}: {e}") from e
 
 
 def validate_mcp_server_name(name: str) -> None:

--- a/tracecat/secrets/common.py
+++ b/tracecat/secrets/common.py
@@ -1,6 +1,12 @@
-import re
-from collections.abc import Iterable, Mapping, Sequence
+from __future__ import annotations
 
+import re
+import traceback
+from collections.abc import Callable, Coroutine, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from tracecat.exceptions import TracecatException
 from tracecat.secrets.constants import MASK_VALUE
 
 
@@ -45,3 +51,105 @@ def _apply_masks_object[T](obj: T, pattern: re.Pattern[str] | None) -> T:
 def apply_masks_object[T](obj: T, masks: Iterable[str]) -> T:
     """Mask secret values in strings, sequences, and mappings."""
     return _apply_masks_object(obj, _compile_mask_pattern(masks))
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedFailure:
+    """Where a masked exception originally failed, and what it was.
+
+    Captured before the original traceback is dropped: frame objects retain
+    their locals, which is where the resolved secret lives, so the traceback
+    cannot be carried over just to keep the location.
+    """
+
+    original_type: str
+    filename: str
+    function: str
+    lineno: int | None = None
+
+    @classmethod
+    def from_exc(cls, exc: BaseException) -> CapturedFailure:
+        """Capture the last traceback frame, or an unknown site when there is none."""
+        if frames := traceback.extract_tb(exc.__traceback__):
+            last = frames[-1]
+            return cls(
+                original_type=type(exc).__name__,
+                filename=last.filename,
+                function=last.name,
+                lineno=last.lineno,
+            )
+        return cls(
+            original_type=type(exc).__name__,
+            filename="<unknown>",
+            function="<unknown>",
+        )
+
+
+class MaskedSecretError(TracecatException):
+    """An error whose message has had secret values masked out."""
+
+    captured: CapturedFailure | None = None
+    """The original failure, or None when it could not be determined."""
+
+
+def mask_exception(exc: BaseException, masks: Iterable[str]) -> Exception:
+    """Rebuild an exception with secret values masked out of its message.
+
+    Returns a plain wrapper rather than the original type: re-instantiating an
+    arbitrary exception is not safe when its __init__ takes a custom signature.
+
+    The returned object carries no plaintext: its message and detail are masked,
+    and it holds neither the original's cause, context, nor traceback (frame
+    objects retain their locals, which is where the resolved secret lives).
+
+    It does NOT follow that the raised exception is safe for any renderer. Two
+    things remain the caller's responsibility:
+
+    - Raise it only AFTER the `except` block has exited, as
+      `call_with_masked_errors` / `await_with_masked_errors` do. Python attaches
+      the in-flight exception as `__context__` at raise time, so raising in
+      place re-links the plaintext regardless of what this builds.
+    - `raise` builds a NEW traceback rooted at the raising frame. That frame's
+      locals typically still hold the resolved secrets, and Sentry defaults to
+      include_local_variables=True, so it captures them. Masking cannot reach
+      those; only disabling local capture can.
+
+    The failing location is copied out first so callers keep it.
+    """
+    pattern = _compile_mask_pattern(masks)
+    masked_message = _apply_mask_pattern(str(exc), pattern)
+    detail = getattr(exc, "detail", None)
+    masked = MaskedSecretError(masked_message)
+    if detail is not None:
+        masked.detail = _apply_masks_object(detail, pattern)
+    if exc.__traceback__ is not None:
+        masked.captured = CapturedFailure.from_exc(exc)
+    return masked
+
+
+def call_with_masked_errors[T](fn: Callable[[], T], *, masks: Iterable[str]) -> T:
+    """Run ``fn``; any failure is re-raised as a masked copy with no chain.
+
+    Owns the capture-then-raise contract for :func:`mask_exception`: Python
+    attaches the in-flight exception as ``__context__`` at raise time (and
+    ``raise ... from None`` clears only ``__cause__``), so the masked copy is
+    built inside the handler but raised only after the handler has exited,
+    leaving neither the plaintext exception nor its frame locals reachable
+    through the chain.
+    """
+    try:
+        return fn()
+    except Exception as e:
+        error = mask_exception(e, masks)
+    raise error
+
+
+async def await_with_masked_errors[T](
+    coro: Coroutine[Any, Any, T], *, masks: Iterable[str]
+) -> T:
+    """Awaiting counterpart of :func:`call_with_masked_errors`."""
+    try:
+        return await coro
+    except Exception as e:
+        error = mask_exception(e, masks)
+    raise error


### PR DESCRIPTION
## Summary

When an expression fails with a secret as its operand, the error message quoted the operand. That message persists to execution history and logs. Exact-string masking cannot close this on its own: `repr()` escaping re-spells the value, so the mask never matches.

This PR decides what to show from the parse tree instead. A failing expression that may reference a secret-derived value now returns:

```
Error evaluating expression `int(inputs.value)`
Details withheld: the expression may reference a secret.
```

Masking stays as defence in depth.

Full analysis and decisions in ENG-1682.

## What changed

**Static gate on the parse tree** (`expressions/policy.py`, `expressions/core.py`)

| Namespace | On failure | Resolver |
| -- | -- | -- |
| `SECRETS.*` | withheld | syntax alone |
| `inputs.*` | exact | provenance from the caller's authored args |
| `steps.*` | exact | per-step `TaintState` ledger |
| `ACTIONS.*`, `var.*` | withheld | none, values are inspectable in the run view |
| `TRIGGER`, `ENV`, `VARS` | full error | openly readable already |

`TaintState` is invocation-scoped: provenance plus a per-step bit, accumulated in execution order, read only after a failure. A step is tainted when its args are secret-dependent or its action declares secrets, since declared secrets arrive through the environment sandbox rather than authored args. Absent taint state, `inputs.*` and `steps.*` fail closed.

**Exception chain severing** (`secrets/common.py`)

`call_with_masked_errors` and `await_with_masked_errors` build the sanitized replacement inside the handler and raise it after the handler exits. `raise ... from None` clears only `__cause__`, so raising in place would leave the plaintext original reachable through `__context__`. The original traceback is dropped too: frame locals hold the resolved secret. `CapturedFailure` keeps the failing type, file, function, and line so error info still names the real site.

**Executor boundaries** (`executor/service.py`)

- Masks are derived from raw secrets before argument evaluation or preprocessors can throw.
- `invoke_once` withholds error text when secrets are in scope or the action's args are secret-dependent, and raises outside the handlers.
- Template step errors are classified per step by `_invoke_template_step`.
- Template validation renders pydantic errors without the rejected input or user-controlled `loc` keys.
- `for_each` errors no longer attach loop variables. The `loop_vars` field stays declared for the generated client but is never populated.

**Child process** (`executor/minimal_runner.py`, `executor/action_runner.py`)

- The runner withholds action exception text whenever the invocation carries secrets.
- The parent no longer logs child stderr or unparsed stdout. Subprocess failures report the exit code and byte counts only.

**Also**

- Evaluator trace logs carry structural metadata only, never resolved values.
- Jsonpath misses no longer attach or log the operand, in both copies.
- STS assume-role failures report the error code, not the message, and an invalid role ARN is not echoed.
- MCP env validation and stdio env resolution locate bad entries by position rather than key, since keys are resolved too.

## Not covered

Values that never pass through an expression are out of reach here: `secrets.get()` credentials in vendor SDK errors and `run_python` tracebacks. Tracked separately.

## Verification

- `uv run ruff check .` and `uv run ruff format --check .` clean
- `uv run basedpyright --warnings` clean on touched modules
- Unit tests for the executor, expressions, runner protocol, and template actions: 301 passed
- Regression tests drive the production routes (`invoke_once`, `_execute_template_action`, `main_minimal`, `resolve_stdio_env`)

## LOC breakdown

| Category | + | - |
| -- | -- | -- |
| Logic | 667 | 160 |
| Tests | 1148 | 25 |
| Docs | 11 | 0 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops expression errors from leaking secret plaintext into execution history and logs. A failing expression that may reference a secret now returns a withheld-details message instead of quoting the operand, which `repr()` escaping made impossible for exact-string masking to catch.

**Secret-dependent error gating**
- A static parse-tree gate classifies namespaces: `SECRETS.*` and `ACTIONS.*`/`var.*` are withheld, `inputs.*`/`steps.*` are exact when provenance or taint exists, and `TRIGGER`/`ENV`/`VARS` keep full errors.
- Missing parse trees fail closed; `TaintState` is an invocation-scoped, per-step ledger accumulated in execution order and read only after failure, and without it `inputs.*` and `steps.*` fail closed.
- Masking remains as defense in depth.
- Implements the withheld-details approach specified in ENG-1682.

**Exception safety across boundaries**
- Sanitized exceptions are raised only after the handler exits (`raise ... from None` clears `__cause__` but not `__context__`), and the original traceback is dropped because frame locals hold the resolved secret; the failure site and error classification are preserved separately so error info still names the real site and downstream boundaries re-classify correctly.
- `invoke_once` and the child process withhold error text whenever secrets are in scope or args are secret-dependent; template validation renders pydantic errors without the rejected input or `loc` keys, and `for_each` no longer attaches loop variables.
- Subprocess failures now report only the exit code and byte counts — the parent no longer logs child stderr or unparsed stdout.
- Jsonpath misses, STS assume-role failures, and MCP env validation no longer echo values or keys.
- `secrets.get()` credentials in vendor SDK errors and `run_python` tracebacks are out of scope and tracked separately.
- `ruff` and `basedpyright` are clean; unit and regression tests pass (301 unit tests plus production-route coverage).

<sup>Written for commit 255fc7e9e2a1de5b918224e4adc07c4713a1cf47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

