### PR TITLE
fix(logging): preserve originating LLM proxy failure stacks

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -1557,7 +1557,8 @@ class DurableAgentWorkflow:
                 # a broken executor contract. Treat it as a platform invariant,
                 # never infer ownership from the free-form error string.
                 raise_application_error_from_classification(
-                    result.classification or agent_workflow_internal_error()
+                    result.classification or agent_workflow_internal_error(),
+                    capture=result.sentry_capture,
                 )
 
             if result.approval_requested:

--- a/tests/unit/test_agent_executor_result.py
+++ b/tests/unit/test_agent_executor_result.py
@@ -19,11 +19,14 @@ def test_agent_executor_result_legacy_result_output_alias() -> None:
     assert result.output == "legacy2"
 
 
-def test_source_capture_is_not_serialized_into_workflow_results() -> None:
+def test_source_capture_roundtrips_in_workflow_results() -> None:
     result = AgentExecutorResult(
         success=False,
         sentry_capture=PlatformErrorCapture.for_error(
             "a" * 32, agent_executor_unavailable()
         ),
     )
-    assert "sentry_capture" not in result.model_dump(mode="json")
+    assert (
+        AgentExecutorResult.model_validate_json(result.model_dump_json()).sentry_capture
+        == result.sentry_capture
+    )

--- a/tests/unit/test_sentry_interceptor.py
+++ b/tests/unit/test_sentry_interceptor.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 from collections.abc import Awaitable, Callable, Iterator, Mapping
 from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import Any, cast
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
 import sentry_sdk
 from fastapi import Depends, FastAPI, HTTPException
@@ -42,6 +44,12 @@ from tracecat.agent.error_policy import (
     invalid_agent_configuration,
     user_agent_execution_failed,
 )
+from tracecat.agent.sandbox.llm_proxy import (
+    LLMProxyError,
+    LLMRoute,
+    LLMRoutingPlan,
+    LLMSocketProxy,
+)
 from tracecat.api.common import auth_pool_exhausted_exception_handler
 from tracecat.auth.credentials import _authenticate_executor
 from tracecat.db.exceptions import AuthPoolExhaustedError
@@ -77,6 +85,7 @@ from tracecat.runtime.errors import (
     RetryDisposition,
     RuntimeErrorClassification,
     RuntimeErrorKind,
+    RuntimeErrorOwner,
 )
 from tracecat.temporal.errors import (
     activity_error_boundary,
@@ -1267,6 +1276,12 @@ async def test_activity_capture_preserves_source_stack_across_temporal_transport
     with pytest.raises(ApplicationError):
         await attribution.execute_workflow(_workflow_input())
     assert len(sentry_events) == 2
+    terminal_event = sentry_events[1]
+    assert "contexts" in terminal_event
+    assert (
+        terminal_event["contexts"]["tracecat_workflow"]["source_event_id"]
+        == capture.event_id
+    )
     event = sentry_events[0]
     assert "tags" in event
     assert "exception" in event
@@ -1364,3 +1379,71 @@ def test_activity_receipt_deduplicates_only_matching_source(
         )
         is None
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("transport_failure", [False, True])
+async def test_proxy_source_capture_keeps_safe_origin_and_receipt(
+    sentry_events: list[Event], tmp_path: Path, transport_failure: bool
+) -> None:
+    errors: list[LLMProxyError] = []
+
+    async def upstream(request: httpx.Request) -> httpx.Response:
+        if transport_failure:
+            raise httpx.ConnectError(_SENSITIVE_VALUE, request=request)
+        return httpx.Response(401, text=_SENSITIVE_VALUE)
+
+    proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        routing_plan=LLMRoutingPlan(
+            managed_route=LLMRoute(
+                base_url="https://example.com", model_provider="openai", mode="managed"
+            ),
+            direct_routes={},
+        ),
+        on_error=errors.append,
+    )
+    writer = Mock()
+    writer.is_closing.return_value = False
+    writer.drain = AsyncMock()
+    environment = ActivityEnvironment()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(upstream)) as client:
+        proxy._client = client
+        for _ in range(2):
+            await environment.run(
+                proxy._forward_request,
+                {
+                    "method": "POST",
+                    "path": "/v1/messages",
+                    "headers": {"Authorization": _SENSITIVE_VALUE},
+                    "body": b"{}",
+                },
+                writer,
+            )
+    assert len(errors) == len(sentry_events) == 1
+    error = errors[0]
+    assert error.sentry_capture is not None
+    event = sentry_events[0]
+    assert "event_id" in event
+    assert error.sentry_capture.event_id == event["event_id"]
+    assert error.classification.owner is RuntimeErrorOwner.PLATFORM
+    expected_type = "ConnectError" if transport_failure else "HTTPStatusError"
+    assert error.classification.cause_type == expected_type
+    assert "contexts" in event
+    assert "exception" in event
+    assert event["contexts"]["tracecat_proxy"]["route"] == "managed"
+    if not transport_failure:
+        assert event["contexts"]["tracecat_proxy"]["status_code"] == 401
+    frames = [
+        frame
+        for value in event["exception"]["values"]
+        for frame in value.get("stacktrace", {}).get("frames", [])
+    ]
+    assert any(
+        frame["function"]
+        == ("upstream" if transport_failure else "_forward_http_backend_request")
+        for frame in frames
+    )
+    assert all("vars" not in frame for frame in frames)
+    assert _SENSITIVE_VALUE not in json.dumps(event)
+    assert "https://example.com" not in json.dumps(event)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -247,7 +247,7 @@ class AgentExecutorResult(BaseModel):
     # Typed terminal attribution produced by the trusted executor boundary.
     # None keeps activity results recorded before this field replayable.
     classification: RuntimeErrorClassification | None = None
