### PR TITLE
fix(api): skip denied Temporal search attribute registration

### DIFF
--- a/tests/unit/test_temporal_search_attribute_registration.py
+++ b/tests/unit/test_temporal_search_attribute_registration.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from temporalio.api.enums.v1 import IndexedValueType
 from temporalio.api.operatorservice.v1 import ListSearchAttributesResponse
+from temporalio.service import RPCError, RPCStatusCode
 from tenacity import stop_after_attempt, wait_none
 
 from tracecat.api import common
@@ -116,6 +117,62 @@ async def test_add_temporal_search_attributes_rejects_wrong_registered_type(
         await single_attempt_add()
 
     operator_service.add_search_attributes.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("denied_operation", ["list", "add"])
+async def test_add_temporal_search_attributes_skips_permission_denied_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    denied_operation: str,
+) -> None:
+    error = RPCError("Operator access denied", RPCStatusCode.PERMISSION_DENIED, b"")
+    list_attributes = AsyncMock(return_value=ListSearchAttributesResponse())
+    add_attributes = AsyncMock()
+    if denied_operation == "list":
+        list_attributes.side_effect = error
+    else:
+        add_attributes.side_effect = error
+    client = SimpleNamespace(
+        operator_service=SimpleNamespace(
+            list_search_attributes=list_attributes,
+            add_search_attributes=add_attributes,
+        )
+    )
+    monkeypatch.setattr(common, "get_temporal_client", AsyncMock(return_value=client))
+    register = cast(Any, common.add_temporal_search_attributes).retry_with(
+        wait=wait_none(),
+    )
+
+    await register()
+
+    list_attributes.assert_awaited_once()
+    assert add_attributes.await_count == (1 if denied_operation == "add" else 0)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "status", [RPCStatusCode.UNAVAILABLE, RPCStatusCode.UNAUTHENTICATED]
+)
+async def test_add_temporal_search_attributes_retries_other_rpc_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    status: RPCStatusCode,
+) -> None:
+    error = RPCError("Temporal RPC failed", status, b"")
+    list_attributes = AsyncMock(side_effect=error)
+    client = SimpleNamespace(
+        operator_service=SimpleNamespace(list_search_attributes=list_attributes)
+    )
+    monkeypatch.setattr(common, "get_temporal_client", AsyncMock(return_value=client))
+    register = cast(Any, common.add_temporal_search_attributes).retry_with(
+        stop=stop_after_attempt(2),
+        wait=wait_none(),
+    )
+
+    with pytest.raises(RPCError) as exc_info:
+        await register()
+
+    assert exc_info.value is error
+    assert list_attributes.await_count == 2
 
 
 @pytest.mark.anyio

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -283,10 +283,6 @@ async def add_temporal_search_attributes():
                 namespace=namespace,
                 exc=e,
             )
-                "Skipping automatic Temporal search attribute registration: "
-                "operator access denied; provision search attributes externally",
-                namespace=namespace,
-            )
             return
         logger.error(
             "Error adding temporal search attributes",

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -10,6 +10,7 @@ from temporalio.api.operatorservice.v1 import (
     ListSearchAttributesRequest,
     RemoveSearchAttributesRequest,
 )
+from temporalio.service import RPCError, RPCStatusCode
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -273,6 +274,15 @@ async def add_temporal_search_attributes():
             )
         )
     except Exception as e:
+        if isinstance(e, RPCError) and e.status == RPCStatusCode.PERMISSION_DENIED:
+            # Cloud runtime credentials may lack operator-service access.
+            # Attributes must be provisioned externally in these deployments.
+            logger.warning(
+                "Skipping automatic Temporal search attribute registration: "
+                "operator access denied; provision search attributes externally",
+                namespace=namespace,
+            )
+            return
         logger.error(
             "Error adding temporal search attributes",
             exc=e,

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -281,6 +281,11 @@ async def add_temporal_search_attributes():
                 "Skipping automatic Temporal search attribute registration: "
                 "operator access denied; provision search attributes externally",
                 namespace=namespace,
+                exc=e,
+            )
+                "Skipping automatic Temporal search attribute registration: "
+                "operator access denied; provision search attributes externally",
+                namespace=namespace,
             )
             return
         logger.error(


### PR DESCRIPTION
## Description

API startup attempts to inspect and register Temporal search attributes. When runtime credentials lack operator-service access, the task retries five times and reports an expected permission denial to Sentry.

Handle `RPCStatusCode.PERMISSION_DENIED` from listing or adding search attributes by logging a warning to provision attributes externally and returning successfully. Other failures still retry and propagate to the background-task supervisor.

## Validation

- 23 focused registration and API lifespan tests passed.
- Regression coverage verifies denied list/add operations do not retry, while unavailable and unauthenticated RPC failures still retry and propagate.
- Targeted Ruff checks, formatting, and basedpyright passed.
- Commit hooks passed, including client generation and Python type checking.

## LOC breakdown

Computed from `git diff --numstat origin/main...HEAD`.

| Category | + | - |
| --- | ---: | ---: |
| Logic | 11 | 0 |
| Tests | 57 | 0 |

## Steps to QA

Run `uv run pytest --confcutdir=tests/unit tests/unit/test_temporal_search_attribute_registration.py tests/unit/test_api_lifespan.py -q`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents API startup from retrying and reporting to Sentry when Temporal search attribute registration is denied due to missing operator-service access. `PERMISSION_DENIED` responses now log a warning that attributes must be provisioned externally and return successfully; unavailable and unauthenticated RPC failures still retry and propagate. Adds regression coverage for both denied and non-denied RPC failures.

<sup>Written for commit 5fca9b849ff4030e5425cf10fa8d2a4301f6cc51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

