### PR TITLE
refactor(logging): separate activity timeout metadata from Sentry

### DIFF
--- a/tests/unit/test_sentry_interceptor.py
+++ b/tests/unit/test_sentry_interceptor.py
@@ -742,7 +742,7 @@ async def test_reporting_failure_does_not_replace_the_workflow_error(
     monkeypatch.setattr(
         interceptor_module,
         "capture_platform_failure",
-        lambda *_: (_ for _ in ()).throw(RuntimeError("capture unavailable")),
+        lambda *_, **__: (_ for _ in ()).throw(RuntimeError("capture unavailable")),
     )
     attribution = _RuntimeErrorAttributionWorkflowInterceptor(_RaisingInbound(error))
 

--- a/tests/unit/test_temporal_failure_metadata.py
+++ b/tests/unit/test_temporal_failure_metadata.py
@@ -1,0 +1,62 @@
+"""Failure metadata follows deliberate Temporal causes only."""
+
+import pytest
+from temporalio.exceptions import ActivityError, ApplicationError, TimeoutType
+from temporalio.exceptions import TimeoutError as TemporalTimeoutError
+
+from tracecat.temporal.failure_metadata import ActivityTimeout, extract_activity_timeout
+
+
+def _activity_timeout(timeout_type: TimeoutType | None) -> ActivityError:
+    error = ActivityError(
+        "synthetic activity failure",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="synthetic-worker",
+        activity_type="synthetic_activity",
+        activity_id="synthetic-activity",
+        retry_state=None,
+    )
+    error.__cause__ = TemporalTimeoutError(
+        "synthetic timeout", type=timeout_type, last_heartbeat_details=[]
+    )
+    return error
+
+
+@pytest.mark.parametrize("timeout_type", list(TimeoutType))
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_extract_activity_timeout(timeout_type: TimeoutType, wrapped: bool) -> None:
+    error: BaseException = _activity_timeout(timeout_type)
+    if wrapped:
+        wrapper = ApplicationError("synthetic wrapper")
+        wrapper.__cause__ = error
+        error = wrapper
+    assert extract_activity_timeout(error) == ActivityTimeout(timeout_type=timeout_type)
+
+
+def test_incidental_context_does_not_supply_timeout_metadata() -> None:
+    try:
+        raise _activity_timeout(TimeoutType.HEARTBEAT)
+    except ActivityError:
+        try:
+            raise ApplicationError("independent handler failure")
+        except ApplicationError as error:
+            assert isinstance(error.__context__, ActivityError)
+            assert extract_activity_timeout(error) is None
+
+
+def test_standalone_timeout_is_not_an_activity_timeout() -> None:
+    error = TemporalTimeoutError(
+        "synthetic timeout", type=TimeoutType.START_TO_CLOSE, last_heartbeat_details=[]
+    )
+    assert extract_activity_timeout(error) is None
+
+
+def test_missing_timeout_type_is_not_reported() -> None:
+    assert extract_activity_timeout(_activity_timeout(None)) is None
+
+
+def test_cyclic_causes_terminate_without_metadata() -> None:
+    error = ApplicationError("synthetic cycle")
+    error.__cause__ = error
+    assert extract_activity_timeout(error) is None

--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -34,6 +34,7 @@ with workflow.unsafe.imports_passed_through():
         extract_error_classifications,
         iter_error_chain,
     )
+    from tracecat.temporal.failure_metadata import extract_activity_timeout
     from tracecat.temporal.patches import WorkflowPatch
     from tracecat.workflow.executions.enums import TemporalSearchAttr
 
@@ -81,6 +82,7 @@ def _report_terminal_failure(
                 attempt=info.attempt,
                 trigger_type=trigger_type.value,
             ),
+            activity_timeout=extract_activity_timeout(error),
         )
     else:
         terminal_logger.warning("Terminal user workflow failure")

--- a/tracecat/observability/sentry.py
+++ b/tracecat/observability/sentry.py
@@ -16,8 +16,6 @@ from sentry_sdk.integrations.starlette import StarletteIntegration
 from sentry_sdk.transport import Transport
 from sentry_sdk.types import Event, Hint
 from temporalio import activity
-from temporalio.exceptions import ActivityError
-from temporalio.exceptions import TimeoutError as TemporalTimeoutError
 
 from tracecat import __version__ as APP_VERSION
 from tracecat import config