-    sentry_capture: PlatformErrorCapture | None = Field(default=None, exclude=True)
+    sentry_capture: PlatformErrorCapture | None = Field(default=None)
     # None means a legacy activity result did not carry this field. The
     # workflow treats unknown failed results as already terminal-emitted so old
     # histories keep their original command shape.
@@ -902,6 +902,7 @@ class SandboxedAgentExecutor:
                         proxy_error = fatal_error_task.result()
                         result.error = proxy_error.message
                         result.classification = proxy_error.classification
+                        result.sentry_capture = proxy_error.sentry_capture
                         result.terminal_stream_error_emitted = (
                             await handler.emit_terminal_error(proxy_error.message)
                         )

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -36,6 +36,8 @@ from tracecat.agent.service import AgentManagementService
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.logger import logger
+from tracecat.observability.sentry import capture_activity_failure
+from tracecat.observability.types import PlatformErrorCapture, ProxyFailureContext
 from tracecat.runtime.errors import RuntimeErrorClassification
 
 # Strip a trailing "/vN" segment (with optional trailing slash) from a
@@ -152,6 +154,7 @@ class LLMProxyError:
 
     message: str
     classification: RuntimeErrorClassification
+    sentry_capture: PlatformErrorCapture | None = None
 
 
 def _http_error_classification(
@@ -719,16 +722,30 @@ class LLMSocketProxy:
         self,
         message: str,
         classification: RuntimeErrorClassification,
+        *,
+        error: Exception | None = None,
+        context: ProxyFailureContext | None = None,
     ) -> None:
         """Emit error via callback (only once)."""
         if not self._error_emitted:
             self._error_emitted = True
+            if error is not None:
+                classification = classification.model_copy(
+                    update={"cause_type": type(error).__name__}
+                )
             logger.error("LLM proxy error", error=message, **_load_fields())
             if self._on_error:
                 self._on_error(
                     LLMProxyError(
                         message=message,
                         classification=classification,
+                        sentry_capture=(
+                            capture_activity_failure(
+                                error, classification, proxy_context=context
+                            )
+                            if error is not None
+                            else None
+                        ),
                     )
                 )
 
