### PR TITLE
fix(skills): lock MCP references before publication

### DIFF
--- a/tests/integration/test_skill_mcp_deletion.py
+++ b/tests/integration/test_skill_mcp_deletion.py
@@ -4,11 +4,11 @@ import asyncio
 import uuid
 
 import pytest
-from sqlalchemy import select, text
+from sqlalchemy import delete, select, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from tests.database import TEST_DB_CONFIG
-from tracecat.agent.skill.frontmatter import SkillFrontmatter
+from tracecat.agent.skill.frontmatter import SkillFrontmatter, SkillMetadata
 from tracecat.agent.skill.service import ManifestValidationResult, SkillService
 from tracecat.agent.skill.types import ResolvedSkillMcpTool, SkillToolProjection
 from tracecat.auth.types import Role
@@ -118,4 +118,123 @@ async def test_deletion_rechecks_references_after_concurrent_publication(
             )
             assert projected_id == integration_id
     finally:
-        await engine.dispose()
+        try:
+            async with factory() as cleanup:
+                await cleanup.execute(
+                    delete(Workspace).where(Workspace.id == role.workspace_id)
+                )
+                await cleanup.commit()
+        finally:
+            await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publication_reports_integration_deleted_after_validation(
+    svc_role: Role,
+) -> None:
+    role = svc_role.model_copy(update={"workspace_id": uuid.uuid4()})
+    engine = create_async_engine(TEST_DB_CONFIG.test_url)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    integration = MCPIntegration(
+        workspace_id=role.workspace_id,
+        name="Synthetic MCP",
+        slug=f"synthetic-{uuid.uuid4().hex}",
+        server_type="http",
+        server_uri="https://mcp.example.test",
+        auth_type=MCPAuthType.NONE,
+        tools=[],
+    )
+    skill = Skill(
+        workspace_id=role.workspace_id,
+        name="concurrent-skill",
+        slug=f"concurrent-{uuid.uuid4().hex}",
+    )
+    try:
+        async with factory() as seed:
+            seed.add(
+                Workspace(
+                    id=role.workspace_id,
+                    name="concurrent-projection-test",
+                    organization_id=role.organization_id,
+                )
+            )
+            await seed.flush()
+            seed.add_all([integration, skill])
+            await seed.commit()
+        async with (
+            factory() as publishing,
+            factory() as deleting,
+            factory() as observer,
+        ):
+            publisher = SkillService(session=publishing, role=role)
+            published_skill = await publishing.scalar(
+                select(Skill).where(Skill.id == skill.id)
+            )
+            assert published_skill is not None
+            tool_id = f"mcp.{integration.slug}"
+            validation = ManifestValidationResult(
+                frontmatter=SkillFrontmatter(
+                    name="concurrent-skill",
+                    metadata=SkillMetadata(tools=[tool_id]),
+                )
+            )
+            await publisher._validate_declared_tools(validation)
+            assert not validation.errors
+            assert validation.tool_projection is not None
+
+            # Deletion wins the row lock after validation, before any projection insert.
+            await deleting.scalar(
+                select(MCPIntegration.id)
+                .where(MCPIntegration.id == integration.id)
+                .with_for_update()
+            )
+            publisher_pid = await publishing.scalar(text("SELECT pg_backend_pid()"))
+            deleter_pid = await deleting.scalar(text("SELECT pg_backend_pid()"))
+            publication = asyncio.create_task(
+                publisher.publish_version_from_blob_refs(
+                    skill=published_skill,
+                    file_refs=[],
+                    validation=validation,
+                )
+            )
+            try:
+                async with asyncio.timeout(10):
+                    while not await observer.scalar(
+                        text("SELECT :deleter = ANY(pg_blocking_pids(:publisher))"),
+                        {"publisher": publisher_pid, "deleter": deleter_pid},
+                    ):
+                        if publication.done():
+                            await publication
+                            pytest.fail("Publication did not wait for deletion")
+                        await asyncio.sleep(0.01)
+                assert await IntegrationService(
+                    session=deleting, role=role
+                ).delete_mcp_integration(mcp_integration_id=integration.id)
+                with pytest.raises(TracecatValidationError) as exc_info:
+                    await asyncio.wait_for(publication, timeout=10)
+                assert exc_info.value.detail == {
+                    "code": "skill_publish_validation_failed",
+                    "errors": [
+                        {
+                            "code": "unknown_skill_tools",
+                            "message": "MCP integrations were deleted before publication. Validate the skill again.",
+                            "path": "SKILL.md",
+                        }
+                    ],
+                }
+                # A structured rejection must leave the transaction usable.
+                assert await publishing.scalar(text("SELECT 1")) == 1
+            finally:
+                if not publication.done():
+                    publication.cancel()
+                await asyncio.gather(publication, return_exceptions=True)
+                await publishing.rollback()
+    finally:
+        try:
+            async with factory() as cleanup:
+                await cleanup.execute(
+                    delete(Workspace).where(Workspace.id == role.workspace_id)
+                )
+                await cleanup.commit()
+        finally:
+            await engine.dispose()

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -75,6 +75,7 @@ from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentPresetSkill,
     AgentPresetVersionSkill,
+    MCPIntegration,
     Skill,
     SkillBlob,
     SkillDraftFile,
@@ -1617,6 +1618,43 @@ class SkillService(SkillBindingService):
                 )
             )
 
+    async def _lock_projected_mcp_integrations(
+        self, projection: SkillToolProjection
+    ) -> None:
+        """Keep resolved MCP rows alive until publication commits."""
+        integration_ids = {tool.mcp_integration_id for tool in projection.mcp_tools}
+        if not integration_ids:
+            return
+        # Validation may precede this transaction. Recheck UUIDs under key-share
+        # locks so deletion either wins here or waits for the published references.
+        locked_ids = set(
+            await self.session.scalars(
+                select(MCPIntegration.id)
+                .where(
+                    MCPIntegration.workspace_id == self.workspace_id,
+                    MCPIntegration.id.in_(integration_ids),
+                )
+                .order_by(MCPIntegration.id)
+                .with_for_update(read=True, key_share=True)
+            )
+        )
+        if integration_ids - locked_ids:
+            error = SkillValidationErrorDetail(
+                code="unknown_skill_tools",
+                message=(
+                    "MCP integrations were deleted before publication. "
+                    "Validate the skill again."
+                ),
+                path="SKILL.md",
+            )
+            raise TracecatValidationError(
+                "Skill draft failed validation",
+                detail={
+                    "code": "skill_publish_validation_failed",
+                    "errors": [error.model_dump(mode="json")],
+                },
+            )
+
     async def publish_version_from_blob_refs(
         self,
         *,
@@ -1641,6 +1679,7 @@ class SkillService(SkillBindingService):
                 "Skill tool declarations were not projected",
                 detail={"code": "skill_tools_not_projected"},
             )
+        await self._lock_projected_mcp_integrations(validation.tool_projection)
         manifest_name = validation.name
         await self.validate_publication_names({skill.id: manifest_name})
         sorted_file_refs = sorted(file_refs, key=lambda item: item[0])


### PR DESCRIPTION
An MCP integration deleted between validation and publication left the published skill version pointing at a missing row (the FK is `ON DELETE SET NULL`, so the grant silently vanished). Take key-share locks on the projected MCP integrations inside the publish transaction and fail validation when any of them are gone.

Layer 3 of 5 in the split of #3325.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 39 | 0 |
| Tests | 122 | 3 |

https://claude.ai/code/session_01LHvvWytf7Uz8nfcycVAbF8

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
