### PR TITLE
fix(engine): raise executor payload limit default to 5 GiB

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1021,9 +1021,15 @@ TRACECAT__RATE_LIMIT_BY_ENDPOINT = env_bool(
 """Whether to rate limit by endpoint."""
 
 TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES = int(
-    os.environ.get("TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES") or 1024 * 1024
+    os.environ.get("TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES") or 5 * 1024**3
 )
-"""The maximum size of a payload in bytes the executor can return. Defaults to 1MB"""
+"""The maximum size of a payload in bytes the executor can return.
+
+Defaults to 5 GiB, the largest single-object upload S3 and MinIO accept.
+Results above ``TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES`` are
+externalized to blob storage with a single PUT, so the object store's
+single-upload cap is the effective ceiling on an action's result.
+"""
 
 TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_BYTES = int(
     os.environ.get("TRACECAT__SANDBOX_PACKAGE_CACHE_MAX_BYTES") or 5 * 1024**3


### PR DESCRIPTION
Closes ENG-1791.

## Problem

`TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES` caps the `result.json` an action or script sandbox may return. It defaulted to 1 MiB, so any action returning a moderately large API response, file contents, or a big list failed with `Sandbox file exceeds the read limit`. Operators had to discover the env var to fix it.

Results above `TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES` (128 KiB) are already externalized to blob storage, so this executor cap, not workflow history, was the effective ceiling on action output.

## Change

Default the limit to 5 GiB. The externalizer (`tracecat/storage/backends/s3.py` via `blob.upload_file`) writes each result with a single `put_object`, and 5 GiB is the largest single-object upload S3 and MinIO accept, so this matches the real ceiling rather than an arbitrary one. The env var stays as an operator override.

No Compose, Fargate, or Helm files reference this variable, so no deployment changes are needed.

## Review guide

- `read_bytes_beneath` still reads the whole result file into memory before JSON decoding. A result near the new cap would hold the raw bytes plus the decoded object in executor RAM. This PR does not change that path; the tracking issue notes it as a follow-up if it turns out to be a realistic OOM path under the executor's memory limits.

## Verification

- `ruff check`, `ruff format --check`, `basedpyright --warnings` on `tracecat/config.py`: clean
- `tests/unit/test_config.py`: 80 passed
- `just check-pr-title`: OK

## LOC breakdown

| Category | + | - |
| --- | --- | --- |
| Logic | 8 | 2 |

https://claude.ai/code/session_01CJ2c6SoZ1d8Vcx4P7LZCuL


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes ENG-1791. Raises the default executor payload limit from 1 MiB to 5 GiB, so larger action and script results no longer fail at the default limit. Externalized results already use blob storage, making 5 GiB the effective single-object limit for S3 and MinIO.

- `TRACECAT__EXECUTOR_PAYLOAD_MAX_SIZE_BYTES` remains available as an operator override.
- Very large results still load into executor memory before JSON decoding.
- No Compose, Fargate, or Helm changes are required.

<sup>Written for commit 98fe2cbb48724bd57e9344a1455118fbd925514d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

