### PR TITLE
fix(engine): preserve registry tool timeout attribution

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/registry_tool.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/registry_tool.py
@@ -10,6 +10,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat import config
     from tracecat.agent.workflows.tool_execution import (
         AGENT_TOOL_PRIORITY,
+        REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS,
         ExecuteRegistryToolWorkflowInput,
     )
     from tracecat.dsl.common import RETRY_POLICIES
@@ -22,11 +23,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.storage.object import StoredObject, StoredObjectValidator
     from tracecat.temporal.errors import application_error_from_classification
     from tracecat.temporal.patches import WorkflowPatch
-
-
-# The activity also prepares the environment and stores the result. Let sandbox
-# termination and its classified failure reach Temporal before the outer timer.
-_REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS = 60
 
 
 def _activity_error_message(error: ActivityError) -> str:
@@ -48,7 +44,7 @@ class ExecuteRegistryToolWorkflow:
         )
         timeout_seconds = config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT
         if classify_timeout:
-            timeout_seconds += _REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS
+            timeout_seconds += REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS
         else:
             timeout_seconds = int(timeout_seconds)
         try:

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/registry_tool.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/registry_tool.py
@@ -11,6 +11,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.workflows.tool_execution import (
         AGENT_TOOL_PRIORITY,
         REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS,
+        REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS,
         ExecuteRegistryToolWorkflowInput,
     )
     from tracecat.dsl.common import RETRY_POLICIES
@@ -33,6 +34,20 @@ def _activity_error_message(error: ActivityError) -> str:
     return str(error)
 
 
+def _activity_timeout_error(
+    cause: TemporalTimeoutError | None = None,
+) -> ApplicationError:
+    # Queueing, setup, persistence, or a lost worker can exhaust this budget;
+    # it does not prove that the workload exceeded its own resource limit.
+    classification = RuntimeErrorClassification.platform(
+        kind=RuntimeErrorKind.EXECUTOR_ACTIVITY_TIMED_OUT,
+        message="Tracecat executor activity timed out",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+        cause=cause,
+    )
+    return application_error_from_classification(classification)
+
+
 @workflow.defn
 class ExecuteRegistryToolWorkflow:
     """Short workflow that routes a single registry UDF to executor."""
@@ -43,8 +58,22 @@ class ExecuteRegistryToolWorkflow:
             WorkflowPatch.REGISTRY_TOOL_ACTIVITY_TIMEOUT
         )
         timeout_seconds = config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT
+        schedule_to_close_timeout = None
         if classify_timeout:
             timeout_seconds += REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS
+            schedule_to_close_timeout = timedelta(seconds=timeout_seconds)
+            info = workflow.info()
+            if info.run_timeout is not None:
+                # Workflow startup may already have consumed part of the budget.
+                remaining = (
+                    info.workflow_start_time
+                    + info.run_timeout
+                    - workflow.now()
+                    - timedelta(seconds=REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS)
+                )
+                if remaining <= timedelta(0):
+                    raise _activity_timeout_error()
+                schedule_to_close_timeout = min(schedule_to_close_timeout, remaining)
         else:
             timeout_seconds = int(timeout_seconds)
         try:
@@ -53,6 +82,7 @@ class ExecuteRegistryToolWorkflow:
                 args=[input.run_input, input.role],
                 task_queue=config.TRACECAT__EXECUTOR_QUEUE,
                 start_to_close_timeout=timedelta(seconds=timeout_seconds),
+                schedule_to_close_timeout=schedule_to_close_timeout,
                 heartbeat_timeout=timedelta(
                     seconds=config.TRACECAT__ACTIVITY_HEARTBEAT_TIMEOUT
                 )
@@ -63,16 +93,8 @@ class ExecuteRegistryToolWorkflow:
             )
         except ActivityError as e:
             if classify_timeout and isinstance(e.cause, TemporalTimeoutError):
-                # An outer timeout does not prove the workload exceeded its limit:
-                # setup, persistence, or a lost worker may also be responsible.
                 # Do not retry a tool whose side effects may already have occurred.
-                classification = RuntimeErrorClassification.platform(
-                    kind=RuntimeErrorKind.EXECUTOR_ACTIVITY_TIMED_OUT,
-                    message="Tracecat executor activity timed out",
-                    retry_disposition=RetryDisposition.NON_RETRYABLE,
-                    cause=e.cause,
-                )
-                raise application_error_from_classification(classification) from e
+                raise _activity_timeout_error(e.cause) from e
             raise ApplicationError(
                 _activity_error_message(e),
                 non_retryable=True,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/registry_tool.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/registry_tool.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from temporalio import workflow
 from temporalio.exceptions import ActivityError, ApplicationError
+from temporalio.exceptions import TimeoutError as TemporalTimeoutError
 
 with workflow.unsafe.imports_passed_through():
     from tracecat import config
@@ -13,7 +14,19 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.dsl.common import RETRY_POLICIES
     from tracecat.executor.activities import ExecutorActivities
+    from tracecat.runtime.errors import (
+        RetryDisposition,
+        RuntimeErrorClassification,
+        RuntimeErrorKind,
+    )
     from tracecat.storage.object import StoredObject, StoredObjectValidator
+    from tracecat.temporal.errors import application_error_from_classification
+    from tracecat.temporal.patches import WorkflowPatch
+
+
+# The activity also prepares the environment and stores the result. Let sandbox
+# termination and its classified failure reach Temporal before the outer timer.
+_REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS = 60
 
 
 def _activity_error_message(error: ActivityError) -> str:
@@ -30,14 +43,20 @@ class ExecuteRegistryToolWorkflow:
 
     @workflow.run
     async def run(self, input: ExecuteRegistryToolWorkflowInput) -> StoredObject:
+        classify_timeout = workflow.patched(
+            WorkflowPatch.REGISTRY_TOOL_ACTIVITY_TIMEOUT
+        )
+        timeout_seconds = config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT
+        if classify_timeout:
+            timeout_seconds += _REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS
+        else:
+            timeout_seconds = int(timeout_seconds)
         try:
             stored = await workflow.execute_activity(
                 ExecutorActivities.execute_action_activity,
                 args=[input.run_input, input.role],
                 task_queue=config.TRACECAT__EXECUTOR_QUEUE,
-                start_to_close_timeout=timedelta(
-                    seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT)
-                ),
+                start_to_close_timeout=timedelta(seconds=timeout_seconds),
                 heartbeat_timeout=timedelta(
                     seconds=config.TRACECAT__ACTIVITY_HEARTBEAT_TIMEOUT
                 )
@@ -47,6 +66,17 @@ class ExecuteRegistryToolWorkflow:
                 priority=AGENT_TOOL_PRIORITY,
             )
         except ActivityError as e:
