### PR TITLE
feat(cases): aggregate cases by dropdowns and tags

### DIFF
--- a/tests/unit/test_case_aggregation.py
+++ b/tests/unit/test_case_aggregation.py
@@ -19,7 +19,20 @@ from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.service import CasesService
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session
-from tracecat.db.models import Case, CaseFields, Organization, User, Workspace
+from tracecat.db.models import (
+    Case,
+    CaseDropdownDefinition,
+    CaseDropdownOption,
+    CaseDropdownValue,
+    CaseFields,
+    CaseTag,
+    CaseTagLink,
+    Organization,
+    OrganizationTier,
+    Tier,
+    User,
+    Workspace,
+)
 from tracecat.executor.action_gateway.app import create_app
 
 pytestmark = pytest.mark.anyio
@@ -514,7 +527,7 @@ async def test_reporting_limits_validation_and_transaction_reuse(
     "payload",
     [
         {"group_by": ["fields.absent"]},
-        {"group_by": ["tags"]},
+        {"group_by": [], "filters": {"field": "tags", "op": "eq", "value": "urgent"}},
         {"group_by": ["dropdowns.absent"]},
         {"group_by": ["created_at"]},
         {"group_by": ["short_id"]},
@@ -680,3 +693,359 @@ async def test_gateway_scope_enforcement_and_schema_visibility(
     assert response.status_code == 200, response.text
     assert response.json()["groups"] == [{"count": 1}]
     assert "/internal/cases/aggregate" not in aggregate_app.openapi()["paths"]
+
+
+async def add_dropdown(
+    service: CasesService, ref: str
+) -> tuple[CaseDropdownDefinition, CaseDropdownOption]:
+    definition = CaseDropdownDefinition(
+        workspace_id=service.workspace_id, name=ref, ref=ref
+    )
+    service.session.add(definition)
+    await service.session.flush()
+    option = CaseDropdownOption(
+        definition_id=definition.id, label="Display label", ref="selected"
+    )
+    service.session.add(option)
+    await service.session.flush()
+    return definition, option
+
+
+async def test_dropdown_groups_filters_and_deleted_options(
+    aggregate_service: CasesService, aggregate_client: httpx.AsyncClient
+) -> None:
+    service = aggregate_service
+    definition, option = await add_dropdown(service, "verdict")
+    other_definition, other_option = await add_dropdown(service, "source")
+    cases = [await add_case(service) for _ in range(3)]
+    service.session.add_all(
+        [
+            CaseDropdownValue(
+                case_id=cases[0].id, definition_id=definition.id, option_id=option.id
+            ),
+            CaseDropdownValue(
+                case_id=cases[1].id, definition_id=definition.id, option_id=None
+            ),
+            CaseDropdownValue(
+                case_id=cases[0].id,
+                definition_id=other_definition.id,
+                option_id=other_option.id,
+            ),
+            CaseDropdownValue(
+                case_id=cases[2].id,
+                definition_id=other_definition.id,
+                option_id=other_option.id,
+            ),
+        ]
+    )
+    await service.session.flush()
+    path = "/internal/cases/aggregate"
+    response = await aggregate_client.post(
+        path, json={"group_by": ["dropdowns.verdict"]}
+    )
+    assert response.status_code == 200, response.text
+    assert {
+        row["dropdowns.verdict"]: row["count"] for row in response.json()["groups"]
+    } == {None: 2, "selected": 1}
+
+    for predicate, count in [
+        ({"field": "dropdowns.verdict", "op": "is_null"}, 2),
+        ({"field": "dropdowns.verdict", "op": "eq", "value": "selected"}, 1),
+        ({"field": "dropdowns.verdict", "op": "in", "value": ["selected"]}, 1),
+        ({"not": {"field": "dropdowns.verdict", "op": "eq", "value": "selected"}}, 0),
+    ]:
+        response = await aggregate_client.post(
+            path, json={"group_by": [], "filters": predicate}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["groups"] == [{"count": count}]
+
+    response = await aggregate_client.post(
+        path,
+        json={
+            "group_by": ["dropdowns.verdict", "dropdowns.source"],
+            "aggs": [
+                {"function": "count"},
+                {"function": "count", "field": "dropdowns.verdict"},
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert {
+        (r["dropdowns.verdict"], r["dropdowns.source"], r["count"], r["count_verdict"])
+        for r in response.json()["groups"]
+    } == {
+        ("selected", "selected", 1, 1),
+        (None, None, 1, 0),
+        (None, "selected", 1, 0),
+    }
+    response = await aggregate_client.post(
+        path,
+        json={
+            "group_by": ["dropdowns.verdict", {"field": "created_at", "bucket": "day"}]
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert {
+        (r["dropdowns.verdict"], r["created_at"], r["count"])
+        for r in response.json()["groups"]
+    } == {
+        ("selected", "2026-03-08T00:00:00Z", 1),
+        (None, "2026-03-08T00:00:00Z", 2),
+    }
+    await service.session.execute(
+        sa.delete(CaseDropdownOption).where(CaseDropdownOption.id == option.id)
+    )
+    for filters in [None, {"field": "dropdowns.verdict", "op": "is_null"}]:
+        response = await aggregate_client.post(
+            path, json={"group_by": ["dropdowns.verdict"], "filters": filters}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["groups"] == [{"dropdowns.verdict": None, "count": 3}]
+
+
+async def test_tags_count_cases_and_filter_before_grouping(
+    aggregate_service: CasesService,
+    aggregate_client: httpx.AsyncClient,
+    custom_cases: sa.Table,
+) -> None:
+    service = aggregate_service
+    cases = (
+        await service.session.scalars(
+            sa.select(Case)
+            .where(Case.workspace_id == service.workspace_id)
+            .order_by(Case.surrogate_id)
+        )
+    ).all()
+    red = CaseTag(workspace_id=service.workspace_id, name="Red label", ref="red")
+    blue = CaseTag(workspace_id=service.workspace_id, name="Blue label", ref="blue")
+    service.session.add_all([red, blue])
+    await service.session.flush()
+    service.session.add_all(
+        [
+            CaseTagLink(case_id=cases[0].id, tag_id=red.id),
+            CaseTagLink(case_id=cases[0].id, tag_id=blue.id),
+            CaseTagLink(case_id=cases[1].id, tag_id=red.id),
+        ]
+    )
+    await service.session.flush()
+    path = "/internal/cases/aggregate"
+    aggs = [
+        {"function": "count"},
+        {"function": "count", "field": "tags"},
+        {"function": "count", "field": "fields.amount"},
+    ]
+    response = await aggregate_client.post(
+        path, json={"group_by": ["priority", "tags"], "aggs": aggs}
+    )
+    assert response.status_code == 200, response.text
+    assert {
+        (r["priority"], r["tags"], r["count"], r["count_tags"], r["count_amount"])
+        for r in response.json()["groups"]
+    } == {
+        ("high", "red", 2, 2, 2),
+        ("high", "blue", 1, 1, 1),
+        ("high", None, 2, 0, 0),
+    }
+    response = await aggregate_client.post(path, json={"group_by": [], "aggs": aggs})
+    assert response.status_code == 200, response.text
+    assert response.json()["groups"] == [
+        {"count": 4, "count_tags": 2, "count_amount": 2}
+    ]
+    response = await aggregate_client.post(
+        path, json={"group_by": [], "aggs": aggs, "min_count": 5}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["groups"] == []
+    response = await aggregate_client.post(
+        path, json={"group_by": ["tags"], "min_count": 2}
+    )
+    assert response.status_code == 200, response.text
+    assert {r["tags"]: r["count"] for r in response.json()["groups"]} == {
+        "red": 2,
+        None: 2,
+    }
+
+    for predicate, count in [
+        ({"field": "tags", "op": "contains", "value": "red"}, 2),
+        ({"field": "tags", "op": "contains", "value": "re"}, 0),
+        ({"field": "tags", "op": "in", "value": ["red", "blue"]}, 2),
+        ({"field": "tags", "op": "in", "value": []}, 0),
+        ({"field": "tags", "op": "is_null"}, 2),
+        ({"not": {"field": "tags", "op": "contains", "value": "red"}}, 2),
+        (
+            {
+                "and": [
+                    {"field": "tags", "op": "contains", "value": "red"},
+                    {"field": "tags", "op": "contains", "value": "blue"},
+                ]
+            },
+            1,
+        ),
+        (
+            {
+                "or": [
+                    {"field": "tags", "op": "contains", "value": "red"},
+                    {"field": "tags", "op": "is_null"},
+                ]
+            },
+            4,
+        ),
+    ]:
+        response = await aggregate_client.post(
+            path, json={"group_by": [], "filters": predicate}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["groups"] == [{"count": count}]
+
+    tag_filter = {"field": "tags", "op": "contains", "value": "red"}
+    response = await aggregate_client.post(
+        path, json={"group_by": ["tags"], "filters": tag_filter}
+    )
+    assert response.status_code == 200, response.text
+    assert {r["tags"]: r["count"] for r in response.json()["groups"]} == {
+        "red": 2,
+        "blue": 1,
+    }
+    for function in ["sum", "mean", "median"]:
+        response = await aggregate_client.post(
+            path,
+            json={
+                "group_by": ["tags"],
+                "aggs": [{"function": function, "field": "fields.amount"}],
+            },
+        )
+        assert response.status_code == 400, response.text
+        # A tag filter alone cannot multiply rows, so numeric calculations work.
+        response = await aggregate_client.post(
+            path,
+            json={
+                "group_by": [],
+                "filters": tag_filter,
+                "aggs": [{"function": function, "field": "fields.amount"}],
+            },
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["groups"] == [
+            {f"{function}_amount": 4.0 if function == "sum" else 2.0}
+        ]
+
+
+async def test_dimension_workspace_isolation(
+    aggregate_service: CasesService, aggregate_client: httpx.AsyncClient
+) -> None:
+    service = aggregate_service
+    other = Workspace(
+        name="other-dimension-workspace", organization_id=service.role.organization_id
+    )
+    service.session.add(other)
+    await service.session.flush()
+    foreign = CasesService(
+        service.session, service.role.model_copy(update={"workspace_id": other.id})
+    )
+    local_definition, local_option = await add_dropdown(service, "verdict")
+    foreign_definition, foreign_option = await add_dropdown(foreign, "verdict")
+    local_tag = CaseTag(workspace_id=service.workspace_id, name="Local", ref="shared")
+    foreign_tag = CaseTag(workspace_id=other.id, name="Foreign", ref="shared")
+    service.session.add_all([local_tag, foreign_tag])
+    await service.session.flush()
+    local_case = await add_case(service)
+    empty_case = await add_case(service)
+    foreign_case = await add_case(foreign)
+    service.session.add_all(
+        [
+            CaseDropdownValue(
+                case_id=local_case.id,
+                definition_id=local_definition.id,
+                option_id=local_option.id,
+            ),
+            CaseDropdownValue(
+                case_id=local_case.id,
+                definition_id=foreign_definition.id,
+                option_id=foreign_option.id,
+            ),
+            CaseDropdownValue(
+                case_id=foreign_case.id,
+                definition_id=foreign_definition.id,
+                option_id=foreign_option.id,
+            ),
+            # Even an inconsistent option link must not expose another definition.
+            CaseDropdownValue(
+                case_id=empty_case.id,
+                definition_id=local_definition.id,
+                option_id=foreign_option.id,
+            ),
+            CaseTagLink(case_id=local_case.id, tag_id=local_tag.id),
+            CaseTagLink(case_id=local_case.id, tag_id=foreign_tag.id),
+            CaseTagLink(case_id=empty_case.id, tag_id=foreign_tag.id),
+            CaseTagLink(case_id=foreign_case.id, tag_id=foreign_tag.id),
+        ]
+    )
+    await service.session.flush()
+    for field, ref in [("tags", "shared"), ("dropdowns.verdict", "selected")]:
+        response = await aggregate_client.post(
+            "/internal/cases/aggregate", json={"group_by": [field]}
+        )
+        assert response.status_code == 200, response.text
+        assert {r[field]: r["count"] for r in response.json()["groups"]} == {
+            ref: 1,
+            None: 1,
+        }
+        response = await aggregate_client.post(
+            "/internal/cases/aggregate",
+            json={"group_by": [field], "filters": {"field": field, "op": "is_null"}},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["groups"] == [{field: None, "count": 1}]
+
+
+async def test_dropdown_entitlement_required_for_every_use(
+    aggregate_service: CasesService,
+    aggregate_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = aggregate_service
+    await add_dropdown(service, "verdict")
+    await add_case(service)
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
+    tier = Tier(
+        display_name="Synthetic restricted tier", entitlements={"case_addons": False}
+    )
+    service.session.add(tier)
+    await service.session.flush()
+    service.session.add(
+        OrganizationTier(organization_id=service.organization_id, tier_id=tier.id)
+    )
+    await service.session.flush()
+    for payload in [
+        {"group_by": ["dropdowns.verdict"]},
+        {"group_by": [], "aggs": [{"function": "count", "field": "dropdowns.verdict"}]},
+        {"group_by": [], "filters": {"field": "dropdowns.verdict", "op": "is_null"}},
+    ]:
+        response = await aggregate_client.post(
+            "/internal/cases/aggregate", json=payload
+        )
+        assert response.status_code == 400, response.text
+        assert "dropdowns.verdict" in response.text
+    response = await aggregate_client.post(
+        "/internal/cases/aggregate", json={"group_by": ["tags"]}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["groups"] == [{"tags": None, "count": 1}]
+
+
+async def test_ungated_aggregation_does_not_require_a_configured_tier(
+    aggregate_service: CasesService,
+    aggregate_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await add_case(aggregate_service)
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
+    for field in ["priority", "tags"]:
+        response = await aggregate_client.post(
+            "/internal/cases/aggregate", json={"group_by": [field]}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["groups"] == [
+            {field: "high" if field == "priority" else None, "count": 1}
+        ]

--- a/tests/unit/test_cases_query.py
+++ b/tests/unit/test_cases_query.py
@@ -19,7 +19,9 @@ from tracecat.cases.query import (
     TEXT_OPS,
     UUID_OPS,
     CaseFieldResolver,
+    referenced_dropdown_refs,
 )
+from tracecat.cases.schemas import CaseAggregateRequest
 from tracecat.db.models import Case
 from tracecat.exceptions import TracecatValidationError
 from tracecat.query.compiler import compile_filter
@@ -456,3 +458,66 @@ def test_compiled_filter_is_a_sqlalchemy_boolean_expression() -> None:
     )
 
     assert isinstance(predicate, ColumnElement)
+
+
+@pytest.mark.parametrize(
+    "op", [FilterOp.EQ, FilterOp.NE, FilterOp.NOT_IN, FilterOp.GT, FilterOp.STARTS_WITH]
+)
+def test_tags_reject_non_membership_operations(op: FilterOp) -> None:
+    with pytest.raises(TracecatValidationError, match="not allowed"):
+        _compile(Condition(field="tags", op=op, value="urgent"), _resolver())
+
+
+def test_tag_contains_is_exact_membership() -> None:
+    sql, params = _compile(
+        Condition(field="tags", op=FilterOp.CONTAINS, value="urgent%"), _resolver()
+    )
+    assert "EXISTS" in sql
+    assert "ILIKE" not in sql
+    assert "aggregate_tag.workspace_id =" in sql
+    assert "urgent%" in params.values()
+    assert WORKSPACE_ID in params.values()
+
+
+def test_dropdown_resolution_requires_visible_definition() -> None:
+    resolver = CaseFieldResolver(WORKSPACE_ID, {}, ["verdict"])
+    assert resolver.resolve("dropdowns.verdict") is not None
+    assert resolver.resolve_aggregation("dropdowns.verdict") is not None
+    assert resolver.resolve("dropdowns.absent") is None
+    assert resolver.resolve_aggregation("dropdowns.absent") is None
+    assert _resolver().resolve("dropdowns.verdict") is None
+
+
+def test_dropdown_filters_preserve_nulls_under_negation() -> None:
+    resolver = CaseFieldResolver(WORKSPACE_ID, {}, ["verdict"])
+    sql, params = _compile(
+        NotClause.model_validate(
+            {"not": {"field": "dropdowns.verdict", "op": "eq", "value": "benign"}}
+        ),
+        resolver,
+    )
+    assert "CASE WHEN" in sql
+    assert "dropdown_definition_0.workspace_id =" in sql
+    assert WORKSPACE_ID in params.values()
+
+
+def test_dropdown_metadata_includes_all_request_fields() -> None:
+    request = CaseAggregateRequest.model_validate(
+        {
+            "group_by": ["priority", "dropdowns.verdict"],
+            "aggs": [{"function": "count", "field": "dropdowns.source"}],
+            "filters": {
+                "and": [
+                    {"field": "dropdowns.verdict", "op": "eq", "value": "selected"},
+                    {
+                        "or": [
+                            {"field": "tags", "op": "contains", "value": "urgent"},
+                            {"not": {"field": "dropdowns.team", "op": "is_null"}},
+                        ]
+                    },
+                ]
+            },
+        }
+    )
+    assert referenced_dropdown_refs(request) == {"verdict", "source", "team"}
+    assert referenced_dropdown_refs(CaseAggregateRequest(group_by=[])) == set()

--- a/tracecat/cases/query.py
+++ b/tracecat/cases/query.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from enum import Enum
-from typing import Any, assert_never, cast
+from typing import TYPE_CHECKING, Any, assert_never, cast
 from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import ColumnElement
-from sqlalchemy.sql.selectable import TableClause
 
 from tracecat.cases.constants import RESERVED_CASE_FIELDS
 from tracecat.cases.enums import (
@@ -22,11 +21,18 @@ from tracecat.cases.types import (
     CustomFieldDefinition,
     ResolvedCaseAggregationField,
 )
-from tracecat.db.models import Case
+from tracecat.db.models import (
+    Case,
+    CaseDropdownDefinition,
+    CaseDropdownOption,
+    CaseDropdownValue,
+    CaseTag,
+    CaseTagLink,
+)
 from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers.workflow import WorkspaceUUID
 from tracecat.query.compiler import compile_predicate
-from tracecat.query.filters import FilterOp
+from tracecat.query.filters import AndClause, Condition, FilterOp, NotClause, OrClause
 from tracecat.query.resolver import (
     FieldKind,
     NormalizedFilterValue,
@@ -42,8 +48,13 @@ from tracecat.tables.common import (
 )
 from tracecat.tables.enums import SqlType
 
+if TYPE_CHECKING:
+    from tracecat.cases.schemas import CaseAggregateRequest
+
 CUSTOM_FIELD_PREFIX = "fields."
 CUSTOM_FIELDS_JOIN_KEY = "case_fields"
+DROPDOWN_PREFIX = "dropdowns."
+TAG_OPS = frozenset({FilterOp.CONTAINS, FilterOp.IN, FilterOp.IS_NULL})
 
 TEXT_OPS = frozenset(
     {
@@ -178,6 +189,28 @@ _FIXED_AGGREGATION_FIELDS: Mapping[str, ResolvedAggregationField] = {
 }
 
 
+def referenced_dropdown_refs(request: CaseAggregateRequest) -> set[str]:
+    """Collect dropdown references from grouping, metrics, and nested filters."""
+    fields = {group.field for group in request.group_by}
+    fields.update(agg.field for agg in request.aggs if agg.field is not None)
+    pending = [request.filters] if request.filters is not None else []
+    while pending:
+        match pending.pop():
+            case Condition(field=field):
+                fields.add(field)
+            case AndClause(and_=children) | OrClause(or_=children):
+                pending.extend(children)
+            case NotClause(not_=child):
+                pending.append(child)
+            case _ as unreachable:
+                assert_never(unreachable)
+    return {
+        field.removeprefix(DROPDOWN_PREFIX)
+        for field in fields
+        if field.startswith(DROPDOWN_PREFIX)
+    }
+
+
 class CaseFieldResolver:
     """Resolve user-facing case field addresses to trusted SQL expressions."""
 
@@ -185,7 +218,13 @@ class CaseFieldResolver:
         self,
         workspace_id: UUID,
         field_schema: Mapping[str, object],
+        dropdown_refs: Sequence[str] = (),
     ) -> None:
+        self._dropdowns = {
+            f"{DROPDOWN_PREFIX}{ref}": _dropdown_aggregation_field(workspace_id, ref, i)
+            for i, ref in enumerate(dict.fromkeys(dropdown_refs))
+        }
+        self._tags = _tag_aggregation_field(workspace_id)
         self._custom_fields = _parse_custom_field_schema(field_schema)
         self._custom_fields_by_physical_name = {
             field.physical_name: field for field in self._custom_fields.values()
@@ -224,11 +263,15 @@ class CaseFieldResolver:
             )
         if resolved := _FIXED_FILTER_FIELDS.get(field):
             return resolved
+        if field == "tags":
+            return _joined_filter_field(self._tags, TAG_OPS)
+        if dropdown := self._dropdowns.get(field):
+            return _joined_filter_field(dropdown, ENUM_OPS)
         if custom_field := self._resolve_custom_field_address(field):
             expression, kind, allowed_ops = self._custom_field_expression(custom_field)
             return ResolvedField(
-                expr=_custom_field_predicate_factory(
-                    self._custom_fields_table,
+                expr=_joined_field_predicate_factory(
+                    self._custom_fields_join,
                     expression,
                 ),
                 kind=kind,
@@ -241,6 +284,10 @@ class CaseFieldResolver:
         """Return an aggregation field and any join needed to use it."""
         if resolved := _FIXED_AGGREGATION_FIELDS.get(field):
             return ResolvedCaseAggregationField(field=resolved)
+        if field == "tags":
+            return self._tags
+        if dropdown := self._dropdowns.get(field):
+            return dropdown
         if custom_field := self._resolve_custom_field_address(field):
             expression, kind, _ = self._custom_field_expression(custom_field)
             return ResolvedCaseAggregationField(
@@ -392,9 +439,11 @@ def _ranked_enum_field[
     )
 
 
-def _custom_field_predicate_factory(
-    table: TableClause,
+def _joined_field_predicate_factory(
+    join: CaseFieldJoinSpec,
     expression: ColumnElement[Any],
+    *,
+    is_multi_valued: bool = False,
 ) -> PredicateFactory:
     def predicate(
         op: FilterOp,
@@ -404,9 +453,9 @@ def _custom_field_predicate_factory(
             return sa.not_(
                 sa.exists(
                     sa.select(1)
-                    .select_from(table)
+                    .select_from(join.target)
                     .where(
-                        table.c.case_id == Case.id,
+                        join.onclause,
                         expression.is_not(None),
                     )
                     .correlate(Case)
@@ -414,28 +463,104 @@ def _custom_field_predicate_factory(
             )
         has_non_null_value = sa.exists(
             sa.select(1)
-            .select_from(table)
+            .select_from(join.target)
             .where(
-                table.c.case_id == Case.id,
+                join.onclause,
                 expression.is_not(None),
             )
             .correlate(Case)
         )
         matches = sa.exists(
             sa.select(1)
-            .select_from(table)
+            .select_from(join.target)
             .where(
-                table.c.case_id == Case.id,
-                compile_predicate(expression, op, value),
+                join.onclause,
+                compile_predicate(
+                    expression,
+                    FilterOp.EQ if is_multi_valued and op is FilterOp.CONTAINS else op,
+                    value,
+                ),
             )
             .correlate(Case)
         )
-        # EXISTS is always two-valued. Wrap it so a missing row or NULL custom
+        if is_multi_valued:
+            return matches
+        # EXISTS is always two-valued. Wrap it so a missing row or NULL
         # value stays SQL NULL when a surrounding NOT negates the predicate,
         # matching the semantics of filtering a nullable ordinary column.
         return sa.case((has_non_null_value, matches), else_=None)
 
     return predicate
+
+
+def _joined_filter_field(
+    resolved: ResolvedCaseAggregationField,
+    allowed_ops: frozenset[FilterOp],
+) -> ResolvedField:
+    assert resolved.join is not None
+    expression = resolved.field.expr
+    assert isinstance(expression, ColumnElement)
+    return ResolvedField(
+        expr=_joined_field_predicate_factory(
+            resolved.join,
+            expression,
+            is_multi_valued=resolved.field.is_multi_valued,
+        ),
+        kind=resolved.field.kind,
+        allowed_ops=allowed_ops,
+        value_type=expression.type,
+    )
+
+
+def _dropdown_aggregation_field(
+    workspace_id: UUID, ref: str, index: int
+) -> ResolvedCaseAggregationField:
+    # Generated aliases keep two dropdowns independent without putting user
+    # references into SQL identifiers. Scope the entire backing relation before
+    # LEFT JOINing it to cases, preserving missing values without extra rows.
+    definition = CaseDropdownDefinition.__table__.alias(f"dropdown_definition_{index}")
+    value = CaseDropdownValue.__table__.alias(f"dropdown_value_{index}")
+    option = CaseDropdownOption.__table__.alias(f"dropdown_option_{index}")
+    target = value.join(
+        definition,
+        sa.and_(
+            value.c.definition_id == definition.c.id,
+            definition.c.ref == ref,
+            definition.c.workspace_id == workspace_id,
+        ),
+    ).outerjoin(
+        option,
+        sa.and_(
+            value.c.option_id == option.c.id,
+            option.c.definition_id == definition.c.id,
+        ),
+    )
+    return ResolvedCaseAggregationField(
+        field=ResolvedAggregationField(expr=option.c.ref, kind=FieldKind.ENUM),
+        join=CaseFieldJoinSpec(
+            key=f"{DROPDOWN_PREFIX}{ref}",
+            target=target,
+            onclause=value.c.case_id == Case.id,
+        ),
+    )
+
+
+def _tag_aggregation_field(workspace_id: UUID) -> ResolvedCaseAggregationField:
+    link = CaseTagLink.__table__.alias("aggregate_tag_link")
+    tag = CaseTag.__table__.alias("aggregate_tag")
+    return ResolvedCaseAggregationField(
+        field=ResolvedAggregationField(
+            expr=tag.c.ref, kind=FieldKind.TAG, is_multi_valued=True
+        ),
+        join=CaseFieldJoinSpec(
+            key="tags",
+            target=link.join(
+                tag,
+                sa.and_(link.c.tag_id == tag.c.id, tag.c.workspace_id == workspace_id),
+            ),
+            onclause=link.c.case_id == Case.id,
+        ),
+    )
 
 
 def _invalid_custom_field(

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -81,6 +81,14 @@ class CaseAggregateRequest(AggregationSpec):
     float8 JSON numbers. NUMERIC group keys remain exact decimal strings.
     TEXT/SELECT group keys use their first 256 characters, so values sharing
     that prefix collapse into one group. Missing values form a null group.
+
+    When grouping by tags, each case appears once in each of its tag groups.
+    A case with multiple tags contributes to multiple groups, so adding the
+    group counts can exceed the number of matching cases. Untagged cases form
+    the null group. Counts, counts of populated fields, and minimum group sizes
+    always count each case once per group. Sum, mean, and median are unavailable
+    when grouping by tags. Tag filters select cases before grouping; all tags
+    on the matching cases remain available as groups.
     """
 
     filters: Filter | None = Field(default=None)

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -51,7 +51,7 @@ from tracecat.cases.enums import (
 )
 from tracecat.cases.events import CaseEventsService
 from tracecat.cases.mentions import MentionToken, parse_mentions
-from tracecat.cases.query import CaseFieldResolver
+from tracecat.cases.query import CaseFieldResolver, referenced_dropdown_refs
 from tracecat.cases.schemas import (
     AssigneeChangedEvent,
     CaseAggregateRequest,
@@ -245,8 +245,19 @@ class CasesService(BaseWorkspaceService):
         self, request: CaseAggregateRequest
     ) -> CaseAggregateResponse:
         """Filter, group, and aggregate workspace cases in PostgreSQL."""
+        dropdown_refs: Sequence[str] = ()
+        requested_dropdowns = referenced_dropdown_refs(request)
+        if requested_dropdowns and await self.has_entitlement(Entitlement.CASE_ADDONS):
+            dropdown_refs = (
+                await self.session.scalars(
+                    select(CaseDropdownDefinition.ref).where(
+                        CaseDropdownDefinition.workspace_id == self.workspace_id,
+                        CaseDropdownDefinition.ref.in_(requested_dropdowns),
+                    )
+                )
+            ).all()
         resolver = CaseFieldResolver(
-            self.workspace_id, await self.fields.get_field_schema()
+            self.workspace_id, await self.fields.get_field_schema(), dropdown_refs
         )
         statement = (
             sa.select(sa.literal(1))
@@ -279,7 +290,8 @@ class CasesService(BaseWorkspaceService):
             resolved_fields,
             limit=request.limit,
             entity_id=Case.id,
-            # The custom-fields join is one-to-one; filters use correlated EXISTS.
+            # All joins are represented by resolved_fields, including tags'
+            # multi-valued marker. Filters only add correlated EXISTS queries.
             base_has_multi_valued_join=False,
         )
         transaction = (


### PR DESCRIPTION
## Description

Case aggregation can now filter and group by `dropdowns.<ref>` and `tags`. Dropdowns return option references and preserve unset or deleted selections in the null group. Tag grouping counts each case once per tag group; sums, means, and medians are rejected when tag grouping would repeat cases.

The query explicitly scopes dropdowns and tags to the workspace. Dropdown access and definition lookup run only when the request references a dropdown, including inside nested filters, so ordinary case and tag reports remain independent of Case Addons configuration. The request documentation explains the tag counting behavior for reuse by the registry action.

## Related issues

Closes ENG-1751
https://linear.app/tracecat/issue/ENG-1751

Builds on ENG-1750 / #3419. The registry action is tracked separately in ENG-1753.

## Validation

- 248 focused tests passed, including real PostgreSQL requests through the internal endpoint: `tests/unit/test_cases_query.py`, `tests/unit/test_case_aggregation.py`, and `tests/unit/query/test_aggregations.py`.
- Covers dropdown deletion and missing values, multiple dropdowns, tag counts and minimum group sizes, filter/group interactions, workspace isolation, entitlement rejection, mixed grouping, and the ungated-report regression found during adversarial review.
- Repository Ruff lint and formatting checks passed.
- Full Python type check passed with zero errors or warnings.

## LOC breakdown

| Kind | + | - |
| --- | ---: | ---: |
| Logic | 165 | 20 |
| Tests | 436 | 2 |