@@ -26,6 +24,7 @@ from tracecat.logger import logger
 from tracecat.observability.types import PlatformErrorCapture
 from tracecat.runtime.errors import RuntimeErrorClassification, RuntimeErrorOwner
 from tracecat.temporal.error_chain import iter_error_chain
+from tracecat.temporal.failure_metadata import ActivityTimeout
 
 
 @dataclass(frozen=True, slots=True)
@@ -220,6 +219,8 @@ def capture_platform_failure(
     error: BaseException,
     classification: RuntimeErrorClassification,
     context: WorkflowFailureEventContext,
+    *,
+    activity_timeout: ActivityTimeout | None = None,
 ) -> None:
     """Best-effort capture of a classified data-plane platform failure.
 
@@ -231,20 +232,11 @@ def capture_platform_failure(
         if not client.is_active() or client.options.get("dsn") is None:
             return
 
-        timeout_type = next(
-            (
-                cause.type
-                for current in iter_error_chain(error, include_implicit_context=False)
-                if isinstance(current, ActivityError)
-                and isinstance(cause := current.cause, TemporalTimeoutError)
-                and cause.type is not None
-            ),
-            None,
-        )
         with sentry_sdk.isolation_scope() as scope:
-            if timeout_type is not None:
+            if activity_timeout is not None:
                 scope.set_tag(
-                    SentryTag.ACTIVITY_TIMEOUT_TYPE.value, timeout_type.name.lower()
+                    SentryTag.ACTIVITY_TIMEOUT_TYPE.value,
+                    activity_timeout.timeout_type.name.lower(),
                 )
             scope.fingerprint = [
                 "tracecat-runtime-v1",

--- a/tracecat/temporal/failure_metadata.py
+++ b/tracecat/temporal/failure_metadata.py
@@ -1,0 +1,32 @@
+"""Typed Temporal failure facts, independent of ownership and retry policy."""
+
+from dataclasses import dataclass
+
+from temporalio.exceptions import ActivityError, TimeoutType
+from temporalio.exceptions import TimeoutError as TemporalTimeoutError
+
+from tracecat.temporal.error_chain import iter_error_chain
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityTimeout:
+    """Bounded metadata describing an activity timeout."""
+
+    timeout_type: TimeoutType
+
+
+def extract_activity_timeout(error: BaseException) -> ActivityTimeout | None:
+    """Extract the first activity timeout from deliberate exception causes.
+
+    Incidental Python context may describe a different failure being handled,
+    so it must not supply timeout metadata. Standalone workflow timeouts are
+    excluded by requiring an ActivityError with a direct timeout cause.
+    """
+    for current in iter_error_chain(error, include_implicit_context=False):
+        if (
+            isinstance(current, ActivityError)
+            and isinstance(cause := current.cause, TemporalTimeoutError)
+            and cause.type is not None
+        ):
+            return ActivityTimeout(timeout_type=cause.type)
+    return None


### PR DESCRIPTION
Follow-up to #3421. Terminal Sentry reporting currently interprets Temporal exception chains to identify activity timeouts. Move that interpretation into a Temporal helper returning a frozen `ActivityTimeout` value, and have the workflow interceptor pass the metadata to the Sentry adapter.

The adapter renders the same `temporal.activity.timeout_type` tag. Explicit cause traversal, exclusion of incidental context and standalone timeouts, ownership, retry policy, and issue grouping remain unchanged. This metadata is local to reporting and adds no Temporal history payload.

Validation: 75 focused tests passed across the metadata helper and Sentry interceptor suites. Added coverage for all four timeout types, explicit wrappers, incidental context, missing timeout types, standalone timeouts, and cyclic causes. Ruff and targeted basedpyright passed.

| Change | + | - |
| --- | ---: | ---: |
| Logic | 40 | 14 |
| Tests | 63 | 1 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates activity timeout extraction from Sentry reporting into a new Temporal helper, keeping Sentry's `temporal.activity.timeout_type` tag behavior unchanged.

- The workflow interceptor now extracts and passes `ActivityTimeout` metadata to the Sentry adapter.
- The new helper only follows deliberate causes, so incidental context and standalone timeouts are excluded.
- Adds tests for all timeout types, wrappers, missing types, and cyclic causes.

<sup>Written for commit e105fe5a2e127391e36d2c604bd2d282ccf0fc52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