+            if classify_timeout and isinstance(e.cause, TemporalTimeoutError):
+                # An outer timeout does not prove the workload exceeded its limit:
+                # setup, persistence, or a lost worker may also be responsible.
+                # Do not retry a tool whose side effects may already have occurred.
+                classification = RuntimeErrorClassification.platform(
+                    kind=RuntimeErrorKind.EXECUTOR_ACTIVITY_TIMED_OUT,
+                    message="Tracecat executor activity timed out",
+                    retry_disposition=RetryDisposition.NON_RETRYABLE,
+                    cause=e.cause,
+                )
+                raise application_error_from_classification(classification) from e
             raise ApplicationError(
                 _activity_error_message(e),
                 non_retryable=True,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/registry_tool.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/registry_tool.py
@@ -11,7 +11,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.workflows.tool_execution import (
         AGENT_TOOL_PRIORITY,
         REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS,
-        REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS,
         ExecuteRegistryToolWorkflowInput,
     )
     from tracecat.dsl.common import RETRY_POLICIES
@@ -23,7 +22,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.storage.object import StoredObject, StoredObjectValidator
     from tracecat.temporal.errors import application_error_from_classification
-    from tracecat.temporal.patches import WorkflowPatch
+    from tracecat.temporal.patches import ExecuteRegistryToolWorkflowPatch
 
 
 def _activity_error_message(error: ActivityError) -> str:
@@ -34,9 +33,7 @@ def _activity_error_message(error: ActivityError) -> str:
     return str(error)
 
 
-def _activity_timeout_error(
-    cause: TemporalTimeoutError | None = None,
-) -> ApplicationError:
+def _activity_timeout_error(cause: TemporalTimeoutError) -> ApplicationError:
     # Queueing, setup, persistence, or a lost worker can exhaust this budget;
     # it does not prove that the workload exceeded its own resource limit.
     classification = RuntimeErrorClassification.platform(
@@ -55,25 +52,13 @@ class ExecuteRegistryToolWorkflow:
     @workflow.run
     async def run(self, input: ExecuteRegistryToolWorkflowInput) -> StoredObject:
         classify_timeout = workflow.patched(
-            WorkflowPatch.REGISTRY_TOOL_ACTIVITY_TIMEOUT
+            ExecuteRegistryToolWorkflowPatch.ACTIVITY_TIMEOUT
         )
         timeout_seconds = config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT
         schedule_to_close_timeout = None
         if classify_timeout:
             timeout_seconds += REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS
             schedule_to_close_timeout = timedelta(seconds=timeout_seconds)
-            info = workflow.info()
-            if info.run_timeout is not None:
-                # Workflow startup may already have consumed part of the budget.
-                remaining = (
-                    info.workflow_start_time
-                    + info.run_timeout
-                    - workflow.now()
-                    - timedelta(seconds=REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS)
-                )
-                if remaining <= timedelta(0):
-                    raise _activity_timeout_error()
-                schedule_to_close_timeout = min(schedule_to_close_timeout, remaining)
         else:
             timeout_seconds = int(timeout_seconds)
         try:

--- a/tests/temporal/test_registry_tool_cancellation.py
+++ b/tests/temporal/test_registry_tool_cancellation.py
@@ -1,0 +1,128 @@
+"""A cancelled MCP caller must not leave a queued tool runnable after recovery."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from temporalio import activity
+from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
+from temporalio.common import TypedSearchAttributes
+from temporalio.exceptions import CancelledError as TemporalCancelledError
+from temporalio.service import RPCError, RPCStatusCode
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+from tracecat_ee.agent.workflows.registry_tool import ExecuteRegistryToolWorkflow
+
+from tracecat import config
+from tracecat.agent.mcp import executor
+from tracecat.agent.worker import new_sandbox_runner
+from tracecat.agent.workflows.tool_execution import (
+    ExecuteRegistryToolWorkflowInput,
+    ExecuteRegistryToolWorkflowMemo,
+)
+from tracecat.auth.types import Role
+from tracecat.dsl._converter import get_data_converter
+from tracecat.dsl.schemas import RunActionInput
+from tracecat.registry.lock.types import RegistryLock
+from tracecat.storage.object import InlineObject, StoredObject
+
+pytestmark = [pytest.mark.temporal]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_cancellation_before_worker_start_prevents_tool_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task_queue = f"registry-tool-cancellation-{uuid4()}"
+    workflow_id = f"agent-tool/{uuid4()}"
+    calls: list[RunActionInput] = []
+
+    @activity.defn(name="execute_action_activity")
+    async def execute_action_activity(
+        run_input: RunActionInput, role: Role
+    ) -> StoredObject:
+        calls.append(run_input)
+        return InlineObject(data="unexpected execution")
+
+    monkeypatch.setattr(config, "TRACECAT__AGENT_QUEUE", task_queue)
+    monkeypatch.setattr(config, "TRACECAT__EXECUTOR_QUEUE", task_queue)
+    workflow_input = ExecuteRegistryToolWorkflowInput(
+        role=Role(type="service", service_id="tracecat-mcp"),
+        run_input=executor.build_run_input(
+            "core.http_request",
+            {"url": "https://example.com"},
+            RegistryLock(
+                origins={"tracecat_registry": "test-version"},
+                actions={"core.http_request": "tracecat_registry"},
+            ),
+        ),
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=get_data_converter(),
+    ) as env:
+        monkeypatch.setattr(
+            executor, "get_temporal_client", AsyncMock(return_value=env.client)
+        )
+        caller = asyncio.create_task(
+            executor._execute_action_workflow(
+                workflow_input,
+                workflow_id=workflow_id,
+                memo=ExecuteRegistryToolWorkflowMemo(
+                    parent_agent_session_id=uuid4(), action_name="core.http_request"
+                ),
+                search_attributes=TypedSearchAttributes(search_attributes=[]),
+            )
+        )
+        handle = env.client.get_workflow_handle_for(
+            ExecuteRegistryToolWorkflow.run, workflow_id
+        )
+        try:
+            async with asyncio.timeout(10):
+                # Observe server acceptance without starting a workflow worker.
+                while True:
+                    try:
+                        await handle.describe()
+                        break
+                    except RPCError as error:
+                        if error.status != RPCStatusCode.NOT_FOUND:
+                            raise
+                        await asyncio.sleep(0.01)
+                caller.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await caller
+
+            history = await handle.fetch_history()
+            assert any(
+                event.HasField("workflow_execution_cancel_requested_event_attributes")
+                for event in history.events
+            )
+            async with Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[ExecuteRegistryToolWorkflow],
+                activities=[execute_action_activity],
+                workflow_runner=new_sandbox_runner(),
+            ):
+                with pytest.raises(WorkflowFailureError) as raised:
+                    await asyncio.wait_for(handle.result(), timeout=10)
+            assert isinstance(raised.value.cause, TemporalCancelledError)
+            assert (await handle.describe()).status == WorkflowExecutionStatus.CANCELED
+            assert not calls
+            history = await handle.fetch_history()
+            assert not any(
+                event.HasField("activity_task_started_event_attributes")
+                for event in history.events
+            )
+        finally:
+            if not caller.done():
+                caller.cancel()
+            await asyncio.gather(caller, return_exceptions=True)

--- a/tests/unit/test_agent_mcp_executor.py
+++ b/tests/unit/test_agent_mcp_executor.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import uuid
+from dataclasses import dataclass
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
+import anyio
 import pytest
-from temporalio.client import WorkflowFailureError
+from anyio.abc import TaskStatus
+from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
+from temporalio.service import RPCError, RPCStatusCode
 
 from tracecat.agent.mcp import executor
 from tracecat.agent.tokens import MCPTokenClaims
@@ -34,6 +39,32 @@ def _build_registry_lock() -> RegistryLock:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class _PendingWorkflow:
+    client: Mock
+    handle: Mock
+    waiting: asyncio.Event
+
+
+@pytest.fixture
+def pending_workflow(monkeypatch: pytest.MonkeyPatch) -> _PendingWorkflow:
+    waiting = asyncio.Event()
+
+    async def result() -> None:
+        waiting.set()
+        await asyncio.Event().wait()
+
+    handle = Mock(spec=WorkflowHandle, id="agent-tool/pending")
+    handle.result = AsyncMock(side_effect=result)
+    handle.cancel = AsyncMock()
+    client = Mock(spec=Client)
+    client.start_workflow = AsyncMock(return_value=handle)
+    client.get_workflow_handle_for = Mock(return_value=handle)
+    monkeypatch.setattr(executor, "build_agent_tool_workflow_id", lambda: handle.id)
+    monkeypatch.setattr(executor, "get_temporal_client", AsyncMock(return_value=client))
+    return _PendingWorkflow(client=client, handle=handle, waiting=waiting)
+
+
 @pytest.mark.anyio
 async def test_execute_action_starts_registry_tool_workflow_with_alias_correlation(
     monkeypatch: pytest.MonkeyPatch,
@@ -43,9 +74,8 @@ async def test_execute_action_starts_registry_tool_workflow_with_alias_correlati
     monkeypatch.setattr(
         executor, "build_agent_tool_workflow_id", lambda: "agent-tool/tool-wf-123"
     )
-    fake_client = SimpleNamespace(
-        execute_workflow=AsyncMock(return_value={"uri": "s3://stored"}),
-    )
+    handle = SimpleNamespace(result=AsyncMock(return_value={"uri": "s3://stored"}))
+    fake_client = SimpleNamespace(start_workflow=AsyncMock(return_value=handle))
     monkeypatch.setattr(
         executor, "get_temporal_client", AsyncMock(return_value=fake_client)
     )
@@ -68,23 +98,23 @@ async def test_execute_action_starts_registry_tool_workflow_with_alias_correlati
         tool_call_id="toolu_123",
     )
 
-    call = fake_client.execute_workflow.await_args
-    assert call.kwargs["id"] == "agent-tool/tool-wf-123"
-    assert call.kwargs.get("run_timeout") is None
-    assert call.kwargs.get("execution_timeout") is None
-    workflow_input = call.args[1]
+    start_call = fake_client.start_workflow.await_args
+    assert start_call.kwargs["id"] == "agent-tool/tool-wf-123"
+    assert start_call.kwargs.get("run_timeout") is None
+    assert start_call.kwargs.get("execution_timeout") is None
+    workflow_input = start_call.args[1]
     assert workflow_input.run_input.agent_session_id == claims.session_id
     assert workflow_input.run_input.task.args["agent_session_id"] == str(
         untrusted_session_id
     )
-    assert call.kwargs["memo"] == {
+    assert start_call.kwargs["memo"] == {
         "parent_agent_workflow_id": f"agent/{claims.session_id}",
         "parent_agent_run_id": "run-123",
         "parent_agent_session_id": str(claims.session_id),
         "tool_call_id": "toolu_123",
         "action_name": "core.http_request",
     }
-    search_attributes = call.kwargs["search_attributes"]
+    search_attributes = start_call.kwargs["search_attributes"]
     pairs = {pair.key.name: pair.value for pair in search_attributes.search_attributes}
     assert pairs[
         TemporalSearchAttr.CORRELATION_ID.value
@@ -104,13 +134,14 @@ async def test_execute_action_reuses_existing_workflow_on_duplicate_start(
     monkeypatch.setattr(executor, "build_agent_tool_workflow_id", lambda: workflow_id)
     handle = SimpleNamespace(result=AsyncMock(return_value={"uri": "s3://existing"}))
     fake_client = SimpleNamespace(
-        execute_workflow=AsyncMock(
+        start_workflow=AsyncMock(
             side_effect=WorkflowAlreadyStartedError(
                 workflow_id,
                 "ExecuteRegistryToolWorkflow.run",
+                run_id="existing-run",
             )
         ),
-        get_workflow_handle=Mock(return_value=handle),
+        get_workflow_handle_for=Mock(return_value=handle),
     )
     monkeypatch.setattr(
         executor, "get_temporal_client", AsyncMock(return_value=fake_client)
@@ -131,7 +162,11 @@ async def test_execute_action_reuses_existing_workflow_on_duplicate_start(
         tool_call_id="toolu_123",
     )
 
-    fake_client.get_workflow_handle.assert_called_once_with(workflow_id)
+    fake_client.get_workflow_handle_for.assert_called_once_with(
+        executor.ExecuteRegistryToolWorkflow.run,
+        workflow_id,
+        first_execution_run_id="existing-run",
+    )
     handle.result.assert_awaited_once()
     assert result == {"ok": "existing"}
 
@@ -151,13 +186,13 @@ async def test_execute_action_maps_existing_workflow_failures_on_duplicate_start
         )
     )
     fake_client = SimpleNamespace(
-        execute_workflow=AsyncMock(
+        start_workflow=AsyncMock(
             side_effect=WorkflowAlreadyStartedError(
                 workflow_id,
                 "ExecuteRegistryToolWorkflow.run",
             )
         ),
-        get_workflow_handle=Mock(return_value=handle),
+        get_workflow_handle_for=Mock(return_value=handle),
     )
     monkeypatch.setattr(
         executor, "get_temporal_client", AsyncMock(return_value=fake_client)
@@ -173,6 +208,157 @@ async def test_execute_action_maps_existing_workflow_failures_on_duplicate_start
             _build_registry_lock(),
             tool_call_id="toolu_123",
         )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("during_start", [True, False])
+@pytest.mark.parametrize("already_started", [True, False])
+async def test_caller_cancellation_cancels_workflow_despite_start_race(
+    pending_workflow: _PendingWorkflow,
+    during_start: bool,
+    already_started: bool,
+) -> None:
+    start_entered = asyncio.Event()
+    allow_start = asyncio.Event()
+    cancel_entered = asyncio.Event()
+    allow_cancel = asyncio.Event()
+
+    async def start(*_args: object, **_kwargs: object) -> Mock:
+        start_entered.set()
+        await allow_start.wait()
+        if already_started:
+            raise WorkflowAlreadyStartedError(
+                pending_workflow.handle.id,
+                "ExecuteRegistryToolWorkflow",
+                run_id="existing-run",
+            )
+        return pending_workflow.handle
+
+    async def cancel(**_kwargs: object) -> None:
+        cancel_entered.set()
+        await allow_cancel.wait()
+
+    pending_workflow.client.start_workflow.side_effect = start
+    pending_workflow.handle.cancel.side_effect = cancel
+    task = asyncio.create_task(
+        executor.execute_action(
+            "core.http_request", {}, _build_claims(), _build_registry_lock()
+        )
+    )
+    try:
+        async with asyncio.timeout(5):
+            await start_entered.wait()
+            if not during_start:
+                allow_start.set()
+                await pending_workflow.waiting.wait()
+            task.cancel("caller left")
+            await asyncio.sleep(0)
+            assert not task.done()
+            allow_start.set()
+            await cancel_entered.wait()
+            # A second cancellation must not abandon the remote cancellation RPC.
+            task.cancel("caller still gone")
+            await asyncio.sleep(0)
+            assert not task.done()
+            allow_cancel.set()
+            with pytest.raises(asyncio.CancelledError, match="caller left"):
+                await task
+    finally:
+        allow_start.set()
+        allow_cancel.set()
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    pending_workflow.handle.cancel.assert_awaited_once_with(
+        rpc_timeout=executor._WORKFLOW_RPC_TIMEOUT
+    )
+    if already_started:
+        assert (
+            call(
+                executor.ExecuteRegistryToolWorkflow.run,
+                pending_workflow.handle.id,
+                first_execution_run_id="existing-run",
+            )
+            in pending_workflow.client.get_workflow_handle_for.call_args_list
+        )
+
+
+@pytest.mark.anyio
+async def test_anyio_scope_cancellation_reaches_temporal(
+    pending_workflow: _PendingWorkflow,
+) -> None:
+    finished = asyncio.Event()
+
+    async def run(*, task_status: TaskStatus[anyio.CancelScope]) -> None:
+        with anyio.CancelScope() as scope:
+            task_status.started(scope)
+            await executor.execute_action(
+                "core.http_request", {}, _build_claims(), _build_registry_lock()
+            )
+        finished.set()
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as tasks:
+            scope = await tasks.start(run)
+            await pending_workflow.waiting.wait()
+            scope.cancel()
+            await finished.wait()
+
+    pending_workflow.handle.cancel.assert_awaited_once_with(
+        rpc_timeout=executor._WORKFLOW_RPC_TIMEOUT
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("status", [RPCStatusCode.NOT_FOUND, RPCStatusCode.UNAVAILABLE])
+async def test_cancellation_rpc_failure_preserves_caller_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+    pending_workflow: _PendingWorkflow,
+    status: RPCStatusCode,
+) -> None:
+    pending_workflow.handle.cancel.side_effect = RPCError(
+        "Cancellation request failed", status, b""
+    )
+    logger = Mock()
+    monkeypatch.setattr(executor, "logger", logger)
+    task = asyncio.create_task(
+        executor.execute_action(
+            "core.http_request", {}, _build_claims(), _build_registry_lock()
+        )
+    )
+    async with asyncio.timeout(5):
+        await pending_workflow.waiting.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    pending_workflow.handle.cancel.assert_awaited_once()
+    if status == RPCStatusCode.NOT_FOUND:
+        logger.warning.assert_not_called()
+    else:
+        logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_ambiguous_start_failure_cancels_by_workflow_id(
+    pending_workflow: _PendingWorkflow,
+) -> None:
+    error = RPCError("Start response lost", RPCStatusCode.DEADLINE_EXCEEDED, b"")
+    pending_workflow.client.start_workflow.side_effect = error
+
+    with pytest.raises(RPCError) as raised:
+        await executor.execute_action(
+            "core.http_request", {}, _build_claims(), _build_registry_lock()
+        )
+
+    assert raised.value is error
+    pending_workflow.client.get_workflow_handle_for.assert_called_once_with(
+        executor.ExecuteRegistryToolWorkflow.run, pending_workflow.handle.id
+    )
+    pending_workflow.handle.cancel.assert_awaited_once_with(
+        rpc_timeout=executor._WORKFLOW_RPC_TIMEOUT
+    )
 
 
 def test_build_tool_workflow_alias_attrs_uses_claude_code_prefix() -> None:

--- a/tests/unit/test_agent_mcp_executor.py
+++ b/tests/unit/test_agent_mcp_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -35,9 +36,14 @@ def _build_registry_lock() -> RegistryLock:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("executor_timeout", [300, 45.5])
 async def test_execute_action_starts_registry_tool_workflow_with_alias_correlation(
     monkeypatch: pytest.MonkeyPatch,
+    executor_timeout: float,
 ) -> None:
+    monkeypatch.setattr(
+        executor.config, "TRACECAT__EXECUTOR_CLIENT_TIMEOUT", executor_timeout
+    )
     claims = _build_claims()
     untrusted_session_id = uuid.UUID("00000000-0000-0000-0000-000000000099")
     monkeypatch.setattr(
@@ -70,6 +76,7 @@ async def test_execute_action_starts_registry_tool_workflow_with_alias_correlati
 
     call = fake_client.execute_workflow.await_args
     assert call.kwargs["id"] == "agent-tool/tool-wf-123"
+    assert call.kwargs["run_timeout"] == timedelta(seconds=executor_timeout + 90)
     workflow_input = call.args[1]
     assert workflow_input.run_input.agent_session_id == claims.session_id
     assert workflow_input.run_input.task.args["agent_session_id"] == str(

--- a/tests/unit/test_agent_mcp_executor.py
+++ b/tests/unit/test_agent_mcp_executor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -36,14 +35,9 @@ def _build_registry_lock() -> RegistryLock:
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("executor_timeout", [300, 45.5])
 async def test_execute_action_starts_registry_tool_workflow_with_alias_correlation(
     monkeypatch: pytest.MonkeyPatch,
-    executor_timeout: float,
 ) -> None:
-    monkeypatch.setattr(
-        executor.config, "TRACECAT__EXECUTOR_CLIENT_TIMEOUT", executor_timeout
-    )
     claims = _build_claims()
     untrusted_session_id = uuid.UUID("00000000-0000-0000-0000-000000000099")
     monkeypatch.setattr(
@@ -76,7 +70,8 @@ async def test_execute_action_starts_registry_tool_workflow_with_alias_correlati
 
     call = fake_client.execute_workflow.await_args
     assert call.kwargs["id"] == "agent-tool/tool-wf-123"
-    assert call.kwargs["run_timeout"] == timedelta(seconds=executor_timeout + 90)
+    assert call.kwargs.get("run_timeout") is None
+    assert call.kwargs.get("execution_timeout") is None
     workflow_input = call.args[1]
     assert workflow_input.run_input.agent_session_id == claims.session_id
     assert workflow_input.run_input.task.args["agent_session_id"] == str(

--- a/tests/unit/test_registry_tool_workflow.py
+++ b/tests/unit/test_registry_tool_workflow.py
@@ -1,6 +1,6 @@
 """Registry tool timeout ordering and terminal attribution regressions."""
 
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -22,6 +22,7 @@ from tracecat.temporal.errors import (
 )
 
 MODULE = "tracecat_ee.agent.workflows.registry_tool"
+WORKFLOW_START = datetime(2026, 1, 1, tzinfo=UTC)
 
 
 def _activity_error(cause: Exception) -> ActivityError:
@@ -39,16 +40,30 @@ def _activity_error(cause: Exception) -> ActivityError:
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("patched,expected_seconds", [(True, 360), (False, 300)])
+@pytest.mark.parametrize(
+    ("patched", "expected_seconds", "expected_schedule_to_close"),
+    [
+        (True, 360, timedelta(seconds=360)),
+        (False, 300, None),
+    ],
+)
 async def test_activity_leaves_time_for_sandbox_failure(
-    patched: bool, expected_seconds: int
+    patched: bool,
+    expected_seconds: int,
+    expected_schedule_to_close: timedelta | None,
 ) -> None:
     result = InlineObject(data="done")
     execute = AsyncMock(return_value=result)
+    workflow_info = Mock(
+        workflow_start_time=WORKFLOW_START,
+        run_timeout=timedelta(seconds=390),
+    )
     with (
         patch(f"{MODULE}.workflow.patched", return_value=patched),
         patch(f"{MODULE}.workflow.execute_activity", execute),
         patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
+        patch(f"{MODULE}.workflow.info", return_value=workflow_info) as info,
+        patch(f"{MODULE}.workflow.now", return_value=WORKFLOW_START) as now,
     ):
         assert (
             await ExecuteRegistryToolWorkflow().run(
@@ -61,7 +76,122 @@ async def test_activity_leaves_time_for_sandbox_failure(
     assert execute.call_args.kwargs["start_to_close_timeout"] == timedelta(
         seconds=expected_seconds
     )
+    assert (
+        execute.call_args.kwargs["schedule_to_close_timeout"]
+        == expected_schedule_to_close
+    )
     assert execute.call_args.kwargs["retry_policy"].maximum_attempts == 1
+    if not patched:
+        info.assert_not_called()
+        now.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_activity_schedule_to_close_accounts_for_late_workflow_start() -> None:
+    result = InlineObject(data="done")
+    execute = AsyncMock(return_value=result)
+    workflow_info = Mock(
+        workflow_start_time=WORKFLOW_START,
+        run_timeout=timedelta(seconds=390),
+    )
+    with (
+        patch(f"{MODULE}.workflow.patched", return_value=True),
+        patch(f"{MODULE}.workflow.execute_activity", execute),
+        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
+        patch(f"{MODULE}.workflow.info", return_value=workflow_info),
+        patch(
+            f"{MODULE}.workflow.now",
+            return_value=WORKFLOW_START + timedelta(seconds=90),
+        ),
+    ):
+        await ExecuteRegistryToolWorkflow().run(
+            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
+        )
+
+    assert execute.call_args.kwargs["start_to_close_timeout"] == timedelta(seconds=360)
+    assert execute.call_args.kwargs["schedule_to_close_timeout"] == timedelta(
+        seconds=270
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("elapsed_seconds", [360, 375])
+async def test_exhausted_activity_budget_skips_scheduling(
+    elapsed_seconds: int,
+) -> None:
+    execute = AsyncMock(return_value=InlineObject(data="unreachable"))
+    workflow_info = Mock(
+        workflow_start_time=WORKFLOW_START,
+        run_timeout=timedelta(seconds=390),
+    )
+    with (
+        patch(f"{MODULE}.workflow.patched", return_value=True),
+        patch(f"{MODULE}.workflow.execute_activity", execute),
+        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
+        patch(f"{MODULE}.workflow.info", return_value=workflow_info),
+        patch(
+            f"{MODULE}.workflow.now",
+            return_value=WORKFLOW_START + timedelta(seconds=elapsed_seconds),
+        ),
+        pytest.raises(ApplicationError) as raised,
+    ):
+        await ExecuteRegistryToolWorkflow().run(
+            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
+        )
+
+    assert raised.value.non_retryable
+    classification = extract_error_classifications(raised.value)
+    assert len(classification) == 1
+    assert classification[0].owner is RuntimeErrorOwner.PLATFORM
+    assert classification[0].kind is RuntimeErrorKind.EXECUTOR_ACTIVITY_TIMED_OUT
+    assert classification[0].retry_disposition is RetryDisposition.NON_RETRYABLE
+    execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_no_workflow_run_timeout_uses_activity_duration() -> None:
+    execute = AsyncMock(return_value=InlineObject(data="done"))
+    workflow_info = Mock(workflow_start_time=WORKFLOW_START, run_timeout=None)
+    with (
+        patch(f"{MODULE}.workflow.patched", return_value=True),
+        patch(f"{MODULE}.workflow.execute_activity", execute),
+        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
+        patch(f"{MODULE}.workflow.info", return_value=workflow_info),
+    ):
+        await ExecuteRegistryToolWorkflow().run(
+            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
+        )
+
+    assert execute.call_args.kwargs["start_to_close_timeout"] == timedelta(seconds=360)
+    assert execute.call_args.kwargs["schedule_to_close_timeout"] == timedelta(
+        seconds=360
+    )
+
+
+@pytest.mark.anyio
+async def test_activity_timeout_preserves_fractional_executor_config() -> None:
+    execute = AsyncMock(return_value=InlineObject(data="done"))
+    workflow_info = Mock(
+        workflow_start_time=WORKFLOW_START,
+        run_timeout=timedelta(seconds=900),
+    )
+    with (
+        patch(f"{MODULE}.workflow.patched", return_value=True),
+        patch(f"{MODULE}.workflow.execute_activity", execute),
+        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300.5),
+        patch(f"{MODULE}.workflow.info", return_value=workflow_info),
+        patch(f"{MODULE}.workflow.now", return_value=WORKFLOW_START),
+    ):
+        await ExecuteRegistryToolWorkflow().run(
+            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
+        )
+
+    assert execute.call_args.kwargs["start_to_close_timeout"] == timedelta(
+        seconds=360.5
+    )
+    assert execute.call_args.kwargs["schedule_to_close_timeout"] == timedelta(
+        seconds=360.5
+    )
 
 
 @pytest.mark.anyio
@@ -76,6 +206,14 @@ async def test_outer_timeouts_are_classified_without_retry(
     with (
         patch(f"{MODULE}.workflow.patched", return_value=patched),
         patch(f"{MODULE}.workflow.execute_activity", AsyncMock(side_effect=error)),
+        patch(
+            f"{MODULE}.workflow.info",
+            return_value=Mock(
+                workflow_start_time=WORKFLOW_START,
+                run_timeout=timedelta(seconds=390),
+            ),
+        ),
+        patch(f"{MODULE}.workflow.now", return_value=WORKFLOW_START),
         pytest.raises(ApplicationError) as raised,
     ):
         await ExecuteRegistryToolWorkflow().run(
@@ -105,6 +243,14 @@ async def test_classified_sandbox_failure_keeps_user_ownership() -> None:
     with (
         patch(f"{MODULE}.workflow.patched", return_value=True),
         patch(f"{MODULE}.workflow.execute_activity", AsyncMock(side_effect=error)),
+        patch(
+            f"{MODULE}.workflow.info",
+            return_value=Mock(
+                workflow_start_time=WORKFLOW_START,
+                run_timeout=timedelta(seconds=390),
+            ),
+        ),
+        patch(f"{MODULE}.workflow.now", return_value=WORKFLOW_START),
         pytest.raises(ApplicationError) as raised,
     ):
         await ExecuteRegistryToolWorkflow().run(

--- a/tests/unit/test_registry_tool_workflow.py
+++ b/tests/unit/test_registry_tool_workflow.py
@@ -1,0 +1,114 @@
+"""Registry tool timeout ordering and terminal attribution regressions."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from temporalio.exceptions import ActivityError, ApplicationError, TimeoutType
+from temporalio.exceptions import TimeoutError as TemporalTimeoutError
+from tracecat_ee.agent.workflows.registry_tool import ExecuteRegistryToolWorkflow
+
+from tracecat.agent.workflows.tool_execution import ExecuteRegistryToolWorkflowInput
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorClassification,
+    RuntimeErrorKind,
+    RuntimeErrorOwner,
+)
+from tracecat.storage.object import InlineObject
+from tracecat.temporal.errors import (
+    application_error_from_classification,
+    extract_error_classifications,
+)
+
+MODULE = "tracecat_ee.agent.workflows.registry_tool"
+
+
+def _activity_error(cause: Exception) -> ActivityError:
+    error = ActivityError(
+        "Activity failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="test-executor",
+        activity_type="execute_action_activity",
+        activity_id="1",
+        retry_state=None,
+    )
+    error.__cause__ = cause
+    return error
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("patched,expected_seconds", [(True, 360), (False, 300)])
+async def test_activity_leaves_time_for_sandbox_failure(
+    patched: bool, expected_seconds: int
+) -> None:
+    result = InlineObject(data="done")
+    execute = AsyncMock(return_value=result)
+    with (
+        patch(f"{MODULE}.workflow.patched", return_value=patched),
+        patch(f"{MODULE}.workflow.execute_activity", execute),
+        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
+    ):
+        assert (
+            await ExecuteRegistryToolWorkflow().run(
+                Mock(
+                    spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock()
+                )
+            )
+            == result
+        )
+    assert execute.call_args.kwargs["start_to_close_timeout"] == timedelta(
+        seconds=expected_seconds
+    )
+    assert execute.call_args.kwargs["retry_policy"].maximum_attempts == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("timeout_type", list(TimeoutType))
+@pytest.mark.parametrize("patched", [True, False])
+async def test_outer_timeouts_are_classified_without_retry(
+    timeout_type: TimeoutType, patched: bool
+) -> None:
+    error = _activity_error(
+        TemporalTimeoutError("Timed out", type=timeout_type, last_heartbeat_details=[])
+    )
+    with (
+        patch(f"{MODULE}.workflow.patched", return_value=patched),
+        patch(f"{MODULE}.workflow.execute_activity", AsyncMock(side_effect=error)),
+        pytest.raises(ApplicationError) as raised,
+    ):
+        await ExecuteRegistryToolWorkflow().run(
+            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
+        )
+    assert raised.value.non_retryable
+    assert raised.value.__cause__ is error
+    classifications = extract_error_classifications(raised.value)
+    if patched:
+        assert len(classifications) == 1
+        classification = classifications[0]
+        assert classification.owner is RuntimeErrorOwner.PLATFORM
+        assert classification.kind is RuntimeErrorKind.EXECUTOR_ACTIVITY_TIMED_OUT
+        assert classification.retry_disposition is RetryDisposition.NON_RETRYABLE
+    else:
+        assert not classifications
+
+
+@pytest.mark.anyio
+async def test_classified_sandbox_failure_keeps_user_ownership() -> None:
+    classification = RuntimeErrorClassification.user(
+        kind=RuntimeErrorKind.SANDBOX_RESOURCE_LIMIT_EXCEEDED,
+        message="Sandbox workload exceeded its limit",
+        retry_disposition=RetryDisposition.NON_RETRYABLE,
+    )
+    error = _activity_error(application_error_from_classification(classification))
+    with (
+        patch(f"{MODULE}.workflow.patched", return_value=True),
+        patch(f"{MODULE}.workflow.execute_activity", AsyncMock(side_effect=error)),
+        pytest.raises(ApplicationError) as raised,
+    ):
+        await ExecuteRegistryToolWorkflow().run(
+            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
+        )
+    assert extract_error_classifications(raised.value) == (classification,)
+    assert raised.value.non_retryable

--- a/tests/unit/test_registry_tool_workflow.py
+++ b/tests/unit/test_registry_tool_workflow.py
@@ -1,6 +1,6 @@
 """Registry tool timeout ordering and terminal attribution regressions."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -22,7 +22,6 @@ from tracecat.temporal.errors import (
 )
 
 MODULE = "tracecat_ee.agent.workflows.registry_tool"
-WORKFLOW_START = datetime(2026, 1, 1, tzinfo=UTC)
 
 
 def _activity_error(cause: Exception) -> ActivityError:
@@ -41,29 +40,26 @@ def _activity_error(cause: Exception) -> ActivityError:
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ("patched", "expected_seconds", "expected_schedule_to_close"),
+    ("patched", "executor_seconds", "expected_seconds", "expected_schedule_to_close"),
     [
-        (True, 360, timedelta(seconds=360)),
-        (False, 300, None),
+        (True, 300, 360, timedelta(seconds=360)),
+        (True, 300.5, 360.5, timedelta(seconds=360.5)),
+        (False, 300, 300, None),
+        (False, 300.5, 300, None),
     ],
 )
 async def test_activity_leaves_time_for_sandbox_failure(
     patched: bool,
-    expected_seconds: int,
+    executor_seconds: float,
+    expected_seconds: float,
     expected_schedule_to_close: timedelta | None,
 ) -> None:
     result = InlineObject(data="done")
     execute = AsyncMock(return_value=result)
-    workflow_info = Mock(
-        workflow_start_time=WORKFLOW_START,
-        run_timeout=timedelta(seconds=390),
-    )
     with (
         patch(f"{MODULE}.workflow.patched", return_value=patched),
         patch(f"{MODULE}.workflow.execute_activity", execute),
-        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
-        patch(f"{MODULE}.workflow.info", return_value=workflow_info) as info,
-        patch(f"{MODULE}.workflow.now", return_value=WORKFLOW_START) as now,
+        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", executor_seconds),
     ):
         assert (
             await ExecuteRegistryToolWorkflow().run(
@@ -81,117 +77,6 @@ async def test_activity_leaves_time_for_sandbox_failure(
         == expected_schedule_to_close
     )
     assert execute.call_args.kwargs["retry_policy"].maximum_attempts == 1
-    if not patched:
-        info.assert_not_called()
-        now.assert_not_called()
-
-
-@pytest.mark.anyio
-async def test_activity_schedule_to_close_accounts_for_late_workflow_start() -> None:
-    result = InlineObject(data="done")
-    execute = AsyncMock(return_value=result)
-    workflow_info = Mock(
-        workflow_start_time=WORKFLOW_START,
-        run_timeout=timedelta(seconds=390),
-    )
-    with (
-        patch(f"{MODULE}.workflow.patched", return_value=True),
-        patch(f"{MODULE}.workflow.execute_activity", execute),
-        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
-        patch(f"{MODULE}.workflow.info", return_value=workflow_info),
-        patch(
-            f"{MODULE}.workflow.now",
-            return_value=WORKFLOW_START + timedelta(seconds=90),
-        ),
-    ):
-        await ExecuteRegistryToolWorkflow().run(
-            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
-        )
-
-    assert execute.call_args.kwargs["start_to_close_timeout"] == timedelta(seconds=360)
-    assert execute.call_args.kwargs["schedule_to_close_timeout"] == timedelta(
-        seconds=270
-    )
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize("elapsed_seconds", [360, 375])
-async def test_exhausted_activity_budget_skips_scheduling(
-    elapsed_seconds: int,
-) -> None:
-    execute = AsyncMock(return_value=InlineObject(data="unreachable"))
-    workflow_info = Mock(
-        workflow_start_time=WORKFLOW_START,
-        run_timeout=timedelta(seconds=390),
-    )
-    with (
-        patch(f"{MODULE}.workflow.patched", return_value=True),
-        patch(f"{MODULE}.workflow.execute_activity", execute),
-        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
-        patch(f"{MODULE}.workflow.info", return_value=workflow_info),
-        patch(
-            f"{MODULE}.workflow.now",
-            return_value=WORKFLOW_START + timedelta(seconds=elapsed_seconds),
-        ),
-        pytest.raises(ApplicationError) as raised,
-    ):
-        await ExecuteRegistryToolWorkflow().run(
-            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
-        )
-
-    assert raised.value.non_retryable
-    classification = extract_error_classifications(raised.value)
-    assert len(classification) == 1
-    assert classification[0].owner is RuntimeErrorOwner.PLATFORM
-    assert classification[0].kind is RuntimeErrorKind.EXECUTOR_ACTIVITY_TIMED_OUT
-    assert classification[0].retry_disposition is RetryDisposition.NON_RETRYABLE
-    execute.assert_not_called()
-
-
-@pytest.mark.anyio
-async def test_no_workflow_run_timeout_uses_activity_duration() -> None:
-    execute = AsyncMock(return_value=InlineObject(data="done"))
-    workflow_info = Mock(workflow_start_time=WORKFLOW_START, run_timeout=None)
-    with (
-        patch(f"{MODULE}.workflow.patched", return_value=True),
-        patch(f"{MODULE}.workflow.execute_activity", execute),
-        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300),
-        patch(f"{MODULE}.workflow.info", return_value=workflow_info),
-    ):
-        await ExecuteRegistryToolWorkflow().run(
-            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
-        )
-
-    assert execute.call_args.kwargs["start_to_close_timeout"] == timedelta(seconds=360)
-    assert execute.call_args.kwargs["schedule_to_close_timeout"] == timedelta(
-        seconds=360
-    )
-
-
-@pytest.mark.anyio
-async def test_activity_timeout_preserves_fractional_executor_config() -> None:
-    execute = AsyncMock(return_value=InlineObject(data="done"))
-    workflow_info = Mock(
-        workflow_start_time=WORKFLOW_START,
-        run_timeout=timedelta(seconds=900),
-    )
-    with (
-        patch(f"{MODULE}.workflow.patched", return_value=True),
-        patch(f"{MODULE}.workflow.execute_activity", execute),
-        patch(f"{MODULE}.config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 300.5),
-        patch(f"{MODULE}.workflow.info", return_value=workflow_info),
-        patch(f"{MODULE}.workflow.now", return_value=WORKFLOW_START),
-    ):
-        await ExecuteRegistryToolWorkflow().run(
-            Mock(spec=ExecuteRegistryToolWorkflowInput, run_input=Mock(), role=Mock())
-        )
-
-    assert execute.call_args.kwargs["start_to_close_timeout"] == timedelta(
-        seconds=360.5
-    )
-    assert execute.call_args.kwargs["schedule_to_close_timeout"] == timedelta(
-        seconds=360.5
-    )
 
 
 @pytest.mark.anyio
@@ -206,14 +91,6 @@ async def test_outer_timeouts_are_classified_without_retry(
     with (
         patch(f"{MODULE}.workflow.patched", return_value=patched),
         patch(f"{MODULE}.workflow.execute_activity", AsyncMock(side_effect=error)),
-        patch(
-            f"{MODULE}.workflow.info",
-            return_value=Mock(
-                workflow_start_time=WORKFLOW_START,
-                run_timeout=timedelta(seconds=390),
-            ),
-        ),
-        patch(f"{MODULE}.workflow.now", return_value=WORKFLOW_START),
         pytest.raises(ApplicationError) as raised,
     ):
         await ExecuteRegistryToolWorkflow().run(
@@ -243,14 +120,6 @@ async def test_classified_sandbox_failure_keeps_user_ownership() -> None:
     with (
         patch(f"{MODULE}.workflow.patched", return_value=True),
         patch(f"{MODULE}.workflow.execute_activity", AsyncMock(side_effect=error)),
-        patch(
-            f"{MODULE}.workflow.info",
-            return_value=Mock(
-                workflow_start_time=WORKFLOW_START,
-                run_timeout=timedelta(seconds=390),
-            ),
-        ),
-        patch(f"{MODULE}.workflow.now", return_value=WORKFLOW_START),
         pytest.raises(ApplicationError) as raised,
     ):
         await ExecuteRegistryToolWorkflow().run(

--- a/tests/unit/test_temporal_patches.py
+++ b/tests/unit/test_temporal_patches.py
@@ -3,6 +3,7 @@ from tracecat.temporal.patches import WorkflowPatch
 
 def test_workflow_patch_ids_are_history_stable() -> None:
     assert {patch.name: patch.value for patch in WorkflowPatch} == {
+        "REGISTRY_TOOL_ACTIVITY_TIMEOUT": "registry-tool-activity-timeout-v1",
         "ACTION_HEARTBEAT_TIMEOUT_RETRY": "dsl-action-heartbeat-timeout-retry-v1",
         "ERROR_OWNER_SEARCH_ATTRIBUTE": "dsl-error-owner-search-attribute-v1",
         "ERROR_OWNER_CONTROL_FLOW": "dsl-error-owner-control-flow-v1",

--- a/tests/unit/test_temporal_patches.py
+++ b/tests/unit/test_temporal_patches.py
@@ -1,9 +1,8 @@
-from tracecat.temporal.patches import WorkflowPatch
+from tracecat.temporal.patches import ExecuteRegistryToolWorkflowPatch, WorkflowPatch
 
 
 def test_workflow_patch_ids_are_history_stable() -> None:
     assert {patch.name: patch.value for patch in WorkflowPatch} == {
-        "REGISTRY_TOOL_ACTIVITY_TIMEOUT": "registry-tool-activity-timeout-v1",
         "ACTION_HEARTBEAT_TIMEOUT_RETRY": "dsl-action-heartbeat-timeout-retry-v1",
         "ERROR_OWNER_SEARCH_ATTRIBUTE": "dsl-error-owner-search-attribute-v1",
         "ERROR_OWNER_CONTROL_FLOW": "dsl-error-owner-control-flow-v1",
@@ -15,4 +14,10 @@ def test_workflow_patch_ids_are_history_stable() -> None:
         "RUNTIME_ERROR_ATTRIBUTION_INTERCEPTOR": (
             "runtime-error-attribution-interceptor-v1"
         ),
+    }
+
+
+def test_registry_tool_workflow_patch_ids_are_history_stable() -> None:
+    assert {patch.name: patch.value for patch in ExecuteRegistryToolWorkflowPatch} == {
+        "ACTIVITY_TIMEOUT": "registry-tool-activity-timeout-v1",
     }

--- a/tracecat/agent/mcp/executor.py
+++ b/tracecat/agent/mcp/executor.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from typing import Any, Never
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
 from uuid import UUID, uuid4
 
-from temporalio.client import WorkflowFailureError
+import anyio
+from temporalio.client import WorkflowFailureError, WorkflowHandle
 from temporalio.common import SearchAttributePair, TypedSearchAttributes
 from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
+from temporalio.service import RPCError, RPCStatusCode
 from tracecat_ee.agent.workflows.registry_tool import ExecuteRegistryToolWorkflow
 
 from tracecat import config
@@ -40,6 +43,8 @@ from tracecat.storage.object import (
 )
 from tracecat.workflow.executions.correlation import build_agent_session_correlation_id
 from tracecat.workflow.executions.enums import TemporalSearchAttr
+
+_WORKFLOW_RPC_TIMEOUT = timedelta(seconds=10)
 
 
 class ActionNotAllowedError(Exception):
@@ -196,30 +201,78 @@ async def _execute_action_workflow(
     """Execute a single registry UDF via a short workflow on agent-worker."""
     client = await get_temporal_client()
 
-    def _raise_action_execution_error(error: WorkflowFailureError) -> Never:
-        cause = error.cause
-        if isinstance(cause, ApplicationError):
-            raise ActionExecutionError(str(cause)) from error
-        raise ActionExecutionError(str(error)) from error
-
-    try:
-        stored = await client.execute_workflow(
-            ExecuteRegistryToolWorkflow.run,
-            input,
-            id=workflow_id,
-            task_queue=config.TRACECAT__AGENT_QUEUE,
-            priority=AGENT_TOOL_PRIORITY,
-            memo=memo.model_dump(mode="json", exclude_none=True),
-            search_attributes=search_attributes,
-        )
-    except WorkflowAlreadyStartedError:
+    async def start() -> WorkflowHandle[ExecuteRegistryToolWorkflow, StoredObject]:
         try:
-            stored = await client.get_workflow_handle(workflow_id).result()
-        except WorkflowFailureError as error:
-            _raise_action_execution_error(error)
-    except WorkflowFailureError as e:
-        _raise_action_execution_error(e)
+            return await client.start_workflow(
+                ExecuteRegistryToolWorkflow.run,
+                input,
+                id=workflow_id,
+                task_queue=config.TRACECAT__AGENT_QUEUE,
+                priority=AGENT_TOOL_PRIORITY,
+                memo=memo.model_dump(mode="json", exclude_none=True),
+                search_attributes=search_attributes,
+                rpc_timeout=_WORKFLOW_RPC_TIMEOUT,
+            )
+        except WorkflowAlreadyStartedError as error:
+            return client.get_workflow_handle_for(
+                ExecuteRegistryToolWorkflow.run,
+                workflow_id,
+                first_execution_run_id=error.run_id,
+            )
+
+    # A cancelled start RPC can still create the workflow on the server. Keep
+    # the request alive so cleanup can cancel the run returned by Temporal.
+    start_task = asyncio.create_task(start())
+    try:
+        handle = await asyncio.shield(start_task)
+        stored = await handle.result()
+    except (asyncio.CancelledError, RPCError):
+        cleanup = asyncio.create_task(
+            _cancel_started_workflow(
+                start_task,
+                client.get_workflow_handle_for(
+                    ExecuteRegistryToolWorkflow.run, workflow_id
+                ),
+            )
+        )
+        # MCP uses AnyIO cancellation scopes; repeated asyncio cancellation
+        # must also leave cleanup alive until its bounded RPCs finish.
+        with anyio.CancelScope(shield=True):
+            while not cleanup.done():
+                try:
+                    await asyncio.shield(cleanup)
+                except asyncio.CancelledError:
+                    continue
+            cleanup.result()
+        raise
+    except WorkflowFailureError as error:
+        cause = error.cause
+        message = str(cause) if isinstance(cause, ApplicationError) else str(error)
+        raise ActionExecutionError(message) from error
     return StoredObjectValidator.validate_python(stored)
+
+
+async def _cancel_started_workflow(
+    start_task: asyncio.Task[WorkflowHandle[ExecuteRegistryToolWorkflow, StoredObject]],
+    fallback_handle: WorkflowHandle[ExecuteRegistryToolWorkflow, StoredObject],
+) -> None:
+    """Request cancellation without replacing the caller's original failure."""
+    try:
+        try:
+            handle = await start_task
+        except RPCError:
+            # A lost start response leaves acceptance uncertain. The fresh,
+            # per-call workflow ID still identifies any accepted execution.
+            handle = fallback_handle
+        await handle.cancel(rpc_timeout=_WORKFLOW_RPC_TIMEOUT)
+    except Exception as error:
+        if isinstance(error, RPCError) and error.status == RPCStatusCode.NOT_FOUND:
+            return
+        logger.warning(
+            "Failed to cancel registry tool workflow",
+            workflow_id=fallback_handle.id,
+            error_type=type(error).__name__,
+        )
 
 
 def build_tool_workflow_correlation_attr(session_id: UUID) -> SearchAttributePair[str]:

--- a/tracecat/agent/mcp/executor.py
+++ b/tracecat/agent/mcp/executor.py
@@ -15,6 +15,8 @@ from tracecat import config
 from tracecat.agent.tokens import MCPTokenClaims
 from tracecat.agent.workflows.tool_execution import (
     AGENT_TOOL_PRIORITY,
+    REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS,
+    REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS,
     ExecuteRegistryToolWorkflowInput,
     ExecuteRegistryToolWorkflowMemo,
     build_agent_tool_workflow_id,
@@ -209,7 +211,9 @@ async def _execute_action_workflow(
             id=workflow_id,
             task_queue=config.TRACECAT__AGENT_QUEUE,
             run_timeout=timedelta(
-                seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT) + 30
+                seconds=config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT
+                + REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS
+                + REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS
             ),
             priority=AGENT_TOOL_PRIORITY,
             memo=memo.model_dump(mode="json", exclude_none=True),

--- a/tracecat/agent/mcp/executor.py
+++ b/tracecat/agent/mcp/executor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any, Never
 from uuid import UUID, uuid4
 
@@ -15,8 +15,6 @@ from tracecat import config
 from tracecat.agent.tokens import MCPTokenClaims
 from tracecat.agent.workflows.tool_execution import (
     AGENT_TOOL_PRIORITY,
-    REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS,
-    REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS,
     ExecuteRegistryToolWorkflowInput,
     ExecuteRegistryToolWorkflowMemo,
     build_agent_tool_workflow_id,
@@ -210,11 +208,6 @@ async def _execute_action_workflow(
             input,
             id=workflow_id,
             task_queue=config.TRACECAT__AGENT_QUEUE,
-            run_timeout=timedelta(
-                seconds=config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT
-                + REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS
-                + REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS
-            ),
             priority=AGENT_TOOL_PRIORITY,
             memo=memo.model_dump(mode="json", exclude_none=True),
             search_attributes=search_attributes,

--- a/tracecat/agent/workflows/tool_execution.py
+++ b/tracecat/agent/workflows/tool_execution.py
@@ -11,6 +11,10 @@ from tracecat.dsl.schemas import RunActionInput
 AGENT_TOOL_PRIORITY = Priority(priority_key=2)
 """Priority for tool execution activities. This is higher than the default priority (1) but lower than the priority for agent execution activities (3)."""
 AGENT_TOOL_WORKFLOW_PREFIX = "agent-tool"
+# Allow sandbox termination and classified results to reach the activity caller.
+REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS = 60
+# Leave room for queueing and persisting the terminal workflow result.
+REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS = 30
 
 
 def build_agent_tool_workflow_id() -> str:

--- a/tracecat/agent/workflows/tool_execution.py
+++ b/tracecat/agent/workflows/tool_execution.py
@@ -13,8 +13,6 @@ AGENT_TOOL_PRIORITY = Priority(priority_key=2)
 AGENT_TOOL_WORKFLOW_PREFIX = "agent-tool"
 # Allow sandbox termination and classified results to reach the activity caller.
 REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS = 60
-# Reserve time after the activity deadline to persist the terminal workflow result.
-REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS = 30
 
 
 def build_agent_tool_workflow_id() -> str:

--- a/tracecat/agent/workflows/tool_execution.py
+++ b/tracecat/agent/workflows/tool_execution.py
@@ -13,7 +13,7 @@ AGENT_TOOL_PRIORITY = Priority(priority_key=2)
 AGENT_TOOL_WORKFLOW_PREFIX = "agent-tool"
 # Allow sandbox termination and classified results to reach the activity caller.
 REGISTRY_TOOL_ACTIVITY_BUFFER_SECONDS = 60
-# Leave room for queueing and persisting the terminal workflow result.
+# Reserve time after the activity deadline to persist the terminal workflow result.
 REGISTRY_TOOL_WORKFLOW_BUFFER_SECONDS = 30
 
 

--- a/tracecat/runtime/errors.py
+++ b/tracecat/runtime/errors.py
@@ -59,6 +59,7 @@ class RuntimeErrorKind(StrEnum):
     STORAGE_PERSISTENCE_TRANSPORT_UNAVAILABLE = (
         "storage.persistence.transport_unavailable"
     )
+    EXECUTOR_ACTIVITY_TIMED_OUT = "executor.activity.timed_out"
     EXECUTOR_BACKEND_INITIALIZATION_FAILED = "executor.backend.initialization_failed"
     EXECUTOR_REGISTRY_LEASE_CONTENTION = "executor.registry.lease_contention"
     EXECUTOR_REGISTRY_CAPACITY_EXHAUSTED = "executor.registry.capacity_exhausted"

--- a/tracecat/temporal/patches.py
+++ b/tracecat/temporal/patches.py
@@ -7,7 +7,6 @@ from enum import StrEnum, unique
 class WorkflowPatch(StrEnum):
     """Patch IDs recorded in Temporal workflow histories."""
 
-    REGISTRY_TOOL_ACTIVITY_TIMEOUT = "registry-tool-activity-timeout-v1"
     ACTION_HEARTBEAT_TIMEOUT_RETRY = "dsl-action-heartbeat-timeout-retry-v1"
     ERROR_OWNER_SEARCH_ATTRIBUTE = "dsl-error-owner-search-attribute-v1"
     ERROR_OWNER_CONTROL_FLOW = "dsl-error-owner-control-flow-v1"
@@ -17,6 +16,13 @@ class WorkflowPatch(StrEnum):
     )
     PRESERVE_TEMPORAL_CANCELLATION = "dsl-preserve-temporal-cancellation-v1"
     RUNTIME_ERROR_ATTRIBUTION_INTERCEPTOR = "runtime-error-attribution-interceptor-v1"
+
+
+@unique
+class ExecuteRegistryToolWorkflowPatch(StrEnum):
+    """Stable patch IDs recorded in ExecuteRegistryToolWorkflow histories."""
+
+    ACTIVITY_TIMEOUT = "registry-tool-activity-timeout-v1"
 
 
 @unique

--- a/tracecat/temporal/patches.py
+++ b/tracecat/temporal/patches.py
@@ -7,6 +7,7 @@ from enum import StrEnum, unique
 class WorkflowPatch(StrEnum):
     """Patch IDs recorded in Temporal workflow histories."""
 
+    REGISTRY_TOOL_ACTIVITY_TIMEOUT = "registry-tool-activity-timeout-v1"
     ACTION_HEARTBEAT_TIMEOUT_RETRY = "dsl-action-heartbeat-timeout-retry-v1"
     ERROR_OWNER_SEARCH_ATTRIBUTE = "dsl-error-owner-search-attribute-v1"
     ERROR_OWNER_CONTROL_FLOW = "dsl-error-owner-control-flow-v1"


### PR DESCRIPTION
Registry tool activities can expire before their sandbox reports a classified failure because both originally used the same timeout budget. A workload reaching the sandbox limit could then surface as `platform/runtime.unclassified` instead of retaining its action failure classification.

Give the activity 60 seconds beyond the executor timeout for preparation, sandbox cleanup, and result handling. Set a fixed schedule-to-close timeout to bound activity queueing plus execution (360 seconds by default). Remove the enclosing workflow's run timeout so workflow worker delays do not consume the activity budget or prevent the workflow from handling its result. This also removes the remaining-budget calculation and workflow completion buffer. Waiting for the first workflow task is intentionally not bounded by the activity timeout.

Classify Temporal activity timeouts as `platform/executor.activity.timed_out`, since queueing, lost workers, or stalled setup/persistence do not establish a user workload limit. Keep execution non-retryable to avoid repeating side effects. Group the stable patch ID under `ExecuteRegistryToolWorkflowPatch`; histories without the marker retain the original activity timeout and failure behavior during replay.

This is separate from #3421 and #3431, which add and refactor timeout diagnostics. Queueing consumes the activity budget; this change does not increase individual sandbox execution limits.

Caller cancellation now explicitly requests cancellation of the Temporal workflow, including when cancellation arrives during its start request. Cleanup is shielded from AnyIO and repeated asyncio cancellation. The start and cancellation RPCs have 10-second deadlines; these do not limit workflow duration. If the start response is lost, cleanup attempts cancellation by the fresh per-call workflow ID. Cleanup failures are logged without replacing the caller's original cancellation or RPC error. This covers cooperative caller cancellation; it does not undo activity side effects or guarantee cleanup after abrupt process loss.

Validation: 28 focused unit tests and one local Temporal regression passed. Coverage includes fixed activity budgets, fractional settings, all four Temporal timeout types, the old replay branch, preserved sandbox classifications, cancellation during startup and result waiting, duplicate starts, repeated asyncio cancellation, AnyIO cancellation scopes, and failed cleanup RPCs. The Temporal regression cancels before the first workflow worker starts, then verifies CANCELED status with no activity execution after the worker comes online. Ruff, targeted Basedpyright, and commit hooks passed. No production deployment or replay of production histories performed.

| Change | + | - |
| --- | ---: | ---: |
| Logic | 121 | 28 |
| Tests | 467 | 16 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes registry tool timeout attribution and cancellation so sandbox failures keep their classification instead of surfacing as `platform/runtime.unclassified`, and cancelled MCP callers no longer leave queued tool workflows runnable.

- The activity gets 60 seconds beyond the executor timeout for preparation, cleanup, and result handling.
- A schedule-to-close timeout bounds queue time; the enclosing workflow no longer sets a run timeout.
- Fractional executor timeout configs are preserved instead of truncated to integers.
- Activity timeouts are classified as `platform/executor.activity.timed_out` and stay non-retryable to avoid repeating side effects.
- A Temporal patch marker keeps old timeout and failure behavior during replay of existing histories.
- The MCP caller now cancels the started workflow when it is cancelled, covering races with start and ambiguous start-RPC failures, with cleanup shielded from repeated cancellation.

Validation: focused tests pass across registry-tool handling, runtime attribution, and Sentry, including all four Temporal timeout types, the old replay branch, preserved sandbox failures, and cancellation races.

<sup>Written for commit 0d974dd273d0d04e5b873b3c99ff7809bce294c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

