### PR TITLE
fix(agents): route HTTP MCP integrations by unique slug

### DIFF
--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -4444,7 +4444,7 @@ async def test_skill_dependency_policy_is_shared_by_reads_and_runtime(
         assert updated.enable_internet_access
     else:
         assert read.tool_policy.has_approvals
-        assert runtime.tool_approvals == {"mcp.Synthetic.write": True}
+        assert runtime.tool_approvals == {"mcp.synthetic.write": True}
         assert "approvals" in listed.capabilities
         assert not listed.current_version_subagent_eligibility.eligible
         with pytest.raises(TracecatValidationError, match="uses manual approvals"):

--- a/tests/unit/test_mcp_routing_identity.py
+++ b/tests/unit/test_mcp_routing_identity.py
@@ -1,0 +1,168 @@
+"""Duplicate display names must not merge MCP grants or execution endpoints."""
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.fernet import Fernet
+from mcp.types import CallToolResult, TextContent, Tool
+from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.agent import activities
+from tracecat_ee.agent.activities import AgentActivities, BuildToolDefsArgs
+
+from tracecat import config
+from tracecat.agent.common.types import is_http_mcp_server
+from tracecat.agent.mcp import user_client
+from tracecat.agent.mcp.trusted_server import _resolve_user_mcp_config
+from tracecat.agent.preset.service import AgentPresetService
+from tracecat.agent.preset.tool_policy import resolve_tool_policy
+from tracecat.agent.preset.types import PresetToolInputs
+from tracecat.agent.schemas import ToolFilters
+from tracecat.agent.tools import BuildToolsResult
+from tracecat.auth.types import Role
+from tracecat.db.models import MCPIntegration, SkillVersion, SkillVersionMcpTool
+from tracecat.integrations.enums import MCPAuthType
+from tracecat.integrations.service import IntegrationService
+from tracecat.registry.lock.service import RegistryLockService
+from tracecat.registry.lock.types import RegistryLock
+
+
+@pytest.mark.anyio
+async def test_duplicate_display_names_keep_subsets_and_endpoints_separate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        config, "TRACECAT__DB_ENCRYPTION_KEY", Fernet.generate_key().decode()
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-agent-executor",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    integrations = [
+        MCPIntegration(
+            id=uuid.uuid4(),
+            workspace_id=role.workspace_id,
+            name="Shared display name",
+            slug=slug,
+            server_type="http",
+            server_uri=f"https://{slug}.example.test/mcp",
+            auth_type=MCPAuthType.NONE,
+            tools=[
+                {"name": name, "requires_approval": name == "read"}
+                for name in ("read", "write")
+            ],
+        )
+        for slug in ("alpha", "beta")
+    ]
+    by_id = {integration.id: integration for integration in integrations}
+    version = SkillVersion(id=uuid.uuid4(), skill_id=uuid.uuid4(), name="triage")
+    version.tools = []
+    version.mcp_tools = [
+        SkillVersionMcpTool(
+            tool_id=f"mcp.{integration.slug}.{tool}",
+            mcp_integration_id=integration.id,
+            tool_name=tool,
+        )
+        for integration, tool in zip(integrations, ("read", "write"), strict=True)
+    ]
+    policy = resolve_tool_policy(
+        PresetToolInputs(uuid.uuid4(), [], [], [], {}, [version.id]),
+        {version.id: version},
+        by_id,
+    )
+    assert policy.tool_approvals == {"mcp.alpha.read": True}
+    session = AsyncMock(spec=AsyncSession)
+    service = AgentPresetService(session, role=role)
+    refs = service._resolve_tool_mcp_grants(policy.mcp_grants, by_id)
+    assert refs is not None
+    assert [ref["name"] for ref in refs] == ["alpha", "beta"]
+    integration_service = IntegrationService(session, role=role)
+    for integration, ref in zip(integrations, refs, strict=True):
+        server_config = await integration_service.resolve_mcp_http_server_config(
+            integration
+        )
+        assert server_config["name"] == ref["name"]
+    monkeypatch.setattr(
+        IntegrationService,
+        "list_mcp_integrations",
+        AsyncMock(return_value=integrations),
+    )
+
+    @asynccontextmanager
+    async def preset_context(**_kwargs: object) -> AsyncIterator[AgentPresetService]:
+        yield service
+
+    lock_service = MagicMock(spec=RegistryLockService)
+    lock_service.resolve_lock_with_bindings = AsyncMock(
+        return_value=RegistryLock(origins={}, actions={})
+    )
+
+    @asynccontextmanager
+    async def lock_context() -> AsyncIterator[RegistryLockService]:
+        yield lock_service
+
+    calls: list[tuple[str, str]] = []
+
+    class RemoteClient:
+        def __init__(self, url: str) -> None:
+            self.url = url
+
+        async def __aenter__(self) -> "RemoteClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            pass
+
+        async def list_tools(self) -> list[Tool]:
+            return [Tool(name=name, inputSchema={}) for name in ("read", "write")]
+
+        async def call_tool(self, name: str, args: object) -> CallToolResult:
+            calls.append((self.url, name))
+            return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    monkeypatch.setattr(AgentPresetService, "with_session", preset_context)
+    monkeypatch.setattr(RegistryLockService, "with_session", lock_context)
+    monkeypatch.setattr(
+        activities,
+        "build_agent_tools",
+        AsyncMock(return_value=BuildToolsResult(tools=[], collected_secrets=set())),
+    )
+    monkeypatch.setattr(
+        AgentActivities, "_check_tool_approval_entitlement", AsyncMock()
+    )
+    monkeypatch.setattr(user_client, "_create_transport", lambda url, *args: url)
+    monkeypatch.setattr(user_client, "Client", RemoteClient)
+
+    result = await AgentActivities().build_tool_definitions(
+        BuildToolDefsArgs(
+            role=role,
+            tool_filters=ToolFilters(actions=[]),
+            mcp_servers=refs,
+            tool_approvals=policy.tool_approvals,
+            fail_on_mcp_discovery_error=True,
+        )
+    )
+    assert set(result.tool_definitions) == {"mcp__alpha__read", "mcp__beta__write"}
+    assert result.tool_approvals == policy.tool_approvals
+    assert result.user_mcp_claims is not None
+    assert {(claim.name, claim.id) for claim in result.user_mcp_claims} == {
+        (integration.slug, integration.id) for integration in integrations
+    }
+    # Rehydrate the actual claims at the trusted execution boundary, then route calls.
+    executable_configs = [
+        await _resolve_user_mcp_config(claim, role) for claim in result.user_mcp_claims
+    ]
+    assert all(is_http_mcp_server(config) for config in executable_configs)
+    client = user_client.UserMCPClient(executable_configs)
+    for name in result.tool_definitions:
+        parsed = client.parse_user_mcp_tool_name(name)
+        assert parsed is not None
+        await client.call_tool(*parsed, {})
+    assert calls == [
+        ("https://alpha.example.test/mcp", "read"),
+        ("https://beta.example.test/mcp", "write"),
+    ]

