### PR TITLE
fix(engine): preserve cancellation while returning workflow results

### DIFF
--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -380,6 +380,83 @@ async def test_run_workflow_preserves_scheduler_cancellation() -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("preserve_cancellation", [True, False])
+@pytest.mark.parametrize(
+    "error_kind", ["cancellation", "wrapped_cancellation", "failure"]
+)
+async def test_run_workflow_return_error_classification(
+    preserve_cancellation: bool, error_kind: str
+) -> None:
+    workflow = _build_workflow()
+    task = ActionStatement(ref="noop", action="core.noop")
+    dsl = DSLInput(
+        title="Return cancellation",
+        description="preserve native cancellation",
+        entrypoint=DSLEntrypoint(ref=task.ref),
+        actions=[task],
+    )
+    time_anchor = datetime.now(UTC)
+    run_args = DSLRunArgs(
+        role=workflow.role,
+        dsl=dsl,
+        wf_id=workflow.run_context.wf_id,
+        time_anchor=time_anchor,
+    )
+    workflow.dsl = dsl
+    workflow.dispatch_type = "push"
+    workflow.wf_run_id = str(workflow.run_context.wf_run_id)
+    workflow.start_to_close_timeout = run_args.timeout
+    error: Exception
+    match error_kind:
+        case "cancellation":
+            error = CancelledError("cancelled by sibling")
+        case "wrapped_cancellation":
+            error = _activity_error_from(CancelledError("cancelled by sibling"))
+        case _:
+            error = _activity_error_from(RuntimeError("return storage failed"))
+    scheduler = SimpleNamespace(start=AsyncMock(return_value=None))
+    workflow_info = SimpleNamespace(
+        start_time=time_anchor,
+        workflow_id=workflow.run_context.wf_exec_id,
+        run_id=str(workflow.run_context.wf_run_id),
+        execution_timeout=None,
+    )
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.info", return_value=workflow_info),
+        patch(
+            "tracecat.dsl.workflow.get_trigger_type",
+            return_value=TriggerType.MANUAL,
+        ),
+        patch("tracecat.dsl.workflow.DSLScheduler", return_value=scheduler),
+        patch.object(workflow, "_handle_return", new=AsyncMock(side_effect=error)),
+        patch(
+            "tracecat.dsl.workflow.workflow.patched",
+            return_value=preserve_cancellation,
+        ) as patched,
+    ):
+        if preserve_cancellation and error_kind != "failure":
+            with pytest.raises(type(error)) as exc_info:
+                await workflow._run_workflow(run_args)
+            assert exc_info.value is error
+        else:
+            with pytest.raises(ApplicationError) as classified_exc_info:
+                await workflow._run_workflow(run_args)
+            classification = extract_error_classification(classified_exc_info.value)
+            assert classification is not None
+            assert classification.owner is RuntimeErrorOwner.PLATFORM
+            assert (
+                classification.kind
+                is RuntimeErrorKind.WORKFLOW_RUNTIME_INVARIANT_VIOLATION
+            )
+
+    if error_kind == "failure":
+        patched.assert_not_called()
+    else:
+        patched.assert_called_once_with(WorkflowPatch.PRESERVE_RETURN_CANCELLATION)
+
+
+@pytest.mark.anyio
 async def test_execute_task_releases_action_permit_when_cancelled_during_heartbeat_stop() -> (
     None
 ):

--- a/tests/unit/test_temporal_patches.py
+++ b/tests/unit/test_temporal_patches.py
@@ -10,6 +10,7 @@ def test_workflow_patch_ids_are_history_stable() -> None:
         "PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE": (
             "dsl-preserve-original-error-after-handler-failure-v1"
         ),
+        "PRESERVE_RETURN_CANCELLATION": "dsl-preserve-return-cancellation-v1",
         "PRESERVE_TEMPORAL_CANCELLATION": "dsl-preserve-temporal-cancellation-v1",
         "RUNTIME_ERROR_ATTRIBUTION_INTERCEPTOR": (
             "runtime-error-attribution-interceptor-v1"

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -685,6 +685,10 @@ class DSLWorkflow:
             self.logger.info("DSL workflow completed")
             return await self._handle_return()
         except Exception as e:
+            if is_cancelled_exception(e) and workflow.patched(
+                WorkflowPatch.PRESERVE_RETURN_CANCELLATION
+            ):
+                raise
             if classifications := extract_error_classifications(
                 e,
                 include_implicit_context=False,

--- a/tracecat/temporal/patches.py
+++ b/tracecat/temporal/patches.py
@@ -14,6 +14,7 @@ class WorkflowPatch(StrEnum):
     PRESERVE_ORIGINAL_ERROR_AFTER_HANDLER_FAILURE = (
         "dsl-preserve-original-error-after-handler-failure-v1"
     )
+    PRESERVE_RETURN_CANCELLATION = "dsl-preserve-return-cancellation-v1"
     PRESERVE_TEMPORAL_CANCELLATION = "dsl-preserve-temporal-cancellation-v1"
     RUNTIME_ERROR_ATTRIBUTION_INTERCEPTOR = "runtime-error-attribution-interceptor-v1"
 


### PR DESCRIPTION
When a parent cancels a sibling while the sibling is resolving its return value, the return handler currently converts the cancellation into a platform invariant violation. That secondary failure can obscure the original action error and trigger a misleading platform alert.

Preserve native Temporal cancellation, including cancellation wrapped in an activity error, before applying return-error classification. A dedicated Temporal patch marker retains the previous behavior when replaying histories without the marker. Genuine return failures retain their existing platform classification.

Validation:
- Reproduced cancellation misclassification before the fix.
- 37 focused unit tests passed across workflow concurrency and runtime error attribution interceptors.
- Six regression cases cover direct and activity-wrapped cancellation, genuine return failures, and both patch branches.
- Ruff lint/format and targeted basedpyright passed.
- Coverage exercises the exception boundary with mocks; no new live Temporal cancellation-race or history-replay test was run.

LOC breakdown:

| Category | + | - |
| --- | ---: | ---: |
| Logic | 5 | 0 |
| Tests | 77 | 0 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cancellation misclassification when a sibling cancels a workflow while it's resolving its return value. Previously the cancellation was converted into a platform invariant violation, obscuring the original error; now native Temporal cancellation is preserved, while genuine return failures keep their existing classification.

- Adds a `WorkflowPatch.PRESERVE_RETURN_CANCELLATION` marker to retain old behavior when replaying histories without the patch.

<sup>Written for commit 34942c75b9bc3a95627b48ed380b554466299bf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

