### PR TITLE
fix(agents): preserve dependency data during upgrades

### DIFF
--- a/alembic/versions/c3a17be4d902_default_agents_config_to_empty_subagents.py
+++ b/alembic/versions/c3a17be4d902_default_agents_config_to_empty_subagents.py
@@ -8,9 +8,10 @@ The deprecated ``enabled`` key remains readable by older app versions during
 rolling deploys and application rollback. New app writes normalize it to True;
 existing values are preserved here because the migration runs before rollout.
 
-Existing references to deleted agents and Skills are removed from current and
-saved versions; this unlinking is permanent.
-The cleanup preserves the legacy ``enabled`` key and all other configuration.
+Only defaults for new rows change. Existing configurations and dependency links,
+including references to deleted agents and archived Skills in saved versions,
+remain untouched so application rollback retains the previous data. Permanent
+cleanup belongs in a later contract release after the rollback window closes.
 """
 
 from collections.abc import Sequence
@@ -29,6 +30,7 @@ depends_on: str | Sequence[str] | None = None
 
 _AGENTS_TABLES = ("agent_preset", "agent_preset_version")
 _AGENTS_TYPE = postgresql.JSONB(astext_type=sa.Text())
+_PREVIOUS_AGENTS_DEFAULT_SQL = sa.text("'{\"enabled\": false}'::jsonb")
 _AGENTS_DEFAULT_SQL = sa.text('\'{"enabled": true, "subagents": []}\'::jsonb')
 
 
@@ -42,47 +44,13 @@ def upgrade() -> None:
             server_default=_AGENTS_DEFAULT_SQL,
         )
 
-    # Data-only migration: schema autogeneration cannot infer this cleanup.
-    # Match UUIDs, never recycled slugs; preserve all other configuration/order.
-    for table in ("agent_preset", "agent_preset_version"):
-        op.execute(
-            sa.text(f"""
-            UPDATE {table} AS parent
-            SET agents = jsonb_set(parent.agents, '{{subagents}}', (
-                SELECT COALESCE(jsonb_agg(ref ORDER BY ordinal), '[]'::jsonb)
-                FROM jsonb_array_elements(parent.agents->'subagents')
-                     WITH ORDINALITY AS refs(ref, ordinal)
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM agent_preset AS child
-                    WHERE child.workspace_id = parent.workspace_id
-                      AND child.id::text = ref->>'preset_id'
-                      AND child.deleted_at IS NOT NULL
-                )
-            ))
-            WHERE EXISTS (
-                SELECT 1
-                FROM jsonb_array_elements(parent.agents->'subagents') AS refs(ref)
-                JOIN agent_preset AS child
-                  ON child.id::text = ref->>'preset_id'
-                 AND child.workspace_id = parent.workspace_id
-                WHERE child.deleted_at IS NOT NULL
-            )
-        """)
-        )
-    for table in ("agent_preset_skill", "agent_preset_version_skill"):
-        op.execute(
-            sa.text(f"""
-            DELETE FROM {table} AS binding USING skill
-            WHERE binding.workspace_id = skill.workspace_id
-              AND binding.skill_id = skill.id
-              AND (skill.deleted_at IS NOT NULL OR skill.archived_at IS NOT NULL)
-        """)
-        )
-
 
 def downgrade() -> None:
-    raise NotImplementedError(
-        "Database downgrade is unsupported: deleted dependency links cannot be "
-        "restored by this migration. Roll back the application only. Recover "
-        "deleted database data from a backup or snapshot if needed."
-    )
+    for table in _AGENTS_TABLES:
+        op.alter_column(
+            table,
+            "agents",
+            existing_type=_AGENTS_TYPE,
+            existing_nullable=False,
+            server_default=_PREVIOUS_AGENTS_DEFAULT_SQL,
+        )

--- a/tests/migration/test_deleted_dependency_cleanup.py
+++ b/tests/migration/test_deleted_dependency_cleanup.py
@@ -1,4 +1,4 @@
-"""Exercise the deletion backfill against PostgreSQL JSONB and binding rows."""
+"""Verify default changes preserve dependency data across upgrade and downgrade."""
 
 import importlib.util
 import uuid
@@ -15,14 +15,16 @@ from tests.database import TEST_DB_CONFIG
 
 
 @pytest.mark.parametrize("deletion_marker", ["archived_at", "deleted_at"])
-def test_deleted_dependency_backfill_preserves_live_refs_and_order(
+@pytest.mark.parametrize("enabled", [None, False, True])
+def test_agents_defaults_migration_preserves_existing_data(
     deletion_marker: str,
+    enabled: bool | None,
 ) -> None:
     migration_path = (
         Path(__file__).parents[2]
         / "alembic/versions/c3a17be4d902_default_agents_config_to_empty_subagents.py"
     )
-    spec = importlib.util.spec_from_file_location("dependency_backfill", migration_path)
+    spec = importlib.util.spec_from_file_location("agents_defaults", migration_path)
     assert spec is not None and spec.loader is not None
     migration = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(migration)
@@ -32,6 +34,11 @@ def test_deleted_dependency_backfill_preserves_live_refs_and_order(
         {"preset_id": str(value), "preset": "reused-slug"}
         for value in (live, deleted, other)
     ]
+    agents_config = (
+        {"subagents": refs}
+        if enabled is None
+        else {"enabled": enabled, "subagents": refs}
+    )
     try:
         with engine.begin() as conn:
             # Temporary tables shadow production names only on this connection.
@@ -39,7 +46,7 @@ def test_deleted_dependency_backfill_preserves_live_refs_and_order(
                 conn.execute(
                     sa.text(f"""
                     CREATE TEMP TABLE {table} (
-                        id uuid, workspace_id uuid, agents jsonb,
+                        id uuid, workspace_id uuid, agents jsonb NOT NULL DEFAULT '{{"enabled": false}}'::jsonb,
                         deleted_at timestamptz
                     ) ON COMMIT DROP
                 """)
@@ -51,9 +58,7 @@ def test_deleted_dependency_backfill_preserves_live_refs_and_order(
                     {
                         "id": parent,
                         "workspace": workspace,
-                        "agents": orjson.dumps(
-                            {"enabled": True, "subagents": refs}
-                        ).decode(),
+                        "agents": orjson.dumps(agents_config).decode(),
                     },
                 )
             for child, is_deleted in ((deleted, True), (live, False), (other, False)):
@@ -94,30 +99,42 @@ def test_deleted_dependency_backfill_preserves_live_refs_and_order(
                     ),
                     {"deleted": deleted, "live": live, "workspace": workspace},
                 )
+            # Compare every row, including legacy shapes and all binding columns.
+            tables = (
+                "agent_preset",
+                "agent_preset_version",
+                "agent_preset_skill",
+                "agent_preset_version_skill",
+                "skill",
+            )
+            snapshots = {
+                table: conn.execute(sa.text(f"SELECT * FROM {table}")).all()
+                for table in tables
+            }
             with Operations.context(MigrationContext.configure(conn)):
-                migration.upgrade()
-                migration.upgrade()  # Safe if retried.
-                for table in ("agent_preset", "agent_preset_version"):
-                    assert conn.scalar(
-                        sa.text(f"INSERT INTO {table} DEFAULT VALUES RETURNING agents")
-                    ) == {"enabled": True, "subagents": []}
-                with pytest.raises(
-                    NotImplementedError, match="Database downgrade is unsupported"
+                for migrate, expected_default in (
+                    (migration.upgrade, {"enabled": True, "subagents": []}),
+                    (migration.upgrade, {"enabled": True, "subagents": []}),
+                    (migration.downgrade, {"enabled": False}),
+                    (migration.upgrade, {"enabled": True, "subagents": []}),
                 ):
-                    migration.downgrade()
-                for table in ("agent_preset", "agent_preset_version"):
-                    assert conn.scalar(
-                        sa.text(f"INSERT INTO {table} DEFAULT VALUES RETURNING agents")
-                    ) == {"enabled": True, "subagents": []}
-            for table in ("agent_preset", "agent_preset_version"):
-                agents = conn.scalar(
-                    sa.text(f"SELECT agents FROM {table} WHERE id = :parent"),
-                    {"parent": parent},
-                )
-                assert agents == {"enabled": True, "subagents": [refs[0], refs[2]]}
-            for table in ("agent_preset_skill", "agent_preset_version_skill"):
-                assert conn.scalars(sa.text(f"SELECT skill_id FROM {table}")).all() == [
-                    live
-                ]
+                    migrate()
+                    for table, before in snapshots.items():
+                        assert (
+                            conn.execute(sa.text(f"SELECT * FROM {table}")).all()
+                            == before
+                        )
+                    for table in ("agent_preset", "agent_preset_version"):
+                        # Roll back probe inserts so the next snapshot stays exact.
+                        with conn.begin_nested() as probe:
+                            assert (
+                                conn.scalar(
+                                    sa.text(
+                                        f"INSERT INTO {table} DEFAULT VALUES RETURNING agents"
+                                    )
+                                )
+                                == expected_default
+                            )
+                            probe.rollback()
     finally:
         engine.dispose()


### PR DESCRIPTION
The agent defaults migration permanently removed references to deleted agents and deleted or archived Skills from current presets and saved versions during upgrade. Preserve those rows so application rollback retains the previous dependency data.

Change the existing, undeployed revision to alter only defaults for new rows. Implement downgrade by restoring the previous defaults, and defer permanent cleanup to a later contract release. Explicit user-triggered deletion behavior is unchanged.

Validation: six PostgreSQL regression cases passed using isolated temporary tables. They cover archived/deleted Skills, missing/false/true legacy enabled values, preservation of all existing rows, repeated upgrade, downgrade, and re-upgrade. Focused Ruff checks, formatting, and basedpyright passed.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic (migration) | 13 | 45 |
| Tests | 47 | 30 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the agents migration from deleting dependency data during upgrades. The upgrade now only changes the default value for new rows; existing agent presets, saved versions, and skill bindings are left untouched, so application rollback retains the previous configuration. Downgrade restores the previous default instead of raising, and permanent cleanup is deferred to a later contract release; explicit user-triggered deletion behavior is unchanged.

**Validation**
- Adds regression tests for archived/deleted skills, missing/false/true legacy `enabled` values, exact row preservation, repeated upgrade, downgrade, and re-upgrade.

<sup>Written for commit 7ac517870347b6d3ab78689ba544aac218a21097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

