### PR TITLE
fix(logging): capture ActionGateway failures in Sentry

### DIFF
--- a/tests/unit/test_sentry_interceptor.py
+++ b/tests/unit/test_sentry_interceptor.py
@@ -11,6 +11,7 @@ import sentry_sdk
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from opentelemetry import trace
+from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sentry_sdk.client import Client
 from sentry_sdk.envelope import Envelope
@@ -966,9 +967,13 @@ def test_gateway_excludes_typed_dependency_failures(
 
 @pytest.mark.parametrize("component", ["api", "action_gateway"])
 def test_request_trace_survives_span_unwind(
+    request: pytest.FixtureRequest,
     monkeypatch: pytest.MonkeyPatch,
     component: str,
 ) -> None:
+    previous_propagator = get_global_textmap()
+    # Register cleanup before initialization so setup failures restore it too.
+    request.addfinalizer(lambda: set_global_textmap(previous_propagator))
     shutdown_platform_tracing()
     monkeypatch.setattr(sentry_module.config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
     service = "tracecat-api" if component == "api" else "tracecat-executor"

--- a/tests/unit/test_sentry_interceptor.py
+++ b/tests/unit/test_sentry_interceptor.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 import sentry_sdk
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from opentelemetry import trace
 from sentry_sdk.client import Client
@@ -33,11 +33,14 @@ from tracecat.agent.error_policy import (
     invalid_agent_configuration,
     user_agent_execution_failed,
 )
+from tracecat.auth.credentials import _authenticate_executor
+from tracecat.db.exceptions import AuthPoolExhaustedError
 from tracecat.dsl import interceptor as interceptor_module
 from tracecat.dsl.interceptor import (
     RuntimeErrorAttributionInterceptor,
     _RuntimeErrorAttributionWorkflowInterceptor,
 )
+from tracecat.exceptions import EntitlementRequired, ScopeDeniedError
 from tracecat.executor.action_gateway import app as gateway_module
 from tracecat.logger import logger
 from tracecat.observability import sentry as sentry_module
@@ -52,6 +55,7 @@ from tracecat.observability.sentry import (
     initialize_worker_sentry,
     initialize_worker_sentry_from_environment,
 )
+from tracecat.query.errors import TracecatQueryOverflowError, TracecatQueryTimeoutError
 from tracecat.runtime.errors import (
     RetryDisposition,
     RuntimeErrorClassification,
@@ -851,3 +855,104 @@ def test_api_capture_preserves_only_active_otel_identifiers(
         "span_id": "0000000000000002",
     }
     assert _SENSITIVE_VALUE not in json.dumps(event)
+
+
+@pytest.mark.parametrize("authorization", [None, "Bearer invalid-token"])
+def test_gateway_excludes_executor_credential_failures(
+    executor_sentry_events: list[Event],
+    monkeypatch: pytest.MonkeyPatch,
+    authorization: str | None,
+) -> None:
+    monkeypatch.setattr(gateway_module, "_include_internal_routers", lambda app: None)
+    app = gateway_module.create_app()
+
+    async def authenticate(request: Request) -> None:
+        # Exercise the real credential verifier; missing/invalid tokens fail
+        # before any workspace database lookup is needed.
+        await _authenticate_executor(
+            request=request,
+            workspace_id=None,
+            require_workspace="yes",
+        )
+
+    async def protected_route() -> None:
+        pytest.fail("Unauthorized requests must not reach the route")
+
+    app.add_api_route(
+        "/internal/protected", protected_route, dependencies=[Depends(authenticate)]
+    )
+    headers = {"Authorization": authorization} if authorization else {}
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/internal/protected", headers=headers)
+    sentry_sdk.flush()
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
+    assert executor_sentry_events == []
+
+
+def test_gateway_excludes_request_validation_failure(
+    executor_sentry_events: list[Event],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gateway_module, "_include_internal_routers", lambda app: None)
+    app = gateway_module.create_app()
+
+    async def validated_route(count: int) -> None:
+        pytest.fail("Invalid input must not reach the route")
+
+    app.add_api_route("/internal/validated", validated_route)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/internal/validated", params={"count": "not-an-integer"})
+    sentry_sdk.flush()
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["type"] == "int_parsing"
+    assert executor_sentry_events == []
+
+
+@pytest.mark.parametrize(
+    ("error", "status_code", "response_marker"),
+    [
+        (
+            ScopeDeniedError(
+                required_scopes=["cases:read"], missing_scopes=["cases:read"]
+            ),
+            403,
+            "insufficient_scope",
+        ),
+        (EntitlementRequired("synthetic-feature"), 403, "EntitlementRequired"),
+        (
+            AuthPoolExhaustedError("synthetic pool exhaustion"),
+            503,
+            "auth_database_unavailable",
+        ),
+        (TracecatQueryTimeoutError(), 422, "query_timeout"),
+        (TracecatQueryOverflowError(), 400, "query_numeric_overflow"),
+    ],
+)
+def test_gateway_excludes_typed_dependency_failures(
+    executor_sentry_events: list[Event],
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    status_code: int,
+    response_marker: str,
+) -> None:
+    monkeypatch.setattr(gateway_module, "_include_internal_routers", lambda app: None)
+    app = gateway_module.create_app()
+
+    async def failing_dependency() -> None:
+        raise error
+
+    async def protected_route() -> None:
+        pytest.fail("Failed dependencies must not reach the route")
+
+    app.add_api_route(
+        "/internal/protected",
+        protected_route,
+        dependencies=[Depends(failing_dependency)],
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/internal/protected")
+    sentry_sdk.flush()
+    assert response.status_code == status_code
+    assert response_marker in response.text
+    assert executor_sentry_events == []

--- a/tests/unit/test_sentry_interceptor.py
+++ b/tests/unit/test_sentry_interceptor.py
@@ -10,6 +10,7 @@ import pytest
 import sentry_sdk
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from opentelemetry import trace
 from sentry_sdk.client import Client
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.integrations.atexit import AtexitIntegration
@@ -37,13 +38,17 @@ from tracecat.dsl.interceptor import (
     RuntimeErrorAttributionInterceptor,
     _RuntimeErrorAttributionWorkflowInterceptor,
 )
+from tracecat.executor.action_gateway import app as gateway_module
 from tracecat.logger import logger
 from tracecat.observability import sentry as sentry_module
 from tracecat.observability.sentry import (
     SentryTag,
+    WorkflowFailureEventContext,
     _sanitize_platform_event,
     capture_api_background_task_failure,
+    capture_platform_failure,
     initialize_api_sentry,
+    initialize_executor_sentry,
     initialize_worker_sentry,
     initialize_worker_sentry_from_environment,
 )
@@ -116,6 +121,25 @@ def api_sentry_events(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[Event]]:
     monkeypatch.setattr(sentry_module.config, "TRACECAT__SERVICE_NAME", "api")
     transport = _InMemoryTransport()
     initialize_api_sentry(
+        dsn="https://public@example.com/1",
+        environment="test-eu",
+        release="tracecat@test",
+        transport=transport,
+    )
+    yield transport.events
+    sentry_sdk.flush()
+    sentry_sdk.init(
+        dsn=None,
+        default_integrations=False,
+        auto_enabling_integrations=False,
+    )
+
+
+@pytest.fixture
+def executor_sentry_events(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[Event]]:
+    monkeypatch.setattr(sentry_module.config, "TRACECAT__SERVICE_NAME", "executor")
+    transport = _InMemoryTransport()
+    initialize_executor_sentry(
         dsn="https://public@example.com/1",
         environment="test-eu",
         release="tracecat@test",
@@ -450,6 +474,8 @@ def test_fastapi_integration_captures_sanitized_unhandled_request_failure(
         SentryTag.API_METHOD.value: "GET",
         SentryTag.API_ROUTE.value: "/items/{item_id}",
         SentryTag.SERVICE_NAME.value: "api",
+        SentryTag.ERROR_OWNER.value: "platform",
+        SentryTag.COMPONENT.value: "api",
     }
     assert "contexts" in event
     contexts = event["contexts"]
@@ -557,6 +583,8 @@ def test_service_task_failure_emits_only_stable_task_name(
         "name": "platform_registry_sync"
     }
     assert set(event["tags"]) == {
+        SentryTag.ERROR_OWNER.value,
+        SentryTag.COMPONENT.value,
         SentryTag.SERVICE_NAME.value,
         SentryTag.SERVICE_TASK_NAME.value,
     }
@@ -707,3 +735,119 @@ def test_error_logs_are_not_promoted_to_sentry_events(
     sentry_sdk.flush()
 
     assert sentry_events == []
+
+
+def test_gateway_captures_once_without_replacing_runtime_capture(
+    executor_sentry_events: list[Event], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Keep the real gateway middleware and exception handlers, without DB routes.
+    monkeypatch.setattr(gateway_module, "_include_internal_routers", lambda app: None)
+    app = gateway_module.create_app()
+    app.dependency_overrides[gateway_module.enforce_agent_script_gateway_access] = (
+        lambda: None
+    )
+
+    async def failing_route(item_id: str) -> None:
+        raise RuntimeError(f"{_SENSITIVE_VALUE}:{item_id}")
+
+    app.add_api_route("/internal/items/{item_id}", failing_route)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            f"/internal/items/{_SENSITIVE_VALUE}?token={_SENSITIVE_VALUE}"
+        )
+    sentry_sdk.flush()
+    assert response.status_code == 500
+    assert len(executor_sentry_events) == 1
+    event = executor_sentry_events[0]
+    assert "tags" in event
+    assert "exception" in event
+    assert event["tags"] == {
+        SentryTag.SERVICE_NAME.value: "executor",
+        SentryTag.COMPONENT.value: "action_gateway",
+        SentryTag.ERROR_OWNER.value: "platform",
+        SentryTag.API_METHOD.value: "GET",
+        SentryTag.API_ROUTE.value: "/internal/items/{item_id}",
+    }
+    assert _SENSITIVE_VALUE not in json.dumps(event)
+    assert any(
+        frame.get("function") == "failing_route"
+        for value in event["exception"]["values"]
+        for frame in value.get("stacktrace", {}).get("frames", [])
+    )
+
+    # Ordinary captures still need runtime attribution; gateway ownership must
+    # not leak into subsequent Temporal work in the same process.
+    sentry_sdk.capture_exception(ValueError(_SENSITIVE_VALUE))
+    logger.error(_SENSITIVE_VALUE)
+    sentry_sdk.flush()
+    assert len(executor_sentry_events) == 1
+    error = RuntimeError("synthetic platform failure")
+    classification = RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+        message="synthetic platform failure",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=error,
+    )
+    capture_platform_failure(
+        error,
+        classification,
+        WorkflowFailureEventContext(
+            run_id="00000000-0000-4000-8000-000000000001",
+            workflow_type="DSLWorkflow",
+            attempt=1,
+            trigger_type="manual",
+        ),
+    )
+    sentry_sdk.flush()
+    assert len(executor_sentry_events) == 2
+    runtime_event = executor_sentry_events[1]
+    assert "tags" in runtime_event
+    assert SentryTag.COMPONENT.value not in runtime_event["tags"]
+    assert runtime_event["tags"][SentryTag.ERROR_OWNER.value] == "platform"
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 422, 503])
+def test_gateway_excludes_handled_errors(
+    executor_sentry_events: list[Event],
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+) -> None:
+    monkeypatch.setattr(gateway_module, "_include_internal_routers", lambda app: None)
+    app = gateway_module.create_app()
+    app.dependency_overrides[gateway_module.enforce_agent_script_gateway_access] = (
+        lambda: None
+    )
+
+    async def expected_error() -> None:
+        raise HTTPException(status_code=status_code, detail=_SENSITIVE_VALUE)
+
+    app.add_api_route("/internal/expected", expected_error)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/internal/expected")
+    sentry_sdk.flush()
+    assert response.status_code == status_code
+    assert executor_sentry_events == []
+
+
+def test_api_capture_preserves_only_active_otel_identifiers(
+    api_sentry_events: list[Event],
+) -> None:
+    span_context = trace.SpanContext(
+        trace_id=1,
+        span_id=2,
+        is_remote=False,
+    )
+    with trace.use_span(trace.NonRecordingSpan(span_context)):
+        capture_api_background_task_failure(
+            RuntimeError(_SENSITIVE_VALUE),
+            task_name="platform_registry_sync",
+        )
+    sentry_sdk.flush()
+    assert len(api_sentry_events) == 1
+    event = api_sentry_events[0]
+    assert "contexts" in event
+    assert event["contexts"]["tracecat_otel"] == {
+        "trace_id": "00000000000000000000000000000001",
+        "span_id": "0000000000000002",
+    }
+    assert _SENSITIVE_VALUE not in json.dumps(event)

--- a/tests/unit/test_sentry_interceptor.py
+++ b/tests/unit/test_sentry_interceptor.py
@@ -47,6 +47,7 @@ from tracecat.executor.action_gateway import app as gateway_module
 from tracecat.logger import logger
 from tracecat.observability import sentry as sentry_module
 from tracecat.observability.otel import (
+    _sanitize_server_span,
     initialize_platform_tracing,
     instrument_fastapi_app,
     shutdown_platform_tracing,
@@ -1034,3 +1035,22 @@ def test_request_trace_survives_span_unwind(
         sentry_sdk.init(
             dsn=None, default_integrations=False, auto_enabling_integrations=False
         )
+
+
+def test_disabled_sentry_leaves_trace_context_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with sentry_sdk.isolation_scope() as scope:
+        # A configured SDK with no DSN must also skip scope writes.
+        scope.set_client(
+            Client(
+                dsn=None, default_integrations=False, auto_enabling_integrations=False
+            )
+        )
+        set_context = Mock()
+        monkeypatch.setattr(sentry_sdk, "set_context", set_context)
+        span = trace.NonRecordingSpan(
+            trace.SpanContext(trace_id=1, span_id=2, is_remote=False)
+        )
+        _sanitize_server_span(span, {"type": "http"})
+        set_context.assert_not_called()

--- a/tests/unit/test_sentry_interceptor.py
+++ b/tests/unit/test_sentry_interceptor.py
@@ -11,6 +11,7 @@ import sentry_sdk
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from opentelemetry import trace
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sentry_sdk.client import Client
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.integrations.atexit import AtexitIntegration
@@ -44,6 +45,11 @@ from tracecat.exceptions import EntitlementRequired, ScopeDeniedError
 from tracecat.executor.action_gateway import app as gateway_module
 from tracecat.logger import logger
 from tracecat.observability import sentry as sentry_module
+from tracecat.observability.otel import (
+    initialize_platform_tracing,
+    instrument_fastapi_app,
+    shutdown_platform_tracing,
+)
 from tracecat.observability.sentry import (
     SentryTag,
     WorkflowFailureEventContext,
@@ -956,3 +962,70 @@ def test_gateway_excludes_typed_dependency_failures(
     assert response.status_code == status_code
     assert response_marker in response.text
     assert executor_sentry_events == []
+
+
+@pytest.mark.parametrize("component", ["api", "action_gateway"])
+def test_request_trace_survives_span_unwind(
+    monkeypatch: pytest.MonkeyPatch,
+    component: str,
+) -> None:
+    shutdown_platform_tracing()
+    monkeypatch.setattr(sentry_module.config, "TRACECAT__PLATFORM_OTEL_ENABLED", True)
+    service = "tracecat-api" if component == "api" else "tracecat-executor"
+    monkeypatch.setattr(sentry_module.config, "TRACECAT__SERVICE_NAME", service)
+    exporter = InMemorySpanExporter()
+    initialize_platform_tracing(service, exporter=exporter)
+    transport = _InMemoryTransport()
+    initializer = (
+        initialize_api_sentry if component == "api" else initialize_executor_sentry
+    )
+    initializer(
+        dsn="https://public@example.com/1",
+        environment="test-eu",
+        release="tracecat@test",
+        transport=transport,
+    )
+    try:
+        if component == "api":
+            app = FastAPI()
+            instrument_fastapi_app(app, service_name=service)
+        else:
+            monkeypatch.setattr(
+                gateway_module, "_include_internal_routers", lambda app: None
+            )
+            app = gateway_module.create_app()
+
+        async def failing_route(item_id: str) -> None:
+            raise RuntimeError(f"{_SENSITIVE_VALUE}:{item_id}")
+
+        app.add_api_route("/items/{item_id}", failing_route)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            for _ in range(2):
+                response = client.get(
+                    f"/items/{_SENSITIVE_VALUE}?token={_SENSITIVE_VALUE}"
+                )
+                assert response.status_code == 500
+        sentry_sdk.flush()
+        assert not trace.get_current_span().get_span_context().is_valid
+        assert len(transport.events) == 2
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 2
+        captured_ids: list[str] = []
+        for event, span in zip(transport.events, spans, strict=True):
+            assert "contexts" in event
+            span_context = span.get_span_context()
+            assert span_context is not None
+            assert event["contexts"]["tracecat_otel"] == {
+                "trace_id": f"{span_context.trace_id:032x}",
+                "span_id": f"{span_context.span_id:016x}",
+            }
+            captured_id = event["contexts"]["tracecat_otel"]["trace_id"]
+            assert isinstance(captured_id, str)
+            captured_ids.append(captured_id)
+            assert _SENSITIVE_VALUE not in json.dumps(event)
+        assert captured_ids[0] != captured_ids[1]
+    finally:
+        shutdown_platform_tracing()
+        sentry_sdk.init(
+            dsn=None, default_integrations=False, auto_enabling_integrations=False
+        )

--- a/tracecat/executor/action_gateway/app.py
+++ b/tracecat/executor/action_gateway/app.py
@@ -26,6 +26,7 @@ from tracecat.executor.action_gateway.policy import (
     enforce_agent_script_gateway_access,
 )
 from tracecat.logger import logger
+from tracecat.observability.otel import instrument_fastapi_app
 from tracecat.query.errors import (
     TracecatQueryOverflowError,
     TracecatQueryTimeoutError,
@@ -225,4 +226,5 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(router)
     _include_internal_routers(app)
     _add_exception_handlers(app)
+    instrument_fastapi_app(app, service_name="tracecat-executor")
     return app

--- a/tracecat/executor/worker.py
+++ b/tracecat/executor/worker.py
@@ -67,7 +67,7 @@ with workflow.unsafe.imports_passed_through():
         shutdown_platform_tracing,
     )
     from tracecat.observability.sentry import (
-        initialize_worker_sentry_from_environment,
+        initialize_executor_sentry_from_environment,
     )
     from tracecat.registry.sync.workflow import (
         RegistryArtifactsBackfillWorkflow,
@@ -133,6 +133,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
         executor_backend=config.TRACECAT__EXECUTOR_BACKEND,
     )
     initialize_platform_tracing("tracecat-executor")
+    initialize_executor_sentry_from_environment()
     action_gateway = ActionGateway()
 
     try:
@@ -156,8 +157,6 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
         await initialize_executor_backend()
 
         client = await get_temporal_client()
-
-        initialize_worker_sentry_from_environment()
 
         # Collect all activities from executor and registry sync
         activities = [

--- a/tracecat/observability/otel.py
+++ b/tracecat/observability/otel.py
@@ -17,6 +17,7 @@ from threading import Lock
 from typing import TYPE_CHECKING, Final, Protocol
 from uuid import UUID
 
+import sentry_sdk
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -446,6 +447,18 @@ def current_trace_id() -> str | None:
 
 def _sanitize_server_span(span: Span, scope: Scope) -> None:
     """Replace raw URLs with a credential-safe route template."""
+    # Sentry's outer ASGI wrapper reports after this span has ended. Save
+    # identifiers on its request isolation scope while the span is available.
+    # Non-recording (unsampled) spans still provide useful correlation IDs.
+    span_context = span.get_span_context()
+    if span_context.is_valid:
+        sentry_sdk.set_context(
+            "tracecat_otel",
+            {
+                "trace_id": f"{span_context.trace_id:032x}",
+                "span_id": f"{span_context.span_id:016x}",
+            },
+        )
     if not span.is_recording():
         return
     route_path = getattr(scope.get("route"), "path", None)

--- a/tracecat/observability/otel.py
+++ b/tracecat/observability/otel.py
@@ -451,7 +451,8 @@ def _sanitize_server_span(span: Span, scope: Scope) -> None:
     # identifiers on its request isolation scope while the span is available.
     # Non-recording (unsampled) spans still provide useful correlation IDs.
     span_context = span.get_span_context()
-    if span_context.is_valid:
+    client = sentry_sdk.get_client()
+    if span_context.is_valid and client.is_active() and client.options.get("dsn"):
         sentry_sdk.set_context(
             "tracecat_otel",
             {

--- a/tracecat/observability/sentry.py
+++ b/tracecat/observability/sentry.py
@@ -8,6 +8,7 @@ from functools import partial
 from typing import Any, Literal, Protocol, cast
 
 import sentry_sdk
+from opentelemetry import trace
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations.atexit import AtexitIntegration
 from sentry_sdk.integrations.fastapi import FastApiIntegration
@@ -45,6 +46,7 @@ class SentryTag(StrEnum):
     API_METHOD = "http.request.method"
     API_ROUTE = "http.route"
     SERVICE_TASK_NAME = "tracecat.service.task.name"
+    COMPONENT = "tracecat.component"
 
 
 _WORKER_ALLOWED_TAGS = frozenset(
@@ -61,6 +63,8 @@ _WORKER_ALLOWED_TAGS = frozenset(
 )
 _API_ALLOWED_TAGS = frozenset(
     {
+        SentryTag.ERROR_OWNER.value,
+        SentryTag.COMPONENT.value,
         SentryTag.SERVICE_NAME.value,
         SentryTag.API_METHOD.value,
         SentryTag.API_ROUTE.value,
@@ -75,6 +79,7 @@ _API_ALLOWED_CONTEXT_FIELDS = {
     "runtime": frozenset({"name", "version"}),
     "tracecat_api_request": frozenset({"method", "route"}),
     "tracecat_service_task": frozenset({"name"}),
+    "tracecat_otel": frozenset({"trace_id", "span_id"}),
 }
 _SAFE_HTTP_METHODS = frozenset(
     {"CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"}
@@ -383,11 +388,21 @@ def _sanitize_api_event(
     hint: Hint,
     *,
     service_name: str,
+    component: Literal["api", "action_gateway"] = "api",
 ) -> Event:
     """Strip API events to stable, privacy-reviewed metadata."""
     del hint
     tags = cast(MutableMapping[str, Any], event.get("tags") or {})
     tags[SentryTag.SERVICE_NAME.value] = service_name
+    tags[SentryTag.ERROR_OWNER.value] = "platform"
+    tags[SentryTag.COMPONENT.value] = component
+    span_context = trace.get_current_span().get_span_context()
+    if span_context.is_valid:
+        contexts = event.setdefault("contexts", {})
+        contexts["tracecat_otel"] = {
+            "trace_id": f"{span_context.trace_id:032x}",
+            "span_id": f"{span_context.span_id:016x}",
+        }
     _enrich_api_request_event(event, tags)
     event["tags"] = dict(tags)
     return _sanitize_event(
@@ -446,6 +461,58 @@ def initialize_worker_sentry(
     )
 
 
+def _http_integrations() -> list[Integration]:
+    return [
+        AtexitIntegration(),
+        StarletteIntegration(
+            transaction_style="url",
+            failed_request_status_codes=set(),
+            middleware_spans=False,
+        ),
+        FastApiIntegration(
+            transaction_style="url",
+            failed_request_status_codes=set(),
+            middleware_spans=False,
+        ),
+    ]
+
+
+def _sanitize_executor_event(event: Event, hint: Hint) -> Event | None:
+    """Only framework-captured gateway exceptions bypass runtime attribution."""
+    values = event.get("exception", {}).get("values", [])
+    if any(
+        value.get("mechanism", {}).get("type") == StarletteIntegration.identifier
+        and value.get("mechanism", {}).get("handled") is False
+        for value in values
+    ):
+        return _sanitize_api_event(
+            event,
+            hint,
+            service_name=config.TRACECAT__SERVICE_NAME,
+            component="action_gateway",
+        )
+    return _sanitize_platform_event(event, hint)
+
+
+def initialize_executor_sentry(
+    *,
+    dsn: str,
+    environment: str,
+    release: str,
+    transport: Transport | None = None,
+) -> None:
+    """Capture gateway request exceptions alongside classified runtime failures."""
+    _initialize_sentry(
+        dsn=dsn,
+        environment=environment,
+        release=release,
+        service_name=config.TRACECAT__SERVICE_NAME,
+        integrations=_http_integrations(),
+        before_send=_sanitize_executor_event,
+        transport=transport,
+    )
+
+
 def initialize_api_sentry(
     *,
     dsn: str,
@@ -460,19 +527,7 @@ def initialize_api_sentry(
         environment=environment,
         release=release,
         service_name=service_name,
-        integrations=[
-            AtexitIntegration(),
-            StarletteIntegration(
-                transaction_style="url",
-                failed_request_status_codes=set(),
-                middleware_spans=False,
-            ),
-            FastApiIntegration(
-                transaction_style="url",
-                failed_request_status_codes=set(),
-                middleware_spans=False,
-            ),
-        ],
+        integrations=_http_integrations(),
         before_send=partial(_sanitize_api_event, service_name=service_name),
         transport=transport,
     )
@@ -522,3 +577,8 @@ def initialize_worker_sentry_from_environment() -> None:
 def initialize_api_sentry_from_environment() -> None:
     """Best-effort initialize the API Sentry profile from the environment."""
     _initialize_sentry_from_environment(initialize_api_sentry)
+
+
+def initialize_executor_sentry_from_environment() -> None:
+    """Best-effort initialize Sentry for the executor and its embedded gateway."""
+    _initialize_sentry_from_environment(initialize_executor_sentry)

--- a/tracecat/observability/sentry.py
+++ b/tracecat/observability/sentry.py
@@ -397,8 +397,8 @@ def _sanitize_api_event(
     tags[SentryTag.ERROR_OWNER.value] = "platform"
     tags[SentryTag.COMPONENT.value] = component
     span_context = trace.get_current_span().get_span_context()
-    if span_context.is_valid:
-        contexts = event.setdefault("contexts", {})
+    contexts = event.setdefault("contexts", {})
+    if span_context.is_valid and "tracecat_otel" not in contexts:
         contexts["tracecat_otel"] = {
             "trace_id": f"{span_context.trace_id:032x}",
             "span_id": f"{span_context.span_id:016x}",


### PR DESCRIPTION
Unexpected ActionGateway request exceptions currently return HTTP 500 without reaching Sentry, even though the executor initializes a Sentry client. Give the executor a combined profile: FastAPI/Starlette capture for its embedded gateway, with the existing owner-gated capture retained for runtime failures. Initialize it before the gateway starts.

Unexpected API requests, supervised API task failures, and gateway requests now carry `tracecat.error.owner=platform`, with `tracecat.component` distinguishing `api` and `action_gateway`. Preserve sanitized route metadata and original stack frames. Instrument gateway HTTP requests and save OpenTelemetry trace/span identifiers in the request Sentry scope before the span unwinds, so the later exception capture retains correlation. Handled HTTP errors and ordinary logs remain excluded.

Related to ENG-1410 and ENG-1777. This implements the capture portion of ENG-1410; it does not close the remaining correlation and production verification work.

Validation: 56 Sentry and platform OTel tests passed, including real API/gateway request correlation, handler suppression, and disabled-Sentry behavior. Gateway app and shutdown tests also passed in the earlier focused run. Ruff, targeted basedpyright, and commit hooks passed. Request tests restore the prior global OTel propagator after execution.

Limits: no EU deployment or Sentry-to-incident.io delivery test yet. One event per gateway request is covered; deduplication against a later terminal workflow event across the HTTP/Temporal transport is not implemented or proven here. Issue-based paging deduplication alone does not guarantee those two representations share a Sentry issue. Resolve or explicitly scope that in ENG-1777 before claiming end-to-end paging readiness. Gateway startup failures outside ASGI remain outside this capture path.

| Change | + | - |
| --- | ---: | ---: |
| Logic | 91 | 16 |
| Tests | 348 | 1 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unexpected `ActionGateway` request failures that return HTTP 500 now reach Sentry; previously, they were silently dropped. The executor initializes this capture profile before the gateway starts, while preserving classified runtime captures and correlating events with active OpenTelemetry trace and span IDs. This implements the capture portion of ENG-1410; cross-transport correlation and production verification remain in ENG-1777.

- Adds platform ownership, `action_gateway` component tags, sanitized route metadata, and original stack frames.
- Excludes expected credential, validation, authorization, entitlement, auth-pool, query, and handled HTTP errors.
- Skips OpenTelemetry context writes when Sentry has no DSN configured.
- Tests privacy filtering, single-event capture, scope isolation, and trace IDs that match completed API and gateway spans.

<sup>Written for commit ebb00ca70f2b4c1cfd5649f98248496591f53a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

