### PR TITLE
feat(skills): add a tools picker to the skill frontmatter editor

### DIFF
--- a/frontend/src/components/skills/editor-panel.tsx
+++ b/frontend/src/components/skills/editor-panel.tsx
@@ -18,6 +18,7 @@ import { CenteredSpinner } from "@/components/loading/spinner"
 import { SkillFileTree } from "@/components/skills/file-tree"
 import { RenameDialog } from "@/components/skills/rename-dialog"
 import { SkillFileIcon } from "@/components/skills/skill-file-icon"
+import { SkillToolsDropdown } from "@/components/skills/skill-tools-dropdown"
 
 const CodeEditor = dynamic(
   () =>
@@ -348,6 +349,20 @@ export function EditorPanel({
                           .
                         </div>
                       </div>
+                      {selectedFile.path === SKILL_MD_PATH ? (
+                        <SkillToolsDropdown
+                          workspaceId={skill.workspace_id}
+                          frontmatter={splitFrontmatter.frontmatter}
+                          onChange={(nextFrontmatter) =>
+                            onEditorChange(
+                              composeMarkdownFrontmatter(
+                                nextFrontmatter,
+                                splitFrontmatter.body
+                              )
+                            )
+                          }
+                        />
+                      ) : null}
                       <CodeEditor
                         value={splitFrontmatter.frontmatter}
                         onChange={(nextFrontmatter) =>

--- a/frontend/src/components/skills/skill-tools-dropdown.tsx
+++ b/frontend/src/components/skills/skill-tools-dropdown.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { PlugZapIcon } from "lucide-react"
+import { useId, useMemo } from "react"
+import { getIcon } from "@/components/icons"
+import { MultiTagCommandInput, type Suggestion } from "@/components/tags-input"
+import { useListMcpIntegrations, useRegistryActions } from "@/lib/hooks"
+import {
+  buildSkillToolOptions,
+  MAX_SKILL_TOOLS,
+  readSkillFrontmatterTools,
+  updateSkillFrontmatterTools,
+} from "@/lib/skill-tools"
+
+const TOOL_SEARCH_KEYS: (keyof Suggestion)[] = [
+  "label",
+  "value",
+  "description",
+  "group",
+]
+
+interface SkillToolsDropdownProps {
+  workspaceId: string
+  frontmatter: string
+  onChange: (frontmatter: string) => void
+}
+
+/**
+ * Searchable registry and MCP tool picker backed by `metadata.tools` in the
+ * root SKILL.md frontmatter.
+ */
+export function SkillToolsDropdown({
+  workspaceId,
+  frontmatter,
+  onChange,
+}: SkillToolsDropdownProps) {
+  const inputId = useId()
+  const { registryActions, registryActionsIsLoading, registryActionsError } =
+    useRegistryActions()
+  const { mcpIntegrations, mcpIntegrationsIsLoading, mcpIntegrationsError } =
+    useListMcpIntegrations(workspaceId)
+  const toolsState = useMemo(
+    () =>
+      readSkillFrontmatterTools(
+        frontmatter,
+        mcpIntegrationsIsLoading || mcpIntegrationsError
+          ? undefined
+          : mcpIntegrations,
+        registryActionsIsLoading || registryActionsError
+          ? undefined
+          : registryActions
+      ),
+    [
+      frontmatter,
+      mcpIntegrations,
+      mcpIntegrationsIsLoading,
+      mcpIntegrationsError,
+      registryActions,
+      registryActionsIsLoading,
+      registryActionsError,
+    ]
+  )
+  const suggestions = useMemo<Suggestion[]>(
+    () =>
+      buildSkillToolOptions(registryActions ?? [], mcpIntegrations ?? []).map(
+        (option) => ({
+          id: option.value,
+          value: option.value,
+          label: option.label,
+          description: option.description,
+          group: option.group,
+          tagLabel: option.tagLabel,
+          tagGroup: option.tagGroup,
+          showHoverCard: true,
+          icon:
+            option.kind === "registry" ? (
+              getIcon(option.value, { className: "size-4" })
+            ) : (
+              <PlugZapIcon className="size-4" />
+            ),
+        })
+      ),
+    [mcpIntegrations, registryActions]
+  )
+  const suggestionsLoading =
+    registryActionsIsLoading || mcpIntegrationsIsLoading
+  const suggestionsError = registryActionsError || mcpIntegrationsError
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div>
+        <label htmlFor={inputId} className="text-xs font-medium">
+          Tools
+        </label>
+        <div className="text-xs text-muted-foreground">
+          Add registry and MCP tools to this skill&apos;s portable metadata.
+        </div>
+      </div>
+      <MultiTagCommandInput
+        value={toolsState.tools}
+        inputId={inputId}
+        onChange={(nextTools) => {
+          if (!toolsState.valid && !toolsState.canRemove) {
+            return
+          }
+          onChange(updateSkillFrontmatterTools(frontmatter, nextTools))
+        }}
+        suggestions={suggestions}
+        placeholder={
+          suggestionsLoading ? "Loading tools..." : "Search tools..."
+        }
+        disabled={!toolsState.valid && !toolsState.canRemove}
+        disableSuggestions={
+          !toolsState.valid || suggestionsLoading || Boolean(suggestionsError)
+        }
+        maxTags={toolsState.valid ? MAX_SKILL_TOOLS : toolsState.tools.length}
+        searchKeys={TOOL_SEARCH_KEYS}
+      />
+      {!toolsState.valid ? (
+        <p className="text-xs text-destructive">{toolsState.message}</p>
+      ) : suggestionsError ? (
+        <p className="text-xs text-muted-foreground">
+          Some available tools could not be loaded. Existing IDs are preserved.
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Selected IDs are written directly to metadata.tools.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/tags-input.tsx
+++ b/frontend/src/components/tags-input.tsx
@@ -91,6 +91,8 @@ export interface MultiTagCommandInputProps {
   placeholder?: string
   className?: string
   disabled?: boolean
+  /** ID applied to the underlying text input for accessible labels. */
+  inputId?: string
   maxTags?: number
   searchKeys: (keyof Suggestion)[]
   /**
@@ -110,12 +112,18 @@ export function MultiTagCommandInput({
   placeholder = "Add tags...",
   className,
   disabled = false,
+  inputId,
   maxTags,
   searchKeys,
   allowCustomTags = false,
   disableSuggestions = false,
 }: MultiTagCommandInputProps) {
-  const [open, setOpen] = useState(false)
+  const [requestedOpen, setOpen] = useState(false)
+  const open = requestedOpen && !disabled && !disableSuggestions
+  // Disabling dismisses the request; re-enabling requires a new user action.
+  if (requestedOpen && (disabled || disableSuggestions)) {
+    setOpen(false)
+  }
   const [inputValue, setInputValue] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -179,6 +187,7 @@ export function MultiTagCommandInput({
   const rowCount = filteredSuggestions.length + (showCustomRow ? 1 : 0)
 
   const handleSelect = (suggestion: Suggestion) => {
+    if (disabled || disableSuggestions) return
     if (suggestion.locked) {
       suggestion.onSelect?.()
       return
@@ -317,6 +326,7 @@ export function MultiTagCommandInput({
                   {!disabled && (
                     <button
                       type="button"
+                      aria-label={`Remove ${tag.group ? `${tag.group} · ` : ""}${tag.text}`}
                       onClick={(e) => {
                         e.stopPropagation()
                         handleRemoveTag(tag.value)
@@ -366,6 +376,7 @@ export function MultiTagCommandInput({
             {/* Input */}
             <input
               ref={inputRef}
+              id={inputId}
               type="text"
               value={inputValue}
               onChange={(e) => handleInputChange(e.target.value)}

--- a/frontend/src/lib/skill-tools.ts
+++ b/frontend/src/lib/skill-tools.ts
@@ -1,0 +1,335 @@
+import {
+  isMap,
+  isNode,
+  isSeq,
+  type Node,
+  parseDocument,
+  visit,
+  type YAMLMap,
+} from "yaml"
+import type { MCPIntegrationRead, RegistryActionReadMinimal } from "@/client"
+import { isAgentToolSelectable } from "@/lib/agent-tools"
+
+/** Maximum number of tool declarations accepted by skill frontmatter. */
+export const MAX_SKILL_TOOLS = 64
+
+// Keep in sync with ToolId in tracecat/agent/skill/frontmatter.py.
+const MCP_TOOL_ID_RE = /^mcp\.[a-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?$/
+const REGISTRY_TOOL_ID_RE = /^[a-z0-9_]+(?:\.[a-z0-9_]+)+$/
+
+function isCanonicalToolId(value: string): boolean {
+  const pattern = value.startsWith("mcp.")
+    ? MCP_TOOL_ID_RE
+    : REGISTRY_TOOL_ID_RE
+  return (
+    value.length >= 3 &&
+    value.length <= 255 &&
+    pattern.exec(value)?.[0] === value
+  )
+}
+
+/** Tool option shown in the Skills Studio frontmatter picker. */
+export interface SkillToolOption {
+  value: string
+  label: string
+  description?: string
+  group: string
+  kind: "registry" | "mcp-integration" | "mcp-tool"
+  tagLabel?: string
+  tagGroup?: string
+}
+
+/** Parsed `metadata.tools` state from raw skill frontmatter YAML. */
+export type SkillFrontmatterToolsState =
+  | { valid: true; tools: string[] }
+  | { valid: false; message: string; tools: string[]; canRemove?: boolean }
+
+/**
+ * Read tool declarations without changing the user's raw frontmatter YAML.
+ */
+export function readSkillFrontmatterTools(
+  frontmatter: string,
+  mcpIntegrations?: MCPIntegrationRead[],
+  registryActions?: RegistryActionReadMinimal[]
+): SkillFrontmatterToolsState {
+  const document = parseDocument(frontmatter, { keepSourceTokens: true })
+  if (document.errors.length > 0 || !isMap(document.contents)) {
+    return invalidToolsState("Fix the frontmatter YAML to edit tools here.")
+  }
+
+  const metadata = document.get("metadata", true)
+  if (document.contents.has("<<") || (isMap(metadata) && metadata.has("<<"))) {
+    return invalidToolsState(
+      "Edit tools in the YAML editor when metadata uses merge keys."
+    )
+  }
+  if (metadata === undefined || metadata === null) {
+    return { valid: true, tools: [] }
+  }
+  if (!isMap(metadata)) {
+    return invalidToolsState("metadata must be a YAML mapping.")
+  }
+
+  const tools = metadata.get("tools", true)
+  const editedNodes = new Set<Node>([metadata])
+  if (isNode(tools)) {
+    visit(tools, (_, node) => {
+      if (isNode(node)) editedNodes.add(node)
+    })
+  }
+  let hasReferencedValue = false
+  visit(document, {
+    Alias(_, alias) {
+      const target = alias.resolve(document)
+      if (target && editedNodes.has(target)) {
+        hasReferencedValue = true
+        return visit.BREAK
+      }
+    },
+  })
+  if (hasReferencedValue) {
+    return invalidToolsState(
+      "Edit tools in the YAML editor when other values reference metadata or its tools."
+    )
+  }
+  if (tools === undefined || tools === null) {
+    return { valid: true, tools: [] }
+  }
+  if (!isSeq(tools)) {
+    return invalidToolsState("metadata.tools must be a YAML list.")
+  }
+
+  const values = tools.toJSON()
+  if (
+    !Array.isArray(values) ||
+    values.some((value) => typeof value !== "string")
+  ) {
+    return invalidToolsState("metadata.tools must contain only tool IDs.")
+  }
+
+  if (values.some((value) => value.trim().length === 0)) {
+    return invalidToolsState("metadata.tools must not contain blank tool IDs.")
+  }
+  if (values.length > MAX_SKILL_TOOLS) {
+    return invalidToolsState(
+      `metadata.tools supports at most ${MAX_SKILL_TOOLS} tool IDs.`
+    )
+  }
+
+  const normalized = Array.from(
+    new Set<string>(values.map((value) => value.trim()))
+  )
+  const stdioSlugs = new Set(
+    (mcpIntegrations ?? [])
+      .filter((integration) => integration.server_type === "stdio")
+      .map((integration) => integration.slug)
+  )
+  const invalid = normalized.filter((value) => {
+    const [namespace, slug, tool] = value.split(".")
+    return (
+      !isCanonicalToolId(value) ||
+      (namespace === "mcp" && tool !== undefined && stdioSlugs.has(slug))
+    )
+  })
+  if (invalid.length > 0) {
+    return {
+      valid: false,
+      message: `Invalid tool IDs: ${invalid.join(", ")}. Remove them or fix them in the YAML editor.`,
+      tools: normalized,
+      canRemove: true,
+    }
+  }
+  // An absent catalog means availability is unknown, not that it is empty.
+  const registryIds = registryActions
+    ? new Set(registryActions.map((action) => action.action))
+    : undefined
+  const integrationsBySlug = mcpIntegrations
+    ? new Map(
+        mcpIntegrations.map((integration) => [integration.slug, integration])
+      )
+    : undefined
+  const unavailable = normalized.filter((value) => {
+    if (!value.startsWith("mcp.")) {
+      return registryIds !== undefined && !registryIds.has(value)
+    }
+    if (!integrationsBySlug) return false
+    const [, slug, toolName] = value.split(".")
+    const integration = integrationsBySlug.get(slug)
+    if (!integration) return true
+    if (toolName === undefined) return false
+    return !integration.tools?.some(
+      (tool) =>
+        tool.name === toolName &&
+        tool.enabled !== false &&
+        tool.status === "available"
+    )
+  })
+  if (unavailable.length > 0) {
+    return {
+      valid: false,
+      message: `Unavailable tool IDs: ${unavailable.join(", ")}. Remove them or restore their availability before adding tools.`,
+      tools: normalized,
+      canRemove: true,
+    }
+  }
+  return { valid: true, tools: normalized }
+}
+
+/**
+ * Replace only `metadata.tools` while preserving unrelated YAML source.
+ */
+export function updateSkillFrontmatterTools(
+  frontmatter: string,
+  tools: string[]
+): string {
+  const state = readSkillFrontmatterTools(frontmatter)
+  if (
+    !state.valid &&
+    !(
+      state.canRemove &&
+      tools.length < state.tools.length &&
+      tools.every((tool) => state.tools.includes(tool))
+    )
+  ) {
+    throw new Error(state.message)
+  }
+
+  const normalized = Array.from(
+    new Set(tools.map((tool) => tool.trim()).filter(Boolean))
+  )
+  if (normalized.length > MAX_SKILL_TOOLS) {
+    throw new Error(`Skills support at most ${MAX_SKILL_TOOLS} tools.`)
+  }
+
+  if (state.valid && normalized.some((tool) => !isCanonicalToolId(tool))) {
+    throw new Error("Tools must use canonical registry or MCP IDs.")
+  }
+
+  const document = parseDocument(frontmatter, { keepSourceTokens: true })
+  const existing = document.getIn(["metadata", "tools"], true)
+  const serialized = JSON.stringify(normalized)
+  const newline = frontmatter.includes("\r\n") ? "\r\n" : "\n"
+  if (isSeq(existing) && existing.range) {
+    // Node ranges exclude the sequence's anchor. Keep it and all source
+    // outside the tools value verbatim, including YAML 1.1 scalar spellings.
+    const [start, end] = existing.range
+    const suffix = frontmatter.slice(start, end).endsWith("\n") ? newline : ""
+    return (
+      frontmatter.slice(0, start) + serialized + suffix + frontmatter.slice(end)
+    )
+  }
+
+  const metadata = document.get("metadata", true)
+  if (isMap(metadata)) {
+    return insertMappingEntry(
+      frontmatter,
+      metadata,
+      `tools: ${serialized}`,
+      newline
+    )
+  }
+  if (isMap(document.contents)) {
+    return insertMappingEntry(
+      frontmatter,
+      document.contents,
+      `metadata: { tools: ${serialized} }`,
+      newline
+    )
+  }
+  throw new Error("Frontmatter must be a YAML mapping.")
+}
+
+/** Insert a new key without serializing any existing YAML nodes. */
+function insertMappingEntry(
+  source: string,
+  mapping: YAMLMap,
+  entry: string,
+  newline: string
+): string {
+  if (!mapping.range) {
+    throw new Error("Cannot locate the YAML mapping in the source.")
+  }
+  const start = mapping.range[0]
+  if (mapping.flow) {
+    const separator = mapping.items.length > 0 ? ", " : ""
+    return (
+      source.slice(0, start + 1) + entry + separator + source.slice(start + 1)
+    )
+  }
+  const token = mapping.srcToken
+  const indent = " ".repeat(token && "indent" in token ? token.indent : 0)
+  return source.slice(0, start) + entry + newline + indent + source.slice(start)
+}
+
+/**
+ * Build canonical registry and MCP tool options for the frontmatter picker.
+ */
+export function buildSkillToolOptions(
+  registryActions: RegistryActionReadMinimal[],
+  mcpIntegrations: MCPIntegrationRead[]
+): SkillToolOption[] {
+  const registryOptions = registryActions
+    .filter((action) => isAgentToolSelectable(action.action))
+    .map<SkillToolOption>((action) => ({
+      value: action.action,
+      label: action.default_title || action.action,
+      description: action.description,
+      group: action.display_group || action.namespace,
+      kind: "registry",
+      tagLabel: action.default_title || action.name,
+      tagGroup: action.display_group || action.namespace,
+    }))
+
+  const nameCounts = new Map<string, number>()
+  for (const integration of mcpIntegrations) {
+    nameCounts.set(
+      integration.name,
+      (nameCounts.get(integration.name) ?? 0) + 1
+    )
+  }
+  const mcpOptions = mcpIntegrations.flatMap<SkillToolOption>((integration) => {
+    const integrationLabel =
+      (nameCounts.get(integration.name) ?? 0) > 1
+        ? `${integration.name} (${integration.slug})`
+        : integration.name
+    const integrationOption: SkillToolOption = {
+      value: `mcp.${integration.slug}`,
+      label: "All tools",
+      description:
+        integration.description || `Allow every tool from ${integration.name}.`,
+      group: integrationLabel,
+      kind: "mcp-integration",
+      tagLabel: "All tools",
+      tagGroup: integrationLabel,
+    }
+    if (integration.server_type === "stdio") {
+      return [integrationOption]
+    }
+    const toolOptions = (integration.tools ?? [])
+      .filter(
+        (tool) =>
+          tool.enabled !== false &&
+          tool.status !== "missing" &&
+          isCanonicalToolId(`mcp.${integration.slug}.${tool.name}`)
+      )
+      .map<SkillToolOption>((tool) => ({
+        value: `mcp.${integration.slug}.${tool.name}`,
+        label: tool.name,
+        description: tool.description || undefined,
+        group: integrationLabel,
+        kind: "mcp-tool",
+        tagLabel: tool.name,
+        tagGroup: integrationLabel,
+      }))
+
+    return [integrationOption, ...toolOptions]
+  })
+
+  return [...registryOptions, ...mcpOptions].sort((left, right) =>
+    left.value.localeCompare(right.value)
+  )
+}
+
+function invalidToolsState(message: string): SkillFrontmatterToolsState {
+  return { valid: false, message, tools: [] }
+}

--- a/frontend/tests/skill-tools-dropdown.test.tsx
+++ b/frontend/tests/skill-tools-dropdown.test.tsx
@@ -1,0 +1,235 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { MCPIntegrationRead, RegistryActionReadMinimal } from "@/client"
+import { SkillToolsDropdown } from "@/components/skills/skill-tools-dropdown"
+import { readSkillFrontmatterTools } from "@/lib/skill-tools"
+
+const mockRegistryAction: RegistryActionReadMinimal = {
+  id: "action-1",
+  name: "get_case",
+  description: "Get one case.",
+  namespace: "core.cases",
+  type: "udf",
+  origin: "tracecat_registry.core.cases",
+  default_title: "Get case",
+  display_group: "Cases",
+  action: "core.cases.get_case",
+}
+
+let mockLoading = false
+let mockError: Error | null = null
+
+let mockMcpIntegrations: MCPIntegrationRead[] = []
+
+jest.mock("@/lib/hooks", () => ({
+  useRegistryActions: () => ({
+    registryActions: [mockRegistryAction],
+    registryActionsIsLoading: mockLoading,
+    registryActionsError: mockError,
+  }),
+  useListMcpIntegrations: () => ({
+    mcpIntegrations: mockMcpIntegrations,
+    mcpIntegrationsIsLoading: mockLoading,
+    mcpIntegrationsError: mockError,
+  }),
+}))
+
+describe("SkillToolsDropdown", () => {
+  beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  })
+
+  it("labels the input and writes a selected tool to frontmatter", () => {
+    const handleChange = jest.fn()
+    render(
+      <SkillToolsDropdown
+        workspaceId="workspace-1"
+        frontmatter="name: incident-triage"
+        onChange={handleChange}
+      />
+    )
+
+    const input = screen.getByRole("textbox", { name: "Tools" })
+    fireEvent.focus(input)
+    fireEvent.mouseDown(screen.getByText("Get case"))
+    fireEvent.click(screen.getByText("Get case"))
+
+    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(readSkillFrontmatterTools(handleChange.mock.calls[0][0])).toEqual({
+      valid: true,
+      tools: ["core.cases.get_case"],
+    })
+  })
+
+  it("disables structured editing when metadata.tools is malformed", () => {
+    render(
+      <SkillToolsDropdown
+        workspaceId="workspace-1"
+        frontmatter={`name: incident-triage
+metadata:
+  tools: core.cases.get_case`}
+        onChange={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole("textbox", { name: "Tools" })).toBeDisabled()
+    expect(
+      screen.getByText("metadata.tools must be a YAML list.")
+    ).toBeInTheDocument()
+  })
+})
+
+it("shows malformed IDs and lets users remove them", () => {
+  const onChange = jest.fn()
+  render(
+    <SkillToolsDropdown
+      workspaceId="workspace-1"
+      frontmatter='metadata: { tools: ["not-a-tool", "core.cases.get_case"] }'
+      onChange={onChange}
+    />
+  )
+  expect(screen.getByText(/Invalid tool IDs: not-a-tool/)).toBeInTheDocument()
+  fireEvent.focus(screen.getByRole("textbox", { name: "Tools" }))
+  expect(screen.queryByRole("option")).not.toBeInTheDocument()
+  fireEvent.click(screen.getByRole("button", { name: "Remove not-a-tool" }))
+  expect(readSkillFrontmatterTools(onChange.mock.calls[0][0])).toEqual({
+    valid: true,
+    tools: ["core.cases.get_case"],
+  })
+})
+
+it("warns about individual stdio grants and allows their removal", () => {
+  mockMcpIntegrations = [
+    {
+      id: "integration-1",
+      workspace_id: "workspace-1",
+      name: "Synthetic",
+      slug: "synthetic",
+      server_type: "stdio",
+      description: null,
+      server_uri: null,
+      oauth_integration_id: null,
+      stdio_command: "synthetic",
+      stdio_args: [],
+      timeout: 30,
+      auth_type: "NONE",
+      state: "connected",
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    },
+  ]
+  try {
+    const onChange = jest.fn()
+    render(
+      <SkillToolsDropdown
+        workspaceId="workspace-1"
+        frontmatter="metadata: {tools: [mcp.synthetic.read, mcp.synthetic]}"
+        onChange={onChange}
+      />
+    )
+    expect(
+      screen.getByText(/Invalid tool IDs: mcp.synthetic.read/)
+    ).toBeInTheDocument()
+    fireEvent.focus(screen.getByRole("textbox", { name: "Tools" }))
+    expect(screen.queryByRole("option")).not.toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove mcp.synthetic.read" })
+    )
+    expect(
+      readSkillFrontmatterTools(onChange.mock.calls[0][0], mockMcpIntegrations)
+    ).toEqual({
+      valid: true,
+      tools: ["mcp.synthetic"],
+    })
+  } finally {
+    mockMcpIntegrations = []
+  }
+})
+
+it("blocks additions until unavailable chips are removed", () => {
+  const onChange = jest.fn()
+  const { rerender } = render(
+    <SkillToolsDropdown
+      workspaceId="workspace-1"
+      frontmatter="metadata: {tools: [core.cases.removed]}"
+      onChange={onChange}
+    />
+  )
+  expect(screen.getByText(/Unavailable tool IDs/)).toBeInTheDocument()
+  fireEvent.focus(screen.getByRole("textbox", { name: "Tools" }))
+  expect(screen.queryByRole("option")).not.toBeInTheDocument()
+  fireEvent.click(
+    screen.getByRole("button", { name: "Remove core.cases.removed" })
+  )
+  rerender(
+    <SkillToolsDropdown
+      workspaceId="workspace-1"
+      frontmatter={onChange.mock.calls[0][0]}
+      onChange={onChange}
+    />
+  )
+  fireEvent.focus(screen.getByRole("textbox", { name: "Tools" }))
+  expect(screen.getByText("Get case")).toBeInTheDocument()
+})
+
+it.each(["loading", "error"])(
+  "preserves IDs without declaring them unavailable during %s",
+  (state) => {
+    mockLoading = state === "loading"
+    mockError = state === "error" ? new Error("Unavailable") : null
+    try {
+      const onChange = jest.fn()
+      render(
+        <SkillToolsDropdown
+          workspaceId="workspace-1"
+          frontmatter="metadata: {tools: [core.cases.removed, mcp.deleted]}"
+          onChange={onChange}
+        />
+      )
+      expect(screen.queryByText(/Unavailable tool IDs/)).not.toBeInTheDocument()
+      fireEvent.focus(screen.getByRole("textbox", { name: "Tools" }))
+      expect(screen.queryByRole("option")).not.toBeInTheDocument()
+      fireEvent.click(
+        screen.getByRole("button", { name: "Remove mcp.deleted" })
+      )
+      expect(
+        readSkillFrontmatterTools(onChange.mock.calls[0][0]).tools
+      ).toEqual(["core.cases.removed"])
+    } finally {
+      mockLoading = false
+      mockError = null
+    }
+  }
+)
+
+it.each(["loading", "error"])(
+  "blocks an open picker when the catalog enters %s",
+  (state) => {
+    const onChange = jest.fn()
+    const props = {
+      workspaceId: "workspace-1",
+      frontmatter: "name: triage",
+      onChange,
+    }
+    const { rerender } = render(<SkillToolsDropdown {...props} />)
+    const input = screen.getByRole("textbox", { name: "Tools" })
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: "case" } })
+    expect(screen.getByRole("option")).toBeInTheDocument()
+    try {
+      mockLoading = state === "loading"
+      mockError = state === "error" ? new Error("Catalog unavailable") : null
+      rerender(<SkillToolsDropdown {...props} />)
+      expect(screen.queryByRole("option")).not.toBeInTheDocument()
+      fireEvent.keyDown(input, { key: "ArrowDown" })
+      fireEvent.keyDown(input, { key: "Enter" })
+      expect(onChange).not.toHaveBeenCalled()
+    } finally {
+      mockLoading = false
+      mockError = null
+    }
+  }
+)

--- a/frontend/tests/skill-tools.test.ts
+++ b/frontend/tests/skill-tools.test.ts
@@ -1,0 +1,359 @@
+import { parseDocument } from "yaml"
+import type { MCPIntegrationRead, RegistryActionReadMinimal } from "@/client"
+import {
+  buildSkillToolOptions,
+  MAX_SKILL_TOOLS,
+  readSkillFrontmatterTools,
+  updateSkillFrontmatterTools,
+} from "@/lib/skill-tools"
+
+const registryAction: RegistryActionReadMinimal = {
+  id: "action-1",
+  name: "get_case",
+  description: "Get one case.",
+  namespace: "core.cases",
+  type: "udf",
+  origin: "tracecat_registry.core.cases",
+  default_title: "Get case",
+  display_group: "Cases",
+  action: "core.cases.get_case",
+}
+
+const mcpIntegration: MCPIntegrationRead = {
+  id: "integration-1",
+  workspace_id: "workspace-1",
+  name: "Slack",
+  description: "Send and read Slack messages.",
+  slug: "slack",
+  server_type: "http",
+  server_uri: "https://example.invalid/mcp",
+  auth_type: "OAUTH2",
+  oauth_integration_id: null,
+  state: "connected",
+  stdio_command: null,
+  stdio_args: null,
+  timeout: 30,
+  tools: [
+    {
+      name: "post_message",
+      description: "Post a message.",
+      enabled: true,
+      status: "available",
+    },
+    {
+      name: "disabled_tool",
+      enabled: false,
+      status: "available",
+    },
+    {
+      name: "removed_tool",
+      enabled: true,
+      status: "missing",
+    },
+  ],
+  created_at: "2026-08-26T00:00:00.000Z",
+  updated_at: "2026-08-26T00:00:00.000Z",
+}
+
+describe("skill frontmatter tools", () => {
+  it("reads deduplicated tool IDs from metadata", () => {
+    const state = readSkillFrontmatterTools(`name: incident-triage
+metadata:
+  tools:
+    - core.cases.get_case
+    - mcp.slack.post_message
+    - core.cases.get_case`)
+
+    expect(state).toEqual({
+      valid: true,
+      tools: ["core.cases.get_case", "mcp.slack.post_message"],
+    })
+  })
+
+  it("updates only metadata.tools and preserves unrelated comments and keys", () => {
+    const frontmatter = `name: incident-triage
+# Keep this comment.
+metadata:
+  owner: security
+  tools:
+    - core.cases.get_case
+license: MIT`
+
+    const updated = updateSkillFrontmatterTools(frontmatter, [
+      "mcp.slack.post_message",
+    ])
+
+    expect(updated).toContain("# Keep this comment.")
+    expect(updated).toContain("owner: security")
+    expect(updated).toContain("license: MIT")
+    expect(updated).not.toContain("core.cases.get_case")
+    expect(readSkillFrontmatterTools(updated)).toEqual({
+      valid: true,
+      tools: ["mcp.slack.post_message"],
+    })
+  })
+
+  it("creates metadata.tools when metadata is absent", () => {
+    const updated = updateSkillFrontmatterTools(
+      "name: incident-triage\r\ndescription: Triage incidents.",
+      ["core.cases.get_case"]
+    )
+
+    expect(updated).toContain(
+      'metadata: { tools: ["core.cases.get_case"] }\r\n'
+    )
+    expect(readSkillFrontmatterTools(updated)).toEqual({
+      valid: true,
+      tools: ["core.cases.get_case"],
+    })
+  })
+
+  it("reports malformed tools without rewriting the YAML", () => {
+    expect(
+      readSkillFrontmatterTools(`name: incident-triage
+metadata:
+  tools: core.cases.get_case`)
+    ).toEqual({
+      valid: false,
+      message: "metadata.tools must be a YAML list.",
+      tools: [],
+    })
+  })
+
+  it("enforces the backend tool limit", () => {
+    const tools = Array.from(
+      { length: MAX_SKILL_TOOLS + 1 },
+      (_, index) => `core.test.tool_${index}`
+    )
+
+    expect(() =>
+      updateSkillFrontmatterTools("name: incident-triage", tools)
+    ).toThrow(`Skills support at most ${MAX_SKILL_TOOLS} tools.`)
+  })
+})
+
+describe("skill tool options", () => {
+  it("combines registry actions with available MCP integration tools", () => {
+    const options = buildSkillToolOptions(
+      [
+        registryAction,
+        {
+          ...registryAction,
+          id: "action-2",
+          name: "run_python",
+          action: "core.script.run_python",
+        },
+      ],
+      [mcpIntegration]
+    )
+
+    expect(options.map((option) => option.value)).toEqual([
+      "core.cases.get_case",
+      "mcp.slack",
+      "mcp.slack.post_message",
+    ])
+    expect(
+      options.find((option) => option.value === "mcp.slack")
+    ).toMatchObject({
+      label: "All tools",
+      group: "Slack",
+      kind: "mcp-integration",
+    })
+    expect(
+      options.find((option) => option.value === "mcp.slack.post_message")
+    ).toMatchObject({
+      label: "post_message",
+      description: "Post a message.",
+      kind: "mcp-tool",
+    })
+  })
+})
+
+it("omits MCP options that cannot form canonical tool IDs", () => {
+  const options = buildSkillToolOptions(
+    [],
+    [
+      {
+        ...mcpIntegration,
+        tools: ["issue.get", "with space", "x".repeat(256), "issue_get"].map(
+          (name) => ({ name })
+        ),
+      },
+    ]
+  )
+  expect(options.map((option) => option.value)).toEqual([
+    "mcp.slack",
+    "mcp.slack.issue_get",
+  ])
+})
+
+it.each([
+  "metadata:\n  tools: &allowed [core.old]\ncopy: *allowed",
+  "metadata: &metadata {tools: [core.old]}\ncopy: *metadata",
+  "metadata: &metadata {owner: team}\ncopy: *metadata",
+  "metadata: {tools: [&tool core.old]}\ncopy: *tool",
+])("requires raw editing for aliased values: %s", (source) => {
+  expect(readSkillFrontmatterTools(source).valid).toBe(false)
+  expect(() => updateSkillFrontmatterTools(source, ["core.new"])).toThrow(
+    "Edit tools in the YAML editor"
+  )
+})
+
+it("offers only whole-server grants for stdio integrations", () => {
+  expect(
+    buildSkillToolOptions(
+      [],
+      [{ ...mcpIntegration, server_type: "stdio" }]
+    ).map((option) => option.value)
+  ).toEqual(["mcp.slack"])
+})
+
+it.each([
+  "defaults: &defaults\n  metadata: { tools: [core.old], revision: 1 }\n<<: *defaults",
+  "defaults: &defaults { tools: [core.old], revision: 1 }\nmetadata:\n  <<: *defaults",
+])("blocks structured edits of merged metadata", (source) => {
+  expect(readSkillFrontmatterTools(source)).toMatchObject({ valid: false })
+  expect(() => updateSkillFrontmatterTools(source, ["core.new"])).toThrow(
+    "merge keys"
+  )
+})
+
+it.each(["", "   "])(
+  "rejects blank tool IDs without hiding the error",
+  (value) => {
+    const source = `metadata: { tools: [${JSON.stringify(value)}] }`
+    expect(readSkillFrontmatterTools(source)).toMatchObject({
+      valid: false,
+      message: "metadata.tools must not contain blank tool IDs.",
+    })
+    expect(() => updateSkillFrontmatterTools(source, ["core.new"])).toThrow(
+      "blank"
+    )
+  }
+)
+
+it("checks the raw declaration count before deduplicating", () => {
+  const source = `metadata: { tools: ${JSON.stringify(Array(65).fill("core.example"))} }`
+  expect(readSkillFrontmatterTools(source)).toMatchObject({
+    valid: false,
+    message: "metadata.tools supports at most 64 tool IDs.",
+  })
+})
+
+it("disambiguates duplicate integration names in options and chips", () => {
+  const options = buildSkillToolOptions(
+    [],
+    [
+      mcpIntegration,
+      {
+        ...mcpIntegration,
+        id: "integration-2",
+        slug: "slack-2",
+      },
+    ]
+  )
+  expect(options.find((option) => option.value === "mcp.slack")).toMatchObject({
+    group: "Slack (slack)",
+    tagGroup: "Slack (slack)",
+  })
+  expect(
+    options.find((option) => option.value === "mcp.slack-2.post_message")
+  ).toMatchObject({
+    group: "Slack (slack-2)",
+    tagGroup: "Slack (slack-2)",
+  })
+})
+
+it.each([
+  "name: example\nmetadata: { revision: 0123, tools: [core.old] }",
+  "name: example\nmetadata: { revision: 0123 }",
+  "name: example\nrevision: 0123",
+  "{ name: example, revision: 0123 }",
+  "name: example\nmetadata:\n  revision: 0123\n  tools:\n    - core.old\nother: yes",
+  "name: example\nmetadata:\n  revision: 0123\nother: yes",
+  "name: example\nmetadata: {}",
+])("preserves untouched YAML scalar source: %s", (source) => {
+  const updated = updateSkillFrontmatterTools(source, ["core.new"])
+  if (source.includes("revision: 0123")) {
+    expect(updated).toContain("revision: 0123")
+  }
+  expect(readSkillFrontmatterTools(updated)).toEqual({
+    valid: true,
+    tools: ["core.new"],
+  })
+  if (source.includes("other: yes")) expect(updated).toContain("other: yes")
+})
+
+it("preserves CRLF and block sequence anchors", () => {
+  const source =
+    "name: example\r\nmetadata:\r\n  tools: &allowed\r\n    - core.old\r\n"
+  const updated = updateSkillFrontmatterTools(source, ["core.new"])
+  expect(updated.replace(/\r\n/g, "")).not.toContain("\n")
+  expect(updated).toContain("&allowed")
+  expect(parseDocument(updated).toJS().metadata.tools).toEqual(["core.new"])
+})
+
+it.each([
+  "not-a-tool",
+  "mcp.server.issue.get",
+  "core.Upper",
+  "core." + "x".repeat(256),
+])("keeps malformed IDs visible and removable: %s", (id) => {
+  const source = `metadata: { tools: ${JSON.stringify([id, "core.ok"])} }`
+  expect(readSkillFrontmatterTools(source)).toMatchObject({
+    valid: false,
+    canRemove: true,
+    tools: [id, "core.ok"],
+  })
+  expect(
+    readSkillFrontmatterTools(updateSkillFrontmatterTools(source, ["core.ok"]))
+  ).toEqual({ valid: true, tools: ["core.ok"] })
+  expect(() =>
+    updateSkillFrontmatterTools(source, [id, "core.ok", "core.new"])
+  ).toThrow("Invalid tool IDs")
+})
+
+it("allows removing malformed IDs one at a time", () => {
+  const source = 'metadata: { tools: ["bad-one", "bad-two", "core.ok"] }'
+  const updated = updateSkillFrontmatterTools(source, ["bad-two", "core.ok"])
+  expect(readSkillFrontmatterTools(updated)).toMatchObject({
+    valid: false,
+    canRemove: true,
+    tools: ["bad-two", "core.ok"],
+  })
+})
+
+it.each([
+  "core.cases.removed",
+  "mcp.deleted",
+  "mcp.deleted.read",
+  "mcp.slack.unknown",
+  "mcp.slack.disabled_tool",
+  "mcp.slack.removed_tool",
+])("preserves unavailable ID %s for removal", (id) => {
+  const source = `metadata: {tools: ["${id}", "core.cases.get_case"]}`
+  expect(
+    readSkillFrontmatterTools(source, [mcpIntegration], [registryAction])
+  ).toMatchObject({
+    valid: false,
+    canRemove: true,
+    tools: [id, "core.cases.get_case"],
+    message: expect.stringContaining(`Unavailable tool IDs: ${id}`),
+  })
+})
+
+it("accepts available registry, whole-server, and individual MCP grants", () => {
+  expect(
+    readSkillFrontmatterTools(
+      "metadata: {tools: [core.cases.get_case, mcp.slack, mcp.slack.post_message]}",
+      [mcpIntegration],
+      [registryAction]
+    ).valid
+  ).toBe(true)
+})
+
+it("distinguishes unknown catalogs from loaded empty catalogs", () => {
+  const source = "metadata: {tools: [core.cases.get_case, mcp.slack]}"
+  expect(readSkillFrontmatterTools(source).valid).toBe(true)
+  expect(readSkillFrontmatterTools(source, [], []).valid).toBe(false)
+})

--- a/frontend/tests/tags-input.test.tsx
+++ b/frontend/tests/tags-input.test.tsx
@@ -10,6 +10,26 @@ describe("MultiTagCommandInput", () => {
     }
   })
 
+  it("gives selected-tag remove buttons accessible names", () => {
+    render(
+      <MultiTagCommandInput
+        value={["tools.alpha.run"]}
+        suggestions={[
+          {
+            id: "alpha",
+            label: "Alpha tool",
+            value: "tools.alpha.run",
+          },
+        ]}
+        searchKeys={["value", "label"]}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Remove Alpha tool" })
+    ).toBeInTheDocument()
+  })
+
   it("invokes the locked suggestion handler when clicking the action row", () => {
     const handleLockedSelect = jest.fn()
 
@@ -73,6 +93,44 @@ describe("MultiTagCommandInput", () => {
 
     expect(handleChange).toHaveBeenCalledWith([unsafeValue])
   })
+
+  it.each(["disabled", "disableSuggestions"])(
+    "stays closed after %s is cleared until the user opens it again",
+    (prop) => {
+      const onChange = jest.fn()
+      function input(blocked: boolean) {
+        return (
+          <MultiTagCommandInput
+            onChange={onChange}
+            disabled={blocked && prop === "disabled"}
+            disableSuggestions={blocked && prop === "disableSuggestions"}
+            suggestions={[
+              { id: "alpha", value: "tools.alpha.run", label: "Alpha tool" },
+            ]}
+            searchKeys={["label", "value"]}
+          />
+        )
+      }
+      const { rerender } = render(input(false))
+      const textbox = screen.getByRole("textbox")
+      fireEvent.focus(textbox)
+      fireEvent.change(textbox, { target: { value: "alpha" } })
+      fireEvent.keyDown(textbox, { key: "ArrowDown" })
+      expect(screen.getByRole("option")).toBeInTheDocument()
+
+      rerender(input(true))
+      expect(screen.queryByRole("option")).not.toBeInTheDocument()
+      rerender(input(false))
+      expect(screen.queryByRole("option")).not.toBeInTheDocument()
+      fireEvent.keyDown(textbox, { key: "Enter" })
+      expect(onChange).not.toHaveBeenCalled()
+
+      fireEvent.change(textbox, { target: { value: "alpha tool" } })
+      expect(screen.getByRole("option")).toBeInTheDocument()
+      fireEvent.keyDown(textbox, { key: "Enter" })
+      expect(onChange).toHaveBeenCalledWith(["tools.alpha.run"])
+    }
+  )
 
   describe("keyboard selection", () => {
     const suggestions = [
@@ -238,4 +296,26 @@ describe("MultiTagCommandInput", () => {
       expect(handleChange).toHaveBeenCalledWith(["zzzzqqqq"])
     })
   })
+})
+
+it("distinguishes removal buttons for whole-server grants", () => {
+  const onChange = jest.fn()
+  render(
+    <MultiTagCommandInput
+      value={["mcp.alpha", "mcp.beta"]}
+      searchKeys={["value", "label"]}
+      onChange={onChange}
+      suggestions={["alpha", "beta"].map((slug) => ({
+        id: slug,
+        value: `mcp.${slug}`,
+        label: "All tools",
+        tagLabel: "All tools",
+        tagGroup: slug,
+      }))}
+    />
+  )
+  fireEvent.click(
+    screen.getByRole("button", { name: "Remove beta · All tools" })
+  )
+  expect(onChange).toHaveBeenCalledWith(["mcp.alpha"])
 })

--- a/tests/unit/test_builtin_skills.py
+++ b/tests/unit/test_builtin_skills.py
@@ -18,6 +18,7 @@ import yaml
 from tracecat import config
 from tracecat.agent.executor.activity import SandboxedAgentExecutor
 from tracecat.agent.skill.builtin import PLATFORM_SKILLS
+from tracecat.agent.skill.frontmatter import parse_skill_markdown
 from tracecat.agent.skill.schemas import SkillCreate
 from tracecat.agent.skill.types import SkillOrigin
 
@@ -48,8 +49,10 @@ class TestSkillOrigin:
 
     def test_platform_origin_is_explicit(self):
         assert all(skill.origin is SkillOrigin.PLATFORM for skill in PLATFORM_SKILLS)
-        assert PLATFORM_SKILLS[0].skill_name == "workspace-chat"
-        assert PLATFORM_SKILLS[0].qualified_name == "tracecat:workspace-chat"
+        workspace_chat = next(
+            skill for skill in PLATFORM_SKILLS if skill.skill_name == "workspace-chat"
+        )
+        assert workspace_chat.qualified_name == "tracecat:workspace-chat"
 
 
 class TestBuiltinSkillsConstant:
@@ -239,11 +242,13 @@ class TestStageBuiltinSkills:
         await _executor_with_builtin_skills(
             ["tracecat-automation-best-practices"]
         ).stage(skills_dir)
-        assert (
-            (skills_dir / "skills" / "automation-best-practices" / "SKILL.md")
-            .read_text()
-            .endswith("vendored content")
-        )
+        staged_markdown = (
+            skills_dir / "skills" / "automation-best-practices" / "SKILL.md"
+        ).read_text()
+        assert staged_markdown.endswith("vendored content")
+        frontmatter = parse_skill_markdown(staged_markdown)
+        assert frontmatter is not None
+        assert frontmatter.name == "automation-best-practices"
 
     @pytest.mark.anyio
     async def test_errors_when_vendored_dir_absent(

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -4346,6 +4346,34 @@ metadata:
         assert exc_info.value.detail["code"] == "skill_draft_tool_validation_failed"
         assert exc_info.value.detail["errors"][0]["code"] == "unknown_skill_tools"
 
+    async def test_malformed_tool_declaration_saves_draft_but_cannot_publish(
+        self, skill_service: SkillService
+    ) -> None:
+        created = await skill_service.create_skill(SkillCreate(name="draft-tools"))
+        draft = await skill_service.get_draft(created.id)
+        assert draft is not None
+        await skill_service.patch_draft(
+            skill_id=created.id,
+            params=SkillDraftPatch(
+                base_revision=draft.draft_revision,
+                operations=[
+                    SkillDraftUpsertTextFileOp(
+                        path="SKILL.md",
+                        content="---\nname: draft-tools\nmetadata: {tools: not-a-list}\n---\n",
+                        content_type="text/markdown",
+                    )
+                ],
+            ),
+        )
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await skill_service.publish_skill(created.id)
+        assert exc_info.value.detail is not None
+        assert exc_info.value.detail["code"] == "skill_publish_validation_failed"
+        assert (
+            exc_info.value.detail["errors"][0]["code"]
+            == "invalid_skill_tool_declaration"
+        )
+
     async def test_dispatch_treats_absent_projection_rows_as_empty(
         self,
         session: AsyncSession,

--- a/tests/unit/test_skill_tool_grants.py
+++ b/tests/unit/test_skill_tool_grants.py
@@ -55,6 +55,7 @@ async def test_explicit_requirements_are_validated_before_union(
     session.execute.return_value = rows
     integration = MCPIntegration(
         id=integration_id,
+        server_type="http",
         tools=[{"name": "read", "enabled": available, "status": "available"}],
     )
     monkeypatch.setattr(

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -109,9 +109,9 @@ MAX_CONTENT_TYPE_LENGTH = 255
 SKILL_SLUG_MAX_LENGTH = 64
 SKILL_SLUG_INSERT_ATTEMPTS = 3
 SKILL_SLUG_UNIQUE_CONSTRAINT = "uq_skill_workspace_slug_active"
-SKILL_TOOL_ERROR_CODES = frozenset(
+# Drafts may retain malformed declarations for repair in the raw editor.
+SKILL_DRAFT_TOOL_ERROR_CODES = frozenset(
     {
-        "invalid_skill_tool_declaration",
         "unknown_skill_tools",
         "unavailable_skill_tools",
         STDIO_MCP_TOOL_SUBSET_UNSUPPORTED,
@@ -2561,7 +2561,7 @@ class SkillService(SkillBindingService):
                         tool_errors = [
                             error
                             for error in validation.errors
-                            if error.code in SKILL_TOOL_ERROR_CODES
+                            if error.code in SKILL_DRAFT_TOOL_ERROR_CODES
                         ]
                         if tool_errors:
                             raise TracecatValidationError(


### PR DESCRIPTION
Skill frontmatter tools had to be typed by hand. Add a searchable picker that lists registry actions and MCP tools, wire it into the SKILL.md editor panel, and keep malformed declarations out of the draft tool error codes so the raw YAML editor can repair them.

- `frontend/src/lib/skill-tools.ts` reads and rewrites `metadata.tools` while preserving the rest of the frontmatter source, and builds the option list from the registry and MCP catalogs.
- `skill-tools-dropdown.tsx` renders the picker on top of `MultiTagCommandInput`, which gains an accessible input id, labelled remove buttons, and closes when suggestions are disabled.
- Backend: `SKILL_DRAFT_TOOL_ERROR_CODES` no longer includes `invalid_skill_tool_declaration`, so drafts with malformed IDs save but cannot publish.

Layer 5 of 5 in the split of #3325. This is the feature; layers 1 to 4 are the backend fixes that were previously bundled with it. Supersedes #3325.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 497 | 4 |
| Tests | 715 | 7 |

https://claude.ai/code/session_01LHvvWytf7Uz8nfcycVAbF8

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
