### PR TITLE
fix(agents): avoid fatal LLM errors during proxy shutdown

### DIFF
--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from dataclasses import replace
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import cast
 
 import httpx
@@ -1489,3 +1490,117 @@ def test_anthropic_route_preserves_tool_reference_blocks_and_tool_fields() -> No
         data=data,
     )
     assert orjson.loads(request.body) == data
+
+
+@pytest.fixture
+def short_socket_path() -> Iterator[Path]:
+    # pytest's per-test directory can exceed macOS's Unix socket path limit.
+    with TemporaryDirectory() as directory:
+        yield Path(directory) / "llm.sock"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("fail_on_cancel", [False, True])
+async def test_stop_cancels_stream_before_closing_client(
+    short_socket_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fail_on_cancel: bool,
+) -> None:
+    errors: list[LLMProxyError] = []
+    reading = asyncio.Event()
+    stream_closed = asyncio.Event()
+    client_closed = asyncio.Event()
+
+    class BlockingStream(httpx.AsyncByteStream):
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            yield b"data: ready\n\n"
+            reading.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                if fail_on_cancel:
+                    # Some transports surface a read error during cancellation.
+                    raise httpx.ReadError("stream closed during teardown") from None
+                raise
+
+        async def aclose(self) -> None:
+            assert not client_closed.is_set()
+            stream_closed.set()
+
+    class Transport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                stream=BlockingStream(),
+            )
+
+        async def aclose(self) -> None:
+            assert stream_closed.is_set()
+            client_closed.set()
+
+    client = httpx.AsyncClient(transport=Transport())
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: client)
+    proxy = LLMSocketProxy(short_socket_path, _routing_plan(), errors.append)
+    await proxy.start()
+    reader, writer = await asyncio.open_unix_connection(proxy.socket_path)
+    try:
+        writer.write(b"POST /v1/messages HTTP/1.1\r\nContent-Length: 0\r\n\r\n")
+        await writer.drain()
+        await asyncio.wait_for(reading.wait(), timeout=2)
+        await asyncio.wait_for(proxy.stop(), timeout=2)
+        response = await asyncio.wait_for(reader.read(), timeout=2)
+        assert b"data: ready" in response
+        assert b"event: error" not in response
+        assert errors == []
+        assert stream_closed.is_set()
+        assert client_closed.is_set()
+        assert not proxy._connection_tasks
+        assert not proxy.socket_path.exists()
+        await proxy.stop()
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await proxy.stop()
+
+
+@pytest.mark.anyio
+async def test_stop_closes_connection_canceled_before_handler_starts(
+    tmp_path: Path,
+) -> None:
+    proxy = LLMSocketProxy(tmp_path / "llm.sock", _routing_plan())
+    writer = _FakeWriter()
+    proxy._accept_connection(asyncio.StreamReader(), cast(asyncio.StreamWriter, writer))
+
+    await proxy.stop()
+
+    assert writer.is_closing()
+    assert not proxy._connection_tasks
+
+
+@pytest.mark.anyio
+async def test_restart_reports_active_stream_failure(short_socket_path: Path) -> None:
+    errors: list[LLMProxyError] = []
+    proxy = LLMSocketProxy(short_socket_path, _routing_plan(), errors.append)
+    for _ in range(2):
+        await proxy.start()
+        try:
+            writer = _FakeWriter()
+            await proxy._write_response(
+                cast(asyncio.StreamWriter, writer),
+                status_code=200,
+                reason_phrase="OK",
+                headers={"Content-Type": "text/event-stream"},
+                body_chunks=_FailingResponseStream(
+                    httpx.Request("POST", "http://example.com")
+                ),
+                path="/v1/messages",
+            )
+            assert b"event: error" in writer.buffer
+        finally:
+            await proxy.stop()
+
+    assert len(errors) == 2
+    assert all(
+        error.classification.owner == RuntimeErrorOwner.PLATFORM for error in errors
+    )

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -644,6 +644,8 @@ class LLMSocketProxy:
         self.routing_plan = routing_plan
         self._server: asyncio.Server | None = None
         self._client: httpx.AsyncClient | None = None
+        self._connection_tasks: set[asyncio.Task[None]] = set()
+        self._stopping = False
         self._on_error = on_error
         self._error_emitted = False  # Only call callback once
 
@@ -669,9 +671,12 @@ class LLMSocketProxy:
             )
         )
 
