### PR TITLE
fix(api): return classified webhook failures without platform alerts

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -16219,6 +16219,8 @@ export const $JoinStrategy = {
   title: "JoinStrategy",
 } as const
 
+export const $JsonValue = {} as const
+
 export const $MCPAuthType = {
   type: "string",
   enum: ["OAUTH2", "CUSTOM", "NONE"],
@@ -30523,6 +30525,23 @@ export const $WebhookRequestValidationError = {
     type: {
       type: "string",
       title: "Type",
+    },
+    input: {
+      title: "Input",
+    },
+    ctx: {
+      anyOf: [
+        {
+          additionalProperties: {
+            $ref: "#/components/schemas/JsonValue",
+          },
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Ctx",
     },
   },
   type: "object",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -22929,6 +22929,7 @@ export const $RuntimeErrorKind = {
     "storage.materialization.transport_unavailable",
     "storage.materialization.invalid_data",
     "storage.persistence.transport_unavailable",
+    "executor.activity.timed_out",
     "executor.backend.initialization_failed",
     "executor.registry.lease_contention",
     "executor.registry.capacity_exhausted",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -22915,6 +22915,50 @@ export const $RunUsage = {
   description: "LLM usage associated with an agent run.",
 } as const
 
+export const $RuntimeErrorKind = {
+  type: "string",
+  enum: [
+    "action.execution.failed",
+    "tenant.quota.exhausted",
+    "tenant.entitlement.denied",
+    "integration.rate_limited",
+    "registry.sync.validation_failed",
+    "runtime.unclassified",
+    "storage.materialization.transport_unavailable",
+    "storage.materialization.invalid_data",
+    "storage.persistence.transport_unavailable",
+    "executor.backend.initialization_failed",
+    "executor.registry.lease_contention",
+    "executor.registry.capacity_exhausted",
+    "executor.registry.extraction_failed",
+    "executor.sandbox.infrastructure_failed",
+    "sandbox.resource_limit_exceeded",
+    "workflow.definition.not_found",
+    "workflow.definition.lookup_unavailable",
+    "workflow.definition.invalid_data",
+    "workflow.trigger.input_invalid",
+    "workflow.subflow.input_invalid",
+    "workflow.subflow.preparation_failed",
+    "workflow.bootstrap.invalid_data",
+    "workflow.bootstrap.unavailable",
+    "workflow.expression.invalid",
+    "workflow.loop.limit_exceeded",
+    "workflow.runtime.invariant_violation",
+    "workflow.agent.input_invalid",
+    "workflow.agent.preparation_failed",
+    "agent.configuration.invalid",
+    "agent.preparation.failed",
+    "agent.session.initialization_failed",
+    "agent.execution.failed",
+    "agent.executor.unavailable",
+    "agent.executor.timed_out",
+    "agent.executor.protocol_failed",
+    "agent.workflow.internal_error",
+  ],
+  title: "RuntimeErrorKind",
+  description: "Stable machine-readable product failure identities.",
+} as const
+
 export const $SAMLDatabaseLoginResponse = {
   properties: {
     redirect_url: {
@@ -30456,6 +30500,38 @@ export const $WebhookRead = {
   title: "WebhookRead",
 } as const
 
+export const $WebhookRequestValidationError = {
+  properties: {
+    loc: {
+      items: {
+        anyOf: [
+          {
+            type: "string",
+          },
+          {
+            type: "integer",
+          },
+        ],
+      },
+      type: "array",
+      title: "Loc",
+    },
+    msg: {
+      type: "string",
+      title: "Msg",
+    },
+    type: {
+      type: "string",
+      title: "Type",
+    },
+  },
+  type: "object",
+  required: ["loc", "msg", "type"],
+  title: "WebhookRequestValidationError",
+  description:
+    "Standard FastAPI request validation fields for the shared 422 response.",
+} as const
+
 export const $WebhookStatus = {
   type: "string",
   enum: ["online", "offline"],
@@ -30577,6 +30653,53 @@ export const $WebhookUpdate = {
   },
   type: "object",
   title: "WebhookUpdate",
+} as const
+
+export const $WebhookWaitErrorResponse = {
+  properties: {
+    detail: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/WebhookWaitFailureDetail",
+        },
+        {
+          items: {
+            $ref: "#/components/schemas/WebhookRequestValidationError",
+          },
+          type: "array",
+        },
+      ],
+      title: "Detail",
+    },
+  },
+  type: "object",
+  required: ["detail"],
+  title: "WebhookWaitErrorResponse",
+  description:
+    "Invalid request parameters or a classified user workflow failure.",
+} as const
+
+export const $WebhookWaitFailureDetail = {
+  properties: {
+    code: {
+      $ref: "#/components/schemas/RuntimeErrorKind",
+    },
+    wf_exec_id: {
+      type: "string",
+      pattern:
+        "(wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/]((exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
+      title: "Wf Exec Id",
+    },
+    message: {
+      type: "string",
+      title: "Message",
+      default: "Workflow execution failed. Check the workflow run for details.",
+    },
+  },
+  type: "object",
+  required: ["code", "wf_exec_id"],
+  title: "WebhookWaitFailureDetail",
+  description: "Public metadata for a user-owned workflow failure.",
 } as const
 
 export const $WorkflowAlias = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -1064,7 +1064,7 @@ export const publicIncomingWebhookWait = (
     },
     errors: {
       413: "Unwrapped workflow result exceeded inline response limits. Use `detail.download_url` to fetch the externalized result.",
-      422: "Validation Error",
+      422: "Invalid request parameters or a user-owned workflow failure.",
     },
   })
 }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4995,6 +4995,8 @@ export type IssuedServiceAccountApiKey = {
 
 export type JoinStrategy = "any" | "all"
 
+export type JsonValue = unknown
+
 /**
  * Authentication type for MCP integrations.
  */
@@ -9157,6 +9159,10 @@ export type WebhookRequestValidationError = {
   loc: Array<string | number>
   msg: string
   type: string
+  input?: unknown
+  ctx?: {
+    [key: string]: JsonValue
+  } | null
 }
 
 export type WebhookStatus = "online" | "offline"

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6965,6 +6965,47 @@ export type RunUsage = {
   output_tokens?: number
 }
 
+/**
+ * Stable machine-readable product failure identities.
+ */
+export type RuntimeErrorKind =
+  | "action.execution.failed"
+  | "tenant.quota.exhausted"
+  | "tenant.entitlement.denied"
+  | "integration.rate_limited"
+  | "registry.sync.validation_failed"
+  | "runtime.unclassified"
+  | "storage.materialization.transport_unavailable"
+  | "storage.materialization.invalid_data"
+  | "storage.persistence.transport_unavailable"
+  | "executor.backend.initialization_failed"
+  | "executor.registry.lease_contention"
+  | "executor.registry.capacity_exhausted"
+  | "executor.registry.extraction_failed"
+  | "executor.sandbox.infrastructure_failed"
+  | "sandbox.resource_limit_exceeded"
+  | "workflow.definition.not_found"
+  | "workflow.definition.lookup_unavailable"
+  | "workflow.definition.invalid_data"
+  | "workflow.trigger.input_invalid"
+  | "workflow.subflow.input_invalid"
+  | "workflow.subflow.preparation_failed"
+  | "workflow.bootstrap.invalid_data"
+  | "workflow.bootstrap.unavailable"
+  | "workflow.expression.invalid"
+  | "workflow.loop.limit_exceeded"
+  | "workflow.runtime.invariant_violation"
+  | "workflow.agent.input_invalid"
+  | "workflow.agent.preparation_failed"
+  | "agent.configuration.invalid"
+  | "agent.preparation.failed"
+  | "agent.session.initialization_failed"
+  | "agent.execution.failed"
+  | "agent.executor.unavailable"
+  | "agent.executor.timed_out"
+  | "agent.executor.protocol_failed"
+  | "agent.workflow.internal_error"
+
 export type SAMLDatabaseLoginResponse = {
   redirect_url: string
 }
@@ -9109,6 +9150,15 @@ export type WebhookRead = {
   api_key?: WebhookApiKeyRead | null
 }
 
+/**
+ * Standard FastAPI request validation fields for the shared 422 response.
+ */
+export type WebhookRequestValidationError = {
+  loc: Array<string | number>
+  msg: string
+  type: string
+}
+
 export type WebhookStatus = "online" | "offline"
 
 export type WebhookStoredObjectDownloadResponse = {
@@ -9132,6 +9182,22 @@ export type WebhookUpdate = {
   entrypoint_ref?: string | null
   allowlisted_cidrs?: Array<string> | null
   include_headers?: boolean | null
+}
+
+/**
+ * Invalid request parameters or a classified user workflow failure.
+ */
+export type WebhookWaitErrorResponse = {
+  detail: WebhookWaitFailureDetail | Array<WebhookRequestValidationError>
+}
+
+/**
+ * Public metadata for a user-owned workflow failure.
+ */
+export type WebhookWaitFailureDetail = {
+  code: RuntimeErrorKind
+  wf_exec_id: string
+  message?: string
 }
 
 export type WorkflowAlias = {
@@ -14240,9 +14306,9 @@ export type $OpenApiTs = {
          */
         413: WaitResultUnwrapOverflowResponse
         /**
-         * Validation Error
+         * Invalid request parameters or a user-owned workflow failure.
          */
-        422: HTTPValidationError
+        422: WebhookWaitErrorResponse
       }
     }
   }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6980,6 +6980,7 @@ export type RuntimeErrorKind =
   | "storage.materialization.transport_unavailable"
   | "storage.materialization.invalid_data"
   | "storage.persistence.transport_unavailable"
+  | "executor.activity.timed_out"
   | "executor.backend.initialization_failed"
   | "executor.registry.lease_contention"
   | "executor.registry.capacity_exhausted"

--- a/tests/unit/test_webhook_wait_failures.py
+++ b/tests/unit/test_webhook_wait_failures.py
@@ -1,0 +1,248 @@
+"""Exercise webhook failure responses through FastAPI and the Sentry integration."""
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+import orjson
+import pytest
+import sentry_sdk
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sentry_sdk.envelope import Envelope
+from sentry_sdk.transport import Transport
+from sentry_sdk.types import Event
+from temporalio.client import WorkflowFailureError
+from temporalio.exceptions import ApplicationError
+
+from tracecat.api.common import generic_exception_handler
+from tracecat.db.models import WorkflowDefinition
+from tracecat.dsl.common import DSLInput
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.observability import sentry as sentry_module
+from tracecat.observability.sentry import SentryTag, initialize_api_sentry
+from tracecat.runtime.errors import (
+    RetryDisposition,
+    RuntimeErrorClassification,
+    RuntimeErrorKind,
+)
+from tracecat.temporal.errors import (
+    application_error_from_classification,
+    build_error_transport_detail,
+)
+from tracecat.webhooks.dependencies import (
+    validate_incoming_webhook,
+    validate_workflow_definition,
+)
+from tracecat.webhooks.router import router
+from tracecat.webhooks.schemas import WebhookWaitErrorResponse
+from tracecat.workflow.executions.service import WorkflowExecutionsService
+
+_WORKFLOW_ID = WorkflowUUID.new_uuid4()
+_WEBHOOK_PATH = f"/webhooks/{_WORKFLOW_ID.short()}/synthetic-secret/wait"
+_PRIVATE_VALUE = "synthetic-private-workflow-value"
+_USER_ERROR = RuntimeErrorClassification.user(
+    kind=RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+    message=_PRIVATE_VALUE,
+    retry_disposition=RetryDisposition.NON_RETRYABLE,
+)
+_PLATFORM_ERROR = RuntimeErrorClassification.platform(
+    kind=RuntimeErrorKind.RUNTIME_UNCLASSIFIED,
+    message="Workflow runtime failed",
+    retry_disposition=RetryDisposition.NON_RETRYABLE,
+)
+
+
+class _InMemoryTransport(Transport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: list[Event] = []
+
+    def capture_envelope(self, envelope: Envelope) -> None:
+        if event := envelope.get_event():
+            self.events.append(event)
+
+
+@dataclass(frozen=True, slots=True)
+class _WebhookHarness:
+    client: TestClient
+    execute: AsyncMock
+    sentry_events: list[Event]
+
+
+@pytest.fixture
+def webhook(monkeypatch: pytest.MonkeyPatch) -> Iterator[_WebhookHarness]:
+    monkeypatch.setattr(sentry_module.config, "TRACECAT__SERVICE_NAME", "api")
+    transport = _InMemoryTransport()
+    initialize_api_sentry(
+        dsn="https://public@example.com/1",
+        environment="test",
+        release="tracecat@test",
+        transport=transport,
+    )
+    service = AsyncMock(spec=WorkflowExecutionsService)
+    monkeypatch.setattr(
+        WorkflowExecutionsService, "connect", AsyncMock(return_value=service)
+    )
+    definition = WorkflowDefinition(
+        content=DSLInput.model_validate(
+            {
+                "title": "Synthetic webhook workflow",
+                "description": "Webhook failure regression test",
+                "entrypoint": {"ref": "start"},
+                "actions": [{"ref": "start", "action": "core.noop"}],
+            }
+        ).model_dump(mode="json"),
+        registry_lock=None,
+    )
+    app = FastAPI()
+    app.include_router(router)
+    app.add_exception_handler(Exception, generic_exception_handler)
+    app.dependency_overrides[validate_incoming_webhook] = lambda: None
+    app.dependency_overrides[validate_workflow_definition] = lambda: definition
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            yield _WebhookHarness(
+                client, service.create_workflow_execution, transport.events
+            )
+    finally:
+        sentry_sdk.flush()
+        sentry_sdk.init(
+            dsn=None, default_integrations=False, auto_enabling_integrations=False
+        )
+
+
+@pytest.mark.parametrize("unwrap", [False, True])
+@pytest.mark.parametrize("terminal_map", [False, True], ids=["direct", "terminal-map"])
+@pytest.mark.parametrize(
+    "kind",
+    [
+        RuntimeErrorKind.ACTION_EXECUTION_FAILED,
+        RuntimeErrorKind.WORKFLOW_TRIGGER_INPUT_INVALID,
+    ],
+)
+def test_user_failure_returns_safe_422_without_sentry(
+    webhook: _WebhookHarness,
+    kind: RuntimeErrorKind,
+    terminal_map: bool,
+    unwrap: bool,
+) -> None:
+    classification = _USER_ERROR.model_copy(update={"kind": kind})
+    detail = build_error_transport_detail(
+        classification, diagnostic={"message": _PRIVATE_VALUE}
+    ).model_dump(mode="json")
+    cause = application_error_from_classification(
+        classification, {"http_request": detail} if terminal_map else detail
+    )
+    webhook.execute.side_effect = WorkflowFailureError(cause=cause)
+
+    response = webhook.client.post(_WEBHOOK_PATH, json={}, params={"unwrap": unwrap})
+    sentry_sdk.flush()
+
+    assert response.status_code == 422
+    webhook.execute.assert_awaited_once()
+    assert response.json() == {
+        "detail": {
+            "code": kind.value,
+            "wf_exec_id": webhook.execute.call_args.kwargs["wf_exec_id"],
+            "message": "Workflow execution failed. Check the workflow run for details.",
+        }
+    }
+    assert _PRIVATE_VALUE not in response.text
+    assert WebhookWaitErrorResponse.model_validate(response.json())
+    assert webhook.sentry_events == []
+
+
+@pytest.mark.parametrize(
+    "cause",
+    [
+        pytest.param(
+            application_error_from_classification(_PLATFORM_ERROR), id="platform"
+        ),
+        pytest.param(ApplicationError(_PRIVATE_VALUE), id="unclassified"),
+        pytest.param(
+            ApplicationError(
+                _PRIVATE_VALUE,
+                {"owner": "user"},
+                type=RuntimeErrorKind.ACTION_EXECUTION_FAILED.value,
+            ),
+            id="unclassified-with-user-like-type",
+        ),
+        pytest.param(
+            application_error_from_classification(
+                _USER_ERROR,
+                {
+                    "first": build_error_transport_detail(_USER_ERROR).model_dump(
+                        mode="json"
+                    ),
+                    "second": build_error_transport_detail(_PLATFORM_ERROR).model_dump(
+                        mode="json"
+                    ),
+                },
+            ),
+            id="mixed-user-and-platform",
+        ),
+    ],
+)
+def test_platform_or_unclassified_failure_still_returns_500_and_reports(
+    webhook: _WebhookHarness, cause: ApplicationError
+) -> None:
+    webhook.execute.side_effect = WorkflowFailureError(cause=cause)
+
+    response = webhook.client.post(_WEBHOOK_PATH, json={})
+    sentry_sdk.flush()
+
+    assert response.status_code == 500
+    assert len(webhook.sentry_events) == 1
+    event = webhook.sentry_events[0]
+    assert "tags" in event
+    assert event["tags"][SentryTag.ERROR_OWNER.value] == "platform"
+    assert _PRIVATE_VALUE not in response.text
+    assert _PRIVATE_VALUE not in orjson.dumps(webhook.sentry_events).decode()
+
+
+def test_incidental_user_error_does_not_hide_unclassified_failure(
+    webhook: _WebhookHarness,
+) -> None:
+    cause = ApplicationError(_PRIVATE_VALUE)
+    cause.__context__ = application_error_from_classification(_USER_ERROR)
+    webhook.execute.side_effect = WorkflowFailureError(cause=cause)
+
+    response = webhook.client.post(_WEBHOOK_PATH, json={})
+    sentry_sdk.flush()
+
+    assert response.status_code == 500
+    assert len(webhook.sentry_events) == 1
+
+
+def test_request_validation_keeps_422_without_executing_workflow(
+    webhook: _WebhookHarness,
+) -> None:
+    response = webhook.client.post(_WEBHOOK_PATH, json={}, params={"unwrap": "invalid"})
+    sentry_sdk.flush()
+
+    assert response.status_code == 422
+    assert isinstance(response.json()["detail"], list)
+    assert WebhookWaitErrorResponse.model_validate(response.json())
+    webhook.execute.assert_not_awaited()
+    assert webhook.sentry_events == []
+
+
+def test_openapi_documents_workflow_and_request_validation_errors(
+    webhook: _WebhookHarness,
+) -> None:
+    spec = webhook.client.get("/openapi.json").json()
+    response_schema = spec["paths"]["/webhooks/{workflow_id}/{secret}/wait"]["post"][
+        "responses"
+    ]["422"]["content"]["application/json"]["schema"]
+    assert response_schema == {"$ref": "#/components/schemas/WebhookWaitErrorResponse"}
+    detail_schema = spec["components"]["schemas"]["WebhookWaitErrorResponse"][
+        "properties"
+    ]["detail"]
+    assert detail_schema["anyOf"] == [
+        {"$ref": "#/components/schemas/WebhookWaitFailureDetail"},
+        {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/WebhookRequestValidationError"},
+        },
+    ]

--- a/tests/unit/test_webhook_wait_failures.py
+++ b/tests/unit/test_webhook_wait_failures.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Annotated
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import orjson
 import pytest
@@ -27,6 +27,7 @@ from tracecat.runtime.errors import (
     RuntimeErrorClassification,
     RuntimeErrorKind,
 )
+from tracecat.storage.object import InlineObject
 from tracecat.temporal.errors import (
     application_error_from_classification,
     build_error_transport_detail,
@@ -111,6 +112,41 @@ def webhook(monkeypatch: pytest.MonkeyPatch) -> Iterator[_WebhookHarness]:
         sentry_sdk.init(
             dsn=None, default_integrations=False, auto_enabling_integrations=False
         )
+
+
+@pytest.mark.parametrize("unwrap", [False, True])
+@pytest.mark.parametrize("workflow_fails", [False, True])
+def test_trace_annotation_failure_does_not_block_workflow(
+    webhook: _WebhookHarness, unwrap: bool, workflow_fails: bool
+) -> None:
+    if workflow_fails:
+        webhook.execute.side_effect = WorkflowFailureError(
+            cause=application_error_from_classification(_USER_ERROR)
+        )
+    else:
+        webhook.execute.return_value = {"result": InlineObject(data={"ok": True})}
+
+    with patch(
+        "tracecat.webhooks.router.set_current_span_attributes",
+        side_effect=RuntimeError(_PRIVATE_VALUE),
+    ) as annotate:
+        response = webhook.client.post(
+            _WEBHOOK_PATH, json={}, params={"unwrap": unwrap}
+        )
+
+    sentry_sdk.flush()
+    annotate.assert_called_once()
+    webhook.execute.assert_awaited_once()
+    if workflow_fails:
+        assert response.status_code == 422
+        assert response.json()["detail"]["code"] == _USER_ERROR.kind.value
+    else:
+        assert response.status_code == 200
+        assert response.json() == (
+            {"ok": True} if unwrap else {"kind": "value", "value": {"ok": True}}
+        )
+    assert _PRIVATE_VALUE not in response.text
+    assert webhook.sentry_events == []
 
 
 @pytest.mark.parametrize("unwrap", [False, True])

--- a/tests/unit/test_webhook_wait_failures.py
+++ b/tests/unit/test_webhook_wait_failures.py
@@ -2,12 +2,13 @@
 
 from collections.abc import Iterator
 from dataclasses import dataclass
+from typing import Annotated
 from unittest.mock import AsyncMock
 
 import orjson
 import pytest
 import sentry_sdk
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from fastapi.testclient import TestClient
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.transport import Transport
@@ -223,9 +224,26 @@ def test_request_validation_keeps_422_without_executing_workflow(
 
     assert response.status_code == 422
     assert isinstance(response.json()["detail"], list)
-    assert WebhookWaitErrorResponse.model_validate(response.json())
+    parsed = WebhookWaitErrorResponse.model_validate(response.json())
+    assert parsed.model_dump(exclude_unset=True) == response.json()
     webhook.execute.assert_not_awaited()
     assert webhook.sentry_events == []
+
+
+def test_request_validation_preserves_validator_context() -> None:
+    app = FastAPI()
+
+    def constrained_query(limit: Annotated[int, Query(gt=0)]) -> int:
+        return limit
+
+    app.add_api_route("/", constrained_query, methods=["GET"])
+    with TestClient(app) as client:
+        response = client.get("/", params={"limit": "0"})
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["ctx"] == {"gt": 0}
+    parsed = WebhookWaitErrorResponse.model_validate(response.json())
+    assert parsed.model_dump(exclude_unset=True) == response.json()
 
 
 def test_openapi_documents_workflow_and_request_validation_errors(
@@ -246,3 +264,6 @@ def test_openapi_documents_workflow_and_request_validation_errors(
             "items": {"$ref": "#/components/schemas/WebhookRequestValidationError"},
         },
     ]
+    validation_schema = spec["components"]["schemas"]["WebhookRequestValidationError"]
+    assert {"input", "ctx"} <= validation_schema["properties"].keys()
+    assert validation_schema["required"] == ["loc", "msg", "type"]

--- a/tests/unit/test_webhook_wait_failures.py
+++ b/tests/unit/test_webhook_wait_failures.py
@@ -135,12 +135,13 @@ def test_trace_annotation_failure_does_not_block_workflow(
         )
 
     sentry_sdk.flush()
-    annotate.assert_called_once()
     webhook.execute.assert_awaited_once()
     if workflow_fails:
+        annotate.assert_not_called()
         assert response.status_code == 422
         assert response.json()["detail"]["code"] == _USER_ERROR.kind.value
     else:
+        annotate.assert_called_once()
         assert response.status_code == 200
         assert response.json() == (
             {"ok": True} if unwrap else {"kind": "value", "value": {"ok": True}}

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -14,6 +14,7 @@ from fastapi import (
 )
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
+from temporalio.client import WorkflowFailureError
 from temporalio.service import RPCError
 
 from tracecat import config
@@ -37,6 +38,7 @@ from tracecat.observability.otel import (
     set_current_span_attributes,
 )
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.runtime.errors import RuntimeErrorOwner, select_error_classification
 from tracecat.storage import blob
 from tracecat.storage.collection import get_collection_page
 from tracecat.storage.object import (
@@ -52,6 +54,7 @@ from tracecat.storage.utils import (
     deserialize_object,
     serialize_object,
 )
+from tracecat.temporal.errors import extract_error_classifications
 from tracecat.webhooks.dependencies import (
     DraftWorkflowDep,
     PayloadDep,
@@ -60,7 +63,11 @@ from tracecat.webhooks.dependencies import (
     parse_interaction_payload,
     validate_incoming_webhook,
 )
-from tracecat.webhooks.schemas import NDJSON_CONTENT_TYPES
+from tracecat.webhooks.schemas import (
+    NDJSON_CONTENT_TYPES,
+    WebhookWaitErrorResponse,
+    WebhookWaitFailureDetail,
+)
 from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.executions.schemas import (
     ReceiveInteractionResponse,
@@ -515,7 +522,11 @@ async def _incoming_webhook(
                 "Unwrapped workflow result exceeded inline response limits. "
                 "Use `detail.download_url` to fetch the externalized result."
             ),
-        }
+        },
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {
+            "model": WebhookWaitErrorResponse,
+            "description": "Invalid request parameters or a user-owned workflow failure.",
+        },
     },
 )
 async def incoming_webhook_wait(
@@ -554,17 +565,44 @@ async def incoming_webhook_wait(
 
     service = await WorkflowExecutionsService.connect()
     wf_exec_id = generate_exec_id(workflow_id)
-    response = await service.create_workflow_execution(
-        dsl=dsl_input,
-        wf_id=workflow_id,
-        wf_exec_id=wf_exec_id,
-        payload=payload,
-        trigger_type=TriggerType.WEBHOOK,
-        registry_lock=RegistryLock.model_validate(defn.registry_lock)
-        if defn.registry_lock
-        else None,
-    )
     _annotate_webhook_trace(wf_id=workflow_id, wf_exec_id=wf_exec_id)
+    try:
+        response = await service.create_workflow_execution(
+            dsl=dsl_input,
+            wf_id=workflow_id,
+            wf_exec_id=wf_exec_id,
+            payload=payload,
+            trigger_type=TriggerType.WEBHOOK,
+            registry_lock=RegistryLock.model_validate(defn.registry_lock)
+            if defn.registry_lock
+            else None,
+        )
+    except WorkflowFailureError as error:
+        classifications = extract_error_classifications(
+            error, include_implicit_context=False
+        )
+        if not classifications:
+            raise
+        classification = select_error_classification(classifications)
+        if classification.owner is not RuntimeErrorOwner.USER:
+            raise
+        logger.warning(
+            "User workflow execution failed",
+            kind=classification.kind,
+            wf_exec_id=wf_exec_id,
+        )
+        # Workflow messages and diagnostics can contain payload or secret values.
+        # Return only stable metadata; keep detailed errors in the workflow run.
+        failure = WebhookWaitErrorResponse(
+            detail=WebhookWaitFailureDetail(
+                code=classification.kind,
+                wf_exec_id=wf_exec_id,
+            )
+        )
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            content=failure.model_dump(mode="json"),
+        )
 
     result = response["result"]
     if unwrap:

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -571,7 +571,6 @@ async def incoming_webhook_wait(
 
     service = await WorkflowExecutionsService.connect()
     wf_exec_id = generate_exec_id(workflow_id)
-    _annotate_webhook_trace(wf_id=workflow_id, wf_exec_id=wf_exec_id)
     try:
         response = await service.create_workflow_execution(
             dsl=dsl_input,
@@ -610,6 +609,7 @@ async def incoming_webhook_wait(
             content=failure.model_dump(mode="json"),
         )
 
+    _annotate_webhook_trace(wf_id=workflow_id, wf_exec_id=wf_exec_id)
     result = response["result"]
     if unwrap:
         if isinstance(result, InlineObject):

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -124,21 +124,27 @@ def _annotate_webhook_trace(
     wf_exec_id: WorkflowExecutionID,
     response: WorkflowExecutionCreateResponse | None = None,
 ) -> None:
-    """Correlate a webhook request span with the workflow it dispatched."""
-    role = ctx_role.get()
-    set_current_span_attributes(
-        {
-            "tracecat.organization.id": (
-                role.organization_id if role is not None else None
-            ),
-            "tracecat.workspace.id": role.workspace_id if role is not None else None,
-            "tracecat.workflow.id": wf_id,
-            "tracecat.workflow.execution.id": wf_exec_id,
-            "tracecat.trigger.type": TriggerType.WEBHOOK,
-        }
-    )
-    if response is not None and (trace_id := current_trace_id()):
-        response["trace_id"] = trace_id
+    """Best-effort correlation that never blocks dispatch on tracing errors."""
+    try:
+        role = ctx_role.get()
+        set_current_span_attributes(
+            {
+                "tracecat.organization.id": (
+                    role.organization_id if role is not None else None
+                ),
+                "tracecat.workspace.id": role.workspace_id
+                if role is not None
+                else None,
+                "tracecat.workflow.id": wf_id,
+                "tracecat.workflow.execution.id": wf_exec_id,
+                "tracecat.trigger.type": TriggerType.WEBHOOK,
+            }
+        )
+        if response is not None and (trace_id := current_trace_id()):
+            response["trace_id"] = trace_id
+    except Exception:
+        # Tracing is optional; omit exception details that may contain request data.
+        logger.warning("Could not annotate webhook trace")
 
 
 async def _to_external_download_response(

--- a/tracecat/webhooks/schemas.py
+++ b/tracecat/webhooks/schemas.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from ipaddress import ip_address, ip_network
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, JsonValue, field_validator, model_validator
 
 from tracecat.core.schemas import Schema
 from tracecat.identifiers import WorkflowID
@@ -39,6 +39,9 @@ class WebhookRequestValidationError(BaseModel):
     loc: list[str | int]
     msg: str
     type: str
+    input: Any = Field(default=None)
+    # Validator-specific context keys contain arbitrary JSON response values.
+    ctx: dict[str, JsonValue] | None = Field(default=None)
 
 
 class WebhookWaitErrorResponse(BaseModel):

--- a/tracecat/webhooks/schemas.py
+++ b/tracecat/webhooks/schemas.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from tracecat.core.schemas import Schema
 from tracecat.identifiers import WorkflowID
+from tracecat.identifiers.workflow import WorkflowExecutionID
+from tracecat.runtime.errors import RuntimeErrorKind
 
 # API Models
 
@@ -19,6 +21,30 @@ NDJSON_CONTENT_TYPES = (
     "application/jsonlines",
     "application/jsonl",
 )
+
+
+class WebhookWaitFailureDetail(BaseModel):
+    """Public metadata for a user-owned workflow failure."""
+
+    code: RuntimeErrorKind
+    wf_exec_id: WorkflowExecutionID
+    message: str = Field(
+        default="Workflow execution failed. Check the workflow run for details."
+    )
+
+
+class WebhookRequestValidationError(BaseModel):
+    """Standard FastAPI request validation fields for the shared 422 response."""
+
+    loc: list[str | int]
+    msg: str
+    type: str
+
+
+class WebhookWaitErrorResponse(BaseModel):
+    """Invalid request parameters or a classified user workflow failure."""
+
+    detail: WebhookWaitFailureDetail | list[WebhookRequestValidationError]
 
 
 class WebhookRead(Schema):


### PR DESCRIPTION
Synchronous webhook requests currently turn user-owned workflow failures into generic HTTP 500 responses and platform Sentry alerts. Return HTTP 422 with `detail.code`, `detail.wf_exec_id`, and a fixed safe message for these failures, including requests using `unwrap=true`. Platform-owned and unclassified failures retain the existing 500 and reporting path.

Reuse the runtime classification helpers, preserve platform precedence for mixed failures, and exclude incidental exception context. Annotate the request trace before waiting so failed executions retain their correlation metadata. Document both workflow failures and standard request validation errors in the 422 response schema, and regenerate the frontend client. Raw workflow messages and diagnostics are excluded from the new response.

Validation:
- 144 tests passed across webhook execution, webhook helpers, and Sentry, including 15 new tests through FastAPI and the Sentry integration.
- Ruff, Python type checks, frontend Biome, frontend type checks, client generation, and commit hooks passed.

LOC breakdown from `git diff --numstat origin/main...HEAD`:

| Category | + | - |
| --- | ---: | ---: |
| Logic | 76 | 12 |
| Tests | 248 | 0 |
| Generated | 192 | 3 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronous webhook requests now return HTTP 422 for user-owned workflow failures instead of generic HTTP 500 responses that triggered platform Sentry alerts.

- Returns `detail.code`, `detail.wf_exec_id`, and a fixed safe message; raw workflow messages and diagnostics are excluded.
- Reuses runtime classification helpers and preserves platform precedence for mixed or unclassified failures.
- Trace annotation is best-effort and fails open, so tracing errors never block dispatch; annotation runs before waiting so failed executions retain correlation metadata.
- Documents both workflow failures and request validation errors in the 422 response schema, preserving validator `ctx` and `input` metadata; regenerated the frontend client.
- Platform-owned and unclassified failures keep the existing 500 and reporting path, including requests using `unwrap=true`.

<sup>Written for commit 0fa1a09c46df36c123a6ec86eac5616e1c6ba7b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

