### PR TITLE
fix(logging): preserve registry discovery crash diagnostics

### DIFF
--- a/tests/unit/test_registry_sync_sandbox.py
+++ b/tests/unit/test_registry_sync_sandbox.py
@@ -447,9 +447,12 @@ async def test_registry_discovery_runs_without_network_or_worker_environment(
         sandbox_config,
         cache_key=None,
         script_name: str = "wrapper.py",
+        *,
+        log_raw_crash_stderr: bool = False,
     ) -> SandboxResult:
         assert cache_key is None
         assert script_name == "wrapper.py"
+        assert log_raw_crash_stderr is True
         assert sandbox_config.network is None
         assert sandbox_config.env_vars == {"PYTHONFAULTHANDLER": "1"}
         assert job_dir.parent.name.startswith("tracecat_registry_discovery_")
@@ -530,9 +533,12 @@ async def test_registry_discovery_ignores_installer_planted_symlinks(
         _sandbox_config,
         cache_key=None,
         script_name: str = "wrapper.py",
+        *,
+        log_raw_crash_stderr: bool = False,
     ) -> SandboxResult:
         assert cache_key is None
         assert script_name == "wrapper.py"
+        assert log_raw_crash_stderr is True
         assert job_dir != old_job_dir
         assert not (job_dir / "script.py").is_symlink()
         discovery_job_dirs.append(job_dir)