+        self._stopping = False
+        self._error_emitted = False
+
         # Start Unix socket server
         self._server = await asyncio.start_unix_server(
-            self._handle_connection,
+            self._accept_connection,
             path=str(self.socket_path),
         )
 
@@ -686,8 +691,18 @@ class LLMSocketProxy:
 
     async def stop(self) -> None:
         """Stop the Unix socket server and clean up."""
+        self._stopping = True
         if self._server:
             self._server.close()
+
+        # Stop readers before closing their shared upstream client. Closing the
+        # client first can turn normal teardown into a fatal transport error.
+        tasks = tuple(self._connection_tasks)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+        if self._server:
             await self._server.wait_closed()
             self._server = None
 
@@ -721,7 +736,7 @@ class LLMSocketProxy:
         classification: RuntimeErrorClassification,
     ) -> None:
         """Emit error via callback (only once)."""
-        if not self._error_emitted:
+        if not self._stopping and not self._error_emitted:
             self._error_emitted = True
             logger.error("LLM proxy error", error=message, **_load_fields())
             if self._on_error:
@@ -741,6 +756,25 @@ class LLMSocketProxy:
             message = str(exc).lower()
             return "handler is closed" in message or "transport closed" in message
         return False
+
+    def _accept_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        # Register synchronously so stop also owns handlers not yet scheduled.
+        if self._stopping:
+            writer.close()
+            return
+        task = asyncio.create_task(self._handle_connection(reader, writer))
+        self._connection_tasks.add(task)
+
+        def connection_done(task: asyncio.Task[None]) -> None:
+            self._connection_tasks.discard(task)
+            # A task canceled before its first step never reaches its finally.
+            writer.close()
+
+        task.add_done_callback(connection_done)
 
     async def _handle_connection(
         self,
@@ -773,7 +807,7 @@ class LLMSocketProxy:
                 logger.debug("Client disconnected during proxy request")
                 return
             # Don't emit fatal error if server is already shutting down
-            if self._server is None:
+            if self._stopping:
                 logger.debug("Proxy error during shutdown (ignored)", error=str(e))
             else:
                 logger.exception("LLM proxy error", error=str(e))
@@ -1027,6 +1061,8 @@ class LLMSocketProxy:
                     route_is_direct=route.is_direct,
                 )
         except httpx.TransportError as exc:
+            if self._stopping:
+                return
             timed_out = isinstance(exc, httpx.TimeoutException)
             await self._write_error_response(
                 writer,
@@ -1120,6 +1156,9 @@ class LLMSocketProxy:
                     logger.debug("Client disconnected during response streaming")
                     return
         except Exception as exc:
+            if self._stopping:
+                logger.debug("Response stream closed during proxy shutdown")
+                return
             # Headers (200 OK) are already flushed — we cannot write a
             # second HTTP error response.  Emit the error as an SSE event
             # so the client can surface it.  This covers HTTPException from


### PR DESCRIPTION
Stopping an agent while its LLM response is still streaming can close the shared HTTP client before the response handler finishes. The resulting read error can emit a fatal callback after the agent has already succeeded.

Track accepted connection tasks and cancel/await them before closing the upstream client. Explicit shutdown state prevents teardown errors from generating SSE errors or fatal callbacks, while active request failures still surface. Reset that state when the proxy restarts, and close connections even when cancellation happens before their handler starts.

Validation: all 51 proxy unit tests pass, including Unix-socket mid-stream shutdown with normal cancellation and a transport read error during cancellation, cleanup ordering, repeated stop, and active failure reporting after restart. Changed-file Ruff and Basedpyright pass. Required commit hooks also pass, including frontend client generation/checks, repository Python typechecking, and secret scanning. No deployment performed.

| Change | + | - |
| --- | ---: | ---: |
| Logic | 42 | 3 |
| Tests | 116 | 1 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stopping an agent while an LLM stream was active could close the shared HTTP client first, causing a transport error and fatal callback after successful completion. The proxy now cancels and awaits connection tasks before closing the client, ignoring teardown errors while still surfacing active request failures.

**Bug Fixes**

- Tracks accepted connections immediately and closes sockets canceled before their handlers start.
- Resets shutdown and error state when the proxy restarts.
- Adds coverage for cancellation errors, cleanup ordering, repeated stops, and post-restart failures.

<sup>Written for commit 73228ccf6fb3714dc5c74103d656b555cc707e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