@@ -780,6 +797,7 @@ class LLMSocketProxy:
                 self._emit_error(
                     f"Proxy error: {e}",
                     agent_executor_protocol_failed(e),
+                    error=e,
                 )
         finally:
             _proxy_load_tracker.end_connection()
@@ -997,18 +1015,27 @@ class LLMSocketProxy:
                 body_chunks: AsyncIterable[bytes] | list[bytes]
                 if response.status_code >= 400 and not _is_non_critical_path(path):
                     error_body = await response.aread()
-                    self._emit_error(
-                        _format_litellm_http_error(
-                            status_code=response.status_code,
-                            reason_phrase=response.reason_phrase,
-                            body=error_body,
-                            trace_request_id=trace_request_id,
-                        ),
-                        _http_error_classification(
-                            response.status_code,
-                            route_is_direct=route.is_direct,
-                        ),
-                    )
+                    # This traceback is the local HTTP response callsite, not the remote server stack.
+                    try:
+                        response.raise_for_status()
+                    except httpx.HTTPStatusError as exc:
+                        self._emit_error(
+                            _format_litellm_http_error(
+                                status_code=response.status_code,
+                                reason_phrase=response.reason_phrase,
+                                body=error_body,
+                                trace_request_id=trace_request_id,
+                            ),
+                            _http_error_classification(
+                                response.status_code,
+                                route_is_direct=route.is_direct,
+                            ),
+                            error=exc,
+                            context=ProxyFailureContext(
+                                route="direct" if route.is_direct else "managed",
+                                status_code=response.status_code,
+                            ),
+                        )
                     body_chunks = [error_body]
                 else:
                     body_chunks = response.aiter_bytes()
@@ -1047,6 +1074,10 @@ class LLMSocketProxy:
                         exc,
                         route_is_direct=route.is_direct,
                         timed_out=timed_out,
+                    ),
+                    error=exc,
+                    context=ProxyFailureContext(
+                        route="direct" if route.is_direct else "managed"
                     ),
                 )
 
