### PR TITLE
fix(agents): validate effective preset tool counts

### DIFF
--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -4460,3 +4460,60 @@ async def test_skill_dependency_policy_is_shared_by_reads_and_runtime(
                     }
                 )
             )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("operation", ["create", "preview", "runtime", "update"])
+async def test_effective_skill_tool_limit_is_checked_before_execution(
+    operation: str,
+    configure_minio_for_skills: None,
+    session: AsyncSession,
+    svc_role: Role,
+    agent_preset_service: AgentPresetService,
+    agent_preset_create_params: AgentPresetCreate,
+    registry_actions: list[RegistryAction],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill_service = SkillService(session=session, role=svc_role)
+    skill = await skill_service.create_skill(SkillCreate(name="extra-tool"))
+    await skill_service.patch_draft(
+        skill_id=skill.id,
+        params=SkillDraftPatch(
+            base_revision=skill.draft_revision,
+            operations=[
+                SkillDraftUpsertTextFileOp(
+                    path="SKILL.md",
+                    content="---\nname: extra-tool\nmetadata: {tools: [tools.test.test_action]}\n---\n",
+                )
+            ],
+        ),
+    )
+    await skill_service.publish_skill(skill.id)
+    agent_preset_create_params.skills = [AgentPresetSkillBindingBase(skill_id=skill.id)]
+    agent_preset_create_params.actions = ["core.http_request"]
+    monkeypatch.setattr(config, "TRACECAT__AGENT_MAX_TOOLS", 2)
+    preset = await agent_preset_service.create_preset(agent_preset_create_params)
+    version = await agent_preset_service.get_current_version_for_preset(preset)
+    monkeypatch.setattr(config, "TRACECAT__AGENT_MAX_TOOLS", 1)
+    with pytest.raises(TracecatValidationError) as exc_info:
+        match operation:
+            case "create":
+                agent_preset_create_params.name = "Over limit"
+                await agent_preset_service.create_preset(agent_preset_create_params)
+            case "preview":
+                await agent_preset_service.preview_tool_policy(
+                    AgentPresetToolPolicyPreview(
+                        actions=["core.http_request"], skill_ids=[skill.id]
+                    )
+                )
+            case "runtime":
+                await agent_preset_service._version_to_agent_config(version)
+            case "update":
+                await agent_preset_service.update_preset(
+                    preset, AgentPresetUpdate(instructions="Updated instructions")
+                )
+    assert exc_info.value.detail == {
+        "code": "agent_tool_limit_exceeded",
+        "tool_count": 2,
+        "max_tools": 1,
+    }

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -14,6 +14,7 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import JSONB, aggregate_order_by
 from sqlalchemy.orm import load_only, selectinload
 
+from tracecat import config
 from tracecat.agent.access.service import AgentModelAccessService
 from tracecat.agent.channels.service import AgentChannelService
 from tracecat.agent.common.config import AGENT_RUNTIME_PROTECTED_ENV_VARS
@@ -341,6 +342,19 @@ class AgentPresetService(BaseWorkspaceService):
             )
         )[version.id]
 
+    @staticmethod
+    def _validate_effective_tool_count(policy: EffectivePresetTools) -> None:
+        max_tools = config.TRACECAT__AGENT_MAX_TOOLS
+        if max_tools > 0 and len(policy.actions) > max_tools:
+            raise TracecatValidationError(
+                f"Cannot request more than {max_tools} tools",
+                detail={
+                    "code": "agent_tool_limit_exceeded",
+                    "tool_count": len(policy.actions),
+                    "max_tools": max_tools,
+                },
+            )
+
     async def preview_tool_policy(
         self, params: AgentPresetToolPolicyPreview
     ) -> AgentPresetToolPolicyRead:
@@ -367,6 +381,7 @@ class AgentPresetService(BaseWorkspaceService):
             inputs.mcp_integrations, list(metadata.integrations.values())
         )
         policy = resolve_tool_policy(inputs, metadata.versions, metadata.integrations)
+        self._validate_effective_tool_count(policy)
         return self._tool_policy_read(policy)
 
     async def build_preset_list_reads(
@@ -2356,6 +2371,7 @@ class AgentPresetService(BaseWorkspaceService):
             metadata=metadata,
         )
         policy = resolve_tool_policy(inputs, metadata.versions, metadata.integrations)
+        self._validate_effective_tool_count(policy)
         mcp_servers = self._resolve_tool_mcp_grants(
             policy.mcp_grants, metadata.integrations
         )
@@ -2525,6 +2541,7 @@ class AgentPresetService(BaseWorkspaceService):
                 ]
             )
         )[preset.id]
+        self._validate_effective_tool_count(policy)
         preset.enable_internet_access = (
             preset.enable_internet_access or policy.requires_internet_access
         )


### PR DESCRIPTION
The tool limit was only checked against the requested action list, so a preset whose skills expanded past `TRACECAT__AGENT_MAX_TOOLS` still built and ran. Check the resolved effective policy on preview, create, update, and runtime config build.

Layer 2 of 5 in the split of #3325.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 17 | 0 |
| Tests | 57 | 0 |

https://claude.ai/code/session_01LHvvWytf7Uz8nfcycVAbF8

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