--- a/tests/unit/test_registry_sync_sandbox.py
+++ b/tests/unit/test_registry_sync_sandbox.py
@@ -451,7 +451,7 @@ async def test_registry_discovery_runs_without_network_or_worker_environment(
         assert cache_key is None
         assert script_name == "wrapper.py"
         assert sandbox_config.network is None
-        assert sandbox_config.env_vars == {}
+        assert sandbox_config.env_vars == {"PYTHONFAULTHANDLER": "1"}
         assert job_dir.parent.name.startswith("tracecat_registry_discovery_")
         assert job_dir.parent != site_packages.parent.parent / "sandbox-discovery"
         assert sandbox_config.python_path_dirs == [

--- a/tests/unit/test_sandbox_executor_exit_attribution.py
+++ b/tests/unit/test_sandbox_executor_exit_attribution.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import signal
+from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
-from tracecat.sandbox.executor import _classify_missing_nsjail_result
-from tracecat.sandbox.types import SandboxErrorCode
+from tracecat.sandbox.executor import NsjailExecutor, _classify_missing_nsjail_result
+from tracecat.sandbox.nsjail_protocol import NsjailCompletedProcess
+from tracecat.sandbox.types import SandboxConfig, SandboxErrorCode
 
 
 @pytest.mark.parametrize(
@@ -109,3 +112,42 @@ def test_classify_missing_nsjail_result(
         )
         is expected_code
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("startup_chars", [0, 20_000])
+async def test_missing_result_preserves_crash_tail_and_launch_status(
+    tmp_path: Path, mocker: MockerFixture, startup_chars: int
+) -> None:
+    crash = (
+        'Fatal Python error: Segmentation fault\n  File "native_module.py", line 7\n'
+    )
+    stderr = "I" * startup_chars + crash
+    mocker.patch(
+        "tracecat.sandbox.executor.invoke_nsjail",
+        return_value=NsjailCompletedProcess(
+            returncode=139,
+            stdout=b"",
+            stderr=stderr.encode(),
+            workload_started=True,
+        ),
+    )
+    log_error = mocker.patch("tracecat.sandbox.executor.logger.error")
+    executor = NsjailExecutor(cache_dir=str(tmp_path / "cache"))
+    mocker.patch.object(executor, "_build_config", return_value="")
+
+    result = await executor.execute(tmp_path, SandboxConfig())
+
+    assert result.success is False
+    assert result.exit_code == 139
+    assert result.error_code is SandboxErrorCode.WORKLOAD_FAILURE
+    assert result.stderr == stderr[-8192:]
+    assert result.stderr.endswith(crash)
+    assert result.error == "Sandbox workload exited without producing a result"
+    fields = log_error.call_args.kwargs
+    assert fields["stderr"] == stderr[:500]
+    assert fields["stderr_tail"] == result.stderr
+    assert fields["stderr_chars"] == len(stderr)
+    assert fields["stderr_tail_truncated"] is (len(stderr) > 8192)
+    assert fields["workload_started"] is True
+    assert fields["result_file_exists"] is False

--- a/tests/unit/test_sandbox_executor_exit_attribution.py
+++ b/tests/unit/test_sandbox_executor_exit_attribution.py
@@ -116,8 +116,12 @@ def test_classify_missing_nsjail_result(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("startup_chars", [0, 20_000])
+@pytest.mark.parametrize("log_raw_crash_stderr", [False, True])
 async def test_missing_result_preserves_crash_tail_and_launch_status(
-    tmp_path: Path, mocker: MockerFixture, startup_chars: int
+    tmp_path: Path,
+    mocker: MockerFixture,
+    startup_chars: int,
+    log_raw_crash_stderr: bool,
 ) -> None:
     crash = (
         'Fatal Python error: Segmentation fault\n  File "native_module.py", line 7\n'
@@ -136,7 +140,9 @@ async def test_missing_result_preserves_crash_tail_and_launch_status(
     executor = NsjailExecutor(cache_dir=str(tmp_path / "cache"))
     mocker.patch.object(executor, "_build_config", return_value="")
 
-    result = await executor.execute(tmp_path, SandboxConfig())
+    result = await executor.execute(
+        tmp_path, SandboxConfig(), log_raw_crash_stderr=log_raw_crash_stderr
+    )
 
     assert result.success is False
     assert result.exit_code == 139
@@ -145,9 +151,44 @@ async def test_missing_result_preserves_crash_tail_and_launch_status(
     assert result.stderr.endswith(crash)
     assert result.error == "Sandbox workload exited without producing a result"
     fields = log_error.call_args.kwargs
-    assert fields["stderr"] == stderr[:500]
-    assert fields["stderr_tail"] == result.stderr
+    if log_raw_crash_stderr:
+        assert fields["stderr"] == stderr[:500]
+        assert fields["stderr_tail"] == result.stderr
+    else:
+        assert "stderr" not in fields
+        assert "stderr_tail" not in fields
     assert fields["stderr_chars"] == len(stderr)
     assert fields["stderr_tail_truncated"] is (len(stderr) > 8192)
     assert fields["workload_started"] is True
     assert fields["result_file_exists"] is False
+
+
+@pytest.mark.anyio
+async def test_script_crash_does_not_log_injected_secrets(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    env_vars = {
+        "TRACECAT__EXECUTOR_TOKEN": "synthetic-executor-token",
+        "USER_SECRET": "synthetic-user-secret",
+    }
+    stderr = "\n".join(env_vars.values())
+    mocker.patch(
+        "tracecat.sandbox.executor.invoke_nsjail",
+        return_value=NsjailCompletedProcess(
+            returncode=1,
+            stdout=b"",
+            stderr=stderr.encode(),
+            workload_started=True,
+        ),
+    )
+    log_error = mocker.patch("tracecat.sandbox.executor.logger.error")
+    executor = NsjailExecutor(cache_dir=str(tmp_path / "cache"))
+    mocker.patch.object(executor, "_build_config", return_value="")
+
+    result = await executor.execute(tmp_path, SandboxConfig(env_vars=env_vars))
+
+    assert result.stderr == stderr
+    log_error.assert_called_once()
+    for secret in env_vars.values():
+        assert secret not in str(log_error.call_args)
+    assert log_error.call_args.kwargs["returncode"] == 1

--- a/tracecat/registry/sync/sandbox.py
+++ b/tracecat/registry/sync/sandbox.py
@@ -745,6 +745,9 @@ class RegistrySyncSandbox:
                         *_host_site_packages_paths(),
                         *other_trusted_roots,
                     ],
+                    # Enable before any imports, including the wrapper's. Fatal
+                    # signals bypass Python exceptions and result.json writing.
+                    env_vars={"PYTHONFAULTHANDLER": "1"},
                 ),
                 script_name="wrapper.py",
             )

--- a/tracecat/registry/sync/sandbox.py
+++ b/tracecat/registry/sync/sandbox.py
@@ -750,6 +750,7 @@ class RegistrySyncSandbox:
                     env_vars={"PYTHONFAULTHANDLER": "1"},
                 ),
                 script_name="wrapper.py",
+                log_raw_crash_stderr=True,
             )
             if not result.success:
                 detail = result.error or result.stderr or "Unknown discovery error"

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -137,6 +137,7 @@ _NSJAIL_RESOURCE_LIMIT_EXIT_CODES = {
 }
 _WORKLOAD_LAUNCHER_NAME = ".tracecat-workload-launcher.py"
 _WORKLOAD_STARTED_MARKER = b"\x00tracecat-workload-started\x00"
+_FAILURE_STDERR_TAIL_CHARS = 8192
 _WORKLOAD_LAUNCHER_SCRIPT = f"""\
 import os
 import resource
@@ -643,18 +644,29 @@ class NsjailExecutor:
             workload_started=workload_started,
         )
         error_msg = _missing_nsjail_result_message(error_code, stderr=stderr)
+        # nsjail startup output can fill the prefix before Python emits a fatal
+        # error. Keep a bounded tail as well so crash diagnostics survive.
+        stderr_tail = stderr[-_FAILURE_STDERR_TAIL_CHARS:]
         logger.error(
             "Sandbox execution did not produce a usable result",
             error_code=error_code,
             returncode=returncode,
             stderr=stderr[:500],
+            stderr_tail=stderr_tail,
+            stderr_chars=len(stderr),
+            stderr_tail_truncated=len(stderr) > _FAILURE_STDERR_TAIL_CHARS,
+            workload_started=workload_started,
+            result_file_exists=result_file_exists,
+            execution_time_ms=execution_time_ms,
+            memory_mb=config.resources.memory_mb,
+            max_processes=config.resources.max_processes,
         )
         return SandboxResult(
             success=False,
             error=error_msg,
             error_code=error_code,
             stdout=stdout,
-            stderr=stderr[:500],
+            stderr=stderr_tail,
             exit_code=returncode,
             execution_time_ms=execution_time_ms,
         )

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -557,6 +557,8 @@ class NsjailExecutor:
         config: SandboxConfig,
         cache_key: str | None = None,
         script_name: str = "wrapper.py",
+        *,
+        log_raw_crash_stderr: bool = False,
     ) -> SandboxResult:
         """Execute a Python script inside the nsjail sandbox.
 
@@ -565,6 +567,8 @@ class NsjailExecutor:
             config: Sandbox configuration.
             cache_key: Cache key for package lookup.
             script_name: Name of the script to execute (default: wrapper.py).
+            log_raw_crash_stderr: Enable only for registry discovery, which does
+                not receive user secrets or executor credentials.
 
         Returns:
             SandboxResult with execution outcome.
@@ -647,12 +651,16 @@ class NsjailExecutor:
         # nsjail startup output can fill the prefix before Python emits a fatal
         # error. Keep a bounded tail as well so crash diagnostics survive.
         stderr_tail = stderr[-_FAILURE_STDERR_TAIL_CHARS:]
+        # Scripts can print injected credentials or user secrets. Only registry
+        # discovery opts into raw crash diagnostics.
+        raw_stderr_fields: dict[str, str] = {}
+        if log_raw_crash_stderr:
+            raw_stderr_fields = {"stderr": stderr[:500], "stderr_tail": stderr_tail}
         logger.error(
             "Sandbox execution did not produce a usable result",
             error_code=error_code,
             returncode=returncode,
-            stderr=stderr[:500],
-            stderr_tail=stderr_tail,
+            **raw_stderr_fields,
             stderr_chars=len(stderr),
             stderr_tail_truncated=len(stderr) > _FAILURE_STDERR_TAIL_CHARS,
             workload_started=workload_started,


### PR DESCRIPTION
## Description

When a sandbox exits without a result file, the first 500 characters of stderr can contain only nsjail startup messages, hiding the crash diagnostic. Preserve an additional bounded 8,192-character stderr tail and record workload-start status, result-file presence, duration, and configured memory/process limits. Raw stderr logging is explicitly enabled only for registry discovery, which receives no user secrets or executor credentials. Ordinary script failure logs retain metadata only. The shared script executor still returns the tail in the failed sandbox result.

Enable Python's fault handler before registry discovery starts so fatal signals can emit a Python stack even when normal exception handling cannot write a result. This improves diagnostics; it does not fix the underlying crash or change resource limits or retry policy. The retained tail is bounded and may still omit part of a long native crash report.

## Validation

- 32 focused tests passed using the command below, excluding unrelated service fixtures.
- Ruff checks and formatting, targeted BasedPyright, and `git diff --check` passed.
- Synthetic allocation probes against the existing Linux runtime returned `resource_limit_exceeded`, exit 1, and a valid result file. Those probes establish baseline behavior; this patch has not been deployed.

## Steps to QA

```bash
uv run pytest --confcutdir=tests/unit tests/unit/test_sandbox_executor_exit_attribution.py tests/unit/test_registry_sync_sandbox.py -k 'not trio' -q
```

Regression coverage verifies that a synthetic crash diagnostic survives a long startup prefix, truncation stays bounded, and the existing workload-failure classification remains intact. Registry discovery coverage checks that fault handling is enabled in its otherwise isolated environment.

## LOC breakdown

| Category | + | - |
| --- | ---: | ---: |
| Logic | 26 | 2 |
| Tests | 92 | 3 |

## Checklist

- [x] Read CONTRIBUTING.md.
- [x] PR title passes the convention check.
- [x] PR implements one diagnostics improvement.
- [x] Focused tests, lint, and targeted type checks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves bounded crash diagnostics when a sandbox exits without a result file, and restricts raw stderr logging to registry discovery so user secrets are never leaked.

- Failed sandbox results now carry the last 8192 stderr characters instead of the first 500.
- Error logs include workload-start status, result-file presence, duration, and resource limits; raw stderr appears only when `log_raw_crash_stderr` is set, which only registry discovery enables.
- Enables Python's fault handler in the registry discovery sandbox so fatal signals emit a stack trace.

<sup>Written for commit 185c67fab548601b76d160e0157d46ae1d835d49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