@@ -1170,6 +1201,11 @@ class LLMSocketProxy:
                     self._emit_error(
                         surfaced_error,
                         classification,
+                        error=exc,
+                        context=ProxyFailureContext(
+                            route="direct" if route_is_direct else "managed",
+                            status_code=status_code,
+                        ),
                     )
                 error_payload = orjson.dumps(
                     {

--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -31,6 +31,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.temporal.errors import (
         application_error_from_classification,
+        extract_error_capture,
         extract_error_classifications,
         iter_error_chain,
     )
@@ -72,10 +73,12 @@ def _report_terminal_failure(
     )
     if classification.owner is RuntimeErrorOwner.PLATFORM:
         terminal_logger.error("Terminal platform workflow failure")
+        capture = extract_error_capture(error, classification)
         capture_platform_failure(
             error,
             classification,
             WorkflowFailureEventContext(
+                source_event_id=capture.event_id if capture is not None else None,
                 run_id=info.run_id,
                 workflow_type=info.workflow_type,
                 attempt=info.attempt,

--- a/tracecat/observability/sentry.py
+++ b/tracecat/observability/sentry.py
@@ -23,7 +23,7 @@ from tracecat import __version__ as APP_VERSION
 from tracecat import config
 from tracecat.db.exceptions import AuthPoolExhaustedError
 from tracecat.logger import logger
-from tracecat.observability.types import PlatformErrorCapture
+from tracecat.observability.types import PlatformErrorCapture, ProxyFailureContext
 from tracecat.runtime.errors import RuntimeErrorClassification, RuntimeErrorOwner
 from tracecat.temporal.error_chain import iter_error_chain
 
@@ -36,6 +36,7 @@ class WorkflowFailureEventContext:
     workflow_type: str
     attempt: int
     trigger_type: str
+    source_event_id: str | None = None
 
 
 class SentryTag(StrEnum):
@@ -89,7 +90,10 @@ _API_ALLOWED_TAGS = frozenset(
 )
 _WORKER_ALLOWED_CONTEXT_FIELDS = {
     "runtime": frozenset({"name", "version"}),
-    "tracecat_workflow": frozenset({"run_id", "type", "attempt", "trigger_type"}),
+    "tracecat_workflow": frozenset(
+        {"run_id", "type", "attempt", "trigger_type", "source_event_id"}
+    ),
+    "tracecat_proxy": frozenset({"route", "status_code"}),
     "tracecat_otel": frozenset({"trace_id", "span_id"}),
 }
 _API_ALLOWED_CONTEXT_FIELDS = {
@@ -146,6 +150,7 @@ def capture_activity_failure(
     classification: RuntimeErrorClassification,
     *,
     existing_capture: PlatformErrorCapture | None = None,
+    proxy_context: ProxyFailureContext | None = None,
 ) -> PlatformErrorCapture | None:
     """Capture a platform failure before its activity stack is serialized.
 
@@ -203,6 +208,14 @@ def capture_activity_failure(
                     {
                         "trace_id": f"{span_context.trace_id:032x}",
                         "span_id": f"{span_context.span_id:016x}",
+                    },
+                )
+            if proxy_context is not None:
+                scope.set_context(
+                    "tracecat_proxy",
+                    {
+                        "route": proxy_context.route,
+                        "status_code": proxy_context.status_code,
                     },
                 )
             event_id = sentry_sdk.capture_exception(error)
@@ -271,6 +284,7 @@ def capture_platform_failure(
             scope.set_context(
                 "tracecat_workflow",
                 {
+                    "source_event_id": context.source_event_id,
                     "run_id": context.run_id,
                     "type": context.workflow_type,
                     "attempt": context.attempt,

--- a/tracecat/observability/types.py
+++ b/tracecat/observability/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -58,3 +59,11 @@ class PlatformErrorCapture(BaseModel):
         if representative is None:
             return None
         return cls.for_error(representative.event_id, classification)
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyFailureContext:
+    """Bounded local proxy diagnostics; never upstream URLs or payloads."""
+
+    route: Literal["managed", "direct"]
+    status_code: int | None = None


### PR DESCRIPTION
LLM proxy failures could reach Sentry only after conversion to a classified workflow error, leaving the source stack and exception type unavailable. Capture platform-owned HTTP, transport, and stream failures before conversion, with sanitized stack frames and bounded route/status context. HTTP response failures show the local response-check callsite; remote provider stacks are not available over HTTP.

Carry the existing typed Sentry receipt through executor results and workflow error details, and include its source event ID on the terminal event. Keep terminal reporting independent, retain error-chain suppression in Temporal, and capture only once per proxy terminal failure. The existing sanitizer removes exception messages, local variables, request data, and upstream URLs.

Validation: 115 focused tests passed covering proxy behavior, source-stack privacy, duplicate suppression, receipt serialization, and terminal correlation. Targeted basedpyright and Ruff checks passed. All commit hooks passed, including full Python type checks and frontend client generation/checks. No deployment performed.

| Change | + | - |
| --- | ---: | ---: |
| Logic | 80 | 16 |
| Tests | 89 | 3 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves originating stack traces for platform-owned LLM proxy HTTP, transport, and stream failures instead of reporting only the classified workflow error. The proxy captures a sanitized, bounded Sentry event before conversion, while terminal workflow reporting remains separate and links back to the source event.

**Bug Fixes**

- Carries typed Sentry receipts through executor results and serialized workflow error details.
- Adds the source event ID to terminal workflow events and suppresses duplicate captures.
- Limits proxy context to route and status, excluding messages, locals, request data, and upstream URLs.
- HTTP failures show the local response-check callsite; remote provider stacks remain unavailable over HTTP.
- Focused privacy, deduplication, serialization, and correlation tests pass with targeted type and lint checks.

<sup>Written for commit bb0cc382eff4cbc9a7d6310484b3de130d90a39b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

