### PR TITLE
fix(ui): reset session state across account changes

### DIFF
--- a/frontend/src/hooks/use-auth.test.tsx
+++ b/frontend/src/hooks/use-auth.test.tsx
@@ -1,0 +1,185 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import Cookies from "js-cookie"
+import type { ReactNode } from "react"
+import {
+  type AuthAuthDatabaseLoginData,
+  authAuthDatabaseLogin,
+  authAuthDatabaseLogout,
+  usersUsersCurrentUser,
+} from "@/client"
+import { useAuth, useAuthActions } from "@/hooks/use-auth"
+import { User } from "@/lib/auth"
+import {
+  navigateToDocument,
+  reloadCurrentDocument,
+} from "@/lib/auth-navigation"
+import { QueryClient, QueryClientProvider } from "@/lib/query"
+
+jest.mock("@/client", () => {
+  const actual = jest.requireActual("@/client")
+  return {
+    ...actual,
+    authAuthDatabaseLogin: jest.fn(),
+    authAuthDatabaseLogout: jest.fn(),
+    usersUsersCurrentUser: jest.fn(),
+  }
+})
+
+jest.mock("@/lib/auth-navigation", () => ({
+  navigateToDocument: jest.fn(),
+  reloadCurrentDocument: jest.fn(),
+}))
+
+const mockLogin = jest.mocked(authAuthDatabaseLogin)
+const mockLogout = jest.mocked(authAuthDatabaseLogout)
+const mockCurrentUser = jest.mocked(usersUsersCurrentUser)
+const mockReloadCurrentDocument = jest.mocked(reloadCurrentDocument)
+const mockNavigateToDocument = jest.mocked(navigateToDocument)
+const mockCookieRemove = jest.spyOn(Cookies, "remove")
+
+const loginData: AuthAuthDatabaseLoginData = {
+  formData: {
+    username: "new-user@example.test",
+    password: "synthetic-password",
+  },
+}
+
+const currentUser = new User({
+  id: "old-user",
+  email: "old-user@example.test",
+  role: "basic",
+  settings: {},
+})
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe("useAuthActions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCurrentUser.mockReset()
+  })
+
+  afterAll(() => {
+    mockCookieRemove.mockRestore()
+  })
+
+  it("reloads the document only after login succeeds", async () => {
+    const queryClient = createQueryClient()
+    const pendingLogin = deferred<void>()
+    mockLogin.mockReturnValue(pendingLogin.promise as never)
+
+    const { result } = renderHook(() => useAuthActions(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    const loginPromise = result.current.login(loginData)
+    expect(mockReloadCurrentDocument).not.toHaveBeenCalled()
+
+    await act(async () => {
+      pendingLogin.resolve(undefined)
+      await expect(loginPromise).resolves.toBeUndefined()
+    })
+
+    expect(mockReloadCurrentDocument).toHaveBeenCalledTimes(1)
+    queryClient.clear()
+  })
+
+  it("clears the active organization and navigates only after logout succeeds", async () => {
+    const queryClient = createQueryClient()
+    const pendingLogout = deferred<void>()
+    mockLogout.mockReturnValue(pendingLogout.promise as never)
+
+    const { result } = renderHook(() => useAuthActions(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    const logoutPromise = result.current.logout("/sign-in?logged-out=true")
+    expect(mockCookieRemove).not.toHaveBeenCalled()
+    expect(mockNavigateToDocument).not.toHaveBeenCalled()
+
+    await act(async () => {
+      pendingLogout.resolve(undefined)
+      await expect(logoutPromise).resolves.toBeUndefined()
+    })
+
+    expect(mockCookieRemove).toHaveBeenCalledWith("tracecat:active-org-id")
+    expect(mockNavigateToDocument).toHaveBeenCalledWith(
+      "/sign-in?logged-out=true"
+    )
+    queryClient.clear()
+  })
+
+  it("keeps the mounted auth observer and cache when login fails", async () => {
+    const queryClient = createQueryClient()
+    queryClient.setQueryData(["auth"], currentUser)
+    mockLogin.mockRejectedValue(new Error("invalid credentials"))
+
+    const { result } = renderHook(
+      () => ({ auth: useAuth(), actions: useAuthActions() }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await waitFor(() => expect(result.current.auth.user).toBe(currentUser))
+
+    await act(async () => {
+      await expect(result.current.actions.login(loginData)).rejects.toThrow(
+        "invalid credentials"
+      )
+    })
+
+    expect(queryClient.getQueryData(["auth"])).toBe(currentUser)
+    expect(result.current.auth.user).toBe(currentUser)
+    expect(mockReloadCurrentDocument).not.toHaveBeenCalled()
+    queryClient.clear()
+  })
+
+  it("keeps mounted workspace data when logout fails", async () => {
+    const queryClient = createQueryClient()
+    const workspaceData = { id: "old-workspace", name: "Old workspace" }
+    queryClient.setQueryData(["workspace", "old-workspace"], workspaceData)
+    mockLogout.mockRejectedValue(new Error("logout unavailable"))
+
+    const { result } = renderHook(
+      () => ({ auth: useAuth(), actions: useAuthActions() }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await act(async () => {
+      await expect(result.current.actions.logout("/sign-in")).rejects.toThrow(
+        "logout unavailable"
+      )
+    })
+
+    expect(queryClient.getQueryData(["workspace", "old-workspace"])).toEqual(
+      workspaceData
+    )
+    expect(mockCookieRemove).not.toHaveBeenCalled()
+    expect(mockNavigateToDocument).not.toHaveBeenCalled()
+    queryClient.clear()
+  })
+})

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,7 +1,6 @@
 "use client"
 
 import Cookies from "js-cookie"
-import { useRouter } from "next/navigation"
 import { useCallback } from "react"
 import {
   type ApiError,
@@ -12,37 +11,27 @@ import {
 } from "@/client"
 import { authConfig } from "@/config/auth"
 import { getCurrentUser, User } from "@/lib/auth"
-import { useQuery, useQueryClient } from "@/lib/query"
+import {
+  navigateToDocument,
+  reloadCurrentDocument,
+} from "@/lib/auth-navigation"
+import { useQuery } from "@/lib/query"
 
 /* ── AUTH ACTIONS HOOK ─────────────────────────────────────────────────── */
 
 export function useAuthActions() {
-  const queryClient = useQueryClient()
-  const router = useRouter()
+  const login = useCallback(async (data: AuthAuthDatabaseLoginData) => {
+    const loginResponse = await authAuthDatabaseLogin(data)
+    reloadCurrentDocument()
+    return loginResponse
+  }, [])
 
-  const login = useCallback(
-    async (data: AuthAuthDatabaseLoginData) => {
-      const loginResponse = await authAuthDatabaseLogin(data)
-      await queryClient.invalidateQueries({
-        queryKey: ["auth"],
-      })
-      return loginResponse
-    },
-    [queryClient]
-  )
-
-  const logout = useCallback(
-    async (redirectUrl?: string) => {
-      const logoutResponse = await authAuthDatabaseLogout()
-      Cookies.remove("tracecat:active-org-id")
-      await queryClient.invalidateQueries({
-        queryKey: ["auth"],
-      })
-      router.push(redirectUrl ?? "/sign-in")
-      return logoutResponse
-    },
-    [queryClient, router]
-  )
+  const logout = useCallback(async (redirectUrl?: string) => {
+    const logoutResponse = await authAuthDatabaseLogout()
+    Cookies.remove("tracecat:active-org-id")
+    navigateToDocument(redirectUrl ?? "/sign-in")
+    return logoutResponse
+  }, [])
 
   return {
     login,

--- a/frontend/src/lib/auth-navigation.test.ts
+++ b/frontend/src/lib/auth-navigation.test.ts
@@ -1,0 +1,26 @@
+import {
+  navigateToDocument,
+  reloadCurrentDocument,
+} from "@/lib/auth-navigation"
+
+describe("authentication document navigation", () => {
+  it("reloads the current URL, including auth return parameters", () => {
+    const reload = jest.fn()
+    const location = {
+      href: "https://tracecat.example/sign-in?returnUrl=%2Fworkspaces",
+      reload,
+    }
+
+    reloadCurrentDocument(location)
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it("navigates to the requested logout destination", () => {
+    const assign = jest.fn()
+
+    navigateToDocument("/sign-in", { assign })
+
+    expect(assign).toHaveBeenCalledWith("/sign-in")
+  })
+})

--- a/frontend/src/lib/auth-navigation.ts
+++ b/frontend/src/lib/auth-navigation.ts
@@ -1,0 +1,21 @@
+type DocumentNavigator = Pick<Location, "reload">
+
+/**
+ * Reload the current document so authentication transitions start with a new
+ * query client and no state from the previous session.
+ */
+export function reloadCurrentDocument(
+  location: DocumentNavigator = window.location
+): void {
+  location.reload()
+}
+
+/**
+ * Navigate to a URL through a full document load.
+ */
+export function navigateToDocument(
+  url: string,
+  location: Pick<Location, "assign"> = window.location
+): void {
+  location.assign(url)
+}


### PR DESCRIPTION
## Problem

After a successful account transition, the mounted frontend could retain account-scoped React Query state for the previous user. Workspace, resource, scope, and entitlement observers could therefore continue rendering stale data while the new session was being established.

## Change

- Reload the current document after successful basic login so the new session starts with a fresh query client and mounted component tree.
- Remove the active organization cookie and perform a full document navigation after successful logout.
- Keep all transition side effects after the corresponding API call succeeds; failed login and logout requests leave the current session state untouched.
- Add focused navigation and hook tests for delayed success and failed transitions.

Follow-up to #3462. Resolves ENG-1806.

## Validation

- `pnpm -C frontend exec jest src/hooks/use-auth.test.tsx src/lib/auth-navigation.test.ts --runInBand`
- `pnpm -C frontend run typecheck`
- `pnpm -C frontend exec biome check src/hooks/use-auth.ts src/hooks/use-auth.test.tsx src/lib/auth-navigation.ts src/lib/auth-navigation.test.ts`
- `uv run ruff check .`

## LOC

| Category | Added | Removed |
| --- | ---: | ---: |
| Logic | 38 | 28 |
| Tests | 211 | 0 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale session state after account transitions by resetting the React Query cache and mounted component tree on login and logout.

- Reloads the document after a successful login so the new session starts with a fresh query client and component tree.
- Replaces `router.push` with full document navigation after logout and removes the `tracecat:active-org-id` cookie.
- Runs these side effects only after the API call succeeds; failed login or logout attempts leave the current session untouched.
- Adds tests for delayed success and failed transitions.

Resolves ENG-1806.

<sup>Written for commit 56ebdb385e49a0b419069703d0540735a114baa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/3463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

