### PR TITLE
refactor(agents): share reserved subagent server names

### DIFF
--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -16,7 +16,7 @@ import os
 import re
 import tempfile
 import uuid
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncIterator, Callable, Iterable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -414,6 +414,17 @@ class ClaudeAgentRuntime:
     @staticmethod
     def _subagent_registry_server_name(alias: str) -> str:
         return f"{SUBAGENT_REGISTRY_MCP_SERVER_PREFIX}{alias}"
+
+    @classmethod
+    def _reserved_subagent_server_names(cls, aliases: Iterable[str]) -> set[str]:
+        return {
+            name
+            for alias in aliases
+            for name in (
+                cls._subagent_registry_server_name(alias),
+                f"{LEGACY_REGISTRY_MCP_SERVER_NAME}-{alias}",
+            )
+        }
 
     @staticmethod
     def _trusted_mcp_server_config(auth_token: str) -> McpHttpServerConfig:
@@ -1403,11 +1414,8 @@ class ClaudeAgentRuntime:
 
         used_mcp_names = set(existing_mcp_names or ())
         used_mcp_names.update(
-            name
-            for child in payload.subagents
-            for name in (
-                self._subagent_registry_server_name(child.alias),
-                f"{LEGACY_REGISTRY_MCP_SERVER_NAME}-{child.alias}",
+            self._reserved_subagent_server_names(
+                child.alias for child in payload.subagents
             )
         )
         definitions: dict[str, AgentDefinition] = {}
@@ -1767,14 +1775,9 @@ class ClaudeAgentRuntime:
             )
 
             stderr_queue: asyncio.Queue[str] = asyncio.Queue()
-            reserved_subagent_server_names = {
-                server_name
-                for subagent in payload.subagents
-                for server_name in (
-                    self._subagent_registry_server_name(subagent.alias),
-                    f"{LEGACY_REGISTRY_MCP_SERVER_NAME}-{subagent.alias}",
-                )
-            }
+            reserved_subagent_server_names = self._reserved_subagent_server_names(
+                subagent.alias for subagent in payload.subagents
+            )
             stdio_mcp_spec = self._stdio_mcp_server_spec(
                 source_configs=payload.config.mcp_servers,
                 existing_names=set(mcp_servers) | reserved_subagent_server_names,


### PR DESCRIPTION
Two call sites built the same set of reserved subagent MCP server names inline. Extract a classmethod so both derive the names identically. No behaviour change.

Layer 4 of 5 in the split of #3325.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 17 | 14 |

https://claude.ai/code/session_01LHvvWytf7Uz8nfcycVAbF8

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