--- a/tests/unit/test_preset_tool_policy.py
+++ b/tests/unit/test_preset_tool_policy.py
@@ -80,7 +80,11 @@ def test_stdio_requirement_is_independent_of_source(direct: bool) -> None:
 
 
 @pytest.mark.parametrize(
-    "whole_integration, expected", [(False, {}), (True, {"mcp.Synthetic.write": True})]
+    "whole_integration, expected",
+    [
+        (False, {}),
+        (True, {"mcp.synthetic.write": True}),
+    ],
 )
 def test_mcp_approvals_apply_only_to_selected_available_tools(
     whole_integration: bool, expected: dict[str, bool]
@@ -89,6 +93,7 @@ def test_mcp_approvals_apply_only_to_selected_available_tools(
     integration = MCPIntegration(
         id=integration_id,
         name="Synthetic",
+        slug="synthetic",
         server_type="http",
         tools=[
             {
@@ -194,8 +199,33 @@ async def test_runtime_loads_direct_mcp_metadata_once(
     assert result.mcp_servers and result.mcp_servers[0].get("id") == str(integration_id)
     load.assert_awaited_once()
 
-    load.reset_mock()
-    integration.server_type = "stdio"
+
+@pytest.mark.anyio
+async def test_preview_loads_direct_mcp_metadata_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        config, "TRACECAT__DB_ENCRYPTION_KEY", Fernet.generate_key().decode()
+    )
+    integration_id = uuid.uuid4()
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    integration = MCPIntegration(
+        id=integration_id,
+        workspace_id=role.workspace_id,
+        name="Synthetic",
+        slug="synthetic",
+        server_type="stdio",
+        tools=[],
+    )
+    service = AgentPresetService(AsyncMock(spec=AsyncSession), role=role)
+    monkeypatch.setattr(service.skill_tools, "require_entitlement", AsyncMock())
+    load = AsyncMock(return_value=[integration])
+    monkeypatch.setattr(IntegrationService, "list_mcp_integrations", load)
     monkeypatch.setattr(service.skills, "validate_binding_inputs", AsyncMock())
     monkeypatch.setattr(
         service, "_binding_specs_from_inputs", AsyncMock(return_value=[])

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -1345,7 +1345,8 @@ class AgentPresetService(BaseWorkspaceService):
                 continue
             http_ref: MCPHttpServerConfig = {
                 "type": "http",
-                "name": mcp_integration.name,
+                # Display names need not be unique; route by the workspace-unique slug.
+                "name": mcp_integration.slug,
                 "url": mcp_integration.server_uri,
                 "id": str(mcp_integration.id),
             }

--- a/tracecat/agent/preset/tool_policy.py
+++ b/tracecat/agent/preset/tool_policy.py
@@ -127,11 +127,12 @@ def resolve_tool_policy(
                 tool.enabled
                 and tool.status == "available"
                 and tool.requires_approval
+                # HTTP discovery excludes dotted remote names.
                 and "." not in tool.name
                 and (allowed_names is None or tool.name in allowed_names)
             ):
                 key = normalize_mcp_tool_name(
-                    f"mcp__{REGISTRY_MCP_SERVER_NAME}__mcp__{integration.name}__{tool.name}"
+                    f"mcp__{REGISTRY_MCP_SERVER_NAME}__mcp__{integration.slug}__{tool.name}"
                 )
                 approvals[key] = True
 

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -4350,7 +4350,8 @@ class IntegrationService(BaseWorkspaceService):
 
         server_config: MCPHttpServerConfig = {
             "type": "http",
-            "name": mcp_integration.name,
+            # Display names need not be unique; route by the workspace-unique slug.
+            "name": mcp_integration.slug,
             "url": mcp_integration.server_uri,
             "headers": headers,
             "id": str(mcp_integration.id),


### PR DESCRIPTION
Display names are not unique within a workspace, so two MCP integrations sharing a name collapsed into one server entry for HTTP routing and for approval keys. Route by the workspace-unique slug instead.

Layer 1 of 5 in the split of #3325. Each layer is independently reviewable; the top of the stack reproduces #3325's net diff exactly.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 6 | 3 |
| Tests | 202 | 4 |

https://claude.ai/code/session_01LHvvWytf7Uz8nfcycVAbF8

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes HTTP MCP integrations by the workspace-unique slug instead of display name. Two integrations sharing a display name previously collapsed into a single server entry, merging their HTTP routing and tool approval keys.

**Migration**
- Tool approval keys now use the slug format, so `mcp.Synthetic.write` becomes `mcp.synthetic.write`; update any stored approval keys.

<sup>Written for commit b2c87c6fe223956fca24ebf4af07f8e7f5404083. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


